### PR TITLE
test(showcase): screenshot capture harness with seeded demo data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ test-results
 playwright-report
 /playwright/.cache
 
+# Showcase screenshot output (generated marketing assets)
+showcase/output
+
 # Unit-test coverage output (vitest)
 coverage
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
+    "showcase": "playwright test --config showcase/showcase.config.ts",
     "release:patch": "npm version patch --no-git-tag-version",
     "release:minor": "npm version minor --no-git-tag-version",
     "release:major": "npm version major --no-git-tag-version"

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -1,0 +1,31 @@
+# Showcase screenshots
+
+Capture marketing-ready screenshots of the Ring UI across device sizes and themes.
+It boots the same isolated stack as the e2e suite (`e2e/global-setup.ts`: an
+isolated `ringd` on `:8081` + a fresh `ring_e2e` DB + a test Vite on `:5174`),
+registers a passwordless account, seeds a curated demo dataset through the dev-only
+`window.__ringTest.seedShowcase()` hook (see `src/services/showcase-seed.ts`), and
+screenshots each key screen.
+
+## Run
+
+```sh
+make db-up                                 # Docker Postgres (once)
+npx playwright install webkit chromium     # iPhone/iPad use WebKit; Pixel/Desktop use Chromium
+npm run showcase
+```
+
+Output lands in `showcase/output/<device>/<theme>/NN-screen.png` (gitignored):
+
+- **devices**: `iphone`, `ipad` (WebKit → iOS-mode styling), `android`, `desktop` (Chromium)
+- **themes**: `light`, `dark`
+- **screens**: auth, chats, a rich chat, calls, contacts, group info, settings, profile
+
+## Notes
+
+- Pure screenshots, no live calls — so no fake-media flags are needed. An
+  active-call screen would need two real accounts + WebRTC (the e2e harness can do
+  that) and is a future addition.
+- The seed is deterministic; tweak the dataset (people, messages, media) in
+  `src/services/showcase-seed.ts`. It's dev-only and tree-shaken from prod.
+- To capture a subset, pass a Playwright project: `npm run showcase -- --project=iphone`.

--- a/showcase/capture.spec.ts
+++ b/showcase/capture.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Showcase screen capture. For each device project (see showcase.config.ts) this
+ * registers a passwordless account, sets a profile, seeds the demo dataset via the
+ * dev-only test hook, then screenshots each key screen in both light and dark into
+ * showcase/output/<device>/<theme>/.
+ */
+import { test, type Page } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const THEMES = ['light', 'dark'] as const;
+type Theme = (typeof THEMES)[number];
+
+const SELF_NAME = 'Maya Chen';
+
+// Screens to capture: [file name, route]. Routes resolve against the seeded data
+// (chat/group ids come from showcase-seed.ts).
+const SCREENS: Array<[string, string]> = [
+  ['02-chats', '/tabs/chats'],
+  ['03-chat', '/chat/sc-alice'],
+  ['04-calls', '/tabs/calls'],
+  ['05-contacts', '/tabs/contacts'],
+  ['06-group', '/group/sc-trip'],
+  ['07-settings', '/tabs/settings'],
+  ['08-profile', '/settings/profile'],
+];
+
+async function waitHook(page: Page): Promise<void> {
+  await page.waitForFunction(() => !!(window as any).__ringTest, null, { timeout: 30_000 });
+}
+
+async function setTheme(page: Page, theme: Theme): Promise<void> {
+  await page.evaluate((t) => {
+    document.documentElement.classList.toggle('ion-palette-dark', t === 'dark');
+  }, theme);
+  await page.waitForTimeout(250);
+}
+
+test('capture showcase', async ({ page }, info) => {
+  const project = info.project.name;
+  const outRoot = path.resolve(info.config.rootDir, 'output', project);
+
+  const shoot = async (name: string, theme: Theme): Promise<void> => {
+    const dir = path.join(outRoot, theme);
+    mkdirSync(dir, { recursive: true });
+    await page.screenshot({ path: path.join(dir, `${name}.png`) });
+  };
+
+  // Pretend notifications are granted so the onboarding permission step doesn't
+  // sit in front of the UI we want to capture.
+  await page.context().addInitScript(() => {
+    try {
+      Object.defineProperty(Notification, 'permission', { get: () => 'granted', configurable: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  // 1) Auth (logged out).
+  await page.goto('/');
+  await waitHook(page);
+  await page.waitForTimeout(800);
+  for (const theme of THEMES) {
+    await setTheme(page, theme);
+    await shoot('01-auth', theme);
+  }
+
+  // 2) Register passwordless, set a profile (green initials avatar), seed demo data.
+  await page.evaluate(async () => {
+    const t = (window as any).__ringTest;
+    const code = await t.freshCode();
+    await t.register(code);
+    await t.createAuto();
+  });
+  await page.waitForFunction(() => (window as any).__ringTest.isUnlocked() === true, null, { timeout: 30_000 });
+  await page.evaluate(async (name) => {
+    const t = (window as any).__ringTest;
+    // Inline initials avatar (the generator isn't exposed on window).
+    const parts = name.trim().split(/\s+/);
+    const initials = ((parts[0]?.[0] ?? '') + (parts[1]?.[0] ?? '')).toUpperCase();
+    const c = document.createElement('canvas');
+    c.width = 200;
+    c.height = 200;
+    const ctx = c.getContext('2d')!;
+    ctx.fillStyle = '#10b981';
+    ctx.fillRect(0, 0, 200, 200);
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 90px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(initials, 100, 108);
+    await t.setProfile(name, c.toDataURL('image/png'));
+    await t.seedShowcase();
+  }, SELF_NAME);
+  await page.waitForTimeout(800);
+
+  // 3) Main screens, each in both themes (full reload per route keeps state clean).
+  for (const theme of THEMES) {
+    for (const [name, route] of SCREENS) {
+      await page.goto(route);
+      await page.waitForTimeout(700);
+      await setTheme(page, theme);
+      await shoot(name, theme);
+    }
+  }
+});

--- a/showcase/showcase.config.ts
+++ b/showcase/showcase.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Repo root (this config lives in showcase/). webServer.cwd defaults to the config
+// dir, so pin it to the root or Vite would start in showcase/ with the wrong root.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Showcase capture harness — NOT a test suite. It boots the same isolated stack as
+ * e2e (global-setup: ringd :8081 + fresh ring_e2e DB + test vite :5174), seeds a
+ * curated demo dataset via the dev-only test hook, and screenshots the UI across
+ * device sizes and light/dark themes into showcase/output/<device>/<theme>/.
+ *
+ * Prereqs: `make db-up` (Docker Postgres) and the webkit browser
+ * (`npx playwright install webkit chromium`). Run with: `npm run showcase`.
+ *
+ * iPhone/iPad use the device emulation (viewport + iOS user-agent → Ionic iOS mode);
+ * Pixel + Desktop use Chromium (Android Material mode + desktop). We render all of
+ * them in Chromium because Playwright's WebKit isn't available on every host (e.g.
+ * macOS 12). For pixel-perfect iOS Safari, set browserName: 'webkit' on the iPhone/
+ * iPad projects on a host that supports it. No fake-media flags — static screens only.
+ */
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 180_000,
+  reporter: [['list']],
+  globalSetup: '../e2e/global-setup.ts',
+  globalTeardown: '../e2e/global-teardown.ts',
+  outputDir: '../.tmp/showcase-results',
+  use: {
+    baseURL: 'http://localhost:5174',
+  },
+  webServer: {
+    command: 'npx vite --port 5174 --strictPort',
+    cwd: repoRoot,
+    url: 'http://localhost:5174',
+    reuseExistingServer: true,
+    // Generous: a cold `go build` of ringd in global-setup can saturate CPU while
+    // Vite is also coming up on the first run.
+    timeout: 180_000,
+    env: { RING_PROXY_TARGET: 'http://localhost:8081' },
+  },
+  projects: [
+    { name: 'iphone', use: { ...devices['iPhone 14 Pro'], browserName: 'chromium' } },
+    { name: 'ipad', use: { ...devices['iPad (gen 7)'], browserName: 'chromium' } },
+    { name: 'android', use: { ...devices['Pixel 7'] } },
+    { name: 'desktop', use: { ...devices['Desktop Chrome'], viewport: { width: 1366, height: 900 } } },
+  ],
+});

--- a/src/services/showcase-seed.ts
+++ b/src/services/showcase-seed.ts
@@ -1,0 +1,217 @@
+/**
+ * DEV-ONLY showcase seeder. Injects a curated, deterministic demo dataset
+ * (contacts, 1:1 + group chats, both-sided messages with reactions/replies/media,
+ * and a call log) straight into IndexedDB so the screenshot harness
+ * (showcase/capture.spec.ts) can capture a rich, realistic app state from a single
+ * account — without a real second device.
+ *
+ * Messages are normally crypto-bound to the Double Ratchet, so this writes the
+ * rendered records directly; the ratchet desync is irrelevant because a showcase
+ * session never sends another real message. Imported only by the dev-only test
+ * hook (testhook.ts), so it is tree-shaken out of production builds entirely.
+ */
+import { put } from '@/db/idb';
+import { initialsAvatar, groupAvatar } from '@/db/avatars';
+import { uid } from '@/utils/uid';
+import type { Call, Chat, Contact, Media, Message } from '@/db/types';
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+/** Draw a soft gradient "photo" on a canvas and return it as a JPEG blob, so image
+ *  bubbles render an actual picture rather than a broken thumbnail. */
+async function gradientPhoto(c1: string, c2: string): Promise<Blob> {
+  const w = 1080;
+  const h = 1350;
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d')!;
+  const g = ctx.createLinearGradient(0, 0, w, h);
+  g.addColorStop(0, c1);
+  g.addColorStop(1, c2);
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, w, h);
+  // A soft sun + a horizon band, enough to read as a landscape photo.
+  ctx.fillStyle = 'rgba(255,255,255,0.85)';
+  ctx.beginPath();
+  ctx.arc(w * 0.72, h * 0.28, w * 0.11, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = 'rgba(0,0,0,0.12)';
+  ctx.fillRect(0, h * 0.66, w, h * 0.34);
+  return await new Promise<Blob>((resolve) => canvas.toBlob((b) => resolve(b!), 'image/jpeg', 0.85));
+}
+
+interface SeedPerson {
+  id: string;
+  name: string;
+  username?: string;
+  about: string;
+}
+
+const PEOPLE: SeedPerson[] = [
+  { id: 'sc-alice', name: 'Alice Rivera', username: 'alice', about: 'Designer. Mountain person. ⛰️' },
+  { id: 'sc-daniel', name: 'Daniel Okafor', username: 'daniel', about: 'Coffee → code → repeat.' },
+  { id: 'sc-sofia', name: 'Sofia Lindqvist', username: 'sofia', about: 'Photographer 📷' },
+  { id: 'sc-mom', name: 'Mom', about: '' },
+  { id: 'sc-tomas', name: 'Tomás García', username: 'tomas', about: 'Always planning the next trip.' },
+];
+
+const byId = (id: string): SeedPerson => PEOPLE.find((p) => p.id === id)!;
+
+/** Build one message record with sensible defaults. `from` is a person id for an
+ *  incoming message, or 'me' for an outgoing one. */
+function message(
+  chatId: string,
+  from: string,
+  body: string,
+  ageMs: number,
+  extra: Partial<Message> = {},
+): Message {
+  const outgoing = from === 'me';
+  return {
+    id: uid(),
+    chatId,
+    senderId: outgoing ? 'me' : from,
+    senderName: outgoing ? 'You' : byId(from).name,
+    body,
+    kind: 'text',
+    timestamp: Date.now() - ageMs,
+    outgoing,
+    status: 'read',
+    updatedAt: Date.now(),
+    ...extra,
+  };
+}
+
+async function putAll<T>(store: 'contacts' | 'chats' | 'messages' | 'media' | 'calls', rows: T[]): Promise<void> {
+  for (const row of rows) await put(store, row as never);
+}
+
+export async function seedShowcase(): Promise<void> {
+  const now = Date.now();
+
+  // --- Contacts ---------------------------------------------------------------
+  const contacts: Contact[] = PEOPLE.map((p) => ({
+    id: p.id,
+    name: p.name,
+    username: p.username,
+    avatar: initialsAvatar(p.name),
+    phone: '',
+    about: p.about,
+    updatedAt: now,
+  }));
+  await putAll('contacts', contacts);
+
+  const messages: Message[] = [];
+  const media: Media[] = [];
+
+  // --- Alice: the rich, pinned conversation we open for the chat-detail shot ---
+  const photoBlob = await gradientPhoto('#fda085', '#f6d365');
+  const photoId = uid();
+  media.push({
+    id: photoId,
+    kind: 'image',
+    mime: 'image/jpeg',
+    name: 'sunrise.jpg',
+    size: photoBlob.size,
+    blob: photoBlob,
+    updatedAt: now,
+  });
+  const voiceBlob = new Blob([new Uint8Array(4096)], { type: 'audio/ogg' });
+  const voiceId = uid();
+  media.push({ id: voiceId, kind: 'voice', mime: 'audio/ogg', name: 'voice.ogg', size: voiceBlob.size, blob: voiceBlob, durationSec: 12, updatedAt: now });
+
+  const aliceImg = message('sc-alice', 'me', 'Sunrise from the hike this morning ⛰️', 40 * MIN, {
+    kind: 'image',
+    mediaId: photoId,
+    status: 'read',
+    reactions: [{ userId: 'sc-alice', emoji: '❤️', at: now - 35 * MIN }],
+  });
+  messages.push(
+    message('sc-alice', 'sc-alice', 'Morning! Did you try the new Ring update? 🎉', 2 * HOUR),
+    message('sc-alice', 'me', 'Yes! The "What’s new" sheet is such a nice touch', 110 * MIN, { status: 'read' }),
+    message('sc-alice', 'sc-alice', 'Voice message', 90 * MIN, { kind: 'voice', mediaId: voiceId, durationSec: 12 }),
+    aliceImg,
+    message('sc-alice', 'sc-alice', 'Gorgeous! Where is this?', 30 * MIN, {
+      replyTo: { id: aliceImg.id, senderId: 'me', preview: 'Sunrise from the hike this morning ⛰️', kind: 'image' },
+    }),
+    message('sc-alice', 'me', 'The ridge above the lake 😄 we should go together', 28 * MIN, { status: 'delivered' }),
+  );
+
+  // --- Daniel: short, unread ---
+  messages.push(
+    message('sc-daniel', 'sc-daniel', 'Are we still on for tomorrow?', 3 * HOUR),
+    message('sc-daniel', 'sc-daniel', 'Let me know 🙏', 50 * MIN),
+  );
+
+  // --- Mom: favorite ---
+  messages.push(message('sc-mom', 'sc-mom', 'Call me when you get a chance ❤️', 5 * HOUR));
+
+  // --- Sofia: a photo preview ---
+  const photo2 = await gradientPhoto('#a1c4fd', '#c2e9fb');
+  const photo2Id = uid();
+  media.push({ id: photo2Id, kind: 'image', mime: 'image/jpeg', name: 'harbor.jpg', size: photo2.size, blob: photo2, updatedAt: now });
+  messages.push(
+    message('sc-sofia', 'sc-sofia', 'From the shoot today 📷', 7 * HOUR, { kind: 'image', mediaId: photo2Id }),
+  );
+
+  // --- Group: Weekend Trip ---
+  const groupMembers = ['sc-alice', 'sc-daniel', 'sc-sofia'];
+  const myMsg = message('sc-trip', 'me', "Perfect, I’ll bring snacks 🍫", 4 * HOUR, {
+    status: 'read',
+    reactions: [{ userId: 'sc-sofia', emoji: '👍', at: now - 3.5 * HOUR }],
+  });
+  messages.push(
+    message('sc-trip', 'sc-alice', "Who’s driving on Saturday?", 5 * HOUR),
+    message('sc-trip', 'sc-daniel', 'I can! 🚗 room for 3', 4.5 * HOUR),
+    myMsg,
+    message('sc-trip', 'sc-sofia', 'Can’t wait! 🏔️', 2 * HOUR),
+  );
+
+  await putAll('messages', messages);
+  await putAll('media', media);
+
+  // --- Chats (previews + ordering) -------------------------------------------
+  const chat = (over: Partial<Chat> & Pick<Chat, 'id' | 'name' | 'avatar' | 'isGroup' | 'participantIds' | 'lastMessage' | 'lastMessageTime'>): Chat => ({
+    unread: 0,
+    updatedAt: now,
+    ...over,
+  });
+  const chats: Chat[] = [
+    chat({
+      id: 'sc-alice', name: 'Alice Rivera', avatar: initialsAvatar('Alice Rivera'), isGroup: false,
+      participantIds: ['sc-alice'], lastMessage: 'The ridge above the lake 😄 we should go together',
+      lastMessageTime: now - 28 * MIN, pinned: true, favorite: true,
+    }),
+    chat({
+      id: 'sc-daniel', name: 'Daniel Okafor', avatar: initialsAvatar('Daniel Okafor'), isGroup: false,
+      participantIds: ['sc-daniel'], lastMessage: 'Let me know 🙏', lastMessageTime: now - 50 * MIN, unread: 2,
+    }),
+    chat({
+      id: 'sc-trip', name: 'Weekend Trip 🏔️', avatar: groupAvatar('sc-trip'), isGroup: true,
+      participantIds: groupMembers, lastMessage: 'Sofia: Can’t wait! 🏔️', lastKind: 'text',
+      lastMessageTime: now - 2 * HOUR, autoName: false,
+    }),
+    chat({
+      id: 'sc-sofia', name: 'Sofia Lindqvist', avatar: initialsAvatar('Sofia Lindqvist'), isGroup: false,
+      participantIds: ['sc-sofia'], lastMessage: '📷 Photo', lastKind: 'image', lastMessageTime: now - 7 * HOUR,
+    }),
+    chat({
+      id: 'sc-mom', name: 'Mom', avatar: initialsAvatar('Mom'), isGroup: false,
+      participantIds: ['sc-mom'], lastMessage: 'Call me when you get a chance ❤️', lastMessageTime: now - 5 * HOUR,
+      favorite: true,
+    }),
+  ];
+  await putAll('chats', chats);
+
+  // --- Call log ---------------------------------------------------------------
+  const calls: Call[] = [
+    { id: uid(), contactId: 'sc-alice', name: 'Alice Rivera', avatar: initialsAvatar('Alice Rivera'), direction: 'incoming', missed: false, video: true, durationSec: 754, timestamp: now - 90 * MIN, updatedAt: now },
+    { id: uid(), contactId: 'sc-trip', name: 'Weekend Trip 🏔️', avatar: groupAvatar('sc-trip'), direction: 'outgoing', missed: false, video: false, durationSec: 1325, timestamp: now - 6 * HOUR, updatedAt: now, isGroup: true, roomId: 'sc-trip', participants: ['Alice Rivera', 'Daniel Okafor'] },
+    { id: uid(), contactId: 'sc-mom', name: 'Mom', avatar: initialsAvatar('Mom'), direction: 'incoming', missed: true, video: false, timestamp: now - 1 * DAY, updatedAt: now },
+    { id: uid(), contactId: 'sc-daniel', name: 'Daniel Okafor', avatar: initialsAvatar('Daniel Okafor'), direction: 'outgoing', missed: false, video: false, durationSec: 96, timestamp: now - 2 * DAY, updatedAt: now },
+  ];
+  await putAll('calls', calls);
+}

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -101,6 +101,7 @@ import { peerPresence } from '@/composables/usePresence';
 import { setSecret } from '@/db/secrets';
 import { getAll, put } from '@/db/idb';
 import { uid } from '@/utils/uid';
+import { seedShowcase as runSeedShowcase } from '@/services/showcase-seed';
 import type { FriendRequest, Media, Message } from '@/db/types';
 import {
   startDirectCall,
@@ -435,6 +436,10 @@ export function installTestHook(): void {
         updatedAt: Date.now(),
       });
     },
+
+    /** Inject the curated showcase demo dataset (contacts, chats, messages, media,
+     *  call log) for the screenshot harness. See services/showcase-seed.ts. */
+    seedShowcase: (): Promise<void> => runSeedShowcase(),
     /** Total on-device media bytes by kind. */
     storageByType: () => dbStorageByType(),
     deleteMediaByKind: (kinds: Media['kind'][], chatId?: string) => dbDeleteMediaByKind(kinds, chatId),


### PR DESCRIPTION
A tool to capture marketing-ready screenshots of the Ring UI across device sizes and themes, by booting the real stack and seeding realistic demo data.

## How it works
Reuses the e2e bootstrap (`e2e/global-setup.ts`: isolated `ringd` + fresh DB + test Vite), registers a passwordless account, seeds a curated dataset via a new **dev-only** `__ringTest.seedShowcase()`, then screenshots each screen.

- **`src/services/showcase-seed.ts`** (dev-only, tree-shaken from prod): injects contacts, 1:1 + group chats with both-sided messages (text, reactions, replies, a canvas-generated image, a voice note), and a call log straight into IndexedDB.
- **`showcase/`**: a separate Playwright config (iPhone/iPad/Pixel/Desktop projects) + capture spec → `showcase/output/<device>/<theme>/NN-screen.png` (gitignored). Screens: auth, chats, a rich chat, calls, contacts, group info, settings, profile.
- **`npm run showcase`** (prereqs in `showcase/README.md`).

## Validated
Ran locally → **64 screenshots** (4 devices × 2 themes × 8 screens). The chats list, rich chat (image/voice/reaction/reply/receipts), and dark mode all render correctly.

## Notes
- Pure stills, no live calls (no fake-media needed); an active-call screen is a future addition (needs two real accounts).
- iPhone/iPad render via Chromium device emulation (iOS UA → Ionic iOS mode); WebKit isn't available on every host (e.g. macOS 12). Swap to `browserName: 'webkit'` for pixel-perfect iOS on a supported host.
- No zero-knowledge/app-behavior impact — dev-only hook + a capture harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
