### PR TITLE
feat(pwa): smooth tab transitions (1001)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,5 +222,6 @@ GitFlow. **`develop`** is the integration branch; **`main`** is production.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+`specs/1001-smooth-tab-transitions/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,9 @@ Specs are grouped by category band; status moves
 
 ## ⚡ Ad-hoc (1001–1999)
 
-_None yet._
+| Spec | Title | Status |
+|------|-------|--------|
+| [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Specs are grouped by category band; status moves
 
 | Spec | Title | Status |
 |------|-------|--------|
-| [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | ⚪ planned |
+| [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Specs are grouped by category band; status moves
 
 | Spec | Title | Status |
 |------|-------|--------|
-| [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🟡 in-progress |
+| [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/tab-transitions.spec.ts
+++ b/e2e/tab-transitions.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Smooth tab transitions (spec 1001). The four bottom tabs must appear FULLY
+ * FORMED on switch — header (search + action buttons), structure, and data all
+ * present together — rather than rendering in pieces (title, then controls, then
+ * data), and Settings must show the REAL identity, not the "You"/initials
+ * placeholder. These are driven through the real tab bar so we exercise the warm
+ * stores + eager-loaded pages + keep-alive, not the test hook.
+ *
+ * Frame-by-frame "no pop-in" is verified manually (quickstart.md); here we assert
+ * the observable consequences: controls + content are present together, the empty
+ * state never shows on a populated account, returning a tab restores its content
+ * instantly, and Settings never shows "You".
+ */
+
+const AVATAR = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>';
+
+const tabBtn = (page: any, label: string) => page.locator('ion-tab-button', { hasText: label });
+
+test.describe('tab transitions', () => {
+  test('Settings shows the real identity on first paint, never the "You" placeholder', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const a = await createAccount(ctx, 'TABTRAN1');
+    await a.page.evaluate((av) => (window as any).__ringTest.setProfile('Kamran Real', av), AVATAR);
+
+    // Enter on Chats, then switch to Settings via the tab bar (the warm path).
+    await a.page.goto('/tabs/chats');
+    await tabBtn(a.page, 'Settings').waitFor({ state: 'visible', timeout: 30_000 });
+    await tabBtn(a.page, 'Settings').click();
+    await a.page.waitForURL('**/tabs/settings');
+
+    // Real name present; the generic placeholder name is never shown.
+    await expect(a.page.getByText('Kamran Real')).toBeVisible();
+    await expect(a.page.locator('ion-content').getByText('You', { exact: true })).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test('populated tabs appear fully formed with no empty-state flash, and restore on return', async ({ browser }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    const a = await createAccount(ctxA, 'TABTRAN2');
+    const b = await createAccount(ctxB, 'TABTRAN3');
+    await a.page.evaluate((av) => (window as any).__ringTest.setProfile('Aria', av), AVATAR);
+    await b.page.evaluate((av) => (window as any).__ringTest.setProfile('Bahar', av), AVATAR);
+    await pair(a, b); // gives A a contact "Bahar" and a 1:1 chat with her
+
+    await a.page.goto('/tabs/chats');
+    await tabBtn(a.page, 'Contacts').waitFor({ state: 'visible', timeout: 30_000 });
+
+    // --- Contacts: header controls + content present together; no empty flash ---
+    await tabBtn(a.page, 'Contacts').click();
+    await a.page.waitForURL('**/tabs/contacts');
+    await expect(a.page.getByRole('button', { name: 'Add contact' })).toBeVisible(); // action button
+    await expect(a.page.locator('ion-searchbar').first()).toBeVisible(); // search bar
+    await expect(a.page.getByText('Bahar')).toBeVisible(); // list content
+    await expect(a.page.getByText('No contacts found')).toHaveCount(0); // never flashes empty
+
+    // --- Chats: fully formed, the chat is present ---
+    await tabBtn(a.page, 'Chats').click();
+    await a.page.waitForURL('**/tabs/chats');
+    await expect(a.page.getByRole('button', { name: 'New chat' })).toBeVisible();
+    await expect(a.page.getByText('Bahar')).toBeVisible();
+
+    // --- Return to Contacts: content restored instantly, still no empty flash ---
+    await tabBtn(a.page, 'Contacts').click();
+    await a.page.waitForURL('**/tabs/contacts');
+    await expect(a.page.getByText('Bahar')).toBeVisible();
+    await expect(a.page.getByText('No contacts found')).toHaveCount(0);
+
+    await ctxA.close();
+    await ctxB.close();
+  });
+
+  test('rapid tab switching leaves every tab fully rendered', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const a = await createAccount(ctx, 'TABTRAN4');
+    await a.page.evaluate((av) => (window as any).__ringTest.setProfile('Speedy', av), AVATAR);
+
+    await a.page.goto('/tabs/chats');
+    await tabBtn(a.page, 'Calls').waitFor({ state: 'visible', timeout: 30_000 });
+
+    // Cycle quickly across all four tabs without waiting between taps.
+    for (const t of ['Calls', 'Contacts', 'Settings', 'Chats', 'Calls', 'Settings'] as const) {
+      await tabBtn(a.page, t).click();
+    }
+    // After the burst, the last tab (Settings) must be fully rendered, not stuck
+    // in a placeholder/partial state.
+    await a.page.waitForURL('**/tabs/settings');
+    await expect(a.page.getByText('Speedy')).toBeVisible();
+
+    // And each tab still renders its own page marker when selected.
+    await tabBtn(a.page, 'Calls').click();
+    await expect(a.page.getByRole('button', { name: 'New call' })).toBeVisible();
+    await tabBtn(a.page, 'Contacts').click();
+    await expect(a.page.getByRole('button', { name: 'Add contact' })).toBeVisible();
+
+    await ctx.close();
+  });
+});

--- a/specs/1001-smooth-tab-transitions/checklists/requirements.md
+++ b/specs/1001-smooth-tab-transitions/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Smooth Tab Transitions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- "Native feeling" is given a concrete definition in Assumptions and verifiable
+  criteria in SC-001..SC-005 (frame-by-frame absence of partial states, no
+  layout shift, no placeholder identity), so it passes the testable/unambiguous bar.

--- a/specs/1001-smooth-tab-transitions/checklists/zero-knowledge.md
+++ b/specs/1001-smooth-tab-transitions/checklists/zero-knowledge.md
@@ -1,0 +1,65 @@
+# Zero-Knowledge & Privacy Requirements Checklist: Smooth Tab Transitions
+
+**Purpose**: Validate that the zero-knowledge / privacy requirements for this
+feature are complete, clear, consistent, and measurable BEFORE implementation.
+Required by Constitution Principle I (this spec introduces an in-memory cache of
+decrypted user content). This tests the *requirements writing*, not the code.
+**Created**: 2026-06-15
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [data-model.md](../data-model.md)
+**Audience / timing**: Reviewer at PR / pre-implementation gate. Depth: Standard.
+
+## Zero-Knowledge Boundary Completeness
+
+- [x] CHK001 Are the requirements explicit that no new data crosses the client/server wire as a result of this feature? [Completeness, Spec §Zero-Knowledge Impact]
+- [x] CHK002 Is it specified that no new server-side log line, metric, or error payload is introduced by the warm-cache change? [Completeness, Spec §Zero-Knowledge Impact]
+- [x] CHK003 Are the data categories held in the warm cache (own-profile name/avatar, chat/call/contact lists) each enumerated as user content subject to the boundary? [Completeness, Data-model §In-memory warm stores]
+- [x] CHK004 Is there a requirement stating that no migration, object store, or `DB_VERSION` change is introduced (so no new at-rest surface is created)? [Completeness, Plan §Technical Context]
+
+## Plaintext-at-Rest Prohibition (the core decision)
+
+- [x] CHK005 Is the requirement that decrypted profile/list values live **in memory only** stated unambiguously (not "should", not implied)? [Clarity, Spec §Zero-Knowledge Impact / FR-ZK-1]
+- [x] CHK006 Is the prohibition on persisting any warm-cache plaintext to clear storage (IndexedDB, localStorage, sessionStorage, SW caches) stated as a testable invariant? [Measurability, Spec §FR-ZK-1 / Data-model §Validation/invariants]
+- [x] CHK007 Is the rejected alternative (a cleartext-at-rest cache) documented with its rationale, so the decision is traceable? [Traceability, Research §D2]
+- [x] CHK008 Is "clear storage" defined or scoped enough that a reviewer can objectively check no excluded medium (e.g., service-worker cache, in-flight serialization) leaks plaintext? [Ambiguity → resolved, Spec §FR-ZK-1 enumerates media + reload/cross-origin scope]
+
+## Lifecycle: Warm & Clear-on-Lock
+
+- [x] CHK009 Is the trigger for warming the cache (keystore unlock / `isUnlocked` → true) specified precisely enough to be verifiable? [Clarity, Contracts/warm-stores.md §Wiring]
+- [x] CHK010 Is the requirement that the cache is fully cleared on lock/teardown stated, including "no decrypted residue reachable in memory"? [Completeness, Spec §FR-ZK-2 / Data-model §lifecycle]
+- [x] CHK011 Is "fully cleared" measurable — does a requirement define what evidence proves no residue remains (e.g., refs reset to cold initial values)? [Measurability, Spec §FR-ZK-3 / SC-006]
+- [x] CHK012 Are requirements defined for the sign-out / account-removal path (not just lock) to ensure the warm cache does not outlive the session? [Coverage, Spec §FR-ZK-2 / Tasks §T006]
+- [x] CHK013 Is behavior specified for the locked state (app open but keystore locked) — that the cache stays cold and falls back to the non-identifying placeholder? [Coverage, Spec §FR-ZK-5]
+
+## Consistency With Existing Crypto/Privacy Invariants
+
+- [x] CHK014 Do the warm-cache requirements stay consistent with reading secrets only through the existing `getSecret` path (no new decryption route)? [Consistency, Spec §FR-ZK-7 / Research §D2]
+- [x] CHK015 Is it consistent that the warm stores still subscribe to the `idb` change bus, so a profile edit or list change propagates without re-introducing stale plaintext or a reload? [Consistency, Data-model §lifecycle]
+- [x] CHK016 Are the privacy/data-minimization requirements aligned — i.e., the feature collects/transmits nothing new (Constitution IX)? [Consistency, Spec §Zero-Knowledge Impact]
+- [x] CHK017 Do the requirements avoid conflict between "show real identity on first paint" (FR-005) and "never reveal plaintext at rest" — resolved explicitly via the in-memory path? [Conflict → resolved, Spec §FR-005 + §FR-ZK-1/FR-ZK-7]
+
+## Acceptance Criteria & Verifiability
+
+- [x] CHK018 Is there a measurable acceptance criterion that an inspection of clear storage after using all tabs reveals no profile/list plaintext? [Measurability, Spec §SC-006 / Tasks §T025b]
+- [x] CHK019 Is the zero-knowledge invariant represented in the task list with an explicit verification step (not only prose in the spec)? [Traceability, Tasks §T025b, §T026]
+- [x] CHK020 Is the unit-test obligation for "clearWarm leaves no decrypted residue" captured as a requirement, with a definition of pass/fail? [Measurability, Spec §FR-ZK-3 / Tasks §T003]
+
+## Edge Cases & Failure Modes
+
+- [x] CHK021 Are requirements defined for a failed/aborted unlock — that warming does not run and no partial plaintext is cached? [Edge Case, Spec §FR-ZK-4]
+- [x] CHK022 Is behavior specified if `getSecret` decryption fails mid-warm (does the cache stay cold/empty rather than caching a partial or fallback value as if real)? [Exception Flow, Spec §FR-ZK-4 / Tasks §T003]
+- [x] CHK023 Are requirements defined for app backgrounding/resume so the warm cache's plaintext lifetime matches the intended unlocked-session scope (re: "Returning after backgrounding" edge case)? [Coverage, Spec §FR-ZK-2/FR-ZK-5 — lifetime bound to unlocked session, cleared on lock]
+- [x] CHK024 Is the multi-tab / multi-window PWA case considered — does any requirement address whether warm plaintext could be shared or leaked across contexts? [Coverage, Spec §Assumptions — per-context singleton, no cross-context sharing]
+
+## Scope Boundary & Assumptions
+
+- [x] CHK025 Is the assumption that "no server/wire/data-model change is required" stated and validated against the actual design (warm cache is purely client-side)? [Assumption, Spec §Assumptions]
+- [x] CHK026 Are the surfaces that consume own-profile (call tiles, group lists, reply quotes, media captions) in-scope for the same in-memory guarantee, or explicitly out of scope? [Boundary, Spec §FR-ZK-6 / Contracts/warm-stores.md §useSelfProfile]
+- [x] CHK027 Is it documented that this feature does not weaken the existing AEAD-at-rest wrapping of secrets (only adds an in-memory read cache on top)? [Clarity, Spec §FR-ZK-7]
+
+## Notes
+
+- Check items off as completed: `[x]`. Record findings inline.
+- An unchecked item is a requirements-quality gap to fix in spec/plan/data-model
+  before `/speckit-implement` — not an implementation bug.
+- This checklist intentionally tests the *requirements*, not the code; behavioral
+  verification lives in the e2e/unit tasks (T003, T026).

--- a/specs/1001-smooth-tab-transitions/contracts/rendering-invariants.md
+++ b/specs/1001-smooth-tab-transitions/contracts/rendering-invariants.md
@@ -1,0 +1,58 @@
+# UI Contract: Tab-Switch Rendering Invariants
+
+This is the observable contract the feature must satisfy. It is technology-agnostic
+and frame-based, so it can be checked by visual capture and by e2e assertions.
+
+## Invariant R1 — Complete first frame (FR-001, FR-002, SC-001)
+
+For any switch from tab A to tab B, every painted frame shows **either** tab A
+**or** a fully-formed tab B. There is no frame in which tab B is missing any of:
+
+- its title,
+- its search field,
+- its top action buttons (Calls: new group / new call; Contacts: add contact;
+  Chats: compose; Settings: QR + search field),
+- its filter chips (Chats: All / Unread / Favorites / Groups),
+- its list content (when data exists).
+
+## Invariant R2 — No layout shift after first paint (FR-004, SC-002)
+
+No element present in tab B's first painted frame changes position in any later
+frame. Space for asynchronously-arriving regions is reserved up front.
+
+## Invariant R3 — Real identity immediately (FR-005, SC-003)
+
+When Settings (or any surface showing the user's own avatar/name) appears and a
+real profile exists, the real photo and name are present in the first painted
+frame. The generic "You"/initials placeholder is never shown in place of an
+existing real profile.
+
+## Invariant R4 — Instant return with preserved state (FR-003, SC-004)
+
+Returning to a tab visited earlier in the session restores its previous content
+and scroll position with no re-render of empty or placeholder states.
+
+## Invariant R5 — Honest empty states (FR-006)
+
+An empty state ("No calls found", "No contacts found", empty Chats) is shown only
+once the absence of data is confirmed — never as a flash preceding real content.
+
+## Invariant R6 — Stable under stress (FR-007, FR-009, FR-010)
+
+- Rapid/repeated tab switching never surfaces a half-built screen or leaves a tab
+  stuck in a placeholder/partial state.
+- Behavior is identical across supported themes and for LTR and RTL content.
+- On a genuinely cold first run, a single stable loading presentation is shown
+  that does not shift layout when real content arrives (no
+  empty→placeholder→populated sequence).
+
+## How each invariant is verified
+
+| Invariant | Verification |
+|-----------|--------------|
+| R1 | e2e: after switching to a (warm) tab, header + chips + list assert present synchronously; manual frame capture |
+| R2 | manual frame capture / visual diff: no element bounding-box change after first paint |
+| R3 | e2e: open Settings, assert real display name present without an intervening "You" text |
+| R4 | e2e: scroll a tab, switch away and back, assert content + scrollTop preserved, no empty-state element |
+| R5 | e2e: empty account shows empty state; populated account never renders empty-state element before list |
+| R6 | e2e: rapid tab cycling leaves each tab fully rendered; bidi spec coverage for RTL |

--- a/specs/1001-smooth-tab-transitions/contracts/warm-stores.md
+++ b/specs/1001-smooth-tab-transitions/contracts/warm-stores.md
@@ -1,0 +1,64 @@
+# Internal Contract: Shared Warm Stores
+
+Internal module API (not a network/public interface) for the in-memory warm cache
+layer. Names are indicative; the implementation may refine them.
+
+## Module `src/composables/warmStores.ts` (new)
+
+```ts
+// Eagerly populate all warm stores. Idempotent. Called when the keystore unlocks.
+export function warmAll(): void;
+
+// Clear all warm stores (drop decrypted values from memory). Called on lock/teardown.
+export function clearWarm(): void;
+```
+
+### Contract
+
+- `warmAll()` MUST be safe to call multiple times; a second call while warm is a
+  no-op (or a cheap refresh), never a reset to cold.
+- `warmAll()` MUST only run its decrypt/query work when `isUnlocked` is true.
+- `clearWarm()` MUST leave no decrypted profile/list values reachable in memory
+  (Principle I). It MUST be wired to the same lock transition the rest of the app
+  uses (`isUnlocked` → false).
+- Warm stores MUST stay live: they subscribe to the relevant `idb` change-bus
+  stores so user edits propagate without a reload.
+
+## `useSelfProfile()` (converted to singleton-backed)
+
+```ts
+export function useSelfProfile(): { name: Ref<string>; avatar: Ref<string> };
+```
+
+- Returns refs backed by the **shared** SelfProfileStore singleton (same identity
+  across all callers), not freshly-created per-call `useLiveQuery` refs.
+- Fallback semantics unchanged: `@username` → "You" for name while cold/locked; a
+  generated initials avatar when no photo is set. A face/name is always shown.
+- Existing call sites keep working with no API change.
+
+## `useLiveQuery(...)` (optional warm-source)
+
+```ts
+export function useLiveQuery<T>(
+  querier: () => Promise<T>,
+  stores: StoreName[],
+  initial: T,
+  deps?: () => unknown,
+  warmSource?: () => T | undefined,   // NEW (optional)
+): LiveRef<T>;
+```
+
+- When `warmSource` returns a defined value, it is used as the first paint value
+  (and `loaded` is treated as already true) instead of `initial`.
+- When `warmSource` is absent or returns `undefined`, behavior is **identical to
+  today** (no breaking change to existing callers).
+
+## Wiring contract
+
+- `warmAll()` is invoked when `isUnlocked` transitions to `true` (e.g. from the
+  app-entry / `useKeyGuard` unlock path) — before the user can navigate tabs.
+- `clearWarm()` is invoked on the lock transition.
+- Tab pages (Chats/Calls/Contacts) read their list from the corresponding warm
+  store for first paint and derive search/pagination as page-local `computed`s.
+- `SettingsPage.vue` drops its inlined cold profile reads and uses
+  `useSelfProfile()`.

--- a/specs/1001-smooth-tab-transitions/data-model.md
+++ b/specs/1001-smooth-tab-transitions/data-model.md
@@ -1,0 +1,93 @@
+# Phase 1 Data Model: Smooth Tab Transitions
+
+This feature introduces **no persistent data model change** — no new IndexedDB
+object store, no `DB_VERSION` bump, no SQL migration, no wire schema. IndexedDB
+(via `src/db/idb.ts`) and the encrypted-at-rest secrets remain the source of
+truth, unchanged.
+
+What it does add is an **in-memory, derived state layer**: module-level singleton
+reactive views that mirror data already in IndexedDB so it is available
+synchronously at a tab's first paint. These are caches, not storage.
+
+## In-memory warm stores (transient, derived)
+
+Each store is a module-level singleton living only for the app session. It is
+populated by the existing `getSecret` / list-query paths, stays live via the
+`idb` change bus, and is **cleared on lock/teardown**.
+
+### SelfProfileStore (singleton)
+
+| Field      | Type            | Initial (cold) | Warm value                          | Notes |
+|------------|-----------------|----------------|-------------------------------------|-------|
+| `name`     | `Ref<string>`   | username → "You" | decrypted `profileName`            | falls back to `@username` then "You" only while cold/locked |
+| `avatar`   | `Ref<string>`   | initials avatar | decrypted `profileAvatar` (data URL) | falls back to generated initials avatar so a face always shows |
+| `warmed`   | `Ref<boolean>`  | `false`        | `true` after first successful decrypt | drives whether first paint is "real" |
+
+- **Source**: `getSecret('profileName')`, `getSecret('profileAvatar')` (existing).
+- **Lifecycle**: warmed eagerly when `isUnlocked` becomes `true`; updated live when
+  the user edits their profile (the `settings` store change bus); cleared on lock.
+- **Consumers**: `SettingsPage.vue` and every existing `useSelfProfile()` caller
+  (call tiles, group member lists, reply quotes, media captions).
+
+### List warm stores: Chats / Calls / Contacts (singletons)
+
+| Field      | Type                 | Initial (cold) | Warm value                | Notes |
+|------------|----------------------|----------------|---------------------------|-------|
+| `items`    | `Ref<T[]>`           | `[]`           | result of the list query  | `T` = Chat / CallGroup / Contact |
+| `loaded`   | `Ref<boolean>`       | `false`        | `true` after first resolve | gates empty-state rendering |
+
+- **Source**: existing `listChats` / `listCallGroups` / `listContacts` queries,
+  invoked with an **empty search term** (the default/unfiltered list).
+- **Search contract**: The warm store holds only the **unfiltered** default list —
+  this is what first paint needs (a tab is always entered with an empty search box).
+  Search term is page-local UI state. When the search box is **empty**, the page
+  renders from the warm store (instant, populated first paint). When the user
+  **types a term**, the page falls back to the existing live query path
+  (`listChats(term)` / `listContacts(term)` / `listCallGroups(term)`) — this is an
+  active-interaction moment where a brief async resolve is acceptable and avoids
+  re-implementing data-layer filtering on the client. Net effect: no behavior or
+  search-semantics change versus today; only the empty-search first paint becomes
+  warm. Pagination (`visible`) stays page-local and resets on term change as today.
+- **Lifecycle**: warmed at unlock; kept live via the `idb` change bus
+  (`chats`/`messages`/`chatlists`, calls, contacts stores); cleared on lock.
+
+## State transitions (per store)
+
+```text
+[locked / pre-unlock]
+      │  isUnlocked → true  (warmAll())
+      ▼
+[warming]  ── first query/getSecret resolves ──►  [warm]  (loaded/warmed = true)
+      ▲                                              │
+      │                                  idb change bus fires (live edit)
+      │                                              ▼
+      │                                          [warm, refreshed]
+      │  isUnlocked → false (lock / teardown)
+      └──────────────────────  [cleared]  ◄─────────┘
+```
+
+## Relationship to `useLiveQuery`
+
+`useLiveQuery` keeps its current contract (initial value + async resolve + live
+subscription) and gains an **optional warm-source** parameter so a page can supply
+the singleton's current value as its `initial`. When a warm value exists, the first
+paint is already populated and `loaded` is effectively true; when cold, behavior is
+exactly as today. No breaking change to existing callers.
+
+## Validation / invariants
+
+- The warm cache MUST never be serialized to clear storage (Principle I; spec
+  FR-ZK-1) — not IndexedDB, `localStorage`, `sessionStorage`, Cache Storage, or any
+  serialized form.
+- A consumer MUST treat the warm value as authoritative for first paint but still
+  reactive to live edits (no stale lock-in).
+- Clearing MUST run on **every** session-end transition — keystore lock, sign-out,
+  and account removal (spec FR-ZK-2) — and MUST be complete: every ref returns to
+  its cold initial value (lists `[]` + `loaded=false`; profile name→username/"You",
+  avatar→initials, `warmed=false`). This is the verifiable evidence of "no residue"
+  (spec FR-ZK-3 / SC-006).
+- `warmAll()` MUST run only when unlocked; a failed/aborted unlock MUST NOT warm
+  any store. If a `getSecret`/list query fails mid-warm, that store stays cold (its
+  cold fallback) rather than caching a partial/fallback value as real (spec FR-ZK-4).
+- The singleton is scoped to one document/JS context; separate PWA tabs/windows do
+  not share warm plaintext (spec Assumptions).

--- a/specs/1001-smooth-tab-transitions/plan.md
+++ b/specs/1001-smooth-tab-transitions/plan.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Smooth Tab Transitions
+
+**Branch**: `feat/1001-smooth-tab-transitions` | **Date**: 2026-06-15 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1001-smooth-tab-transitions/spec.md`
+
+## Summary
+
+Tab switching shows the destination screen rendering in pieces — title first, then
+search bar / action buttons / filter chips, then list data, and on Settings a
+placeholder "You"/initials profile that swaps to the real photo and name. The
+root causes are: (1) the four tab pages are **lazy-loaded** (`() => import()`), so
+the first switch pays a chunk fetch + fresh mount; (2) every tab reads its data
+through `useLiveQuery`, which starts at an **empty `initial` value** and resolves
+asynchronously, so the first paint is empty/placeholder; (3) own-profile is read
+through a **per-call factory** (`useSelfProfile`) that always starts at the
+`'You'`/initials fallback and decrypts async; (4) Calls and Contacts show their
+"No … found" empty state with **no `loaded` gate**, so they can flash empty before
+data arrives.
+
+The approach is entirely client-side presentation/navigation work, no wire or
+data-model changes:
+
+1. **Warm, shared in-memory stores.** Promote own-profile (and the per-tab list
+   queries) from cold per-mount factories to **module-level singletons** that are
+   **eagerly warmed right after keystore unlock**, so by the time the user
+   navigates, the reactive values are already populated. A tab then mounts with
+   real data in its first paint instead of an empty/placeholder state. The warm
+   cache lives only in memory (decrypted client-side); nothing plaintext is
+   persisted in the clear — this preserves the zero-knowledge boundary.
+2. **Eager-load the four tab page components** (static imports for the `/tabs`
+   children) so the first switch has no chunk-fetch/parse delay.
+3. **Rely on and lock in `IonRouterOutlet` keep-alive** for return visits
+   (instant restore of content + scroll), with an e2e test that proves a
+   previously-visited tab restores without re-showing empty states.
+4. **Gate every empty state behind `loaded`** (Calls, Contacts — Chats already
+   does this) as defense-in-depth against the empty-flash, and **reserve layout
+   space** for late elements to remove post-paint layout shift.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES modules, `@/` → `src/`), Vue 3 `<script setup>`, Ionic Vue 8
+
+**Primary Dependencies**: `@ionic/vue` + `@ionic/vue-router` (IonTabs / IonRouterOutlet / iosTransitionAnimation), Vue 3 reactivity, libsodium-backed `getSecret` (read-only here), IndexedDB via `src/db/idb.ts` + `useLiveQuery`
+
+**Storage**: IndexedDB is the source of truth (unchanged). This feature adds an **in-memory** warm cache only — no new object store, no `DB_VERSION` bump, no cleartext-at-rest.
+
+**Testing**: `vue-tsc --noEmit` typecheck (`npm run build`), vitest unit (`npm run test:unit`), Playwright e2e (`npm run test:e2e`, driven via `window.__ringTest`)
+
+**Target Platform**: Installable PWA; primary risk surface is iOS WebKit (large-title transition, no WS headers), plus Android/desktop browsers
+
+**Project Type**: Single project — Vue 3 + Ionic PWA client (no server changes)
+
+**Performance Goals**: 60 fps tab transition; destination screen visually complete in its first painted frame on return visits and (with warm caches) on first visit; zero layout shift after first paint
+
+**Constraints**: Must not persist profile/list plaintext in the clear (zero-knowledge); must not regress RTL/bidi or a11y; must keep `swipeBackEnabled: false` / `scrollAssist: false` and the existing `switchTab('root','replace')` navigation semantics that fixed prior tab-highlight desync; must not silently reload the PWA (`registerType: 'prompt'`)
+
+**Scale/Scope**: 4 bottom-tab pages (Calls, Chats, Contacts, Settings), 1 router config, 1 shared-profile composable, `useLiveQuery` (optional warm-source support), the existing in-memory warm stores; no backend
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary (NON-NEGOTIABLE)** — PASS. Nothing new crosses the
+  wire; the server is untouched. The one sensitive design choice — how to make
+  the profile appear instantly — is resolved **in memory only**: decrypt via the
+  existing `getSecret` once at unlock and hold the result in a module-level
+  reactive cache. We explicitly **reject** any cleartext-at-rest profile/list
+  cache. The spec's *Zero-Knowledge Impact* section records this.
+- **II. Spec-Driven Development** — PASS. Spec → (clarify skipped: unambiguous) →
+  this plan → tasks → analyze → implement, all under `1001-` with traceable branch.
+- **III. Test-Driven Development** — PASS (planned). New user-facing behavior adds
+  e2e specs under `e2e/` (no empty-flash, instant return with preserved scroll,
+  real identity on first Settings paint). Shared warm-store composable gets vitest
+  unit tests. Tests are authored before implementation in `tasks.md` ordering.
+- **IV. Crypto Discipline** — PASS. No crypto is added or changed; we only *read*
+  existing secrets through the existing `getSecret` path. The crypto core stays
+  pure; the warm cache lives in the service/composable layer.
+- **V. Offline-First Data Integrity** — PASS. IndexedDB stays the source of truth;
+  no store added, no `DB_VERSION` bump. Warm caches are derived in-memory views
+  that still subscribe to the `idb` change bus (live edits propagate).
+- **VI. Stateless Server & Forward-Only Migrations** — PASS. No server/DB change.
+- **VII. Quality Gates** — PASS (planned). `npm run build`, vitest + floors, e2e
+  where behavior changed; `registerType: 'prompt'` preserved.
+- **IX. Privacy & Data Minimization** — PASS. No new data collected/transmitted.
+- **X. Accessibility & Internationalization** — PASS. Ionic-native components kept;
+  RTL/bidi and a11y explicitly covered by FR-009 and a regression check.
+
+**Checklist requirement**: This spec makes an explicit decision bearing on
+**Principle I** (in-memory vs at-rest profile cache), so `/speckit-checklist` is
+REQUIRED before `/speckit-implement` (see Domain Constraints in the constitution).
+
+**Gate result**: PASS — no violations; Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1001-smooth-tab-transitions/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (in-memory warm-cache state shapes)
+├── quickstart.md        # Phase 1 output (how to verify smoothness)
+├── contracts/           # Phase 1 output
+│   ├── rendering-invariants.md   # UI contract: what every tab-switch frame guarantees
+│   └── warm-stores.md            # internal module API for the shared warm stores
+└── checklists/
+    └── requirements.md  # spec quality checklist (from /speckit-specify)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── router/
+│   └── index.ts                 # /tabs children: lazy import() → static import (eager-load)
+├── views/
+│   ├── TabsPage.vue             # IonTabs/IonRouterOutlet host; confirm keep-alive holds with switchTab('root','replace')
+│   └── tabs/
+│       ├── ChatsPage.vue        # consume shared warm chat store; keep loaded-gate
+│       ├── CallsPage.vue        # consume shared warm calls store; ADD loaded-gate to empty state
+│       ├── ContactsPage.vue     # consume shared warm contacts store; ADD loaded-gate to empty state
+│       └── SettingsPage.vue     # adopt shared singleton self-profile (drop inlined cold copy)
+├── composables/
+│   ├── useSelfProfile.ts        # factory → module-level singleton; warm eagerly at unlock
+│   ├── useLiveQuery.ts          # optional: accept a warm-source so `initial` can be a populated cached value
+│   └── (new) warmStores.ts      # module-level shared chats/calls/contacts/profile refs + warmAll() on unlock
+└── (wiring) app entry / useKeyGuard.ts  # call warmAll() when isUnlocked flips true
+
+e2e/
+├── tab-transitions.spec.ts      # NEW: no empty-flash, instant return + scroll, real identity on first Settings paint
+└── (existing specs unchanged)
+
+src/composables/__tests__/ (or sibling *.test.ts)
+└── warmStores / useSelfProfile singleton unit tests   # NEW
+```
+
+**Structure Decision**: Single-project Vue 3 + Ionic PWA. All changes are
+client-side under `src/` (router, four tab views, profile/live-query composables,
+one new warm-stores module) plus tests under `e2e/` and vitest unit files. No
+`server/`, no migrations, no `DB_VERSION` change.
+
+## Complexity Tracking
+
+*No constitution violations — section intentionally empty.*

--- a/specs/1001-smooth-tab-transitions/quickstart.md
+++ b/specs/1001-smooth-tab-transitions/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart: Verifying Smooth Tab Transitions
+
+How to reproduce the problem and confirm the fix. Assumes the standard dev stack.
+
+## Run the app
+
+```sh
+make start          # PostgreSQL + ringd (air) + Vite on http://localhost:5173
+```
+
+Register/sign in with a dev invite code so the account has some chats, calls, and
+contacts (the flicker is most visible with real data + a profile photo set).
+
+## Reproduce the original problem (baseline)
+
+1. Open the app on a phone or in a mobile-emulated viewport.
+2. Tap rapidly between the four bottom tabs (Calls ↔ Chats ↔ Contacts ↔ Settings).
+3. Observe on each switch (record a screen video and step frames if needed):
+   - destination tab shows its **title first**, then the search bar / action
+     buttons / filter chips pop in;
+   - Calls/Contacts briefly show "No … found" before the list appears;
+   - Settings shows a "You"/initials avatar that swaps to the real photo + name.
+
+## Confirm the fix
+
+After implementation, repeat the same steps and confirm the rendering invariants
+in `contracts/rendering-invariants.md`:
+
+- **R1**: every frame of a switch shows either the old tab or a fully-formed new
+  tab — search bar, action buttons, filter chips, and list are present together.
+- **R2**: nothing shifts position after the first frame of the new tab.
+- **R3**: Settings shows the real photo + "Kamran" immediately, no "You" flash.
+- **R4**: scroll a tab, leave and return — content and scroll position restored,
+  no empty-state flash.
+- **R5**: an empty account shows the empty state cleanly; a populated account never
+  flashes the empty state.
+- **R6**: rapid cycling stays fully rendered; check an RTL chat (existing bidi
+  fixtures) looks correct.
+
+## Automated checks
+
+```sh
+npm run build          # vue-tsc typecheck + vite build
+npm run test:unit      # vitest: warm-store singleton + clearing-on-lock + useSelfProfile sharing
+make db-up             # once, for e2e
+npm run test:e2e       # Playwright incl. e2e/tab-transitions.spec.ts
+```
+
+The e2e spec drives the app via `window.__ringTest`, switches tabs, and asserts:
+no empty-state element appears before the list on a populated account; a return
+visit preserves content + scrollTop; the Settings display name is real on first
+paint. RTL coverage stays in `e2e/bidi.spec.ts`.
+
+## Notes
+
+- The warm cache is **in memory only**; locking the app (or signing out) must clear
+  decrypted profile/list values. Verify nothing plaintext is persisted in the clear.
+- Do not change `swipeBackEnabled`/`scrollAssist` or the `switchTab('root',
+  'replace')` semantics — those fixed a prior tab-highlight desync.

--- a/specs/1001-smooth-tab-transitions/research.md
+++ b/specs/1001-smooth-tab-transitions/research.md
@@ -1,0 +1,122 @@
+# Phase 0 Research: Smooth Tab Transitions
+
+This document records the investigation of the current rendering pipeline and the
+decisions that resolve each cause of visible pop-in on tab switch. No open
+`NEEDS CLARIFICATION` items remain.
+
+## Current behavior (as found in code)
+
+- **Tabs host** (`src/views/TabsPage.vue`): bare `<ion-router-outlet>` inside
+  `<ion-tabs>`; tab taps call `switchTab()` →
+  `ionRouter.navigate(path, 'root', 'replace', emptyAnimation)`. The `'root'`
+  direction + empty animation were deliberate fixes for a prior tab-highlight /
+  page desync bug — must be preserved.
+- **Routing** (`src/router/index.ts`): all four `/tabs` children are
+  `() => import()` (lazy chunks). Auth guard redirects unauthenticated users to
+  `/auth`.
+- **Ionic init** (`src/main.ts`): `IonicVue` configured with
+  `swipeBackEnabled: false`, `scrollAssist: false`, and a custom `navAnimation`
+  (empty for `'back'`, `iosTransitionAnimation` forward). Relies on
+  `IonRouterOutlet`'s default page caching (pages stay mounted, hidden off-screen).
+- **Data loading** (`src/composables/useLiveQuery.ts`): every query starts at a
+  caller-supplied `initial` value with `loaded=false`, calls `run()` on mount, and
+  resolves the real value in a later microtask; `loaded` flips true after the first
+  resolve. So the **first paint of a freshly-mounted page is always the empty/
+  placeholder state.**
+- **Per-tab specifics**:
+  - Chats: header (search + filter chips) renders unconditionally; empty state is
+    correctly gated `v-if="loaded && chats.length === 0"`.
+  - Calls: empty state `v-if="calls.length === 0"` — **no `loaded` gate** → can
+    flash "No calls found".
+  - Contacts: empty state `v-if="contacts.length === 0"` — **no `loaded` gate** →
+    can flash "No contacts found".
+  - Settings: own-profile read via cold `useLiveQuery` (`name='You'`,
+    `avatar=''→initials`), resolves after keystore unlock → visible "You"/"Y" →
+    real "Kamran"/photo swap. `useSelfProfile` is a **factory**, not a singleton,
+    so every mount restarts cold.
+
+## Decisions
+
+### D1 — Eager-load the four tab page components
+
+- **Decision**: Change the `/tabs` child routes from `() => import()` to **static
+  imports** so the tab components are in the entry graph and incur no chunk fetch /
+  parse delay on first switch.
+- **Rationale**: The four tabs are the app's core surface, reachable within
+  seconds of launch and already precached by the service worker. Lazy-splitting
+  them saves negligible initial bytes while guaranteeing a first-switch stall.
+- **Alternatives considered**:
+  - *Idle prefetch of the other three chunks after the first tab paints* — keeps a
+    smaller entry chunk but leaves a race if the user switches before prefetch
+    completes; more moving parts. Rejected in favor of deterministic static import.
+  - *Status quo (lazy)* — rejected; it is a direct cause of the pop-in.
+
+### D2 — Shared, warm in-memory stores (the core fix)
+
+- **Decision**: Introduce module-level **singleton** reactive stores for
+  own-profile and the per-tab lists (chats, calls, contacts), and **warm them
+  eagerly when the keystore unlocks** (`isUnlocked` flips true, e.g. via
+  `useKeyGuard`/app entry). Tab pages and `useSelfProfile` consume these shared
+  refs instead of creating cold per-mount queries. `useLiveQuery` gains an optional
+  warm-source so a page's first `initial` value can be the already-populated cached
+  value rather than `[]`/`'You'`.
+- **Rationale**: This makes the destination screen's data present in its **first
+  painted frame** on both first and return visits, which is what "appears fully
+  formed" (FR-001, FR-002, SC-001) and "real identity immediately" (FR-005, SC-003)
+  require. Sharing the refs also means edits propagate everywhere (the stores still
+  subscribe to the `idb` change bus), and avoids redundant re-decryption per mount.
+- **Zero-knowledge**: the warm cache holds decrypted values **in memory only**,
+  produced by the existing `getSecret` path. No plaintext is written to clear
+  storage; on lock/teardown the in-memory refs are cleared. This is the explicit
+  Principle-I decision (see plan Constitution Check and spec Zero-Knowledge Impact).
+- **Alternatives considered**:
+  - *Cleartext-at-rest cache of last-known profile/lists for instant first paint* —
+    **rejected**: violates the zero-knowledge boundary (profile/contacts/chat
+    metadata are user content and must be AEAD-wrapped at rest).
+  - *Skeleton placeholders instead of real data* — acceptable only as a fallback
+    when caches are genuinely cold (see D4); not a substitute for warm data because
+    the spec asks for the *real* screen, not a shimmer.
+
+### D3 — Lock in `IonRouterOutlet` keep-alive for return visits
+
+- **Decision**: Keep relying on Ionic's page caching so a previously-visited tab is
+  restored instantly with its content and scroll position; add an e2e test that
+  fails if a return visit re-shows an empty/placeholder state or loses scroll, and
+  verify `switchTab('root','replace')` does not tear pages down.
+- **Rationale**: Satisfies FR-003 / SC-004 with the framework's built-in mechanism;
+  the test prevents future regressions (e.g. someone adding `v-if` on the outlet).
+- **Risk + fallback**: `switchTab` uses the `'root'` direction + `'replace'` action
+  (a deliberate fix for a prior tab-highlight desync) — these MUST be preserved. If
+  that combination turns out to **not** retain the cached page (so scroll/content is
+  lost on return), the warm stores already restore *content* on the next mount, but
+  **scroll position** would still be lost. Fallback for that case only: persist each
+  tab's `scrollTop` on `onIonViewWillLeave` and restore it on `onIonViewDidEnter`
+  (in-memory, page-local). This fallback is conditional — implemented only if the
+  keep-alive verification fails.
+- **Alternatives considered**: *Explicit `<keep-alive>`* — redundant with
+  `IonRouterOutlet` and can conflict with Ionic's lifecycle; rejected. *Changing
+  `'root'`/`'replace'` to restore caching* — rejected; would reopen the desync bug.
+
+### D4 — Gate empty states behind `loaded`; reserve layout space
+
+- **Decision**: Add a `loaded` gate to the Calls and Contacts empty states (mirror
+  Chats), and reserve vertical space for late-arriving header/list regions so
+  nothing reflows after first paint.
+- **Rationale**: Defense-in-depth against the empty-flash (FR-006) even if a cache
+  is momentarily cold, and removes post-paint layout shift (FR-004 / SC-002).
+- **Alternatives considered**: *Rely solely on warm caches* — rejected; the gate is
+  cheap insurance for genuinely cold first-run and slow-decrypt edge cases.
+
+### D5 — First-run / cold-cache presentation (FR-010 edge case)
+
+- **Decision**: When a cache is genuinely not yet warm (very first launch before
+  unlock completes), show a **single stable intentional state** (the gated empty
+  region with reserved space, or a brief skeleton) that does **not** shift layout
+  when real content arrives — never an empty→placeholder→populated sequence.
+- **Rationale**: Directly satisfies FR-010 and the "first visit" / "slow load"
+  edge cases without re-introducing flicker.
+
+## Open questions
+
+None. The spec carried no `NEEDS CLARIFICATION` markers and the investigation
+resolved the mechanism behind every observed frame.

--- a/specs/1001-smooth-tab-transitions/spec.md
+++ b/specs/1001-smooth-tab-transitions/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-15
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1001-smooth-tab-transitions/spec.md
+++ b/specs/1001-smooth-tab-transitions/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-15
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1001-smooth-tab-transitions/spec.md
+++ b/specs/1001-smooth-tab-transitions/spec.md
@@ -1,0 +1,280 @@
+# Feature Specification: Smooth Tab Transitions
+
+**Feature Branch**: `feat/1001-smooth-tab-transitions`
+
+**Created**: 2026-06-15
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "navigating the ui is not as smooth as it should be, when switching between tabs I can see the rendering of different sections and that is not a native feeling you'd expect from using ionic, I have captured a video and then exported the before and after frames from when changes are happening so you better understand the problem and can come up with proper solution for it"
+
+## Overview
+
+When a user switches between the four bottom tabs (Calls, Chats, Contacts,
+Settings), the destination screen does not appear fully formed. Instead the
+user briefly sees an incomplete version of the screen that then "fills in" over
+the next moment. The captured before/after frames show this consistently:
+
+- **Calls**: first frame shows only the large "Calls" title, "Recent" heading,
+  and "No calls found" — with **no search bar and no top-right action buttons**.
+  A later frame shows the same screen now **with** the search bar and the
+  "new group / new call" action buttons, and (when data exists) the populated
+  recent-calls list.
+- **Chats**: first frame shows only the "Chats" title on an otherwise empty
+  screen — **no search bar, no filter chips (All / Unread / Favorites /
+  Groups), and no chat list**. A later frame shows the full screen with search,
+  filter chips, and the conversation list.
+- **Contacts**: first frame shows the "Contacts" title and the "Browse user
+  directory" row with **no search bar, no add-contact button, and "No contacts
+  found"**. A later frame shows the search bar, the add-contact button, the
+  "Invited" section, and the populated contact list.
+- **Settings**: first frame shows a **generic placeholder profile** — a plain
+  "Y" avatar and the name "You" — and is missing the search field and the
+  top-right QR action. A later frame shows the **real profile photo and name
+  ("Kamran")**, the "Search settings" field, and the QR action.
+
+The net effect is visible pop-in, layout shift, and a non-native feel on every
+tab switch. The goal of this feature is to make tab switching present the
+destination screen as a single, complete, stable view — matching the instant,
+fully-rendered transitions users expect from a native Ionic app.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Tab content appears fully formed on switch (Priority: P1)
+
+A user taps a different bottom tab. The destination screen appears already
+complete: its header (title, search field, and any top action buttons), its
+section structure, and its data are all present at the same time. The user never
+sees a partially built screen that then fills in.
+
+**Why this priority**: This is the core complaint. Visible progressive
+rendering on every navigation is the single biggest contributor to the "not
+native" feeling, and it affects every user on every tab switch.
+
+**Independent Test**: Switch between each pair of tabs repeatedly and capture
+frames during the transition. Every captured frame of the destination tab shows
+either the previous tab or the fully-formed destination tab — never an
+intermediate state missing the search bar, action buttons, filter chips, or
+list content.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on any tab, **When** they tap another tab, **Then**
+   the destination screen's header (title, search field, and top action buttons)
+   is fully present from the first painted frame of that screen.
+2. **Given** the user switches to the Chats tab, **When** the screen appears,
+   **Then** the filter chips (All / Unread / Favorites / Groups) and the chat
+   list are visible together with the header, with no intermediate frame that
+   shows only the title.
+3. **Given** the user returns to a tab they have already visited this session,
+   **When** the tab appears, **Then** it restores its previous content and
+   scroll position without re-showing empty or placeholder states.
+
+---
+
+### User Story 2 - No layout shift as a screen settles (Priority: P2)
+
+When a tab screen appears, elements do not jump, reflow, or shift position after
+the first paint. The search bar, headings, and list rows occupy their final
+positions immediately.
+
+**Why this priority**: Even when content loads quickly, elements appearing in
+sequence (e.g., a search bar pushing the list down a moment later) reads as
+janky. Eliminating layout shift is what makes the transition feel "settled".
+
+**Independent Test**: Record a tab switch and confirm that no on-screen element
+changes position between the first painted frame of the destination screen and
+the steady state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tab is appearing, **When** its header and list render, **Then**
+   no element that is present in the first frame moves to a different position in
+   a later frame.
+2. **Given** a tab whose data is still loading, **When** the screen appears,
+   **Then** the space for the eventual content is reserved so its arrival does
+   not push other elements.
+
+---
+
+### User Story 3 - Identity-bearing screens show the real user immediately (Priority: P2)
+
+When the Settings screen appears, it shows the user's actual profile photo and
+name rather than a generic placeholder that is then replaced.
+
+**Why this priority**: Showing "You" with a placeholder avatar and then swapping
+in the real photo and "Kamran" is a jarring, identity-level flicker that
+undermines confidence in the app. It is highly visible because the profile sits
+at the top center of the screen.
+
+**Independent Test**: Open Settings from any other tab and capture frames; the
+real avatar and display name are present in the first painted frame of the
+Settings screen, with no placeholder-then-real swap.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has a profile photo and name set, **When** they open the
+   Settings tab, **Then** the real photo and name appear immediately with no
+   "You"/placeholder intermediate state.
+2. **Given** any tab that displays the user's own avatar or name, **When** it
+   appears, **Then** the real identity is shown from the first frame.
+
+---
+
+### Edge Cases
+
+- **First visit to a tab in a session**: the very first time a tab is opened
+  (before any caching warms up), the transition must still avoid showing a
+  visibly incomplete screen; if data genuinely cannot be ready instantly, a
+  stable, intentional loading presentation is acceptable as long as it does not
+  read as broken or shift layout when content arrives.
+- **Genuinely empty data**: a tab with no data (e.g., "No calls found", "No
+  contacts found") must show its empty state only when the absence of data is
+  confirmed — not as a flash that precedes real data appearing.
+- **Slow data load**: when underlying data takes longer than usual to become
+  available, the screen must not oscillate between empty, placeholder, and
+  populated states.
+- **Rapid tab switching**: quickly tapping between tabs must not surface
+  half-built screens or leave a tab stuck in a placeholder state.
+- **Returning after backgrounding**: returning to the app and switching tabs
+  should not regress to the placeholder-then-real behavior.
+- **Right-to-left / long content**: screens containing RTL text or long names
+  (visible in the Chats list) must still appear fully formed without reflow.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Switching between bottom tabs MUST present the destination screen
+  as a single, complete view; the user MUST NOT see an intermediate frame in
+  which the destination screen's header, search field, action buttons, filter
+  chips, or list content are missing.
+- **FR-002**: Each tab's full header — title, search field, and all top action
+  buttons — MUST be present from the first painted frame of that screen.
+- **FR-003**: Once a tab has been visited in a session, returning to it MUST
+  restore its rendered content and scroll position without re-displaying empty
+  or placeholder states.
+- **FR-004**: Screens MUST NOT exhibit layout shift after first paint; elements
+  present in the first frame MUST remain in their final positions.
+- **FR-005**: The Settings screen (and any screen showing the user's own avatar
+  or name) MUST display the user's real profile photo and name from the first
+  painted frame, with no placeholder-then-real swap.
+- **FR-006**: Empty states ("No calls found", "No contacts found", empty Chats)
+  MUST be shown only when the absence of data is confirmed, never as a flash
+  that precedes real content.
+- **FR-007**: Rapid or repeated tab switching MUST NOT produce half-rendered
+  screens or leave any tab stuck in a placeholder/partial state.
+- **FR-008**: The smoothness improvement MUST apply to all four bottom tabs
+  (Calls, Chats, Contacts, Settings) consistently.
+- **FR-009**: The transition behavior MUST remain correct and visually stable
+  across the app's supported themes (the captured frames are in dark mode) and
+  for both left-to-right and right-to-left content.
+- **FR-010**: When data genuinely cannot be ready at the moment a tab is first
+  opened, the screen MUST present a single intentional loading state that does
+  not shift layout when real content arrives, rather than a sequence of
+  empty/placeholder/populated frames.
+
+### Key Entities
+
+*(Not applicable — this feature changes presentation/navigation behavior, not
+the data model.)*
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: Nothing new. This is a client-side
+  presentation/navigation change; the server is not touched and no new request,
+  field, log line, or metric is added.
+- **What is encrypted**: Unchanged. Profile name/avatar and the chat/call/contact
+  data remain encrypted-at-rest (AEAD-wrapped under the PIN-derived key) and are
+  only ever decrypted client-side through the existing `getSecret`/query paths.
+- **The one sensitive decision**: To make a tab (especially Settings) appear fully
+  formed on first paint, decrypted profile/list values are held in an **in-memory**
+  warm cache for the duration of the unlocked session. This plaintext lives only in
+  memory and is **cleared when the keystore locks**. It is **never** persisted in
+  the clear. A cleartext-at-rest cache was explicitly rejected as a zero-knowledge
+  violation.
+- **Metadata unavoidably visible to the server**: Unchanged from today (none added).
+
+### Zero-Knowledge Requirements
+
+- **FR-ZK-1**: Warm-cache plaintext (own-profile name/avatar, chat/call/contact
+  lists) MUST exist only in process memory. It MUST NOT be written to any clear
+  (non-AEAD-wrapped) medium — IndexedDB, `localStorage`, `sessionStorage`,
+  service-worker / Cache Storage, or any serialized form. "Clear storage" here
+  means any persistence reachable after a page reload or by another origin context.
+- **FR-ZK-2**: The warm cache MUST be cleared on **every** transition that ends the
+  unlocked session — keystore lock, sign-out, and account removal — leaving no
+  decrypted residue reachable in memory (all warm refs reset to their cold initial
+  values: lists `[]`/`loaded=false`, profile name→username/"You", avatar→initials,
+  `warmed=false`).
+- **FR-ZK-3**: Clearing MUST be objectively verifiable: after a lock/sign-out, an
+  inspection of the warm refs shows cold initial values, and an inspection of clear
+  storage after exercising all tabs reveals no profile/list plaintext.
+- **FR-ZK-4**: If unlock fails or is aborted, warming MUST NOT run and no partial
+  plaintext may be cached. If a `getSecret`/list decryption fails mid-warm, the
+  affected store MUST stay cold (its cold fallback) rather than caching a partial or
+  fallback value as though it were real data.
+- **FR-ZK-5**: While the keystore is locked, every own-identity surface MUST show
+  the non-identifying fallback (username/"You" + initials avatar), never decrypted
+  content from a prior session.
+- **FR-ZK-6**: The in-memory warm guarantee (FR-ZK-1, FR-ZK-2) applies to **all**
+  consumers of own-profile (Settings plus call tiles, group member lists, reply
+  quotes, media captions), not only the Settings tab.
+- **FR-ZK-7**: This feature MUST NOT weaken the existing AEAD-at-rest wrapping of
+  secrets; it only adds an in-memory read cache layered on the unchanged
+  `getSecret` decryption path.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In frame-by-frame capture of any tab-to-tab switch, 100% of frames
+  show either the source tab or the fully-formed destination tab — zero frames
+  show a destination screen missing its search bar, action buttons, filter
+  chips, or list content.
+- **SC-002**: Across all four tabs, there is no measurable layout shift after a
+  screen's first paint (no element changes position between first paint and
+  steady state).
+- **SC-003**: The Settings screen never shows the generic "You"/placeholder
+  avatar-and-name when a real profile exists; the real identity is present in the
+  first painted frame in 100% of openings.
+- **SC-004**: A previously-visited tab restores its content and scroll position
+  on return without re-rendering empty/placeholder states in 100% of returns
+  within a session.
+- **SC-006**: After locking or signing out, inspection of the warm cache shows all
+  refs reset to their cold initial values, and inspection of clear storage after
+  exercising every tab reveals zero profile/list plaintext (FR-ZK-2, FR-ZK-3).
+- **SC-005**: A before/after review (the `quickstart.md` frame-capture walkthrough)
+  confirms, for every tab-to-tab switch, that none of the partial-frame symptoms
+  catalogued in the Overview reproduce (title-only header, missing search/buttons/
+  chips, empty-state flash, placeholder identity), and the reviewer signs off that
+  the result reads as "native / instant" rather than "fills in / janky". This is the
+  holistic acceptance gate over the objective per-criterion checks (SC-001–SC-004).
+
+## Assumptions
+
+- The visual flicker shown in the captured frames is caused by destination tab
+  screens rendering progressively after navigation (header and action controls,
+  list data, and own-profile identity arriving in separate paints), not by an
+  intentional design choice.
+- "Native feeling" is defined as the destination screen appearing complete and
+  stable in a single step, consistent with standard Ionic tab navigation
+  expectations.
+- Restoring a previously-visited tab's exact content and scroll position within
+  the same session is desirable and in scope.
+- The underlying data sources (local conversation, calls, contacts, and profile
+  data) can be made available quickly enough that, for already-visited tabs,
+  content is effectively instant; first-visit timing is handled per FR-010.
+- No change to the zero-knowledge boundary, data model, or server behavior is
+  required; this is a client-side presentation/navigation concern.
+- The four-tab structure and the existing per-tab feature set (search, filters,
+  action buttons, directory/invite rows) remain unchanged; only the smoothness
+  of their appearance changes.
+- The warm cache is a module-level singleton scoped to a single document/JS context.
+  Multiple PWA tabs/windows each have their own isolated heap, so warm plaintext is
+  not shared across browsing contexts; no cross-context sharing is introduced.

--- a/specs/1001-smooth-tab-transitions/tasks.md
+++ b/specs/1001-smooth-tab-transitions/tasks.md
@@ -1,0 +1,209 @@
+---
+
+description: "Task list for Smooth Tab Transitions (1001)"
+---
+
+# Tasks: Smooth Tab Transitions
+
+**Input**: Design documents from `/specs/1001-smooth-tab-transitions/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: REQUIRED here. Per Constitution Principle III (TDD), new user-facing
+behavior MUST add/extend e2e specs and the new shared warm-store composable MUST
+ship unit tests. Test tasks are ordered BEFORE the implementation they cover and
+must be written failing first (Red → Green → Refactor).
+
+**Organization**: Tasks are grouped by user story so each story is independently
+implementable and testable. All work is client-side (Vue 3 + Ionic PWA); no
+server, no migration, no `DB_VERSION` change.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 (maps to spec.md user stories)
+- Exact file paths included in each task
+
+## Path notes
+
+- Single-project client; all paths are repo-root-relative.
+- Unit tests are sibling `src/**/*.test.ts` (vitest); e2e is `e2e/*.spec.ts` (Playwright).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the files the rest of the work builds on.
+
+- [ ] T001 Create the warm-stores module skeleton in `src/composables/warmStores.ts` with exported `warmAll()` and `clearWarm()` no-op stubs plus placeholders for the SelfProfile / chats / calls / contacts singletons (typed per `data-model.md`), so downstream tasks have a stable import target.
+- [ ] T002 [P] Create empty e2e spec file `e2e/tab-transitions.spec.ts` with the standard `window.__ringTest` harness boilerplate (copy the setup pattern from an existing spec such as `e2e/chat-filters.spec.ts`) and a `test.describe('tab transitions')` block.
+
+**Checkpoint**: New module + e2e file exist and the project still typechecks (`npm run build`).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared warm-cache infrastructure every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T003 Write failing unit tests for the warm-store infrastructure in `src/composables/warmStores.test.ts`: `warmAll()` is idempotent and only runs work when unlocked; populates each singleton from the (mocked) `getSecret`/list-query sources; stays live on `idb` change-bus events; `clearWarm()` resets every ref to its cold initial value leaving no decrypted residue (FR-ZK-2/FR-ZK-3); a failed/aborted unlock does NOT warm any store and a mid-warm `getSecret`/query failure leaves that store cold rather than caching a partial/fallback value (FR-ZK-4). Tests MUST fail initially.
+- [ ] T004 Implement the singleton warm stores + `warmAll()` / `clearWarm()` in `src/composables/warmStores.ts` to satisfy T003: module-level reactive `SelfProfileStore` (`name`, `avatar`, `warmed`) and list stores (`items`, `loaded`) for chats/calls/contacts, sourced via existing `getSecret('profileName'|'profileAvatar')` and `listChats`/`listCallGroups`/`listContacts`, subscribed to the relevant `idb` stores. `warmAll()` runs only when unlocked and guards each source so a decrypt/query failure leaves that store cold (FR-ZK-4); `clearWarm()` resets all refs to cold initial values with no residue (FR-ZK-2). Never serialize warm values to any clear storage (FR-ZK-1). (depends on T003)
+- [ ] T005 Add the optional `warmSource` parameter to `useLiveQuery` in `src/composables/useLiveQuery.ts` per `contracts/warm-stores.md`: when `warmSource()` returns a defined value, use it as the first-paint value and treat `loaded` as already true; otherwise behavior is byte-for-byte unchanged (no breaking change to existing callers). (depends on T001)
+- [ ] T006 Wire lifecycle in `src/composables/useKeyGuard.ts` (or the app-entry unlock path): call `warmAll()` when `isUnlocked` transitions to `true` (before the user can navigate tabs) and `clearWarm()` on **every** session-end transition — keystore lock, sign-out, and account removal (FR-ZK-2). Reuse the existing lock/sign-out paths; ensure no session-end path is missed. (depends on T004)
+
+**Checkpoint**: `npm run build` passes and `npm run test:unit` passes T003. Warm caches populate at unlock and clear at lock. User stories can now proceed.
+
+---
+
+## Phase 3: User Story 1 - Tab content appears fully formed on switch (Priority: P1) 🎯 MVP
+
+**Goal**: Switching to a tab shows its header, controls, and list data together in the first painted frame; return visits restore content + scroll instantly.
+
+**Independent Test**: With a populated account, switch into Chats/Calls/Contacts and assert (e2e + frame capture) the search bar, action buttons, filter chips, and list are present together — no title-only intermediate frame; leave and return to a tab and confirm content + scrollTop are preserved with no empty-state render.
+
+### Tests for User Story 1 ⚠️ (write first, must fail)
+
+- [ ] T007 [P] [US1] Extend `e2e/tab-transitions.spec.ts`: on a populated account, after switching to Chats/Calls/Contacts, assert header (search field), action buttons, and (Chats) filter chips and the list rows are present in the same assertion tick — no frame missing them (Invariant R1).
+- [ ] T008 [P] [US1] Extend `e2e/tab-transitions.spec.ts`: scroll a tab's list, switch away and back, assert the list content and `scrollTop` are preserved and no empty-state element is rendered on return (Invariant R4 / keep-alive).
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Convert the four `/tabs` child routes in `src/router/index.ts` from `() => import()` to static imports so the tab components are eager-loaded (no first-switch chunk stall); leave the auth guard and all other lazy routes unchanged. (depends on Phase 2)
+- [ ] T010 [US1] In `src/views/tabs/ChatsPage.vue`, source the base chat list from the shared warm chats store **when the search term is empty** (via `useLiveQuery`'s `warmSource`), and **fall back to the existing `listChats(term)` live query when a search term is present** (data-layer filtering stays server/DB-side — do NOT re-implement search on the client). Keep filter/pagination as page-local `computed`s and preserve the existing `loaded`-gated empty state. (depends on T004, T005; see data-model.md "Search contract")
+- [ ] T011 [US1] In `src/views/tabs/CallsPage.vue`, source the base call-groups list from the shared warm calls store **when search is empty** via `warmSource`, and **fall back to `listCallGroups(term)` when a term is present**; `visible` pagination stays page-local and resets on term change as today. (depends on T004, T005; see data-model.md "Search contract")
+- [ ] T012 [US1] In `src/views/tabs/ContactsPage.vue`, source the base contacts list from the shared warm contacts store **when search is empty** via `warmSource`, and **fall back to `listContacts(term)` when a term is present**; `visible` pagination stays page-local and the server-invite refresh on `onIonViewWillEnter` stays as-is. (depends on T004, T005; see data-model.md "Search contract")
+- [ ] T013 [US1] Verify and, if needed, fix `IonRouterOutlet` keep-alive in `src/views/TabsPage.vue`: confirm `switchTab(path, 'root', 'replace', …)` does not tear down cached pages (no `v-if` on the outlet, pages stay mounted); make T008 pass. Do NOT change `swipeBackEnabled`/`scrollAssist` or the `'root'`/`'replace'` semantics. (depends on T009)
+- [ ] T013b [US1] **CONDITIONAL — only if T013 finds keep-alive does NOT retain scroll** under `'root'`/`'replace'`: add a page-local scroll save/restore in each tab page (`src/views/tabs/{Chats,Calls,Contacts,Settings}Page.vue`) — persist `ion-content` `scrollTop` on `onIonViewWillLeave` to an in-memory map and restore it on `onIonViewDidEnter`, so FR-003/SC-004 hold without altering navigation semantics. Skip this task entirely if T013/T008 already pass. (depends on T013)
+
+**Checkpoint**: Tabs (warm) appear fully formed and restore instantly; T007–T008 pass.
+
+---
+
+## Phase 4: User Story 3 - Identity-bearing screens show the real user immediately (Priority: P2)
+
+> Sequenced before US2 because it is self-contained (profile only) and shares no
+> files with US2. Implemented after the P1 MVP.
+
+**Goal**: Settings (and every own-avatar/name surface) shows the real photo and name in the first painted frame — never the "You"/initials placeholder when a real profile exists.
+
+**Independent Test**: Open Settings from another tab and assert (e2e) the real display name is present with no intervening "You" text and no placeholder-then-real avatar swap.
+
+### Tests for User Story 3 ⚠️ (write first, must fail)
+
+- [ ] T014 [P] [US3] Add unit test `src/composables/useSelfProfile.test.ts`: two `useSelfProfile()` calls return refs backed by the SAME singleton (shared identity), warm values appear without a per-call cold restart, and fallback semantics (`@username` → "You"; initials avatar) hold while cold/locked. Must fail initially.
+- [ ] T015 [P] [US3] Extend `e2e/tab-transitions.spec.ts`: open Settings on an account with a real name/photo set and assert the real display name is shown on first paint with no "You" placeholder text appearing (Invariant R3).
+
+### Implementation for User Story 3
+
+- [ ] T016 [US3] Convert `src/composables/useSelfProfile.ts` from a per-call factory to a singleton-backed composable that returns refs from the shared `SelfProfileStore` (same identity across all callers); keep the exported signature and fallback behavior unchanged so existing call sites need no edits. (depends on T004)
+- [ ] T017 [US3] Update `src/views/tabs/SettingsPage.vue` to drop its inlined cold profile `useLiveQuery` reads and consume `useSelfProfile()` for name + avatar, so first paint uses the warm singleton. (depends on T016)
+
+**Checkpoint**: Settings shows real identity on first paint; T014–T015 pass; existing `useSelfProfile` call sites (call tiles, group lists, reply quotes, media captions) still render correctly.
+
+---
+
+## Phase 5: User Story 2 - No layout shift as a screen settles (Priority: P2)
+
+> Touches CallsPage/ContactsPage already edited in US1, so it follows US1 to
+> avoid same-file conflicts.
+
+**Goal**: No element moves after a tab's first paint; empty states only appear once absence of data is confirmed.
+
+**Independent Test**: Record a tab switch (and run e2e) confirming no element changes position after the first frame, and that a populated account never flashes "No calls/contacts found" before its list.
+
+### Tests for User Story 2 ⚠️ (write first, must fail)
+
+- [ ] T018 [P] [US2] Extend `e2e/tab-transitions.spec.ts`: on a populated account, assert the "No calls found" / "No contacts found" empty-state elements are never present before their lists render (Invariant R5); and on an empty account they render cleanly once. Must fail for Calls/Contacts initially (they currently lack a `loaded` gate).
+
+### Implementation for User Story 2
+
+- [ ] T019 [US2] In `src/views/tabs/CallsPage.vue`, gate the "No calls found" empty state behind the warm store's `loaded` flag (mirror ChatsPage's `loaded && length === 0`) so it never flashes before data. (depends on T011)
+- [ ] T020 [US2] In `src/views/tabs/ContactsPage.vue`, gate the "No contacts found" empty state behind the warm store's `loaded` flag so it never flashes before data. (depends on T012)
+- [ ] T021 [P] [US2] Reserve vertical space for asynchronously-arriving header/list regions across `src/views/tabs/CallsPage.vue` and `src/views/tabs/ContactsPage.vue` (and verify Chats/Settings) so nothing reflows after first paint (Invariant R2); use stable min-heights/placeholders, not content-dependent collapse. (depends on T019, T020)
+- [ ] T022 [US2] Implement the cold-start fallback presentation (FR-010): when a warm store is genuinely cold (very first launch pre-unlock), show a single stable loading/empty region (reserved space, no empty→placeholder→populated sequence) in `src/views/tabs/CallsPage.vue` and `src/views/tabs/ContactsPage.vue`. (depends on T021)
+
+**Checkpoint**: No post-paint layout shift; no empty-state flash; T018 passes.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T023 [P] Extend `e2e/bidi.spec.ts` (or add an RTL assertion in `e2e/tab-transitions.spec.ts`) to confirm a tab containing RTL content appears fully formed without reflow after the warm-cache change (FR-009 / Invariant R6). **Also cover the theme half of FR-009**: assert tab-switch completeness holds in both light and dark themes (toggle via the existing theme setting / `useTheme`), so the warm-cache change is verified theme-agnostic.
+- [ ] T024 [P] Add a rapid-switch stress assertion in `e2e/tab-transitions.spec.ts`: cycle Calls↔Chats↔Contacts↔Settings quickly and assert every tab ends fully rendered with no tab stuck in a placeholder/partial state (FR-007 / Invariant R6).
+- [ ] T025 Run the `quickstart.md` manual verification (frame capture of each switch) and confirm Invariants R1–R6; capture before/after notes in the PR description.
+- [ ] T025b Zero-knowledge verification (FR-ZK-3 / SC-006): after exercising every tab, inspect clear storage (IndexedDB / `localStorage` / `sessionStorage` / Cache Storage) and confirm no profile/list plaintext is present; then lock and sign out and confirm the warm refs are reset to cold initial values. Record the result in the PR.
+- [ ] T026 Final gates: `npm run build` (vue-tsc + vite build), `npm run test:unit` (with coverage floors), and `npm run test:e2e` all green; confirm `registerType: 'prompt'` and the zero-knowledge boundary (no plaintext persisted in the clear; warm cache cleared on lock/sign-out) are intact.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: depends on Setup — BLOCKS all user stories.
+- **US1 (Phase 3)**: depends on Phase 2. MVP.
+- **US3 (Phase 4)**: depends on Phase 2 (specifically T004/T016). Independent of US1/US2 (profile-only, no shared files).
+- **US2 (Phase 5)**: depends on Phase 2 and on US1's edits to CallsPage/ContactsPage (T011/T012) — same files, so it follows US1.
+- **Polish (Phase 6)**: depends on the desired user stories being complete.
+
+### Within each user story
+
+- Tests written first and failing, then implementation (Red → Green → Refactor).
+- US1: routing eager-load (T009) before page warm-source edits (T010–T012) before keep-alive verification (T013); T013b runs only if T013 finds scroll is not retained.
+- US2: `loaded`-gates (T019/T020) before reserve-space (T021) before cold-start fallback (T022).
+
+### Parallel opportunities
+
+- T002 ∥ T001 (different files).
+- Test authoring within a story is parallel: T007 ∥ T008; T014 ∥ T015.
+- T010 ∥ T011 ∥ T012 (three different tab files) once T004/T005 exist.
+- US3 (Phase 4) can run in parallel with US1 (Phase 3) by a second developer — disjoint files (profile vs lists/router), both only need Phase 2.
+- Polish T023 ∥ T024.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests first (parallel):
+Task: "Extend e2e/tab-transitions.spec.ts — fully-formed first frame (R1)"   # T007
+Task: "Extend e2e/tab-transitions.spec.ts — return preserves scroll (R4)"    # T008
+
+# Then page edits (parallel, different files):
+Task: "ChatsPage.vue consume warm chats store"      # T010
+Task: "CallsPage.vue consume warm calls store"      # T011
+Task: "ContactsPage.vue consume warm contacts store" # T012
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (US1 only)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (CRITICAL) → 3. Phase 3 US1 →
+4. STOP & validate: tabs appear fully formed and restore instantly → demo.
+
+### Incremental delivery
+
+1. Setup + Foundational → foundation ready.
+2. US1 → the core "feels native" win (MVP) → demo.
+3. US3 → real identity on Settings → demo.
+4. US2 → no layout shift / no empty flash → demo.
+5. Polish → RTL + stress + gates.
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete-task dependency.
+- Constitution: this spec touches Principle I (in-memory vs at-rest cache) → run
+  `/speckit-checklist` before `/speckit-implement`; `/speckit-analyze` must be
+  clean (or findings waived) before implementing.
+- Do not change `swipeBackEnabled`/`scrollAssist` or the `switchTab('root',
+  'replace')` semantics (they fixed a prior tab-highlight desync).
+- No `DB_VERSION` bump, no migration, no server change — keep it that way.
+- Commit per task or logical group; each checkpoint is a safe stopping point.

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,8 @@
 import { onMounted, onUnmounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { isAuthenticated } from '@/services/auth';
-import { isUnlockedNow } from '@/services/crypto/identity';
+import { isUnlockedNow, isUnlocked } from '@/services/crypto/identity';
+import { warmAll, clearWarm } from '@/composables/warmStores';
 import { IonApp, IonRouterOutlet, toastController } from '@ionic/vue';
 import { inviteNeedsProfile } from '@/services/invites';
 import { useViewportHeight } from '@/composables/useViewportHeight';
@@ -53,6 +54,21 @@ useSync();
 useAppUpdate();
 
 const router = useRouter();
+
+// Warm the shared in-memory stores (own profile + chat/call/contact lists) the
+// instant the keystore unlocks, so a tab's first paint is already populated and
+// Settings shows the real identity without a placeholder swap. Clearing on every
+// session-end (lock / sign-out / account removal all flip isUnlocked → false)
+// wipes the decrypted plaintext from memory — it never touches disk (spec 1001,
+// FR-ZK-1/FR-ZK-2). immediate: handle an already-unlocked state at startup.
+watch(
+  isUnlocked,
+  (unlocked) => {
+    if (unlocked) void warmAll();
+    else clearWarm();
+  },
+  { immediate: true },
+);
 
 // If authentication is lost mid-session, e.g. the server no longer recognizes
 // this device (account deleted / database wiped) and verifySessionOrReset wiped

--- a/src/composables/useLiveQuery.ts
+++ b/src/composables/useLiveQuery.ts
@@ -17,9 +17,16 @@ export function useLiveQuery<T>(
   stores: StoreName[],
   initial: T,
   deps: () => unknown = () => undefined,
+  // Optional warm source: when it returns a defined value, that value seeds the
+  // FIRST paint (and `loaded` starts true) instead of the cold `initial`, so a
+  // page backed by a pre-warmed singleton renders populated immediately. When it
+  // returns undefined (or is omitted) behavior is identical to before. The live
+  // `run()` below still executes and reconciles, so the value stays fresh.
+  warmSource?: () => T | undefined,
 ): LiveRef<T> {
-  const value = ref(initial) as Ref<T>;
-  const loaded = ref(false);
+  const warm = warmSource?.();
+  const value = ref(warm !== undefined ? warm : initial) as Ref<T>;
+  const loaded = ref(warm !== undefined);
   let token = 0;
 
   const run = async () => {

--- a/src/composables/useSelfProfile.test.ts
+++ b/src/composables/useSelfProfile.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { vi } from 'vitest';
+
+// Mock the warm singleton with real refs we can mutate, and the avatar generator
+// so the test is deterministic and doesn't pull IndexedDB/crypto into node env.
+vi.mock('@/db/avatars', () => ({ initialsAvatar: (n: string) => `initials:${n}` }));
+vi.mock('@/composables/warmStores', async () => {
+  const { ref } = await import('vue');
+  return {
+    profileName: ref('Alice'),
+    profileAbout: ref('Hey there! I am using Ring.'),
+    profileAvatarRaw: ref(''),
+  };
+});
+
+import { useSelfProfile } from './useSelfProfile';
+import { profileName, profileAvatarRaw } from '@/composables/warmStores';
+
+beforeEach(() => {
+  profileName.value = 'Alice';
+  profileAvatarRaw.value = '';
+});
+
+describe('useSelfProfile', () => {
+  it('returns the SAME singleton refs across calls (shared identity)', () => {
+    const a = useSelfProfile();
+    const b = useSelfProfile();
+    // name + about are the singleton refs themselves, identical across callers.
+    expect(a.name).toBe(b.name);
+    expect(a.about).toBe(b.about);
+    expect(a.name).toBe(profileName);
+  });
+
+  it('reflects warm-store updates without a per-call cold restart', () => {
+    const { name } = useSelfProfile();
+    expect(name.value).toBe('Alice');
+    profileName.value = 'Bob Real';
+    expect(name.value).toBe('Bob Real');
+  });
+
+  it('falls back to a generated initials avatar when no photo is set', () => {
+    const { avatar } = useSelfProfile();
+    expect(avatar.value).toBe('initials:Alice');
+  });
+
+  it('uses the real photo once present', () => {
+    const { avatar } = useSelfProfile();
+    profileAvatarRaw.value = 'data:image/png;base64,REAL';
+    expect(avatar.value).toBe('data:image/png;base64,REAL');
+  });
+});

--- a/src/composables/useSelfProfile.ts
+++ b/src/composables/useSelfProfile.ts
@@ -1,37 +1,24 @@
 /**
- * Reactive access to the local user's OWN chosen profile name + avatar, for every
- * place the user is shown to themselves (call tiles, group member lists, reply quotes,
- * media captions, …). Both are encrypted-at-rest secrets, so we read them through
- * `useLiveQuery` over the `settings` store: the value re-resolves when the keystore
- * unlocks and updates live when the user edits their profile (Profile/Settings write
- * the same secret), so a rename propagates everywhere without a reload.
+ * Reactive access to the local user's OWN chosen profile name + avatar (+ about),
+ * for every place the user is shown to themselves (Settings header, call tiles,
+ * group member lists, reply quotes, media captions, …).
  *
- * Name falls back to the immutable @username (then "You") while the profile is empty or
- * the store is still locked; the avatar falls back to a generated initials avatar so a
- * face is always shown.
+ * Backed by the shared, warm singleton in `warmStores` rather than a fresh
+ * per-call query: the singleton is decrypted once when the keystore unlocks and
+ * kept live via the `settings` change bus, so every consumer shows the REAL
+ * identity from its first paint — no "You"/initials placeholder that swaps to the
+ * real photo/name a moment later (spec 1001 FR-005/FR-ZK-6). The decrypted values
+ * live in memory only.
+ *
+ * Name falls back to the immutable @username (then "You") while the profile is
+ * empty or the keystore is locked; the avatar falls back to a generated initials
+ * avatar so a face is always shown.
  */
 import { computed, type Ref } from 'vue';
-import { useLiveQuery } from '@/composables/useLiveQuery';
-import { getSecret } from '@/db/secrets';
-import { getSelfUsername } from '@/services/auth';
-import { isUnlocked } from '@/services/crypto/identity';
+import { profileName, profileAbout, profileAvatarRaw } from '@/composables/warmStores';
 import { initialsAvatar } from '@/db/avatars';
-import { capitalizeFirst } from '@/utils/text';
 
-export function useSelfProfile(): { name: Ref<string>; avatar: Ref<string> } {
-  const fallbackName = capitalizeFirst(getSelfUsername() ?? 'You');
-  const name = useLiveQuery(
-    () => getSecret('profileName', fallbackName),
-    ['settings'],
-    fallbackName,
-    () => isUnlocked.value,
-  );
-  const rawAvatar = useLiveQuery(
-    () => getSecret('profileAvatar', ''),
-    ['settings'],
-    '',
-    () => isUnlocked.value,
-  );
-  const avatar = computed(() => rawAvatar.value || initialsAvatar(name.value));
-  return { name, avatar };
+export function useSelfProfile(): { name: Ref<string>; avatar: Ref<string>; about: Ref<string> } {
+  const avatar = computed(() => profileAvatarRaw.value || initialsAvatar(profileName.value));
+  return { name: profileName, avatar, about: profileAbout };
 }

--- a/src/composables/warmStores.test.ts
+++ b/src/composables/warmStores.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// warmStores talks to IndexedDB-backed and crypto-heavy modules; mock them so the
+// store logic (warm/clear/idempotency/zero-knowledge invariants) is tested in
+// isolation in the node env. `isUnlocked` is a plain {value} we can flip per test.
+const h = vi.hoisted(() => ({
+  unlocked: { value: false },
+  getSecret: vi.fn(),
+  listChats: vi.fn(),
+  listCallGroups: vi.fn(),
+  listContacts: vi.fn(),
+  unsub: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
+vi.mock('@/services/crypto/identity', () => ({ isUnlocked: h.unlocked }));
+vi.mock('@/db/secrets', () => ({ getSecret: h.getSecret }));
+vi.mock('@/db/queries', () => ({
+  listChats: h.listChats,
+  listCallGroups: h.listCallGroups,
+  listContacts: h.listContacts,
+}));
+vi.mock('@/db/idb', () => ({ subscribe: h.subscribe }));
+vi.mock('@/services/auth', () => ({ getSelfUsername: () => 'alice' }));
+
+import {
+  warmAll, clearWarm,
+  profileName, profileAbout, profileAvatarRaw, profileWarmed,
+  warmChats, warmChatsLoaded, warmCalls, warmCallsLoaded, warmContacts, warmContactsLoaded,
+} from './warmStores';
+
+function happyPaths() {
+  h.getSecret.mockImplementation(async (key: string, fallback: unknown) => {
+    if (key === 'profileName') return 'Alice Real';
+    if (key === 'profileAbout') return 'About me';
+    if (key === 'profileAvatar') return 'data:image/png;base64,REAL';
+    return fallback;
+  });
+  h.listChats.mockResolvedValue([{ id: 'c1' }]);
+  h.listCallGroups.mockResolvedValue([{ id: 'g1' }]);
+  h.listContacts.mockResolvedValue([{ id: 'p1' }]);
+}
+
+beforeEach(() => {
+  h.unlocked.value = false;
+  clearWarm(); // reset singleton to cold between tests
+  vi.clearAllMocks();
+  h.subscribe.mockReturnValue(h.unsub); // each subscribe returns the same unsub spy
+});
+
+describe('warmStores', () => {
+  it('does not warm while locked (failed/aborted unlock)', async () => {
+    happyPaths();
+    h.unlocked.value = false;
+    await warmAll();
+
+    expect(h.getSecret).not.toHaveBeenCalled();
+    expect(h.listChats).not.toHaveBeenCalled();
+    expect(h.subscribe).not.toHaveBeenCalled();
+    expect(warmChatsLoaded.value).toBe(false);
+    expect(profileWarmed.value).toBe(false);
+  });
+
+  it('populates every store and subscribes once when unlocked', async () => {
+    happyPaths();
+    h.unlocked.value = true;
+    await warmAll();
+
+    expect(profileName.value).toBe('Alice Real');
+    expect(profileAbout.value).toBe('About me');
+    expect(profileAvatarRaw.value).toBe('data:image/png;base64,REAL');
+    expect(profileWarmed.value).toBe(true);
+
+    expect(warmChats.value).toEqual([{ id: 'c1' }]);
+    expect(warmChatsLoaded.value).toBe(true);
+    expect(warmCalls.value).toEqual([{ id: 'g1' }]);
+    expect(warmCallsLoaded.value).toBe(true);
+    expect(warmContacts.value).toEqual([{ id: 'p1' }]);
+    expect(warmContactsLoaded.value).toBe(true);
+
+    // One subscription per store set (profile, chats, calls, contacts).
+    expect(h.subscribe).toHaveBeenCalledTimes(4);
+  });
+
+  it('is idempotent: a second warmAll does not re-subscribe', async () => {
+    happyPaths();
+    h.unlocked.value = true;
+    await warmAll();
+    await warmAll();
+    expect(h.subscribe).toHaveBeenCalledTimes(4); // not 8
+  });
+
+  it('leaves a store COLD if its query throws (no partial plaintext cached)', async () => {
+    happyPaths();
+    h.listChats.mockRejectedValue(new Error('decrypt failed'));
+    h.unlocked.value = true;
+    await warmAll();
+
+    // Chats stayed cold; the others still warmed.
+    expect(warmChats.value).toEqual([]);
+    expect(warmChatsLoaded.value).toBe(false);
+    expect(warmCallsLoaded.value).toBe(true);
+    expect(warmContactsLoaded.value).toBe(true);
+  });
+
+  it('clearWarm resets every ref to its cold initial value and unsubscribes', async () => {
+    happyPaths();
+    h.unlocked.value = true;
+    await warmAll();
+    expect(profileWarmed.value).toBe(true); // sanity: it was warm
+
+    clearWarm();
+
+    // No decrypted residue: everything back to cold initial values.
+    expect(profileName.value).toBe('Alice'); // fallback from @username
+    expect(profileAbout.value).toBe('Hey there! I am using Ring.');
+    expect(profileAvatarRaw.value).toBe('');
+    expect(profileWarmed.value).toBe(false);
+    expect(warmChats.value).toEqual([]);
+    expect(warmChatsLoaded.value).toBe(false);
+    expect(warmCalls.value).toEqual([]);
+    expect(warmCallsLoaded.value).toBe(false);
+    expect(warmContacts.value).toEqual([]);
+    expect(warmContactsLoaded.value).toBe(false);
+
+    // Each live subscription was torn down.
+    expect(h.unsub).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/composables/warmStores.test.ts
+++ b/src/composables/warmStores.test.ts
@@ -23,8 +23,9 @@ vi.mock('@/db/queries', () => ({
 vi.mock('@/db/idb', () => ({ subscribe: h.subscribe }));
 vi.mock('@/services/auth', () => ({ getSelfUsername: () => 'alice' }));
 
+import { ref } from 'vue';
 import {
-  warmAll, clearWarm,
+  warmAll, clearWarm, warmWhenIdle,
   profileName, profileAbout, profileAvatarRaw, profileWarmed,
   warmChats, warmChatsLoaded, warmCalls, warmCallsLoaded, warmContacts, warmContactsLoaded,
 } from './warmStores';
@@ -125,5 +126,32 @@ describe('warmStores', () => {
 
     // Each live subscription was torn down.
     expect(h.unsub).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('warmWhenIdle', () => {
+  it('seeds first paint only when idle AND loaded', () => {
+    const source = ref(['x']);
+    const loaded = ref(true);
+    const search = ref('');
+    const src = warmWhenIdle(source, loaded, search);
+    expect(src()).toEqual(['x']);
+  });
+
+  it('returns undefined while the warm store is still cold (no empty-state flash)', () => {
+    const source = ref<string[]>([]);
+    const loaded = ref(false); // warmAll not finished yet
+    const search = ref('');
+    const src = warmWhenIdle(source, loaded, search);
+    // Cold → undefined, so useLiveQuery keeps loaded=false and the gate holds.
+    expect(src()).toBeUndefined();
+  });
+
+  it('returns undefined when a search term is present (live query path)', () => {
+    const source = ref(['x']);
+    const loaded = ref(true);
+    const search = ref('bob');
+    const src = warmWhenIdle(source, loaded, search);
+    expect(src()).toBeUndefined();
   });
 });

--- a/src/composables/warmStores.ts
+++ b/src/composables/warmStores.ts
@@ -126,9 +126,16 @@ export function clearWarm(): void {
   warmContactsLoaded.value = false;
 }
 
-/** Warm-source helper for `useLiveQuery`: return the warm value only when the
- *  search box is empty (the first-paint case). A typed term falls back to the
- *  live query so data-layer filtering stays where it is (spec "Search contract"). */
-export function warmWhenIdle<T>(source: Ref<T>, search: Ref<string>): () => T | undefined {
-  return () => (search.value ? undefined : source.value);
+/** Warm-source helper for `useLiveQuery`: seed first paint from `source` ONLY when
+ *  the search box is empty AND the warm store has actually loaded. If the store is
+ *  still cold (e.g. a page mounts before `warmAll()` finishes on a fresh launch),
+ *  return undefined so `useLiveQuery` keeps its cold behaviour (loaded=false) and
+ *  the empty state stays gated — no empty→populated flash. A typed term also falls
+ *  back to the live query so data-layer filtering stays put (spec "Search contract"). */
+export function warmWhenIdle<T>(
+  source: Ref<T>,
+  loaded: Ref<boolean>,
+  search: Ref<string>,
+): () => T | undefined {
+  return () => (!search.value && loaded.value ? source.value : undefined);
 }

--- a/src/composables/warmStores.ts
+++ b/src/composables/warmStores.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared, warm in-memory stores for the data a bottom tab needs the instant it
+ * mounts: the user's own profile (name/about/avatar) and the default chat / call /
+ * contact lists. Tab pages read these so their FIRST paint is already populated —
+ * no empty-then-filled flicker, no "You"/initials placeholder swap on Settings.
+ *
+ * Why a singleton (not a per-mount `useLiveQuery`): the existing composables start
+ * cold (`[]` / "You") and resolve asynchronously after the page is already on
+ * screen, which is exactly the pop-in this feature removes. Warming once at unlock
+ * means the values are ready before the user can navigate (see spec 1001).
+ *
+ * Zero-knowledge (Constitution Principle I, spec FR-ZK-1..7): every value here is
+ * DECRYPTED PLAINTEXT and therefore lives ONLY in process memory. It is read via
+ * the existing `getSecret` / query paths, never persisted to any clear medium, and
+ * is wiped by `clearWarm()` on every session-end (lock / sign-out / account
+ * removal — all of which flip `isUnlocked` to false). A failed/aborted unlock never
+ * warms; a list query that throws mid-warm leaves its store cold rather than
+ * caching a partial value.
+ */
+import { ref, type Ref } from 'vue';
+import { subscribe } from '@/db/idb';
+import { getSecret } from '@/db/secrets';
+import { isUnlocked } from '@/services/crypto/identity';
+import { getSelfUsername } from '@/services/auth';
+import { capitalizeFirst } from '@/utils/text';
+import { listChats, listCallGroups, listContacts, type CallGroup } from '@/db/queries';
+import type { Chat, Contact } from '@/db/types';
+
+const DEFAULT_ABOUT = 'Hey there! I am using Ring.';
+/** Cold/fallback display name: the immutable @username, then "You". Mirrors
+ *  `useSelfProfile`'s fallback so a locked or empty profile still shows a name. */
+function fallbackName(): string {
+  return capitalizeFirst(getSelfUsername() ?? 'You');
+}
+
+// --- Own profile (singleton refs; the computed avatar is composed in useSelfProfile) ---
+export const profileName = ref(fallbackName());
+export const profileAbout = ref(DEFAULT_ABOUT);
+export const profileAvatarRaw = ref('');
+export const profileWarmed = ref(false);
+
+// --- Default (unfiltered) lists. `*Loaded` gates empty states like useLiveQuery.loaded ---
+export const warmChats = ref<Chat[]>([]);
+export const warmChatsLoaded = ref(false);
+export const warmCalls = ref<CallGroup[]>([]);
+export const warmCallsLoaded = ref(false);
+export const warmContacts = ref<Contact[]>([]);
+export const warmContactsLoaded = ref(false);
+
+let unsubs: Array<() => void> = [];
+
+/** Re-read own profile. Profile reads go through `getSecret`, which returns the
+ *  fallback (never throws) when absent/locked, so this is safe to call any time
+ *  we're unlocked; `warmed` flips true once we've populated it at least once. */
+async function refreshProfile(): Promise<void> {
+  if (!isUnlocked.value) return;
+  const [name, about, avatar] = await Promise.all([
+    getSecret('profileName', fallbackName()),
+    getSecret('profileAbout', DEFAULT_ABOUT),
+    getSecret('profileAvatar', ''),
+  ]);
+  profileName.value = name;
+  profileAbout.value = about;
+  profileAvatarRaw.value = avatar;
+  profileWarmed.value = true;
+}
+
+// Each list refresh guards on unlock and leaves the store COLD on failure
+// (FR-ZK-4): no partial/stale plaintext is cached if the query throws.
+async function refreshChats(): Promise<void> {
+  if (!isUnlocked.value) return;
+  try {
+    warmChats.value = await listChats();
+    warmChatsLoaded.value = true;
+  } catch { /* stay cold */ }
+}
+async function refreshCalls(): Promise<void> {
+  if (!isUnlocked.value) return;
+  try {
+    warmCalls.value = await listCallGroups();
+    warmCallsLoaded.value = true;
+  } catch { /* stay cold */ }
+}
+async function refreshContacts(): Promise<void> {
+  if (!isUnlocked.value) return;
+  try {
+    warmContacts.value = await listContacts();
+    warmContactsLoaded.value = true;
+  } catch { /* stay cold */ }
+}
+
+/**
+ * Populate every warm store and keep them live via the idb change bus. Idempotent:
+ * a second call while already warm is a no-op (subscriptions are only wired once).
+ * Only does work while unlocked, so a failed/aborted unlock never warms (FR-ZK-4).
+ */
+export async function warmAll(): Promise<void> {
+  if (!isUnlocked.value) return;
+  if (unsubs.length) return; // already warm + subscribed
+  // Same store sets the existing tab queries depend on, so live edits propagate.
+  unsubs.push(subscribe(['settings'], () => void refreshProfile()));
+  unsubs.push(subscribe(['chats', 'messages', 'chatlists'], () => void refreshChats()));
+  unsubs.push(subscribe(['calls'], () => void refreshCalls()));
+  unsubs.push(subscribe(['contacts', 'chats'], () => void refreshContacts()));
+  await Promise.all([refreshProfile(), refreshChats(), refreshCalls(), refreshContacts()]);
+}
+
+/**
+ * Drop all decrypted plaintext from memory and unsubscribe. Called on every
+ * session-end transition (lock / sign-out / account removal). Every ref returns
+ * to its cold initial value — this is the verifiable "no residue" evidence
+ * (FR-ZK-2/FR-ZK-3, SC-006).
+ */
+export function clearWarm(): void {
+  for (const u of unsubs) u();
+  unsubs = [];
+  profileName.value = fallbackName();
+  profileAbout.value = DEFAULT_ABOUT;
+  profileAvatarRaw.value = '';
+  profileWarmed.value = false;
+  warmChats.value = [];
+  warmChatsLoaded.value = false;
+  warmCalls.value = [];
+  warmCallsLoaded.value = false;
+  warmContacts.value = [];
+  warmContactsLoaded.value = false;
+}
+
+/** Warm-source helper for `useLiveQuery`: return the warm value only when the
+ *  search box is empty (the first-paint case). A typed term falls back to the
+ *  live query so data-layer filtering stays where it is (spec "Search contract"). */
+export function warmWhenIdle<T>(source: Ref<T>, search: Ref<string>): () => T | undefined {
+  return () => (search.value ? undefined : source.value);
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,15 @@
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import type { RouteRecordRaw } from 'vue-router';
 import { isAuthenticated } from '@/services/auth';
+// The four bottom-tab pages are eager-loaded (static imports), NOT lazy
+// `() => import()` chunks. They are the app's core surface, reached within
+// seconds of launch and already SW-precached; lazy-splitting them only bought a
+// first-switch chunk-fetch stall that rendered the tab in pieces. Folding them
+// into the entry graph means the first switch has no fetch/parse delay (spec 1001).
+import CallsPage from '@/views/tabs/CallsPage.vue';
+import ChatsPage from '@/views/tabs/ChatsPage.vue';
+import ContactsPage from '@/views/tabs/ContactsPage.vue';
+import SettingsPage from '@/views/tabs/SettingsPage.vue';
 
 const routes: RouteRecordRaw[] = [
   // Land inside the tabs; the guard below bounces unauthenticated users to the
@@ -27,13 +36,10 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/TabsPage.vue'),
     children: [
       { path: '', redirect: '/tabs/chats' },
-      { path: 'calls', component: () => import('@/views/tabs/CallsPage.vue') },
-      { path: 'chats', component: () => import('@/views/tabs/ChatsPage.vue') },
-      {
-        path: 'contacts',
-        component: () => import('@/views/tabs/ContactsPage.vue'),
-      },
-      { path: 'settings', component: () => import('@/views/tabs/SettingsPage.vue') },
+      { path: 'calls', component: CallsPage },
+      { path: 'chats', component: ChatsPage },
+      { path: 'contacts', component: ContactsPage },
+      { path: 'settings', component: SettingsPage },
       // Backward-compat for old links/bookmarks to the former "You" tab.
       { path: 'you', redirect: '/tabs/settings' },
     ],

--- a/src/services/chat-filters.ts
+++ b/src/services/chat-filters.ts
@@ -7,7 +7,7 @@
  */
 import { computed, ref, watch, type Ref, type ComputedRef } from 'vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
-import { warmChats, warmWhenIdle } from '@/composables/warmStores';
+import { warmChats, warmChatsLoaded, warmWhenIdle } from '@/composables/warmStores';
 import { listChats, listChatLists, getSetting, setSetting, chatIsUnread } from '@/db/queries';
 import type { Chat, ChatList } from '@/db/types';
 
@@ -104,7 +104,7 @@ export function useChatFilters(search: Ref<string>): {
     ['chats', 'messages', 'chatlists'],
     [] as Chat[],
     () => search.value,
-    warmWhenIdle(warmChats, search),
+    warmWhenIdle(warmChats, warmChatsLoaded, search),
   );
   const lists = useLiveQuery(() => listChatLists(), ['chatlists'], [] as ChatList[]);
   const listsMap = computed(() => new Map(lists.value.map((l) => [l.id, l])));

--- a/src/services/chat-filters.ts
+++ b/src/services/chat-filters.ts
@@ -7,6 +7,7 @@
  */
 import { computed, ref, watch, type Ref, type ComputedRef } from 'vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
+import { warmChats, warmWhenIdle } from '@/composables/warmStores';
 import { listChats, listChatLists, getSetting, setSetting, chatIsUnread } from '@/db/queries';
 import type { Chat, ChatList } from '@/db/types';
 
@@ -94,11 +95,16 @@ export function useChatFilters(search: Ref<string>): {
   loaded: Ref<boolean>;
   tabFilters: Ref<FilterId[]>;
 } {
+  // When the search box is empty, seed first paint from the warm chats store so
+  // the list is already populated on tab entry; a typed term falls back to the
+  // live `listChats(term)` query (filtering stays in the data layer). See the
+  // "Search contract" in spec 1001's data-model.
   const allChats = useLiveQuery(
     () => listChats(search.value),
     ['chats', 'messages', 'chatlists'],
     [] as Chat[],
     () => search.value,
+    warmWhenIdle(warmChats, search),
   );
   const lists = useLiveQuery(() => listChatLists(), ['chatlists'], [] as ChatList[]);
   const listsMap = computed(() => new Map(lists.value.map((l) => [l.id, l])));

--- a/src/views/tabs/CallsPage.vue
+++ b/src/views/tabs/CallsPage.vue
@@ -145,7 +145,7 @@ import { deleteCalls, listCallGroups, markCallsSeen, listContacts } from '@/db/q
 import type { CallGroup } from '@/db/queries';
 import type { Call } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
-import { warmCalls, warmWhenIdle } from '@/composables/warmStores';
+import { warmCalls, warmCallsLoaded, warmWhenIdle } from '@/composables/warmStores';
 import { formatTime } from '@/utils/time';
 
 const PAGE = 15;
@@ -160,7 +160,7 @@ const calls = useLiveQuery(
   ['calls'],
   [] as CallGroup[],
   () => search.value,
-  warmWhenIdle(warmCalls, search),
+  warmWhenIdle(warmCalls, warmCallsLoaded, search),
 );
 // Gate the empty state so "No calls found" only shows once data has actually
 // resolved (true immediately when seeded from the warm store), never as a flash

--- a/src/views/tabs/CallsPage.vue
+++ b/src/views/tabs/CallsPage.vue
@@ -79,7 +79,7 @@
         <ion-infinite-scroll-content />
       </ion-infinite-scroll>
 
-      <div v-if="calls.length === 0" class="empty">
+      <div v-if="loaded && calls.length === 0" class="empty">
         <ion-note>No calls found</ion-note>
       </div>
     </ion-content>
@@ -145,6 +145,7 @@ import { deleteCalls, listCallGroups, markCallsSeen, listContacts } from '@/db/q
 import type { CallGroup } from '@/db/queries';
 import type { Call } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
+import { warmCalls, warmWhenIdle } from '@/composables/warmStores';
 import { formatTime } from '@/utils/time';
 
 const PAGE = 15;
@@ -152,12 +153,19 @@ const router = useRouter();
 const openInfo = (contactId: string) => router.push(`/call/${contactId}`);
 const search = ref('');
 const visible = ref(PAGE);
+// Empty search → seed first paint from the warm calls store; a typed term falls
+// back to the live query (spec 1001 "Search contract").
 const calls = useLiveQuery(
   () => listCallGroups(search.value),
   ['calls'],
-  [],
+  [] as CallGroup[],
   () => search.value,
+  warmWhenIdle(warmCalls, search),
 );
+// Gate the empty state so "No calls found" only shows once data has actually
+// resolved (true immediately when seeded from the warm store), never as a flash
+// before the list arrives (spec 1001 FR-006).
+const loaded = calls.loaded;
 watch(search, () => (visible.value = PAGE));
 const visibleCalls = computed(() => calls.value.slice(0, visible.value));
 

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -188,7 +188,7 @@
         <ion-infinite-scroll-content />
       </ion-infinite-scroll>
 
-      <div v-if="contacts.length === 0" class="empty">
+      <div v-if="loaded && contacts.length === 0" class="empty">
         <ion-note>No contacts found</ion-note>
       </div>
     </ion-content>
@@ -222,6 +222,7 @@ import { listInvitations, extendInvitation, type ServerInvitation } from '@/serv
 import { initialsAvatar } from '@/db/avatars';
 import type { Contact, FriendRequest } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
+import { warmContacts, warmWhenIdle } from '@/composables/warmStores';
 import { useConnect } from '@/composables/useConnect';
 import { peerPresence } from '@/composables/usePresence';
 import { capitalizeFirst } from '@/utils/text';
@@ -241,7 +242,13 @@ const contacts = useLiveQuery(
   ['contacts', 'chats'], // listContacts hides contacts whose 1:1 chat is pending
   [] as Contact[],
   () => search.value,
+  // Empty search → seed first paint from the warm contacts store; a typed term
+  // falls back to the live query (spec 1001 "Search contract").
+  warmWhenIdle(warmContacts, search),
 );
+// Gate the empty state so "No contacts found" only shows once data has resolved
+// (true immediately when seeded from the warm store), never as a flash (FR-006).
+const loaded = contacts.loaded;
 // Reset the page window when the search term changes.
 watch(search, () => (visible.value = PAGE));
 

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -222,7 +222,7 @@ import { listInvitations, extendInvitation, type ServerInvitation } from '@/serv
 import { initialsAvatar } from '@/db/avatars';
 import type { Contact, FriendRequest } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
-import { warmContacts, warmWhenIdle } from '@/composables/warmStores';
+import { warmContacts, warmContactsLoaded, warmWhenIdle } from '@/composables/warmStores';
 import { useConnect } from '@/composables/useConnect';
 import { peerPresence } from '@/composables/usePresence';
 import { capitalizeFirst } from '@/utils/text';
@@ -244,7 +244,7 @@ const contacts = useLiveQuery(
   () => search.value,
   // Empty search → seed first paint from the warm contacts store; a typed term
   // falls back to the live query (spec 1001 "Search contract").
-  warmWhenIdle(warmContacts, search),
+  warmWhenIdle(warmContacts, warmContactsLoaded, search),
 );
 // Gate the empty state so "No contacts found" only shows once data has resolved
 // (true immediately when seeded from the warm store), never as a flash (FR-006).

--- a/src/views/tabs/SettingsPage.vue
+++ b/src/views/tabs/SettingsPage.vue
@@ -112,11 +112,9 @@ import { logOutOutline, warningOutline } from 'ionicons/icons';
 import { YOU_SECTIONS, ICONS, searchSettings } from '@/settings/schema';
 import { clearToken } from '@/services/auth';
 import { listAlerts, resolveAlert } from '@/db/queries';
-import { getSecret } from '@/db/secrets';
-import { isUnlocked } from '@/services/crypto/identity';
 import type { Alert } from '@/db/types';
-import { initialsAvatar } from '@/db/avatars';
 import { useLiveQuery } from '@/composables/useLiveQuery';
+import { useSelfProfile } from '@/composables/useSelfProfile';
 
 const router = useRouter();
 const open = (section: string) => router.push(`/settings/${section}`);
@@ -133,28 +131,10 @@ async function handleAlert(alert: Alert) {
   router.push(`/settings/${alert.section}`);
 }
 
-// Profile fields are encrypted at rest (Class B); the isUnlocked dep re-reads
-// them once the keystore unlocks.
-const profileNameRef = useLiveQuery(
-  () => getSecret('profileName', 'You'),
-  ['settings'],
-  'You',
-  () => isUnlocked.value,
-);
-const about = useLiveQuery(
-  () => getSecret('profileAbout', 'Hey there! I am using Ring.'),
-  ['settings'],
-  'Hey there! I am using Ring.',
-  () => isUnlocked.value,
-);
-const photo = useLiveQuery(
-  () => getSecret('profileAvatar', ''),
-  ['settings'],
-  '',
-  () => isUnlocked.value,
-);
-const profileName = computed(() => profileNameRef.value);
-const avatar = computed(() => photo.value || initialsAvatar(profileNameRef.value));
+// Own profile from the shared warm singleton: decrypted once at unlock and kept
+// live, so the header shows the real name/photo on first paint instead of the
+// "You"/initials placeholder that used to swap in a moment later (spec 1001).
+const { name: profileName, avatar, about } = useSelfProfile();
 
 function logout() {
   clearToken();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "noEmit": true,
-    "baseUrl": ".",
-    "paths": { "@/*": ["src/*"] },
+    "paths": { "@/*": ["./src/*"] },
     "types": ["vite/client", "vite-plugin-pwa/client"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue", "vite.config.ts"],


### PR DESCRIPTION
Implements spec **1001 — smooth tab transitions**: eliminate the visible pop-in when switching bottom tabs (header/search/list rendering in pieces) and the Settings "You"/initials placeholder swap.

## Approach (client-side only; no server/wire/data-model change)
- **Shared warm stores** (`src/composables/warmStores.ts`): own profile + chat/call/contact lists, decrypted once on keystore unlock, kept live via the idb bus, cleared on every session-end. In-memory only — no plaintext at rest (FR-ZK-1..7).
- **Eager-load** the four tab pages (static imports) — no first-switch chunk stall.
- Tabs seed first paint from the warm store when search is empty; typed terms still hit the live query.
- `useSelfProfile` is now singleton-backed → real identity on first paint everywhere.
- Calls/Contacts empty states gated on `loaded` → no "No … found" flash; cold-start guard so an unwarmed store doesn't flash empty.

## Tests / gates
- `npm run build` ✅, `npm run test:unit` ✅ (warmStores + useSelfProfile), `e2e/tab-transitions.spec.ts` ✅ (+ navigation/chat-filters/bidi, no regressions).
- Keep-alive verified (return restores content+scroll) → conditional scroll fallback not needed.

## Notes
- Includes a tiny unrelated chore (drop deprecated tsconfig `baseUrl`).
- Manual verification pending (device frame-capture, theme toggle, ZK clear-storage spot check).

Closes #25
Closes #26
Closes #27
Closes #28
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)