### PR TITLE
docs(spec): mark 2001 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,4 +21,4 @@ _None yet._
 
 | Spec | Title | Status |
 |------|-------|--------|
-| [2001](specs/2001-stabilize-message-status/spec.md) | Stabilize message status reporting around downloaded-blob receipts | 🔵 in-review |
+| [2001](specs/2001-stabilize-message-status/spec.md) | Stabilize message status reporting around downloaded-blob receipts | 🟢 shipped |

--- a/specs/2001-stabilize-message-status/spec.md
+++ b/specs/2001-stabilize-message-status/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-15
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User description: "Fix the message status updates instability. We introduced a


### PR DESCRIPTION
Advance spec 2001 lifecycle status `in-review -> shipped` (merged to develop via #10) and regenerate `ROADMAP.md`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)