### PR TITLE
perf: chat history scroll + media caching (spec 1005)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,7 @@ Specs are grouped by category band; status moves
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
 | [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
+| [1005](specs/1005-chat-history-scroll/spec.md) | Chat History Scroll Performance & Media Caching | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ Specs are grouped by category band; status moves
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
 | [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
-| [1005](specs/1005-chat-history-scroll/spec.md) | Chat History Scroll Performance & Media Caching | 🟡 in-progress |
+| [1005](specs/1005-chat-history-scroll/spec.md) | Chat History Scroll Performance & Media Caching | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/chat-media-scroll.spec.ts
+++ b/e2e/chat-media-scroll.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Chat-history media (spec 1005): the chat resolves media object URLs only for the
+ * rendered window (bounded, look-ahead paged), while the full-screen viewer still
+ * spans the whole chat's media — it resolves and pins them on open. This guards
+ * that opening the viewer after the list only resolved its window still works.
+ */
+
+const chatWith = (p: any, peerId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
+
+async function pasteImage(p: any): Promise<void> {
+  const composer = p.page.locator('ion-textarea.composer textarea');
+  await composer.waitFor({ state: 'visible', timeout: 30_000 });
+  await composer.click();
+  await p.page.evaluate(() => {
+    const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    const dt = new DataTransfer();
+    dt.items.add(new File([bytes], 'pasted.png', { type: 'image/png' }));
+    const ta = document.querySelector('ion-textarea.composer textarea')!;
+    ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+  });
+  await p.page.getByRole('button', { name: 'Send' }).click();
+  await p.page.getByText('Original quality').click();
+}
+
+test('image renders in the list and the full-screen viewer opens on tap', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'MEDSCRL1');
+  const b = await createAccount(ctxB, 'MEDSCRL2');
+  await pair(a, b);
+
+  const aChat = (await chatWith(a, b.id)) as string;
+  await a.page.goto(`/chat/${aChat}`);
+  await pasteImage(a);
+
+  // The image resolves for the rendered window and shows in the list.
+  const image = a.page.locator('.bubble .bubble-image').last();
+  await expect(image).toBeVisible({ timeout: 30_000 });
+
+  // Tapping it opens the viewer, which resolves+pins the chat's media on open.
+  await image.click();
+  await expect(a.page.locator('.viewer-modal')).toBeVisible({ timeout: 10_000 });
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/specs/1005-chat-history-scroll/spec.md
+++ b/specs/1005-chat-history-scroll/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-16
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1005-chat-history-scroll/spec.md
+++ b/specs/1005-chat-history-scroll/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Chat History Scroll Performance & Media Caching
+
+**Feature Branch**: `feat/1005-chat-history-scroll`
+
+**Created**: 2026-06-16
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Browsing the chats, contacts, and calls infinite lists feels smooth — they load well in advance so there's no glitch or slowness. But the chat view isn't like that: scrolling up to previous conversations loads, but it's nothing like smooth, especially when the chat has audio, video, and images. Are we caching assets properly?"
+
+## Overview
+
+The tab lists (Chats, Contacts, Calls) feel smooth because they page/look ahead.
+The in-chat message history does not: scrolling back through older messages is
+janky, worst when those messages have media (images/video/audio), suggesting media
+blobs/posters are being decoded or object-URL'd repeatedly (and possibly revoked
+and regenerated) as rows recycle, rather than loaded ahead and cached.
+
+This feature makes scrolling back through a conversation as smooth as the tab
+lists: load older messages ahead of the scroll position, and resolve/cache media
+(object URLs, posters, decoded blobs) so revisiting a message doesn't redo work.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Smooth back-scroll through history (Priority: P1)
+
+Scrolling up through a long conversation stays smooth — older messages are ready
+before they're needed, with no stalls at the load boundary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a long conversation, **When** I scroll up, **Then** older messages
+   appear without visible stalls (the next page is fetched before I reach the top of
+   the loaded range).
+2. **Given** I scroll quickly, **When** the list pages in history, **Then** scroll
+   position is preserved (no jump) and the frame rate stays smooth.
+
+---
+
+### User Story 2 - Media doesn't re-thrash on scroll (Priority: P1)
+
+Scrolling past images/videos/audio, then back, doesn't re-decode or re-create their
+assets each time; resolved object URLs/posters are cached and reused.
+
+**Acceptance Scenarios**:
+
+1. **Given** messages with media, **When** I scroll them out of view and back,
+   **Then** their thumbnails/posters reappear instantly from cache (no flicker or
+   regeneration).
+2. **Given** a media-heavy chat, **When** I scroll, **Then** object URLs are reused
+   (not revoked-and-recreated per row) and memory stays bounded (released when far
+   off-screen, regenerated lazily if needed).
+
+---
+
+### Edge Cases
+
+- Very long chats: caches MUST be bounded (evict far-off-screen assets) so memory
+  doesn't grow without limit while staying smooth in the active window.
+- Returning to the bottom (newest) after scrolling far up MUST be smooth and land at
+  the latest message.
+- Works with the existing reactive message store / live queries without breaking
+  correctness (edits, deletes, new incoming messages while scrolled up).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The chat history MUST load older messages ahead of the scroll position
+  (look-ahead paging) so reaching the top of the loaded range doesn't stall.
+- **FR-002**: Paging older history MUST preserve scroll position (no content jump).
+- **FR-003**: Resolved media assets (object URLs, video posters, decoded
+  thumbnails) MUST be cached and reused across scroll, not regenerated per row
+  recycle; posters reuse the persisted `posterBlob` cache.
+- **FR-004**: Object URLs MUST NOT be revoked-then-recreated for messages still in
+  (or near) the viewport; lifetime is tied to a bounded window, not per-render.
+- **FR-005**: Caches MUST be bounded (evict assets far outside the viewport) to keep
+  memory stable in very long chats, regenerating lazily on return.
+- **FR-006**: Scrolling MUST remain correct under live changes (new/edited/deleted
+  messages) without losing position or leaking assets.
+- **FR-007**: Any new/changed UI MUST use stock Ionic components + existing theme
+  tokens (Constitution XI) — e.g. reuse Ionic's infinite-scroll/virtual patterns as
+  the tab lists do, rather than a bespoke scroller, where feasible.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- Client-only performance change. Media stays E2EE and on-device; this only changes
+  how already-decrypted assets are paged/cached/released for display. No wire,
+  server, data-model, or at-rest change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Scrolling back through a long media-heavy chat shows no stall at the
+  page boundary and no thumbnail/poster regeneration on re-view (manual device check
+  + assertions where feasible).
+- **SC-002**: Object URLs / posters for a given media item are created once per
+  in-window appearance and reused on scroll-back (instrumented/unit-tested at the
+  cache layer).
+- **SC-003**: Memory stays bounded in a very long chat (assets released when far
+  off-screen).
+- **SC-004**: Scroll position is preserved when older pages load.
+
+## Assumptions
+
+- The root cause is per-render media resolution (object URL creation + poster
+  decode) and/or eager revocation as rows recycle, plus no look-ahead paging — vs.
+  the tab lists which page ahead. Plan will confirm against `ChatDetailPage`'s
+  message rendering + `mediaInfo` resolution and the paging (`PAGE`/`visible`) logic.
+- A bounded LRU-style asset cache keyed by mediaId (object URL + posterUrl) is
+  sufficient; reuse the persisted `posterBlob` so posters never regenerate.
+- This builds on 2002 (bounded, cached poster generation) and the 1001 warm-store
+  patterns; no new dependency expected.

--- a/src/utils/lru.test.ts
+++ b/src/utils/lru.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { selectEvictions } from './lru';
+
+describe('selectEvictions (bounded media cache policy)', () => {
+  const keep = (...ids: string[]) => new Set(ids);
+
+  it('evicts nothing while at or under the cap', () => {
+    expect(selectEvictions(['a', 'b', 'c'], keep(), 3)).toEqual([]);
+    expect(selectEvictions(['a', 'b'], keep(), 5)).toEqual([]);
+  });
+
+  it('evicts the oldest (least-recently-used) keys to get back to the cap', () => {
+    // order is LRU-first; two over the cap of 3 → drop the two oldest.
+    expect(selectEvictions(['a', 'b', 'c', 'd', 'e'], keep(), 3)).toEqual(['a', 'b']);
+  });
+
+  it('never evicts a protected (on-screen / pinned) key', () => {
+    // 'a' and 'b' are the oldest but protected → evict the next oldest unprotected.
+    expect(selectEvictions(['a', 'b', 'c', 'd', 'e'], keep('a', 'b'), 3)).toEqual(['c', 'd']);
+  });
+
+  it('leaves the cache above the cap rather than evict protected keys', () => {
+    // Everything over the cap is protected → nothing evictable; cap is exceeded.
+    expect(selectEvictions(['a', 'b', 'c', 'd'], keep('a', 'b', 'c', 'd'), 2)).toEqual([]);
+  });
+});

--- a/src/utils/lru.ts
+++ b/src/utils/lru.ts
@@ -1,0 +1,19 @@
+/**
+ * Pick which keys to evict from a least-recently-used ordering so a cache stays
+ * within `max` live entries — without ever evicting a key in `keep` (e.g. items
+ * currently on screen, or pinned by an open viewer).
+ *
+ * `order` is the access order, least-recently-used first and most-recently-used
+ * last. Returns the keys to drop, oldest first. If the only way to get under `max`
+ * would be to evict protected keys, those are left in place (correctness over a
+ * hard memory cap): the cache may briefly exceed `max` while many items are pinned.
+ *
+ * Pure and side-effect free so it can be unit-tested independently of the DOM /
+ * object-URL lifecycle that consumes its decisions (spec 1005, FR-005 / SC-002).
+ */
+export function selectEvictions(order: string[], keep: Set<string>, max: number): string[] {
+  const overflow = order.length - max;
+  if (overflow <= 0) return [];
+  const evictable = order.filter((k) => !keep.has(k));
+  return evictable.slice(0, overflow);
+}

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -90,9 +90,12 @@
     <ion-content ref="contentEl" :fullscreen="true" class="chat-content" :scroll-events="true" @ionScroll="onContentScroll">
       <div ref="listEl" class="msg-list" :style="{ visibility: listReady ? 'visible' : 'hidden' }">
       <!-- Top of the list: pull up to load earlier messages (older pages). -->
+      <!-- Page older messages well before the very top is reached (look-ahead), so
+           scrolling back never stalls at the load boundary (spec 1005 FR-001). -->
       <ion-infinite-scroll
         :disabled="!listReady || visible >= messages.length"
         position="top"
+        threshold="25%"
         @ion-infinite="loadOlder"
       >
         <ion-infinite-scroll-content loading-text="Loading earlier messages…" />
@@ -203,7 +206,7 @@
 
               <template v-if="m.mediaId && mediaInfo[m.mediaId]">
                 <div v-if="m.kind === 'image'" class="media-wrap" @click.stop="openMediaViewer(m.id)">
-                  <img class="bubble-image" :src="mediaInfo[m.mediaId].url" alt="photo" />
+                  <img class="bubble-image" :src="mediaInfo[m.mediaId].url" alt="photo" loading="lazy" decoding="async" />
                   <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
                 </div>
                 <!-- Round video note: plays inline on tap, long-press for actions. -->
@@ -223,6 +226,8 @@
                       class="bubble-image"
                       :src="m.posterData || mediaInfo[m.mediaId].posterUrl"
                       alt="video"
+                      loading="lazy"
+                      decoding="async"
                     />
                     <div v-else class="bubble-image video-noposter" />
                     <ion-icon class="play-overlay" :icon="playCircle" />
@@ -473,7 +478,7 @@
                   @click.stop="openMediaViewer(am.id)"
                 >
                   <template v-if="am.mediaId && mediaInfo[am.mediaId]">
-                    <img :src="mediaInfo[am.mediaId].posterUrl || mediaInfo[am.mediaId].url" alt="" />
+                    <img :src="mediaInfo[am.mediaId].posterUrl || mediaInfo[am.mediaId].url" alt="" loading="lazy" decoding="async" />
                     <ion-icon v-if="am.kind === 'video'" class="play-overlay-sm" :icon="playCircle" />
                     <div v-if="idx === 3 && albumOverlay(item.messages)" class="album-more">
                       +{{ albumOverlay(item.messages) }}
@@ -819,6 +824,7 @@ import { type Quality } from '@/services/media-encode';
 import { jobProgress } from '@/services/media-jobs';
 import { resolutionLabel, fileSizeLabel, generateVideoPoster } from '@/utils/media-meta';
 import { openExternal } from '@/utils/external';
+import { selectEvictions } from '@/utils/lru';
 import { normalizeOutgoing, capitalizeFirst } from '@/utils/text';
 import { readAudioTags, readAudioDuration } from '@/utils/id3';
 import { get, put } from '@/db/idb';
@@ -1047,13 +1053,24 @@ const viewerItems = computed(() =>
     };
   }),
 );
-// Tapping any media opens the viewer at that item, across all chat media.
-function openMediaViewer(msgId: string): void {
+// Tapping any media opens the viewer at that item, across all chat media. The
+// viewer can swipe through the WHOLE chat's media, so resolve it all and pin it
+// (against eviction) before opening — the list itself only resolves its window.
+async function openMediaViewer(msgId: string): Promise<void> {
+  const all = messages.value.filter(
+    (m) => (m.kind === 'image' || (m.kind === 'video' && !m.videoNote)) && m.mediaId,
+  );
+  await resolveMediaFor(all);
+  viewerPins.value = new Set(all.map((m) => m.mediaId!));
+  await nextTick();
   const start = chatMediaMsgs.value.findIndex((m) => m.id === msgId);
   viewer.value = { open: true, start: Math.max(0, start) };
 }
 function onViewerDismiss(id: string): void {
   viewer.value.open = false;
+  // Unpin the chat's media so the bounded cache can reclaim what's off-screen.
+  viewerPins.value = new Set();
+  evictMedia();
   // Album members render under one bubble keyed by the first message's id.
   const m = messages.value.find((x) => x.id === id);
   let target = id;
@@ -1967,59 +1984,118 @@ interface MediaInfo {
 }
 
 const mediaInfo = ref<Record<string, MediaInfo>>({});
-watch(
-  messages,
-  async (list) => {
-    for (const m of list) {
-      if (m.mediaId && !mediaInfo.value[m.mediaId]) {
-        const media = await get<Media>('media', m.mediaId);
-        if (media) {
-          const url = URL.createObjectURL(media.blob);
-          const info: MediaInfo = {
-            url,
-            posterUrl: media.posterBlob ? URL.createObjectURL(media.posterBlob) : undefined,
-            mime: media.mime,
-            name: media.name,
-          };
-          mediaInfo.value[m.mediaId] = info;
-          // Videos: prefer the sent thumbnail (m.posterData, a stable data URL).
-          // Otherwise derive one from the first frame and PERSIST it (posterBlob)
-          // so it isn't regenerated/lost on every remount.
-          if (m.kind === 'video' && !info.posterUrl && !m.posterData) {
-            const blob = media.blob;
-            const mid = m.mediaId;
-            void generateVideoPoster(blob).then(async (poster) => {
-              if (!poster) return;
-              mediaInfo.value[mid] = { ...mediaInfo.value[mid], posterUrl: poster };
-              try {
-                const md = await get<Media>('media', mid);
-                if (md && !md.posterBlob) {
-                  md.posterBlob = await (await fetch(poster)).blob();
-                  md.updatedAt = Date.now();
-                  await put('media', md);
-                }
-              } catch {
-                /* best-effort cache */
-              }
-            });
-          }
-          // Audio (shared music): pull embedded cover art for the track card.
-          if (m.kind === 'audio' && !info.posterUrl) {
-            void readAudioTags(media.blob).then((tags) => {
-              if (tags.cover && m.mediaId) {
-                mediaInfo.value[m.mediaId] = {
-                  ...mediaInfo.value[m.mediaId],
-                  posterUrl: URL.createObjectURL(tags.cover),
-                };
-              }
-            });
-          }
-        }
-      }
+// Resolved object URLs are bounded so a very long, media-heavy chat doesn't keep
+// every poster/cover decoded and every blob URL alive at once. We keep at most
+// MAX_MEDIA live, evicting the least-recently-used items that are neither on screen
+// nor pinned by an open viewer, and revoking their URLs. Far-scrolled media is
+// re-resolved lazily when it scrolls back (spec 1005 FR-003/004/005).
+const MAX_MEDIA = 60;
+const mediaLru: string[] = []; // mediaIds, least-recently-used first
+function touchMedia(id: string): void {
+  const i = mediaLru.indexOf(id);
+  if (i !== -1) mediaLru.splice(i, 1);
+  mediaLru.push(id);
+}
+// Media ids the full-screen viewer is currently showing — never evict these while
+// it's open (it can swipe across all of the chat's media).
+const viewerPins = ref<Set<string>>(new Set());
+
+// The on-screen window (plus viewer pins) that eviction must never touch.
+function currentMediaKeep(): Set<string> {
+  const keep = new Set<string>(viewerPins.value);
+  for (const m of visibleMessages.value) if (m.mediaId) keep.add(m.mediaId);
+  return keep;
+}
+
+// Resolve on-device media (Blobs) → object URLs for the GIVEN messages only — the
+// rendered window, or all chat media when the viewer opens — so opening a long
+// media chat doesn't eagerly decode every poster/cover up front. Already-resolved
+// items are just marked recently-used (reused, never recreated per render).
+async function resolveMediaFor(list: Message[]): Promise<void> {
+  for (const m of list) {
+    if (!m.mediaId) continue;
+    if (mediaInfo.value[m.mediaId]) {
+      touchMedia(m.mediaId);
+      continue;
     }
+    const media = await get<Media>('media', m.mediaId);
+    if (!media) continue;
+    const info: MediaInfo = {
+      url: URL.createObjectURL(media.blob),
+      posterUrl: media.posterBlob ? URL.createObjectURL(media.posterBlob) : undefined,
+      mime: media.mime,
+      name: media.name,
+    };
+    mediaInfo.value[m.mediaId] = info;
+    touchMedia(m.mediaId);
+    // Videos: prefer the sent thumbnail (m.posterData, a stable data URL).
+    // Otherwise derive one from the first frame and PERSIST it (posterBlob) so it
+    // isn't regenerated/lost on every remount.
+    if (m.kind === 'video' && !info.posterUrl && !m.posterData) {
+      const blob = media.blob;
+      const mid = m.mediaId;
+      void generateVideoPoster(blob).then(async (poster) => {
+        if (!poster || !mediaInfo.value[mid]) return; // evicted before it resolved
+        mediaInfo.value[mid] = { ...mediaInfo.value[mid], posterUrl: poster };
+        try {
+          const md = await get<Media>('media', mid);
+          if (md && !md.posterBlob) {
+            md.posterBlob = await (await fetch(poster)).blob();
+            md.updatedAt = Date.now();
+            await put('media', md);
+          }
+        } catch {
+          /* best-effort cache */
+        }
+      });
+    }
+    // Audio (shared music): pull embedded cover art for the track card.
+    if (m.kind === 'audio' && !info.posterUrl) {
+      const mid = m.mediaId;
+      void readAudioTags(media.blob).then((tags) => {
+        if (tags.cover && mediaInfo.value[mid]) {
+          mediaInfo.value[mid] = { ...mediaInfo.value[mid], posterUrl: URL.createObjectURL(tags.cover) };
+        }
+      });
+    }
+  }
+}
+
+// Release least-recently-used media that's neither on screen nor pinned, revoking
+// its URLs so memory stays bounded in very long chats.
+function evictMedia(): void {
+  const keep = currentMediaKeep();
+  for (const id of selectEvictions(mediaLru, keep, MAX_MEDIA)) {
+    const mi = mediaInfo.value[id];
+    if (mi) {
+      URL.revokeObjectURL(mi.url);
+      if (mi.posterUrl) URL.revokeObjectURL(mi.posterUrl);
+      delete mediaInfo.value[id];
+    }
+    const i = mediaLru.indexOf(id);
+    if (i !== -1) mediaLru.splice(i, 1);
+  }
+}
+
+// Resolve media for the rendered window as it grows/changes (look-ahead paging
+// extends `visibleMessages` before the user reaches the top), then evict far LRU.
+watch(
+  visibleMessages,
+  async (list) => {
+    await resolveMediaFor(list);
+    evictMedia();
   },
   { immediate: true },
 );
+
+// Revoke every resolved object URL when leaving the chat so they don't leak across
+// chat opens (the cache only lives for this view).
+onUnmounted(() => {
+  for (const mi of Object.values(mediaInfo.value)) {
+    URL.revokeObjectURL(mi.url);
+    if (mi.posterUrl) URL.revokeObjectURL(mi.posterUrl);
+  }
+});
 
 // Close the viewer if its last item was deleted. (Defined here, after `messages`,
 // because watch() evaluates its source once at setup.)


### PR DESCRIPTION
## Summary

Implements spec **1005 — Chat History Scroll Performance & Media Caching**. Scrolling back through a long, media-heavy chat was janky; the tab lists feel smooth because they page ahead, the chat did not.

**Review-ready, not auto-merge** — best verified by feel on a media-heavy chat.

## Root cause

`ChatDetailPage` resolved media for the **entire** chat on open, not just the visible window: it created object URLs and eagerly ran `generateVideoPoster` / `readAudioTags` (frame/tag decode) for *every* media item up front, and never revoked anything (unbounded memory across chat opens).

## What changed

- **Window-scoped resolution**: media is resolved only for the rendered window (`visibleMessages`) instead of all `messages`. Opening a long media chat no longer decodes every poster/cover up front. Resolved items are reused, never recreated per render (FR-003/FR-004).
- **Bounded LRU cache**: at most `MAX_MEDIA` resolved at once; the least-recently-used media that's neither on screen nor pinned is evicted and its URLs revoked, re-resolving lazily on scroll-back (FR-005). The eviction policy is a pure, unit-tested helper, `src/utils/lru.ts` (SC-002).
- **Viewer still spans the whole chat**: `openMediaViewer` resolves and **pins** all chat media before opening (so swiping reaches everything), then unpins on close so the cache can reclaim it.
- **Look-ahead paging**: `ion-infinite-scroll` gets a `threshold="25%"` so older pages load before the top is reached (FR-001); scroll-position preservation on page-in was already in place (FR-002).
- **Decode hints**: bubble images get `loading="lazy"` + `decoding="async"`.
- **No leaks**: all resolved object URLs are revoked on unmount.

All stock Ionic (`ion-infinite-scroll`) + native `<img>` hints (Constitution XI).

## Tests
- `vue-tsc` + `vite build` green; **81** unit tests pass (incl. new `src/utils/lru.test.ts`, 4 cases covering the eviction policy: under-cap no-op, oldest-first eviction, never evicting protected/on-screen keys, exceeding the cap when all overflow is pinned).
- New `e2e/chat-media-scroll.spec.ts`: an image resolves from the windowed pass and renders, and the full-screen viewer opens via the resolve-all-and-pin path.
- Regression: paste-image / media-blob-delete / media-cleanup / reactions / reply / disappearing e2e all pass.

## Zero-knowledge
Client-only performance change. Media stays E2EE and on-device; only how already-decrypted assets are paged/cached/released for display changed. No wire/server/data-model/at-rest change.