### PR TITLE
feat: message action menu — single-tap, scrollable reactions (spec 1004)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,7 @@ Specs are grouped by category band; status moves
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
 | [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
+| [1004](specs/1004-message-action-menu/spec.md) | Message Action Menu | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ Specs are grouped by category band; status moves
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
 | [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
-| [1004](specs/1004-message-action-menu/spec.md) | Message Action Menu | 🟡 in-progress |
+| [1004](specs/1004-message-action-menu/spec.md) | Message Action Menu | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/message-menu.spec.ts
+++ b/e2e/message-menu.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Message action menu (spec 1004): a single tap anywhere on a bubble — text or the
+ * full image/video/album area — opens the unified menu (a horizontally-scrolling
+ * quick-react row with an always-visible "+" on top, actions below). These tests
+ * drive the real popover via taps, and verify usage-based reordering of the row.
+ */
+
+const chatWith = (p: any, peerId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
+const send = (p: any, chatId: string, body: string) =>
+  p.page.evaluate(
+    (args: [string, string]) => (window as any).__ringTest.sendChatMessage(args[0], args[1]),
+    [chatId, body] as [string, string],
+  );
+const messages = (p: any, chatId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.messages(id), chatId);
+const getReactions = (p: any, messageId: string): Promise<string[]> =>
+  p.page.evaluate(
+    (id: string) => (window as any).__ringTest.getReactions(id).then((rs: any[]) => rs.map((r) => r.emoji)),
+    messageId,
+  );
+
+test('single tap on a text bubble opens the menu; the emoji row + "+" work', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'MSGMENU1');
+  const b = await createAccount(ctxB, 'MSGMENU2');
+  await pair(a, b);
+
+  const aChat = (await chatWith(a, b.id)) as string;
+  await send(a, aChat, 'tap me');
+  const mid = ((await messages(a, aChat)) as any[]).find((m) => m.body === 'tap me').id as string;
+
+  await a.page.goto(`/chat/${aChat}`);
+  const bubble = a.page.locator(`.bubble[data-mid="${mid}"]`);
+  await bubble.waitFor({ state: 'visible', timeout: 30_000 });
+
+  // A single tap opens the action menu (no long-press needed).
+  await bubble.click();
+  const menu = a.page.locator('.ma');
+  await expect(menu).toBeVisible();
+
+  // The reaction row scrolls (its own track) and the trailing "+" is fully visible.
+  await expect(a.page.locator('.ma .ma-emoji-track')).toBeVisible();
+  await expect(a.page.locator('.ma .ma-more')).toBeVisible();
+
+  // Tapping the first quick emoji applies it as a reaction, then dismisses the menu.
+  await a.page.locator('.ma .ma-emoji-track .ma-emoji').first().click();
+  await expect(menu).toBeHidden();
+  await expect.poll(() => getReactions(a, mid)).not.toEqual([]);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('single tap on an image bubble opens the menu with a "View" action', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'MSGMENU3');
+  const b = await createAccount(ctxB, 'MSGMENU4');
+  await pair(a, b);
+
+  const aChat = (await chatWith(a, b.id)) as string;
+  await a.page.goto(`/chat/${aChat}`);
+
+  // Paste + send a 1×1 PNG so a real image bubble renders (no precise edge-tapping).
+  const composer = a.page.locator('ion-textarea.composer textarea');
+  await composer.waitFor({ state: 'visible', timeout: 30_000 });
+  await composer.click();
+  await a.page.evaluate(() => {
+    const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    const dt = new DataTransfer();
+    dt.items.add(new File([bytes], 'pasted.png', { type: 'image/png' }));
+    const ta = document.querySelector('ion-textarea.composer textarea')!;
+    ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+  });
+  await a.page.getByRole('button', { name: 'Send' }).click();
+  await a.page.getByText('Original quality').click();
+
+  const image = a.page.locator('.bubble .bubble-image').last();
+  await expect(image).toBeVisible({ timeout: 30_000 });
+
+  // Tapping anywhere on the image opens the menu (the whole bubble is the hit
+  // target), and the viewer is reachable from there via "View".
+  await image.click();
+  await expect(a.page.locator('.ma')).toBeVisible();
+  await expect(a.page.getByText('View', { exact: true })).toBeVisible();
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('the reaction row reorders by usage — a more-used emoji surfaces first', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'MSGMENU5');
+  const b = await createAccount(ctxB, 'MSGMENU6');
+  await pair(a, b);
+
+  const aChat = (await chatWith(a, b.id)) as string;
+  await send(a, aChat, 'react here');
+  const mid = ((await messages(a, aChat)) as any[]).find((m) => m.body === 'react here').id as string;
+
+  // Reacting with a custom (non-default) emoji records a use; it should then lead
+  // the quick-react order ahead of the zero-use defaults (FR-006 / SC-005).
+  const quickFirst = async (): Promise<string> => {
+    const q = (await a.page.evaluate(() => (window as any).__ringTest.quickReactEmojis(12))) as string[];
+    return q[0];
+  };
+  expect(await quickFirst()).not.toBe('🔥'); // a fresh account leads with a default
+  await a.page.evaluate((id: string) => (window as any).__ringTest.reactToMessage(id, '🔥'), mid);
+  await expect.poll(quickFirst).toBe('🔥');
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/specs/1004-message-action-menu/spec.md
+++ b/specs/1004-message-action-menu/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-16
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1004-message-action-menu/spec.md
+++ b/specs/1004-message-action-menu/spec.md
@@ -1,0 +1,165 @@
+# Feature Specification: Message Action Menu
+
+**Feature Branch**: `feat/1004-message-action-menu`
+
+**Created**: 2026-06-16
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "It's very hard to tap the border of a video/album/image to get the menu to show up — maybe make the lower bezel a bit thicker so it's easier. The emoji row above the popup menu should scroll horizontally and have a + at the end to choose another emoji (which then reorders by use/popularity and is shown more); it's now broken and doesn't slide properly, and when it did, it sometimes slid the other sections of the menu too — only the top emoji row should slide, everything else stays put, and the + must be fully visible and selectable. Regardless of how wide/narrow the message is, tapping it (or its borders, for images/videos) should open the menu fully visible and interactable, clearly showing which message it's for. Maybe slightly zoom the focused message (hover feel) and blur the others — thinking out loud, you judge if it's reasonable performance-wise. A single tap (not necessarily long-press) opens the menu — many users prefer that."
+
+## Overview
+
+The per-message action menu (the popup with a quick-reaction emoji row on top and
+actions below) is hard to invoke and partly broken. On media bubbles (image,
+video, album) the tappable area is finicky — it's hard to hit to open the menu.
+The emoji reaction row doesn't scroll horizontally as intended, has no working
+"+" to pick a custom emoji, and when it did move it dragged the rest of the menu
+with it. The menu can also open in awkward positions on very wide/narrow messages.
+
+This feature makes the menu reliably **single-tap** to open from anywhere on a
+message (including the full media bubble area), gives the reaction row a smooth
+**horizontal scroll** with a fully-visible **"+" custom-emoji** affordance and
+**usage-based reordering**, keeps every section **except** the reaction row
+stationary, and positions the menu **fully visible and interactive** while clearly
+indicating which message it belongs to.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Easy single-tap to open on any message, including media (Priority: P1)
+
+A single tap anywhere on a message bubble — including the whole image/video/album
+area — opens its action menu. No precise border-tapping or long-press required.
+
+**Acceptance Scenarios**:
+
+1. **Given** any message (text, image, video, album), **When** I single-tap it,
+   **Then** its action menu opens.
+2. **Given** a media bubble, **When** I tap anywhere within it (including near the
+   edges), **Then** the menu opens (the hit target covers the bubble; the media's
+   own primary action, e.g. open viewer, remains reachable per the chosen gesture
+   split).
+
+---
+
+### User Story 2 - Reaction row scrolls horizontally with a working "+" (Priority: P1)
+
+The emoji reaction row at the top of the menu scrolls horizontally and ends with a
+"+" to choose a custom emoji; the "+" is always fully visible and tappable.
+
+**Acceptance Scenarios**:
+
+1. **Given** the menu is open, **When** I swipe the emoji row left/right, **Then**
+   only the emoji row scrolls; all other menu sections stay stationary.
+2. **Given** the emoji row, **When** it renders, **Then** the trailing "+" is fully
+   visible and selectable regardless of message width.
+3. **Given** I tap "+", **When** the emoji picker opens and I choose an emoji,
+   **Then** it is applied as a reaction.
+
+---
+
+### User Story 3 - Reaction row reorders by usage/popularity (Priority: P2)
+
+Emojis I use more often surface earlier in the reaction row over time.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have reacted with some emojis more than others, **When** the reaction
+   row renders, **Then** more-used emojis appear earlier (after any always-pinned
+   defaults), within a stable, sensible scheme.
+
+---
+
+### User Story 4 - Menu opens fully visible and clearly attached to its message (Priority: P1)
+
+However wide or narrow the message, the menu opens fully on-screen and interactive,
+and it's visually clear which message it's acting on.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message near the top/bottom/edge of the screen, **When** I open its
+   menu, **Then** the whole menu (reaction row + actions) is within the viewport and
+   interactive (no clipping, nothing off-screen).
+2. **Given** the menu is open, **When** I look at the screen, **Then** it's clear
+   which message it belongs to (the message is visually associated with the menu).
+
+---
+
+### Edge Cases
+
+- Very wide media and very narrow text bubbles both yield a fully-visible menu.
+- The emoji row never causes horizontal scrolling of the page or sibling sections.
+- A message at the very top or bottom still gets a fully-visible menu (flip/anchor
+  as needed).
+- RTL layouts: the reaction row scrolls and the "+" sits correctly for RTL.
+- The optional focus zoom/blur (US5) must not drop frames or it is omitted.
+
+### Optional / judgment (US5 - Focus emphasis, Priority: P3)
+
+Slightly emphasize the focused message (e.g. a subtle scale) and de-emphasize the
+rest (dim/blur) to give a "hovering" feel — **only if** it's smooth on target
+devices. This is explicitly optional: if it risks jank, omit it and keep a simple
+clear association (the spec does not require the blur).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A single tap anywhere on a message bubble — including the full
+  image/video/album area — MUST open that message's action menu.
+- **FR-002**: The media bubble's tap target MUST be easy to hit (cover the bubble;
+  thicken/extend the hit area as needed) so opening the menu doesn't require precise
+  edge tapping.
+- **FR-003**: The reaction (emoji) row MUST scroll horizontally independently; no
+  other menu section may move when the row is scrolled.
+- **FR-004**: The reaction row MUST end with a "+" custom-emoji affordance that is
+  fully visible and selectable regardless of message/bubble width.
+- **FR-005**: Choosing a custom emoji via "+" MUST apply it as a reaction.
+- **FR-006**: The reaction row MUST order emojis by usage/popularity over time
+  (after any fixed defaults), persisted on-device.
+- **FR-007**: The menu MUST always open fully within the viewport and interactive,
+  for any message width and screen position (anchor/flip as needed).
+- **FR-008**: The open menu MUST make it visually clear which message it acts on.
+- **FR-009**: The interaction MUST be reliable in RTL and LTR and across themes.
+- **FR-010**: All UI MUST use stock Ionic components + existing theme tokens; build
+  custom only where no Ionic primitive fits, composed from Ionic (Constitution XI).
+- **FR-011 (optional)**: A focus emphasis (subtle zoom + dim/blur of others) MAY be
+  added only if it stays smooth (no dropped frames) on target devices; otherwise it
+  is omitted.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- Client-only UI/interaction change. No wire, server, or data-model change. Reaction
+  emoji-usage ordering is stored on-device only (a local preference), never sent to
+  the server; reactions themselves use the existing E2EE reaction path unchanged.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A single tap anywhere on text/image/video/album bubbles opens the menu
+  (verified e2e for each kind).
+- **SC-002**: Scrolling the reaction row moves only that row; other sections stay
+  fixed; the trailing "+" is fully visible (verified visually + by assertion).
+- **SC-003**: The "+" opens the emoji picker and the chosen emoji is applied.
+- **SC-004**: The menu is fully within the viewport for messages at top/bottom/edge
+  and for very wide/narrow bubbles.
+- **SC-005**: More-used reaction emojis appear earlier over repeated use.
+
+## Assumptions
+
+- The current menu is a custom component (action sheet / popover-like) with a
+  reaction row; the layout bug is the row and its siblings sharing a scroll/overflow
+  context — the fix isolates the row's horizontal scroll. (Plan will confirm against
+  the actual component, e.g. a reactions/menu component under `src/components/`.)
+- "Single tap opens the menu" replaces/augments long-press as the primary gesture;
+  the media bubble's existing "open viewer" action is reconciled with the tap-to-menu
+  gesture in the plan (e.g. tap = menu, with viewer reachable from the menu or a
+  distinct affordance) — to be settled in clarify/plan.
+- Usage-ordering is a local, non-secret preference; a small persisted tally suffices.
+- Focus zoom/blur is optional and dropped if it can't stay smooth.

--- a/src/components/MessageActions.vue
+++ b/src/components/MessageActions.vue
@@ -4,22 +4,32 @@
        control dismisses the popover with the chosen { action, emoji }. -->
   <div class="ma">
     <div class="ma-emojis">
-      <button
-        v-for="e in quickSet"
-        :key="e"
-        type="button"
-        class="ma-emoji"
-        :class="{ on: myEmojis?.includes(e) }"
-        @click="pick(e)"
-      >
-        <emoji :emoji="e" />
-      </button>
+      <!-- Only this inner track scrolls horizontally; the "+" sits outside it so it
+           is always fully visible and tappable regardless of how many emoji there
+           are or how narrow the bubble is. The outer .ma owns pan-y, this track
+           owns pan-x, so a sideways swipe never drags the action list. -->
+      <div class="ma-emoji-track">
+        <button
+          v-for="e in quickSet"
+          :key="e"
+          type="button"
+          class="ma-emoji"
+          :class="{ on: myEmojis?.includes(e) }"
+          @click="pick(e)"
+        >
+          <emoji :emoji="e" />
+        </button>
+      </div>
       <button type="button" class="ma-emoji ma-more" aria-label="More emoji" @click="choose('more')">
         <ion-icon :icon="addOutline" />
       </button>
     </div>
 
     <ion-list class="ma-actions" lines="none">
+      <ion-item v-if="canView" button :detail="false" @click="choose('view')">
+        <ion-icon slot="start" :icon="expandOutline" />
+        <ion-label>View</ion-label>
+      </ion-item>
       <ion-item button :detail="false" @click="choose('reply')">
         <ion-icon slot="start" :icon="arrowUndoOutline" />
         <ion-label>Reply</ion-label>
@@ -67,7 +77,7 @@
 <script setup lang="ts">
 import { IonList, IonItem, IonLabel, IonIcon, popoverController } from '@ionic/vue';
 import {
-  addOutline, informationCircleOutline, copyOutline, happyOutline, arrowUndoOutline, arrowRedoOutline, downloadOutline,
+  addOutline, expandOutline, informationCircleOutline, copyOutline, happyOutline, arrowUndoOutline, arrowRedoOutline, downloadOutline,
   createOutline, checkmarkCircleOutline, trashOutline,
 } from 'ionicons/icons';
 import { computed } from 'vue';
@@ -76,6 +86,7 @@ import Emoji from '@/components/Emoji.vue';
 const props = defineProps<{
   isOutgoing: boolean;
   canCopy: boolean;
+  canView?: boolean; // image/video/album: offer "View" (open the full-screen viewer)
   canEdit?: boolean; // own, not-deleted text message: offer "Edit"
   canSave?: boolean; // single image/video/file/audio: offer "Save"
   canSaveAll?: boolean; // album bubble: offer "Save all"
@@ -84,11 +95,12 @@ const props = defineProps<{
   quick?: string[]; // most-used-first quick-react set (from the caller)
 }>();
 
-// Exactly 4 quick emoji + a "+"; the "+" opens the full picker. All fit without
-// scrolling (Teams-style). Falls back to a default set.
-const DEFAULT_QUICK = ['👍', '❤️', '😂', '😮'];
+// The most-used-first quick-react set; the trailing "+" opens the full picker. The
+// row scrolls horizontally so it can hold more than fits, while the "+" stays put.
+// Falls back to a sensible default set.
+const DEFAULT_QUICK = ['👍', '❤️', '😂', '😮', '😢', '🙏'];
 const quickSet = computed(() =>
-  (props.quick && props.quick.length ? props.quick : DEFAULT_QUICK).slice(0, 4),
+  (props.quick && props.quick.length ? props.quick : DEFAULT_QUICK).slice(0, 12),
 );
 
 // Report the chosen emoji; the caller (reactToMessage) toggles it off if it's
@@ -109,10 +121,26 @@ const choose = (action: string) => void popoverController.dismiss({ action });
 .ma-emojis {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 2px;
   padding: 6px 6px 4px;
-  /* No horizontal scroll: the 4 quick emoji + the "+" are all visible at once. */
+}
+/* The scrolling part of the row. Only this overflows horizontally; the "+" sibling
+   stays anchored at the trailing edge, always fully visible. */
+.ma-emoji-track {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none; /* Firefox */
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-x;
+  scroll-snap-type: x proximity;
+}
+.ma-emoji-track::-webkit-scrollbar {
+  display: none; /* WebKit/Blink */
 }
 .ma-emoji {
   flex: 0 0 auto;
@@ -136,8 +164,12 @@ const choose = (action: string) => void popoverController.dismiss({ action });
   background: color-mix(in srgb, var(--ion-color-primary) 22%, transparent);
 }
 .ma-more {
+  flex: 0 0 auto; /* never shrink/scroll away — the "+" is always reachable */
   font-size: 20px;
   color: var(--app-text-muted, #8e8e93);
+  border-left: 1px solid var(--ion-color-step-150, rgba(0, 0, 0, 0.08));
+  margin-left: 2px;
+  border-radius: 0 8px 8px 0;
 }
 .ma-actions {
   padding: 0;

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -43,6 +43,7 @@ import {
   editMessage as dbEditMessage,
   deleteMessageForEveryone as dbDeleteMessageForEveryone,
   reactToMessage as dbReactToMessage,
+  quickReactEmojis as dbQuickReactEmojis,
   getMessage as dbGetMessage,
   sendLocation as dbSendLocation,
   sendPoll as dbSendPoll,
@@ -308,6 +309,9 @@ export function installTestHook(): void {
     },
     /** Add/toggle the local user's emoji reaction on a message. */
     reactToMessage: (messageId: string, emoji: string) => dbReactToMessage(messageId, emoji),
+    /** The most-used-first quick-react set (the menu's emoji row order). Lets e2e
+     *  assert usage-based reordering (spec 1004 FR-006). */
+    quickReactEmojis: (limit?: number) => dbQuickReactEmojis(limit),
 
     /* ---- location / poll / contact ---- */
     sendLocation: (chatId: string, lat: number, lng: number, label?: string) =>

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -163,7 +163,7 @@
               </span>
             <div
               class="bubble"
-              :class="{ out: m.outgoing, 'bubble-plain': m.videoNote && !m.deleted, 'bubble-media': mediaBubble(m) }"
+              :class="{ out: m.outgoing, 'bubble-plain': m.videoNote && !m.deleted, 'bubble-media': mediaBubble(m), 'menu-focus': menuFocusId === m.id }"
               :data-mid="m.id"
               :style="swipeStyle(m.id)"
               @touchstart.passive="onSwipeStart($event, m)"
@@ -202,7 +202,9 @@
               >
 
               <template v-if="m.mediaId && mediaInfo[m.mediaId]">
-                <div v-if="m.kind === 'image'" class="media-wrap" @click.stop="openMediaViewer(m.id)">
+                <!-- A tap anywhere on the image opens the action menu (the whole
+                     bubble is the hit target); "View" in the menu opens the viewer. -->
+                <div v-if="m.kind === 'image'" class="media-wrap">
                   <img class="bubble-image" :src="mediaInfo[m.mediaId].url" alt="photo" />
                   <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
                 </div>
@@ -214,10 +216,11 @@
                   :duration-sec="m.durationSec"
                   @menu="(ev) => openMenu(m, ev)"
                 />
-                <!-- Video: a still thumbnail with a play button; tapping opens the
-                     full-screen viewer (falls back to inline if no thumbnail). -->
+                <!-- Video: a still thumbnail with a play button. Tapping the poster
+                     opens the action menu (whole bubble is the hit target); the play
+                     button is the direct affordance to the full-screen viewer. -->
                 <template v-else-if="m.kind === 'video'">
-                  <div class="video-poster" @click.stop="openMediaViewer(m.id)">
+                  <div class="video-poster">
                     <img
                       v-if="m.posterData || mediaInfo[m.mediaId].posterUrl"
                       class="bubble-image"
@@ -225,7 +228,13 @@
                       alt="video"
                     />
                     <div v-else class="bubble-image video-noposter" />
-                    <ion-icon class="play-overlay" :icon="playCircle" />
+                    <ion-icon
+                      class="play-overlay"
+                      :icon="playCircle"
+                      role="button"
+                      aria-label="Play video"
+                      @click.stop="openMediaViewer(m.id)"
+                    />
                     <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
                   </div>
                 </template>
@@ -441,7 +450,7 @@
             <div
               v-else
               class="bubble album-bubble"
-              :class="{ out: item.messages[0].outgoing }"
+              :class="{ out: item.messages[0].outgoing, 'menu-focus': item.messages.some((mm) => mm.id === menuFocusId) }"
               :data-mid="item.messages[0].id"
               :style="swipeStyle(item.messages[0].id)"
               @touchstart.passive="onSwipeStart($event, item.messages[0])"
@@ -465,12 +474,14 @@
               </button>
               <span v-if="item.messages[0].albumName" class="album-name">{{ item.messages[0].albumName }}</span>
               <div class="album-grid">
+                <!-- A tap on a cell opens the menu for that specific image/video
+                     (FR-001 covers the album area); "View" opens the viewer at it. -->
                 <button
                   v-for="(am, idx) in albumCells(item.messages)"
                   :key="am.id"
                   type="button"
                   class="album-cell"
-                  @click.stop="openMediaViewer(am.id)"
+                  @click.stop="openMenu(am, $event)"
                 >
                   <template v-if="am.mediaId && mediaInfo[am.mediaId]">
                     <img :src="mediaInfo[am.mediaId].posterUrl || mediaInfo[am.mediaId].url" alt="" />
@@ -1030,6 +1041,8 @@ const chatMediaMsgs = computed(() =>
   ),
 );
 const viewer = ref<{ open: boolean; start: number }>({ open: false, start: 0 });
+// The bubble whose action menu is open, so it can be subtly emphasised (FR-008).
+const menuFocusId = ref<string | null>(null);
 const viewerItems = computed(() =>
   chatMediaMsgs.value.map((m) => {
     const mi = mediaInfo.value[m.mediaId!];
@@ -1156,18 +1169,24 @@ async function openMenu(m: Message, ev: Event) {
   const SAVE_KINDS = ['image', 'video', 'file', 'audio', 'voice'];
   const canSaveAll = !!m.albumId;
   const canSave = !canSaveAll && SAVE_KINDS.includes(m.kind) && (!!m.mediaId || !!m.pendingMedia);
+  // A single tap on a media bubble now opens this menu (the whole bubble is the hit
+  // target), so the full-screen viewer is reached from here via "View".
+  const canView = (m.kind === 'image' || m.kind === 'video') && !m.videoNote && !!m.mediaId;
+  // Briefly emphasise the tapped bubble so it's clear which message the menu acts on.
+  menuFocusId.value = m.id;
   const popover = await popoverController.create({
     component: MessageActions,
     cssClass: 'reaction-popover',
     componentProps: {
       isOutgoing: m.outgoing,
       canCopy: !!m.body,
+      canView,
       canEdit: m.outgoing && m.kind === 'text' && !m.deleted,
       canSave,
       canSaveAll,
       myEmojis: myEmojisFor(m),
       reactionCount: m.reactions?.length ?? 0,
-      quick: await quickReactEmojis(4),
+      quick: await quickReactEmojis(12),
     },
     event: ev,
     reference: 'event',
@@ -1176,8 +1195,10 @@ async function openMenu(m: Message, ev: Event) {
   });
   await popover.present();
   const { data } = await popover.onWillDismiss();
+  menuFocusId.value = null;
   if (!data) return;
   if (data.action === 'react') await onReact(m.id, data.emoji);
+  else if (data.action === 'view') openMediaViewer(m.id);
   else if (data.action === 'more') await openEmojiPicker(m);
   else if (data.action === 'details') await openReactionDetails(m);
   else if (data.action === 'reply') void startReply(m);
@@ -2937,6 +2958,16 @@ function cancelRecording() {
 .bubble.out {
   background: var(--app-bubble-out);
 }
+/* While its action menu is open, the bubble lifts slightly so it's clear which
+   message the menu acts on (FR-008). A cheap transform-only emphasis — no blur of
+   the rest, which would risk jank on long chats (the optional FR-011 effect). */
+.bubble.menu-focus {
+  transform: scale(1.04);
+  transform-origin: center;
+  transition: transform 0.15s ease;
+  position: relative;
+  z-index: 2;
+}
 /* A round video note has no chat bubble behind it; instead the circle gets a
    thin frame ring and its timestamp sits in a small pill, both matching the
    in/out bubble colour. */
@@ -3538,6 +3569,11 @@ function cancelRecording() {
   font-size: 48px;
   color: #fff;
   filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.5));
+  cursor: pointer;
+  /* The poster opens the menu; only this play button opens the viewer, so give it
+     a comfortable hit area distinct from the surrounding bubble. */
+  padding: 6px;
+  border-radius: 50%;
 }
 .bubble-audio {
   width: 240px;


### PR DESCRIPTION
## Summary

Implements spec **1004 — Message Action Menu**: makes the per-message menu reliable to open and fixes the quick-react emoji row.

**Review-ready, not auto-merge** — this touches a subjective interaction (media tap behavior), so please try it before merging.

## What changed

**Single tap opens the menu, including on media**
- The root cause of "it's very hard to tap the border of a video/image to get the menu" was that media taps opened the viewer (`@click.stop`), so only the ~3px frame fell through to the menu. Now a single tap **anywhere** on an image, video poster, or album cell opens the action menu (the whole bubble is the hit target — FR-001/FR-002).
- The full-screen **viewer** stays reachable via the new **"View"** action in the menu; a video's **play button** still opens it directly (the chosen gesture split the spec deferred to plan). Album cells open the menu for *that specific* image, and "View" opens the viewer at it.

**Reaction row (FR-003/004/005/006)**
- The emoji row now scrolls horizontally on its **own track**; the menu and the action list never move when it's swiped (`.ma` owns `pan-y`, the track owns `pan-x`).
- The trailing **"+"** sits outside the scroll track, so it's always fully visible and selectable regardless of width; it opens the existing emoji picker.
- The row holds more emoji (up to 12), **most-used first** (existing `quickReactEmojis` usage tally, now surfaced at 12).

**Focus emphasis (FR-008, cheap)**
- The tapped bubble lifts slightly (`scale(1.04)`, transform-only) while its menu is open so it's clear which message the menu acts on. No blur of other bubbles — that optional effect (FR-011) is omitted to avoid jank, as the spec allows.

All UI is stock Ionic (`ion-popover`, `ion-list`/`ion-item`, `ion-icon`) + existing theme tokens (Constitution XI).

## Tests
- `vue-tsc` typecheck + `vite build` — green.
- New `e2e/message-menu.spec.ts`: single-tap opens the menu on a **text** bubble (emoji track + "+" visible, tapping an emoji applies a reaction) and on an **image** bubble (menu + "View"), plus **usage reordering** (a custom emoji surfaces first after one use).
- Regression: reactions / reply / edit-delete / paste-image / bidi e2e all pass (8/8 with the new spec).

## Zero-knowledge
Client-only UI change. Emoji-usage ordering is an on-device preference; reactions use the existing E2EE path unchanged.