### PR TITLE
fix(chat): use happy-outline for the add-reaction button

### DIFF
--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -397,7 +397,7 @@
                   aria-label="React"
                   @click.stop="openQuickReact(m, $event)"
                 >
-                  <ion-icon :icon="addCircleOutline" />
+                  <ion-icon :icon="happyOutline" />
                 </button>
                 <span class="time">
                   <span v-if="m.editedAt" class="edited">edited</span>
@@ -536,7 +536,7 @@
                   aria-label="React"
                   @click.stop="openQuickReact(item.messages[0], $event)"
                 >
-                  <ion-icon :icon="addCircleOutline" />
+                  <ion-icon :icon="happyOutline" />
                 </button>
                 <span class="time">
                   {{ formatClock(item.messages[item.messages.length - 1].timestamp) }}
@@ -835,7 +835,7 @@ import {
 import type { InfiniteScrollCustomEvent } from '@ionic/vue';
 import {
   callOutline, videocamOutline, documentOutline, playCircle, play, sendOutline,
-  timeOutline, checkmark, checkmarkDone, addOutline, addCircleOutline, cameraOutline,
+  timeOutline, checkmark, checkmarkDone, addOutline, happyOutline, cameraOutline,
   micOutline, trashOutline, closeOutline, pause, banOutline, arrowRedoOutline, arrowUndoOutline, globeOutline,
   locationOutline, barChartOutline, personOutline, refreshOutline, downloadOutline,
   imageOutline, musicalNotesOutline, calendarOutline, checkmarkCircle, ellipseOutline,


### PR DESCRIPTION
Swaps the message-foot reaction button icon from `add-circle-outline` (`+`) to **`happy-outline`**, which reads more clearly as "react".

Two spots in `ChatDetailPage.vue` (message-foot + album-foot) + the icon import. Stock Ionic `ion-icon` (Constitution XI). Typecheck + build green; no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)