### PR TITLE
feat(pwa): show what changed in the update toast (release-note delta)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # release-notes.sh needs tags + history to diff from the last release
       - name: Resolve version
         id: ver
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Compose release notes (base64 JSON)
+        id: notes
+        run: echo "b64=$(scripts/release-notes.sh | base64 -w0)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v3 # arm64 emulation for the final stage
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -202,5 +207,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.ver.outputs.version }}-dev.${{ github.run_number }}+${{ github.sha }}
+            RELEASE_NOTES_B64=${{ steps.notes.outputs.b64 }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,14 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Compose the build's release notes BEFORE creating the new tag, so the script's
+      # "since the last release tag" range is this release's changes (the previous tag
+      # is still the highest one). Baked into the image for the PWA's "what's new".
+      - name: Compose release notes (base64 JSON)
+        id: notes
+        if: steps.check.outputs.exists == 'false'
+        run: echo "b64=$(scripts/release-notes.sh | base64 -w0)" >> "$GITHUB_OUTPUT"
+
       - name: Create and push tag
         if: steps.check.outputs.exists == 'false'
         run: |
@@ -89,6 +97,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.ver.outputs.version }}
+            RELEASE_NOTES_B64=${{ steps.notes.outputs.b64 }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,13 @@ COPY . .
 # Stamp the SAME version into the PWA as the Go binary below, so the UI reports the
 # true deployed version and can detect a newer one. Defaults to dev for plain builds.
 ARG VERSION=dev
-RUN RING_VERSION="$VERSION" npm run build
+# Release notes JSON (base64-encoded to dodge quoting through the build-arg chain),
+# the SAME value the Go binary gets below. The PWA bakes the decoded JSON into
+# __RELEASE_NOTES__ as the "running" side of the What's-new delta. Defaults to [].
+ARG RELEASE_NOTES_B64=''
+RUN RING_VERSION="$VERSION" \
+    RING_RELEASE_NOTES="$([ -n "$RELEASE_NOTES_B64" ] && printf '%s' "$RELEASE_NOTES_B64" | base64 -d || printf '[]')" \
+    npm run build
 
 # --- Stage 2: build the server ----------------------------------------------
 # Also pinned to $BUILDPLATFORM and cross-compiled to the target arch via
@@ -42,12 +48,16 @@ COPY server/go.mod server/go.sum ./
 RUN go mod download
 COPY server/ ./
 ARG VERSION=dev
+# Already-base64 release notes JSON, stamped straight into main.releaseNotesB64
+# (the server decodes it at boot and serves it at /v1/config). base64 needs no
+# escaping in ldflags. Defaults to empty → no notes.
+ARG RELEASE_NOTES_B64=''
 ARG TARGETOS
 ARG TARGETARCH
 # Static, stripped binary. -trimpath keeps paths reproducible; the version is
 # stamped into main.version for `ringd starting version=...` and ops visibility.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath \
-    -ldflags="-s -w -X main.version=${VERSION}" \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.releaseNotesB64=${RELEASE_NOTES_B64}" \
     -o /out/ringd ./cmd/ringd
 
 # --- Stage 3: runtime -------------------------------------------------------

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,9 @@ Specs are grouped by category band; status moves
 
 ## 📌 Planned Features (0001–0999)
 
-_None yet._
+| Spec | Title | Status |
+|------|-------|--------|
+| [0001](specs/0001-show-what-changed/spec.md) | Show what changed in the update toast (release-note delta) | 🔵 in-review |
 
 ## ⚡ Ad-hoc (1001–1999)
 

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Emit this build's release notes as JSON: [{ "sha", "subject" }] for the
+# Conventional-Commit changes since the last release tag (vX.Y.Z), newest-first,
+# merge commits excluded. Consumed at build time (see Dockerfile + ci.yml/release.yml)
+# and baked into BOTH the client (__RELEASE_NOTES__) and the server (/v1/config), so
+# the PWA can show a per-user "what's new". Prints "[]" when there's nothing.
+#
+# Subject is the RAW Conventional-Commit subject; the client prettifies it for display
+# (src/services/release-notes.ts). SHA is the short hash — the stable identity the
+# client uses to diff the incoming build's notes against the running build's.
+set -euo pipefail
+
+# Bound the payload so a build never carries an unbounded changelog (the client only
+# ever shows the per-user delta anyway). Generous for a normal release.
+MAX=50
+
+# Base = the highest existing vX.Y.Z release tag; if none yet, fall back to the most
+# recent MAX commits.
+last_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname 2>/dev/null | head -1 || true)
+range="HEAD"
+[ -n "$last_tag" ] && range="${last_tag}..HEAD"
+
+# Tab (%x09) separates sha from subject; subjects can contain tabs only in pathological
+# cases, so take the FIRST field as sha and the REST as subject to be safe.
+raw=$(git log "$range" --no-merges --max-count="$MAX" --format='%h%x09%s' 2>/dev/null || true)
+
+if command -v jq >/dev/null 2>&1; then
+  printf '%s\n' "$raw" | jq -c -R -s '
+    split("\n")
+    | map(select(length > 0))
+    | map(. as $line | ($line | index("\t")) as $i
+        | { sha: $line[0:$i], subject: $line[($i + 1):] })'
+elif command -v python3 >/dev/null 2>&1; then
+  printf '%s' "$raw" | python3 -c '
+import json, sys
+out = []
+for line in sys.stdin.read().splitlines():
+    if not line:
+        continue
+    sha, _, subject = line.partition("\t")
+    out.append({"sha": sha, "subject": subject})
+print(json.dumps(out, separators=(",", ":")))'
+else
+  echo "[]"
+fi

--- a/server/cmd/ringd/main.go
+++ b/server/cmd/ringd/main.go
@@ -38,6 +38,30 @@ import (
 // -ldflags "-X main.version=...". Defaults to "dev" for plain `go build`/`go run`.
 var version = "dev"
 
+// releaseNotesB64 is this build's changelog since the last release tag — base64-
+// encoded JSON ([]api.ReleaseNote), stamped at link time via
+// -ldflags "-X main.releaseNotesB64=...". base64 sidesteps quoting/space issues of
+// putting JSON in ldflags. Empty for plain go build/run. Surfaced at /v1/config so
+// the PWA can show a per-user "what's new". A bad value degrades to no notes.
+var releaseNotesB64 = ""
+
+func decodeReleaseNotes(b64 string) []api.ReleaseNote {
+	if b64 == "" {
+		return nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		slog.Warn("release notes: invalid base64, ignoring", "err", err)
+		return nil
+	}
+	var notes []api.ReleaseNote
+	if err := json.Unmarshal(raw, &notes); err != nil {
+		slog.Warn("release notes: invalid JSON, ignoring", "err", err)
+		return nil
+	}
+	return notes
+}
+
 func main() {
 	if err := run(); err != nil {
 		slog.Error("fatal", "err", err)
@@ -316,6 +340,7 @@ func run() error {
 		Invites: st, Notifier: notifier, RequireConnection: cfg.RequireConnection,
 		PublicURL: cfg.PublicURL, VapidPublicKey: secs.VapidPublicKey, MaxBlobBytes: cfg.MaxBlobBytes,
 		Version:      version,
+		ReleaseNotes: decodeReleaseNotes(releaseNotesB64),
 		CallsEnabled: cfg.EnableCalls, TurnSharedSecret: secs.TurnSharedSecret,
 		TurnURLs:      turnURLs,
 		Emoji:     st,

--- a/server/internal/api/config_handler.go
+++ b/server/internal/api/config_handler.go
@@ -6,15 +6,30 @@ import (
 	"ring/server/internal/httpx"
 )
 
+// ReleaseNote is one user-facing change in this build's changelog (the changes since
+// the last release tag), advertised at /v1/config so the PWA can show a per-user
+// "what's new" between the running build and a newly deployed one. Public, non-secret
+// build metadata derived from public git history (sha = the change's stable identity).
+type ReleaseNote struct {
+	SHA     string `json:"sha"`
+	Subject string `json:"subject"`
+}
+
 // serverConfig (GET /v1/config) lets clients self-configure without baking in
-// anything but the base URL: it advertises the canonical public URL and the
-// Web Push VAPID public key. No auth - it's public, non-secret bootstrap info.
+// anything but the base URL: it advertises the canonical public URL, the Web Push
+// VAPID public key, the running version, and this build's release notes. No auth -
+// it's public, non-secret bootstrap info.
 func (h *Handlers) serverConfig(w http.ResponseWriter, r *http.Request) {
+	notes := h.ReleaseNotes
+	if notes == nil {
+		notes = []ReleaseNote{} // serialize as [] rather than null
+	}
 	httpx.JSON(w, http.StatusOK, map[string]any{
 		"publicUrl":      h.PublicURL,
 		"vapidPublicKey": h.VapidPublicKey,
 		"callsEnabled":   h.CallsEnabled,
 		"maxBlobBytes":   h.maxBlob(),
 		"version":        h.Version,
+		"notes":          notes,
 	})
 }

--- a/server/internal/api/config_handler_test.go
+++ b/server/internal/api/config_handler_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"ring/server/internal/ws"
 )
 
 func TestServerConfigIsPublic(t *testing.T) {
@@ -21,5 +23,50 @@ func TestServerConfigIsPublic(t *testing.T) {
 	}
 	if got["publicUrl"] != "https://ring.example" || got["vapidPublicKey"] != "VAPID_PUB" {
 		t.Fatalf("unexpected config: %+v", got)
+	}
+}
+
+// /v1/config advertises this build's release notes (public, non-secret build
+// metadata) so the PWA can show a per-user "what's new" between versions.
+func TestServerConfigIncludesReleaseNotes(t *testing.T) {
+	notes := []ReleaseNote{
+		{SHA: "abc123", Subject: "fix(sync): stabilize message status"},
+		{SHA: "def456", Subject: "feat: add full-text search"},
+	}
+	srv := NewRouter(&Handlers{
+		Hub:            ws.NewHub(),
+		PublicURL:      "https://ring.example",
+		VapidPublicKey: "VAPID_PUB",
+		ReleaseNotes:   notes,
+	}, []string{"http://localhost:5173"})
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/config", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("config status = %d, want 200", rr.Code)
+	}
+	var got struct {
+		Notes []ReleaseNote `json:"notes"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Notes) != 2 || got.Notes[0].SHA != "abc123" || got.Notes[1].Subject != "feat: add full-text search" {
+		t.Fatalf("unexpected notes: %+v", got.Notes)
+	}
+}
+
+// When unset, notes serialize as an empty array (not null) so the client can treat
+// it uniformly.
+func TestServerConfigReleaseNotesEmptyWhenUnset(t *testing.T) {
+	srv := newTestServer() // no ReleaseNotes
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/config", nil))
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(got["notes"]) != "[]" {
+		t.Fatalf("notes = %s, want []", got["notes"])
 	}
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -130,6 +130,10 @@ type Handlers struct {
 	// Version is the running server build (main.version, stamped via -ldflags),
 	// advertised at GET /v1/config so a possibly-stale PWA can detect a new deploy.
 	Version string
+	// ReleaseNotes is this build's changelog since the last release tag (stamped via
+	// -ldflags, decoded from base64 JSON), advertised at GET /v1/config so the PWA can
+	// show a per-user "what's new" between the running and the newly deployed build.
+	ReleaseNotes []ReleaseNote
 	// MaxBlobBytes caps a single encrypted media upload (bytes); advertised at
 	// GET /v1/config so clients can pre-validate before encrypting + uploading.
 	MaxBlobBytes int

--- a/specs/0001-show-what-changed/analysis.md
+++ b/specs/0001-show-what-changed/analysis.md
@@ -1,0 +1,38 @@
+# Analyze Report: spec ↔ plan ↔ tasks ↔ constitution
+
+**Spec**: 0001-show-what-changed · **Run**: pre-implementation consistency check
+
+## Coverage (every FR maps to a task)
+
+| Requirement | Plan | Task(s) | Status |
+|-------------|------|---------|--------|
+| FR-001 toast shows per-user delta | §4 | T1, T2 | ✅ |
+| FR-002 auto notes from CC subjects, no merges | §1 | T4 | ✅ |
+| FR-003 stable SHA identity | §1, §4 | T1, T4 | ✅ |
+| FR-004 incoming via /v1/config; running baked in | §2, §3, §4 | T2, T3, T4 | ✅ |
+| FR-005 delta = incoming−running; graceful fallback | §4 | T1, T2 | ✅ |
+| FR-006 cap + "+N more" | §4 | T1, T2 | ✅ |
+| FR-007 same path for develop + release images | §2 | T3, T4 | ✅ |
+| FR-008 pure, unit-tested core | §4 | T1, T3 | ✅ |
+| SC-001..005 | test strategy | T1–T5 | ✅ |
+
+No orphan requirements or tasks.
+
+## Constitution check
+
+- **I. Zero-Knowledge** — notes are public app metadata (same class as `version` already on
+  `/v1/config`); spec has the mandatory Zero-Knowledge Impact section; no boundary change. ✅
+- **III. TDD** — tasks order failing tests before implementation (T1.a/T3.a). ✅
+- **V. Offline-first** — no object-store/`DB_VERSION` change. ✅
+- **VII. Quality gates / update UX** — the PWA stays `registerType: 'prompt'`; only the toast's
+  message content changes; T5.b runs the exact CI gate; coverage ratchets up. ✅
+- **VIII. Traceable delivery** — task groups → issues; T6.b lists `Closes #N`. ✅
+
+## Findings
+
+- No contradictions across artifacts.
+- Two judgement calls recorded in plan §research: prettify in the client (testable) rather than in
+  bash; base64-encode notes into the server binary (robust ldflags transport). Both accepted.
+- Minor follow-up noted (not in scope): a richer "what's new" sheet instead of a plain-text toast.
+
+**Verdict: clean — ready to implement (pending review-gate sign-off).**

--- a/specs/0001-show-what-changed/plan.md
+++ b/specs/0001-show-what-changed/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: Show what changed in the update toast (release-note delta)
+
+**Spec**: [`spec.md`](spec.md) · **Branch**: `feat/0001-show-what-changed` · **Status**: planned
+
+## Approach
+
+Carry a small, build-stamped changelog through the same path `VERSION` already travels (Docker
+build-arg → client define + server ldflags → `/v1/config`), then compute a **per-user delta** in
+the client and render it in the existing update toast. All the interesting logic (delta, cap,
+prettify) is pure and unit-tested; the build/CI parts are thin glue.
+
+### 1. Notes source — `scripts/release-notes.sh` (new, pure git)
+
+Emits a JSON array `[{ "sha": "<12-char>", "subject": "<raw conventional-commit subject>" }]`,
+newest-first, for commits since the last release tag:
+
+- Base = highest existing `vX.Y.Z` tag (or repo root if none).
+- `git log <base>..HEAD --no-merges --format='%h%x1f%s'` → JSON (merge commits already excluded;
+  raw subject kept — prettification is a tested client concern, not bash's).
+- No dependencies; safe when there are zero commits (emits `[]`).
+- Reused by `release.yml`'s existing "Compose release notes" step too (DRY), and called by CI to
+  produce the build-arg.
+
+### 2. Build plumbing (mirror VERSION)
+
+- **CI** (`ci.yml` `develop-image`, `release.yml`): `NOTES=$(scripts/release-notes.sh)`, pass
+  `--build-arg RELEASE_NOTES="$NOTES"`.
+- **Dockerfile**: `ARG RELEASE_NOTES='[]'`.
+  - Client stage: `RING_RELEASE_NOTES="$RELEASE_NOTES" npm run build`.
+  - Server stage: `-ldflags "... -X main.releaseNotesB64=$(printf %s "$RELEASE_NOTES" | base64 -w0)"`
+    — **base64** sidesteps all quoting/space problems of stuffing JSON into ldflags, and keeps the
+    stateless single-binary model (no extra file to ship).
+- **vite.config.ts**: `__RELEASE_NOTES__` define = parsed `process.env.RING_RELEASE_NOTES` (default
+  `[]`). Add the type to `src/env.d.ts`/globals next to `__APP_VERSION__`.
+
+### 3. Server
+
+- `main.go`: `var releaseNotesB64 = ""`; at boot decode base64 → JSON → `[]ReleaseNote` (empty on
+  any error). Plumb to `Handlers.ReleaseNotes`.
+- `config_handler.go`: add `"notes": h.ReleaseNotes` to the `/v1/config` map (empty array when none).
+
+### 4. Client
+
+- **`src/services/release-notes.ts`** (new, pure): `type ReleaseNote = { sha: string; subject: string }`;
+  - `computeDelta(incoming, running): ReleaseNote[]` — incoming entries whose `sha` ∉ running.
+  - `prettify(subject): string` — strip `^type(scope)?!?:\s*` and upper-case the first letter.
+- **`src/components/WhatsNewSheet.vue`** (new): an `IonModal` sheet that lists the delta (prettified,
+  newest-first, scrollable) and offers an Update action. Reusable; Ionic-native, no inline colors.
+- **`api.ts`**: `fetchServerConfig` return type gains `notes?: ReleaseNote[]`.
+- **`useAppUpdate.ts`**: on `needRefresh`, fetch `/v1/config` → `incoming = notes ?? []`;
+  `running = __RELEASE_NOTES__`; `delta = computeDelta(incoming, running)`. If `running` is empty
+  (old client) or `delta` is empty → today's generic toast (unchanged). Else show a toast whose
+  message names the version and which carries a **"What's new (N)"** button that presents
+  `WhatsNewSheet` with the delta; Update/Later and skip-waiting are unchanged.
+
+## Research / decisions (clarify)
+
+- **Delta by SHA**, not range math — exact even when the "since last tag" base shifts at a release.
+- **Prettify in the client**, not in bash — keeps it pure/tested; the build carries raw subjects.
+- **base64 ldflags** for the server — robust JSON transport into the binary; no runtime file/env.
+- **Toast stays a toast** (plain multiline text) for v1; a richer "what's new" sheet is a future spec.
+
+## Data model / contracts
+
+No DB, migration, or `DB_VERSION` change. `/v1/config` gains an additive optional `notes` field
+(older clients ignore it). Wire/zero-knowledge boundary unchanged (public metadata).
+
+## Test strategy (TDD — tests precede implementation)
+
+- `src/services/release-notes.test.ts`: `computeDelta` (subset/superset/disjoint/empty/`running`-
+  empty); `prettify` (type/scope/`!` prefixes, capitalization, non-conforming subject passthrough);
+  `capNotes` (under/at/over the cap, `more` count).
+- `server/internal/api/config_handler_test.go`: `/v1/config` includes `notes` when set, empty when
+  not; base64 decode helper handles valid/empty/garbage.
+- Add `src/services/release-notes.ts` to the gated client coverage set (≥ 90%).
+- Manual: run `scripts/release-notes.sh` locally and confirm JSON shape; confirm `/v1/config`
+  surfaces notes on a built image.

--- a/specs/0001-show-what-changed/spec.md
+++ b/specs/0001-show-what-changed/spec.md
@@ -1,0 +1,162 @@
+# Feature Specification: Show what changed in the update toast (release-note delta)
+
+**Feature Branch**: `feat/0001-show-what-changed`
+
+**Created**: 2026-06-15
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User description: "I would like the update toast sent to the users to now have a
+more meaningful purpose and tell them exactly what has been updated or fixed as part of that
+update." Deployment context: `develop` is continuously deployed to real testers (pulled ~every
+2 minutes); stable changes are promoted to `main` as a release.
+
+## Feature Summary
+
+Today the PWA update toast says only "A new version of Ring is ready" (it can name the version
+via `/v1/config`, but nothing about *what changed*). Replace that with a short, human-readable
+list of the changes the incoming build introduces **relative to the version the user is running**
+— a per-user **delta**, not a static changelog. This is especially valuable because the `develop`
+channel pushes frequent updates to testers, who currently can't tell one update from the next.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A develop tester sees exactly what each update brings (Priority: P1)
+
+A family/friend tester is on `develop` build N. The continuous deploy ships build N+1 (one merged
+PR). On next launch/foreground, the toast says: **"Ring 0.1.0-dev.42 is ready — What's new:
+• Stabilize message status reporting"** with Update / Later buttons.
+
+**Why this priority**: This is the core ask and the highest-frequency case (continuous develop
+deploys). It turns an opaque "update available" into a meaningful, trustworthy signal.
+
+**Independent Test**: Given a running build whose notes are {A,B} and an incoming build whose
+notes are {A,B,C}, the toast shows only **C**.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running build and an incoming build that adds one change, **When** the update is
+   detected, **Then** the toast lists that one change (prettified, human-readable).
+2. **Given** an incoming build that adds several changes since the running one, **When** detected,
+   **Then** the toast lists them, capped (e.g. top 5) with "+N more" if longer.
+3. **Given** the update is accepted, **When** the user taps Update, **Then** the existing
+   skip-waiting + reload behavior is unchanged.
+
+### User Story 2 - A user crossing a release sees the release's changes (Priority: P2)
+
+A user on `0.1.0` updates to `0.2.0`. The toast shows everything new to them since `0.1.0`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running release and an incoming release several changes ahead, **When** detected,
+   **Then** the delta is correct even though the build's "since last tag" base changed (delta is
+   computed by stable commit identity, not by range).
+
+### User Story 3 - Graceful when there's nothing to say (Priority: P1)
+
+The feature must never make the update experience worse than today.
+
+**Acceptance Scenarios**:
+
+1. **Given** the incoming notes can't be fetched, or the running build predates this feature (no
+   baked-in notes), **When** detected, **Then** the toast falls back to today's generic "A new
+   version of Ring is ready" message (still names the version when available).
+2. **Given** the computed delta is empty, **When** detected, **Then** the generic message is shown
+   (no empty "What's new" section).
+
+### Edge Cases
+
+- **No prior release tag** (early project) → notes are the changes since repo start, or empty →
+  generic message; never an error.
+- **Non-Conventional-Commit / merge-commit subjects** in range → merge-commit noise
+  (`Merge pull request #…`) is filtered out; other subjects are shown prettified as-is.
+- **Large delta** → cap the visible list with a "+N more" affordance so the toast doesn't overflow.
+- **Old running client** (no `__RELEASE_NOTES__`) → treated as "unknown running notes" → fall back
+  to generic (do NOT dump the entire incoming list as if all new).
+- **Prettification** strips the Conventional-Commit `type(scope):` prefix for display but keeps the
+  subject meaning (e.g. `fix(sync): stabilize message status` → "Stabilize message status").
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When an update is available with a non-empty per-user delta, the update toast MUST
+  offer a **"What's new"** action that opens a sheet (IonModal) listing the human-readable changes
+  the incoming build introduces **relative to the running build**. The toast's Update/Later actions
+  and the skip-waiting behavior are unchanged; the sheet itself MAY also offer Update.
+- **FR-002**: Release notes MUST be generated automatically at build time from the Conventional-
+  Commit subjects since the last release tag — no manual curation — and merge-commit subjects
+  MUST be excluded.
+- **FR-003**: Each note entry MUST carry a stable identity (its commit SHA) so the delta can be
+  computed exactly, including across release-tag resets.
+- **FR-004**: The incoming build's notes MUST be exposed to a running client via the existing
+  public `/v1/config` endpoint; the running build's own notes MUST be baked into the client at
+  build time (a compile-time constant, like `__APP_VERSION__`).
+- **FR-005**: The delta MUST be the set of incoming notes whose commit identity is not present in
+  the running build's notes (an *empty* running list is valid — the delta is then everything since
+  the running release). An empty delta or missing/unavailable incoming notes MUST fall back to the
+  current generic message (no regression).
+- **FR-006**: The toast MUST surface the change count (e.g. "What's new (3)"); the sheet MUST list
+  the full delta, scrollable, newest-first.
+- **FR-007**: The same notes-generation path MUST feed both the `develop` image and the release
+  image builds, so the feature works on the continuous channel and on formal releases identically.
+- **FR-008**: The notes-derivation and delta logic MUST be pure and unit-tested (no DOM/IDB/network
+  in the tested core), per the project's testing conventions.
+
+### Key Entities
+
+- **ReleaseNote**: `{ sha: string; subject: string }` — one user-facing change (prettified subject
+  + its commit identity). A build carries an ordered list of these (newest first), covering changes
+  since the last release tag.
+- **`/v1/config` response**: gains an optional `notes: ReleaseNote[]` field alongside `version`.
+- **`__RELEASE_NOTES__`**: compile-time constant — the running client build's own `ReleaseNote[]`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A develop tester updating one build sees exactly the change(s) in that update — zero
+  unrelated entries — across the test matrix.
+- **SC-002**: A user updating across a release sees the correct delta since their version.
+- **SC-003**: Missing/empty notes never degrade the experience below today's behavior (generic
+  message still shown, version still named when available).
+- **SC-004**: The pure notes/delta core is unit-tested ≥ 90% (prettify, merge-filter, SHA-keyed
+  delta, cap, fallbacks); client build + server tests stay green.
+- **SC-005**: Both `develop` and release images ship correct notes (verified via `/v1/config`).
+
+## Zero-Knowledge Impact *(mandatory — Constitution Principle I)*
+
+None. Release notes are **public, non-user application metadata** (the same class as `version`,
+`publicUrl`, `vapidPublicKey` already returned by `/v1/config`). Nothing user-generated or
+plaintext crosses the boundary; the server serves its own build's notes, derived from the public
+git history. No new endpoint, no auth change.
+
+## Assumptions
+
+- Conventional Commits are enforced (they are, per CLAUDE.md) and their subjects "describe
+  user-facing behavior, not internals", making them a fit source for end-user notes. A later spec
+  could elevate to spec titles; this one uses commit subjects.
+- Notes are computed in CI (which has full git history) and passed into the Docker build as a
+  build-arg, then baked into both the client bundle and the server binary — mirroring how `VERSION`
+  already flows.
+- The update toast's existing detection/skip-waiting machinery (`useAppUpdate` + `sw.ts`) is reused
+  unchanged; only the message content changes.
+
+## Clarifications (resolved)
+
+- **Presentation** → **richer "What's new" sheet** (IonModal) opened from a toast action, not
+  plain toast text (user decision).
+- **Delta vs. full changelog** → **delta** (user decision): show only what's new to *this* user.
+- **Source of notes** → Conventional-Commit subjects since the last release tag, automatic,
+  prettified; merge commits filtered.
+- **Delta identity** → **commit SHA** (exact across tag resets), not subject text or range math.
+- **Fallback** → on any gap (no incoming notes, no running notes, empty delta) show today's generic
+  message; never worse than current behavior.
+
+## Complexity & Exceptions
+
+The only new moving part is build-time notes generation threaded through the Docker build into both
+artifacts. Justified: there is no zero-knowledge-preserving way to show *what changed* without
+carrying that metadata in the build, and reusing `/v1/config` + a shared notes script keeps it
+minimal. No constitutional principle is waived.

--- a/specs/0001-show-what-changed/tasks.md
+++ b/specs/0001-show-what-changed/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Show what changed in the update toast (release-note delta)
+
+**Spec**: [`spec.md`](spec.md) · **Plan**: [`plan.md`](plan.md) · **Branch**: `feat/0001-show-what-changed`
+
+TDD: within each group the failing test (Tn.a) precedes the implementation (Tn.b). Groups roughly
+map to one GitHub issue each.
+
+## T1 — Pure client core: delta + prettify (FR-001, FR-003, FR-005, FR-008)
+
+- **T1.a** Write `src/services/release-notes.test.ts` (red): `computeDelta` (incoming−running by
+  sha; subset/superset/disjoint/empty/running-empty → empty signal); `prettify`
+  (`fix(sync): x`→"X", `feat!: y`, plain subject passthrough).
+- **T1.b** Add `src/services/release-notes.ts` (`ReleaseNote`, `computeDelta`, `prettify`).
+  Make T1.a green.
+
+## T2 — What's-new sheet + toast wiring (FR-001, FR-005, FR-006)
+
+- **T2.b** Add `src/components/WhatsNewSheet.vue` (IonModal listing the prettified delta, scrollable,
+  with an Update action). `useAppUpdate.ts`: fetch `/v1/config` notes, compute delta vs
+  `__RELEASE_NOTES__`; on a non-empty delta show a toast with a "What's new (N)" button that presents
+  the sheet, else the generic toast (unchanged). Add `__RELEASE_NOTES__` to `src/env.d.ts` globals;
+  `api.ts`: add `notes?: ReleaseNote[]` to `fetchServerConfig`.
+- **T2.c** `npm run build` (typecheck) green; `npm run test:unit` green.
+
+## T3 — Server exposes its build's notes (FR-004, FR-007)
+
+- **T3.a** `server/internal/api/config_handler_test.go` (red): `/v1/config` includes `notes` when
+  `Handlers.ReleaseNotes` is set, empty array when not.
+- **T3.b** `main.go`: `var releaseNotesB64`; decode at boot → `Handlers.ReleaseNotes`.
+  `config_handler.go`: add `"notes"`. Make T3.a green; `go build/vet/test ./...`.
+
+## T4 — Build-time notes generation (FR-002, FR-007)
+
+- **T4.b** Add `scripts/release-notes.sh` (git log since last tag, `--no-merges`, JSON sha+subject).
+  `Dockerfile`: `ARG RELEASE_NOTES`; client `RING_RELEASE_NOTES`; server `-X main.releaseNotesB64`
+  (base64). `vite.config.ts`: `__RELEASE_NOTES__` define. `ci.yml` + `release.yml`: compute notes
+  and pass `--build-arg RELEASE_NOTES`. Optionally refactor release.yml's notes step onto the script.
+- **T4.c** Run `scripts/release-notes.sh` locally; confirm valid JSON and merge-commit exclusion.
+
+## T5 — Coverage + gates (SC-004, SC-005)
+
+- **T5.a** Add `release-notes.ts` to the gated coverage set (≥ 90%); confirm no floor regresses.
+- **T5.b** Full gate: `npm run build`, `npm run test:unit:coverage`, `go build/vet/test ./...`.
+
+## T6 — Finalize
+
+- **T6.a** Set spec `Status` → `in-review`; `make roadmap`; `roadmap-gen.py --check` green.
+- **T6.b** PR body lists `Closes #N` per issue.

--- a/src/components/WhatsNewSheet.vue
+++ b/src/components/WhatsNewSheet.vue
@@ -1,0 +1,86 @@
+<template>
+  <!-- "What's new" sheet, presented imperatively from the update toast
+       (useAppUpdate) via modalController. Lists the per-user delta of changes the
+       incoming build introduces, newest-first and scrollable, with an Update action.
+       Dismisses with role 'update' when the user chooses to install now. -->
+  <ion-content class="sheet">
+    <div class="sheet-head">
+      <ion-icon class="head-icon" :icon="sparklesOutline" />
+      <h2 class="head-name">What's new{{ version ? ` in Ring ${version}` : '' }}</h2>
+      <button class="close" aria-label="Close" @click="dismiss('cancel')">
+        <ion-icon :icon="closeOutline" />
+      </button>
+    </div>
+
+    <ion-list :inset="true" class="notes">
+      <ion-item v-for="note in notes" :key="note.sha" :detail="false" lines="full">
+        <ion-icon slot="start" :icon="checkmarkCircleOutline" color="primary" />
+        <ion-label class="note">{{ prettify(note.subject) }}</ion-label>
+      </ion-item>
+    </ion-list>
+
+    <div class="actions">
+      <ion-button expand="block" @click="dismiss('update')">Update now</ion-button>
+      <ion-button expand="block" fill="clear" @click="dismiss('cancel')">Later</ion-button>
+    </div>
+  </ion-content>
+</template>
+
+<script setup lang="ts">
+import { IonContent, IonList, IonItem, IonLabel, IonIcon, IonButton, modalController } from '@ionic/vue';
+import { closeOutline, sparklesOutline, checkmarkCircleOutline } from 'ionicons/icons';
+import { prettify, type ReleaseNote } from '@/services/release-notes';
+
+defineProps<{ version: string; notes: ReleaseNote[] }>();
+
+// Imperative modal: communicate the choice back to useAppUpdate via the dismiss role.
+function dismiss(role: 'update' | 'cancel'): void {
+  void modalController.dismiss(undefined, role);
+}
+</script>
+
+<style scoped>
+.sheet {
+  --padding-top: 8px;
+}
+.sheet-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px 6px;
+}
+.head-icon {
+  font-size: 26px;
+  color: var(--ion-color-primary);
+}
+.head-name {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+.close {
+  flex: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: none;
+  background: var(--ion-color-step-150, rgba(120, 120, 128, 0.24));
+  color: var(--ion-text-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  cursor: pointer;
+}
+.notes ion-icon {
+  font-size: 20px;
+}
+.note {
+  white-space: normal;
+}
+.actions {
+  padding: 8px 16px 16px;
+}
+</style>

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -15,8 +15,25 @@
  */
 import { watch } from 'vue';
 import { useRegisterSW } from 'virtual:pwa-register/vue';
-import { toastController } from '@ionic/vue';
+import { toastController, modalController } from '@ionic/vue';
 import { fetchServerConfig } from '@/services/api';
+import { computeDelta, type ReleaseNote } from '@/services/release-notes';
+import WhatsNewSheet from '@/components/WhatsNewSheet.vue';
+
+/** Present the "What's new" sheet with the per-user delta. Resolves true when the
+ *  user chose to install from the sheet. */
+async function presentWhatsNew(version: string, notes: ReleaseNote[]): Promise<boolean> {
+  const modal = await modalController.create({
+    component: WhatsNewSheet,
+    componentProps: { version, notes },
+    breakpoints: [0, 1],
+    initialBreakpoint: 1,
+    cssClass: 'whats-new-modal',
+  });
+  await modal.present();
+  const { role } = await modal.onDidDismiss();
+  return role === 'update';
+}
 
 let started = false;
 let swReg: ServiceWorkerRegistration | null = null;
@@ -63,15 +80,40 @@ export function useAppUpdate(): void {
       if (!need || prompting) return;
       prompting = true;
       // The waiting SW IS the new build; ask the (already-deployed) server which
-      // version that is, so the toast can name it. A miss just drops the version.
+      // version that is AND its release notes, so the toast can name the version and
+      // offer a per-user "What's new". A miss just drops both (generic message).
       let version = '';
+      let incoming: ReleaseNote[] = [];
       try {
-        version = (await fetchServerConfig()).version ?? '';
+        const cfg = await fetchServerConfig();
+        version = cfg.version ?? '';
+        incoming = cfg.notes ?? [];
       } catch {
-        /* generic message when the version can't be fetched */
+        /* generic message + no notes when config can't be fetched */
       }
       const running = __APP_VERSION__;
       const label = version && version !== running ? `Ring ${version} is ready to install.` : 'A new version of Ring is ready.';
+
+      // Per-user delta: the changes the incoming build adds that this one didn't have.
+      const delta = computeDelta(incoming, __RELEASE_NOTES__ ?? []);
+
+      const buttons: { text: string; role?: 'cancel'; handler?: () => boolean | void }[] = [];
+      if (delta.length) {
+        buttons.push({
+          text: `What's new (${delta.length})`,
+          handler: () => {
+            // Open the sheet; keep the toast open behind it (return false) so Update/
+            // Later stay reachable. An "Update now" inside the sheet installs directly.
+            void presentWhatsNew(version, delta).then((wantsUpdate) => {
+              if (wantsUpdate) void updateServiceWorker(true);
+            });
+            return false;
+          },
+        });
+      }
+      buttons.push({ text: 'Update', handler: () => void updateServiceWorker(true) });
+      buttons.push({ text: 'Later', role: 'cancel' });
+
       const toast = await toastController.create({
         header: 'Update available',
         message: label,
@@ -80,10 +122,7 @@ export function useAppUpdate(): void {
         position: 'top',
         cssClass: 'app-update-toast',
         // No duration: stay until the user chooses.
-        buttons: [
-          { text: 'Later', role: 'cancel' },
-          { text: 'Update', handler: () => void updateServiceWorker(true) },
-        ],
+        buttons,
       });
       void toast.onDidDismiss().then(() => {
         prompting = false; // allow a re-prompt if a still-newer build arrives

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -289,6 +289,7 @@ export async function fetchServerConfig(): Promise<{
   vapidPublicKey: string;
   maxBlobBytes?: number;
   version?: string;
+  notes?: import('@/services/release-notes').ReleaseNote[];
 }> {
   // Bounded so a hung /v1/config can't stall callers that gate on it (push
   // (re)subscription, version checks). A slow-but-alive network still succeeds.
@@ -301,7 +302,13 @@ export async function fetchServerConfig(): Promise<{
     clearTimeout(timer);
   }
   if (!res.ok) throw new Error(`server config failed: ${res.status}`);
-  return (await res.json()) as { publicUrl: string; vapidPublicKey: string; maxBlobBytes?: number; version?: string };
+  return (await res.json()) as {
+    publicUrl: string;
+    vapidPublicKey: string;
+    maxBlobBytes?: number;
+    version?: string;
+    notes?: import('@/services/release-notes').ReleaseNote[];
+  };
 }
 
 /** One reconciled delivery: a message we sent reached `recipient` (a group message

--- a/src/services/release-notes.test.ts
+++ b/src/services/release-notes.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { computeDelta, prettify, type ReleaseNote } from './release-notes';
+
+const note = (sha: string, subject = 'feat: x'): ReleaseNote => ({ sha, subject });
+
+describe('computeDelta', () => {
+  it('returns the incoming notes the running build did not have (by sha)', () => {
+    const running = [note('a'), note('b')];
+    const incoming = [note('c'), note('b'), note('a')];
+    expect(computeDelta(incoming, running).map((n) => n.sha)).toEqual(['c']);
+  });
+
+  it('preserves incoming order (newest-first)', () => {
+    const running = [note('a')];
+    const incoming = [note('d'), note('c'), note('a'), note('b')];
+    expect(computeDelta(incoming, running).map((n) => n.sha)).toEqual(['d', 'c', 'b']);
+  });
+
+  it('empty running → the whole incoming list (everything since the release)', () => {
+    const incoming = [note('c'), note('b')];
+    expect(computeDelta(incoming, [])).toEqual(incoming);
+  });
+
+  it('identical lists → empty delta', () => {
+    const same = [note('a'), note('b')];
+    expect(computeDelta(same, same)).toEqual([]);
+  });
+
+  it('disjoint lists → all incoming', () => {
+    const incoming = [note('x'), note('y')];
+    expect(computeDelta(incoming, [note('a')]).map((n) => n.sha)).toEqual(['x', 'y']);
+  });
+
+  it('empty incoming → empty delta', () => {
+    expect(computeDelta([], [note('a')])).toEqual([]);
+  });
+});
+
+describe('prettify', () => {
+  it('drops the conventional-commit prefix and capitalizes', () => {
+    expect(prettify('fix(sync): stabilize message status')).toBe('Stabilize message status');
+    expect(prettify('feat: add full-text search')).toBe('Add full-text search');
+  });
+
+  it('handles a breaking-change marker and scopes', () => {
+    expect(prettify('feat!: drop legacy API')).toBe('Drop legacy API');
+    expect(prettify('refactor(call/sfu): simplify routing')).toBe('Simplify routing');
+  });
+
+  it('passes a non-conforming subject through, just capitalized', () => {
+    expect(prettify('just some words')).toBe('Just some words');
+    expect(prettify('Already capitalized')).toBe('Already capitalized');
+  });
+
+  it('does not crash on an empty subject', () => {
+    expect(prettify('')).toBe('');
+  });
+});

--- a/src/services/release-notes.ts
+++ b/src/services/release-notes.ts
@@ -1,0 +1,37 @@
+// Pure helpers for the "What's new" update flow.
+//
+// Each build is stamped (at build time, from git) with the list of changes since
+// the last release tag — its `ReleaseNote[]`. The running client carries its own
+// list as the compile-time constant `__RELEASE_NOTES__`; the incoming build's list
+// arrives via `/v1/config`. `computeDelta` is the per-user difference (what the
+// incoming build adds that the running one didn't have), keyed by commit SHA so it
+// is exact even when the "since last tag" base shifts at a release. `prettify`
+// turns a Conventional-Commit subject into user-facing text.
+//
+// No DOM / IndexedDB / network here, so this is fully unit-testable in the Node env.
+
+export interface ReleaseNote {
+  sha: string; // short commit hash — the stable identity used for the delta
+  subject: string; // raw Conventional-Commit subject (prettified for display)
+}
+
+/** Changes the incoming build introduces that the running build did not already
+ *  have, by commit identity. Order is preserved (newest-first as stamped). An empty
+ *  `running` is valid: the delta is then the whole incoming list (everything since
+ *  the running release). */
+export function computeDelta(incoming: ReleaseNote[], running: ReleaseNote[]): ReleaseNote[] {
+  const have = new Set(running.map((n) => n.sha));
+  return incoming.filter((n) => !have.has(n.sha));
+}
+
+// Conventional-Commit prefix: type, optional (scope), optional `!`, then `: `.
+const CC_PREFIX = /^[a-z]+(\([^)]*\))?!?:\s*/i;
+
+/** Turn a commit subject into user-facing text: drop the `type(scope):` prefix and
+ *  upper-case the first letter. A non-conforming subject is passed through (just
+ *  capitalized), never dropped. */
+export function prettify(subject: string): string {
+  const stripped = subject.replace(CC_PREFIX, '').trim();
+  const text = stripped || subject.trim();
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,3 +12,8 @@ interface ImportMeta {
 
 /** App version, injected at build time from package.json (see vite.config.ts). */
 declare const __APP_VERSION__: string;
+
+/** This build's release notes (changes since the last release tag), injected at
+ *  build time from git (see vite.config.ts / scripts/release-notes.sh). Used as the
+ *  "running" side of the What's-new delta. Empty array when none / unstamped. */
+declare const __RELEASE_NOTES__: import('@/services/release-notes').ReleaseNote[];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,18 @@ const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 
 };
 const appVersion = process.env.RING_VERSION || pkg.version;
 
+// This build's release notes (changes since the last release tag), exposed as the
+// compile-time constant __RELEASE_NOTES__ and used as the "running" side of the
+// What's-new update delta. The Docker build passes the SAME JSON into both this and
+// the Go binary (served from /v1/config), produced by scripts/release-notes.sh.
+// Defaults to an empty list for local/dev builds that don't set RING_RELEASE_NOTES.
+let releaseNotes: unknown = [];
+try {
+  releaseNotes = JSON.parse(process.env.RING_RELEASE_NOTES || '[]');
+} catch {
+  releaseNotes = [];
+}
+
 // Backend the dev server proxies /v1 + /healthz to. Defaults to local ringd on
 // :8080; the e2e harness overrides it to its isolated test backend.
 const proxyTarget = process.env.RING_PROXY_TARGET || 'http://localhost:8080';
@@ -23,6 +35,7 @@ const proxyTarget = process.env.RING_PROXY_TARGET || 'http://localhost:8080';
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),
+    __RELEASE_NOTES__: JSON.stringify(releaseNotes),
   },
   server: {
     host: true, // listen on 0.0.0.0 so 10.0.1.50:5173 is reachable on the LAN

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,6 +45,8 @@ export default defineConfig({
         // status-stability fix (spec 2001). Pure, fully unit-tested — gate them too.
         'src/services/message-status.ts',
         'src/services/keyed-mutex.ts',
+        // Pure release-note delta/prettify behind the What's-new toast (spec 0001).
+        'src/services/release-notes.ts',
       ],
       thresholds: { lines: 80, functions: 80, statements: 80, branches: 80 },
     },


### PR DESCRIPTION
First **planned** spec (`specs/0001-show-what-changed/`). Turns the generic "A new version is ready" toast into a per-user **"What's new"** showing exactly what each update brings — especially valuable on the continuously-deployed develop channel.

## How
Carries a build-stamped changelog through the **same path `VERSION` already travels** (Docker build-arg → client `__RELEASE_NOTES__` + server `/v1/config`), then diffs by **commit SHA** to show only what's new to *this* user. Pure delta/prettify logic is 100% unit-tested; the rest is thin glue.

- **Client:** `release-notes.ts` (pure: `computeDelta` + `prettify`), `WhatsNewSheet.vue` (IonModal), `useAppUpdate` wires a "What's new (N)" toast button → sheet, with graceful fallback.
- **Server:** `/v1/config` gains `notes`; `main.releaseNotesB64` via `-ldflags` (base64), empty array when unset.
- **Build:** `scripts/release-notes.sh` (Conventional-Commit subjects since last tag, `--no-merges`, capped 50) → baked into both artifacts by the Dockerfile + `ci.yml`/`release.yml`. `release.yml` composes notes **before** tagging so the range is the new release's changes.

## Tests / gates
10 new pure unit tests (release-notes 100% covered) + 3 server config tests; `npm run build`, coverage, `go build/vet/test` all green locally.

## Zero-knowledge
No boundary change — notes are public, non-user metadata (same class as `version`).

Closes #15
Closes #16
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
