### PR TITLE
docs(spec): mark spec 1009 shipped; regen roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Specs are grouped by category band; status moves
 | [1006](specs/1006-test-coverage-uplift/spec.md) | Test Coverage Uplift | 🟢 shipped |
 | [1007](specs/1007-media-playback-and/spec.md) | Media Playback & Embedded Thumbnails | 🟢 shipped |
 | [1008](specs/1008-one-tap-media/spec.md) | One-Tap Media Open & Inline Quick-React Bar | 🟢 shipped |
-| [1009](specs/1009-activity-indicators/spec.md) | Ephemeral Activity Indicators (Typing & Recording) | 🔵 in-review |
+| [1009](specs/1009-activity-indicators/spec.md) | Ephemeral Activity Indicators (Typing & Recording) | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1009-activity-indicators/spec.md
+++ b/specs/1009-activity-indicators/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-17
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Spec **1009** (ephemeral activity indicators — typing & recording) merged into `develop` via #99 — all five user stories implemented and verified live (3 e2e). Bump its `Status` line `in-review → shipped` and regenerate `ROADMAP.md`.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)