### PR TITLE
ci: skip heavy jobs for doc/spec-only changes via an aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,48 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether this change touches anything the heavy build/test/e2e jobs
+  # actually validate. Doc/spec/tooling-only changes (markdown, specs/, .specify/,
+  # ROADMAP.md, scripts/) skip the heavy suite — the always-on roadmap-guard below
+  # is the real gate for those. Anything in app code, server, e2e, deps, configs,
+  # the Dockerfile, or the workflows themselves runs the full suite.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # paths-filter needs history to diff a push event
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # `code` is true when ANY path the heavy jobs cover changed. If nothing
+          # here matched, the change is docs/specs/tooling-only and verify is skipped.
+          filters: |
+            code:
+              - 'src/**'
+              - 'server/**'
+              - 'e2e/**'
+              - 'public/**'
+              - 'index.html'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'vite.config.*'
+              - 'vitest.config.*'
+              - 'playwright.config.*'
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.github/workflows/**'
+
+  # The full build + test suite. Skipped for doc/spec-only changes (see `changes`)
+  # so a roadmap badge edit doesn't pay the multi-minute Playwright tax. The CI gate
+  # below still reports a single required status either way.
   verify:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     uses: ./.github/workflows/build-test.yml
 
   # Gate the one merge that actually ships: a PR into main must carry a version
@@ -86,6 +127,39 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify ROADMAP.md matches specs/
         run: python3 scripts/roadmap-gen.py --check
+
+  # Single required status check for branch protection. Because `verify` is
+  # conditionally skipped, its individual "verify / *" checks can't be required
+  # directly — a skipped-but-required check blocks the PR forever. This gate runs
+  # ALWAYS and passes when every upstream job either succeeded or was deliberately
+  # skipped, failing only if one actually failed or was cancelled. Branch protection
+  # requires THIS plus the always-on roadmap + release guards (see
+  # scripts/setup-branch-protection.sh).
+  ci-gate:
+    name: CI gate
+    if: always()
+    needs: [changes, verify, roadmap-guard, release-guard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every upstream job to have passed (or been skipped)
+        run: |
+          set -euo pipefail
+          declare -A results=(
+            [changes]='${{ needs.changes.result }}'
+            [verify]='${{ needs.verify.result }}'
+            [roadmap-guard]='${{ needs.roadmap-guard.result }}'
+            [release-guard]='${{ needs.release-guard.result }}'
+          )
+          fail=0
+          for job in "${!results[@]}"; do
+            r="${results[$job]}"
+            echo "$job: $r"
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then fail=1; fi
+          done
+          if [ "$fail" = "1" ]; then
+            echo "::error::a required CI job did not pass"; exit 1
+          fi
+          echo "All required CI jobs passed or were intentionally skipped."
 
   develop-image:
     name: Publish develop image

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -38,18 +38,25 @@ set -euo pipefail
 REPO="${REPO:-zuptalo/ring}"
 BRANCHES=(develop main)
 
-# Required status check contexts. These are "<caller-job> / <job name>" where the
-# caller job is `verify` (in ci.yml / release.yml) and the names come from the jobs
-# in .github/workflows/build-test.yml. If you rename a job, update it here too.
+# Required status check contexts.
 #
-# "Release guard (version bump)" is a top-level job in ci.yml (not under `verify`),
-# so it has no caller prefix. It reports green on PRs into develop and only enforces
-# a version bump on PRs into main — safe to require on both branches.
+# The heavy build/test/e2e jobs (the `verify` caller of build-test.yml) are
+# CONDITIONALLY SKIPPED for doc/spec/tooling-only changes (see the `changes` job in
+# ci.yml). A skipped check that is *required* would block the PR forever, so we must
+# NOT require the individual "verify / *" contexts. Instead we require "CI gate" —
+# an always-running aggregate that passes when every upstream job succeeded or was
+# intentionally skipped, and fails if any actually failed. That keeps doc-only PRs
+# unblocked while still enforcing the full suite whenever code changes.
+#
+# "Roadmap up to date" and "Release guard (version bump)" are top-level ci.yml jobs
+# that always run (cheap), so they are required directly too. The release guard is
+# green on PRs into develop and only enforces a version bump on PRs into main.
+#
+# IMPORTANT: run this script only AFTER the ci.yml that defines "CI gate" has merged,
+# or PRs will require a check that doesn't exist yet.
 REQUIRED_CHECKS=(
-  "verify / Client (typecheck + build)"
-  "verify / Client (unit tests)"
-  "verify / Server (build + vet + test)"
-  "verify / End-to-end (Playwright)"
+  "CI gate"
+  "Roadmap up to date"
   "Release guard (version bump)"
 )
 


### PR DESCRIPTION
Skip the heavy build/test/e2e suite for **doc/spec/tooling-only** changes, which the spec-driven workflow produces a lot of (spec/plan/tasks files, status bumps, ROADMAP regenerations). A roadmap badge edit shouldn't pay the multi-minute Playwright tax.

## How (Approach A — footgun-safe)
- **`changes`** job (`dorny/paths-filter`): `code` is true only when app code / server / e2e / deps / configs / Dockerfile / workflows changed.
- **`verify`** (full suite) is gated on `code == 'true'` → skipped for docs-only.
- **`roadmap-guard`** stays always-on — the real gate for spec/roadmap edits.
- **`CI gate`** always runs and passes iff every upstream job succeeded *or was intentionally skipped*; fails on a real failure. A skipped *required* check would block a PR forever, so branch protection must require this aggregate instead of the conditionally-skipped `verify / *` checks.

## Required-checks switch (after merge)
`setup-branch-protection.sh` is updated to require **`CI gate`**, **`Roadmap up to date`**, **`Release guard (version bump)`** (dropping the four `verify / *`). It must be **re-run after this PR merges** — the `CI gate` context has to exist before it's required.

## Behavior
- This PR touches `.github/workflows/**` → `code=true` → full suite runs here (and the new `CI gate` reports alongside the still-required `verify / *`, so it merges cleanly under current protection).
- Future doc-only PRs: `changes` → `roadmap-guard` → `CI gate`, ~30s instead of ~10min.

No app/runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
