### PR TITLE
ci: contribution flow, PR template, CODEOWNERS, and branch-protection script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for Ring. A matching owner is auto-requested for review on PRs that
+# touch the path. With required reviews currently set to 0 (solo maintainer) this is
+# informational; raise the review count in the branch-protection ruleset once there
+# are additional maintainers and these requests become enforced.
+
+# Default owner for everything in the repo.
+* @zuptalo

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Thanks for contributing to Ring! Keep the summary focused on user-facing behavior.
+See CONTRIBUTING.md for the full workflow.
+-->
+
+## What & why
+
+<!-- What does this change do, and why? Link any issue. -->
+
+## Checklist
+
+- [ ] Targets `develop` (not `main`).
+- [ ] `npm run build` passes (typecheck + bundle).
+- [ ] `npm run test:unit` passes; added/updated unit tests where it made sense.
+- [ ] `cd server && go test ./...` passes; added/updated `_test.go` where it made sense.
+- [ ] `npm run test:e2e` run if this affects user-facing flows (or N/A).
+- [ ] Commits follow Conventional Commits with a scope (e.g. `feat(call): …`).
+
+## Zero-knowledge invariant
+
+<!--
+Required if this touches the client/server boundary (anything on the wire, storage,
+sync, push, or media). The server must never see plaintext.
+-->
+
+- [ ] This change does **not** require the server to read user plaintext, **or** it
+      does not touch the client/server boundary.
+- Notes: <!-- how the server stays blind to plaintext, if relevant -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to Ring
+
+Thanks for your interest in Ring — a private, end-to-end-encrypted messenger and
+calling app (an installable Vue 3 + Ionic PWA backed by a small Go server). This
+guide covers how we branch, test, and ship. For the architecture and the
+conventions behind the code, read [`CLAUDE.md`](CLAUDE.md) first — it is the map.
+
+## License of contributions
+
+Ring is licensed **AGPL-3.0-only** (see [`LICENSE`](LICENSE)). By submitting a
+contribution you agree it is licensed under the same terms. The network-copyleft
+clause (AGPL §13) is intentional: anyone running a modified Ring server over a
+network must offer its source. Keep that in mind for anything that touches the
+client/server boundary.
+
+## The zero-knowledge invariant (read this)
+
+The server only ever relays **sealed envelopes** and stores **opaque ciphertext** —
+it never sees message bodies, contacts, profiles, or media. Every change that
+crosses the client/server boundary must preserve this: encrypt on the client, send
+ciphertext. A PR that would require the server to read user plaintext will not be
+accepted. When in doubt, say how your change keeps the server blind.
+
+## Local setup
+
+Requires **Go 1.26, Node 22, Docker** (for the dev PostgreSQL).
+
+```sh
+npm install
+make start      # PostgreSQL + ringd (air hot-reload) + Vite, all at once
+```
+
+The app comes up on http://localhost:5173 and proxies the API to `ringd` on `:8080`.
+In dev the server seeds fixed invite codes (`RINGDEV1`..`RINGDEV9`, `TESTCODE`) so
+you can register test accounts immediately.
+
+## Branching model (GitFlow)
+
+- **`develop`** is the integration branch — all work targets it.
+- **`main`** is production — only `develop` is merged in, to cut a release.
+- **Feature branches** branch off `develop` and open a PR back into `develop`.
+  Name them descriptively, e.g. `feat/group-call-roster`, `fix/ios-audio-route`.
+
+Both `develop` and `main` are protected: changes land **only via pull request with
+all CI checks green** (see [the branch-protection setup](#branch-protection)).
+Direct pushes are rejected.
+
+## Making a change
+
+1. Branch off the latest `develop`.
+2. Make your change, matching the surrounding code (see Code style in `CLAUDE.md` —
+   we favor explanatory comments on the *why*).
+3. Run the gates locally (below). Add or update tests.
+4. Open a PR into `develop`. Fill in the PR template, including the zero-knowledge
+   confirmation for anything touching the wire.
+5. Once CI is green, the PR can be merged.
+
+### Commit messages
+
+Conventional Commits with a scope, e.g. `feat(call): …`, `fix(media): …`,
+`feat(server): …`, `test(e2e): …`, `ci: …`, `docs: …`. The subject describes
+user-facing behavior, not internals.
+
+## Test gates (run before opening a PR)
+
+These mirror exactly what CI runs (`.github/workflows/build-test.yml`):
+
+```sh
+npm run build                 # client: vue-tsc --noEmit (typecheck) THEN vite build
+npm run test:unit             # client: Vitest unit tests (crypto core + pure logic)
+cd server && go test ./...    # server unit tests (in-memory fake store, NO DB needed)
+npm run test:e2e              # Playwright e2e (needs `make db-up`; spins its own ringd)
+```
+
+- Server tests need no database (in-memory fake store). Each handler file has a
+  sibling `_test.go` — keep that pattern.
+- The e2e harness resets a throwaway `ring_e2e` DB and launches an isolated test
+  `ringd`; it does **not** touch your `make start` stack.
+
+## Releases and release candidates
+
+Releases are driven by `package.json` `version`:
+
+- **Release:** bump `"version"` on `develop`, open a PR into `main`. On merge, the
+  pipeline re-verifies the merge commit and — if green and the `vX.Y.Z` tag is new —
+  tags `main`, publishes the production image (`latest`, `X.Y.Z`, `X.Y`), and cuts a
+  GitHub release.
+- **Release candidate:** push a `vX.Y.Z-rc.N` tag (off `develop`). It runs the full
+  suite and publishes a single immutable `:X.Y.Z-rc.N` image + a GitHub pre-release.
+  An RC never moves `:latest`/`:X.Y`.
+
+Operator upgrade/rollback guidance lives in [`docs/UPGRADING.md`](docs/UPGRADING.md).
+
+## Branch protection
+
+The exact protected-branch ruleset is applied (and re-applied) with
+[`scripts/setup-branch-protection.sh`](scripts/setup-branch-protection.sh). See that
+script's header for what it enforces and the one prerequisite (an authenticated
+`gh`). Note: GitHub requires a paid plan for branch protection on **private** repos;
+it is free once a repo is public.

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -36,11 +36,9 @@ BRANCHES=(develop main)
 # Required status check contexts. These are "<caller-job> / <job name>" where the
 # caller job is `verify` (in ci.yml / release.yml) and the names come from the jobs
 # in .github/workflows/build-test.yml. If you rename a job, update it here too.
-#
-# Once the frontend Vitest job is added to build-test.yml, add its context here, e.g.
-#   "verify / Client (unit tests)"
 REQUIRED_CHECKS=(
   "verify / Client (typecheck + build)"
+  "verify / Client (unit tests)"
   "verify / Server (build + vet + test)"
   "verify / End-to-end (Playwright)"
 )

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Apply (and re-apply) Ring's protected-branch ruleset to develop and main.
+#
+# WHAT IT ENFORCES on each branch:
+#   - Pull request required before merging (0 required approvals — we're a solo
+#     maintainer and GitHub won't let you approve your own PR; raise this once there
+#     are other maintainers).
+#   - Required status checks, strict (branch must be up to date before merge):
+#     the three jobs produced by the `verify` caller running build-test.yml.
+#   - Conversation resolution required.
+#   - Force-pushes and branch deletion blocked.
+#   - enforce_admins: rules apply to admins too (no bypass).
+#   - Linear history NOT required (so develop -> main keeps its merge commit).
+#
+# PREREQUISITES:
+#   - An authenticated GitHub CLI: `gh auth status` must succeed, with a token that
+#     has admin rights on the repo.
+#   - Branch protection on a PRIVATE repo requires a paid GitHub plan (Pro/Team/
+#     Enterprise). It is FREE once the repo is public. The API call below returns 403
+#     ("Upgrade to GitHub Pro…") on a free private repo — that's the plan limit, not
+#     a bug; run this after going public, or upgrade the plan.
+#
+# USAGE:
+#   scripts/setup-branch-protection.sh                  # defaults to zuptalo/ring
+#   REPO=owner/name scripts/setup-branch-protection.sh  # another repo
+#   DRY_RUN=1 scripts/setup-branch-protection.sh         # print payloads, change nothing
+#
+# This is idempotent: the protection endpoint is a PUT, so re-running just restates
+# the desired config.
+set -euo pipefail
+
+REPO="${REPO:-zuptalo/ring}"
+BRANCHES=(develop main)
+
+# Required status check contexts. These are "<caller-job> / <job name>" where the
+# caller job is `verify` (in ci.yml / release.yml) and the names come from the jobs
+# in .github/workflows/build-test.yml. If you rename a job, update it here too.
+#
+# Once the frontend Vitest job is added to build-test.yml, add its context here, e.g.
+#   "verify / Client (unit tests)"
+REQUIRED_CHECKS=(
+  "verify / Client (typecheck + build)"
+  "verify / Server (build + vet + test)"
+  "verify / End-to-end (Playwright)"
+)
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh (GitHub CLI) not found on PATH." >&2
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh is not authenticated. Run 'gh auth login' first." >&2
+  exit 1
+fi
+
+# Build the required_status_checks.checks array from REQUIRED_CHECKS.
+checks_json=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" \
+  | jq -R '{context: .}' | jq -s '.')
+
+payload=$(jq -n --argjson checks "$checks_json" '{
+  required_status_checks: { strict: true, checks: $checks },
+  enforce_admins: true,
+  required_pull_request_reviews: {
+    required_approving_review_count: 0,
+    dismiss_stale_reviews: true,
+    require_code_owner_reviews: false
+  },
+  restrictions: null,
+  required_conversation_resolution: true,
+  required_linear_history: false,
+  allow_force_pushes: false,
+  allow_deletions: false
+}')
+
+for branch in "${BRANCHES[@]}"; do
+  echo "==> ${REPO}@${branch}"
+  if [[ "${DRY_RUN:-}" == "1" ]]; then
+    echo "$payload" | jq .
+    continue
+  fi
+  echo "$payload" | gh api \
+    --method PUT \
+    -H "Accept: application/vnd.github+json" \
+    "repos/${REPO}/branches/${branch}/protection" \
+    --input - >/dev/null
+  echo "    protection applied."
+done
+
+echo "Done. Verify in Settings -> Branches, or:"
+echo "  gh api repos/${REPO}/branches/develop/protection | jq ."


### PR DESCRIPTION
Formalizes and enforces the development/release flow ahead of going open-source.

## What's here
- **`CONTRIBUTING.md`** — the GitFlow model (feature → PR into `develop`; `develop` → `main` for releases), local test gates mirroring CI, commit conventions, the release + RC process, and an upfront statement of the **zero-knowledge invariant** contributors must preserve.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — a short checklist incl. an explicit zero-knowledge confirmation for wire-touching changes.
- **`.github/CODEOWNERS`** — `* @zuptalo` (informational at 0 required reviews; enforced once the review count is raised).
- **`scripts/setup-branch-protection.sh`** — idempotent `gh`-based helper that applies the protected-branch ruleset to `develop` and `main`:
  - PR required, **0** approvals (solo maintainer)
  - required status checks (strict): the three `verify / …` contexts from `build-test.yml`
  - conversation resolution required; force-push + deletion blocked
  - **enforced on admins**; linear history **not** required (keeps the `develop`→`main` merge commit)

## How to apply (owner action)
There is no `gh`/token in the Claude session, so protection can't be set from here. Run, from a machine with an authenticated `gh`:

```sh
scripts/setup-branch-protection.sh            # DRY_RUN=1 to preview the payload first
```

⚠️ Branch protection on a **private** repo needs a paid GitHub plan; it's **free once the repo is public**. The API returns 403 on a free private repo — run it after going public (or upgrade the plan). The script header documents this.

## Notes
- The frontend `verify / Client (unit tests)` check (from the test-foundation PR) should be added to `REQUIRED_CHECKS` once that lands; the script has a comment marking where.
- `bash -n` clean; the generated JSON payload validated against the GitHub branch-protection schema.

Part of the go-public prep series (follows the AGPL/RC/upgrade-docs PR #3).

https://claude.ai/code/session_01PZhxoDiudFMjtXqLrSCyWf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZhxoDiudFMjtXqLrSCyWf)_