### PR TITLE
feat: connections & friendship (spec 0002)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ Specs are grouped by category band; status moves
 | Spec | Title | Status |
 |------|-------|--------|
 | [0001](specs/0001-show-what-changed/spec.md) | Show what changed in the update toast (release-note delta) | 🟢 shipped |
-| [0002](specs/0002-connections-and-friendship/spec.md) | Connections & Friendship | 🟡 in-progress |
+| [0002](specs/0002-connections-and-friendship/spec.md) | Connections & Friendship | 🔵 in-review |
 
 ## ⚡ Ad-hoc (1001–1999)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,7 @@ Specs are grouped by category band; status moves
 | Spec | Title | Status |
 |------|-------|--------|
 | [0001](specs/0001-show-what-changed/spec.md) | Show what changed in the update toast (release-note delta) | 🟢 shipped |
+| [0002](specs/0002-connections-and-friendship/spec.md) | Connections & Friendship | 🟡 in-progress |
 
 ## ⚡ Ad-hoc (1001–1999)
 

--- a/e2e/friendship.spec.ts
+++ b/e2e/friendship.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+import { createAccount } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Friendship gate (spec 0002): you become friends only via request → accept. The
+ * directory/key gate is server-enforced; these specs verify the request lifecycle
+ * across two accounts — accept makes BOTH sides friends (the requester is imported
+ * on the connect-update), an outgoing request can be withdrawn (retracting it from
+ * the other inbox), and an incoming request badges the Contacts tab.
+ */
+
+const conns = (p: any): Promise<{ incoming: any[]; outgoing: any[] }> =>
+  p.page.evaluate(() => (window as any).__ringTest.connections());
+const contactIds = (p: any): Promise<string[]> =>
+  p.page.evaluate(() => (window as any).__ringTest.contactIds());
+const incomingFrom = async (p: any): Promise<string[]> => (await conns(p)).incoming.map((r) => r.requester);
+const outgoingTo = async (p: any): Promise<string[]> => (await conns(p)).outgoing.map((r) => r.target);
+
+test('friendship: accept makes both friends (requester imported on accept); badge tracks it', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'FRIEND01');
+  const b = await createAccount(ctxB, 'FRIEND02');
+
+  // A requests friendship with B.
+  await a.page.evaluate((id) => (window as any).__ringTest.connectRequest(id), b.id);
+
+  // B has an incoming request from A; A has an outgoing one to B.
+  await expect.poll(() => incomingFrom(b)).toContain(a.id);
+  await expect.poll(() => outgoingTo(a)).toContain(b.id);
+
+  // Not friends yet — no local contact on either side (a pending request makes none).
+  expect(await contactIds(a)).not.toContain(b.id);
+  expect(await contactIds(b)).not.toContain(a.id);
+
+  // B's Contacts-tab badge counts incoming requests in the reactive connections
+  // store (useBadges → incomingRequests). The live connect-req push is best-effort,
+  // so reconcile B's store the way useSync does on (re)connect, then assert the
+  // badge's source of truth shows A's request.
+  const bIncoming = async (): Promise<string[]> => {
+    await b.page.evaluate(() => (window as any).__ringTest.syncConnections());
+    return b.page.evaluate(() => (window as any).__ringTest.incomingRequestIds());
+  };
+  await expect.poll(bIncoming).toContain(a.id);
+
+  // B accepts → both become friends; A imports B when the connect-update arrives.
+  await b.page.evaluate((id) => (window as any).__ringTest.connectAccept(id), a.id);
+  await expect.poll(() => contactIds(b)).toContain(a.id);
+  await expect.poll(() => contactIds(a)).toContain(b.id);
+
+  // The request leaves both lists, and B's badge clears once answered.
+  await expect.poll(() => outgoingTo(a)).not.toContain(b.id);
+  await expect.poll(bIncoming).not.toContain(a.id);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('friendship: withdrawing an outgoing request retracts it from the other inbox', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'FRIEND03');
+  const b = await createAccount(ctxB, 'FRIEND04');
+
+  await a.page.evaluate((id) => (window as any).__ringTest.connectRequest(id), b.id);
+  await expect.poll(() => incomingFrom(b)).toContain(a.id);
+
+  // A withdraws → it's gone from B's incoming AND A's outgoing (authoritative,
+  // server-side — not just a local removal).
+  await a.page.evaluate((id) => (window as any).__ringTest.connectWithdraw(id), b.id);
+  await expect.poll(() => incomingFrom(b)).not.toContain(a.id);
+  await expect.poll(() => outgoingTo(a)).not.toContain(b.id);
+
+  // Neither is a friend (no contact was ever created for a pending request).
+  expect(await contactIds(a)).not.toContain(b.id);
+  expect(await contactIds(b)).not.toContain(a.id);
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/server/internal/api/connections_handlers.go
+++ b/server/internal/api/connections_handlers.go
@@ -87,6 +87,31 @@ func (h *Handlers) acceptConnection(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// withdrawConnection (POST /v1/connections/withdraw) lets the caller (requester)
+// take back a pending request they sent to {target}. The pending row is removed
+// server-side so the target's incoming list drops it; the target is notified so its
+// UI/badge update live.
+func (h *Handlers) withdrawConnection(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var req connTargetReq
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&req); err != nil ||
+		!uuidRE.MatchString(req.Target) || req.Target == uid {
+		httpx.Error(w, http.StatusBadRequest, "invalid target")
+		return
+	}
+	if err := h.Connections.WithdrawConnection(r.Context(), uid, req.Target); err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not withdraw")
+		return
+	}
+	// Tell the target their incoming request is gone (so it leaves their list/badge).
+	h.notifyConn(req.Target, map[string]any{"t": "connect-update", "from": uid, "state": "withdrawn"})
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // rejectConnection (POST /v1/connections/reject) rejects (optionally + blocks) the
 // pending request from {requester}; a block also hides the caller from them.
 func (h *Handlers) rejectConnection(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/api/connections_handlers_test.go
+++ b/server/internal/api/connections_handlers_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"ring/server/internal/store"
+	"ring/server/internal/ws"
+)
+
+// fakeConn is a minimal in-memory ConnectionsStore for handler tests. It records
+// the last withdraw so the test can assert the handler called the store correctly.
+type fakeConn struct {
+	withdrawn map[[2]string]bool // (requester,target) -> true
+}
+
+func newFakeConn() *fakeConn { return &fakeConn{withdrawn: map[[2]string]bool{}} }
+
+func (c *fakeConn) Connected(_ context.Context, _, _ string) (bool, error)          { return false, nil }
+func (c *fakeConn) ConnectionState(_ context.Context, _, _ string) (string, error)  { return "", nil }
+func (c *fakeConn) RequestConnection(_ context.Context, _, _ string) (string, error) {
+	return "pending", nil
+}
+func (c *fakeConn) AcceptConnection(_ context.Context, _, _ string) error        { return nil }
+func (c *fakeConn) RejectConnection(_ context.Context, _, _ string, _ bool) error { return nil }
+func (c *fakeConn) WithdrawConnection(_ context.Context, requester, target string) error {
+	c.withdrawn[[2]string{requester, target}] = true
+	return nil
+}
+func (c *fakeConn) IncomingRequests(_ context.Context, _ string) ([]store.ConnectionReq, error) {
+	return nil, nil
+}
+func (c *fakeConn) OutgoingRequests(_ context.Context, _ string) ([]store.ConnectionReq, error) {
+	return nil, nil
+}
+
+// newConnTestServer builds the router with a real fake store (for register/auth)
+// plus a fake Connections store, so the connection handlers can be exercised.
+func newConnTestServer(conn ConnectionStore) (http.Handler, *fakeStore) {
+	as := newFakeStore()
+	srv := NewRouter(&Handlers{
+		Store:          as,
+		Directory:      as,
+		Contacts:       as,
+		Blocks:         as,
+		Relay:          as,
+		Connections:    conn,
+		Hub:            ws.NewHub(),
+		Keys:           newFakeKeysStore(),
+		Blobs:          newFakeBlobStore(),
+		Sync:           newFakeSyncStore(),
+		Push:           newFakePushStore(),
+		Invites:        as,
+		PublicURL:      "https://ring.example",
+		VapidPublicKey: "VAPID_PUB",
+	}, []string{"http://localhost:5173"})
+	return srv, as
+}
+
+func TestWithdrawConnectionRemovesPendingRequest(t *testing.T) {
+	conn := newFakeConn()
+	srv, _ := newConnTestServer(conn)
+
+	tokA, _, _ := registerNamed(t, srv, "alice")
+	_, bobID, _ := registerNamed(t, srv, "bob")
+
+	rr := do(t, srv, http.MethodPost, "/v1/connections/withdraw", tokA, `{"target":"`+bobID+`"}`)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("withdraw status = %d, want 204; body=%s", rr.Code, rr.Body.String())
+	}
+	// The handler must call WithdrawConnection(requester=alice, target=bob).
+	aliceID := registerLookup(t, srv, tokA)
+	if !conn.withdrawn[[2]string{aliceID, bobID}] {
+		t.Fatalf("WithdrawConnection not called with (alice,bob); recorded=%v", conn.withdrawn)
+	}
+}
+
+func TestWithdrawConnectionRejectsBadTarget(t *testing.T) {
+	conn := newFakeConn()
+	srv, _ := newConnTestServer(conn)
+	tokA, _, _ := registerNamed(t, srv, "alice")
+
+	// Not a UUID.
+	if rr := do(t, srv, http.MethodPost, "/v1/connections/withdraw", tokA, `{"target":"nope"}`); rr.Code != http.StatusBadRequest {
+		t.Fatalf("bad target status = %d, want 400", rr.Code)
+	}
+	// Self-target is rejected.
+	self := registerLookup(t, srv, tokA)
+	if rr := do(t, srv, http.MethodPost, "/v1/connections/withdraw", tokA, `{"target":"`+self+`"}`); rr.Code != http.StatusBadRequest {
+		t.Fatalf("self target status = %d, want 400", rr.Code)
+	}
+}
+
+func TestWithdrawConnectionRequiresAuth(t *testing.T) {
+	conn := newFakeConn()
+	srv, _ := newConnTestServer(conn)
+	if rr := do(t, srv, http.MethodPost, "/v1/connections/withdraw", "", `{"target":"00000000-0000-0000-0000-000000000009"}`); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("no-token status = %d, want 401", rr.Code)
+	}
+}
+
+// registerLookup returns the userID behind a token via /v1/me.
+func registerLookup(t *testing.T, srv http.Handler, token string) string {
+	t.Helper()
+	rr := do(t, srv, http.MethodGet, "/v1/me", token, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/v1/me status = %d", rr.Code)
+	}
+	var me struct {
+		UserID string `json:"userId"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &me); err != nil {
+		t.Fatalf("decode me: %v", err)
+	}
+	return me.UserID
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -48,6 +48,7 @@ type ConnectionStore interface {
 	RequestConnection(ctx context.Context, requester, target string) (string, error)
 	AcceptConnection(ctx context.Context, target, requester string) error
 	RejectConnection(ctx context.Context, target, requester string, block bool) error
+	WithdrawConnection(ctx context.Context, requester, target string) error
 	IncomingRequests(ctx context.Context, user string) ([]store.ConnectionReq, error)
 	OutgoingRequests(ctx context.Context, user string) ([]store.ConnectionReq, error)
 }
@@ -210,6 +211,7 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	mux.Handle("POST /v1/connections/request", authMW(http.HandlerFunc(h.requestConnection)))
 	mux.Handle("POST /v1/connections/accept", authMW(http.HandlerFunc(h.acceptConnection)))
 	mux.Handle("POST /v1/connections/reject", authMW(http.HandlerFunc(h.rejectConnection)))
+	mux.Handle("POST /v1/connections/withdraw", authMW(http.HandlerFunc(h.withdrawConnection)))
 	mux.Handle("POST /v1/connections/link", authMW(http.HandlerFunc(h.linkConnection)))
 
 	// Public in-network directory: discover any member, fetch one profile, update

--- a/server/internal/store/connections.go
+++ b/server/internal/store/connections.go
@@ -76,6 +76,17 @@ func (s *Store) AcceptConnection(ctx context.Context, target, requester string) 
 	return err
 }
 
+// WithdrawConnection lets the REQUESTER take back a request they sent: it removes
+// the pending requester→target row entirely (no-op if it isn't pending), so the
+// target's incoming list no longer shows it and both can rediscover each other in
+// the directory. Authoritative server-side cancel (vs. the best-effort peer card).
+func (s *Store) WithdrawConnection(ctx context.Context, requester, target string) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM connections WHERE requester = $1 AND target = $2 AND state = 'pending'`,
+		requester, target)
+	return err
+}
+
 // RejectConnection marks the request requester->target rejected. When block is true
 // it also blocks the requester, so they can no longer see target in the directory or
 // its presence (and the request shows as rejected for them).

--- a/specs/0002-connections-and-friendship/plan.md
+++ b/specs/0002-connections-and-friendship/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Connections & Friendship (0002)
+
+**Branch**: `feat/0002-connections-and-friendship` | **Date**: 2026-06-16 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Make the friendship model coherent on top of the EXISTING server `connections`
+table (pending/accepted/rejected + `created_at`/`updated_at`): the directory shows
+only not-yet-connected people, the single action is **Request Friendship**, one
+**Friend Requests** section shows incoming + outgoing with timestamps, accepted
+people are **Friends**, outgoing requests can be **withdrawn** server-side
+(retracting from the other inbox), and incoming requests **badge** the Contacts tab
++ app icon until answered.
+
+## Clarifications (resolved by judgment — no user prompt)
+
+- **C1 — Source of truth**: the server `connections` store is authoritative for
+  friend requests + friendship. The client connections store (GET /v1/connections →
+  `incoming`/`outgoing` with `updatedMs`) drives the Friend Requests UI; **Friends**
+  = accepted connections. Legacy local `FriendRequest` records are kept ONLY for the
+  accept→(create contact + 1:1 chat) mechanics and for **group invites**
+  (`kind:'group-invite'`), and are reconciled so a friend request never shows twice.
+- **C2 — Cancel = server withdraw**: add `POST /v1/connections/withdraw {target}`.
+  The requester's pending `requester→target` row is removed; the target is notified
+  via the existing `connect-update` frame with `state:"withdrawn"`. This makes cancel
+  authoritative and offline-safe (the target reconciles via GET /v1/connections even
+  if it was offline at cancel time) — replacing today's best-effort peer "cancel" card
+  (kept only as a fast-path UI hint). No DB migration (delete of an existing row).
+- **C3 — Directory stops auto-connecting**: directory **browse** no longer imports
+  members as contacts or marks them connected. Browse fetches directory users and
+  **filters out** anyone with an accepted OR pending (either-direction) connection,
+  using the connections state map. Import/connect happens only on Request Friendship
+  / Accept. `refreshContactProfiles` (profile refresh for EXISTING contacts) stays.
+- **C4 — Contacts sections consolidated**: replace the overlapping sections
+  (Connection requests / Sent / Requests / Requested) with one **Friend Requests**
+  (incoming: Accept/Decline; outgoing: Cancel; each with a timestamp) sourced from the
+  connections store, plus a **Friends** section (accepted). Group **Invitations**
+  (group invites) and **Invited** (invite codes) stay as separate existing sections.
+- **C5 — Timestamps**: `ConnItem` carries `updatedMs`; the UI renders a relative time
+  via the existing time util.
+- **C6 — Badges**: `countPendingRequests` includes incoming **connection** requests
+  (deduped against local `FriendRequest` records), so the Contacts-tab + app-icon
+  badges (via `useBadges`) reflect incoming friend requests and persist until
+  accept/decline (the request row persists until then).
+
+## Technical Context
+
+**Stack**: Go stdlib server (`internal/store`, `internal/api`) + PG `connections`
+table; Vue 3 + Ionic client (`services/connections.ts`, `services/directory.ts`,
+`db/queries.ts`, `views/detail/DirectoryPage.vue`, `views/tabs/ContactsPage.vue`,
+`composables/useBadges.ts`). **No DB migration** (states + timestamps already exist).
+
+**Testing**: server handler tests vs the in-memory fake store (withdraw); client
+unit tests for reconciliation/filtering helpers; e2e across two accounts (directory
+hides connected/pending, request→accept→Friends, cancel retracts the other side,
+badge).
+
+## Constitution Check
+
+- **I. Zero-Knowledge / IX. Privacy** — PASS: the connection graph + request states
+  already live server-side (the consent gate). Withdraw deletes a row the server
+  already holds; surfaces existing timestamps. No new user content/plaintext or
+  server-visible metadata beyond what a consent gate inherently needs.
+- **III. TDD** — server withdraw handler test first; client reconciliation/filter
+  unit tests; e2e for the flows.
+- **V. Offline-First / VI. Stateless+Forward-only** — no object-store/`DB_VERSION`
+  change client-side; no SQL migration server-side (reuse `connections`). Handlers
+  stay stdlib + fake-store-tested.
+- **X / XI. Ionic-first** — Contacts/directory UI uses stock Ionic components +
+  existing theme tokens; no bespoke widgets.
+
+Gate: PASS (no migration, no new server-visible metadata, consent model preserved).
+
+## Approach (phased)
+
+1. **Server withdraw** (contained, TDD): `Store.WithdrawConnection(requester,target)`
+   (delete pending row), `POST /v1/connections/withdraw`, notify target
+   `connect-update{state:"withdrawn"}`; handler test vs fake store.
+2. **Client connections store**: add `withdraw(userId)`; carry `updatedMs`; map
+   states for directory filtering + Friends/Requests.
+3. **Directory**: stop auto-import/auto-connect on browse; filter out
+   accepted+pending (either direction); DirectoryPage action = "Request Friendship"
+   only (drop "Save to contacts").
+4. **Contacts UI**: one Friend Requests section (incoming+outgoing+timestamps) +
+   Friends section; reconcile with legacy records; keep group invites + invite codes.
+5. **Badges**: `countPendingRequests` counts incoming connection requests (deduped).
+6. **Tests**: unit (reconcile/filter/withdraw) + e2e (two-account flows).
+
+## Project Structure
+
+```text
+server/internal/store/connections.go        # + WithdrawConnection
+server/internal/api/connections_handlers.go  # + POST /v1/connections/withdraw (+ _test.go)
+server/internal/api/router.go                # route
+src/services/connections.ts                  # + withdraw, updatedMs, state map
+src/services/directory.ts                    # browse: no auto-import; filter connected/pending
+src/views/detail/DirectoryPage.vue           # action: Request Friendship only
+src/views/tabs/ContactsPage.vue              # Friend Requests + Friends sections
+src/db/queries.ts                            # countPendingRequests incl. incoming conns; reconcile
+src/composables/useBadges.ts                 # (verify) contacts badge reflects incoming conns
+e2e/connect.spec.ts / directory.spec.ts      # extend for the new flows
+```
+
+## Complexity Tracking
+
+No constitution violations. The one real risk is the consent-gate refactor (dual
+request representation); mitigated by keeping the server `connections` store
+authoritative, reconciling (not rewriting) the local records, and covering the gate
+with two-account e2e before merge.

--- a/specs/0002-connections-and-friendship/spec.md
+++ b/specs/0002-connections-and-friendship/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-16
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/0002-connections-and-friendship/spec.md
+++ b/specs/0002-connections-and-friendship/spec.md
@@ -1,0 +1,226 @@
+# Feature Specification: Connections & Friendship
+
+**Feature Branch**: `feat/0002-connections-and-friendship`
+
+**Created**: 2026-06-16
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "When a new user browses the directory they should not see people they're already connected to. Tapping a directory user offers Connect and Save to contacts — drop Save to contacts (you should first accept friendship) and rename Connect to 'Request Friendship'. Add a Friend Requests section (incoming + outgoing) and a Friends section (accepted either way). While an open valid request exists, that user shouldn't appear in the directory. An incoming request shows a badge on the Contacts tab AND the app icon, accumulating with message badges; the badge persists until the request is answered. Requests carry timestamps (incoming and outgoing). You can cancel an outgoing request, which also retracts it from the other party's incoming list."
+
+## Overview
+
+Ring already has a server-side consent gate (`connections`: pending/accepted/
+rejected with timestamps) and a directory, but the UX contradicts a friendship
+model: the directory **auto-connects and auto-imports every member**, shows
+everyone (including people you already know), and offers a "Save to contacts"
+shortcut that skips consent. Requests are split across two overlapping
+representations (the server connections store and local `FriendRequest` records),
+surfaced in several confusing Contacts sections, and an outgoing request can't be
+cleanly withdrawn from the other person's inbox.
+
+This feature makes the model coherent: browsing the directory shows only people
+you are **not** already connected to and have **no open request** with; the single
+action is **Request Friendship**; requests live in one **Friend Requests** section
+(incoming + outgoing, each with a timestamp); accepted people live in a **Friends**
+section; you can **cancel an outgoing request** and it disappears from the other
+person's incoming list; and an incoming request badges the **Contacts tab and the
+app icon** (accumulating with unread messages) until you answer it.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Directory shows only not-yet-connected people (Priority: P1)
+
+Browsing the user directory, I see people I'm not already friends with and have no
+open request with — not my existing friends, and not anyone I already have a
+pending request to/from.
+
+**Why this priority**: Without this, the directory is cluttered with people you
+can't meaningfully act on, and it currently auto-adds everyone, breaking consent.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am friends with user X (accepted, either direction), **When** I
+   browse the directory, **Then** X does not appear.
+2. **Given** I have a pending request to/from user Y, **When** I browse the
+   directory, **Then** Y does not appear (until the request is answered/cancelled).
+3. **Given** I browse the directory, **When** members load, **Then** they are NOT
+   silently imported as contacts or auto-connected; they appear only as directory
+   entries I can act on.
+
+---
+
+### User Story 2 - Request Friendship is the only action (Priority: P1)
+
+Tapping a directory user offers a single primary action, **Request Friendship**
+(no "Save to contacts"). Sending it creates an outgoing request.
+
+**Acceptance Scenarios**:
+
+1. **Given** a directory user I'm not connected to, **When** I tap them, **Then**
+   the action is "Request Friendship" and there is no "Save to contacts" option.
+2. **When** I send the request, **Then** it appears in my Friend Requests
+   (outgoing) and the user disappears from my directory browse list.
+
+---
+
+### User Story 3 - Friend Requests section with incoming + outgoing + timestamps (Priority: P1)
+
+The Contacts tab has one **Friend Requests** section listing both incoming
+("wants to be friends") and outgoing ("requested") requests, each showing **when**
+it was made; incoming requests have Accept/Decline, outgoing have Cancel.
+
+**Acceptance Scenarios**:
+
+1. **Given** incoming and outgoing requests exist, **When** I open Contacts, **Then**
+   one Friend Requests section shows both, each with a human timestamp, incoming with
+   Accept/Decline and outgoing with Cancel.
+2. **Given** I accept an incoming request (or my outgoing one is accepted), **Then**
+   that person moves to the Friends section and leaves Friend Requests.
+
+---
+
+### User Story 4 - Friends section (Priority: P2)
+
+Accepted connections (whether I accepted theirs or they accepted mine) appear in a
+**Friends** section.
+
+**Acceptance Scenarios**:
+
+1. **Given** an accepted connection, **When** I open Contacts, **Then** the person
+   is in Friends and not in Friend Requests or the directory.
+
+---
+
+### User Story 5 - Cancel an outgoing request retracts it everywhere (Priority: P1)
+
+I can cancel an outgoing request; it leaves my outgoing list AND disappears from
+the other person's incoming list, and both of us can then re-discover each other in
+the directory.
+
+**Why this priority**: A request you can't cleanly take back is a trust/UX problem;
+the current cancel is a best-effort peer message that fails if the peer is offline.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have an outgoing pending request to Z, **When** I cancel it, **Then**
+   it is removed from my outgoing list and from Z's incoming list (server-side
+   withdraw, not only a peer message), and Z's badge for it clears.
+2. **Given** I cancelled, **When** either of us browses the directory, **Then** the
+   other reappears (no lingering open request).
+
+---
+
+### User Story 6 - Incoming-request badges that persist until answered (Priority: P2)
+
+An incoming friend request raises a count badge on the **Contacts tab** and the
+**app icon**, combined with unread-message/missed-call counts, and the badge stays
+until I accept or decline the request.
+
+**Acceptance Scenarios**:
+
+1. **Given** one or more incoming requests, **When** I view the app, **Then** the
+   Contacts tab shows a count badge and the app-icon badge includes it (added to
+   unread messages and missed calls).
+2. **Given** an unanswered incoming request, **When** I navigate around without
+   answering it, **Then** the badge does not clear; it clears only on accept/decline.
+
+### Edge Cases
+
+- A request whose target/requester later blocks the other: directory hiding +
+  request state must stay consistent (no ghost entries).
+- Cancel arriving when the other party already accepted: the accept wins (no
+  resurrection of a withdrawn request); state converges.
+- Offline cancel: the withdraw is recorded server-side so the other side reflects it
+  on next sync even if it was offline at cancel time.
+- Group-invite requests (existing `kind:'group-invite'`) are a separate flow and
+  MUST NOT be merged into the friend Friend Requests/Friends sections incorrectly.
+- Directory entry for someone with a *rejected* prior request: define whether they
+  reappear (assumption: a rejected/withdrawn request frees them to reappear; a
+  block keeps them hidden).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Directory browse/search MUST exclude users who are already friends
+  (accepted connection, either direction) and users with an open pending request
+  (incoming or outgoing).
+- **FR-002**: Browsing the directory MUST NOT auto-import members as contacts or
+  auto-mark them connected; membership in the directory is not friendship.
+- **FR-003**: The only directory action for a not-yet-connected user MUST be
+  "Request Friendship"; "Save to contacts" MUST be removed.
+- **FR-004**: Sending a request MUST create an outgoing pending request and remove
+  that user from the requester's directory browse results.
+- **FR-005**: The Contacts tab MUST present a single **Friend Requests** section
+  containing both incoming and outgoing pending requests; incoming offer
+  Accept/Decline, outgoing offer Cancel.
+- **FR-006**: Each request (incoming and outgoing) MUST display a timestamp of when
+  it was made (sourced from the existing server `created_at`/`updated_at`).
+- **FR-007**: Accepted connections (either direction) MUST appear in a **Friends**
+  section and not in Friend Requests or the directory.
+- **FR-008**: Cancelling an outgoing request MUST withdraw it server-side so it is
+  removed from the other party's incoming list (not only via a peer message),
+  converging even if a side was offline.
+- **FR-009**: After cancel/withdraw (or decline), the two users MUST be able to
+  rediscover each other in the directory (no lingering open request) — unless a
+  block applies.
+- **FR-010**: Incoming friend requests MUST contribute to the Contacts tab badge
+  and the app-icon badge, accumulating with unread messages and missed calls, and
+  MUST persist until the request is accepted or declined.
+- **FR-011**: The two request representations (server connections + local
+  `FriendRequest` records) MUST be reconciled so each pending request is shown once,
+  with consistent state, timestamp, and actions (no duplicate/contradictory rows).
+- **FR-012**: All new/changed UI MUST use stock Ionic components + existing theme
+  tokens (Constitution XI).
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: The connection graph + request states already live on
+  the server (existing `connections` table — the consent gate). This feature adds a
+  **withdraw/cancel** endpoint that abandons a *pending* row the server already
+  holds, and surfaces existing timestamps. No message/profile plaintext is added to
+  the wire. The server already sees who-requested-whom (unavoidable for a consent
+  gate); this does not expand that beyond what relaying a request requires.
+- **What is encrypted**: Profile data shown for a request (name/avatar) continues to
+  come from the directory/contact via existing paths; no new plaintext at rest.
+- **Metadata**: No new server-visible metadata beyond the request/withdraw the
+  consent gate inherently needs. The withdraw notification reuses the existing
+  `connect-update` frame style.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The directory never lists a current friend or a user with an open
+  request (verified e2e for both directions).
+- **SC-002**: Tapping a directory user offers only "Request Friendship"; no
+  "Save to contacts" anywhere.
+- **SC-003**: Friend Requests shows incoming + outgoing with timestamps; accepting
+  moves the person to Friends; both verified e2e.
+- **SC-004**: Cancelling an outgoing request removes it from the other party's
+  incoming list server-side (verified across two accounts e2e), and both reappear in
+  each other's directory.
+- **SC-005**: An incoming request increments the Contacts-tab and app-icon badges
+  (added to unread/missed), and the badge persists until answered.
+
+## Assumptions
+
+- Reuse the existing server `connections` table (states + `created_at`/`updated_at`)
+  rather than a new model; add a withdraw endpoint + store method + a
+  `connect-update`-style frame, and a forward-only migration only if a column is
+  missing (none expected — timestamps already exist).
+- "Friends" = an accepted connection in either direction; the local contact record
+  remains the address-book entry, gated by connection state for messaging.
+- The dual request representation is consolidated by treating the server connections
+  store as the source of truth for friend requests, with local records reconciled to
+  it (group invites stay a separate `kind`).
+- A rejected or withdrawn request frees both users to reappear in the directory; a
+  block keeps the blocker hidden from the blocked (existing behavior).
+- Badge plumbing reuses `useBadges` + `countPendingRequests`; the change ensures
+  incoming *connection* requests (server) are counted, not only legacy local records.

--- a/src/composables/useBadges.ts
+++ b/src/composables/useBadges.ts
@@ -16,6 +16,7 @@ import {
   countUnread,
   countUnresolvedAlerts,
 } from '@/db/queries';
+import { incomingRequests } from '@/services/connections';
 
 function setAppBadge(total: number): void {
   try {
@@ -33,7 +34,12 @@ function setAppBadge(total: number): void {
 export function useBadges() {
   const chats = useLiveQuery(() => countUnread(), ['chats'], 0);
   const calls = useLiveQuery(() => countMissedUnseen(), ['calls'], 0);
-  const contacts = useLiveQuery(() => countPendingRequests(), ['requests'], 0);
+  // Contacts badge = group invites + legacy db requests (countPendingRequests) PLUS
+  // incoming friend requests, which live in the connections store (server-driven,
+  // reconciled on connect by useSync). Persists until the request is answered
+  // (accept/decline refresh the store). Spec 0002 FR-010.
+  const pendingDb = useLiveQuery(() => countPendingRequests(), ['requests'], 0);
+  const contacts = computed(() => pendingDb.value + incomingRequests.value.length);
   const you = useLiveQuery(() => countUnresolvedAlerts(), ['alerts'], 0);
 
   const total = computed(

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -21,7 +21,7 @@ import { runOwnSync, ownSyncQuiet } from '@/services/ownsync';
 import { publishOwnProfile, syncContactEdges, refreshContactProfiles } from '@/services/directory';
 import { applyPushPreference, disablePush, revalidatePushSubscription } from '@/services/push';
 import { checkForUpdate } from '@/composables/useAppUpdate';
-import { refreshConnections } from '@/services/connections';
+import { refreshConnections, onConnectionAccepted } from '@/services/connections';
 import { notifyIncoming } from '@/services/notify';
 import { runInviteSync } from '@/services/invites';
 import { clearPresence } from '@/composables/usePresence';
@@ -229,11 +229,17 @@ function start(): void {
   transport.onMessage((f) => {
     // Connect-request notifications: re-read the authoritative state, and alert on a
     // new incoming request (so it surfaces like a friend request).
-    if (f.t === 'connect-req' || f.t === 'connect-update') {
+    if (f.t === 'connect-req') {
       void refreshConnections();
-      if (f.t === 'connect-req') {
-        void notifyIncoming({ kind: 'request', name: 'Someone', body: 'wants to connect' });
-      }
+      void notifyIncoming({ kind: 'request', name: 'Someone', body: 'wants to be friends' });
+      return;
+    }
+    if (f.t === 'connect-update') {
+      // Our outgoing request was accepted → they're a friend now: import + mark
+      // connected (we no longer auto-import the directory). Rejected/withdrawn just
+      // reconcile the lists.
+      if (f.state === 'accepted') void onConnectionAccepted(f.from);
+      else void refreshConnections();
       return;
     }
     const live = f.t.startsWith('call-') || f.t.startsWith('sfu-') || f.t === 'presence';

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -376,6 +376,17 @@ export async function connectReject(requester: string, block: boolean): Promise<
   if (!res.ok) throw new Error(`connect reject failed: ${res.status}`);
 }
 
+/** Withdraw a pending request you sent to `target`: removes it server-side so it
+ *  leaves the target's incoming list (authoritative cancel). */
+export async function connectWithdraw(target: string): Promise<void> {
+  const res = await fetch(`${apiBaseUrl()}/v1/connections/withdraw`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ target }),
+  });
+  if (!res.ok) throw new Error(`connect withdraw failed: ${res.status}`);
+}
+
 /** Create an accepted connection to `target` without a request (group co-members:
  *  membership is the consent), so fan-out can fetch their bundle under the gate. */
 export async function connectLink(target: string): Promise<void> {

--- a/src/services/connections.ts
+++ b/src/services/connections.ts
@@ -9,7 +9,7 @@
  */
 import { ref } from 'vue';
 import {
-  listConnections, connectRequest, connectAccept, connectReject, connectLink as apiLink,
+  listConnections, connectRequest, connectAccept, connectReject, connectWithdraw, connectLink as apiLink,
   fetchDirectoryUser,
 } from '@/services/api';
 import { importDirectoryUser } from '@/services/directory';
@@ -20,6 +20,8 @@ export interface ConnItem {
   name: string;
   avatar: string;
   state: string;
+  /** When the request was last updated (ms epoch, from the server), for "2h ago". */
+  updatedMs: number;
 }
 
 export const incomingRequests = ref<ConnItem[]>([]);
@@ -42,17 +44,27 @@ async function hydrate(userId: string): Promise<{ name: string; avatar: string }
 /** Reconcile the reactive request lists from the server. Safe to call on connect and
  *  whenever a connect-req / connect-update frame arrives. */
 export async function refreshConnections(): Promise<void> {
-  let data: { incoming: { requester: string }[]; outgoing: { target: string; state: string }[] };
+  let data: Awaited<ReturnType<typeof listConnections>>;
   try {
     data = await listConnections();
   } catch {
     return;
   }
   incomingRequests.value = await Promise.all(
-    data.incoming.map(async (r) => ({ userId: r.requester, ...(await hydrate(r.requester)), state: 'pending' })),
+    data.incoming.map(async (r) => ({
+      userId: r.requester,
+      ...(await hydrate(r.requester)),
+      state: 'pending',
+      updatedMs: r.updatedAt,
+    })),
   );
   outgoingRequests.value = await Promise.all(
-    data.outgoing.map(async (r) => ({ userId: r.target, ...(await hydrate(r.target)), state: r.state })),
+    data.outgoing.map(async (r) => ({
+      userId: r.target,
+      ...(await hydrate(r.target)),
+      state: r.state,
+      updatedMs: r.updatedAt,
+    })),
   );
 }
 
@@ -75,6 +87,13 @@ export async function acceptConnect(userId: string): Promise<void> {
 /** Reject (optionally + block) an incoming request. */
 export async function rejectConnect(userId: string, block: boolean): Promise<void> {
   await connectReject(userId, block);
+  await refreshConnections();
+}
+
+/** Withdraw (cancel) an outgoing request we sent: removes it server-side so it
+ *  leaves the other party's incoming list too. */
+export async function withdrawConnect(userId: string): Promise<void> {
+  await connectWithdraw(userId);
   await refreshConnections();
 }
 

--- a/src/services/connections.ts
+++ b/src/services/connections.ts
@@ -13,7 +13,7 @@ import {
   fetchDirectoryUser,
 } from '@/services/api';
 import { importDirectoryUser } from '@/services/directory';
-import { getContact } from '@/db/queries';
+import { getContact, markContactConnected } from '@/db/queries';
 
 export interface ConnItem {
   userId: string;
@@ -68,19 +68,26 @@ export async function refreshConnections(): Promise<void> {
   );
 }
 
-/** Send a connect request to a directory user (and save them as a contact so we can
- *  message once accepted). Returns the resulting state. */
+/** Request friendship with a directory user. A plain pending request creates NO
+ *  local contact — they're not a friend yet (they show under outgoing requests,
+ *  hydrated read-only from the directory). Only a mutual 'accepted' (they had
+ *  already requested us) makes them a friend right away. Returns the state. */
 export async function requestConnect(userId: string): Promise<string> {
   const state = await connectRequest(userId);
-  await importDirectoryUser(userId); // so their profile is on hand once accepted
+  if (state === 'accepted') {
+    await importDirectoryUser(userId); // now a friend → save their profile
+    await markContactConnected(userId);
+  }
   await refreshConnections();
   return state;
 }
 
-/** Accept an incoming request: connect + add them as a contact (so a chat can start). */
+/** Accept an incoming request: now a friend → import their profile as a contact and
+ *  mark connected (so a chat can start; the server already recorded the accept). */
 export async function acceptConnect(userId: string): Promise<void> {
   await connectAccept(userId);
   await importDirectoryUser(userId);
+  await markContactConnected(userId);
   await refreshConnections();
 }
 

--- a/src/services/connections.ts
+++ b/src/services/connections.ts
@@ -97,6 +97,15 @@ export async function rejectConnect(userId: string, block: boolean): Promise<voi
   await refreshConnections();
 }
 
+/** Our outgoing request was accepted (a connect-update frame arrived). They're a
+ *  friend now: import their profile as a contact + mark connected (we no longer
+ *  auto-import the directory), then reconcile the request lists. */
+export async function onConnectionAccepted(userId: string): Promise<void> {
+  await importDirectoryUser(userId);
+  await markContactConnected(userId);
+  await refreshConnections();
+}
+
 /** Withdraw (cancel) an outgoing request we sent: removes it server-side so it
  *  leaves the other party's incoming list too. */
 export async function withdrawConnect(userId: string): Promise<void> {

--- a/src/services/directory.ts
+++ b/src/services/directory.ts
@@ -2,12 +2,12 @@
  * Public in-network directory → local contacts.
  *
  * The network is invite-only, but inside it every member is discoverable. This
- * service pulls the server directory (GET /v1/users) and mirrors each member into
- * the local `contacts` store as an auto-connected contact, so they appear in the
- * Contacts list and you can start an E2EE chat/call with them WITHOUT a friend
- * request. The directory is the source of truth for OTHER members' profile fields
- * (display name, avatar, About, username); it never overrides local block/ghost
- * state, and Block stays the only barrier.
+ * service reads the server directory (GET /v1/users) and mirrors a member's
+ * PROFILE (display name, avatar, About, username) into the local `contacts` store.
+ * It does NOT make them a friend: friendship is established only via the
+ * request/accept flow (spec 0002), which is what the server consent gate enforces
+ * (you can't fetch a non-connected peer's key bundle). Mirroring a profile never
+ * overrides local block/ghost state, and Block stays the only barrier.
  */
 import {
   fetchDirectory,
@@ -18,7 +18,7 @@ import {
 } from './api';
 import { getSelfUserId } from './auth';
 import { get, put } from '@/db/idb';
-import { markContactConnected, isPeerBlocked, getSetting, downscaleAvatar, listContacts } from '@/db/queries';
+import { isPeerBlocked, getSetting, downscaleAvatar, listContacts } from '@/db/queries';
 import { getSecret } from '@/db/secrets';
 import { isUnlockedNow } from '@/services/crypto/identity';
 import { initialsAvatar } from '@/db/avatars';
@@ -49,8 +49,7 @@ export async function upsertDirectoryContact(u: DirectoryUser): Promise<void> {
     existing.avatar === avatar &&
     existing.about === about
   ) {
-    await markContactConnected(u.id); // still ensure the friendship flag is set
-    return;
+    return; // nothing the directory owns changed
   }
 
   const contact: Contact = {
@@ -62,10 +61,9 @@ export async function upsertDirectoryContact(u: DirectoryUser): Promise<void> {
     about,
     updatedAt: u.profileAt || Date.now(),
   };
+  // Mirror the PROFILE only — this does not make them a friend. Friendship is set
+  // (markContactConnected) by the accept flow; the server gate enforces it.
   await put('contacts', contact);
-  // Every directory member is an accepted "friend"; their messages show
-  // immediately (no friend-request gate) and they appear in the contacts list.
-  await markContactConnected(u.id);
 }
 
 /** Pull the whole directory and mirror it into contacts. Paged; best-effort

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -89,13 +89,18 @@ import {
 } from '@/services/chat-filters';
 import {
   createInvitation, deleteAccount, fetchPeerBundle,
-  connectRequest as apiConnectRequest, connectAccept as apiConnectAccept,
-  connectReject as apiConnectReject, listConnections as apiListConnections,
+  listConnections as apiListConnections,
   connectLink as apiConnectLink,
 } from '@/services/api';
 import { runInviteSync } from '@/services/invites';
 import { notifyBanners } from '@/services/notify';
 import { syncContactEdges } from '@/services/directory';
+import {
+  requestConnect as storeRequestConnect, acceptConnect as storeAcceptConnect,
+  rejectConnect as storeRejectConnect, withdrawConnect as storeWithdrawConnect,
+  refreshConnections as storeRefreshConnections,
+  incomingRequests as storeIncomingRequests,
+} from '@/services/connections';
 import { subscribePresence } from '@/composables/useSync';
 import { peerPresence } from '@/composables/usePresence';
 import { setSecret } from '@/db/secrets';
@@ -445,11 +450,22 @@ export function installTestHook(): void {
     deleteMediaByKind: (kinds: Media['kind'][], chatId?: string) => dbDeleteMediaByKind(kinds, chatId),
     deleteMediaLargerThan: (bytes: number, chatId?: string) => dbDeleteMediaLargerThan(bytes, chatId),
     /** Server-side directory search → [{id, username, displayName}]. */
-    connectRequest: (target: string) => apiConnectRequest(target),
+    // Drive the real client store actions (import + mark-connected + reconcile),
+    // not the raw API, so e2e exercises the actual friend-request behavior.
+    connectRequest: (target: string) => storeRequestConnect(target),
     connectLink: (target: string) => apiConnectLink(target),
-    connectAccept: (requester: string) => apiConnectAccept(requester),
-    connectReject: (requester: string, block: boolean) => apiConnectReject(requester, block),
+    connectAccept: (requester: string) => storeAcceptConnect(requester),
+    connectReject: (requester: string, block: boolean) => storeRejectConnect(requester, block),
+    connectWithdraw: (target: string) => storeWithdrawConnect(target),
     connections: () => apiListConnections(),
+    // Reconcile the reactive connections store from the server — the same thing
+    // useSync does on (re)connect. Lets e2e assert the badge deterministically
+    // instead of racing the best-effort live connect-req push.
+    syncConnections: () => storeRefreshConnections(),
+    // The Contacts-tab badge counts exactly these (useBadges → incomingRequests),
+    // so asserting on the store is asserting the badge's source of truth without
+    // having to drive the full auth UI into the tab bar.
+    incomingRequestIds: (): string[] => storeIncomingRequests.value.map((r) => r.userId),
     searchDirectory: async (q: string) =>
       (await searchDirectory(q)).map((u) => ({ id: u.id, username: u.username, displayName: u.displayName })),
 

--- a/src/views/detail/DirectoryPage.vue
+++ b/src/views/detail/DirectoryPage.vue
@@ -62,7 +62,7 @@ import {
 } from '@ionic/vue';
 import { fetchDirectory, type DirectoryUser } from '@/services/api';
 import { requestConnect, incomingRequests, outgoingRequests, refreshConnections } from '@/services/connections';
-import { getContact, startDirectChat } from '@/db/queries';
+import { getContact, startDirectChat, listContacts } from '@/db/queries';
 import { ensureProfile } from '@/composables/useProfileGate';
 import { initialsAvatar } from '@/db/avatars';
 import { peerPresence, presenceLabel } from '@/composables/usePresence';
@@ -83,7 +83,18 @@ const pendingIds = computed(() => {
   for (const r of outgoingRequests.value) if (r.state === 'pending') ids.add(r.userId);
   return ids;
 });
-const visibleResults = computed(() => results.value.filter((u) => !pendingIds.value.has(u.id)));
+// Friends = local contacts (only the accept flow creates one now), so hide them too.
+const friendIds = ref<Set<string>>(new Set());
+async function loadFriends(): Promise<void> {
+  try {
+    friendIds.value = new Set((await listContacts()).map((c) => c.id));
+  } catch {
+    /* leave as-is; directory just shows a few already-known people until next load */
+  }
+}
+const visibleResults = computed(() =>
+  results.value.filter((u) => !pendingIds.value.has(u.id) && !friendIds.value.has(u.id)),
+);
 
 // Token so a slow earlier search can't overwrite a newer one.
 let seq = 0;
@@ -114,6 +125,7 @@ function onSearch(q: string): void {
 onMounted(() => {
   void load('');
   void refreshConnections(); // so pending requests are hidden from the list
+  void loadFriends(); // so existing friends are hidden too
 });
 
 async function connect(u: DirectoryUser): Promise<void> {

--- a/src/views/detail/DirectoryPage.vue
+++ b/src/views/detail/DirectoryPage.vue
@@ -20,7 +20,7 @@
     <ion-content :fullscreen="true">
       <ion-list>
         <ion-item
-          v-for="u in results"
+          v-for="u in visibleResults"
           :key="u.id"
           button
           :detail="false"
@@ -42,7 +42,7 @@
         </ion-item>
       </ion-list>
 
-      <div v-if="!loading && results.length === 0" class="empty">
+      <div v-if="!loading && visibleResults.length === 0" class="empty">
         <ion-note>{{ query ? 'No one matches that.' : 'No other members yet.' }}</ion-note>
       </div>
       <div v-if="loading" class="empty">
@@ -53,7 +53,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonContent,
@@ -61,8 +61,7 @@ import {
   actionSheetController, toastController,
 } from '@ionic/vue';
 import { fetchDirectory, type DirectoryUser } from '@/services/api';
-import { importDirectoryUser } from '@/services/directory';
-import { requestConnect } from '@/services/connections';
+import { requestConnect, incomingRequests, outgoingRequests, refreshConnections } from '@/services/connections';
 import { getContact, startDirectChat } from '@/db/queries';
 import { ensureProfile } from '@/composables/useProfileGate';
 import { initialsAvatar } from '@/db/avatars';
@@ -73,6 +72,18 @@ const router = useRouter();
 const query = ref('');
 const results = ref<DirectoryUser[]>([]);
 const loading = ref(false);
+
+// Hide people you already have an OPEN friend request with (either direction) —
+// there's nothing to act on for them here; they live in Friend Requests instead.
+// (Accepted friends are excluded in a follow-up once directory auto-connect is
+// removed; a rejected/withdrawn request frees them to reappear.) Spec 0002 FR-001.
+const pendingIds = computed(() => {
+  const ids = new Set<string>();
+  for (const r of incomingRequests.value) ids.add(r.userId);
+  for (const r of outgoingRequests.value) if (r.state === 'pending') ids.add(r.userId);
+  return ids;
+});
+const visibleResults = computed(() => results.value.filter((u) => !pendingIds.value.has(u.id)));
 
 // Token so a slow earlier search can't overwrite a newer one.
 let seq = 0;
@@ -100,12 +111,10 @@ function onSearch(q: string): void {
   void load(q);
 }
 
-onMounted(() => void load(''));
-
-// Save someone from the directory: import their profile into contacts.
-async function save(u: DirectoryUser): Promise<string | null> {
-  return importDirectoryUser(u.id);
-}
+onMounted(() => {
+  void load('');
+  void refreshConnections(); // so pending requests are hidden from the list
+});
 
 async function connect(u: DirectoryUser): Promise<void> {
   if (!(await ensureProfile())) return; // require a name + photo before reaching out
@@ -134,17 +143,8 @@ async function openActions(u: DirectoryUser): Promise<void> {
     header: `${u.displayName} · @${u.username}`,
     buttons: [
       {
-        text: 'Connect',
+        text: 'Request Friendship',
         handler: () => void connect(u),
-      },
-      {
-        text: 'Save to contacts',
-        handler: () => {
-          void (async () => {
-            await save(u);
-            router.push(`/contact/${u.id}`);
-          })();
-        },
       },
       { text: 'Cancel', role: 'cancel' },
     ],

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -47,7 +47,7 @@
           </ion-avatar>
           <ion-label class="ion-text-wrap">
             <h2>{{ req.name }}</h2>
-            <p>wants to connect</p>
+            <p>wants to be friends · {{ formatStamp(req.updatedMs) }}</p>
           </ion-label>
           <ion-button slot="end" fill="solid" size="small" @click="acceptConn(req.userId)">Accept</ion-button>
           <ion-button slot="end" fill="clear" size="small" color="medium" @click="rejectConn(req)">Reject</ion-button>
@@ -64,8 +64,18 @@
           </ion-avatar>
           <ion-label class="ion-text-wrap">
             <h2>{{ req.name }}</h2>
-            <p>{{ req.state === 'rejected' ? 'Declined' : 'Request sent' }}</p>
+            <p>{{ req.state === 'rejected' ? 'Declined' : 'Request sent' }} · {{ formatStamp(req.updatedMs) }}</p>
           </ion-label>
+          <!-- Cancel an outgoing request → server withdraw, retracts it from the
+               other party's incoming list (spec 0002 FR-008). -->
+          <ion-button
+            v-if="req.state === 'pending'"
+            slot="end"
+            fill="clear"
+            size="small"
+            color="medium"
+            @click="withdrawConn(req.userId)"
+          >Cancel</ion-button>
         </ion-item>
       </ion-list>
 
@@ -209,9 +219,10 @@ import {
 import type { InfiniteScrollCustomEvent } from '@ionic/vue';
 import { personAddOutline, trashOutline, ellipsisHorizontal, compassOutline } from 'ionicons/icons';
 import {
-  incomingRequests, outgoingRequests, acceptConnect, rejectConnect, refreshConnections,
+  incomingRequests, outgoingRequests, acceptConnect, rejectConnect, withdrawConnect, refreshConnections,
   type ConnItem,
 } from '@/services/connections';
+import { formatStamp } from '@/utils/time';
 import {
   acceptRequest, cancelSentRequest, deleteContact,
   listContacts, listPendingRequests, listSentRequests, rejectRequest,
@@ -373,6 +384,11 @@ async function doCancel(code: string): Promise<void> {
 // Connect-request actions (the connection store reconciles via WS frames + connect).
 async function acceptConn(userId: string): Promise<void> {
   await acceptConnect(userId);
+}
+// Cancel an outgoing request: authoritative server withdraw (retracts it from the
+// other party's incoming list), not just a local removal (spec 0002 FR-008).
+async function withdrawConn(userId: string): Promise<void> {
+  await withdrawConnect(userId);
 }
 async function rejectConn(req: ConnItem): Promise<void> {
   const sheet = await actionSheetController.create({

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -37,11 +37,13 @@
         </ion-item>
       </ion-list>
 
-      <ion-list v-if="incomingRequests.length">
+      <!-- Friend requests: incoming (Accept/Decline) + outgoing pending (Cancel),
+           one section, sourced from the connections store with timestamps (0002). -->
+      <ion-list v-if="incomingRequests.length || pendingOutgoing.length">
         <ion-list-header>
-          <ion-label>Connection requests</ion-label>
+          <ion-label>Friend requests</ion-label>
         </ion-list-header>
-        <ion-item v-for="req in incomingRequests" :key="req.userId" :detail="false">
+        <ion-item v-for="req in incomingRequests" :key="`in-${req.userId}`" :detail="false">
           <ion-avatar slot="start">
             <img :src="req.avatar || initialsAvatar(req.name)" :alt="req.name" />
           </ion-avatar>
@@ -50,53 +52,19 @@
             <p>wants to be friends · {{ formatStamp(req.updatedMs) }}</p>
           </ion-label>
           <ion-button slot="end" fill="solid" size="small" @click="acceptConn(req.userId)">Accept</ion-button>
-          <ion-button slot="end" fill="clear" size="small" color="medium" @click="rejectConn(req)">Reject</ion-button>
+          <ion-button slot="end" fill="clear" size="small" color="medium" @click="rejectConn(req)">Decline</ion-button>
         </ion-item>
-      </ion-list>
-
-      <ion-list v-if="outgoingRequests.length">
-        <ion-list-header>
-          <ion-label>Sent</ion-label>
-        </ion-list-header>
-        <ion-item v-for="req in outgoingRequests" :key="req.userId" :detail="false">
+        <ion-item v-for="req in pendingOutgoing" :key="`out-${req.userId}`" :detail="false">
           <ion-avatar slot="start">
             <img :src="req.avatar || initialsAvatar(req.name)" :alt="req.name" />
           </ion-avatar>
           <ion-label class="ion-text-wrap">
             <h2>{{ req.name }}</h2>
-            <p>{{ req.state === 'rejected' ? 'Declined' : 'Request sent' }} · {{ formatStamp(req.updatedMs) }}</p>
+            <p>Requested · {{ formatStamp(req.updatedMs) }}</p>
           </ion-label>
-          <!-- Cancel an outgoing request → server withdraw, retracts it from the
-               other party's incoming list (spec 0002 FR-008). -->
-          <ion-button
-            v-if="req.state === 'pending'"
-            slot="end"
-            fill="clear"
-            size="small"
-            color="medium"
-            @click="withdrawConn(req.userId)"
-          >Cancel</ion-button>
-        </ion-item>
-      </ion-list>
-
-      <ion-list v-if="requests.length">
-        <ion-list-header>
-          <ion-label>Requests</ion-label>
-        </ion-list-header>
-        <ion-item v-for="req in requests" :key="req.id" :detail="false">
-          <ion-avatar slot="start">
-            <img :src="req.avatar" :alt="req.name" />
-          </ion-avatar>
-          <ion-label>
-            <h2>{{ req.name }}</h2>
-            <p>wants to connect</p>
-          </ion-label>
-          <ion-button slot="end" fill="solid" size="small" @click="accept(req.id)">
-            Accept
-          </ion-button>
-          <ion-button slot="end" fill="clear" size="small" color="medium" @click="reject(req.id)">
-            Reject
-          </ion-button>
+          <!-- Cancel → confirm → server withdraw, retracting it from their inbox
+               (spec 0002 FR-008). -->
+          <ion-button slot="end" fill="clear" size="small" color="medium" @click="cancelConn(req)">Cancel</ion-button>
         </ion-item>
       </ion-list>
 
@@ -117,24 +85,6 @@
           </ion-button>
           <ion-button slot="end" fill="clear" size="small" color="medium" @click="declineInvite(inv.groupId)">
             Decline
-          </ion-button>
-        </ion-item>
-      </ion-list>
-
-      <ion-list v-if="sent.length">
-        <ion-list-header>
-          <ion-label>Requested</ion-label>
-        </ion-list-header>
-        <ion-item v-for="req in sent" :key="req.id" :detail="false">
-          <ion-avatar slot="start">
-            <img :src="req.avatar" :alt="req.name" />
-          </ion-avatar>
-          <ion-label>
-            <h2>{{ req.name }}</h2>
-            <p>Request sent</p>
-          </ion-label>
-          <ion-button slot="end" fill="clear" size="small" color="medium" @click="cancel(req.id)">
-            Cancel
           </ion-button>
         </ion-item>
       </ion-list>
@@ -165,6 +115,9 @@
       </ion-list>
 
       <ion-list>
+        <ion-list-header v-if="contacts.length">
+          <ion-label>Friends</ion-label>
+        </ion-list-header>
         <template v-for="group in groups" :key="group.letter">
           <ion-item-divider sticky>
             <ion-label>{{ group.letter }}</ion-label>
@@ -199,7 +152,7 @@
       </ion-infinite-scroll>
 
       <div v-if="loaded && contacts.length === 0" class="empty">
-        <ion-note>No contacts found</ion-note>
+        <ion-note>No friends yet</ion-note>
       </div>
     </ion-content>
   </ion-page>
@@ -214,7 +167,7 @@ import {
   IonItemDivider, IonAvatar, IonLabel, IonNote,
   IonInfiniteScroll, IonInfiniteScrollContent,
   IonItemSliding, IonItemOptions, IonItemOption,
-  actionSheetController, toastController, onIonViewWillEnter,
+  actionSheetController, alertController, toastController, onIonViewWillEnter,
 } from '@ionic/vue';
 import type { InfiniteScrollCustomEvent } from '@ionic/vue';
 import { personAddOutline, trashOutline, ellipsisHorizontal, compassOutline } from 'ionicons/icons';
@@ -224,8 +177,7 @@ import {
 } from '@/services/connections';
 import { formatStamp } from '@/utils/time';
 import {
-  acceptRequest, cancelSentRequest, deleteContact,
-  listContacts, listPendingRequests, listSentRequests, rejectRequest,
+  deleteContact, listContacts,
   listPendingInvites, cancelSentInvite, type PendingInvite,
   listGroupInvites, acceptGroupInvite, declineGroupInvite,
 } from '@/db/queries';
@@ -244,7 +196,7 @@ const open = (id: string) => router.push(`/contact/${id}`);
 const removeContact = (id: string) => deleteContact(id);
 
 // Shared add-contact flow (also used by the New-chat modal).
-const { connect, requireProfile } = useConnect();
+const { connect } = useConnect();
 
 const search = ref('');
 const visible = ref(PAGE);
@@ -263,24 +215,9 @@ const loaded = contacts.loaded;
 // Reset the page window when the search term changes.
 watch(search, () => (visible.value = PAGE));
 
-const requests = useLiveQuery(
-  () => listPendingRequests(),
-  ['requests'],
-  [] as FriendRequest[],
-);
-// Outgoing requests we've sent, awaiting the peer's acceptance.
-const sent = useLiveQuery(
-  () => listSentRequests(),
-  ['requests'],
-  [] as FriendRequest[],
-);
-// Accepting also sends your contact card back, so require a profile first.
-async function accept(id: string): Promise<void> {
-  if (!(await requireProfile())) return;
-  await acceptRequest(id);
-}
-const reject = (id: string) => rejectRequest(id);
-const cancel = (id: string) => cancelSentRequest(id);
+// Outgoing friend requests still awaiting a response (pending only). Rejected ones
+// drop out of the list — the person becomes discoverable in the directory again.
+const pendingOutgoing = computed(() => outgoingRequests.value.filter((r) => r.state === 'pending'));
 
 // Incoming group invitations (accept-first): accepting creates the group chat and
 // starts receiving from that point; declining tells the inviter and clears it.
@@ -385,10 +322,18 @@ async function doCancel(code: string): Promise<void> {
 async function acceptConn(userId: string): Promise<void> {
   await acceptConnect(userId);
 }
-// Cancel an outgoing request: authoritative server withdraw (retracts it from the
-// other party's incoming list), not just a local removal (spec 0002 FR-008).
-async function withdrawConn(userId: string): Promise<void> {
-  await withdrawConnect(userId);
+// Cancel an outgoing request → confirm first, then authoritative server withdraw
+// (retracts it from the other party's incoming list, spec 0002 FR-008).
+async function cancelConn(req: ConnItem): Promise<void> {
+  const alert = await alertController.create({
+    header: 'Cancel friend request?',
+    message: `Withdraw your request to ${req.name}? They won't see it anymore.`,
+    buttons: [
+      { text: 'Keep', role: 'cancel' },
+      { text: 'Cancel request', role: 'destructive', handler: () => void withdrawConnect(req.userId) },
+    ],
+  });
+  await alert.present();
 }
 async function rejectConn(req: ConnItem): Promise<void> {
   const sheet = await actionSheetController.create({


### PR DESCRIPTION
## Summary

Implements spec **0002 — Connections & Friendship**: a true friend model on top of the existing server-enforced connect-request gate. You become friends only via **request → accept**; the directory no longer silently auto-friends anyone, and a pending request creates **no** local contact until it's accepted.

**Review-ready, not auto-merge** — please review before merging.

## What changed

**Server**
- New authoritative `POST /v1/connections/withdraw` (cancel an outgoing request): deletes the pending row and pushes a `connect-update {state: "withdrawn"}` frame so it leaves the other party's inbox too. Added to `ConnectionStore` + handler tests.

**Client — friendship lifecycle**
- Directory mirrors **profile only**, never friendship — `upsertDirectoryContact` no longer marks contacts connected.
- `requestConnect` creates only a server-pending request (no local contact); a mutual `accepted` shortcuts straight to friend.
- `acceptConnect` imports the requester's profile + marks connected; the requester reconciles from the live `connect-update` frame via `onConnectionAccepted`.
- `withdrawConnect` cancels server-side; request lists carry server timestamps (`updatedMs`).

**Client — Contacts UI**
- One **"Friend requests"** section: incoming (Accept/Decline) + outgoing (Cancel), each with a relative timestamp, above a **"Friends"** list with an empty state.
- DirectoryPage offers **"Request Friendship"** only (dropped "Save to contacts"); already-friend and already-pending users are filtered out of results.
- **Confirmation prompts** before cancelling an outgoing request and before declining an incoming one (destructive, authoritative).

**Badges**
- Contacts tab + app-icon badge count incoming friend requests from the reactive connections store; persists until the request is answered (FR-010).

## Tests
- `go build/vet/test ./...` — green (incl. new withdraw handler tests).
- `vue-tsc` typecheck + `vite build` — green.
- `vitest` — 77 unit tests pass.
- e2e — new `e2e/friendship.spec.ts` (accept makes both friends; badge source-of-truth tracks the request; withdraw retracts from the other inbox) plus directory/connect/curated-contacts/groups/block/group-invite all pass (10/10).

## Notes / follow-up
- The requester learns of an acceptance via the live `connect-update` frame. If the requester is offline at accept time they reconcile on next sync via the contact import path; exposing accepted connections in `GET /v1/connections` would make this fully pull-based — left as a possible follow-up, not required for this spec.