### PR TITLE
docs(spec): mark specs 1001/1002/1003/2002 shipped; regen roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,9 +20,9 @@ Specs are grouped by category band; status moves
 
 | Spec | Title | Status |
 |------|-------|--------|
-| [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🔵 in-review |
-| [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🔵 in-review |
-| [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🔵 in-review |
+| [1001](specs/1001-smooth-tab-transitions/spec.md) | Smooth Tab Transitions | 🟢 shipped |
+| [1002](specs/1002-local-dev-deployment/spec.md) | Local Dev Deployment Tooling + Hot Reload | 🟢 shipped |
+| [1003](specs/1003-empty-chats-calls/spec.md) | Empty Chats/Calls Hint | 🟢 shipped |
 | [1004](specs/1004-message-action-menu/spec.md) | Message Action Menu | 🟢 shipped |
 | [1005](specs/1005-chat-history-scroll/spec.md) | Chat History Scroll Performance & Media Caching | 🟢 shipped |
 | [1006](specs/1006-test-coverage-uplift/spec.md) | Test Coverage Uplift | 🟢 shipped |
@@ -34,4 +34,4 @@ Specs are grouped by category band; status moves
 | Spec | Title | Status |
 |------|-------|--------|
 | [2001](specs/2001-stabilize-message-status/spec.md) | Stabilize message status reporting around downloaded-blob receipts | 🟢 shipped |
-| [2002](specs/2002-media-thumbnails-stay/spec.md) | Media Thumbnails Stay Thumbnails (no autoplay storm) | 🔵 in-review |
+| [2002](specs/2002-media-thumbnails-stay/spec.md) | Media Thumbnails Stay Thumbnails (no autoplay storm) | 🟢 shipped |

--- a/specs/1001-smooth-tab-transitions/spec.md
+++ b/specs/1001-smooth-tab-transitions/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-15
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1002-local-dev-deployment/spec.md
+++ b/specs/1002-local-dev-deployment/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-15
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1003-empty-chats-calls/spec.md
+++ b/specs/1003-empty-chats-calls/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-15
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2002-media-thumbnails-stay/spec.md
+++ b/specs/2002-media-thumbnails-stay/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-16
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
## What

Reconcile spec bookkeeping that lagged behind already-merged code. Four specs were still marked `in-review` even though their implementing PRs are merged into `develop` and the feature code is present on HEAD (verified: each merge commit is reachable from `develop`, feature files present, tests pass where applicable).

| Spec | Title | Impl PR | Merge commit |
|---|---|---|---|
| 1001 | Smooth Tab Transitions | #30 | `5905eb5` |
| 1002 | Local Dev Deployment Tooling + Hot Reload | #31 | `3d207c4` |
| 1003 | Empty Chats/Calls Hint | #32 | `1c882a4` |
| 2002 | Media Thumbnails Stay Thumbnails (no autoplay storm) | #37 | `8c0f32e` |

## Changes

- Bump each spec's `**Status**:` line `in-review → shipped`.
- Regenerate `ROADMAP.md` via `make roadmap` (generated artifact — not hand-edited).

Docs-only; no code changes. After merge, every spec across all bands is `shipped` and the `Roadmap up to date` CI guard stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)