### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",


### PR DESCRIPTION
Bumps `package.json` (+ lockfile) **0.1.0 → 0.2.0** via `npm run release:minor`.

This is the first tagged production release. It bundles the UX batch already shipped to `develop`:
- 0002 Connections & Friendship
- 1004 Message Action Menu + 1008 One-Tap Media & Inline Quick-React
- 1005 Chat scroll perf & media caching
- 1006 Test coverage uplift
- 1007 Media playback & embedded thumbnails

Minor bump (new backward-compatible features, staying pre-1.0).

**Flow:** this lands the version on `develop`. Once merged, a follow-up **`develop` → `main`** PR is what actually cuts the release — `release.yml` re-verifies the merge commit and, if green, tags `v0.2.0` and publishes the production image (`:0.2.0`, `:0.2`, `:latest`) + a GitHub release.

Bump only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)