### PR TITLE
feat(pwa): empty Chats/Calls hint to start a conversation or call (1003)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ Specs are grouped by category band; status moves
 |------|-------|--------|
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
-| [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🟡 in-progress |
+| [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,7 @@ Specs are grouped by category band; status moves
 |------|-------|--------|
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
+| [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -33,14 +33,20 @@ test('tab switches replace history; drill-downs still push', async ({ browser })
   }
   expect(await a.page.evaluate(() => history.length)).toBe(h0);
 
-  // Drill-down still PUSHES: a fresh account's empty Chats offers "Browse the
-  // directory" → /directory. That must add an entry, and back must return to Chats.
-  await a.page.getByRole('button', { name: /browse the directory/i }).click();
+  // Empty Chats now hints to Contacts to start a conversation (spec 1003). That's a
+  // tab switch (replace), so history must NOT grow.
+  await a.page.getByRole('button', { name: /start a conversation/i }).click();
+  await a.page.waitForURL('**/tabs/contacts');
+  expect(await a.page.evaluate(() => history.length)).toBe(h0);
+
+  // Drill-down still PUSHES: Contacts' "Browse user directory" → /directory adds an
+  // entry, and back must return to Contacts.
+  await a.page.getByRole('button', { name: /browse user directory/i }).click();
   await a.page.waitForURL('**/directory');
   expect(await a.page.evaluate(() => history.length)).toBe(h0 + 1);
 
   await a.page.goBack();
-  await a.page.waitForURL('**/tabs/chats');
+  await a.page.waitForURL('**/tabs/contacts');
 
   await ctx.close();
 });

--- a/specs/1003-empty-chats-calls/spec.md
+++ b/specs/1003-empty-chats-calls/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Empty Chats/Calls Hint
+
+**Feature Branch**: `feat/1003-empty-chats-calls`
+
+**Created**: 2026-06-15
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "when there are no chats or recent calls add a similar first item which gives a hint to the Contacts to start a call or conversation with their contacts, and in Contacts when there are no contacts, we already get a hint to Browse user directory"
+
+## Overview
+
+When the Chats or Calls tab is empty, the screen is a dead end — a bare "No chats
+yet" / "No calls found" with no obvious next step. The Contacts tab already solves
+this: it pins a "Browse user directory" row that points the user forward. This
+feature mirrors that pattern: an empty Chats or Calls tab shows a tappable first
+row that guides the user to the Contacts tab to start a conversation or a call.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Empty Chats hints to start a conversation (Priority: P1)
+
+A user with no chats opens the Chats tab and sees a clear, tappable row inviting
+them to start a conversation, which takes them to Contacts.
+
+**Why this priority**: An empty Chats tab is the most common first-run state; a
+dead end here is the biggest "what now?" moment.
+
+**Independent Test**: With no chats, the Chats tab shows the hint row; tapping it
+navigates to the Contacts tab.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has no chats, **When** they open the Chats tab, **Then** a
+   first row "Start a conversation / Pick a contact to chat with" is shown.
+2. **Given** that row, **When** the user taps it, **Then** the app navigates to the
+   Contacts tab.
+3. **Given** a non-empty filter that happens to match nothing (e.g. Unread), **When**
+   the user views it, **Then** a short contextual message is shown (not the hint row).
+
+---
+
+### User Story 2 - Empty Calls hints to start a call (Priority: P2)
+
+A user with no recent calls opens the Calls tab and sees a tappable row inviting
+them to start a call, which takes them to Contacts.
+
+**Why this priority**: Same dead-end problem on Calls; slightly less frequent than
+Chats but the same fix.
+
+**Independent Test**: With no recent calls, the Calls tab shows the hint row;
+tapping it navigates to the Contacts tab.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has no recent calls, **When** they open the Calls tab, **Then**
+   a first row "Start a call / Pick a contact to call" is shown.
+2. **Given** that row, **When** the user taps it, **Then** the app navigates to the
+   Contacts tab.
+
+---
+
+### Edge Cases
+
+- The hint must appear only once data has loaded (no flash before chats/calls
+  resolve) — reuse the existing `loaded` gate (spec 1001).
+- A brand-new user with no contacts who taps the hint lands on Contacts, which
+  already shows the "Browse user directory" row — so the flow continues naturally.
+- The hint must not appear when the tab actually has content.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When the Chats tab has no chats at all, it MUST show a tappable first
+  row hinting to start a conversation, navigating to the Contacts tab.
+- **FR-002**: When the Calls tab has no recent calls, it MUST show a tappable first
+  row hinting to start a call, navigating to the Contacts tab.
+- **FR-003**: The hint rows MUST visually match the existing Contacts "Browse user
+  directory" row (icon + title + subtitle + chevron, flush at the top).
+- **FR-004**: The hints MUST appear only after data has loaded (no empty-state flash),
+  and MUST NOT appear when the tab has content.
+- **FR-005**: A filtered-but-empty Chats view (e.g. Unread with nothing) MUST keep
+  showing its short contextual message, not the start-a-conversation hint.
+- **FR-006**: Contacts is unchanged — it already hints to "Browse user directory"
+  when empty.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With no chats, the Chats tab shows the hint row and tapping it lands on
+  Contacts, in 100% of cases.
+- **SC-002**: With no recent calls, the Calls tab shows the hint row and tapping it
+  lands on Contacts, in 100% of cases.
+- **SC-003**: No empty-state/hint flash occurs before data resolves (the hint is
+  gated on `loaded`).
+
+## Assumptions
+
+- "Similar first item" means the same visual treatment as the Contacts "Browse user
+  directory" row.
+- Both hints route to the Contacts tab (`/tabs/contacts`), the single place to pick a
+  contact or browse the directory — rather than duplicating a directory CTA.
+- This is a pure presentation change; no data model, server, or zero-knowledge impact.

--- a/specs/1003-empty-chats-calls/spec.md
+++ b/specs/1003-empty-chats-calls/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-15
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/views/tabs/CallsPage.vue
+++ b/src/views/tabs/CallsPage.vue
@@ -79,9 +79,17 @@
         <ion-infinite-scroll-content />
       </ion-infinite-scroll>
 
-      <div v-if="loaded && calls.length === 0" class="empty">
-        <ion-note>No calls found</ion-note>
-      </div>
+      <!-- No calls yet: a hint row points to Contacts to start a call (mirrors the
+           Contacts "Browse user directory" row). -->
+      <ion-list v-if="loaded && calls.length === 0" class="hint-list">
+        <ion-item button :detail="true" lines="full" @click="router.push('/tabs/contacts')">
+          <ion-icon slot="start" :icon="peopleOutline" color="primary" />
+          <ion-label>
+            <h2>Start a call</h2>
+            <p>Pick a contact to call</p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
     </ion-content>
 
     <!-- New call: pick a contact to open their call screen. -->
@@ -200,8 +208,11 @@ onIonViewDidEnter(() => void markCallsSeen());
 </script>
 
 <style scoped>
-.empty {
-  text-align: center;
-  margin-top: 40px;
+/* "Start a call" hint row, flush at the top like the Contacts browse row. */
+.hint-list {
+  padding-top: 0;
+}
+.hint-list ion-icon {
+  font-size: 24px;
 }
 </style>

--- a/src/views/tabs/CallsPage.vue
+++ b/src/views/tabs/CallsPage.vue
@@ -82,7 +82,9 @@
       <!-- No calls yet: a hint row points to Contacts to start a call (mirrors the
            Contacts "Browse user directory" row). -->
       <ion-list v-if="loaded && calls.length === 0" class="hint-list">
-        <ion-item button :detail="true" lines="full" @click="router.push('/tabs/contacts')">
+        <!-- router.replace (not push): a tab switch is terminal and must not grow
+             history, like tapping the tab bar (see navigation.spec). -->
+        <ion-item button :detail="true" lines="full" @click="router.replace('/tabs/contacts')">
           <ion-icon slot="start" :icon="peopleOutline" color="primary" />
           <ion-label>
             <h2>Start a call</h2>

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -50,18 +50,20 @@
         />
       </ion-list>
 
-      <!-- Empty states. The "Browse the directory" CTA is only for a brand-new user
-           with no chats at all; a filtered view that happens to be empty just says so
-           (the directory is reachable from the Contacts tab). -->
-      <div v-if="loaded && chats.length === 0" class="empty">
-        <template v-if="activeFilter === 'all' && allChats.length === 0">
-          <ion-note>No chats yet</ion-note>
-          <ion-button class="browse-btn" fill="solid" size="small" @click="router.push('/directory')">
-            <ion-icon slot="start" :icon="compassOutline" />
-            Browse the directory
-          </ion-button>
-        </template>
-        <ion-note v-else>{{ emptyMessage }}</ion-note>
+      <!-- Empty states. With no chats at all, a hint row points to Contacts to
+           start a conversation (mirrors the Contacts "Browse user directory" row);
+           a filtered view that happens to be empty just says so. -->
+      <ion-list v-if="loaded && activeFilter === 'all' && allChats.length === 0" class="hint-list">
+        <ion-item button :detail="true" lines="full" @click="router.push('/tabs/contacts')">
+          <ion-icon slot="start" :icon="peopleOutline" color="primary" />
+          <ion-label>
+            <h2>Start a conversation</h2>
+            <p>Pick a contact to chat with</p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+      <div v-else-if="loaded && chats.length === 0" class="empty">
+        <ion-note>{{ emptyMessage }}</ion-note>
       </div>
 
       <ChatActionsHost ref="actions" />
@@ -151,7 +153,7 @@ import {
   IonLabel, IonNote, IonModal,
 } from '@ionic/vue';
 import {
-  createOutline, personAddOutline, peopleOutline, compassOutline, archiveOutline, lockClosedOutline,
+  createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline,
 } from 'ionicons/icons';
 import ChatListItem from '@/components/ChatListItem.vue';
 import ChatActionsHost from '@/components/ChatActionsHost.vue';
@@ -255,8 +257,7 @@ async function newGroup() {
 </script>
 
 <style scoped>
-/* Empty state: the label sits near the top, while the "Browse the directory" CTA is
-   centred horizontally and pushed down toward the middle of the content area. */
+/* Empty state: a filtered-but-empty view just shows a short label near the top. */
 .empty {
   display: flex;
   flex-direction: column;
@@ -264,7 +265,11 @@ async function newGroup() {
   text-align: center;
   margin-top: 40px;
 }
-.browse-btn {
-  margin-top: 30vh;
+/* "Start a conversation" hint row, flush at the top like the Contacts browse row. */
+.hint-list {
+  padding-top: 0;
+}
+.hint-list ion-icon {
+  font-size: 24px;
 }
 </style>

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -54,7 +54,9 @@
            start a conversation (mirrors the Contacts "Browse user directory" row);
            a filtered view that happens to be empty just says so. -->
       <ion-list v-if="loaded && activeFilter === 'all' && allChats.length === 0" class="hint-list">
-        <ion-item button :detail="true" lines="full" @click="router.push('/tabs/contacts')">
+        <!-- router.replace (not push): switching to a tab is terminal, like tapping
+             the tab bar — it must not grow history (see navigation.spec). -->
+        <ion-item button :detail="true" lines="full" @click="router.replace('/tabs/contacts')">
           <ion-icon slot="start" :icon="peopleOutline" color="primary" />
           <ion-label>
             <h2>Start a conversation</h2>


### PR DESCRIPTION
Spec **1003** — an empty Chats or Calls tab was a dead end. Now it shows a tappable first row that guides the user to Contacts, mirroring the existing Contacts "Browse user directory" row.

## What's in it
- **Chats**, no chats at all → "Start a conversation / Pick a contact to chat with" → Contacts tab.
- **Calls**, no recent calls → "Start a call / Pick a contact to call" → Contacts tab.
- Same visual treatment as the Contacts browse row (primary icon + title + subtitle + chevron, flush at top).
- Gated on the existing `loaded` flag (no empty-state flash); a filtered-but-empty Chats view still shows its short contextual message.
- Contacts unchanged (already hints to "Browse user directory").

Pure presentation change; no data-model / server / zero-knowledge impact. Light flow (specify → implement); no per-task issues. Verified live via HMR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)