### PR TITLE
ci: release-bump guard, auto-merge, and auto branch cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,37 @@
+<!--
+RELEASE PR — develop → main.
+
+Use this template for the PR that cuts a release (select it with
+?template=release.md in the compose URL, or copy this shape if you're opening
+the PR via the API). Merging this PR SHIPS a release: on merge, CI re-verifies
+the merge commit and then tags main, publishes the production image
+(latest, X.Y.Z, X.Y), and cuts a GitHub release.
+
+Two hard requirements, both enforced by the "Release guard (version bump)" check:
+  1. The base is `main` and the source is `develop`.
+  2. package.json "version" was bumped on develop (run `npm run release:patch`,
+     or :minor / :major) to a new, unreleased version. A PR without a bump
+     cannot be merged — it would silently no-op the release.
+
+The "## Changes" bullets below are what reviewers see is shipping. The GitHub
+release notes are generated automatically from the Conventional-Commit subjects
+between the last tag and this merge, so keeping commit subjects clean keeps the
+release notes clean.
+-->
+
+## Release vX.Y.Z
+
+<!-- Replace X.Y.Z with the bumped package.json version. -->
+
+- [ ] Source is `develop`, base is `main`.
+- [ ] `package.json` version bumped via `npm run release:{patch|minor|major}` to a new version.
+
+## Changes
+
+<!-- One user-facing one-liner per change shipping in this release. -->
+
+- 
+
+## Notes / upgrade considerations
+
+<!-- Anything operators should know (migrations, config, breaking changes). Delete if none. -->

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -17,6 +17,10 @@ The "## Changes" bullets below are what reviewers see is shipping. The GitHub
 release notes are generated automatically from the Conventional-Commit subjects
 between the last tag and this merge, so keeping commit subjects clean keeps the
 release notes clean.
+
+Auto-merge is enabled on this PR automatically: once the guard and the full CI
+suite are green, GitHub merges it (merge commit) on its own. No need to click
+merge; disable auto-merge on the PR if you want to hold it.
 -->
 
 ## Release vX.Y.Z

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,40 @@
+# Auto-merge release PRs: the develop -> main PR that cuts a release shouldn't need
+# babysitting. This enables GitHub's native auto-merge on it, so GitHub merges the
+# PR by itself the moment every required check is green — the "Release guard
+# (version bump)" check plus the full build+test suite — and not a second before.
+#
+# Scope is deliberately narrow: only PRs whose BASE is main (i.e. release PRs from
+# develop). Feature -> develop PRs are untouched; you still merge those yourself.
+#
+# Merge method is a MERGE COMMIT on purpose: release.yml verifies the merge commit,
+# and we keep develop's history joined into main (linear history is intentionally
+# NOT required). Auto-merge only schedules the merge; required checks + branch
+# protection still fully gate it, so a failing guard or red CI blocks the merge.
+name: Auto-merge release PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    branches: [main] # base branch == main
+
+permissions:
+  contents: write # github-actions[bot] performs the eventual merge
+  pull-requests: write # enable auto-merge on the PR
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge
+    # Same-repo PRs only (a fork's token is read-only and couldn't enable it anyway),
+    # and never on drafts.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (merge commit)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --auto --merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,59 @@ jobs:
   verify:
     uses: ./.github/workflows/build-test.yml
 
+  # Gate the one merge that actually ships: a PR into main must carry a version
+  # bump. Without this, a develop -> main merge that forgot to bump silently
+  # no-ops in release.yml (the tag already exists) — green CI, no image, no
+  # release, no signal. This makes that mistake un-mergeable instead.
+  #
+  # Runs on every PR but is a no-op (green) unless the base is main, so it's safe
+  # to require uniformly on both protected branches: feature -> develop PRs always
+  # pass it; only develop -> main PRs are held to a bump.
+  release-guard:
+    name: Release guard (version bump)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need main's history + tags to compare against
+      - name: Require a version bump for release PRs
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          if [ "$BASE_REF" != "main" ]; then
+            echo "Base is '$BASE_REF', not a release PR — no version bump required."
+            exit 0
+          fi
+
+          head_ver=$(node -p "require('./package.json').version")
+          git fetch --quiet origin main
+          base_ver=$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync(0)).version")
+          echo "head (this PR) version: $head_ver"
+          echo "base (main) version:    $base_ver"
+
+          fail() { echo "::error::$1"; exit 1; }
+
+          if [ "$head_ver" = "$base_ver" ]; then
+            fail "package.json version is still $base_ver — merging this PR would no-op the release. Bump it on develop with 'npm run release:patch' (or :minor / :major) and push."
+          fi
+
+          # Strictly greater than main (catches an accidental downgrade too).
+          greater=$(printf '%s\n%s\n' "$base_ver" "$head_ver" | sort -V | tail -n1)
+          if [ "$greater" != "$head_ver" ] || [ "$head_ver" = "$base_ver" ]; then
+            fail "package.json version $head_ver is not greater than main's $base_ver. Bump it forward with 'npm run release:patch' (or :minor / :major)."
+          fi
+
+          # The tag for this version must not already exist (already-shipped).
+          git fetch --quiet --tags origin
+          if git rev-parse "refs/tags/v$head_ver" >/dev/null 2>&1; then
+            fail "Tag v$head_ver already exists — version $head_ver has already shipped. Bump to a new version with 'npm run release:patch' (or :minor / :major)."
+          fi
+
+          echo "✓ Version bumped $base_ver → $head_ver and v$head_ver is unreleased. Release PR is good to merge."
+
   develop-image:
     name: Publish develop image
     needs: verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # Release: fires when develop is merged into main. It re-runs the full build +
 # test suite on the merge commit and, only if that is green, tags main with the
 # package.json version, publishes the production image, and cuts a GitHub release
-# with auto-generated notes.
+# whose notes are the version plus one bullet per change since the last tag.
 #
 # Versioning is driven by package.json: to ship a release, bump the "version"
 # there on develop and open a PR into main. If the tag for the current version
@@ -92,6 +92,35 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Build human-readable notes: the version followed by one bullet per change,
+      # taken from the Conventional-Commit subjects since the previous release tag
+      # (merge commits excluded). This shows the user *what changed*, not a SHA.
+      - name: Compose release notes
+        if: steps.check.outputs.exists == 'false'
+        id: notes
+        run: |
+          set -euo pipefail
+          tag="${{ steps.ver.outputs.tag }}"
+
+          # Highest existing vX.Y.Z tag, excluding the one we're about to create.
+          prev=$(git tag --list 'v*' --sort=-v:refname | grep -vx "$tag" | head -n1 || true)
+
+          {
+            echo "## $tag"
+            echo
+            if [ -n "$prev" ]; then
+              git log "$prev"..HEAD --no-merges --pretty='- %s'
+              echo
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/$prev...$tag"
+            else
+              # First release: list everything reachable, still as one-liners.
+              git log --no-merges --pretty='- %s'
+            fi
+          } > release-notes.md
+
+          echo "Generated release notes:"
+          cat release-notes.md
+
       - name: Create GitHub release
         if: steps.check.outputs.exists == 'false'
         env:
@@ -100,4 +129,4 @@ jobs:
           gh release create "${{ steps.ver.outputs.tag }}" \
             --title "${{ steps.ver.outputs.tag }}" \
             --target "${{ github.sha }}" \
-            --generate-notes
+            --notes-file release-notes.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,8 @@ Direct pushes are rejected.
 3. Run the gates locally (below). Add or update tests.
 4. Open a PR into `develop`. Fill in the PR template, including the zero-knowledge
    confirmation for anything touching the wire.
-5. Once CI is green, the PR can be merged.
+5. Once CI is green, the PR can be merged. Your feature branch is deleted
+   automatically on merge (the protected `develop`/`main` are never auto-deleted).
 
 ### Commit messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,13 +81,41 @@ npm run test:e2e              # Playwright e2e (needs `make db-up`; spins its ow
 
 Releases are driven by `package.json` `version`:
 
-- **Release:** bump `"version"` on `develop`, open a PR into `main`. On merge, the
-  pipeline re-verifies the merge commit and — if green and the `vX.Y.Z` tag is new —
-  tags `main`, publishes the production image (`latest`, `X.Y.Z`, `X.Y`), and cuts a
-  GitHub release.
+- **Release:** bump the version on `develop`, then open a PR into `main`. Bump with
+  the one-shot script (no manual editing, no local tag/commit — it just edits
+  `package.json` + `package-lock.json` for you to commit):
+
+  ```sh
+  npm run release:patch    # 0.1.0 -> 0.1.1   (or release:minor / release:major)
+  ```
+
+  Open the PR using the **release PR template**
+  ([`.github/PULL_REQUEST_TEMPLATE/release.md`](.github/PULL_REQUEST_TEMPLATE/release.md);
+  add `?template=release.md` to the compose URL, or follow its shape if you open the
+  PR via the API). List each user-facing change as a one-liner under **Changes**.
+
+  On merge, the pipeline re-verifies the merge commit and — if green and the
+  `vX.Y.Z` tag is new — tags `main`, publishes the production image (`latest`,
+  `X.Y.Z`, `X.Y`), and cuts a GitHub release whose notes are the version plus one
+  bullet per change (drawn from the Conventional-Commit subjects since the last
+  tag — another reason to keep commit subjects clean).
+
+  A release PR **without a version bump cannot be merged**: the CI check
+  `Release guard (version bump)` fails it, because merging it would silently no-op
+  the release (the tag already exists). The guard is green on every PR into
+  `develop`, so it only matters for the `develop → main` PR.
+
 - **Release candidate:** push a `vX.Y.Z-rc.N` tag (off `develop`). It runs the full
   suite and publishes a single immutable `:X.Y.Z-rc.N` image + a GitHub pre-release.
   An RC never moves `:latest`/`:X.Y`.
+
+### Optional: local release-bump reminder
+
+Run `make hooks` once to opt in to the repo's git hooks
+(`git config core.hooksPath scripts/hooks`). The advisory `pre-push` hook warns —
+without ever blocking the push — when you push `develop` at a version that's already
+been released, so you remember to bump before opening the release PR. CI's release
+guard stays the real gate. Disable with `git config --unset core.hooksPath`.
 
 Operator upgrade/rollback guidance lives in [`docs/UPGRADING.md`](docs/UPGRADING.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,13 @@ Releases are driven by `package.json` `version`:
   the release (the tag already exists). The guard is green on every PR into
   `develop`, so it only matters for the `develop → main` PR.
 
+  You don't merge the release PR by hand. The `Auto-merge release PRs` workflow
+  turns on GitHub auto-merge for any PR into `main`, so GitHub merges it (as a
+  merge commit) the moment the guard and the full suite are green — and not
+  before. Open it and walk away; to cancel, just disable auto-merge on the PR.
+  (This needs the repo-level "Allow auto-merge" setting, which
+  `scripts/setup-branch-protection.sh` turns on.)
+
 - **Release candidate:** push a `vX.Y.Z-rc.N` tag (off `develop`). It runs the full
   suite and publishes a single immutable `:X.Y.Z-rc.N` image + a GitHub pre-release.
   An RC never moves `:latest`/`:X.Y`.

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SERVER_DIR := server
 GOBIN := $(shell go env GOPATH)/bin
 AIR := $(GOBIN)/air
 
-.PHONY: start stop db-up db-down tools backend frontend
+.PHONY: start stop db-up db-down tools backend frontend hooks
 
 ## start: database (if needed) + backend hot reload + frontend hot reload
 start: db-up tools
@@ -50,3 +50,9 @@ tools: $(AIR)
 $(AIR):
 	@echo "▶ Installing air (Go live reload)…"
 	@go install github.com/air-verse/air@latest
+
+## hooks: opt in to the repo's git hooks (advisory release-bump pre-push warning)
+hooks:
+	@git config core.hooksPath scripts/hooks
+	@echo "▶ Git hooks enabled (core.hooksPath = scripts/hooks)."
+	@echo "  Disable with: git config --unset core.hooksPath"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test:unit:watch": "vitest",
     "test:unit:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "release:patch": "npm version patch --no-git-tag-version",
+    "release:minor": "npm version minor --no-git-tag-version",
+    "release:major": "npm version major --no-git-tag-version"
   },
   "dependencies": {
     "@ffmpeg/core": "^0.12.10",

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Advisory pre-push hook for Ring — opt-in via `make hooks`.
+#
+# It never blocks a push (always exits 0). CI's "Release guard (version bump)"
+# job + branch protection are the authoritative gate; this hook just gives you a
+# heads-up locally so you don't open a release PR that the guard will reject.
+#
+# What it warns about: when you push `develop`, if the current package.json
+# version already has a published tag (v<version>), then a develop -> main PR
+# opened now would no-op the release. The fix is to bump on develop first:
+#   npm run release:patch   # or :minor / :major
+#
+# A pre-push hook can't know the eventual PR base, so it can't (and shouldn't)
+# block — it only nudges. Disable with: git config --unset core.hooksPath
+set -euo pipefail
+
+# Only nudge when this push includes the develop branch.
+pushing_develop=false
+while read -r local_ref _local_sha _remote_ref _remote_sha; do
+  if [ "$local_ref" = "refs/heads/develop" ]; then
+    pushing_develop=true
+  fi
+done
+
+[ "$pushing_develop" = true ] || exit 0
+
+# Read the version without requiring node (the hook runs on every push).
+version=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -n1)
+[ -n "$version" ] || exit 0
+
+if git rev-parse "refs/tags/v$version" >/dev/null 2>&1; then
+  cat >&2 <<EOF
+
+  ⚠ Ring release reminder
+  package.json is at v$version, which is already tagged/shipped.
+  A develop → main PR opened now would no-op the release (CI's release guard
+  will block it). Bump before opening the release PR:
+
+      npm run release:patch   # or :minor / :major
+
+  (advisory only — your push is proceeding)
+
+EOF
+fi
+
+exit 0

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -36,11 +36,16 @@ BRANCHES=(develop main)
 # Required status check contexts. These are "<caller-job> / <job name>" where the
 # caller job is `verify` (in ci.yml / release.yml) and the names come from the jobs
 # in .github/workflows/build-test.yml. If you rename a job, update it here too.
+#
+# "Release guard (version bump)" is a top-level job in ci.yml (not under `verify`),
+# so it has no caller prefix. It reports green on PRs into develop and only enforces
+# a version bump on PRs into main — safe to require on both branches.
 REQUIRED_CHECKS=(
   "verify / Client (typecheck + build)"
   "verify / Client (unit tests)"
   "verify / Server (build + vet + test)"
   "verify / End-to-end (Playwright)"
+  "Release guard (version bump)"
 )
 
 if ! command -v gh >/dev/null 2>&1; then

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -13,6 +13,9 @@
 #   - enforce_admins: rules apply to admins too (no bypass).
 #   - Linear history NOT required (so develop -> main keeps its merge commit).
 #
+# It also flips two REPO-LEVEL settings the release flow needs: allow_auto_merge
+# (so the Auto-merge workflow can schedule the release PR) and allow_merge_commit.
+#
 # PREREQUISITES:
 #   - An authenticated GitHub CLI: `gh auth status` must succeed, with a token that
 #     has admin rights on the repo.
@@ -89,6 +92,26 @@ for branch in "${BRANCHES[@]}"; do
     --input - >/dev/null
   echo "    protection applied."
 done
+
+# Repo-level merge settings the release flow depends on:
+#   - allow_auto_merge: lets the Auto-merge workflow schedule the develop -> main
+#     PR to merge itself once required checks pass.
+#   - allow_merge_commit: the release PR must land as a MERGE COMMIT (release.yml
+#     verifies it; develop's history stays joined into main).
+# We deliberately do NOT touch delete_branch_on_merge: deleting the head of a
+# develop -> main PR would mean deleting develop. (Branch protection's
+# allow_deletions:false is a backstop, but we don't enable the setting either.)
+echo "==> ${REPO} repo settings (auto-merge + merge commits)"
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  echo '  { "allow_auto_merge": true, "allow_merge_commit": true }'
+else
+  gh api --method PATCH \
+    -H "Accept: application/vnd.github+json" \
+    "repos/${REPO}" \
+    -F allow_auto_merge=true \
+    -F allow_merge_commit=true >/dev/null
+  echo "    auto-merge enabled."
+fi
 
 echo "Done. Verify in Settings -> Branches, or:"
 echo "  gh api repos/${REPO}/branches/develop/protection | jq ."

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -13,8 +13,10 @@
 #   - enforce_admins: rules apply to admins too (no bypass).
 #   - Linear history NOT required (so develop -> main keeps its merge commit).
 #
-# It also flips two REPO-LEVEL settings the release flow needs: allow_auto_merge
-# (so the Auto-merge workflow can schedule the release PR) and allow_merge_commit.
+# It also flips three REPO-LEVEL settings: allow_auto_merge (so the Auto-merge
+# workflow can schedule the release PR), allow_merge_commit, and
+# delete_branch_on_merge (auto-delete merged feature branches; protected develop/
+# main are exempt via allow_deletions:false, so they're never auto-deleted).
 #
 # PREREQUISITES:
 #   - An authenticated GitHub CLI: `gh auth status` must succeed, with a token that
@@ -93,24 +95,26 @@ for branch in "${BRANCHES[@]}"; do
   echo "    protection applied."
 done
 
-# Repo-level merge settings the release flow depends on:
+# Repo-level merge settings the release flow + housekeeping depend on:
 #   - allow_auto_merge: lets the Auto-merge workflow schedule the develop -> main
 #     PR to merge itself once required checks pass.
 #   - allow_merge_commit: the release PR must land as a MERGE COMMIT (release.yml
 #     verifies it; develop's history stays joined into main).
-# We deliberately do NOT touch delete_branch_on_merge: deleting the head of a
-# develop -> main PR would mean deleting develop. (Branch protection's
-# allow_deletions:false is a backstop, but we don't enable the setting either.)
-echo "==> ${REPO} repo settings (auto-merge + merge commits)"
+#   - delete_branch_on_merge: auto-delete a PR's head branch once it merges, so
+#     stale feature branches don't pile up. SAFE here: develop and main are
+#     protected with allow_deletions:false, so a develop -> main merge can never
+#     delete develop — only unprotected feature -> develop branches get cleaned up.
+echo "==> ${REPO} repo settings (auto-merge, merge commits, branch cleanup)"
 if [[ "${DRY_RUN:-}" == "1" ]]; then
-  echo '  { "allow_auto_merge": true, "allow_merge_commit": true }'
+  echo '  { "allow_auto_merge": true, "allow_merge_commit": true, "delete_branch_on_merge": true }'
 else
   gh api --method PATCH \
     -H "Accept: application/vnd.github+json" \
     "repos/${REPO}" \
     -F allow_auto_merge=true \
-    -F allow_merge_commit=true >/dev/null
-  echo "    auto-merge enabled."
+    -F allow_merge_commit=true \
+    -F delete_branch_on_merge=true >/dev/null
+  echo "    auto-merge + auto branch cleanup enabled."
 fi
 
 echo "Done. Verify in Settings -> Branches, or:"


### PR DESCRIPTION
Hardens the `develop → main` release flow so a missed version bump can't ship a silent no-op, and makes releases self-document and self-merge.

## Why
Releases are driven by `package.json` `version`. A `develop → main` merge that forgot to bump it silently no-ops in `release.yml` (the tag already exists): green CI, no image, no GitHub release, no signal. This makes that mistake un-mergeable and removes the manual toil around the release PR.

## What's here
- **Release guard (`ci.yml`).** A `Release guard (version bump)` job runs on every PR but is a no-op (green) unless the base is `main`, where it fails the PR unless the version was bumped above main's and `v<version>` isn't already tagged. Wired into `setup-branch-protection.sh` as a required check on both protected branches.
- **One-command bump (`package.json`).** `release:patch` / `:minor` / `:major` = `npm version <level> --no-git-tag-version` (edits `package.json` + `package-lock.json`, no local commit/tag).
- **Changelog release notes (`release.yml`).** Notes are now the version plus one bullet per change (Conventional-Commit subjects since the last tag) instead of a bare auto-generated list — shows what shipped, not a SHA.
- **Release PR template** (`.github/PULL_REQUEST_TEMPLATE/release.md`) spelling out the bump + changelog a `develop → main` PR must carry.
- **Auto-merge release PRs** (`.github/workflows/auto-merge-release.yml`). Enables GitHub native auto-merge (merge commit) on any PR into `main`, so it merges itself once the guard + full suite are green. Same-repo, non-draft only; feature → develop PRs untouched.
- **Auto branch cleanup.** `setup-branch-protection.sh` also flips `allow_auto_merge`, `allow_merge_commit`, and `delete_branch_on_merge`. Protected `develop`/`main` are exempt (`allow_deletions:false`), so only merged feature branches are cleaned up.
- **Opt-in advisory pre-push hook** (`make hooks`) reminding you to bump when pushing `develop` at an already-released version; never blocks the push.
- Docs in `CONTRIBUTING.md`.

## Verification
YAML lint + `bash -n` on all touched workflows/scripts; guard version-comparison logic exercised across equal/bump/downgrade/double-digit/tag-exists cases; `npm run release:patch` confirmed to edit only `package.json` + `package-lock.json` (reverted); release-notes git-log composition checked against current history; pre-push hook checked for develop/feature/tag-present scenarios.

Replaces the now-stale `claude/dev-release-flow` branch (its earlier state already merged via #4; this is a clean re-base of the new commits onto `develop`).

https://claude.ai/code/session_01PZhxoDiudFMjtXqLrSCyWf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZhxoDiudFMjtXqLrSCyWf)_