### PR TITLE
docs(spec): mark 0001 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Specs are grouped by category band; status moves
 
 | Spec | Title | Status |
 |------|-------|--------|
-| [0001](specs/0001-show-what-changed/spec.md) | Show what changed in the update toast (release-note delta) | 🔵 in-review |
+| [0001](specs/0001-show-what-changed/spec.md) | Show what changed in the update toast (release-note delta) | 🟢 shipped |
 
 ## ⚡ Ad-hoc (1001–1999)
 

--- a/specs/0001-show-what-changed/spec.md
+++ b/specs/0001-show-what-changed/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-15
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User description: "I would like the update toast sent to the users to now have a


### PR DESCRIPTION
Advance spec 0001 lifecycle status `in-review -> shipped` (merged via #18) and regenerate `ROADMAP.md`. Docs-only → path-filtered CI skips the heavy suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)