### PR TITLE
fix(pwa): update toast version layout + dismiss on What's new

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -235,6 +235,11 @@ ion-toast.app-update-toast {
   --color: #fff;
   --border-radius: 14px;
 }
+/* Defensive: never let a long unbreakable token (e.g. a version with a git sha)
+   wrap one character per line and blow up the toast. */
+ion-toast.app-update-toast::part(message) {
+  overflow-wrap: anywhere;
+}
 ion-toast.app-update-toast::part(button) {
   color: #fff;
 }

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -17,7 +17,7 @@ import { watch } from 'vue';
 import { useRegisterSW } from 'virtual:pwa-register/vue';
 import { toastController, modalController } from '@ionic/vue';
 import { fetchServerConfig } from '@/services/api';
-import { computeDelta, type ReleaseNote } from '@/services/release-notes';
+import { computeDelta, displayVersion, type ReleaseNote } from '@/services/release-notes';
 import WhatsNewSheet from '@/components/WhatsNewSheet.vue';
 
 /** Present the "What's new" sheet with the per-user delta. Resolves true when the
@@ -92,7 +92,10 @@ export function useAppUpdate(): void {
         /* generic message + no notes when config can't be fetched */
       }
       const running = __APP_VERSION__;
-      const label = version && version !== running ? `Ring ${version} is ready to install.` : 'A new version of Ring is ready.';
+      // Display version strips the long +<sha> build metadata (it's an unbreakable
+      // token that otherwise wraps one char per line and wrecks the toast).
+      const shown = displayVersion(version);
+      const label = version && version !== running ? `Ring ${shown} is ready to install.` : 'A new version of Ring is ready.';
 
       // Per-user delta: the changes the incoming build adds that this one didn't have.
       const delta = computeDelta(incoming, __RELEASE_NOTES__ ?? []);
@@ -101,13 +104,12 @@ export function useAppUpdate(): void {
       if (delta.length) {
         buttons.push({
           text: `What's new (${delta.length})`,
+          // No `return false`: tapping this dismisses the toast and opens the sheet,
+          // which carries its own Update / Later actions.
           handler: () => {
-            // Open the sheet; keep the toast open behind it (return false) so Update/
-            // Later stay reachable. An "Update now" inside the sheet installs directly.
-            void presentWhatsNew(version, delta).then((wantsUpdate) => {
+            void presentWhatsNew(shown, delta).then((wantsUpdate) => {
               if (wantsUpdate) void updateServiceWorker(true);
             });
-            return false;
           },
         });
       }

--- a/src/services/release-notes.test.ts
+++ b/src/services/release-notes.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { computeDelta, prettify, type ReleaseNote } from './release-notes';
+import { computeDelta, prettify, displayVersion, type ReleaseNote } from './release-notes';
 
 const note = (sha: string, subject = 'feat: x'): ReleaseNote => ({ sha, subject });
+
+describe('displayVersion', () => {
+  it('drops the +<sha> build metadata that the develop image stamps', () => {
+    expect(displayVersion('0.1.0-dev.127+3ddacbf1750c4e1b75ca0b869f7985b26c24a595')).toBe('0.1.0-dev.127');
+  });
+  it('leaves a clean release or rc version untouched', () => {
+    expect(displayVersion('0.2.0')).toBe('0.2.0');
+    expect(displayVersion('0.2.0-rc.1')).toBe('0.2.0-rc.1');
+  });
+});
 
 describe('computeDelta', () => {
   it('returns the incoming notes the running build did not have (by sha)', () => {

--- a/src/services/release-notes.ts
+++ b/src/services/release-notes.ts
@@ -24,6 +24,13 @@ export function computeDelta(incoming: ReleaseNote[], running: ReleaseNote[]): R
   return incoming.filter((n) => !have.has(n.sha));
 }
 
+/** A version for display: drop semver build metadata (the `+<sha>` the develop image
+ *  stamps, e.g. `0.1.0-dev.127+3ddacbf…`), which is a long unbreakable token that
+ *  wrecks toast/sheet layout. Keeps the pre-release part (`-dev.127`, `-rc.1`). */
+export function displayVersion(v: string): string {
+  return v.split('+')[0];
+}
+
 // Conventional-Commit prefix: type, optional (scope), optional `!`, then `: `.
 const CC_PREFIX = /^[a-z]+(\([^)]*\))?!?:\s*/i;
 


### PR DESCRIPTION
Live bug on device: the update toast was unusable.

**Root cause:** the develop image stamps the full git sha as semver build metadata (`0.1.0-dev.127+3ddacbf…`) — a ~50-char unbreakable token that wrapped **one character per line** and blew the toast up to fill the screen; it also bloated the What's-new sheet header.

**Fixes**
- `displayVersion()` (pure, unit-tested): strips the `+<sha>` build metadata for display (keeps `-dev.127` / `-rc.1`). Used in the toast label and the sheet header.
- "What's new" now **dismisses the toast** and opens the sheet (which already has Update / Later) — no lingering toast.
- Defensive `overflow-wrap: anywhere` on the toast message so no long token can ever wrap per-character again.

Note: the delta itself worked correctly on device (showed the one new change). Verifiable on the next develop update once this is the running build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)