### PR TITLE
fix(pwa): update toast — stacked layout + re-surface on foreground

### DIFF
--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -123,6 +123,11 @@ export function useAppUpdate(): void {
         // toasts) surfaces; see the .app-update-toast rules in App.vue.
         position: 'top',
         cssClass: 'app-update-toast',
+        // Stack the buttons BELOW the message. The default 'baseline' layout puts
+        // the (three) buttons inline with the message and reserves their width, so
+        // on a phone the message gets squeezed into a sliver and wraps one word per
+        // line. Stacked gives the message the full toast width.
+        layout: 'stacked',
         // No duration: stay until the user chooses.
         buttons,
       });


### PR DESCRIPTION
Two related update-toast fixes.

### 1. Stacked layout (readability)
The version string is already clean (the `+sha` is stripped), but the toast was still unreadable on a phone — header + message wrapped one word per line in a narrow left column. Cause: Ionic's default `layout: 'baseline'` lays the three buttons inline with the message and reserves their width. Fix: `layout: 'stacked'` → buttons drop below the message, which now spans the full width.

### 2. Re-surface on foreground (don't bury "Later")
`Later` previously left no in-UI way to update without fully closing the app — and a user who never fully closes it (or won't hunt for a manual reload) could stay on an old build. The toast logic is now `maybePrompt()`, called on **every return to the foreground** as well as on the `needRefresh` watch, so a deferred update **reappears** next time the app is reopened (Update, or dismiss again). A full close still lets the waiting worker activate on its own, so there's nothing left to prompt.

Verified: typecheck. (UI/visual + SW lifecycle; not covered by the node-env vitest suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)