### PR TITLE
ci: fix duplicate step id in release.yml (startup failure)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       # "since the last release tag" range is this release's changes (the previous tag
       # is still the highest one). Baked into the image for the PWA's "what's new".
       - name: Compose release notes (base64 JSON)
-        id: notes
+        id: notes_b64
         if: steps.check.outputs.exists == 'false'
         run: echo "b64=$(scripts/release-notes.sh | base64 -w0)" >> "$GITHUB_OUTPUT"
 
@@ -97,7 +97,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.ver.outputs.version }}
-            RELEASE_NOTES_B64=${{ steps.notes.outputs.b64 }}
+            RELEASE_NOTES_B64=${{ steps.notes_b64.outputs.b64 }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
The base64 release-notes step (added with the What's-new feature) reused `id: notes`, which the existing "Compose release notes" step already owns. **Duplicate step ids in one job = invalid workflow**, so GitHub reports a *startup failure* on every push — which is why red X's appear on `release.yml` for `develop` and feature branches even though it only triggers on `main`.

It never affected develop/PR CI (different workflow), but **would have failed the next release to `main`**. Renames the step to `id: notes_b64` and fixes the build-arg reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)