### PR TITLE
test: coverage uplift — pure-logic unit tests + ratcheted floors (spec 1006)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ Specs are grouped by category band; status moves
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
 | [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
-| [1006](specs/1006-test-coverage-uplift/spec.md) | Test Coverage Uplift | 🟡 in-progress |
+| [1006](specs/1006-test-coverage-uplift/spec.md) | Test Coverage Uplift | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,7 @@ Specs are grouped by category band; status moves
 | [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
 | [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
 | [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
+| [1006](specs/1006-test-coverage-uplift/spec.md) | Test Coverage Uplift | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/server/internal/api/block_handlers_test.go
+++ b/server/internal/api/block_handlers_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func listBlocked(t *testing.T, srv http.Handler, tok string) []string {
+	t.Helper()
+	rr := do(t, srv, http.MethodGet, "/v1/blocks", tok, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list blocks status = %d, want 200", rr.Code)
+	}
+	var body struct {
+		Blocked []string `json:"blocked"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Blocked
+}
+
+func TestBlockUnblockLifecycle(t *testing.T) {
+	srv := newTestServer()
+	aliceTok, _, _ := registerNamed(t, srv, "alice")
+	_, bobID, _ := registerNamed(t, srv, "bob")
+
+	if got := listBlocked(t, srv, aliceTok); len(got) != 0 {
+		t.Fatalf("fresh account blocked = %v, want empty", got)
+	}
+
+	// Block bob → 204, then he's in the list.
+	if rr := do(t, srv, http.MethodPut, "/v1/blocks/"+bobID, aliceTok, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("block status = %d, want 204", rr.Code)
+	}
+	if got := listBlocked(t, srv, aliceTok); len(got) != 1 || got[0] != bobID {
+		t.Fatalf("after block = %v, want [%s]", got, bobID)
+	}
+
+	// Blocking again is idempotent (still 204, no duplicate).
+	if rr := do(t, srv, http.MethodPut, "/v1/blocks/"+bobID, aliceTok, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("re-block status = %d, want 204", rr.Code)
+	}
+	if got := listBlocked(t, srv, aliceTok); len(got) != 1 {
+		t.Fatalf("after re-block = %v, want one entry", got)
+	}
+
+	// Unblock → 204, gone from the list.
+	if rr := do(t, srv, http.MethodDelete, "/v1/blocks/"+bobID, aliceTok, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("unblock status = %d, want 204", rr.Code)
+	}
+	if got := listBlocked(t, srv, aliceTok); len(got) != 0 {
+		t.Fatalf("after unblock = %v, want empty", got)
+	}
+}
+
+func TestBlockRejectsSelfAndBadID(t *testing.T) {
+	srv := newTestServer()
+	tok, selfID, _ := registerNamed(t, srv, "alice")
+
+	if rr := do(t, srv, http.MethodPut, "/v1/blocks/"+selfID, tok, ""); rr.Code != http.StatusBadRequest {
+		t.Fatalf("self-block status = %d, want 400", rr.Code)
+	}
+	if rr := do(t, srv, http.MethodPut, "/v1/blocks/not-a-uuid", tok, ""); rr.Code != http.StatusBadRequest {
+		t.Fatalf("bad-id block status = %d, want 400", rr.Code)
+	}
+}
+
+func TestBlockRequiresAuth(t *testing.T) {
+	srv := newTestServer()
+	for _, tc := range []struct {
+		method, path string
+	}{
+		{http.MethodGet, "/v1/blocks"},
+		{http.MethodPut, "/v1/blocks/11111111-1111-4111-8111-111111111111"},
+		{http.MethodDelete, "/v1/blocks/11111111-1111-4111-8111-111111111111"},
+	} {
+		if rr := do(t, srv, tc.method, tc.path, "", ""); rr.Code != http.StatusUnauthorized {
+			t.Fatalf("%s %s without token = %d, want 401", tc.method, tc.path, rr.Code)
+		}
+	}
+}

--- a/server/internal/api/health_test.go
+++ b/server/internal/api/health_test.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestHealthOK(t *testing.T) {
+	srv := newTestServer()
+	rr := do(t, srv, http.MethodGet, "/healthz", "", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "ok" || body["db"] != "up" {
+		t.Fatalf("body = %v, want status=ok db=up", body)
+	}
+}

--- a/server/internal/api/username_test.go
+++ b/server/internal/api/username_test.go
@@ -1,0 +1,32 @@
+package api
+
+import "testing"
+
+func TestNormalizeUsername(t *testing.T) {
+	cases := []struct {
+		raw      string
+		wantUser string
+		wantFold string
+		wantOK   bool
+	}{
+		{"Alice", "Alice", "alice", true},
+		{"  bob  ", "bob", "bob", true}, // trimmed
+		{"a.b_c", "a.b_c", "a.b_c", true},
+		{"ABC", "ABC", "abc", true}, // case preserved, folded for uniqueness
+		{"ab", "", "", false},       // too short
+		{".bad", "", "", false},     // leading dot
+		{"bad.", "", "", false},     // trailing dot
+		{"no..dots", "", "", false}, // consecutive dots
+		{"has space", "", "", false},
+		{"admin", "", "", false},  // reserved
+		{"GHOST", "", "", false},  // reserved, case-folded
+		{"", "", "", false},
+	}
+	for _, c := range cases {
+		user, fold, ok := normalizeUsername(c.raw)
+		if ok != c.wantOK || user != c.wantUser || fold != c.wantFold {
+			t.Errorf("normalizeUsername(%q) = (%q,%q,%v), want (%q,%q,%v)",
+				c.raw, user, fold, ok, c.wantUser, c.wantFold, c.wantOK)
+		}
+	}
+}

--- a/specs/1006-test-coverage-uplift/spec.md
+++ b/specs/1006-test-coverage-uplift/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-16
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1006-test-coverage-uplift/spec.md
+++ b/specs/1006-test-coverage-uplift/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Test Coverage Uplift
+
+**Feature Branch**: `feat/1006-test-coverage-uplift`
+
+**Created**: 2026-06-16
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "I'd like to increase the test coverage everywhere so we have excellent, meaningful tests for every little thing that can be tested to verify the expected functionality is properly captured and any breaking changes can be quickly and cheaply discovered."
+
+## Overview
+
+Ring has solid coverage on the crypto core (client) and `auth`/`config`/`secrets`
+(server), plus an e2e suite for behavior. But many pure, testable units across the
+client services/utilities and server stores/handlers lack direct tests, so
+regressions surface late (in e2e or manually) instead of cheaply at the unit level.
+
+This effort systematically raises **meaningful** coverage: add fast unit tests for
+pure logic across client (`src/services`, `src/db` query helpers, `src/utils`,
+composables' pure parts) and server (`internal/store`, `internal/api` handlers
+against the in-memory fake store), and extend e2e for user-facing flows not yet
+covered. Then **ratchet the coverage floors** so they can't regress.
+
+The bar is "meaningful" — tests that assert real behavior and would catch real
+breaks — not coverage-number padding.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pure client logic is unit-tested (Priority: P1)
+
+Pure, deterministic client logic (message/status reducers, query filters, text/
+time/bytes utils, the new concurrency limiter, warm stores, chat filters, release
+notes, connection/request reconciliation) has direct unit tests.
+
+**Independent Test**: `npm run test:unit` exercises these modules with table-style
+cases covering happy paths, edge cases, and known past bugs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pure module with branching logic, **When** the suite runs, **Then**
+   its branches/edge cases are asserted (not just imported).
+2. **Given** a previously-fixed bug, **When** practical, **Then** a regression test
+   pins it so it can't silently return.
+
+---
+
+### User Story 2 - Server stores/handlers are unit-tested (Priority: P1)
+
+Server handlers and store logic are tested against the in-memory fake store
+(no DB), following the existing one-`_test.go`-per-file pattern, covering success,
+auth failures, and edge cases (incl. connections/contacts/directory logic).
+
+**Acceptance Scenarios**:
+
+1. **Given** a handler, **When** tested, **Then** success + error/auth paths are
+   asserted against the fake store.
+
+---
+
+### User Story 3 - Key user flows have e2e coverage (Priority: P2)
+
+User-facing flows lacking e2e get coverage (or existing specs are extended),
+especially the flows touched by recent specs (tab transitions, hints, friendship,
+media stability) so breaking changes are caught.
+
+**Acceptance Scenarios**:
+
+1. **Given** a primary user flow without e2e, **When** the suite runs, **Then** a
+   spec drives it through `window.__ringTest` / the UI and asserts the outcome.
+
+---
+
+### User Story 4 - Floors ratchet so coverage can't regress (Priority: P2)
+
+Coverage floors are raised to lock in the gains; CI fails if coverage drops below
+the new floor.
+
+**Acceptance Scenarios**:
+
+1. **Given** the raised floors, **When** a change lowers coverage below them,
+   **Then** CI fails.
+
+### Edge Cases
+
+- Tests MUST be deterministic (no flakiness): avoid time/random/order coupling; a
+  flaky test is a defect to fix, not retry-mask.
+- DOM/Ionic-heavy components that the node-env vitest can't render are covered via
+  e2e or by extracting pure logic to test directly (don't fake the framework).
+- Floors are a ratchet: they may only rise; never lower an existing floor.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Add meaningful unit tests for pure client logic across `src/services`,
+  `src/db` query helpers, `src/utils`, and the testable parts of composables.
+- **FR-002**: Add unit tests for server `internal/store` + `internal/api` handlers
+  against the in-memory fake store, per the existing `_test.go` pattern.
+- **FR-003**: Extend the e2e suite for user-facing flows lacking coverage, prefer
+  extending existing specs over duplicating setup.
+- **FR-004**: Raise the gated coverage floors (client crypto core + server
+  auth/config/secrets, and any newly-covered modules folded into the gate) to lock
+  in gains; floors only ratchet up.
+- **FR-005**: All tests MUST be deterministic and assert real behavior (no
+  coverage-padding, no flakiness); where a component can't be unit-rendered, extract
+  pure logic or cover via e2e.
+- **FR-006**: Tests MUST run within the existing harnesses (`npm run test:unit`,
+  `go test ./...`, `npm run test:e2e`) with no new test framework.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- Tests only; no production code behavior change, no wire/server/data-model change.
+  Tests MUST NOT weaken zero-knowledge invariants (e.g. no test that persists or
+  logs plaintext in a way real code wouldn't); crypto tests keep using the real core.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Measurable, meaningful coverage increase across the targeted client
+  and server modules (new test files exist and assert behavior, not just imports).
+- **SC-002**: The raised coverage floors pass in CI and would fail on a regression.
+- **SC-003**: The full suite stays green and deterministic (no new flakes) across
+  repeated runs.
+- **SC-004**: At least the flows from recent specs (1001/1003/2002 and 0002/1004/1005
+  as they land) have direct unit and/or e2e coverage.
+
+## Assumptions
+
+- This is incremental and ongoing; the spec defines the bar and the first
+  substantial batch, and the floors ratchet thereafter.
+- Prefer extracting pure logic from DOM-heavy components so it's unit-testable in the
+  node-env vitest, rather than adding a heavy component-test runner.
+- Sequenced last among the current initiative so it also covers the new code from
+  0002 (friendship), 1004 (menu), 1005 (scroll), and 2002 (media).

--- a/src/utils/bytes.test.ts
+++ b/src/utils/bytes.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from './bytes';
+
+describe('formatBytes', () => {
+  it('shows whole bytes under 1 KB', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('scales up through the units with one decimal', () => {
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1 MB'); // trailing .0 dropped
+    expect(formatBytes(1.5 * 1024 * 1024)).toBe('1.5 MB');
+    expect(formatBytes(1024 ** 3)).toBe('1 GB');
+    expect(formatBytes(1024 ** 4)).toBe('1 TB');
+  });
+
+  it('caps at the largest unit', () => {
+    expect(formatBytes(5 * 1024 ** 4)).toBe('5 TB');
+  });
+
+  it('treats zero/negative/NaN as 0 KB', () => {
+    expect(formatBytes(0)).toBe('0 KB');
+    expect(formatBytes(-100)).toBe('0 KB');
+    expect(formatBytes(NaN)).toBe('0 KB');
+  });
+});

--- a/src/utils/emoji.test.ts
+++ b/src/utils/emoji.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { segmentEmoji, emojiOnlyCount } from './emoji';
+
+describe('segmentEmoji', () => {
+  it('splits text and emoji into alternating runs', () => {
+    expect(segmentEmoji('hi 👋 there')).toEqual([
+      { text: 'hi ' },
+      { emoji: '👋' },
+      { text: ' there' },
+    ]);
+  });
+
+  it('returns a single text run when there is no emoji', () => {
+    expect(segmentEmoji('plain text')).toEqual([{ text: 'plain text' }]);
+  });
+
+  it('keeps a ZWJ emoji sequence intact as one grapheme', () => {
+    const segs = segmentEmoji('👨‍👩‍👧');
+    expect(segs).toHaveLength(1);
+    expect(segs[0].emoji).toBe('👨‍👩‍👧');
+  });
+});
+
+describe('emojiOnlyCount', () => {
+  it('counts emoji when the message is only emoji (ignoring spaces)', () => {
+    expect(emojiOnlyCount('👍')).toBe(1);
+    expect(emojiOnlyCount('👍 ❤️ 😂')).toBe(3);
+  });
+
+  it('returns 0 when any non-emoji character is present', () => {
+    expect(emojiOnlyCount('👍 ok')).toBe(0);
+    expect(emojiOnlyCount('hello')).toBe(0);
+  });
+
+  it('returns 0 for empty/whitespace-only input', () => {
+    expect(emojiOnlyCount('   ')).toBe(0);
+    expect(emojiOnlyCount('')).toBe(0);
+  });
+});

--- a/src/utils/notify-preview.test.ts
+++ b/src/utils/notify-preview.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { notifyPreview } from './notify-preview';
+import type { MessagePayload } from '@/services/crypto/message';
+
+const p = (over: Partial<MessagePayload>): MessagePayload => ({ kind: 'text', ...over }) as MessagePayload;
+
+describe('notifyPreview', () => {
+  it('prefers an album name over everything', () => {
+    expect(notifyPreview(p({ albumName: 'Trip', body: 'cap', kind: 'image' }))).toBe('Trip');
+  });
+
+  it('uses the body/caption when present', () => {
+    expect(notifyPreview(p({ kind: 'text', body: 'hello' }))).toBe('hello');
+    expect(notifyPreview(p({ kind: 'image', body: 'a caption' }))).toBe('a caption');
+  });
+
+  it('spells out media kinds without a caption', () => {
+    expect(notifyPreview(p({ kind: 'image' }))).toBe('Photo');
+    expect(notifyPreview(p({ kind: 'video' }))).toBe('Video');
+    expect(notifyPreview(p({ kind: 'video', videoNote: true }))).toBe('Video note');
+    expect(notifyPreview(p({ kind: 'voice' }))).toBe('Voice message');
+    expect(notifyPreview(p({ kind: 'file' }))).toBe('Document');
+  });
+
+  it('uses titles/labels for rich kinds, with fallbacks', () => {
+    expect(notifyPreview(p({ kind: 'audio', audio: { title: 'Song' } }))).toBe('Song');
+    expect(notifyPreview(p({ kind: 'audio' }))).toBe('Audio');
+    expect(notifyPreview(p({ kind: 'location', location: { lat: 0, lng: 0, label: 'Home' } }))).toBe('Location: Home');
+    expect(notifyPreview(p({ kind: 'location' }))).toBe('Shared a location');
+    expect(notifyPreview(p({ kind: 'poll', poll: { question: 'Lunch?', options: [], multi: false, votes: [] } }))).toBe('Poll: Lunch?');
+    expect(notifyPreview(p({ kind: 'contact', contact: { userId: 'u', name: 'Ada' } }))).toBe('Contact: Ada');
+  });
+
+  it('falls back to a generic line for an unknown kind', () => {
+    expect(notifyPreview(p({ kind: 'whatever' as MessagePayload['kind'] }))).toBe('New message');
+  });
+});

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeOutgoing, capitalizeFirst } from './text';
+
+describe('normalizeOutgoing', () => {
+  it('strips trailing whitespace on each line', () => {
+    expect(normalizeOutgoing('hello   \nworld\t')).toBe('hello\nworld');
+  });
+
+  it('collapses 3+ blank lines to a single blank line', () => {
+    expect(normalizeOutgoing('a\n\n\n\nb')).toBe('a\n\nb');
+  });
+
+  it('trims leading and trailing blank lines', () => {
+    expect(normalizeOutgoing('\n\n  hi  \n\n')).toBe('hi');
+  });
+
+  it('leaves already-tidy text untouched', () => {
+    expect(normalizeOutgoing('one\n\ntwo')).toBe('one\n\ntwo');
+  });
+});
+
+describe('capitalizeFirst', () => {
+  it('uppercases only the first letter', () => {
+    expect(capitalizeFirst('ada')).toBe('Ada');
+  });
+
+  it('preserves existing casing in the rest', () => {
+    expect(capitalizeFirst('mcDonald')).toBe('McDonald');
+  });
+
+  it('is a no-op on empty input', () => {
+    expect(capitalizeFirst('')).toBe('');
+  });
+});

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatTime, formatClock, sameDay, dayLabel, formatFull, formatStamp, formatDuration,
+} from './time';
+
+const DAY = 86_400_000;
+const HHMM = /^\d{2}:\d{2}$/;
+
+describe('formatClock', () => {
+  it('is a 24-hour HH:MM string', () => {
+    expect(formatClock(Date.now())).toMatch(HHMM);
+  });
+});
+
+describe('formatTime', () => {
+  it('shows the clock for today and "Yesterday" for the prior day', () => {
+    expect(formatTime(Date.now())).toMatch(HHMM);
+    expect(formatTime(Date.now() - DAY)).toBe('Yesterday');
+  });
+
+  it('shows a weekday within the past week, and a date beyond it', () => {
+    const weekday = formatTime(Date.now() - 3 * DAY);
+    expect(weekday).not.toBe('Yesterday');
+    expect(weekday).not.toMatch(HHMM);
+    expect(formatTime(Date.now() - 30 * DAY)).toMatch(/\d/); // a numeric date
+  });
+});
+
+describe('dayLabel', () => {
+  it('labels today and yesterday by name', () => {
+    expect(dayLabel(Date.now())).toBe('Today');
+    expect(dayLabel(Date.now() - DAY)).toBe('Yesterday');
+  });
+
+  it('uses a weekday within the past week and a full date beyond it', () => {
+    const weekday = dayLabel(Date.now() - 3 * DAY);
+    expect(['Today', 'Yesterday']).not.toContain(weekday);
+    expect(dayLabel(Date.now() - 60 * DAY)).toMatch(/\d{4}/); // full date carries the year
+  });
+});
+
+describe('sameDay', () => {
+  it('is true within one calendar day and false across days', () => {
+    const a = new Date(2026, 0, 1, 9, 0).getTime();
+    const b = new Date(2026, 0, 1, 23, 30).getTime();
+    const c = new Date(2026, 0, 2, 0, 30).getTime();
+    expect(sameDay(a, b)).toBe(true);
+    expect(sameDay(a, c)).toBe(false);
+  });
+});
+
+describe('formatFull', () => {
+  it('is a zero-padded local YYYY-MM-DD, HH:MM', () => {
+    const ts = new Date(2026, 0, 4, 1, 10).getTime();
+    expect(formatFull(ts)).toBe('2026-01-04, 01:10');
+  });
+});
+
+describe('formatStamp', () => {
+  it('is just the clock today, and day + clock otherwise', () => {
+    expect(formatStamp(Date.now())).toMatch(HHMM);
+    expect(formatStamp(Date.now() - DAY)).toMatch(/^Yesterday \d{2}:\d{2}$/);
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats sub-minute, minute, and empty cases', () => {
+    expect(formatDuration(0)).toBe('');
+    expect(formatDuration(undefined)).toBe('');
+    expect(formatDuration(45)).toBe('45 sec');
+    expect(formatDuration(90)).toBe('1:30');
+    expect(formatDuration(612)).toBe('10:12');
+  });
+});

--- a/src/utils/uid.test.ts
+++ b/src/utils/uid.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { uid } from './uid';
+
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('uid', () => {
+  it('produces an RFC-4122 v4-shaped id (version + variant bits set)', () => {
+    expect(uid()).toMatch(V4);
+  });
+
+  it('is practically unique across many calls', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 1000; i++) seen.add(uid());
+    expect(seen.size).toBe(1000);
+  });
+});

--- a/src/utils/user-color.test.ts
+++ b/src/utils/user-color.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { userColor, userColorBright } from './user-color';
+
+describe('user-color', () => {
+  it('is stable for the same id (hash fallback, no member list)', () => {
+    expect(userColor('alice')).toBe(userColor('alice'));
+    expect(userColorBright('alice')).toBe(userColorBright('alice'));
+  });
+
+  it('returns a hex color', () => {
+    expect(userColor('alice')).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(userColorBright('bob')).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+
+  it('assigns members from opposite halves of the wheel for adjacency', () => {
+    const members = ['a', 'b', 'c', 'd'];
+    // member 0 → palette index 0, member 1 → index HALF (7): distinct + far apart.
+    expect(userColor('a', members)).not.toBe(userColor('b', members));
+    expect(userColor('a', members)).toBe('#e0564f'); // first palette entry
+  });
+
+  it('falls back to the stable hash for an id not in the member list', () => {
+    const members = ['a', 'b'];
+    expect(userColor('z', members)).toBe(userColor('z'));
+  });
+
+  it('cycles the palette for very large groups without throwing', () => {
+    const members = Array.from({ length: 40 }, (_, i) => `m${i}`);
+    for (const m of members) expect(userColor(m, members)).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,15 @@ export default defineConfig({
         'src/services/keyed-mutex.ts',
         // Pure release-note delta/prettify behind the What's-new toast (spec 0001).
         'src/services/release-notes.ts',
+        // Pure presentation/format utilities, each directly unit-tested (spec 1006).
+        // Gated so their coverage can't regress.
+        'src/utils/bytes.ts',
+        'src/utils/text.ts',
+        'src/utils/uid.ts',
+        'src/utils/user-color.ts',
+        'src/utils/emoji.ts',
+        'src/utils/notify-preview.ts',
+        'src/utils/time.ts',
       ],
       thresholds: { lines: 80, functions: 80, statements: 80, branches: 80 },
     },


### PR DESCRIPTION
## Summary

Implements spec **1006 — Test Coverage Uplift**: add fast, *meaningful* unit tests for pure logic that lacked direct coverage (client + server) and ratchet the coverage floors so the gains can't regress. The bar is "would catch a real break", not coverage-number padding.

**Review-ready, not auto-merge.**

## Client unit tests (US1) — pure, deterministic
- `formatBytes` — unit scaling, decimal rules, zero/negative/NaN.
- `normalizeOutgoing` / `capitalizeFirst` — trailing-space strip, blank-line collapse, trim; first-letter only, casing preserved.
- `uid` — RFC-4122 v4 shape (version + variant bits) and uniqueness across 1000 calls.
- `user-color` — stable per id, opposite-half member assignment for adjacency, hash fallback, large-group palette cycling.
- `emoji` — text/emoji segmentation (incl. ZWJ sequences intact), emoji-only counting with non-emoji/whitespace edge cases.
- `notify-preview` — every message kind + title/label fallbacks + unknown-kind default.
- `time` — today/yesterday/weekday/date selection, `sameDay`, `formatFull`, `formatStamp`, `formatDuration`.

## Coverage floors ratcheted (US4)
These modules are added to the v8 coverage gate's `include` list in `vitest.config.ts` (80% lines/functions/statements/branches), so CI fails if their coverage drops. The gated `utils` set reports ~98%.

## Server unit tests (US2) — in-memory fake store, no DB
- `block_handlers` — block/unblock lifecycle + idempotency + list reconciliation, self-block and bad-id rejection (400), and auth-required paths (401).
- `health` — `/healthz` reports ok/up.
- `normalizeUsername` — pure table test: format, trim, reserved names (case-folded), consecutive dots.

## Tests
- `vue-tsc` + `vite build` green; **115** client unit tests pass (was 77); gated coverage thresholds met.
- `go build/vet/test ./...` green with the new handler/pure tests.

## Notes (US3)
Recent feature specs each ship their own new e2e (0002 friendship, 1004 message-menu, 1005 chat-media-scroll), which extend behavioral coverage of the flows they touch; this PR concentrates on the cheap, fast unit layer and the ratchet.

## Zero-knowledge
Tests only. No runtime/wire/server/data-model change.