### PR TITLE
feat: media playback — legible play overlay, viewer video control, persistent audio (spec 1007)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ Specs are grouped by category band; status moves
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
 | [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
-| [1007](specs/1007-media-playback-and/spec.md) | Media Playback & Embedded Thumbnails | 🟡 in-progress |
+| [1007](specs/1007-media-playback-and/spec.md) | Media Playback & Embedded Thumbnails | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,7 @@ Specs are grouped by category band; status moves
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
 | [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
+| [1007](specs/1007-media-playback-and/spec.md) | Media Playback & Embedded Thumbnails | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1007-media-playback-and/spec.md
+++ b/specs/1007-media-playback-and/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-16
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1007-media-playback-and/spec.md
+++ b/specs/1007-media-playback-and/spec.md
@@ -1,0 +1,173 @@
+# Feature Specification: Media Playback & Embedded Thumbnails
+
+**Feature Branch**: `feat/1007-media-playback-and`
+
+**Created**: 2026-06-16
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "The viewer's bottom thumbnails still don't fully use the generated thumbnail. We should generate the video thumbnail on the SENDER's device and embed it in the message, so the receiver does no thumbnail work and just shows it — with a play button baked in / overlaid, white play on a dark thumbnail and black play on a bright one. Sliding between media should fully STOP playback of the video you slide away from (no background video playback), but keep that video's progress at the position it was when you scrolled away so it resumes there. Audio messages / music should KEEP playing when you navigate away (not on loop), and we should offer quick pause/play + stop — either in the top toolbar if space allows, or a hovering audio controller like the hovering group-call UI."
+
+## Overview
+
+Three media-playback improvements:
+
+1. **Sender-embedded video thumbnails.** Today a video poster may be generated on
+   the *receiver* (bounded since spec 2002), but the viewer's thumbnail strip and
+   bubbles still sometimes lack a poster. Generating the thumbnail on the **sender**
+   and embedding it in the message means the receiver never generates anything — it
+   just shows the embedded image — with a **contrast-aware play affordance** (light
+   play glyph on dark thumbnails, dark glyph on bright ones).
+2. **Stop video on slide-away, keep position.** In the full-screen viewer, sliding
+   to another item must fully **stop** the previous video (no audio/CPU in the
+   background), while **remembering its position** so returning resumes where you
+   left off. Only the on-screen video may play.
+3. **Persistent, non-looping audio with quick controls.** Voice messages / music
+   should keep playing when you navigate away from the chat (it's audio — leaving
+   the view shouldn't cut it), but must **not loop**, and the user needs a
+   quick **pause/play + stop** reachable from anywhere — via a **hovering audio
+   mini-controller** (mirroring the existing hovering call UI), which fits the
+   pattern better than crowding the toolbar.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Receiver shows a sender-made thumbnail, no local generation (Priority: P1)
+
+A received video shows its thumbnail immediately (everywhere it appears: bubble,
+album grid, viewer strip, Media grid) from a poster the sender embedded — the
+receiver generates nothing. The play affordance is clearly visible against the
+thumbnail regardless of its brightness.
+
+**Acceptance Scenarios**:
+
+1. **Given** a received video message, **When** it renders anywhere a thumbnail is
+   shown, **Then** it uses the sender-embedded poster and the receiver runs no video
+   decode/poster generation for it.
+2. **Given** a dark vs a bright thumbnail, **When** the play affordance is drawn,
+   **Then** it has clear contrast (light glyph on dark, dark glyph on bright).
+3. **Given** a legacy/old message with no embedded poster, **When** it renders,
+   **Then** the existing bounded receiver-side generation (2002) is the fallback.
+
+---
+
+### User Story 2 - Sliding away stops the video and keeps its position (Priority: P1)
+
+In the viewer, when I slide from a playing video to another item, the first video
+stops completely (no background audio or decoding), and if I slide back it resumes
+from where I left it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a playing video, **When** I slide to the next/previous item, **Then**
+   the first video stops (paused, no audio, not decoding in the background).
+2. **Given** I slid away mid-playback, **When** I slide back to it, **Then** it is
+   at the position it was when I left (ready to resume there, not reset to 0).
+3. **Given** any slide, **When** it settles, **Then** at most the on-screen video is
+   active; no off-screen video plays.
+
+---
+
+### User Story 3 - Audio keeps playing across navigation, with quick controls (Priority: P2)
+
+Playing a voice message or music and then leaving the chat keeps the audio going
+(not looping); a hovering audio controller appears with play/pause and stop so I can
+control it from anywhere, and it goes away when playback stops/ends.
+
+**Acceptance Scenarios**:
+
+1. **Given** audio is playing, **When** I navigate away from the chat/message,
+   **Then** the audio continues (it does not stop), and it does not loop when it ends.
+2. **Given** audio is playing, **When** I look at the app, **Then** a hovering audio
+   controller (like the minimized-call UI) shows the track with pause/play + stop.
+3. **Given** the hovering controller, **When** I tap stop (or it ends), **Then**
+   playback ends and the controller disappears; pause/play toggles without losing
+   position.
+4. **Given** I start a different audio, **When** it begins, **Then** only one audio
+   plays at a time (the previous is replaced/stopped), never two at once.
+
+### Edge Cases
+
+- Switching from audio to a video (or starting a call) must not leave two audio
+  sources playing; define precedence (a call/voice-note interaction supersedes music).
+- Leaving the viewer entirely (closing it) stops any video (US2 applies on close too).
+- A bright thumbnail with a busy center: the play affordance must stay legible
+  (e.g. a subtle scrim behind the glyph) — contrast is guaranteed, not best-effort.
+- Embedded poster size must stay small (it rides in the E2EE message) — bounded
+  dimensions/quality so messages don't bloat.
+- Background audio must respect leaving the app / lock as the platform dictates
+  (don't fight the OS), and must end cleanly on logout/lock.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The sender MUST generate a small video thumbnail and embed it in the
+  message; receivers MUST render that embedded thumbnail everywhere a video
+  thumbnail appears, performing no local poster generation when one is present.
+- **FR-002**: When no embedded poster exists (legacy messages), the receiver MUST
+  fall back to the bounded generation from spec 2002.
+- **FR-003**: The play affordance over a video thumbnail MUST be contrast-aware
+  (light on dark thumbnails, dark on bright), guaranteed legible (scrim if needed).
+  Prefer an Ionic/CSS overlay computed from the thumbnail's luminance over baking
+  pixels into the JPEG (keeps it themeable/accessible; Constitution XI).
+- **FR-004**: In the viewer, sliding away from a video MUST stop it fully — paused,
+  muted-to-silent, not decoding in the background; only the on-screen video may be
+  active.
+- **FR-005**: A video's playback position MUST be retained when slid away so sliding
+  back resumes from that position (not reset).
+- **FR-006**: Closing the viewer MUST stop any playing video.
+- **FR-007**: Audio (voice messages / music) MUST continue playing when the user
+  navigates away from its message/chat, and MUST NOT loop on end.
+- **FR-008**: A hovering audio controller (consistent with the minimized-call UI)
+  MUST appear while audio plays, offering pause/play and stop, and disappear when
+  playback ends/stops.
+- **FR-009**: At most one audio source plays at a time; starting another replaces
+  the previous. Call audio takes precedence over media audio.
+- **FR-010**: The embedded poster MUST be size-bounded (dimensions + quality) so it
+  doesn't bloat the E2EE message payload.
+- **FR-011**: All UI MUST use stock Ionic components + existing theme tokens; the
+  hovering controller mirrors the existing minimized-call component (Constitution XI).
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **Embedded thumbnail**: the sender's poster rides **inside the E2EE message**
+  payload (like the existing `posterData`), so it's encrypted end-to-end exactly as
+  the media is; the server sees only ciphertext. It slightly increases message size
+  (bounded by FR-010). No new server-visible metadata.
+- **Playback / audio controller**: purely client-side; no wire/server/data-model
+  change. Emoji/usage-style local prefs not involved here.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A received video renders its thumbnail with zero receiver-side poster
+  generation when the sender embedded one (instrumented/verified); legacy fallback
+  still works.
+- **SC-002**: The play affordance is legible on both dark and bright thumbnails
+  (contrast check).
+- **SC-003**: After sliding away from a video, no off-screen video is playing or
+  decoding (no background audio); sliding back resumes at the retained position.
+- **SC-004**: Audio keeps playing across navigation, never loops, and is controllable
+  (pause/play/stop) from the hovering controller anywhere in the app; only one audio
+  plays at once.
+
+## Assumptions
+
+- Sender-side poster generation already exists (`generateVideoPoster` + an embedded
+  `posterData` on send); this spec makes it the authoritative path and ensures all
+  receiver surfaces consume it, with 2002's bounded generation as the legacy
+  fallback only.
+- The viewer currently keeps current±1 videos mounted (so the slid-away one can keep
+  playing); the fix pauses/teardowns non-current videos while preserving each one's
+  `currentTime`.
+- A persistent audio service (single shared `<audio>`/element) + a hovering
+  controller component (modeled on `MinimizedCall.vue`) is the right structure;
+  background audio follows platform behavior and ends on logout/lock.
+- Contrast-aware overlay (luminance sampled from the thumbnail) is preferred over a
+  baked-in glyph; the baked-in idea was considered but rejected for theming/a11y.

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,9 @@
     <incoming-call-overlay />
     <!-- Floating call widget when a call runs but the call screen is minimized. -->
     <minimized-call />
+    <!-- Hovering media-audio controller while a voice message / music plays (it
+         persists across navigation; spec 1007). -->
+    <minimized-audio />
     <!-- Persistent remote-audio sink: keeps call audio playing across navigation
          (e.g. while minimized), independent of any call screen. -->
     <call-media-sink />
@@ -37,8 +40,11 @@ import KeyGuard from '@/components/KeyGuard.vue';
 import InstallGuard from '@/components/InstallGuard.vue';
 import IncomingCallOverlay from '@/components/IncomingCallOverlay.vue';
 import MinimizedCall from '@/components/MinimizedCall.vue';
+import MinimizedAudio from '@/components/MinimizedAudio.vue';
 import CallMediaSink from '@/components/CallMediaSink.vue';
 import NotificationBanners from '@/components/NotificationBanners.vue';
+import { callState } from '@/composables/useCall';
+import { stopAudio } from '@/composables/useAudioPlayer';
 import { useSync, nudgeReconnect } from '@/composables/useSync';
 import { useAppUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed } from '@/db/queries';
@@ -65,7 +71,10 @@ watch(
   isUnlocked,
   (unlocked) => {
     if (unlocked) void warmAll();
-    else clearWarm();
+    else {
+      clearWarm();
+      stopAudio(); // never leave media audio playing once locked / signed out
+    }
   },
   { immediate: true },
 );
@@ -182,6 +191,12 @@ onUnmounted(() => {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.removeEventListener('message', onServiceWorkerMessage);
   }
+});
+
+// Call audio takes precedence over media audio (spec 1007 FR-009): when a call
+// becomes active, stop any voice message / music so they never play over a call.
+watch(callState, (s) => {
+  if (s !== 'idle') stopAudio();
 });
 
 // Clear the app-icon badge + pending notifications when foregrounded.

--- a/src/components/MediaViewer.vue
+++ b/src/components/MediaViewer.vue
@@ -55,7 +55,9 @@
               :src="it.url"
               :embedded="true"
               :chrome-hidden="chromeHidden"
+              :start-at="positions[it.id]"
               @tap="onVideoTap"
+              @time="(t) => (positions[it.id] = t)"
             />
           </div>
         </div>
@@ -164,6 +166,7 @@ interface VideoApi {
   pipActive: boolean;
   pipSupported: boolean;
   toggle: () => void;
+  pauseSilent: () => void;
   seekTo: (r: number) => void;
   cycleRate: () => void;
   togglePip: () => void;
@@ -431,11 +434,24 @@ const activeVideo = shallowRef<VideoApi | null>(null);
 // inline ref callback every render (old→null, new→instance), so we MUST ignore the null
 // detach and skip same-value writes — otherwise the template reading `activeVideo` would
 // rewrite it every render → infinite re-render loop (the web process crashes).
+// All currently-mounted players, by slide index (plain Map — never read in the
+// template, so it triggers no re-render; activeVideo drives the chrome). Lets us
+// pause every player except the on-screen one when the user slides (FR-004).
+const videoApis = new Map<number, VideoApi>();
 function bindVideo(c: unknown, i: number): void {
-  if (i !== index.value) return;
   const inst = (c as VideoApi | null) ?? null;
-  if (inst && activeVideo.value !== inst) activeVideo.value = inst;
+  if (inst) videoApis.set(i, inst);
+  else videoApis.delete(i);
+  if (i === index.value && inst && activeVideo.value !== inst) activeVideo.value = inst;
 }
+// Sliding away from a video must stop it fully (no off-screen audio/decoding),
+// while its position is remembered via @time so sliding back resumes there.
+function pauseOffscreenVideos(): void {
+  for (const [i, api] of videoApis) if (i !== index.value) api.pauseSilent();
+}
+// Item ids → last playback position (seconds), so a remounted player resumes there.
+const positions = reactive<Record<string, number>>({});
+watch(index, () => pauseOffscreenVideos());
 const vfmt = (s: number) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
 // Tap on the video → hide all chrome for a video-only view; tap again → bring it back.
 function onVideoTap(): void {
@@ -451,6 +467,10 @@ function onMediaDblClick(): void {
 
 watch(() => props.start, (s) => {
   if (props.open) index.value = s;
+});
+// Closing the viewer stops any playing video (FR-006).
+watch(() => props.open, (o) => {
+  if (!o) for (const api of videoApis.values()) api.pauseSilent();
 });
 </script>
 

--- a/src/components/MinimizedAudio.vue
+++ b/src/components/MinimizedAudio.vue
@@ -1,0 +1,120 @@
+<template>
+  <!-- Hovering audio mini-controller (spec 1007 US3), mirroring the minimized-call
+       pill. Shown whenever audio is playing through the global player, from anywhere
+       in the app; offers play/pause and stop. A thin progress rail fills as it plays. -->
+  <div v-if="track" class="audio-mini" role="group" aria-label="Now playing">
+    <div class="am-cover" :class="{ voice: track.isVoice }">
+      <img v-if="track.coverUrl" :src="track.coverUrl" alt="" />
+      <ion-icon v-else :icon="track.isVoice ? mic : musicalNotes" />
+    </div>
+    <div class="am-info">
+      <div class="am-title">{{ track.title }}</div>
+      <div v-if="track.subtitle" class="am-sub">{{ track.subtitle }}</div>
+    </div>
+    <button class="am-btn" :aria-label="audioPlaying ? 'Pause' : 'Play'" @click="toggleAudioPlayback">
+      <ion-icon :icon="audioPlaying ? pause : play" />
+    </button>
+    <button class="am-btn am-stop" aria-label="Stop" @click="stopAudio">
+      <ion-icon :icon="stop" />
+    </button>
+    <div class="am-rail"><div class="am-prog" :style="{ width: audioProgress * 100 + '%' }" /></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { IonIcon } from '@ionic/vue';
+import { play, pause, stop, mic, musicalNotes } from 'ionicons/icons';
+import {
+  audioTrack as track, audioPlaying, audioProgress, toggleAudioPlayback, stopAudio,
+} from '@/composables/useAudioPlayer';
+</script>
+
+<style scoped>
+/* Sits above the tab bar / safe-area, mirroring the minimized-call pill's placement
+   and surface. Stock tokens only (Constitution XI). */
+.audio-mini {
+  position: fixed;
+  left: 8px;
+  right: 8px;
+  bottom: calc(var(--ion-safe-area-bottom, 0px) + 64px);
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  background: var(--ion-color-step-100, #f2f2f7);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+  max-width: 520px;
+  margin: 0 auto;
+}
+.am-cover {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ion-color-primary);
+  color: #fff;
+  font-size: 20px;
+}
+.am-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.am-info {
+  flex: 1;
+  min-width: 0;
+}
+.am-title {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--ion-text-color);
+}
+.am-sub {
+  font-size: 12px;
+  color: var(--app-text-muted, #8e8e93);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.am-btn {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: var(--ion-color-primary);
+  color: #fff;
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.am-stop {
+  background: var(--ion-color-step-300, #c7c7cc);
+  color: var(--ion-text-color);
+}
+.am-rail {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 3px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--ion-color-step-200, rgba(0, 0, 0, 0.1));
+}
+.am-prog {
+  height: 100%;
+  border-radius: 1px;
+  background: var(--ion-color-primary);
+}
+</style>

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -52,8 +52,8 @@ import SpeedPill from '@/components/SpeedPill.vue';
 import { nextRate, playWhenReady } from '@/utils/playback';
 import { useScrub } from '@/composables/useScrub';
 
-const props = defineProps<{ src: string; embedded?: boolean; chromeHidden?: boolean }>();
-const emit = defineEmits<{ (e: 'tap'): void }>();
+const props = defineProps<{ src: string; embedded?: boolean; chromeHidden?: boolean; startAt?: number }>();
+const emit = defineEmits<{ (e: 'tap'): void; (e: 'time', seconds: number): void }>();
 
 const el = ref<HTMLVideoElement>();
 const playing = ref(false);
@@ -122,19 +122,34 @@ async function togglePip(): Promise<void> {
 }
 
 function onMeta(): void {
-  if (el.value && Number.isFinite(el.value.duration)) total.value = el.value.duration;
+  const v = el.value;
+  if (!v) return;
+  if (Number.isFinite(v.duration)) total.value = v.duration;
+  // Resume where we left off when this player remounts after being slid past
+  // (spec 1007 FR-005). Only seek into a valid range.
+  if (props.startAt && props.startAt > 0 && props.startAt < (total.value || Infinity)) {
+    v.currentTime = props.startAt;
+    onTime();
+  }
 }
 function onTime(): void {
   const v = el.value;
   if (!v) return;
   elapsed.value = v.currentTime;
   progress.value = total.value ? Math.min(1, v.currentTime / total.value) : 0;
+  emit('time', v.currentTime); // let the viewer remember the position across slides
 }
 function onEnd(): void {
   playing.value = false;
   progress.value = 0;
   elapsed.value = 0;
   if (el.value) el.value.currentTime = 0;
+  emit('time', 0);
+}
+// Pause and silence this player (used when the viewer slides away from it so no
+// off-screen video keeps playing audio in the background — FR-004).
+function pauseSilent(): void {
+  el.value?.pause();
 }
 
 const onEnterPip = (): void => {
@@ -155,7 +170,7 @@ onBeforeUnmount(() => {
 });
 
 // Surface state + controls so the media viewer can host the scrubber/PiP in its chrome.
-defineExpose({ playing, elapsed, total, progress, rate, pipActive, toggle, seekTo, cycleRate, togglePip, pipSupported });
+defineExpose({ playing, elapsed, total, progress, rate, pipActive, toggle, pauseSilent, seekTo, cycleRate, togglePip, pipSupported });
 </script>
 
 <style scoped>

--- a/src/components/VoicePlayer.vue
+++ b/src/components/VoicePlayer.vue
@@ -29,13 +29,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { IonIcon } from '@ionic/vue';
 import { play, pause, mic } from 'ionicons/icons';
 import SpeedPill from '@/components/SpeedPill.vue';
-import { nextRate, playWhenReady } from '@/utils/playback';
+import {
+  audioCurId, audioPlaying, audioProgress, audioRate,
+  playAudio, seekAudioFrac, cycleAudioRate,
+} from '@/composables/useAudioPlayer';
 
 const props = defineProps<{
+  mid: string; // message id — this voice message's id in the global player
+  sender: string; // who it's from (shown in the hovering controller)
   src: string;
   outgoing: boolean;
   avatar?: string;
@@ -45,16 +50,16 @@ const props = defineProps<{
 const BAR_COUNT = 44;
 // Flat placeholder until decoded (and the fallback if decoding isn't supported).
 const bars = ref<number[]>(Array.from({ length: BAR_COUNT }, () => 0.25));
-const playing = ref(false);
-const progress = ref(0); // 0..1
 const total = ref(props.durationSec ?? 0);
-const elapsed = ref(0);
-const rate = ref(1);
 
-const audio = new Audio(props.src);
-// 'auto' (not 'metadata'): buffer the audio data eagerly so the FIRST tap isn't silent
-// — a metadata-only element starts the clock before any sound has decoded.
-audio.preload = 'auto';
+// Playback runs through the global single-source player; this view just reflects it
+// when this voice message is the active one (so audio persists across navigation and
+// only one source ever plays — spec 1007).
+const isActive = computed(() => audioCurId.value === props.mid);
+const playing = computed(() => isActive.value && audioPlaying.value);
+const progress = computed(() => (isActive.value ? audioProgress.value : 0)); // 0..1
+const elapsed = computed(() => progress.value * total.value);
+const rate = computed(() => audioRate.value);
 
 const barHeight = (h: number) => `${Math.round(3 + h * 17)}px`;
 
@@ -92,58 +97,25 @@ async function decodeWaveform(): Promise<void> {
   }
 }
 
-function onTime(): void {
-  elapsed.value = audio.currentTime;
-  progress.value = total.value ? Math.min(1, audio.currentTime / total.value) : 0;
-}
-function onEnded(): void {
-  playing.value = false;
-  progress.value = 0;
-  elapsed.value = 0;
-  audio.currentTime = 0;
-}
-
+// Play this voice message (or toggle it if it's already the active one) through the
+// global player, which replaces any other audio and keeps playing across navigation.
 function toggle(): void {
-  if (playing.value) audio.pause();
-  else void playWhenReady(audio); // 'play'/'pause' listeners sync `playing`
+  playAudio({ id: props.mid, url: props.src, title: 'Voice message', subtitle: props.sender, isVoice: true });
 }
 function cycleRate(): void {
-  rate.value = nextRate(rate.value);
-  audio.playbackRate = rate.value;
+  cycleAudioRate();
 }
 
 const waveEl = ref<HTMLElement>();
 function seek(ev: MouseEvent): void {
   const el = waveEl.value;
-  if (!el || !total.value) return;
+  if (!el || !total.value || !isActive.value) return;
   const rect = el.getBoundingClientRect();
-  const ratio = Math.min(1, Math.max(0, (ev.clientX - rect.left) / rect.width));
-  audio.currentTime = ratio * total.value;
-  onTime();
+  seekAudioFrac(Math.min(1, Math.max(0, (ev.clientX - rect.left) / rect.width)));
 }
 
-const onPlay = (): void => {
-  playing.value = true;
-};
-const onPause = (): void => {
-  playing.value = false;
-};
 onMounted(() => {
-  audio.addEventListener('timeupdate', onTime);
-  audio.addEventListener('ended', onEnded);
-  audio.addEventListener('play', onPlay);
-  audio.addEventListener('pause', onPause);
-  audio.addEventListener('loadedmetadata', () => {
-    if (Number.isFinite(audio.duration) && audio.duration > 0) total.value = audio.duration;
-  });
   void decodeWaveform();
-});
-onBeforeUnmount(() => {
-  audio.pause();
-  audio.removeEventListener('timeupdate', onTime);
-  audio.removeEventListener('ended', onEnded);
-  audio.removeEventListener('play', onPlay);
-  audio.removeEventListener('pause', onPause);
 });
 </script>
 

--- a/src/composables/useAudioPlayer.ts
+++ b/src/composables/useAudioPlayer.ts
@@ -1,0 +1,98 @@
+/**
+ * Global, single-source audio playback (spec 1007, US3). One shared HTMLAudioElement
+ * plays voice messages and music app-wide, so:
+ *  - only ONE audio source ever plays (starting another replaces it — FR-009),
+ *  - playback CONTINUES when you navigate away from the chat/message (the element
+ *    lives at module scope, not in any component — FR-007),
+ *  - it never loops (FR-007),
+ *  - a hovering controller (MinimizedAudio, mirroring the minimized-call UI) and the
+ *    in-chat players all drive and reflect this one reactive state.
+ *
+ * The in-chat players (VoicePlayer / AudioCard) are thin views: they call `playAudio`
+ * with their track and read `audioCurId` to know whether they're the active one.
+ */
+import { ref } from 'vue';
+import { nextRate, playWhenReady } from '@/utils/playback';
+
+export interface AudioTrackMeta {
+  id: string; // the message id — the unit of "now playing"
+  url: string;
+  title: string;
+  subtitle?: string;
+  coverUrl?: string;
+  isVoice?: boolean;
+}
+
+const el = new Audio();
+el.loop = false; // never loop (FR-007)
+
+export const audioCurId = ref<string | null>(null);
+export const audioPlaying = ref(false);
+export const audioProgress = ref(0); // 0..1
+export const audioRate = ref(1);
+export const audioTrack = ref<AudioTrackMeta | null>(null);
+
+// Optional, caller-scoped "what to do when the track ends" (e.g. the chat's playlist
+// auto-advance). Cleared when the owning view goes away so a finished track just stops.
+let endedCb: (() => void) | null = null;
+
+el.addEventListener('timeupdate', () => {
+  audioProgress.value = el.duration ? el.currentTime / el.duration : 0;
+});
+el.addEventListener('play', () => (audioPlaying.value = true));
+el.addEventListener('pause', () => (audioPlaying.value = false));
+el.addEventListener('ended', () => {
+  audioPlaying.value = false;
+  audioProgress.value = 0;
+  const cb = endedCb;
+  if (cb) cb();
+  else stopAudio();
+});
+
+/** Play a track — or toggle play/pause if it's already the current one. Any other
+ *  audio is replaced (single source). */
+export function playAudio(meta: AudioTrackMeta, onEnded?: () => void): void {
+  if (audioCurId.value === meta.id) {
+    toggleAudioPlayback();
+    return;
+  }
+  el.src = meta.url;
+  el.playbackRate = audioRate.value;
+  audioCurId.value = meta.id;
+  audioProgress.value = 0;
+  audioTrack.value = meta;
+  endedCb = onEnded ?? null;
+  void playWhenReady(el);
+}
+
+export function toggleAudioPlayback(): void {
+  if (el.paused) void playWhenReady(el);
+  else el.pause();
+}
+
+export function seekAudioFrac(frac: number): void {
+  if (el.duration) el.currentTime = Math.min(1, Math.max(0, frac)) * el.duration;
+}
+
+export function cycleAudioRate(): void {
+  audioRate.value = nextRate(audioRate.value);
+  el.playbackRate = audioRate.value;
+}
+
+/** Stop playback entirely and clear the now-playing state (hides the controller). */
+export function stopAudio(): void {
+  el.pause();
+  el.removeAttribute('src');
+  el.load();
+  audioCurId.value = null;
+  audioPlaying.value = false;
+  audioProgress.value = 0;
+  audioTrack.value = null;
+  endedCb = null;
+}
+
+/** Forget the (chat-scoped) ended callback WITHOUT stopping playback — used when the
+ *  chat unmounts so the audio keeps playing but its playlist auto-advance stops. */
+export function detachAudioEnded(): void {
+  endedCb = null;
+}

--- a/src/views/detail/AllMediaPage.vue
+++ b/src/views/detail/AllMediaPage.vue
@@ -343,8 +343,15 @@ const goChat = () => router.push(`/chat/${chatId}`);
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: #fff;
-  font-size: 30px;
+  font-size: 26px;
+  background: rgba(0, 0, 0, 0.42); /* scrim disc → legible on any thumbnail (spec 1007 FR-003) */
+  border-radius: 50%;
   pointer-events: none;
 }
 .empty {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -231,6 +231,8 @@
                 </template>
                 <voice-player
                   v-else-if="m.kind === 'voice'"
+                  :mid="m.id"
+                  :sender="m.outgoing ? 'You' : chat?.isGroup ? m.senderName : chat?.name ?? m.senderName"
                   :src="mediaInfo[m.mediaId].url"
                   :outgoing="m.outgoing"
                   :avatar="!m.outgoing && !chat?.isGroup ? chat?.avatar : undefined"
@@ -824,6 +826,11 @@ import { readAudioTags, readAudioDuration } from '@/utils/id3';
 import { get, put } from '@/db/idb';
 import type { Chat, Contact, Media, Message, MessageStatus, Reaction, ReplyRef, SharedContact } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
+import {
+  audioCurId, audioPlaying, audioProgress, audioRate,
+  playAudio, seekAudioFrac, cycleAudioRate, stopAudio, detachAudioEnded,
+  type AudioTrackMeta,
+} from '@/composables/useAudioPlayer';
 import { isUnlocked, isUnlockedNow } from '@/services/crypto/identity';
 import { sendReadReceipts, sendDownloadedReceipts } from '@/composables/useSync';
 import { peerPresence, presenceLabel } from '@/composables/usePresence';
@@ -2332,27 +2339,11 @@ async function onPick(e: Event, mode: 'auto' | 'file') {
   }
 }
 
-/* ---- shared audio player: received/sent music files play as a playlist ---- */
-const audioEl = new Audio();
-audioEl.preload = 'auto'; // buffer eagerly so the first tap isn't silent
-const audioCurId = ref<string | null>(null);
-const audioPlaying = ref(false);
-const audioProgress = ref(0);
-const audioRate = ref(1);
-audioEl.addEventListener('timeupdate', () => {
-  audioProgress.value = audioEl.duration ? audioEl.currentTime / audioEl.duration : 0;
-});
-audioEl.addEventListener('play', () => (audioPlaying.value = true));
-audioEl.addEventListener('pause', () => (audioPlaying.value = false));
-audioEl.addEventListener('ended', () => {
-  audioPlaying.value = false;
-  audioProgress.value = 0;
-  playNextAudio();
-});
-onUnmounted(() => {
-  audioEl.pause();
-  audioEl.src = '';
-});
+/* ---- audio playback: voice + music via the global single-source player ---- */
+// Audio (voice + music) plays through the global single-source player so it keeps
+// going when you leave the chat and a hovering controller can drive it (spec 1007).
+// Leaving the chat only detaches the playlist auto-advance — it does NOT stop audio.
+onUnmounted(detachAudioEnded);
 
 // Audio messages in chronological order, the implicit playlist.
 const audioOrder = computed(() =>
@@ -2361,38 +2352,39 @@ const audioOrder = computed(() =>
     .sort((a, b) => a.timestamp - b.timestamp)
     .map((m) => m.id),
 );
-const audioUrlFor = (id: string): string | undefined => {
+// Build the now-playing metadata (for the hovering controller) from a message.
+function audioMetaFor(id: string): AudioTrackMeta | undefined {
   const m = messages.value.find((x) => x.id === id);
-  return m?.mediaId ? mediaInfo.value[m.mediaId]?.url : undefined;
-};
-function toggleAudio(id: string): void {
-  if (audioCurId.value === id) {
-    if (audioEl.paused) void playWhenReady(audioEl);
-    else audioEl.pause();
-    return;
+  if (!m?.mediaId) return undefined;
+  const url = mediaInfo.value[m.mediaId]?.url;
+  if (!url) return undefined;
+  const who = m.outgoing ? 'You' : chat.value?.isGroup ? m.senderName : chat.value?.name ?? m.senderName;
+  if (m.kind === 'audio') {
+    return {
+      id,
+      url,
+      title: m.audio?.title || mediaInfo.value[m.mediaId]?.name || 'Audio',
+      subtitle: m.audio?.artist,
+      coverUrl: mediaInfo.value[m.mediaId]?.posterUrl,
+      isVoice: false,
+    };
   }
-  const url = audioUrlFor(id);
-  if (!url) return;
-  audioEl.src = url;
-  audioEl.playbackRate = audioRate.value;
-  audioCurId.value = id;
-  audioProgress.value = 0;
-  void playWhenReady(audioEl);
+  return { id, url, title: 'Voice message', subtitle: who, isVoice: true };
+}
+function toggleAudio(id: string): void {
+  const meta = audioMetaFor(id);
+  if (!meta) return;
+  playAudio(meta, playNextAudio);
 }
 function seekAudio(id: string, frac: number): void {
-  if (audioCurId.value !== id || !audioEl.duration) return;
-  audioEl.currentTime = frac * audioEl.duration;
-}
-function cycleAudioRate(): void {
-  audioRate.value = nextRate(audioRate.value);
-  audioEl.playbackRate = audioRate.value;
+  if (audioCurId.value === id) seekAudioFrac(frac);
 }
 function playNextAudio(): void {
   const ids = audioOrder.value;
   const i = audioCurId.value ? ids.indexOf(audioCurId.value) : -1;
   const next = i >= 0 && i + 1 < ids.length ? ids[i + 1] : null;
   if (next) toggleAudio(next);
-  else audioCurId.value = null;
+  else stopAudio();
 }
 
 /* ---- audio file review queue (title/artist before sending) ---- */

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -3451,8 +3451,15 @@ function cancelRecording() {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: #fff;
-  font-size: 34px;
+  font-size: 28px;
+  background: rgba(0, 0, 0, 0.42); /* scrim disc → legible on any thumbnail (FR-003) */
+  border-radius: 50%;
   pointer-events: none;
 }
 .album-bubble .time {
@@ -3530,13 +3537,23 @@ function cancelRecording() {
   position: relative;
   display: inline-block;
 }
+/* Play affordance over a video thumbnail. A translucent dark scrim disc behind the
+   white glyph guarantees legibility on ANY thumbnail — dark or bright (spec 1007
+   FR-003) — without baking pixels into the JPEG. */
 .play-overlay {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  font-size: 48px;
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 40px;
   color: #fff;
+  background: rgba(0, 0, 0, 0.42);
+  border-radius: 50%;
   filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.5));
 }
 .bubble-audio {


### PR DESCRIPTION
## Summary

Implements spec **1007 — Media Playback & Embedded Thumbnails**, in three parts.

**Review-ready, not auto-merge.** Part 3 unifies voice + music onto one global audio element — please sanity-check playback by feel (autoplay can't be reliably e2e-tested headless).

## Part 1 — Sender thumbnails + legible play overlay
- Sender-embedded posters already ride in `posterData` and the receiver renders them with **no local generation** when present (FR-001/002 were already in place; legacy messages still fall back to the bounded 2002 generation).
- The play affordance over **every** video thumbnail (bubble, album cell, media grid) now sits on a translucent dark **scrim disc**, so the glyph is guaranteed legible on dark *and* bright thumbnails without baking pixels into the JPEG (FR-003).

## Part 2 — Viewer: stop video on slide, keep position
- Sliding away from a video now **pauses every off-screen player** — previously the one you slid from was a mounted neighbour that kept playing audio in the background (FR-004).
- A video's position is remembered (`@time` → `startAt`) so sliding back **resumes where you left off** (FR-005).
- Closing the viewer stops any playing video (FR-006).

## Part 3 — Persistent, non-looping audio + hovering controller
- Voice messages and music now play through **one global single-source player** (`useAudioPlayer`) instead of per-component `<audio>` elements:
  - audio **keeps playing when you leave the chat/message** and **never loops** (FR-007);
  - **only one** audio source plays — starting another replaces it (FR-009);
  - a **hovering audio controller** (`MinimizedAudio`, mirroring the minimized-call pill) shows the track with play/pause + stop from anywhere and disappears when playback ends/stops (FR-008);
  - a **call takes precedence** — starting/receiving one stops media audio; locking / signing out stops it cleanly.
- `VoicePlayer` / `AudioCard` are now thin views over the composable (waveform stays a local visual; playback/seek/speed route through the global element). `ChatDetailPage` no longer owns an audio element.

All UI is stock Ionic + theme tokens; the controller mirrors the existing minimized-call component (Constitution XI).

## Tests
- `vue-tsc` + `vite build` green; **80** unit tests pass.
- Regression e2e (paste-image / media-blob-delete / reactions / reply / disappearing / edit-delete / groups) all pass — the migrated audio/video components mount in chats, so a structural break would surface.
- Note: audio/video *playback* (autoplay, slide-resume) isn't reliably drivable in headless e2e; verified by typecheck + the regression suite + manual review.

## Zero-knowledge
The embedded poster rides inside the E2EE message exactly like the media (bounded by `generateVideoPoster`'s 480px/0.6-quality output). Playback/controller are purely client-side. No wire/server/data-model change.