### PR TITLE
test: Vitest crypto-core unit tests + Go auth tests, with CI coverage gates

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,20 @@ jobs:
           path: dist
           retention-days: 7
 
+  client-test:
+    name: Client (unit tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # Vitest unit tests for the crypto core + pure logic, with the coverage floor
+      # enforced (vitest.config.ts thresholds). No browser/DB needed (Node env).
+      - run: npm run test:unit:coverage
+
   server:
     name: Server (build + vet + test)
     runs-on: ubuntu-latest
@@ -43,6 +57,21 @@ jobs:
       - run: go build ./...
       - run: go vet ./...
       - run: go test ./...
+      # Coverage floor on the pure, security-critical packages. The DB/TURN/SFU
+      # packages need a live backend and stay covered by the e2e suite, so they are
+      # intentionally not gated here. Ratchet these floors up as coverage grows.
+      - name: Coverage floor (critical packages)
+        run: |
+          set -euo pipefail
+          declare -A floors=( [auth]=90 [config]=85 [secrets]=70 )
+          for pkg in "${!floors[@]}"; do
+            go test "./internal/$pkg/" -covermode=set -coverprofile=/tmp/cover.out >/dev/null
+            pct=$(go tool cover -func=/tmp/cover.out | awk '/^total:/ {print substr($3, 1, length($3)-1)}')
+            floor=${floors[$pkg]}
+            echo "internal/$pkg: ${pct}% (floor ${floor}%)"
+            awk -v p="$pct" -v f="$floor" 'BEGIN { exit (p+0 >= f+0) ? 0 : 1 }' || {
+              echo "::error::internal/$pkg coverage ${pct}% is below the ${floor}% floor"; exit 1; }
+          done
 
   e2e:
     name: End-to-end (Playwright)

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ test-results
 playwright-report
 /playwright/.cache
 
+# Unit-test coverage output (vitest)
+coverage
+
 # Scratch / tooling state (local only)
 .audit_tmp
 .tmp-review

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,27 @@
         "@types/libsodium-wrappers-sumo": "^0.7.8",
         "@types/node": "^25.9.1",
         "@vitejs/plugin-vue": "^5.2.1",
+        "@vitest/coverage-v8": "^3.2.6",
         "sharp": "^0.34.5",
         "typescript": "^5.6.3",
         "vite": "^6.0.5",
         "vite-plugin-pwa": "^1.3.0",
+        "vitest": "^3.2.6",
         "vue-tsc": "^2.1.10"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -1591,6 +1607,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
@@ -2635,6 +2661,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2693,6 +2729,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@playwright/test": {
@@ -3234,6 +3281,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dom-webcodecs": {
       "version": "0.1.18",
       "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz",
@@ -3306,6 +3371,165 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -3614,6 +3838,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -3770,6 +4033,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -3849,6 +4122,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/cliui": {
       "version": "6.0.0",
@@ -4036,6 +4336,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -4112,6 +4422,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -4249,6 +4566,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -4375,6 +4699,16 @@
       },
       "funding": {
         "url": "https://github.com/bgub/eta?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4774,6 +5108,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -4854,6 +5198,13 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/idb": {
       "version": "7.1.1",
@@ -5308,6 +5659,60 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -5462,6 +5867,13 @@
       "integrity": "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==",
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5479,6 +5891,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5739,6 +6192,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -6487,6 +6957,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6554,6 +7031,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -6572,6 +7063,22 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6696,6 +7203,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -6704,6 +7225,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -6767,6 +7321,255 @@
         "node": ">=10"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/test-exclude/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-exclude/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6782,6 +7585,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tr46": {
@@ -7125,6 +7958,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-pwa": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.3.0.tgz",
@@ -7152,6 +8008,79 @@
       },
       "peerDependenciesMeta": {
         "@vite-pwa/assets-generator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
           "optional": true
         }
       }
@@ -7344,6 +8273,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workbox-background-sync": {
@@ -7578,6 +8524,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
+    "test:unit:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed"
   },
@@ -32,10 +35,12 @@
     "@types/libsodium-wrappers-sumo": "^0.7.8",
     "@types/node": "^25.9.1",
     "@vitejs/plugin-vue": "^5.2.1",
+    "@vitest/coverage-v8": "^3.2.6",
     "sharp": "^0.34.5",
     "typescript": "^5.6.3",
     "vite": "^6.0.5",
     "vite-plugin-pwa": "^1.3.0",
+    "vitest": "^3.2.6",
     "vue-tsc": "^2.1.10"
   }
 }

--- a/server/internal/auth/middleware_test.go
+++ b/server/internal/auth/middleware_test.go
@@ -1,0 +1,124 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeVerifier resolves exactly one token hash to a user id; everything else is
+// "not found". An optional err forces the lookup-failure path.
+type fakeVerifier struct {
+	wantHash []byte
+	userID   string
+	err      error
+}
+
+func (f fakeVerifier) UserIDForToken(_ context.Context, hash []byte) (string, bool, error) {
+	if f.err != nil {
+		return "", false, f.err
+	}
+	if f.wantHash != nil && EqualHash(hash, f.wantHash) {
+		return f.userID, true, nil
+	}
+	return "", false, nil
+}
+
+func TestMiddlewareAuthenticatesValidToken(t *testing.T) {
+	const token = "deadbeef"
+	v := fakeVerifier{wantHash: HashToken(token), userID: "user-1"}
+
+	var gotUID string
+	var gotHashOK bool
+	h := Middleware(v)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUID, _ = UserID(r.Context())
+		h, ok := TokenHash(r.Context())
+		gotHashOK = ok && EqualHash(h, HashToken(token))
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if gotUID != "user-1" {
+		t.Fatalf("UserID = %q, want user-1", gotUID)
+	}
+	if !gotHashOK {
+		t.Fatal("token hash not present/incorrect in context")
+	}
+}
+
+func TestMiddlewareRejects(t *testing.T) {
+	const token = "deadbeef"
+	okVerifier := fakeVerifier{wantHash: HashToken(token), userID: "user-1"}
+
+	cases := []struct {
+		name       string
+		header     string // "" means no Authorization header at all
+		setHeader  bool
+		verifier   TokenVerifier
+		wantStatus int
+	}{
+		{name: "no header", setHeader: false, verifier: okVerifier, wantStatus: http.StatusUnauthorized},
+		{name: "empty header", setHeader: true, header: "", verifier: okVerifier, wantStatus: http.StatusUnauthorized},
+		{name: "wrong scheme", setHeader: true, header: "Basic " + token, verifier: okVerifier, wantStatus: http.StatusUnauthorized},
+		{name: "bearer no token", setHeader: true, header: "Bearer ", verifier: okVerifier, wantStatus: http.StatusUnauthorized},
+		{name: "bearer whitespace token", setHeader: true, header: "Bearer    ", verifier: okVerifier, wantStatus: http.StatusUnauthorized},
+		{name: "unknown token", setHeader: true, header: "Bearer not-the-right-token", verifier: okVerifier, wantStatus: http.StatusUnauthorized},
+		{name: "lookup error", setHeader: true, header: "Bearer " + token, verifier: fakeVerifier{err: errors.New("db down")}, wantStatus: http.StatusInternalServerError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			h := Middleware(tc.verifier)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+			if tc.setHeader {
+				req.Header.Set("Authorization", tc.header)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if called {
+				t.Fatal("next handler was called despite auth failure")
+			}
+		})
+	}
+}
+
+func TestMiddlewareAcceptsCaseInsensitiveScheme(t *testing.T) {
+	const token = "deadbeef"
+	v := fakeVerifier{wantHash: HashToken(token), userID: "user-1"}
+	h := Middleware(v)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/v1/me", nil)
+	req.Header.Set("Authorization", "bearer "+token) // lowercase scheme
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (scheme match should be case-insensitive)", rec.Code)
+	}
+}
+
+func TestContextAccessorsAbsent(t *testing.T) {
+	if _, ok := UserID(context.Background()); ok {
+		t.Fatal("UserID should be absent on a bare context")
+	}
+	if _, ok := TokenHash(context.Background()); ok {
+		t.Fatal("TokenHash should be absent on a bare context")
+	}
+}

--- a/src/services/crypto/envelope.test.ts
+++ b/src/services/crypto/envelope.test.ts
@@ -1,0 +1,69 @@
+// Unit tests for the envelope layer: base64url/utf8 codecs and the versioned
+// seal/open (raw + JSON) used to wrap data at rest and on the wire.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ready, randomBytes, aeadSeal, aeadOpen, equalBytes, KEY_BYTES } from './primitives';
+import {
+  seal,
+  open,
+  sealJson,
+  openJson,
+  packBlob,
+  unpackBlob,
+  bytesToB64url,
+  b64urlToBytes,
+  utf8ToBytes,
+  bytesToUtf8,
+  type Envelope,
+} from './envelope';
+
+beforeAll(async () => {
+  await ready();
+});
+
+describe('codecs', () => {
+  it('base64url round-trips arbitrary bytes', () => {
+    const b = randomBytes(40);
+    expect(equalBytes(b64urlToBytes(bytesToB64url(b)), b)).toBe(true);
+  });
+
+  it('utf8 round-trips multi-byte text', () => {
+    expect(bytesToUtf8(utf8ToBytes('héllo ✓ 🌍'))).toBe('héllo ✓ 🌍');
+  });
+});
+
+describe('envelope seal/open', () => {
+  it('round-trips raw bytes', () => {
+    const key = randomBytes(KEY_BYTES);
+    const raw = seal(key, utf8ToBytes('x'), 'master');
+    expect(equalBytes(open(key, raw), utf8ToBytes('x'))).toBe(true);
+  });
+
+  it('round-trips JSON', () => {
+    const key = randomBytes(KEY_BYTES);
+    const env = sealJson(key, { name: 'Kamran', n: 7 }, 'master');
+    const back = openJson<{ name: string; n: number }>(key, env);
+    expect(back).toEqual({ name: 'Kamran', n: 7 });
+  });
+
+  it('rejects an unknown version', () => {
+    const key = randomBytes(KEY_BYTES);
+    const env = seal(key, utf8ToBytes('x'), 'master');
+    const bad: Envelope = { ...env, v: 99 };
+    expect(() => open(key, bad)).toThrow();
+  });
+
+  it('rejects a wrong key', () => {
+    const env = seal(randomBytes(KEY_BYTES), utf8ToBytes('x'), 'master');
+    expect(() => open(randomBytes(KEY_BYTES), env)).toThrow();
+  });
+});
+
+describe('packBlob / unpackBlob', () => {
+  it('packs a nonce+ciphertext that still decrypts', () => {
+    const key = randomBytes(KEY_BYTES);
+    const data = randomBytes(1000);
+    const { nonce, ct } = aeadSeal(key, data);
+    const u = unpackBlob(packBlob(nonce, ct));
+    expect(equalBytes(aeadOpen(key, u.nonce, u.ct), data)).toBe(true);
+  });
+});

--- a/src/services/crypto/identity.test.ts
+++ b/src/services/crypto/identity.test.ts
@@ -1,0 +1,71 @@
+// Unit tests for identity material: generation, the signed-prekey signature chain,
+// PIN wrap/unwrap, recovery-code wrap/unwrap, and the public-bundle projection
+// (which must never leak private key material).
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ready, equalBytes, KEY_BYTES } from './primitives';
+import { bytesToB64url } from './envelope';
+import {
+  generateIdentityMaterial,
+  verifySignedPreKey,
+  wrapSecret,
+  unwrapSecret,
+  generateRecoveryCode,
+  wrapRecovery,
+  unwrapRecovery,
+  publicBundleOf,
+  fingerprintOf,
+} from './identity';
+
+beforeAll(async () => {
+  await ready();
+});
+
+describe('generateIdentityMaterial', () => {
+  it('produces a master key, prekeys, and a valid signed prekey', () => {
+    const b = generateIdentityMaterial(3);
+    expect(verifySignedPreKey(b)).toBe(true);
+    expect(b.oneTimePreKeys.length).toBe(3);
+    expect(b.masterKey.length).toBe(KEY_BYTES);
+  });
+});
+
+describe('PIN wrap/unwrap', () => {
+  it('restores the full bundle with the right PIN', () => {
+    const b = generateIdentityMaterial(2);
+    const { salt, env } = wrapSecret(b, '1234');
+    const back = unwrapSecret(env, salt, '1234');
+    expect(equalBytes(back.masterKey, b.masterKey)).toBe(true);
+    expect(equalBytes(back.ed.privateKey, b.ed.privateKey)).toBe(true);
+    expect(back.oneTimePreKeys.length).toBe(2);
+  });
+
+  it('fails with the wrong PIN', () => {
+    const b = generateIdentityMaterial(1);
+    const { salt, env } = wrapSecret(b, '1234');
+    expect(() => unwrapSecret(env, salt, '9999')).toThrow();
+  });
+});
+
+describe('recovery code', () => {
+  it('restores identity + master key, and rejects a wrong code', () => {
+    const b = generateIdentityMaterial(1);
+    const code = generateRecoveryCode();
+    const { salt, env } = wrapRecovery(b, code);
+    const r = unwrapRecovery(env, salt, code);
+    expect(equalBytes(r.masterKey, b.masterKey)).toBe(true);
+    expect(equalBytes(r.x.privateKey, b.x.privateKey)).toBe(true);
+    expect(() => unwrapRecovery(env, salt, 'WRONG-CODE')).toThrow();
+  });
+});
+
+describe('public bundle + fingerprint', () => {
+  it('exposes only public material and a stable fingerprint', () => {
+    const b = generateIdentityMaterial(2);
+    const pub = publicBundleOf(b);
+    expect(pub.edPub).toBe(bytesToB64url(b.ed.publicKey));
+    expect(pub.oneTimePreKeys.length).toBe(2);
+    // No private key bytes should appear anywhere in the serialized public bundle.
+    expect(JSON.stringify(pub).includes(bytesToB64url(b.ed.privateKey))).toBe(false);
+    expect(fingerprintOf(b)).toBe(fingerprintOf(b));
+  });
+});

--- a/src/services/crypto/primitives.test.ts
+++ b/src/services/crypto/primitives.test.ts
@@ -1,0 +1,116 @@
+// Unit tests for the crypto primitives (libsodium wrappers). These mirror and
+// extend the in-app self-test (selftest.ts) so the same guarantees are checked in
+// CI with no backend. Everything here is pure — Node environment, no DOM.
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  ready,
+  randomBytes,
+  aeadSeal,
+  aeadOpen,
+  x25519Keypair,
+  x25519,
+  ed25519Keypair,
+  sign,
+  verify,
+  hkdf,
+  argon2id,
+  sha256,
+  equalBytes,
+  KEY_BYTES,
+  ARGON_SALT_BYTES,
+} from './primitives';
+import { utf8ToBytes } from './envelope';
+
+beforeAll(async () => {
+  await ready();
+});
+
+describe('AEAD', () => {
+  it('seals and opens with associated data', () => {
+    const key = randomBytes(KEY_BYTES);
+    const msg = utf8ToBytes('the quick brown fox');
+    const aad = utf8ToBytes('chat:42');
+    const { nonce, ct } = aeadSeal(key, msg, aad);
+    expect(equalBytes(aeadOpen(key, nonce, ct, aad), msg)).toBe(true);
+  });
+
+  it('rejects tampered ciphertext', () => {
+    const key = randomBytes(KEY_BYTES);
+    const { nonce, ct } = aeadSeal(key, utf8ToBytes('secret'));
+    ct[0] ^= 0xff;
+    expect(() => aeadOpen(key, nonce, ct)).toThrow();
+  });
+
+  it('rejects a wrong AAD', () => {
+    const key = randomBytes(KEY_BYTES);
+    const { nonce, ct } = aeadSeal(key, utf8ToBytes('secret'), utf8ToBytes('a'));
+    expect(() => aeadOpen(key, nonce, ct, utf8ToBytes('b'))).toThrow();
+  });
+
+  it('rejects a wrong key', () => {
+    const { nonce, ct } = aeadSeal(randomBytes(KEY_BYTES), utf8ToBytes('secret'));
+    expect(() => aeadOpen(randomBytes(KEY_BYTES), nonce, ct)).toThrow();
+  });
+});
+
+describe('X25519', () => {
+  it('produces an identical shared secret on both sides', () => {
+    const a = x25519Keypair();
+    const b = x25519Keypair();
+    expect(equalBytes(x25519(a.privateKey, b.publicKey), x25519(b.privateKey, a.publicKey))).toBe(true);
+  });
+});
+
+describe('Ed25519', () => {
+  it('verifies a valid signature and rejects a forgery', () => {
+    const kp = ed25519Keypair();
+    const msg = utf8ToBytes('signed prekey');
+    const sig = sign(kp.privateKey, msg);
+    expect(verify(kp.publicKey, msg, sig)).toBe(true);
+    sig[0] ^= 0xff;
+    expect(verify(kp.publicKey, msg, sig)).toBe(false);
+  });
+});
+
+describe('HKDF', () => {
+  it('is deterministic, context-separated, and length-correct', () => {
+    const ikm = randomBytes(32);
+    const salt = randomBytes(16);
+    const k1 = hkdf(ikm, 32, salt, utf8ToBytes('ctx-1'));
+    const k1b = hkdf(ikm, 32, salt, utf8ToBytes('ctx-1'));
+    const k2 = hkdf(ikm, 32, salt, utf8ToBytes('ctx-2'));
+    expect(equalBytes(k1, k1b)).toBe(true);
+    expect(equalBytes(k1, k2)).toBe(false);
+    expect(hkdf(ikm, 64, salt).length).toBe(64);
+  });
+});
+
+describe('Argon2id', () => {
+  it('derives a stable key from PIN+salt and varies with the PIN', () => {
+    const salt = randomBytes(ARGON_SALT_BYTES);
+    const k1 = argon2id('1234', salt);
+    const k2 = argon2id('1234', salt);
+    const k3 = argon2id('9999', salt);
+    expect(equalBytes(k1, k2)).toBe(true);
+    expect(equalBytes(k1, k3)).toBe(false);
+  });
+});
+
+describe('sha256', () => {
+  it('is stable and 32 bytes', () => {
+    const a = sha256(utf8ToBytes('abc'));
+    const b = sha256(utf8ToBytes('abc'));
+    expect(equalBytes(a, b)).toBe(true);
+    expect(a.length).toBe(32);
+  });
+});
+
+describe('randomBytes / equalBytes', () => {
+  it('returns the requested length and differs between draws', () => {
+    const a = randomBytes(32);
+    const b = randomBytes(32);
+    expect(a.length).toBe(32);
+    expect(equalBytes(a, b)).toBe(false);
+    expect(equalBytes(a, a)).toBe(true);
+  });
+});

--- a/src/services/crypto/ratchet.test.ts
+++ b/src/services/crypto/ratchet.test.ts
@@ -1,0 +1,93 @@
+// Unit tests for the 1:1 session: X3DH agreement + the Double Ratchet (via
+// message.ts seal/open). Covers the happy path both directions (incl. a DH ratchet
+// step), out-of-order delivery (skipped message keys), and authentication.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ready, equalBytes } from './primitives';
+import { utf8ToBytes } from './envelope';
+import {
+  x3dhInitiator,
+  x3dhResponder,
+  ratchetInitAlice,
+  ratchetInitBob,
+  type RatchetState,
+} from './ratchet';
+import { sealMessage, openMessage } from './message';
+import { generateIdentityMaterial, type SecretBundle } from './identity';
+
+beforeAll(async () => {
+  await ready();
+});
+
+// Establish a fresh Alice<->Bob pair via X3DH, returning ready ratchet states and
+// the shared secrets each side derived (so the test can assert they match).
+function setupPair(): {
+  alice: RatchetState;
+  bob: RatchetState;
+  ad: Uint8Array;
+  aliceSK: Uint8Array;
+  bobSK: Uint8Array;
+} {
+  const a: SecretBundle = generateIdentityMaterial(2);
+  const b: SecretBundle = generateIdentityMaterial(2);
+  const init = x3dhInitiator(a.x.privateKey, {
+    identityX: b.x.publicKey,
+    signedPreKey: b.signedPreKey.keypair.publicKey,
+    oneTimePreKey: b.oneTimePreKeys[0].keypair.publicKey,
+  });
+  const bobSK = x3dhResponder({
+    identityXPriv: b.x.privateKey,
+    signedPreKeyPriv: b.signedPreKey.keypair.privateKey,
+    oneTimePreKeyPriv: b.oneTimePreKeys[0].keypair.privateKey,
+    initiatorIdentityX: a.x.publicKey,
+    initiatorEphemeral: init.ephemeral.publicKey,
+  });
+  const alice = ratchetInitAlice(init.sk, b.signedPreKey.keypair.publicKey);
+  const bob = ratchetInitBob(bobSK, b.signedPreKey.keypair);
+  return { alice, bob, ad: utf8ToBytes('alice|bob'), aliceSK: init.sk, bobSK };
+}
+
+const msg = (body: string) => ({ body, kind: 'text', timestamp: 1 });
+
+describe('X3DH', () => {
+  it('initiator and responder derive the same shared secret', () => {
+    const { aliceSK, bobSK } = setupPair();
+    expect(equalBytes(aliceSK, bobSK)).toBe(true);
+  });
+});
+
+describe('Double Ratchet', () => {
+  it('round-trips both directions, including a DH ratchet step', () => {
+    const { alice, bob, ad } = setupPair();
+    expect(openMessage(bob, sealMessage(alice, msg('hi bob'), ad), ad).body).toBe('hi bob');
+    expect(openMessage(bob, sealMessage(alice, msg('still alice'), ad), ad).body).toBe('still alice');
+    // Bob replies -> triggers a DH ratchet on Alice's side.
+    expect(openMessage(alice, sealMessage(bob, msg('hey alice'), ad), ad).body).toBe('hey alice');
+    expect(openMessage(bob, sealMessage(alice, msg('after ratchet'), ad), ad).body).toBe('after ratchet');
+  });
+
+  it('handles out-of-order delivery (skipped message keys)', () => {
+    const { alice, bob, ad } = setupPair();
+    const w1 = sealMessage(alice, msg('first'), ad);
+    const w2 = sealMessage(alice, msg('second'), ad);
+    const w3 = sealMessage(alice, msg('third'), ad);
+    expect(openMessage(bob, w3, ad).body).toBe('third');
+    expect(openMessage(bob, w1, ad).body).toBe('first');
+    expect(openMessage(bob, w2, ad).body).toBe('second');
+  });
+
+  it('rejects tampered ciphertext', () => {
+    const { alice, bob, ad } = setupPair();
+    const w = sealMessage(alice, msg('secret'), ad);
+    const tampered = {
+      ...w,
+      env: { ...w.env, ct: w.env.ct.slice(0, -2) + (w.env.ct.endsWith('A') ? 'B' : 'A') },
+    };
+    expect(() => openMessage(bob, tampered, ad)).toThrow();
+  });
+
+  it('enforces associated-data binding', () => {
+    const { alice, bob } = setupPair();
+    const w = sealMessage(alice, msg('bound'), utf8ToBytes('ad-1'));
+    expect(() => openMessage(bob, w, utf8ToBytes('ad-2'))).toThrow();
+  });
+});

--- a/src/services/crypto/senderkeys.test.ts
+++ b/src/services/crypto/senderkeys.test.ts
@@ -1,0 +1,76 @@
+// Unit tests for group messaging via sender keys: fan-out to multiple members,
+// out-of-order delivery, authentication (tamper + cross-member forgery), and key
+// rotation invalidating the prior epoch.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ready } from './primitives';
+import { utf8ToBytes, bytesToUtf8 } from './envelope';
+import {
+  createSenderKey,
+  distributionFrom,
+  receivingFromDistribution,
+  groupEncrypt,
+  groupDecrypt,
+} from './senderkeys';
+
+beforeAll(async () => {
+  await ready();
+});
+
+const ad = utf8ToBytes('group:42');
+const enc = (state: ReturnType<typeof createSenderKey>, body: string) =>
+  groupEncrypt(state, utf8ToBytes(body), ad);
+const dec = (recv: ReturnType<typeof receivingFromDistribution>, m: ReturnType<typeof enc>) =>
+  bytesToUtf8(groupDecrypt(recv, m, ad));
+
+describe('sender keys', () => {
+  it('fans out to multiple members', () => {
+    const alice = createSenderKey();
+    const bob = receivingFromDistribution(distributionFrom(alice));
+    const carol = receivingFromDistribution(distributionFrom(alice));
+    const m1 = enc(alice, 'hello group');
+    const m2 = enc(alice, 'second');
+    expect(dec(bob, m1)).toBe('hello group');
+    expect(dec(carol, m1)).toBe('hello group');
+    expect(dec(bob, m2)).toBe('second');
+    expect(dec(carol, m2)).toBe('second');
+  });
+
+  it('handles out-of-order delivery', () => {
+    const alice = createSenderKey();
+    const bob = receivingFromDistribution(distributionFrom(alice));
+    const m1 = enc(alice, 'one');
+    const m2 = enc(alice, 'two');
+    const m3 = enc(alice, 'three');
+    expect(dec(bob, m3)).toBe('three');
+    expect(dec(bob, m1)).toBe('one');
+    expect(dec(bob, m2)).toBe('two');
+  });
+
+  it('rejects tampered ciphertext and tampered signature', () => {
+    const alice = createSenderKey();
+    const bob = receivingFromDistribution(distributionFrom(alice));
+    const m = enc(alice, 'authentic');
+    const badCt = { ...m, env: { ...m.env, ct: m.env.ct.slice(0, -2) + (m.env.ct.endsWith('A') ? 'B' : 'A') } };
+    expect(() => dec(bob, badCt)).toThrow();
+    const badSig = { ...m, signature: m.signature.slice(0, -2) + (m.signature.endsWith('A') ? 'B' : 'A') };
+    expect(() => dec(bob, badSig)).toThrow();
+  });
+
+  it('prevents one member forging another sender', () => {
+    const alice = createSenderKey();
+    const bobForAlice = receivingFromDistribution(distributionFrom(alice));
+    const mallory = createSenderKey();
+    const forged = enc(mallory, 'pretending to be alice');
+    expect(() => dec(bobForAlice, forged)).toThrow();
+  });
+
+  it('invalidates the old key after rotation', () => {
+    const alice1 = createSenderKey();
+    const bobOld = receivingFromDistribution(distributionFrom(alice1));
+    const alice2 = createSenderKey();
+    const bobNew = receivingFromDistribution(distributionFrom(alice2));
+    const m = enc(alice2, 'after rotation');
+    expect(dec(bobNew, m)).toBe('after rotation');
+    expect(() => dec(bobOld, m)).toThrow();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,48 @@
+/// <reference types="vitest" />
+// Vitest config for client-side unit tests. Kept separate from vite.config.ts on
+// purpose: the unit tests don't need the PWA plugin / dev-server / proxy machinery,
+// and loading the VitePWA plugin under the test runner is pure overhead. We only
+// re-declare the two resolve aliases the source actually depends on.
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      // Same shim as vite.config.ts: libsodium-wrappers-sumo's published ESM entry
+      // imports a missing file, so point the bare specifier at the self-contained
+      // CJS build. Without this, every crypto import fails to load under Vitest.
+      'libsodium-wrappers-sumo': path.resolve(
+        __dirname,
+        'node_modules/libsodium-wrappers-sumo/dist/modules-sumo/libsodium-wrappers.js',
+      ),
+    },
+  },
+  test: {
+    // The crypto core is pure (no DOM/IndexedDB), so the fast Node environment is
+    // enough. Add happy-dom + @vue/test-utils here if/when component tests land.
+    environment: 'node',
+    include: ['src/**/*.test.ts'], // unit tests; e2e/*.spec.ts is Playwright's (testDir: ./e2e)
+    // Force libsodium through Vite's transform so the CJS shim interops cleanly.
+    server: { deps: { inline: ['libsodium-wrappers-sumo'] } },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      // Gate the pure crypto-operation modules we exercise directly — an honest
+      // number for the tested core, not a meaningless whole-app percentage. The
+      // idb-persistence tails of ratchet/senderkeys and the large identity.ts
+      // surface (passkey, prekey management) are stateful/integration territory,
+      // covered behaviorally by identity.test.ts + the e2e suite; fold them into
+      // this gate as they gain dedicated unit tests. Ratchet the floor upward then.
+      include: [
+        'src/services/crypto/primitives.ts',
+        'src/services/crypto/envelope.ts',
+        'src/services/crypto/message.ts',
+        'src/services/crypto/ratchet.ts',
+        'src/services/crypto/senderkeys.ts',
+      ],
+      thresholds: { lines: 80, functions: 80, statements: 80, branches: 80 },
+    },
+  },
+});


### PR DESCRIPTION
Builds the unit-test foundation the repo was missing (frontend had **zero** unit tests — only Playwright e2e) and wires coverage gates into CI.

## Frontend — Vitest
- Adds Vitest (Node env) via a dedicated `vitest.config.ts` that re-declares the two aliases the source needs (`@/`→`src`, and the libsodium-sumo CJS shim — the ESM entry is broken). Scripts: `test:unit`, `test:unit:watch`, `test:unit:coverage`.
- **32 tests** exercising the real crypto core, modeled on the in-app `selftest.ts`:
  - primitives — AEAD (+tamper/AAD/wrong-key), X25519, Ed25519 (+forgery), HKDF, Argon2id, sha256
  - envelope — base64url/utf8 codecs, versioned seal/open (raw+JSON), unknown-version + wrong-key rejection, packBlob
  - identity — generation, signed-prekey chain, PIN wrap/unwrap (+wrong PIN), recovery code (+wrong code), public-bundle (asserts no private-key leak)
  - ratchet — X3DH agreement, Double Ratchet both directions incl. a DH-ratchet step, out-of-order/skipped keys, tamper + AD-binding rejection
  - senderkeys — fan-out, out-of-order, tamper (ct+sig), cross-member forgery, rotation invalidation
- A scoped **v8 coverage floor (≥80%)** gates the pure crypto-operation modules (primitives/envelope/message/ratchet/senderkeys → currently ~83% lines, 88% branches). The idb-persistence tails and the large `identity.ts` surface stay behaviorally tested but out of the gate for now (ratchet up later). `coverage/` is gitignored.

## Backend — Go
- Covers the previously-untested **auth middleware** (bearer parsing incl. case-insensitivity/whitespace, 401 + 500 paths, context accessors) → `internal/auth` **17.6% → 97.1%**.
- Adds a CI **coverage floor** on the pure, security-critical packages (`auth`≥90, `config`≥85, `secrets`≥70). DB/TURN/SFU packages need a live backend and stay e2e-covered, so they're intentionally not gated.

## CI
- New `Client (unit tests)` job in `build-test.yml` (runs `test:unit:coverage`), so it executes under `verify` on every PR alongside the existing checks. Once merged, add `verify / Client (unit tests)` to `REQUIRED_CHECKS` in `scripts/setup-branch-protection.sh` (from the dev-flow PR).

## Verification
- `npm run test:unit:coverage` → 32 passing, gate green. `npm run build` (typecheck+bundle) passes with the test files present. `go test ./internal/auth/ -cover` → 97.1%; `go vet` clean. Coverage-floor shell logic verified locally for all three packages.

Part of the go-public prep series (follows #3 licensing/RC, #4 dev-flow).

https://claude.ai/code/session_01PZhxoDiudFMjtXqLrSCyWf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZhxoDiudFMjtXqLrSCyWf)_