### PR TITLE
feat(chat): group "Seen" receipts — durable, private, counted (spec 1010)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,5 +223,5 @@ GitFlow. **`develop`** is the integration branch; **`main`** is production.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1009-activity-indicators/plan.md`
+`specs/1010-group-seen-receipts/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ Specs are grouped by category band; status moves
 | [1007](specs/1007-media-playback-and/spec.md) | Media Playback & Embedded Thumbnails | 🟢 shipped |
 | [1008](specs/1008-one-tap-media/spec.md) | One-Tap Media Open & Inline Quick-React Bar | 🟢 shipped |
 | [1009](specs/1009-activity-indicators/spec.md) | Ephemeral Activity Indicators (Typing & Recording) | 🟢 shipped |
+| [1010](specs/1010-group-seen-receipts/spec.md) | Group "Seen" Receipts — Durable, Private, and Counted | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/group-seen-receipts.spec.ts
+++ b/e2e/group-seen-receipts.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * Group "Seen" receipts (spec 1010): durable, private, and counted.
+ *
+ * Three real accounts over the pairwise group fan-out. These drive the data layer
+ * through window.__ringTest (the same service calls the UI makes), asserting on the
+ * sender's per-member receipts roster — the exact source the bubble counter and the
+ * message-info lists render from:
+ *   - SC-001 counter climb: delivered count then seen count climb to N (=recipients).
+ *   - SC-002 durability: a 'seen' reported while the sender is OFFLINE is reconciled
+ *     on reconnect (recovered from the server `seen` store), not lost.
+ *   - SC-003 reciprocity (emit side): with "Seen receipts" off, the user never
+ *     advances anyone's view of their seen state, while the others still see each
+ *     other.
+ *   - SC-004 info-list partition: every member falls into exactly one of Seen by /
+ *     Delivered / Not yet delivered.
+ *   - SC-006 1:1 unchanged: a 1:1 message carries no receipts roster (plain tick).
+ */
+import { test, expect, type Browser } from '@playwright/test';
+import { createAccount, pair, type RingClient } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const AVATAR = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>';
+
+async function setProfile(c: RingClient, name: string): Promise<void> {
+  await c.page.evaluate(([n, av]: [string, string]) => (window as any).__ringTest.setProfile(n, av), [name, AVATAR]);
+}
+
+/** Wait until `c` has the group chat `gid`, then return it. */
+async function awaitGroup(c: RingClient, gid: string): Promise<void> {
+  await c.page.waitForFunction(
+    (id) => (window as any).__ringTest.groupChats().then((gs: any[]) => gs.some((g) => g.id === id)),
+    gid,
+    { timeout: 30_000 },
+  );
+}
+
+/** The id of the (first) message with `body` in chat `chatId` on `c`'s device. */
+async function msgIdByBody(c: RingClient, chatId: string, body: string): Promise<string> {
+  return c.page.evaluate(
+    ([cid, b]: [string, string]) =>
+      (window as any).__ringTest.messages(cid).then((ms: any[]) => ms.find((m) => m.body === b)?.id ?? ''),
+    [chatId, body],
+  );
+}
+
+interface Receipt { contactId: string; deliveredAt?: number; seenAt?: number }
+
+async function receiptsOf(c: RingClient, messageId: string): Promise<Receipt[]> {
+  return c.page.evaluate((id) => (window as any).__ringTest.messageReceipts(id), messageId);
+}
+
+const deliveredCount = (recs: Receipt[]) => recs.filter((r) => r.deliveredAt).length;
+const seenCount = (recs: Receipt[]) => recs.filter((r) => r.seenAt).length;
+
+async function setupTrio(browser: Browser): Promise<{ a: RingClient; b: RingClient; c: RingClient; gid: string; ctx: any[] }> {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'RINGSEEN1');
+  const b = await createAccount(ctxB, 'RINGSEEN2');
+  const c = await createAccount(ctxC, 'RINGSEEN3');
+  await setProfile(a, 'Alice');
+  await setProfile(b, 'Bob');
+  await setProfile(c, 'Carol');
+  await pair(a, b);
+  await pair(a, c);
+  const gid = (await a.page.evaluate(
+    (ids) => (window as any).__ringTest.createGroup('Trip', ids),
+    [b.id, c.id],
+  )) as string;
+  await awaitGroup(b, gid);
+  await awaitGroup(c, gid);
+  return { a, b, c, gid, ctx: [ctxA, ctxB, ctxC] };
+}
+
+test('SC-001/SC-004: group counter climbs Delivered X/2 → Seen X/2 → Seen, lists partition all members', async ({ browser }) => {
+  const { a, b, c, gid, ctx } = await setupTrio(browser);
+  try {
+    // Alice sends to the group → her message gets a 2-recipient receipts roster.
+    await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'who is in?'), gid);
+    const mid = await expect
+      .poll(() => msgIdByBody(a, gid, 'who is in?'), { timeout: 30_000 })
+      .toBeTruthy()
+      .then(() => msgIdByBody(a, gid, 'who is in?'));
+
+    // Delivered climbs to N=2 as B and C's devices receive + ack it.
+    await expect.poll(async () => deliveredCount(await receiptsOf(a, mid)), { timeout: 30_000 }).toBe(2);
+    // None seen yet (nobody has opened it).
+    expect(seenCount(await receiptsOf(a, mid))).toBe(0);
+
+    // Bob sees it → Seen 1/2.
+    await b.page.evaluate((id) => (window as any).__ringTest.markSeen(id), gid);
+    await expect.poll(async () => seenCount(await receiptsOf(a, mid)), { timeout: 30_000 }).toBe(1);
+
+    // SC-004: at this point every member is in exactly one tier — Bob seen, Carol
+    // delivered-not-seen, nobody undelivered (both received).
+    const recs = await receiptsOf(a, mid);
+    const seen = recs.filter((r) => r.seenAt).map((r) => r.contactId);
+    const deliveredOnly = recs.filter((r) => r.deliveredAt && !r.seenAt).map((r) => r.contactId);
+    const notDelivered = [b.id, c.id].filter((id) => !recs.some((r) => r.contactId === id && r.deliveredAt));
+    expect(seen).toEqual([b.id]);
+    expect(deliveredOnly).toEqual([c.id]);
+    expect(notDelivered).toEqual([]);
+    // Every member accounted for exactly once.
+    expect([...seen, ...deliveredOnly, ...notDelivered].sort()).toEqual([b.id, c.id].sort());
+
+    // Carol sees it too → Seen 2/2 → the message settles to fully seen.
+    await c.page.evaluate((id) => (window as any).__ringTest.markSeen(id), gid);
+    await expect.poll(async () => seenCount(await receiptsOf(a, mid)), { timeout: 30_000 }).toBe(2);
+    await expect
+      .poll(() => a.page.evaluate(
+        ([cid, m]: [string, string]) =>
+          (window as any).__ringTest.messages(cid).then((ms: any[]) => ms.find((x) => x.id === m)?.status),
+        [gid, mid] as [string, string],
+      ), { timeout: 30_000 })
+      .toBe('seen');
+  } finally {
+    for (const cx of ctx) await cx.close();
+  }
+});
+
+test('SC-002: a member seen while the sender is offline is reconciled on reconnect', async ({ browser }) => {
+  const { a, b, c, gid, ctx } = await setupTrio(browser);
+  try {
+    await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'roll call'), gid);
+    const mid = await expect
+      .poll(() => msgIdByBody(a, gid, 'roll call'), { timeout: 30_000 })
+      .toBeTruthy()
+      .then(() => msgIdByBody(a, gid, 'roll call'));
+    await expect.poll(async () => deliveredCount(await receiptsOf(a, mid)), { timeout: 30_000 }).toBe(2);
+
+    // Alice goes offline; Bob sees the message → his live 'seen' can't reach Alice.
+    await a.page.evaluate(() => (window as any).__ringTest.disconnect());
+    await b.page.evaluate((id) => (window as any).__ringTest.markSeen(id), gid);
+    await b.page.waitForTimeout(500);
+    // Still not reflected on Alice while she's offline.
+    expect(seenCount(await receiptsOf(a, mid))).toBe(0);
+
+    // Alice reconnects → reconcileSeen recovers Bob's seen from the durable store.
+    await a.page.evaluate(() => (window as any).__ringTest.reconnect());
+    await expect.poll(async () => seenCount(await receiptsOf(a, mid)), { timeout: 30_000 }).toBe(1);
+    expect((await receiptsOf(a, mid)).find((r) => r.contactId === b.id)?.seenAt).toBeTruthy();
+  } finally {
+    for (const cx of ctx) await cx.close();
+  }
+});
+
+test('SC-003: with "Seen receipts" off, the user never advances anyone’s view of their seen', async ({ browser }) => {
+  const { a, b, c, gid, ctx } = await setupTrio(browser);
+  try {
+    // Alice turns OFF seen receipts (emit gate).
+    await a.page.evaluate(() => (window as any).__ringTest.setSetting('privacy.seenReceipts', false));
+    await a.page.evaluate(() => (window as any).__ringTest.applySeenPref());
+
+    // Bob sends to the group; everyone receives it.
+    await b.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'snacks?'), gid);
+    const midOnB = await expect
+      .poll(() => msgIdByBody(b, gid, 'snacks?'), { timeout: 30_000 })
+      .toBeTruthy()
+      .then(() => msgIdByBody(b, gid, 'snacks?'));
+    await expect.poll(async () => deliveredCount(await receiptsOf(b, midOnB)), { timeout: 30_000 }).toBe(2);
+
+    // Alice (off) and Carol (on) both open it.
+    await a.page.evaluate((id) => (window as any).__ringTest.markSeen(id), gid);
+    await c.page.evaluate((id) => (window as any).__ringTest.markSeen(id), gid);
+
+    // Bob eventually sees Carol as seen, but NEVER Alice (her client sent nothing).
+    await expect
+      .poll(async () => (await receiptsOf(b, midOnB)).find((r) => r.contactId === c.id)?.seenAt ?? 0, { timeout: 30_000 })
+      .toBeGreaterThan(0);
+    await b.page.waitForTimeout(500); // give any stray receipt time to (not) arrive
+    expect((await receiptsOf(b, midOnB)).find((r) => r.contactId === a.id)?.seenAt ?? null).toBeNull();
+  } finally {
+    for (const cx of ctx) await cx.close();
+  }
+});
+
+test('SC-006: a 1:1 message carries no group receipts roster (plain tick, no fraction)', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const a = await createAccount(ctxA, 'RINGSEEN4');
+    const b = await createAccount(ctxB, 'RINGSEEN5');
+    await setProfile(a, 'Alice');
+    await setProfile(b, 'Bob');
+    await pair(a, b);
+    const chatId = (await a.page.evaluate((peer) => (window as any).__ringTest.chatWith(peer), b.id)) as string;
+    await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'hey'), chatId);
+    const mid = await expect
+      .poll(() => msgIdByBody(a, chatId, 'hey'), { timeout: 30_000 })
+      .toBeTruthy()
+      .then(() => msgIdByBody(a, chatId, 'hey'));
+    // A 1:1 message has no per-member roster (it's the scalar-status path).
+    expect(await receiptsOf(a, mid)).toEqual([]);
+    // Bob opens it → it advances to plain 'seen' (no fraction is ever derived). B's own
+    // 1:1 chat id differs from A's (per-device), so resolve it on B's side, and wait
+    // until B has actually received the message before marking it seen.
+    const bChat = (await b.page.evaluate((peer) => (window as any).__ringTest.chatWith(peer), a.id)) as string;
+    await expect.poll(() => msgIdByBody(b, bChat, 'hey'), { timeout: 30_000 }).toBeTruthy();
+    await b.page.evaluate((id) => (window as any).__ringTest.markSeen(id), bChat);
+    await expect
+      .poll(() => a.page.evaluate(
+        ([cid, m]: [string, string]) =>
+          (window as any).__ringTest.messages(cid).then((ms: any[]) => ms.find((x) => x.id === m)?.status),
+        [chatId, mid] as [string, string],
+      ), { timeout: 30_000 })
+      .toBe('seen');
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});

--- a/server/cmd/ringd/main.go
+++ b/server/cmd/ringd/main.go
@@ -252,6 +252,7 @@ func run() error {
 				"CALLSPK1", "CALLSPK2",
 				"CHATFLT1", "CHATFLT2", "CHATFLT3",
 				"NAVTERM1", "PASTECP1", "PASTECP2", "EDITDEL1", "EDITDEL2",
+				"RINGSEEN1", "RINGSEEN2", "RINGSEEN3", "RINGSEEN4", "RINGSEEN5",
 			}
 			if err := st.SeedDevInvites(ctx, e2eCodes); err != nil {
 				return err
@@ -455,6 +456,14 @@ func run() error {
 					slog.Error("deliveries sweep", "err", derr)
 				} else if dn > 0 {
 					slog.Info("deliveries sweep", "removed", dn)
+				}
+				// Seen records (spec 1010) shadow the same relay queue with the same
+				// retention — swept here for parity with deliveries.
+				sn, serr := st.SweepSeenOlderThan(sctx, relayRetention)
+				if serr != nil {
+					slog.Error("seen sweep", "err", serr)
+				} else if sn > 0 {
+					slog.Info("seen sweep", "removed", sn)
 				}
 				// Backstop blob sweep, batched: keep removing the oldest aged-out blobs
 				// until a batch comes back short (so the first run grinds through any

--- a/server/internal/api/auth_handlers_test.go
+++ b/server/internal/api/auth_handlers_test.go
@@ -32,6 +32,7 @@ type fakeStore struct {
 	relaySeq  int64
 	contacts  map[string][]string         // owner -> contact ids
 	deliv     map[string][]store.Delivery // sender -> recorded deliveries
+	seen      map[string][]store.Seen     // sender -> recorded seen receipts
 }
 
 func newFakeStore() *fakeStore {
@@ -269,6 +270,38 @@ func (f *fakeStore) DeliveriesFor(_ context.Context, sender string, msgIDs []str
 	for _, d := range f.deliv[sender] {
 		if want[d.MsgID] {
 			out = append(out, d)
+		}
+	}
+	return out, nil
+}
+func (f *fakeStore) RecordSeen(_ context.Context, sender, recipient, msgID string) error {
+	if sender == "" || recipient == "" || msgID == "" {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.seen == nil {
+		f.seen = map[string][]store.Seen{}
+	}
+	for _, s := range f.seen[sender] {
+		if s.MsgID == msgID && s.Recipient == recipient {
+			return nil // idempotent
+		}
+	}
+	f.seen[sender] = append(f.seen[sender], store.Seen{MsgID: msgID, Recipient: recipient, SeenMs: 1})
+	return nil
+}
+func (f *fakeStore) SeenFor(_ context.Context, sender string, msgIDs []string) ([]store.Seen, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	want := map[string]bool{}
+	for _, id := range msgIDs {
+		want[id] = true
+	}
+	var out []store.Seen
+	for _, s := range f.seen[sender] {
+		if want[s.MsgID] {
+			out = append(out, s)
 		}
 	}
 	return out, nil

--- a/server/internal/api/relay_handlers.go
+++ b/server/internal/api/relay_handlers.go
@@ -27,7 +27,7 @@ import (
 // Fetching them proves the device received them (the push woke the SW and it
 // pulled the queue), so each frame's sender gets a "delivered" receipt - WITHOUT
 // dequeuing, so the page can still drain + persist them durably. Idempotent: the
-// later WS ack re-sends the same receipt and clients never regress 'read' back to
+// later WS ack re-sends the same receipt and clients never regress 'seen' back to
 // 'delivered'.
 func (h *Handlers) relayPending(w http.ResponseWriter, r *http.Request) {
 	uid, _ := auth.UserID(r.Context())
@@ -149,4 +149,39 @@ func (h *Handlers) deliveriesCheck(w http.ResponseWriter, r *http.Request) {
 		out = append(out, map[string]any{"messageId": d.MsgID, "recipient": d.Recipient, "at": d.DeliveredMs})
 	}
 	httpx.JSON(w, http.StatusOK, map[string]any{"delivered": out})
+}
+
+type seenCheckRequest struct {
+	IDs []string `json:"ids"`
+}
+
+// seenCheck (POST /v1/seen/check) lets a sender reconcile its not-yet-seen messages
+// on reconnect (spec 1010, the twin of deliveriesCheck): given a list of message ids
+// it originated, it returns the durably-recorded seen receipts (one entry per member
+// who has seen it, so a group message can report each). This recovers a 'seen'
+// receipt that was dropped because the sender was offline at the moment a member
+// opened it.
+func (h *Handlers) seenCheck(w http.ResponseWriter, r *http.Request) {
+	uid, _ := auth.UserID(r.Context())
+	var req seenCheckRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 256<<10)).Decode(&req); err != nil {
+		httpx.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	// Bound the query the same way the client bounds what it asks about.
+	const maxIDs = 500
+	if len(req.IDs) > maxIDs {
+		req.IDs = req.IDs[:maxIDs]
+	}
+	rows, err := h.Relay.SeenFor(r.Context(), uid, req.IDs)
+	if err != nil {
+		slog.Error("seen check failed", "err", err, "user", uid)
+		httpx.Error(w, http.StatusInternalServerError, "could not load seen")
+		return
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, s := range rows {
+		out = append(out, map[string]any{"messageId": s.MsgID, "recipient": s.Recipient, "at": s.SeenMs})
+	}
+	httpx.JSON(w, http.StatusOK, map[string]any{"seen": out})
 }

--- a/server/internal/api/relay_handlers_test.go
+++ b/server/internal/api/relay_handlers_test.go
@@ -108,3 +108,48 @@ func TestDeliveriesReconcile(t *testing.T) {
 		t.Fatalf("cross-user delivered = %+v, want none", got.Delivered)
 	}
 }
+
+// TestSeenReconcile proves the spec-1010 sender-side SEEN reconcile (the twin of
+// TestDeliveriesReconcile): once a member's 'seen' is durably recorded, the SENDER
+// can recover it via POST /v1/seen/check even if the live receipt was dropped while
+// the sender was offline — and the lookup is scoped to the querying sender.
+func TestSeenReconcile(t *testing.T) {
+	as := newFakeStore()
+	srv := NewRouter(&Handlers{
+		Store: as, Directory: as, Blocks: as, Relay: as, Hub: ws.NewHub(),
+		Keys: newFakeKeysStore(), Blobs: newFakeBlobStore(),
+		Sync: newFakeSyncStore(), Push: newFakePushStore(), Invites: as,
+		PublicURL: "https://ring.example",
+	}, []string{"http://localhost:5173"})
+
+	senderTok, senderUID, _ := registerNamed(t, srv, "seensender")
+	recipTok, recipUID, _ := registerNamed(t, srv, "seenrecip")
+
+	// A member's 'seen' for the sender's message is recorded durably (as the relay's
+	// receipt case does when it relays a client 'seen').
+	_ = as.RecordSeen(context.Background(), senderUID, recipUID, "mx")
+
+	// Sender reconciles on reconnect: asks which of its ids have been seen.
+	rr := do(t, srv, http.MethodPost, "/v1/seen/check", senderTok, `{"ids":["mx","never"]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("seen check = %d (%s)", rr.Code, rr.Body.String())
+	}
+	var got struct {
+		Seen []struct {
+			MessageID string `json:"messageId"`
+			Recipient string `json:"recipient"`
+			At        int64  `json:"at"`
+		} `json:"seen"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if len(got.Seen) != 1 || got.Seen[0].MessageID != "mx" || got.Seen[0].Recipient != recipUID {
+		t.Fatalf("seen = %+v, want exactly mx -> %s", got.Seen, recipUID)
+	}
+
+	// Scoped to the caller: the recipient sees none of the sender's seen rows.
+	rr = do(t, srv, http.MethodPost, "/v1/seen/check", recipTok, `{"ids":["mx"]}`)
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if len(got.Seen) != 0 {
+		t.Fatalf("cross-user seen = %+v, want none", got.Seen)
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -240,6 +240,9 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	// Sender-side reconcile: which of my still-'sent' messages were delivered while
 	// I was offline (so a dropped 'delivered' receipt is recovered on reconnect).
 	mux.Handle("POST /v1/deliveries/check", authMW(http.HandlerFunc(h.deliveriesCheck)))
+	// Sender-side reconcile for SEEN (spec 1010): which of my messages have been seen
+	// (so a 'seen' receipt dropped while I was offline is recovered on reconnect).
+	mux.Handle("POST /v1/seen/check", authMW(http.HandlerFunc(h.seenCheck)))
 	// A callee's service worker acks an incoming-call ring push (proves reachable →
 	// the caller's UI flips Calling -> Ringing).
 	mux.Handle("POST /v1/call/ack", authMW(http.HandlerFunc(h.callAck)))

--- a/server/internal/db/migrations/0020_seen.sql
+++ b/server/internal/db/migrations/0020_seen.sql
@@ -1,0 +1,22 @@
+-- Durable SEEN records (spec 1010), the symmetric twin of `deliveries` (0019): a
+-- group message's "Seen X/N" must survive the SENDER being offline at the instant a
+-- member opens it. A 'seen' receipt is relayed over a non-blocking socket, so if the
+-- sender is offline it's lost; the sender reconciles its still-unseen messages on
+-- reconnect (POST /v1/seen/check). Same metadata shape/class as `deliveries` (routing
+-- ids + a timestamp, no message content) — no new server-visible metadata class.
+-- Swept by age like the relay queue + deliveries.
+--
+-- Privacy: this only ever holds receipts a recipient's client CHOSE to send (the
+-- "Seen receipts" preference is enforced entirely client-side; an opted-out user
+-- sends nothing, so nothing is stored). There is deliberately NO preference column —
+-- the server is never told the preference.
+CREATE TABLE seen (
+    sender     uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    recipient  uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    msg_id     text NOT NULL,
+    seen_at    timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (sender, recipient, msg_id)
+);
+
+-- Sender-scoped lookup for the reconcile query.
+CREATE INDEX seen_sender_idx ON seen (sender, msg_id);

--- a/server/internal/store/seen.go
+++ b/server/internal/store/seen.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// Durable seen records (see migration 0020), the symmetric twin of deliveries: a
+// message's sender can reconcile its 'seen' state on reconnect even if the receipt
+// was dropped while it was offline (spec 1010). Same metadata shape as deliveries —
+// routing ids + a timestamp, no message content.
+
+// RecordSeen durably notes that msgID (from sender) was seen by recipient.
+// Idempotent; no-op on empty ids.
+func (s *Store) RecordSeen(ctx context.Context, sender, recipient, msgID string) error {
+	if sender == "" || recipient == "" || msgID == "" {
+		return nil
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO seen (sender, recipient, msg_id) VALUES ($1, $2, $3)
+		 ON CONFLICT (sender, recipient, msg_id) DO NOTHING`, sender, recipient, msgID)
+	return err
+}
+
+// Seen is one (msg_id, recipient) seen-confirmation for the querying sender.
+type Seen struct {
+	MsgID     string
+	Recipient string
+	SeenMs    int64
+}
+
+// SeenFor returns the recorded seen receipts for `sender` among the given message
+// ids (a group message has one row per member who has seen it).
+func (s *Store) SeenFor(ctx context.Context, sender string, msgIDs []string) ([]Seen, error) {
+	if len(msgIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT msg_id, recipient::text, (extract(epoch from seen_at)*1000)::bigint
+		   FROM seen WHERE sender::text = $1 AND msg_id = ANY($2)`, sender, msgIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Seen
+	for rows.Next() {
+		var sn Seen
+		if err := rows.Scan(&sn.MsgID, &sn.Recipient, &sn.SeenMs); err != nil {
+			return nil, err
+		}
+		out = append(out, sn)
+	}
+	return out, rows.Err()
+}
+
+// SweepSeenOlderThan deletes seen records older than age, returning how many were
+// removed. Bounds the table like the deliveries sweep (retention parity).
+func (s *Store) SweepSeenOlderThan(ctx context.Context, age time.Duration) (int64, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM seen WHERE seen_at < now() - make_interval(secs => $1)`, age.Seconds())
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}

--- a/server/internal/ws/hub.go
+++ b/server/internal/ws/hub.go
@@ -63,6 +63,11 @@ type RelayStore interface {
 	// sender can reconcile a dropped 'delivered' receipt on reconnect.
 	RecordDelivery(ctx context.Context, sender, recipient, msgID string) error
 	DeliveriesFor(ctx context.Context, sender string, msgIDs []string) ([]store.Delivery, error)
+	// RecordSeen durably notes msgID (from sender) was seen by recipient (spec 1010),
+	// so the sender can reconcile a dropped 'seen' receipt on reconnect — the
+	// symmetric twin of RecordDelivery.
+	RecordSeen(ctx context.Context, sender, recipient, msgID string) error
+	SeenFor(ctx context.Context, sender string, msgIDs []string) ([]store.Seen, error)
 	SetPresencePrefs(ctx context.Context, userID, onlineTier, lastSeenTier string) error
 	TouchLastSeen(ctx context.Context, userID string) error
 	GetPresence(ctx context.Context, ids []string) (map[string]store.PresenceInfo, error)
@@ -1030,18 +1035,29 @@ func (c *Client) handleFrame(data []byte) {
 
 	case "receipt":
 		// Client-originated receipt addressed to another user. Clients may ONLY
-		// originate 'read' and 'downloaded' (the recipient confirming it has the media
-		// bytes, so the sender can delete the blob); 'sent'/'delivered' are
-		// server-authoritative, so a client claiming them is dropped (otherwise a peer
-		// could forge a 'delivered' for a victim's group message id and make the sender
-		// evict its other unsent copies). Stamp From = the authenticated sender so the
-		// recipient can scope it.
-		if f.To == "" || (f.Status != "read" && f.Status != "downloaded") {
+		// originate 'seen' (the viewer opened the message) and 'downloaded' (the
+		// recipient confirming it has the media bytes, so the sender can delete the
+		// blob); 'sent'/'delivered' are server-authoritative, so a client claiming them
+		// is dropped (otherwise a peer could forge a 'delivered' for a victim's group
+		// message id and make the sender evict its other unsent copies). 'read' is no
+		// longer accepted post-cutover (spec 1010). Stamp From = the authenticated
+		// sender so the recipient can scope it.
+		if f.To == "" || (f.Status != "seen" && f.Status != "downloaded") {
 			return
 		}
 		out := frame{T: "receipt", MessageID: f.MessageID, Status: f.Status, At: f.At, From: c.userID}
 		if payload, err := json.Marshal(out); err == nil {
 			c.hub.Send(f.To, payload)
+		}
+		// Durably record a 'seen' so a group's "Seen X/N" survives the sender being
+		// offline at the moment a member opened it (spec 1010) — the parallel of how
+		// 'ack' calls RecordDelivery. f.To is the message author (the reconciling
+		// sender); c.userID is the member who saw it. 'downloaded' is a media-cleanup
+		// signal and is NOT recorded (unchanged).
+		if f.Status == "seen" {
+			if err := c.store.RecordSeen(ctx, f.To, c.userID, f.MessageID); err != nil {
+				slog.Error("record seen", "err", err)
+			}
 		}
 
 	case "activity":

--- a/server/internal/ws/relay_test.go
+++ b/server/internal/ws/relay_test.go
@@ -25,6 +25,8 @@ type memRelay struct {
 	blocks  map[string]map[string]bool   // blocker -> blocked -> true
 	deliv   []store.Delivery             // recorded deliveries (sender-scoped lookup)
 	delivBy map[string]string            // msgID -> sender, for the lookup
+	seen    []store.Seen                 // recorded seen receipts (sender-scoped lookup)
+	seenBy  map[string]string            // msgID -> sender, for the lookup
 }
 
 func newMemRelay() *memRelay {
@@ -33,6 +35,7 @@ func newMemRelay() *memRelay {
 		senders: map[string]map[string]string{},
 		blocks:  map[string]map[string]bool{},
 		delivBy: map[string]string{},
+		seenBy:  map[string]string{},
 	}
 }
 
@@ -127,6 +130,38 @@ func (m *memRelay) DeliveriesFor(_ context.Context, sender string, msgIDs []stri
 	for _, d := range m.deliv {
 		if want[d.MsgID] && m.delivBy[d.MsgID] == sender {
 			out = append(out, d)
+		}
+	}
+	return out, nil
+}
+
+func (m *memRelay) RecordSeen(_ context.Context, sender, recipient, msgID string) error {
+	if sender == "" || recipient == "" || msgID == "" {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, s := range m.seen {
+		if s.MsgID == msgID && s.Recipient == recipient {
+			return nil // idempotent
+		}
+	}
+	m.seen = append(m.seen, store.Seen{MsgID: msgID, Recipient: recipient, SeenMs: 1})
+	m.seenBy[msgID] = sender
+	return nil
+}
+
+func (m *memRelay) SeenFor(_ context.Context, sender string, msgIDs []string) ([]store.Seen, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	want := map[string]bool{}
+	for _, id := range msgIDs {
+		want[id] = true
+	}
+	var out []store.Seen
+	for _, s := range m.seen {
+		if want[s.MsgID] && m.seenBy[s.MsgID] == sender {
+			out = append(out, s)
 		}
 	}
 	return out, nil
@@ -271,25 +306,10 @@ func TestRelayOfflineQueueDrainsOnConnect(t *testing.T) {
 	}
 }
 
-func TestRelayRoutesReadReceipt(t *testing.T) {
-	srv, _ := newRelayServer()
-	defer srv.Close()
-
-	a := dial(t, srv, "tokA")
-	defer a.Close()
-	b := dial(t, srv, "tokB")
-	defer b.Close()
-	time.Sleep(50 * time.Millisecond)
-
-	// B (recipient) reports it read message m1 → routed to A (the sender).
-	if err := b.WriteJSON(map[string]any{"t": "receipt", "messageId": "m1", "status": "read", "to": "user-a"}); err != nil {
-		t.Fatalf("B send read receipt: %v", err)
-	}
-	got := readFrame(t, a)
-	if got["t"] != "receipt" || got["messageId"] != "m1" || got["status"] != "read" || got["from"] != "user-b" {
-		t.Fatalf("A expected read receipt from user-b, got: %v", got)
-	}
-}
+// The client-originated SEEN receipt relay (replacing the old 'read' relay,
+// post-cutover) is covered in seen_test.go: TestRelaySeenReceiptRelayedAndRecorded
+// (relayed + recorded) and TestRelayDropsClientReadReceiptPostCutover (a now-stale
+// 'read' is dropped).
 
 func TestRelayRoutesDownloadedReceipt(t *testing.T) {
 	srv, _ := newRelayServer()

--- a/server/internal/ws/seen_test.go
+++ b/server/internal/ws/seen_test.go
@@ -1,0 +1,129 @@
+package ws_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"ring/server/internal/store"
+)
+
+// pollSeen waits briefly for the relay's RecordSeen (which runs right after the live
+// relay in the same handler goroutine) to land, then returns the recorded rows.
+func pollSeen(relay *memRelay, sender string, ids []string) []store.Seen {
+	deadline := time.Now().Add(time.Second)
+	for {
+		rows, _ := relay.SeenFor(context.Background(), sender, ids)
+		if len(rows) > 0 || time.Now().After(deadline) {
+			return rows
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// A client 'seen' receipt (spec 1010) is relayed to the message author from-stamped
+// AND durably recorded, so "Seen X/N" survives the sender being offline. Mirrors the
+// 'ack' → RecordDelivery durability.
+func TestRelaySeenReceiptRelayedAndRecorded(t *testing.T) {
+	srv, relay := newRelayServer()
+	defer srv.Close()
+
+	a := dial(t, srv, "tokA")
+	defer a.Close()
+	b := dial(t, srv, "tokB")
+	defer b.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	// B (a recipient) reports it SAW A's message m1 → routed to A (the author),
+	// from-stamped to the authenticated viewer.
+	if err := b.WriteJSON(map[string]any{"t": "receipt", "messageId": "m1", "status": "seen", "to": "user-a"}); err != nil {
+		t.Fatalf("B send seen receipt: %v", err)
+	}
+	got := readFrame(t, a)
+	if got["t"] != "receipt" || got["messageId"] != "m1" || got["status"] != "seen" || got["from"] != "user-b" {
+		t.Fatalf("A expected seen receipt from user-b, got: %v", got)
+	}
+
+	// ...and it was durably recorded for the author's reconcile (one row per member).
+	rows := pollSeen(relay, "user-a", []string{"m1"})
+	if len(rows) != 1 || rows[0].Recipient != "user-b" || rows[0].MsgID != "m1" {
+		t.Fatalf("expected one recorded seen for user-b/m1, got: %v", rows)
+	}
+}
+
+// Post-cutover (spec 1010) the server no longer accepts a client-originated 'read';
+// such a receipt is dropped (and never recorded), like the forged 'sent'/'delivered'.
+func TestRelayDropsClientReadReceiptPostCutover(t *testing.T) {
+	srv, relay := newRelayServer()
+	defer srv.Close()
+
+	a := dial(t, srv, "tokA")
+	defer a.Close()
+	b := dial(t, srv, "tokB")
+	defer b.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	if err := b.WriteJSON(map[string]any{"t": "receipt", "messageId": "m1", "status": "read", "to": "user-a"}); err != nil {
+		t.Fatalf("B send read receipt: %v", err)
+	}
+	_ = a.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	if _, _, err := a.ReadMessage(); err == nil {
+		t.Fatal("A must receive nothing for a post-cutover 'read' receipt")
+	}
+	if rows, _ := relay.SeenFor(context.Background(), "user-a", []string{"m1"}); len(rows) != 0 {
+		t.Fatalf("a dropped 'read' must not be recorded as seen, got: %v", rows)
+	}
+}
+
+// A 'downloaded' receipt still relays (media-bytes signal so the sender can free the
+// blob), but it is NOT recorded in the seen store (it's not a "seen" confirmation).
+func TestRelayDownloadedNotRecordedAsSeen(t *testing.T) {
+	srv, relay := newRelayServer()
+	defer srv.Close()
+
+	a := dial(t, srv, "tokA")
+	defer a.Close()
+	b := dial(t, srv, "tokB")
+	defer b.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	if err := b.WriteJSON(map[string]any{"t": "receipt", "messageId": "m1", "status": "downloaded", "to": "user-a"}); err != nil {
+		t.Fatalf("B send downloaded receipt: %v", err)
+	}
+	got := readFrame(t, a)
+	if got["t"] != "receipt" || got["status"] != "downloaded" || got["from"] != "user-b" {
+		t.Fatalf("A expected a downloaded receipt from user-b, got: %v", got)
+	}
+	// Give the handler a moment, then confirm nothing was recorded as seen.
+	time.Sleep(100 * time.Millisecond)
+	if rows, _ := relay.SeenFor(context.Background(), "user-a", []string{"m1"}); len(rows) != 0 {
+		t.Fatalf("'downloaded' must not be recorded as seen, got: %v", rows)
+	}
+}
+
+// The seen store's contract (encoded by the in-memory fake the way store/seen.go's
+// SQL is): RecordSeen is idempotent, and SeenFor returns one row per member for a
+// group message — the shape POST /v1/seen/check relies on to rebuild "Seen X/N".
+func TestSeenStoreIdempotentAndPerMember(t *testing.T) {
+	relay := newMemRelay()
+	ctx := context.Background()
+
+	// Idempotent: recording the same (sender, recipient, msg) twice yields one row.
+	_ = relay.RecordSeen(ctx, "author", "memberA", "g1")
+	_ = relay.RecordSeen(ctx, "author", "memberA", "g1")
+	if rows, _ := relay.SeenFor(ctx, "author", []string{"g1"}); len(rows) != 1 {
+		t.Fatalf("RecordSeen not idempotent: got %d rows, want 1", len(rows))
+	}
+
+	// One row per member for the same group message id.
+	_ = relay.RecordSeen(ctx, "author", "memberB", "g1")
+	rows, _ := relay.SeenFor(ctx, "author", []string{"g1"})
+	if len(rows) != 2 {
+		t.Fatalf("expected one seen row per member (2), got %d: %v", len(rows), rows)
+	}
+
+	// Scoped to the querying sender: another author's lookup sees nothing.
+	if other, _ := relay.SeenFor(ctx, "someone-else", []string{"g1"}); len(other) != 0 {
+		t.Fatalf("SeenFor must be sender-scoped, got: %v", other)
+	}
+}

--- a/specs/1010-group-seen-receipts/checklists/requirements.md
+++ b/specs/1010-group-seen-receipts/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Group "Seen" Receipts — Durable, Private, and Counted
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The Zero-Knowledge Impact section necessarily references the wire/relay + a new
+  durable seen-store at a design level (mirroring `specs/0002-...` and
+  `specs/1009-...` convention); this is required by Constitution Principle I, not
+  tech-stack leakage.
+- `SC-005`/`SC-007` reference a migration and "no new server-visible metadata
+  class" as verifiable zero-knowledge/data-integrity guarantees, not as
+  implementation prescriptions.
+- Wire/server + a local DB migration + a new server migration → a
+  `/speckit-checklist` is **required** (Principles I, V, VI) before implementation.

--- a/specs/1010-group-seen-receipts/checklists/zero-knowledge.md
+++ b/specs/1010-group-seen-receipts/checklists/zero-knowledge.md
@@ -1,0 +1,70 @@
+# Zero-Knowledge & Data-Integrity Checklist: Group "Seen" Receipts
+
+**Purpose**: Validate that the *requirements* (spec + plan + contracts) keep Ring's
+zero-knowledge boundary (Principle I), offline-first data integrity (Principle V),
+and forward-only/stateless-server rules (Principle VI). Requirements-quality gate,
+not an implementation test.
+**Created**: 2026-06-17
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [contracts/seen-receipts.md](../contracts/seen-receipts.md) · [data-model.md](../data-model.md)
+
+## Metadata Parity / Minimization (Principle I)
+
+- [x] CHK001 Are the exact fields the server persists for a seen record enumerated and limited to `(sender, recipient, msg_id, seen_at)`? [Completeness, Spec §Zero-Knowledge Impact; data-model.md]
+- [x] CHK002 Does the spec state the seen store introduces **no new class** of server-visible metadata vs. the existing delivered store? [Clarity, Spec §Zero-Knowledge Impact; research.md D1]
+- [x] CHK003 Is it explicit that **no message body/content/media** is persisted or exposed by the seen store or the receipt frame? [Completeness, Spec §Zero-Knowledge Impact]
+- [x] CHK004 Is the "minimized to what relaying/reconciling requires" justification stated for the seen metadata? [Clarity, Principle I]
+
+## Client-Side Privacy & Consent
+
+- [x] CHK005 Is the seen preference required to be enforced **entirely client-side** (server never told, no preference column)? [Completeness, Spec §FR-010; research.md D6]
+- [x] CHK006 Is the **emit gate** specified (off ⇒ never send ⇒ store never holds it)? [Clarity, Spec §FR-008]
+- [x] CHK007 Is the **reciprocity display gate** specified (off ⇒ don't render others' seen on own messages)? [Completeness, Spec §FR-009]
+- [x] CHK008 Does the spec **preclude server-side gating/withholding** based on the preference? [Consistency, research.md D6; Principle I]
+- [x] CHK009 Is the toggle default (**on**) and its uniform application to 1:1 + groups specified? [Clarity, Spec §FR-007]
+
+## Forward Migration & Data Integrity (Principle V)
+
+- [x] CHK010 Is the client migration specified as **forward-only**, `DB_VERSION 5→6`? [Completeness, Spec §FR-002; plan.md]
+- [x] CHK011 Does the requirement state that **all** existing message data is preserved (status, `readAt→seenAt`, `receipts[].readAt→seenAt`) with no loss? [Completeness, Spec §FR-002; data-model.md]
+- [x] CHK012 Is **no status regression** (monotonicity) explicitly required across the migration? [Clarity, Spec §FR-002]
+- [x] CHK013 Are migration-failure / aborted-upgrade requirements addressed (what happens if the v6 transform fails mid-way)? [Edge Case] — RESOLVED: new edge case requires the migration to abort atomically inside the upgrade transaction (data intact, retried next open).
+
+## Server Migration & Statelessness (Principle VI)
+
+- [x] CHK014 Is the seen table specified as a **new numbered, forward-only** migration (no editing shipped migrations)? [Completeness, plan.md; Principle VI]
+- [x] CHK015 Is the claim that the rename needs **no server data migration** (read was never persisted) stated? [Clarity, research.md D5; Spec §Zero-Knowledge Impact]
+- [x] CHK016 Is the seen-store **retention/cleanup** specified (mirror deliveries)? [Completeness, Spec §Clarifications; research.md D2]
+
+## Wire Cutover & Compatibility
+
+- [x] CHK017 Is the **hard-cutover** behavior specified, including the accepted transient cross-version skew? [Completeness, Spec §Edge Cases; research.md D3]
+- [x] CHK018 Is the skew's **blast radius bounded** (degrades only the seen tier; delivered + messaging unaffected; self-heals)? [Clarity, Spec §Edge Cases]
+
+## Anti-Forgery & Authenticity
+
+- [x] CHK019 Is it required that the server accepts only client-originated `seen`/`downloaded` (rejecting client `sent`/`delivered`)? [Completeness, contracts/seen-receipts.md]
+- [x] CHK020 Is **from-stamping** (server stamps the authenticated sender) required for seen receipts? [Clarity, contracts/seen-receipts.md]
+
+## Durability & Reconciliation
+
+- [x] CHK021 Is durability **testable** — a seen reported while the sender is offline is reconciled on reconnect, not lost? [Measurability, Spec §FR-003 / SC-002]
+- [x] CHK022 Is the reconcile scope specified (group msgs missing `seenAt`; window/cap mirror delivered)? [Completeness, contracts/seen-receipts.md]
+- [x] CHK023 Are downloaded receipts explicitly **excluded** from the durable seen store (relay-only, unchanged)? [Consistency, contracts/seen-receipts.md]
+
+## Acceptance Criteria Quality
+
+- [x] CHK024 Is "no new class of server-visible metadata" stated as a **verifiable** success criterion? [Measurability, Spec §SC-007]
+- [x] CHK025 Is migration preservation (old read → Seen, timestamps intact, no regression) a **verifiable** success criterion? [Measurability, Spec §SC-005]
+- [x] CHK026 Is toggle-off reciprocity verifiable **in both directions**? [Measurability, Spec §SC-003]
+
+## Consistency & Ambiguities
+
+- [x] CHK027 Is the counter denominator **N = recipients only** consistent across spec, plan, and data-model? [Consistency, Spec §FR-004 / data-model.md]
+- [x] CHK028 Does the spec consistently use "Seen" for the status (no lingering "Read" status references)? [Consistency, Spec §FR-001]
+
+## Notes
+
+- Check items off as resolved. Per Constitution II/§Governance this checklist must
+  be clean — or each open finding waived in writing — before `/speckit-implement`.
+- **CHK013** (the one gap surfaced, migration-failure behavior) is now resolved
+  via a new spec edge case; the checklist is clean.

--- a/specs/1010-group-seen-receipts/contracts/seen-receipts.md
+++ b/specs/1010-group-seen-receipts/contracts/seen-receipts.md
@@ -1,0 +1,59 @@
+# Contract: Seen Receipts — wire frame, relay, durable store, reconcile
+
+Two interfaces change/extend. Both mirror the existing **delivered** machinery.
+
+## 1. Receipt frame (WebSocket) — status value renamed
+
+Existing `receipt` frame, with the seen status value renamed (hard cutover):
+
+```jsonc
+{ "t": "receipt", "messageId": "<id>", "status": "seen", "at": <ms>, "to": "<author>", "from": "<server-stamped sender>" }
+```
+
+- Client-originated statuses accepted by the server: **`"seen"` | `"downloaded"`**
+  (was `"read"|"downloaded"`). `"sent"`/`"delivered"` from a client are still
+  rejected (server-authoritative, anti-forgery — spec 2001).
+- The server stamps `from` = the authenticated sender (the member who saw it) and
+  live-relays to `to` (the message author), exactly as today.
+- **NEW**: when `status == "seen"`, the server ALSO durably records it
+  (`RecordSeen(author, sender, messageId, at)`) — the durable parallel of how the
+  `ack` case calls `RecordDelivery`. `"downloaded"` is NOT recorded (unchanged).
+
+## 2. `POST /v1/seen/check` — durable reconcile (mirror `/v1/deliveries/check`)
+
+Request (the caller's own originated message ids):
+```jsonc
+{ "messageIds": ["<id1>", "<id2>", ...] }
+```
+Response (one entry per member who has seen each — like deliveries):
+```jsonc
+{ "seen": [ { "messageId": "<id>", "recipient": "<member>", "at": <ms> }, ... ] }
+```
+
+- Backed by `store.SeenFor(sender, msgIds)`.
+- Client `api.ts checkSeen(ids)` → `SeenEntry{messageId, recipient, at}`.
+- On reconnect, `useSync` replays each as a synthetic frame
+  `{t:'receipt', status:'seen', messageId, at, from: recipient}` through the normal
+  `applyReceipt` path → `applyGroupReceipt` stamps that member's `seenAt`. So
+  "Seen X/N" is rebuilt after the sender was offline.
+- `collectUnconfirmedOutgoing` also flags group messages with any `receipts[]`
+  entry missing `seenAt` (in addition to the existing missing-`deliveredAt`), so
+  they're included in the check.
+
+## Privacy (client-enforced; server is unaware)
+
+- A recipient with `privacy.seenReceipts` **off** never sends a `seen` receipt →
+  the server never relays or records it → the author never sees them reach seen
+  (they stay counted as delivered). The store has no preference column.
+- Reciprocity is a client display gate (off ⇒ the author's own messages don't show
+  the seen tier). Not a wire/server concern.
+
+## Test contract
+
+- `store/seen.go` (fake + real): `RecordSeen` is idempotent; `SeenFor` returns one
+  row per member for a group msg.
+- `hub.go` "receipt" case: a client `seen` receipt is relayed `from`-stamped to the
+  author AND recorded; a client `read`/`sent`/`delivered` is dropped (anti-forgery
+  / post-cutover); `downloaded` relays but is NOT recorded.
+- `POST /v1/seen/check`: returns per-member seen entries for the caller's messages;
+  empty for unknown/foreign ids.

--- a/specs/1010-group-seen-receipts/data-model.md
+++ b/specs/1010-group-seen-receipts/data-model.md
@@ -1,0 +1,76 @@
+# Phase 1 Data Model: Group "Seen" Receipts
+
+Extends existing models; adds one server table. No new client object store.
+
+## Changed: MessageStatus (client enum)
+
+`compressing | pending | sent | delivered | read | failed`
+→ `compressing | pending | sent | delivered | **seen** | failed`
+
+- `STATUS_ORDER` rank unchanged in position (seen replaces read at rank 3,
+  monotonic). The wire status string and the displayed label both become "seen".
+
+## Changed: Message (client, IndexedDB `messages` store)
+
+| Field | Before | After |
+|---|---|---|
+| `status` | `…|'read'|…` | `…|'seen'|…` |
+| `readAt?` | epoch ms | **`seenAt?`** epoch ms |
+| `receipts[].readAt?` | epoch ms | **`receipts[].seenAt?`** epoch ms |
+
+- `receipts?: Receipt[]` (per-member, sender's copy only) becomes
+  `{ contactId, deliveredAt?, seenAt?, downloadedAt? }`. Still embedded on the row
+  (no separate store). `downloadedAt` unchanged.
+- **Migration (`DB_VERSION 5 → 6`)**: forward transform over every `messages` row
+  — `status 'read'→'seen'`, `readAt→seenAt`, `receipts[].readAt→seenAt`. Preserve
+  all else; no status regression.
+
+## Derived: GroupProgress (client, computed — not stored)
+
+From a sent group message's `receipts[]` and the chat's recipient roster:
+
+- `N` = recipient members (chat.participantIds minus self).
+- `delivered` = count of receipts with `deliveredAt`.
+- `seen` = count of receipts with `seenAt`.
+- **Tier/label** (complete-the-tier):
+  - `delivered == 0` → "Sent"
+  - `0 < delivered < N` → "Delivered {delivered}/{N}"
+  - `delivered == N && 0 < seen < N` → "Seen {seen}/{N}"
+  - `seen == N` → "Seen" (no fraction)
+- Fraction shown **only while a tier is partial** (so N=1 never shows one).
+- **Reciprocity**: when `privacy.seenReceipts` is off, the seen tier is not
+  rendered (caps at delivered).
+
+## Derived: message-info member lists (client, computed — not stored)
+
+For a group message, partition `chat.participantIds` (recipients):
+- **Seen by** = receipts with `seenAt` (sorted by `seenAt`).
+- **Delivered** = receipts with `deliveredAt` and no `seenAt`.
+- **Not yet delivered** = participantIds with no receipt `deliveredAt` (NEW).
+- Each row resolves name/avatar via the existing `contactMap` + `nameFor` /
+  `avatarFor` / `initialsAvatar`. Avatar stack caps at ~5 then "+N".
+
+## New: `seen` table (server, Postgres)
+
+Mirrors `deliveries` (migration 0019).
+
+| Column | Type | Notes |
+|---|---|---|
+| `sender` | text | message author (the reconciling party) |
+| `recipient` | text | the member who saw it (server-stamped) |
+| `msg_id` | text | the message id (one row per member for a group msg) |
+| `seen_at` | bigint (ms) | when the seen receipt was relayed |
+
+- **PK** `(sender, recipient, msg_id)`; upsert `ON CONFLICT DO NOTHING`.
+- **Retention/cleanup**: same policy as `deliveries`.
+- **Privacy**: only ever contains receipts the recipient's client chose to send
+  (suppressed when `privacy.seenReceipts` is off). No preference column. Server
+  stays group-blind (no group object; rows are per-(sender,recipient,msg)).
+- **ZK**: same metadata class already stored for delivered — routing ids + a
+  timestamp, no message content.
+
+## Store API (server, `store/seen.go`)
+
+- `RecordSeen(ctx, sender, recipient, msgId, seenAtMs)` — idempotent upsert.
+- `SeenFor(ctx, sender, msgIds) []Seen{MsgID, Recipient, SeenMs}` — one row per
+  member; backs `POST /v1/seen/check`.

--- a/specs/1010-group-seen-receipts/data-model.md
+++ b/specs/1010-group-seen-receipts/data-model.md
@@ -48,7 +48,7 @@ For a group message, partition `chat.participantIds` (recipients):
 - **Delivered** = receipts with `deliveredAt` and no `seenAt`.
 - **Not yet delivered** = participantIds with no receipt `deliveredAt` (NEW).
 - Each row resolves name/avatar via the existing `contactMap` + `nameFor` /
-  `avatarFor` / `initialsAvatar`. Avatar stack caps at ~5 then "+N".
+  `avatarFor` / `initialsAvatar`. Avatar stack caps at 5 then "+N".
 
 ## New: `seen` table (server, Postgres)
 

--- a/specs/1010-group-seen-receipts/plan.md
+++ b/specs/1010-group-seen-receipts/plan.md
@@ -1,0 +1,151 @@
+# Implementation Plan: Group "Seen" Receipts — Durable, Private, and Counted
+
+**Branch**: `feat/1010-group-seen-receipts` | **Date**: 2026-06-17 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1010-group-seen-receipts/spec.md`
+
+## Summary
+
+Make group receipts complete and correct on top of machinery that mostly exists.
+Four changes: (1) **rename `read → seen` everywhere** as a hard cutover, with a
+one-time client IndexedDB migration; (2) make per-member **seen durable** by
+mirroring the existing delivered store (a new server `seen` table + check
+endpoint + reconcile on reconnect), so "Seen X/N" survives the sender being
+offline; (3) wire the currently-**inert privacy toggle** as a reciprocal "Seen
+receipts" switch, enforced entirely client-side; and (4) surface progress — a
+compact **"Delivered/Seen X/N" counter** on the group bubble (complete-the-tier,
+recipients-only N, partial-only) and a **"Not yet delivered"** list with avatars
+in message info. The per-member roster, the group info lists, and the
+delivered durability/reconcile path already exist and are extended, not rebuilt.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Vue 3 + Ionic 8, Vite) client; Go 1.26 server
+(`ringd`, stdlib `net/http`, pgx v5).
+
+**Primary Dependencies**: No new dependency. Reuses the existing receipt/relay
+machinery, the `deliveries` durable-store pattern, and the 1009 settings-gate
+pattern (`applyActivityPref`/`setActivityIndicatorsEnabled`).
+
+**Storage**:
+- **Client**: IndexedDB `messages` store — `DB_VERSION 5 → 6` with a forward
+  migration mapping `status 'read'→'seen'`, `readAt→seenAt`, and
+  `receipts[].readAt→seenAt` on existing rows. No new object store (receipts stay
+  embedded).
+- **Server**: a **new `seen` table** (next numbered migration) mirroring
+  `deliveries` — `(sender, recipient, msg_id, seen_at)`, PK `(sender, recipient,
+  msg_id)`, same retention/cleanup as `deliveries`.
+
+**Testing**: `go test ./...` (in-memory fake store) for the seen store + relay;
+`vitest` for the status reducers + counter derivation; Playwright (`e2e/`,
+multi-account) for counter climb, offline durability, toggle reciprocity, and the
+rename migration.
+
+**Target Platform**: Installable PWA + `ringd`, single container.
+
+**Project Type**: Web — Vue 3 PWA client + Go server.
+
+**Performance Goals**: Counter updates within the existing receipt latency; the
+client migration runs once on upgrade over the local message set; seen reconcile
+mirrors delivered (3-day window, 500-id cap).
+
+**Constraints**: Zero-knowledge — the `seen` store holds the *same metadata shape
+already stored for delivered* (routing ids + timestamp; no message content), and
+the privacy preference is client-enforced (server never told). Forward-only
+migrations (client + server). Hard wire cutover (`read`→`seen`) with an accepted
+transient skew for un-refreshed clients. Stock Ionic + theme tokens; LTR/RTL +
+light/dark.
+
+**Scale/Scope**: 1:1 (unchanged) + groups; counter denominator N = recipient
+members (sender excluded); avatar stack capped (~5 + "+N").
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Verdict | Notes |
+|---|---|---|
+| I. Zero-Knowledge Boundary (NON-NEGOTIABLE) | ✅ PASS | New `seen` store mirrors the existing `deliveries` metadata shape `(sender, recipient, msg_id, seen_at)` — **no new class** of server-visible metadata, no message content. Privacy preference enforced client-side; server never holds opted-out seen. ZK Impact section present. **`/speckit-checklist` REQUIRED.** |
+| II. Spec-Driven Development | ✅ PASS | specify → clarify → plan → … pipeline; spec id 1010. |
+| III. Test-Driven Development | ✅ PASS | `tasks.md` will order failing tests first: server seen-store tests (record/SeenFor; relay records on seen; offline-without-send stores nothing) and the e2e scenarios before implementation. |
+| IV. Crypto Discipline | ✅ PASS (untouched) | Seen receipts are **status metadata**, already plaintext like delivered/read today — not E2EE message bodies. `messaging.ts` and the crypto core are not touched; no primitive change. |
+| V. Offline-First Data Integrity | ✅ PASS | `DB_VERSION 5→6` with a **forward migration** in `onupgradeneeded` that preserves all existing message data (status/timestamps mapped, never dropped); no status regression. |
+| VI. Stateless Server & Forward-Only Migrations | ✅ PASS | One **new numbered, forward-only** migration for the `seen` table; no edits to shipped migrations; all state stays in Postgres. |
+| VII. Quality Gates | ✅ PASS | `npm run build`, `go build/vet/test`, vitest, e2e are the definition of done. |
+| VIII. Traceable, Auto-Closing Delivery | ✅ PASS | `/speckit-taskstoissues` then `Closes #N` on the PR. |
+| IX. Privacy & Data Minimization | ✅ PASS | Client-side suppression (off ⇒ never send ⇒ never stored); seen metadata minimized + symmetric to delivered; no telemetry. |
+| X. Accessibility & Internationalization | ✅ PASS | Counter + lists localizable; avatar stack mirrors in RTL; settings is a schema data edit. |
+| XI. Ionic-First UI | ✅ PASS | Counter is text + the existing tick icon; info lists use `ion-list`/`ion-avatar`; the toggle is a `src/settings/schema.ts` data edit. Existing theme tokens reused. |
+
+**Result**: No violations. **Complexity Tracking empty.** `/speckit-checklist`
+required (Principles I, V, VI).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1010-group-seen-receipts/
+├── plan.md            # this file
+├── spec.md            # /speckit-specify + /speckit-clarify
+├── research.md        # Phase 0
+├── data-model.md      # Phase 1
+├── quickstart.md      # Phase 1
+├── contracts/
+│   └── seen-receipts.md   # wire frame + /v1/seen/check + relay/store contract
+├── checklists/
+│   └── requirements.md    # passing
+└── tasks.md           # /speckit-tasks (later)
+```
+
+### Source Code (repository root)
+
+Edits existing files + one new server migration/store; **no new client object
+store**.
+
+```text
+# Client (Vue 3 + Ionic)
+src/
+├── db/
+│   ├── types.ts          # EDIT: MessageStatus 'read'→'seen'; Receipt.readAt→seenAt; scalar readAt→seenAt
+│   ├── idb.ts            # EDIT: DB_VERSION 5→6 + onupgradeneeded v6 forward migration (read→seen, readAt→seenAt, receipts[].readAt→seenAt)
+│   └── queries.ts        # EDIT: receipts roster uses seenAt; collectUnconfirmedOutgoing flags group msgs missing seenAt
+├── services/
+│   ├── message-status.ts # EDIT: reducers rename; group derivation over seenAt; counts (delivered/seen) helpers
+│   ├── sync.ts           # EDIT: applyReceipt 'seen'
+│   ├── api.ts            # EDIT: checkSeen() (mirror checkDeliveries)
+│   └── transport.ts      # EDIT: ReceiptFrame status 'read'→'seen'
+├── composables/
+│   └── useSync.ts        # EDIT: sendReadReceipts→sendSeenReceipts (+ emit gate); reconcileSeen; applySeenPref/gate (mirror 1009 applyActivityPref)
+├── views/detail/
+│   ├── ChatDetailPage.vue   # EDIT: statusIcon/.tick.seen; group counter "X/N" (recipients, partial-only); reciprocity display gate
+│   └── MessageInfoPage.vue  # EDIT: "Seen by"; NEW "Not yet delivered" (participantIds − delivered); avatar stack (cap 5 +N)
+└── settings/
+    └── schema.ts         # EDIT: privacy.readReceipts → privacy.seenReceipts ("Seen receipts", default on; drop always-for-groups footer)
+
+e2e/
+└── group-seen-receipts.spec.ts  # NEW: counter climb, offline durability, toggle reciprocity, migration
+
+# Server (Go)
+server/internal/
+├── db/migrations/NNNN_seen.sql  # NEW: seen table (sender, recipient, msg_id, seen_at), PK (sender,recipient,msg_id)
+├── store/seen.go                # NEW: RecordSeen (upsert), SeenFor(sender, msgIds)
+├── ws/hub.go                    # EDIT: "receipt" case accepts 'seen'|'downloaded'; RecordSeen on 'seen' (durable, like ack→RecordDelivery)
+├── api/relay_handlers.go        # EDIT: POST /v1/seen/check (mirror deliveriesCheck) + router wiring
+└── ws/seen_test.go, api/*_test.go, store fake  # NEW/EDIT: tests
+```
+
+**Structure Decision**: Reuse the existing client/server layout. Durable seen is a
+**parallel of the delivered store** (table → store → relay-record → check endpoint
+→ client reconcile); the rename is a sweeping but mechanical edit + one client
+migration; the counter and not-yet-delivered list are **derivations over the
+existing `receipts[]` roster** and the existing `participantIds`. No new
+subsystem, no new client object store.
+
+## Complexity Tracking
+
+> No Constitution Check violations — intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |

--- a/specs/1010-group-seen-receipts/quickstart.md
+++ b/specs/1010-group-seen-receipts/quickstart.md
@@ -1,0 +1,60 @@
+# Quickstart: Group "Seen" Receipts
+
+How to exercise and verify, mapped to the Success Criteria (SC).
+
+## Run locally
+
+```sh
+make start          # PostgreSQL + ringd + Vite at http://localhost:5173
+```
+
+Register three test accounts (dev invite codes), connect them, and create a group
+with all three.
+
+## Manual smoke (per SC)
+
+- **SC-001 (counter climbs)**: Account A sends to the group. As B and C's devices
+  receive it, A's bubble shows "Delivered 1/2" → "2/2"; as B and C open the chat,
+  it shows "Seen 1/2" → then the plain "Seen" tick. (N = recipients = 2.)
+- **SC-002 (durable)**: Take A offline; have B open the message; bring A back
+  online → after reconnect the message reflects B as seen (reconciled from the
+  server `seen` store, not lost).
+- **SC-003 (reciprocity)**: In Settings → Privacy, turn **Seen receipts** off on
+  A. Now A opening others' messages never advances A's seen for anyone, AND A's
+  own sent messages show no seen tier (cap at delivered). B and C (on) still see
+  each other.
+- **SC-004 (info lists)**: Open a group message's info → every member appears under
+  exactly one of **Seen by / Delivered / Not yet delivered**.
+- **SC-005 (rename migration)**: Upgrade from a build that had `read` messages →
+  they display as **Seen** with original timestamps, no status regression.
+- **SC-006 (1:1 unchanged)**: A 1:1 message shows the plain tick, no fraction.
+
+## Automated checks
+
+- **Server** (`go test ./...`, in-memory fake store):
+  - `store/seen.go`: `RecordSeen` idempotent; `SeenFor` returns one row per member.
+  - `ws/seen_test.go`: a client `seen` receipt is relayed (from-stamped) AND
+    recorded; `read`/`sent`/`delivered` from a client are dropped; `downloaded`
+    relays but isn't recorded.
+  - `api`: `POST /v1/seen/check` returns per-member entries.
+- **Client unit** (`vitest`): the status reducers under the rename; the group
+  progress derivation (complete-the-tier, N=recipients, partial-only); the
+  `DB_VERSION 5→6` migration transform (read→seen, readAt→seenAt,
+  receipts[].readAt→seenAt) preserves data.
+- **e2e** (`e2e/group-seen-receipts.spec.ts`, multi-account):
+  ```sh
+  make db-up && npm run test:e2e
+  ```
+  Counter climb (SC-001), offline durability (SC-002), toggle reciprocity both
+  directions (SC-003), not-yet-delivered list (SC-004).
+
+## Definition of done (gates)
+
+```sh
+npm run build                 # vue-tsc + vite
+cd server && go build ./... && go vet ./... && go test ./...
+npm run test:e2e
+```
+
+All green = done (Constitution VII). A `/speckit-checklist` (Principles I, V, VI)
+must also be completed clean before `/speckit-implement`.

--- a/specs/1010-group-seen-receipts/research.md
+++ b/specs/1010-group-seen-receipts/research.md
@@ -1,0 +1,121 @@
+# Phase 0 Research: Group "Seen" Receipts
+
+Decisions + rationale + rejected alternatives, grounded in the existing Ring
+receipt/delivery machinery. No `NEEDS CLARIFICATION` remain (the spec's
+Clarifications resolved the open product choices).
+
+## D1 — Durable seen mirrors the delivered store (don't invent a new shape)
+
+- **Decision**: Add a server `seen` table mirroring `deliveries`:
+  `(sender, recipient, msg_id, seen_at)`, PK `(sender, recipient, msg_id)`,
+  upsert idempotently (`ON CONFLICT DO NOTHING`). Record on the relay of a
+  client-originated `seen` receipt (in `hub.go`'s `receipt` case, alongside the
+  existing live relay), the way `ack` already calls `RecordDelivery`. Expose via
+  `POST /v1/seen/check` (mirror `deliveriesCheck`) returning one entry per member;
+  client reconciles on reconnect (mirror `reconcileDeliveries`, replaying
+  synthetic `{t:'receipt', status:'seen', from:recipient}`).
+- **Rationale**: Delivered is already durable + reconciled this exact way; seen
+  is the symmetric gap. Reusing the pattern means **no new metadata class** (same
+  `(sender, recipient, msg_id, when)` shape) and minimal new surface.
+- **Alternatives rejected**: Keep seen live-only (status quo — lossy when the
+  sender is offline); a generic "receipts" table replacing deliveries (needless
+  churn to a shipped, working store).
+
+## D2 — Retention mirrors `deliveries`
+
+- **Decision**: The `seen` table uses the **same retention/cleanup** policy as
+  `deliveries` (clarified). No bespoke retention.
+- **Rationale**: Consistency, an already-accepted ZK posture, least new policy.
+- **Alternatives rejected**: Prune on first sender fetch (breaks a second sender
+  device reconciling); keep indefinitely (weakest minimization).
+
+## D3 — Rename `read → seen`: hard cutover
+
+- **Decision**: Rename end-to-end (UI label, `MessageStatus` value, `ReceiptStatus`,
+  `STATUS_ORDER`, scalar `readAt→seenAt`, `Receipt.readAt→seenAt`, reducers,
+  send/apply paths, the `.tick.read` class, message-info copy, and the wire status
+  string). The server `receipt` case accepts `'seen'|'downloaded'` (was
+  `'read'|'downloaded'`). `'downloaded'` is unchanged (separate media-cleanup
+  signal).
+- **Rationale**: "Seen" generalizes to voice/video/photo; one consistent term
+  avoids future confusion (the user's explicit reason).
+- **Accepted tradeoff (skew)**: a stale (un-refreshed) PWA still emitting/expecting
+  `'read'` has its seen receipts dropped by the updated server until it refreshes —
+  transient, seen-tier-only; delivered + messaging unaffected; self-heals on PWA
+  update. Hard cutover chosen over an accept-both shim for code clarity.
+
+## D4 — Client migration: forward-only, in `onupgradeneeded`
+
+- **Decision**: `DB_VERSION 5 → 6`. The v6 step opens a cursor over the `messages`
+  store and rewrites each row: `status 'read'→'seen'`, `readAt→seenAt`, and each
+  `receipts[].readAt→seenAt`. Preserve all other fields and timestamps; never
+  regress status.
+- **Rationale**: Principle V — upgrades must not lose data. `receipts[]` is an
+  embedded array on the row, so this is a pure document transform (no new store).
+- **Alternatives rejected**: Lazy per-read migration (leaves mixed `read`/`seen`
+  in storage — confusing, and the counter/reducers would need to handle both);
+  dropping old status (data loss).
+
+## D5 — No server data migration for the rename
+
+- **Decision**: The server needs **no data migration** for the rename — `read`
+  was never persisted (the `deliveries` table stores timestamps, not a status
+  string; receipt frames are relay-only). Only the `hub.go` check string flips,
+  and the new `seen` table is greenfield (`seen` from the start).
+- **Rationale**: Confirmed in the investigation — there is no stored `read` value
+  server-side to migrate.
+
+## D6 — Privacy gate: client-side suppression + reciprocity (mirror 1009)
+
+- **Decision**: Repurpose the inert `privacy.readReceipts` → `privacy.seenReceipts`
+  ("Seen receipts", default on, uniform 1:1 + groups; drop the always-for-groups
+  footer). Two client gates, mirroring 1009's `applyActivityPref` /
+  `setActivityIndicatorsEnabled`: (a) **emit gate** — `sendSeenReceipts` is a
+  no-op when off (so nothing is sent → the durable store never holds it →
+  recipient stays counted as delivered); (b) **reciprocity display gate** — when
+  off, the client does not render/aggregate the seen tier on the user's own sent
+  messages. Read the pref on start + on settings change.
+- **Rationale**: ZK minimization — the server never learns the preference; you
+  can't leak what you don't send; the store gate is upstream. Symmetric with read
+  receipts' intended semantics and with 1009.
+- **Alternatives rejected**: Server-side withhold (server must learn + act on the
+  preference = new metadata + policy — violates Principle I); one-directional gate
+  (asymmetric, surprising).
+- **Note**: renaming the key `privacy.readReceipts → privacy.seenReceipts` has no
+  behavioral regression because the old key was **never consulted** (inert);
+  unset → default on.
+
+## D7 — Counter semantics: complete-the-tier over recipients, derived
+
+- **Decision**: N = recipient members (sender excluded). Derive from `receipts[]`:
+  `delivered = count(deliveredAt)`, `seen = count(seenAt)`. Display: 0 delivered →
+  Sent; `1 ≤ delivered < N` → "Delivered X/N"; all delivered, `1 ≤ seen < N` →
+  "Seen X/N"; all seen → plain "Seen". Show the fraction **only while a tier is
+  partial** — so an N=1 group never shows a fraction (renders like 1:1), with no
+  special-casing and no minimum group size. A message may rest permanently at
+  "Seen X/N" (X<N) — intended (privacy: not-opened vs opted-out are
+  indistinguishable).
+- **Rationale**: Matches the clarified product decision and reads as live
+  progress; derivation is free from the existing roster.
+- **Alternatives rejected**: Leading-edge (advance on the furthest any member
+  reached — can look further along than reality); all-or-nothing (current — hides
+  progress).
+
+## D8 — Counter render: compact on the bubble, detail in message info
+
+- **Decision**: Render the state icon + "X/N" inline in the bubble's existing
+  status slot (`ChatDetailPage.vue`, group-only, partial-only); 1:1 unchanged.
+  The per-member avatar detail (Seen by / Delivered / **Not yet delivered**) lives
+  in `MessageInfoPage.vue` (avatar stack cap ~5 + "+N"). Not-yet-delivered =
+  `chat.participantIds` minus members with `deliveredAt`, reusing the existing
+  `contactMap` / `nameFor` / `avatarFor` / `initialsAvatar`.
+- **Rationale**: The bubble bottom row is tiny; a compact fraction fits, the rich
+  view reuses the already-built info page.
+- **Alternatives rejected**: Avatar stack on the bubble (space/RTL/perf fragile on
+  narrow bubbles — kept to the info page).
+
+## Resolved unknowns
+
+None outstanding. The crypto core is untouched (seen is plaintext status metadata,
+like delivered). The only durable additions are the `seen` table (server) and the
+`DB_VERSION 5→6` transform (client), both forward-only.

--- a/specs/1010-group-seen-receipts/spec.md
+++ b/specs/1010-group-seen-receipts/spec.md
@@ -1,0 +1,310 @@
+# Feature Specification: Group "Seen" Receipts — Durable, Private, and Counted
+
+**Feature Branch**: `feat/1010-group-seen-receipts`
+
+**Created**: 2026-06-17
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Rename 'read' receipts to 'Seen' everywhere (hard cutover); make per-member seen durable in groups (survive the sender being offline); wire the currently-inert seen-receipts privacy toggle (default on, reciprocal, client-enforced); add a group progress counter (Delivered X/N → Seen X/N) on the message bubble; and show Seen-by / Delivered / Not-yet-delivered member lists in message info."
+
+## Overview
+
+Ring already tracks group message receipts **per member** on the sender's side
+(each outgoing group message carries a roster of `{member, deliveredAt, seenAt}`)
+and already shows per-member "Seen by / Delivered to" lists on the message-info
+screen. The bubble, however, shows only a single collapsed tick, "read" is the
+word used throughout, and one important guarantee is missing: a member's **seen**
+confirmation is delivered live-only — if the sender is offline at that moment it
+is **lost**, so a group can be fully seen yet never show it.
+
+This feature closes those gaps and makes group receipts feel alive:
+
+1. **Rename "read" → "Seen" everywhere** (a clean hard cutover) so the concept
+   reads correctly for voice notes, video notes, photos, and text alike.
+2. **Durable per-member seen** — seen survives the sender being offline, the same
+   way delivered already reconciles on reconnect.
+3. **A reciprocal "Seen receipts" privacy toggle** (default on) — turn it off and
+   you neither tell others you've seen their messages nor see theirs on your own.
+4. **A group progress counter on the bubble** — "Delivered 3/5", then "Seen 4/5",
+   then "Seen" — so progress is visible at a glance without opening message info.
+5. **Fuller message info** — Seen by / Delivered / **Not yet delivered** lists
+   covering every member, with member avatars.
+
+The zero-knowledge boundary is preserved: durable seen stores the **same shape of
+metadata already stored for delivered** (who → whom → which message → when), never
+message content, and the privacy preference is enforced entirely on the client.
+
+## Clarifications
+
+### Session 2026-06-17
+
+- Q: Keep "read", or rename? → A: Rename to **"Seen"** everywhere — a **hard cutover** (one-time client storage migration; server is code-only, since read was never persisted).
+- Q: Should seen be durable like delivered, or stay live-only? → A: **Durable** — a server seen-store mirroring the existing delivered store, reconciled on reconnect, so "Seen X/N" survives the sender being offline.
+- Q: How is the privacy toggle enforced — server withholds, or client suppresses? → A: **Client-side suppression** — when off the client never sends a seen confirmation (you can't leak what you don't send) and never renders others' seen on your messages (reciprocity). The server never learns the preference.
+- Q: Group indicator semantics? → A: **Complete-the-tier** — "Delivered X/N" climbs until all N, then "Seen X/N" climbs until all N, then "Seen". Compact on the bubble (group-only, partial-only); avatars live in message info.
+- Q: Toggle default + scope? → A: **Default on**, uniform for 1:1 and groups (the old "always sent for groups" rule is dropped).
+- Q: Message-info completeness? → A: Also show **"Not yet delivered"** by cross-referencing the full member roster, not just members who have progressed.
+- Q: What is the denominator N in "Seen X/N"? → A: **Recipients only** — the sender is excluded (you can't deliver to yourself), matching the per-member roster.
+- Q: How should a group with a single recipient (N=1) behave? → A: No special-casing and no minimum group size — because the count shows **only while a tier is partial** (1 ≤ X < N), an N=1 group inherently renders as a plain tick (like 1:1); it starts showing counts once it grows.
+- Q: How long does the server keep durable seen records? → A: **Mirror the existing delivered store's** retention/cleanup.
+- Q: A message may rest at "Seen X/N" (X < N) forever if members never open it or opted out — OK? → A: **Yes, rest at partial** — the sender can't distinguish "not yet opened" from "opted out", so partial is the honest, privacy-preserving terminal state.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Durable "Seen", named consistently (Priority: P1)
+
+The app speaks "Seen" (not "Read") everywhere, and a member's seen confirmation
+is reliable: if the sender was offline when a member opened the message, the
+sender still shows it as seen once they reconnect. Existing message history keeps
+its status after the rename.
+
+**Why this priority**: Reliability + consistent naming is the foundation; the
+counter and lists are only trustworthy if seen is durable and uniformly named.
+
+**Independent Test**: With the sender offline, have a member open a message; bring
+the sender back online and confirm the message reflects that member as seen.
+Confirm older messages that were "read" now display as "Seen" unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** an outgoing message and the sender offline, **When** a recipient
+   sees it and later the sender reconnects, **Then** the sender shows that
+   recipient as seen (the seen state is not lost).
+2. **Given** messages that previously had "read" status, **When** the app updates,
+   **Then** they display as "Seen" with their original timestamps and no status
+   regression.
+3. **Given** any seen state in the UI or copy, **When** it is shown, **Then** it
+   reads "Seen" (never "Read").
+
+---
+
+### User Story 2 - Group progress counter on the bubble (Priority: P1)
+
+In a group chat, an outgoing message shows how far it has progressed across the
+N members: it climbs "Delivered X/N" as members' devices receive it, then "Seen
+X/N" as members open it, then settles to "Seen" once everyone has.
+
+**Why this priority**: This is the headline visible value — group progress at a
+glance, the thing the current single tick can't convey.
+
+**Independent Test**: In a group of 3, watch the indicator go Sent → Delivered
+1/3 → 2/3 → 3/3 → Seen 1/3 → … → Seen as members receive then open the message.
+
+**Acceptance Scenarios**:
+
+1. **Given** a group message not yet delivered to all, **When** members receive
+   it, **Then** the bubble shows "Delivered X/N" with X climbing toward N.
+2. **Given** a group message delivered to all but not yet seen by all, **When**
+   members open it, **Then** the bubble shows "Seen X/N" with X climbing toward N.
+3. **Given** a group message every member has seen, **When** it renders, **Then**
+   the bubble shows the plain "Seen" tick (no fraction).
+4. **Given** a 1:1 message, **When** it renders, **Then** it shows the plain tick
+   with no fraction (unchanged from today).
+
+---
+
+### User Story 3 - Reciprocal "Seen receipts" privacy toggle (Priority: P1)
+
+A "Seen receipts" setting (default on) lets the user stop sharing when they've
+seen messages. Turning it off is reciprocal: the user no longer tells anyone
+they've seen a message, and no longer sees others' seen state on their own sent
+messages. It applies the same way in 1:1 and group chats.
+
+**Why this priority**: Consent is core to Ring; seen state must be suppressible
+without leaking, and the suppression must be symmetric.
+
+**Independent Test**: Turn the setting off on account A; confirm A reading
+messages never advances A's seen state for anyone, and A sees no seen tier on A's
+own messages, while two other members with it on still see each other.
+
+**Acceptance Scenarios**:
+
+1. **Given** the setting is on (default), **When** the user sees a message,
+   **Then** the sender can see the user reach the seen state.
+2. **Given** the user turns the setting off, **When** they see any message,
+   **Then** no seen confirmation is sent to anyone (they stay shown as delivered).
+3. **Given** the user has the setting off, **When** others see the user's sent
+   messages, **Then** the user does not see the seen tier on those messages
+   (it caps at delivered), and the setting copy explains this reciprocity.
+
+---
+
+### User Story 4 - Fuller message info with member lists (Priority: P2)
+
+Opening a group message's info shows, for every member, whether they've seen it,
+merely received it, or not yet received it — each with the member's name and
+avatar.
+
+**Why this priority**: The per-member detail; valuable but secondary to the
+at-a-glance counter, and partly built today (it lacks the "not yet delivered"
+view).
+
+**Acceptance Scenarios**:
+
+1. **Given** a group message, **When** I open its info, **Then** I see "Seen by",
+   "Delivered" (delivered but not yet seen), and "Not yet delivered" lists that
+   together account for every group member.
+2. **Given** a member who has not received the message, **When** I view the info,
+   **Then** that member appears under "Not yet delivered".
+3. **Given** more members in a tier than fit, **When** the list renders, **Then**
+   it shows a capped avatar stack with a "+N" overflow.
+
+---
+
+### Edge Cases
+
+- **Sender offline at seen time**: the seen state is reconciled on the sender's
+  next reconnect (durability), never silently lost.
+- **Stale (un-refreshed) client after the rename cutover**: its seen
+  confirmations may not register until it refreshes — a transient degradation of
+  the seen tier only; delivered and messaging are unaffected and it self-heals on
+  update.
+- **Upgrade migration failure**: the read→seen storage migration runs inside the
+  database upgrade transaction; if it cannot complete it MUST abort atomically,
+  leaving existing message data intact at the prior version (retried on the next
+  open) rather than partially migrating or losing history.
+- **Member with "Seen receipts" off, or who simply never opens it**: counts
+  toward delivered but never toward seen, so a group's "Seen X/N" may rest
+  permanently below N/N. This partial terminal state is intended — the sender
+  cannot distinguish "not yet opened" from "opted out" (the privacy guarantee).
+- **Sender with "Seen receipts" off**: their own messages' indicator caps at the
+  delivered tier (no seen tier shown), per reciprocity.
+- **Roster fixed at send time**: a member who joins the group later is not added
+  to an earlier message's counts/lists.
+- **A member who left / is unknown**: still resolvable to an avatar via a
+  generated fallback; never a broken row.
+- **Large groups**: the bubble shows the compact "X/N"; info-page lists use a
+  capped avatar stack + "+N".
+- **Downloaded-media signal**: remains separate from seen (it is not a displayed
+  status) and is unaffected.
+- **LTR/RTL + light/dark**: the counter and the avatar stack render and mirror
+  correctly in both directions and themes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The product MUST use "Seen" (never "Read") consistently in all
+  user-facing copy and internal status for what was previously "read" — the
+  bubble tick, message info, settings, and the wire/stored status value.
+- **FR-002**: Updating the app MUST migrate existing locally-stored messages so
+  prior "read" status and timestamps are preserved as "Seen", with no loss of
+  history and no status regression.
+- **FR-003**: A member's seen confirmation MUST be durable: if the sender is
+  offline when the member sees the message, the sender MUST reflect it after
+  reconnecting (parity with how delivered already reconciles).
+- **FR-004**: In a group chat, an outgoing message MUST present a progress
+  indicator using complete-the-tier semantics over **N = the recipient members
+  (the sender is excluded)**: Sent → "Delivered X/N" (some but not all delivered)
+  → "Seen X/N" (all delivered, some but not all seen) → "Seen" (all seen).
+- **FR-005**: The group indicator MUST appear compactly on the message bubble
+  (state + "X/N"), **group-only** and **only while a tier is partial** (1 ≤ X < N);
+  a fully-seen group message and all 1:1 messages show the plain tick with no
+  fraction. A group with a single recipient (N=1) therefore renders as a plain
+  tick too (no tier is ever partial) — no special-casing and no minimum group
+  size; counts begin once the group has ≥2 recipients.
+- **FR-006**: Opening a group message's info MUST present three member lists that
+  together cover every member of the message's roster: **Seen by**, **Delivered**
+  (delivered, not yet seen), and **Not yet delivered**, each showing the member's
+  name and avatar.
+- **FR-007**: The user MUST be able to turn "Seen receipts" off via a privacy
+  setting (default **on**), applied uniformly to 1:1 and group chats.
+- **FR-008**: When "Seen receipts" is off, the user's app MUST NOT send any seen
+  confirmation for any message (so no one sees the user reach the seen state).
+- **FR-009**: When "Seen receipts" is off, the user MUST NOT see others' seen
+  state on the messages they sent (the indicator caps at delivered); the setting
+  copy MUST explain this reciprocity.
+- **FR-010**: The seen privacy preference MUST be enforced entirely on the client;
+  the server MUST NOT be told the preference, and MUST never hold seen state the
+  user chose not to send.
+- **FR-011**: Counts and lists MUST be correct for the message's member roster as
+  of send time; a member who has not received the message MUST appear under "Not
+  yet delivered".
+- **FR-012**: The downloaded-media signal MUST remain distinct from seen and
+  unchanged (it is not a displayed status).
+- **FR-013**: All UI MUST use stock Ionic components + existing theme tokens,
+  building custom only where no Ionic primitive fits (Constitution XI).
+- **FR-014**: Behaviour MUST be correct in LTR and RTL (including the avatar stack
+  mirroring) and across light/dark themes, with localizable labels.
+
+### Key Entities *(include if feature involves data)*
+
+- **Seen receipt (per member)**: that member M saw sender S's message MID at time
+  T. Relayed live today; now **also durably stored server-side** with the same
+  shape as the existing delivered record `(sender, recipient, msg_id, seen_at)`
+  and the **same retention/cleanup policy** as that delivered store. No message
+  content.
+- **Per-member receipt roster** (existing, on the sender's message): one entry per
+  member `{member, deliveredAt?, seenAt?, downloadedAt?}`; the source of the
+  counts and the info-page lists.
+- **Derived group progress**: from the roster — delivered count = entries with
+  `deliveredAt`; seen count = entries with `seenAt`; tier + "X/N" follow the
+  complete-the-tier rule.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+This feature is **not** client-only (it adds a server seen-store + a wire/status
+change), so a `/speckit-checklist` is required (Constitution Principle I; it also
+touches Principle V — a local DB migration — and Principle VI — a new server
+migration).
+
+- **What crosses the wire / is stored**: a seen confirmation (member → message
+  author), now persisted durably as `(sender, recipient, msg_id, seen_at)` — the
+  **same metadata shape already stored for delivered** (`deliveries`). No new
+  *class* of server-visible metadata is introduced.
+- **What is NOT exposed**: no message bodies, media, or profile content; the seen
+  store holds only routing ids + a timestamp, minimized to what reconciling a
+  receipt requires (Principle I) and symmetric to delivered.
+- **Consent / preference**: the "Seen receipts" preference is enforced
+  **client-side only** — when off, the client never sends a seen confirmation, so
+  the server's seen-store **never holds** an opted-out user's seen (the gate is
+  upstream of the store). The server is never told the preference and has no
+  preference column. Reciprocity (not seeing others' seen) is also client-side.
+- **Rename**: the status value change is metadata only (a label/enum), exposes no
+  content, and needs no server data migration (read was never persisted).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a group of 3, an outgoing message's indicator climbs
+  "Delivered X/3" as devices receive it, then "Seen X/3" as members open it, then
+  shows plain "Seen" once all have. Verified e2e across three accounts.
+- **SC-002**: A member sees a message while the sender is offline; after the
+  sender reconnects, the message reflects that member as seen (durability).
+  Verified e2e.
+- **SC-003**: With "Seen receipts" off on account A: A never advances anyone's
+  view of A's seen state, AND A sees no seen tier on A's own messages, while two
+  other members with it on still see each other. Verified e2e (both directions).
+- **SC-004**: For a group message, every member appears under exactly one of
+  Seen by / Delivered / Not yet delivered, matching the roster. Verified e2e.
+- **SC-005**: After updating, messages that were previously "read" display as
+  "Seen" with original timestamps preserved and no status regression. Verified by
+  a migration test.
+- **SC-006**: 1:1 messages are visually unchanged (plain tick, no fraction).
+  Verified.
+- **SC-007**: The feature introduces no message content and no new class of
+  server-visible metadata — the seen store mirrors the delivered store's shape.
+  Verified by inspection of the change set.
+
+## Assumptions
+
+- Builds on existing machinery rather than new subsystems: the per-member
+  `receipts[]` roster, the message-info group lists, and the delivered
+  durability/reconcile path. Durable seen mirrors durable delivered; the info
+  lists gain a "not yet delivered" tier; the bubble gains a derived count.
+- The rename is a **hard cutover**; the brief cross-version skew (a stale client
+  still using the old value) degrades only the seen tier transiently and
+  self-heals on refresh — acceptable per the product decision.
+- The member roster for counts/lists is fixed at send time (later joiners are not
+  retroactively added to past messages).
+- A single combined "Seen receipts" toggle governs both 1:1 and groups (no
+  separate group rule); default on.
+- The avatar stack is capped (about five) with a "+N" overflow; "Seen X/N" stays
+  compact on the bubble and defers the per-member detail to message info.

--- a/specs/1010-group-seen-receipts/spec.md
+++ b/specs/1010-group-seen-receipts/spec.md
@@ -306,5 +306,5 @@ migration).
   retroactively added to past messages).
 - A single combined "Seen receipts" toggle governs both 1:1 and groups (no
   separate group rule); default on.
-- The avatar stack is capped (about five) with a "+N" overflow; "Seen X/N" stays
+- The avatar stack is capped at five with a "+N" overflow; "Seen X/N" stays
   compact on the bubble and defers the per-member detail to message info.

--- a/specs/1010-group-seen-receipts/tasks.md
+++ b/specs/1010-group-seen-receipts/tasks.md
@@ -30,7 +30,7 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm the working baseline is green before the sweeping rename: `npm run build` + `cd server && go test ./...` (record the pre-change state so the rename's diff is isolated).
+- [X] T001 Confirm the working baseline is green before the sweeping rename: `npm run build` + `cd server && go test ./...` (record the pre-change state so the rename's diff is isolated).
 
 ---
 
@@ -40,11 +40,11 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 
 > Tests first (T002, T003) — write and confirm they FAIL before T004/T005.
 
-- [ ] T002 [P] Client unit test in `src/db/idb.migration.test.ts` (or alongside idb tests): the `DB_VERSION 5→6` transform maps `status 'read'→'seen'`, `readAt→seenAt`, and `receipts[].readAt→seenAt` on existing rows, preserves all other data, regresses no status, and aborts atomically on failure (FR-002; Edge: upgrade failure). (Write first; fails.)
-- [ ] T003 [P] Client unit test in `src/services/message-status.test.ts`: the status reducers + group derivation operate on `seen`/`seenAt` (rename), aggregate monotonically. (Write first; fails.)
-- [ ] T004 Rename read→seen across the client: `src/db/types.ts` (`MessageStatus 'read'→'seen'`, `ReceiptStatus`, `Receipt.readAt→seenAt`, scalar `readAt→seenAt`), `src/services/message-status.ts` (reducers, `STATUS_ORDER`), `src/services/sync.ts` (`applyReceipt`), `src/services/transport.ts` (`ReceiptFrame` status), `src/db/queries.ts` (roster `seenAt`; `collectUnconfirmedOutgoing`), `src/composables/useSync.ts` (`sendReadReceipts→sendSeenReceipts`), `src/views/detail/ChatDetailPage.vue` (`statusIcon`, `.tick.read→.tick.seen`), `src/views/detail/MessageInfoPage.vue` ("Read by"→"Seen by"). Makes T003 pass.
-- [ ] T005 Client `DB_VERSION 5→6` forward migration in `src/db/idb.ts` `onupgradeneeded` (atomic within the upgrade txn; read→seen, readAt→seenAt, receipts[].readAt→seenAt; preserve + no regression). Makes T002 pass.
-- [ ] T006 Server: flip the `hub.go` "receipt" case to accept client-originated `'seen'|'downloaded'` (was `'read'`); keep the anti-forgery rejection of client `sent`/`delivered`; `'downloaded'` unchanged.
+- [X] T002 [P] Client unit test in `src/db/idb.migration.test.ts` (or alongside idb tests): the `DB_VERSION 5→6` transform maps `status 'read'→'seen'`, `readAt→seenAt`, and `receipts[].readAt→seenAt` on existing rows, preserves all other data, regresses no status, and aborts atomically on failure (FR-002; Edge: upgrade failure). (Write first; fails.)
+- [X] T003 [P] Client unit test in `src/services/message-status.test.ts`: the status reducers + group derivation operate on `seen`/`seenAt` (rename), aggregate monotonically. (Write first; fails.)
+- [X] T004 Rename read→seen across the client: `src/db/types.ts` (`MessageStatus 'read'→'seen'`, `ReceiptStatus`, `Receipt.readAt→seenAt`, scalar `readAt→seenAt`), `src/services/message-status.ts` (reducers, `STATUS_ORDER`), `src/services/sync.ts` (`applyReceipt`), `src/services/transport.ts` (`ReceiptFrame` status), `src/db/queries.ts` (roster `seenAt`; `collectUnconfirmedOutgoing`), `src/composables/useSync.ts` (`sendReadReceipts→sendSeenReceipts`), `src/views/detail/ChatDetailPage.vue` (`statusIcon`, `.tick.read→.tick.seen`), `src/views/detail/MessageInfoPage.vue` ("Read by"→"Seen by"). Makes T003 pass.
+- [X] T005 Client `DB_VERSION 5→6` forward migration in `src/db/idb.ts` `onupgradeneeded` (atomic within the upgrade txn; read→seen, readAt→seenAt, receipts[].readAt→seenAt; preserve + no regression). Makes T002 pass.
+- [X] T006 Server: flip the `hub.go` "receipt" case to accept client-originated `'seen'|'downloaded'` (was `'read'`); keep the anti-forgery rejection of client `sent`/`delivered`; `'downloaded'` unchanged.
 
 **Checkpoint**: app speaks "seen" end-to-end; existing data migrated.
 
@@ -56,12 +56,12 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 
 **Independent Test**: sender offline, member sees a message, sender reconnects → message reflects that member as seen.
 
-- [ ] T007 [P] [US1] Server seen-store test in `server/internal/ws/seen_test.go` (+ store fake): `RecordSeen` idempotent; `SeenFor` returns one row per member; a client `seen` receipt is relayed (from-stamped) AND recorded; `read`/`sent`/`delivered` from a client are dropped; `downloaded` relays but is NOT recorded. (Write first; fails.)
-- [ ] T008 [P] [US1] e2e in `e2e/group-seen-receipts.spec.ts`: a member sees a message while the sender is offline; on the sender's reconnect the seen state is reflected (SC-002). (Write first; fails.)
-- [ ] T009 [US1] New server migration `server/internal/db/migrations/NNNN_seen.sql` — `seen` table `(sender, recipient, msg_id, seen_at)`, PK `(sender, recipient, msg_id)` — plus `server/internal/store/seen.go` `RecordSeen` (upsert ON CONFLICT DO NOTHING) + `SeenFor(sender, msgIds)` + **`SweepSeenOlderThan(age)`** (DELETE older than age, mirroring `SweepDeliveriesOlderThan`). Register the seen sweep on the **same schedule** that runs the deliveries sweep so the table doesn't grow unbounded (retention parity with `deliveries`).
-- [ ] T010 [US1] Wire `hub.go` "receipt" case to `RecordSeen` when `status=='seen'` (durable, like `ack→RecordDelivery`). Makes T007 pass.
-- [ ] T011 [US1] `POST /v1/seen/check` in `server/internal/api/relay_handlers.go` (mirror `deliveriesCheck`) + router; client `src/services/api.ts checkSeen()`.
-- [ ] T012 [US1] Client reconcile in `src/composables/useSync.ts` — on 'online', check seen for unconfirmed outgoing and replay synthetic `{t:'receipt',status:'seen',from:recipient}`; extend `collectUnconfirmedOutgoing` (queries.ts) to flag group msgs missing `seenAt`. Makes T008 pass.
+- [X] T007 [P] [US1] Server seen-store test in `server/internal/ws/seen_test.go` (+ store fake): `RecordSeen` idempotent; `SeenFor` returns one row per member; a client `seen` receipt is relayed (from-stamped) AND recorded; `read`/`sent`/`delivered` from a client are dropped; `downloaded` relays but is NOT recorded. (Write first; fails.)
+- [X] T008 [P] [US1] e2e in `e2e/group-seen-receipts.spec.ts`: a member sees a message while the sender is offline; on the sender's reconnect the seen state is reflected (SC-002). (Write first; fails.)
+- [X] T009 [US1] New server migration `server/internal/db/migrations/NNNN_seen.sql` — `seen` table `(sender, recipient, msg_id, seen_at)`, PK `(sender, recipient, msg_id)` — plus `server/internal/store/seen.go` `RecordSeen` (upsert ON CONFLICT DO NOTHING) + `SeenFor(sender, msgIds)` + **`SweepSeenOlderThan(age)`** (DELETE older than age, mirroring `SweepDeliveriesOlderThan`). Register the seen sweep on the **same schedule** that runs the deliveries sweep so the table doesn't grow unbounded (retention parity with `deliveries`).
+- [X] T010 [US1] Wire `hub.go` "receipt" case to `RecordSeen` when `status=='seen'` (durable, like `ack→RecordDelivery`). Makes T007 pass.
+- [X] T011 [US1] `POST /v1/seen/check` in `server/internal/api/relay_handlers.go` (mirror `deliveriesCheck`) + router; client `src/services/api.ts checkSeen()`.
+- [X] T012 [US1] Client reconcile in `src/composables/useSync.ts` — on 'online', check seen for unconfirmed outgoing and replay synthetic `{t:'receipt',status:'seen',from:recipient}`; extend `collectUnconfirmedOutgoing` (queries.ts) to flag group msgs missing `seenAt`. Makes T008 pass.
 
 **Checkpoint**: seen is durable.
 
@@ -73,10 +73,10 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 
 **Independent Test**: in a group of 3, watch the counter climb as members receive then open the message.
 
-- [ ] T013 [P] [US2] Client unit test in `src/services/message-status.test.ts`: group-progress derivation — N = recipients (excl. sender); 0 delivered→Sent; partial delivered→"Delivered X/N"; all delivered + partial seen→"Seen X/N"; all seen→"Seen"; fraction only while partial (N=1 → plain tick) (FR-004/005). (Write first; fails.)
-- [ ] T014 [P] [US2] e2e in `e2e/group-seen-receipts.spec.ts`: 3 accounts — counter climbs Delivered X/2 → Seen X/2 → Seen (SC-001). (Write first; fails.)
-- [ ] T015 [US2] Add a group-progress derivation helper in `src/services/message-status.ts` (delivered/seen counts over `receipts[]`, tier + N from recipients). Makes T013 pass.
-- [ ] T016 [US2] Render the compact "X/N" next to the tick in `src/views/detail/ChatDetailPage.vue` (group-only, partial-only); `statusIcon`/`.tick.seen` for the seen tier; 1:1 unchanged.
+- [X] T013 [P] [US2] Client unit test in `src/services/message-status.test.ts`: group-progress derivation — N = recipients (excl. sender); 0 delivered→Sent; partial delivered→"Delivered X/N"; all delivered + partial seen→"Seen X/N"; all seen→"Seen"; fraction only while partial (N=1 → plain tick) (FR-004/005). (Write first; fails.)
+- [X] T014 [P] [US2] e2e in `e2e/group-seen-receipts.spec.ts`: 3 accounts — counter climbs Delivered X/2 → Seen X/2 → Seen (SC-001). (Write first; fails.)
+- [X] T015 [US2] Add a group-progress derivation helper in `src/services/message-status.ts` (delivered/seen counts over `receipts[]`, tier + N from recipients). Makes T013 pass.
+- [X] T016 [US2] Render the compact "X/N" next to the tick in `src/views/detail/ChatDetailPage.vue` (group-only, partial-only); `statusIcon`/`.tick.seen` for the seen tier; 1:1 unchanged.
 
 **Checkpoint**: progress visible at a glance.
 
@@ -88,10 +88,10 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 
 **Independent Test**: toggle off on A → B sees nothing of A's seen, and A sees no seen tier on A's own messages; others unaffected.
 
-- [ ] T017 [P] [US3] e2e in `e2e/group-seen-receipts.spec.ts`: toggle off ⇒ both-direction suppression (SC-003). (Write first; fails.)
-- [ ] T018 [US3] `src/settings/schema.ts`: rename/repurpose `privacy.readReceipts → privacy.seenReceipts` ("Seen receipts", default on; drop the always-for-groups footer; reciprocity copy).
-- [ ] T019 [US3] Emit gate + wiring in `src/composables/useSync.ts`: `sendSeenReceipts` is a no-op when off; `applySeenPref()` reads the toggle on start + on settings change (mirror 1009 `applyActivityPref`/`setActivityIndicatorsEnabled`).
-- [ ] T020 [US3] Reciprocity display gate in `src/views/detail/ChatDetailPage.vue` (+ `MessageInfoPage.vue`): when off, do not render/aggregate the seen tier on the user's own sent messages.
+- [X] T017 [P] [US3] e2e in `e2e/group-seen-receipts.spec.ts`: toggle off ⇒ both-direction suppression (SC-003). (Write first; fails.)
+- [X] T018 [US3] `src/settings/schema.ts`: rename/repurpose `privacy.readReceipts → privacy.seenReceipts` ("Seen receipts", default on; drop the always-for-groups footer; reciprocity copy).
+- [X] T019 [US3] Emit gate + wiring in `src/composables/useSync.ts`: `sendSeenReceipts` is a no-op when off; `applySeenPref()` reads the toggle on start + on settings change (mirror 1009 `applyActivityPref`/`setActivityIndicatorsEnabled`).
+- [X] T020 [US3] Reciprocity display gate in `src/views/detail/ChatDetailPage.vue` (+ `MessageInfoPage.vue`): when off, do not render/aggregate the seen tier on the user's own sent messages.
 
 **Checkpoint**: consent + reciprocity enforced client-side; P1 set complete.
 
@@ -103,8 +103,8 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 
 **Independent Test**: open a group message's info → every member appears under exactly one list.
 
-- [ ] T021 [P] [US4] e2e in `e2e/group-seen-receipts.spec.ts`: info lists partition all members into Seen by / Delivered / Not yet delivered (SC-004). (Write first; fails.)
-- [ ] T022 [US4] In `src/views/detail/MessageInfoPage.vue`: add the **"Not yet delivered"** list (`chat.participantIds` minus members with `deliveredAt`); rename "Read by"→"Seen by"; render an avatar stack (cap 5 + "+N") for each tier, reusing `contactMap`/`nameFor`/`avatarFor`/`initialsAvatar`.
+- [X] T021 [P] [US4] e2e in `e2e/group-seen-receipts.spec.ts`: info lists partition all members into Seen by / Delivered / Not yet delivered (SC-004). (Write first; fails.)
+- [X] T022 [US4] In `src/views/detail/MessageInfoPage.vue`: add the **"Not yet delivered"** list (`chat.participantIds` minus members with `deliveredAt`); rename "Read by"→"Seen by"; render an avatar stack (cap 5 + "+N") for each tier, reusing `contactMap`/`nameFor`/`avatarFor`/`initialsAvatar`.
 
 **Checkpoint**: full per-member detail.
 
@@ -112,10 +112,10 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T023 [P] e2e/assertion: 1:1 messages are visually unchanged (plain tick, no fraction) (SC-006).
-- [ ] T024 [P] LTR/RTL + light/dark: the counter and the avatar stack render and mirror correctly; labels localizable (FR-014).
-- [ ] T025 [P] ZK inspection: the `seen` table mirrors the `deliveries` metadata shape (no new class, no message content); confirm no server preference column (SC-007).
-- [ ] T026 Run all gates green: `npm run build`, `cd server && go build ./... && go vet ./... && go test ./...`, vitest, `npm run test:e2e`; then the `quickstart.md` manual smoke.
+- [X] T023 [P] e2e/assertion: 1:1 messages are visually unchanged (plain tick, no fraction) (SC-006).
+- [X] T024 [P] LTR/RTL + light/dark: the counter and the avatar stack render and mirror correctly; labels localizable (FR-014).
+- [X] T025 [P] ZK inspection: the `seen` table mirrors the `deliveries` metadata shape (no new class, no message content); confirm no server preference column (SC-007).
+- [X] T026 Run all gates green: `npm run build`, `cd server && go build ./... && go vet ./... && go test ./...`, vitest, `npm run test:e2e`; then the `quickstart.md` manual smoke.
 
 ---
 

--- a/specs/1010-group-seen-receipts/tasks.md
+++ b/specs/1010-group-seen-receipts/tasks.md
@@ -1,0 +1,142 @@
+---
+description: "Task list for spec 1010 — Group 'Seen' Receipts (durable, private, counted)"
+---
+
+# Tasks: Group "Seen" Receipts — Durable, Private, and Counted
+
+**Input**: Design documents from `/specs/1010-group-seen-receipts/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/seen-receipts.md
+
+**Tests**: REQUIRED — Constitution III (TDD): failing tests before implementation.
+Server logic + the migration + the counter derivation ship unit tests; new
+user-facing behavior adds `e2e/` coverage.
+
+**Organization**: By user story. The **rename + client migration** (the sweeping,
+mechanical change every later task assumes) and the server **receipt-case** flip
+are the Foundational phase; durable seen, the counter, privacy, and the info
+lists build on it.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no incomplete-dependency)
+- **[Story]**: US1–US4 (story phases only)
+
+## Path Conventions
+
+Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm the working baseline is green before the sweeping rename: `npm run build` + `cd server && go test ./...` (record the pre-change state so the rename's diff is isolated).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites — rename + migration)
+
+**⚠️ CRITICAL**: the read→seen rename + client migration block every user story.
+
+> Tests first (T002, T003) — write and confirm they FAIL before T004/T005.
+
+- [ ] T002 [P] Client unit test in `src/db/idb.migration.test.ts` (or alongside idb tests): the `DB_VERSION 5→6` transform maps `status 'read'→'seen'`, `readAt→seenAt`, and `receipts[].readAt→seenAt` on existing rows, preserves all other data, regresses no status, and aborts atomically on failure (FR-002; Edge: upgrade failure). (Write first; fails.)
+- [ ] T003 [P] Client unit test in `src/services/message-status.test.ts`: the status reducers + group derivation operate on `seen`/`seenAt` (rename), aggregate monotonically. (Write first; fails.)
+- [ ] T004 Rename read→seen across the client: `src/db/types.ts` (`MessageStatus 'read'→'seen'`, `ReceiptStatus`, `Receipt.readAt→seenAt`, scalar `readAt→seenAt`), `src/services/message-status.ts` (reducers, `STATUS_ORDER`), `src/services/sync.ts` (`applyReceipt`), `src/services/transport.ts` (`ReceiptFrame` status), `src/db/queries.ts` (roster `seenAt`; `collectUnconfirmedOutgoing`), `src/composables/useSync.ts` (`sendReadReceipts→sendSeenReceipts`), `src/views/detail/ChatDetailPage.vue` (`statusIcon`, `.tick.read→.tick.seen`), `src/views/detail/MessageInfoPage.vue` ("Read by"→"Seen by"). Makes T003 pass.
+- [ ] T005 Client `DB_VERSION 5→6` forward migration in `src/db/idb.ts` `onupgradeneeded` (atomic within the upgrade txn; read→seen, readAt→seenAt, receipts[].readAt→seenAt; preserve + no regression). Makes T002 pass.
+- [ ] T006 Server: flip the `hub.go` "receipt" case to accept client-originated `'seen'|'downloaded'` (was `'read'`); keep the anti-forgery rejection of client `sent`/`delivered`; `'downloaded'` unchanged.
+
+**Checkpoint**: app speaks "seen" end-to-end; existing data migrated.
+
+---
+
+## Phase 3: User Story 1 - Durable per-member seen (Priority: P1)
+
+**Goal**: a member's seen survives the sender being offline (reconciled on reconnect), mirroring delivered.
+
+**Independent Test**: sender offline, member sees a message, sender reconnects → message reflects that member as seen.
+
+- [ ] T007 [P] [US1] Server seen-store test in `server/internal/ws/seen_test.go` (+ store fake): `RecordSeen` idempotent; `SeenFor` returns one row per member; a client `seen` receipt is relayed (from-stamped) AND recorded; `read`/`sent`/`delivered` from a client are dropped; `downloaded` relays but is NOT recorded. (Write first; fails.)
+- [ ] T008 [P] [US1] e2e in `e2e/group-seen-receipts.spec.ts`: a member sees a message while the sender is offline; on the sender's reconnect the seen state is reflected (SC-002). (Write first; fails.)
+- [ ] T009 [US1] New server migration `server/internal/db/migrations/NNNN_seen.sql` — `seen` table `(sender, recipient, msg_id, seen_at)`, PK `(sender, recipient, msg_id)` — plus `server/internal/store/seen.go` `RecordSeen` (upsert ON CONFLICT DO NOTHING) + `SeenFor(sender, msgIds)`. Retention mirrors `deliveries`.
+- [ ] T010 [US1] Wire `hub.go` "receipt" case to `RecordSeen` when `status=='seen'` (durable, like `ack→RecordDelivery`). Makes T007 pass.
+- [ ] T011 [US1] `POST /v1/seen/check` in `server/internal/api/relay_handlers.go` (mirror `deliveriesCheck`) + router; client `src/services/api.ts checkSeen()`.
+- [ ] T012 [US1] Client reconcile in `src/composables/useSync.ts` — on 'online', check seen for unconfirmed outgoing and replay synthetic `{t:'receipt',status:'seen',from:recipient}`; extend `collectUnconfirmedOutgoing` (queries.ts) to flag group msgs missing `seenAt`. Makes T008 pass.
+
+**Checkpoint**: seen is durable.
+
+---
+
+## Phase 4: User Story 2 - Group "Seen X/N" counter on the bubble (Priority: P1)
+
+**Goal**: the group bubble shows complete-the-tier progress (Delivered X/N → Seen X/N → Seen).
+
+**Independent Test**: in a group of 3, watch the counter climb as members receive then open the message.
+
+- [ ] T013 [P] [US2] Client unit test in `src/services/message-status.test.ts`: group-progress derivation — N = recipients (excl. sender); 0 delivered→Sent; partial delivered→"Delivered X/N"; all delivered + partial seen→"Seen X/N"; all seen→"Seen"; fraction only while partial (N=1 → plain tick) (FR-004/005). (Write first; fails.)
+- [ ] T014 [P] [US2] e2e in `e2e/group-seen-receipts.spec.ts`: 3 accounts — counter climbs Delivered X/2 → Seen X/2 → Seen (SC-001). (Write first; fails.)
+- [ ] T015 [US2] Add a group-progress derivation helper in `src/services/message-status.ts` (delivered/seen counts over `receipts[]`, tier + N from recipients). Makes T013 pass.
+- [ ] T016 [US2] Render the compact "X/N" next to the tick in `src/views/detail/ChatDetailPage.vue` (group-only, partial-only); `statusIcon`/`.tick.seen` for the seen tier; 1:1 unchanged.
+
+**Checkpoint**: progress visible at a glance.
+
+---
+
+## Phase 5: User Story 3 - "Seen receipts" privacy toggle + reciprocity (Priority: P1)
+
+**Goal**: a default-on, reciprocal, client-enforced toggle.
+
+**Independent Test**: toggle off on A → B sees nothing of A's seen, and A sees no seen tier on A's own messages; others unaffected.
+
+- [ ] T017 [P] [US3] e2e in `e2e/group-seen-receipts.spec.ts`: toggle off ⇒ both-direction suppression (SC-003). (Write first; fails.)
+- [ ] T018 [US3] `src/settings/schema.ts`: rename/repurpose `privacy.readReceipts → privacy.seenReceipts` ("Seen receipts", default on; drop the always-for-groups footer; reciprocity copy).
+- [ ] T019 [US3] Emit gate + wiring in `src/composables/useSync.ts`: `sendSeenReceipts` is a no-op when off; `applySeenPref()` reads the toggle on start + on settings change (mirror 1009 `applyActivityPref`/`setActivityIndicatorsEnabled`).
+- [ ] T020 [US3] Reciprocity display gate in `src/views/detail/ChatDetailPage.vue` (+ `MessageInfoPage.vue`): when off, do not render/aggregate the seen tier on the user's own sent messages.
+
+**Checkpoint**: consent + reciprocity enforced client-side; P1 set complete.
+
+---
+
+## Phase 6: User Story 4 - Message-info per-tier lists (Priority: P2)
+
+**Goal**: Seen by / Delivered / Not yet delivered covering every member, with avatars.
+
+**Independent Test**: open a group message's info → every member appears under exactly one list.
+
+- [ ] T021 [P] [US4] e2e in `e2e/group-seen-receipts.spec.ts`: info lists partition all members into Seen by / Delivered / Not yet delivered (SC-004). (Write first; fails.)
+- [ ] T022 [US4] In `src/views/detail/MessageInfoPage.vue`: add the **"Not yet delivered"** list (`chat.participantIds` minus members with `deliveredAt`); rename "Read by"→"Seen by"; render an avatar stack (cap ~5 + "+N") for each tier, reusing `contactMap`/`nameFor`/`avatarFor`/`initialsAvatar`.
+
+**Checkpoint**: full per-member detail.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T023 [P] e2e/assertion: 1:1 messages are visually unchanged (plain tick, no fraction) (SC-006).
+- [ ] T024 [P] LTR/RTL + light/dark: the counter and the avatar stack render and mirror correctly; labels localizable (FR-014).
+- [ ] T025 [P] ZK inspection: the `seen` table mirrors the `deliveries` metadata shape (no new class, no message content); confirm no server preference column (SC-007).
+- [ ] T026 Run all gates green: `npm run build`, `cd server && go build ./... && go vet ./... && go test ./...`, vitest, `npm run test:e2e`; then the `quickstart.md` manual smoke.
+
+---
+
+## Dependencies & Story Completion Order
+
+- **Setup (T001)** → **Foundational (T002–T006)** block everything (rename + migration + receipt-case).
+  - T002/T003 (tests) before T004/T005 (impl).
+- **US1 (T007–T012)** durable seen — server store + reconcile. **MVP core.**
+- **US2 (T013–T016)** counter — renders from `receipts[]`; reliability depends on US1 but the derivation works on whatever's in the roster.
+- **US3 (T017–T020)** gates emission/display added by the rename + US1/US2 (do after, or stub the gate and complete here).
+- **US4 (T021–T022)** depends only on the foundation + roster.
+- **Polish (T023–T026)** last; T026 is the definition-of-done gate.
+
+## Parallel Execution Examples
+
+- Foundational: T002 ‖ T003 (different test files); T004 (sweeping) then T005, T006.
+- After foundation: US1 server work (T009–T011) ‖ US2 derivation (T015); the per-story e2e tasks (T008, T014, T017, T021) author in parallel (same file, distinct `describe` blocks).
+- Polish: T023 ‖ T024 ‖ T025.
+
+## Implementation Strategy
+
+- **MVP = Foundation + US1 + US2**: app speaks "seen", seen is durable, and the group counter shows reliable progress.
+- Then **US3** (consent — required for P1 completeness) and **US4** (info detail, P2).
+- **Gate before `/speckit-implement`**: `/speckit-analyze` clean (checklist already clean).

--- a/specs/1010-group-seen-receipts/tasks.md
+++ b/specs/1010-group-seen-receipts/tasks.md
@@ -58,7 +58,7 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 
 - [ ] T007 [P] [US1] Server seen-store test in `server/internal/ws/seen_test.go` (+ store fake): `RecordSeen` idempotent; `SeenFor` returns one row per member; a client `seen` receipt is relayed (from-stamped) AND recorded; `read`/`sent`/`delivered` from a client are dropped; `downloaded` relays but is NOT recorded. (Write first; fails.)
 - [ ] T008 [P] [US1] e2e in `e2e/group-seen-receipts.spec.ts`: a member sees a message while the sender is offline; on the sender's reconnect the seen state is reflected (SC-002). (Write first; fails.)
-- [ ] T009 [US1] New server migration `server/internal/db/migrations/NNNN_seen.sql` — `seen` table `(sender, recipient, msg_id, seen_at)`, PK `(sender, recipient, msg_id)` — plus `server/internal/store/seen.go` `RecordSeen` (upsert ON CONFLICT DO NOTHING) + `SeenFor(sender, msgIds)`. Retention mirrors `deliveries`.
+- [ ] T009 [US1] New server migration `server/internal/db/migrations/NNNN_seen.sql` — `seen` table `(sender, recipient, msg_id, seen_at)`, PK `(sender, recipient, msg_id)` — plus `server/internal/store/seen.go` `RecordSeen` (upsert ON CONFLICT DO NOTHING) + `SeenFor(sender, msgIds)` + **`SweepSeenOlderThan(age)`** (DELETE older than age, mirroring `SweepDeliveriesOlderThan`). Register the seen sweep on the **same schedule** that runs the deliveries sweep so the table doesn't grow unbounded (retention parity with `deliveries`).
 - [ ] T010 [US1] Wire `hub.go` "receipt" case to `RecordSeen` when `status=='seen'` (durable, like `ack→RecordDelivery`). Makes T007 pass.
 - [ ] T011 [US1] `POST /v1/seen/check` in `server/internal/api/relay_handlers.go` (mirror `deliveriesCheck`) + router; client `src/services/api.ts checkSeen()`.
 - [ ] T012 [US1] Client reconcile in `src/composables/useSync.ts` — on 'online', check seen for unconfirmed outgoing and replay synthetic `{t:'receipt',status:'seen',from:recipient}`; extend `collectUnconfirmedOutgoing` (queries.ts) to flag group msgs missing `seenAt`. Makes T008 pass.
@@ -104,7 +104,7 @@ Web app, single container: client `src/`, e2e `e2e/`, server `server/`.
 **Independent Test**: open a group message's info → every member appears under exactly one list.
 
 - [ ] T021 [P] [US4] e2e in `e2e/group-seen-receipts.spec.ts`: info lists partition all members into Seen by / Delivered / Not yet delivered (SC-004). (Write first; fails.)
-- [ ] T022 [US4] In `src/views/detail/MessageInfoPage.vue`: add the **"Not yet delivered"** list (`chat.participantIds` minus members with `deliveredAt`); rename "Read by"→"Seen by"; render an avatar stack (cap ~5 + "+N") for each tier, reusing `contactMap`/`nameFor`/`avatarFor`/`initialsAvatar`.
+- [ ] T022 [US4] In `src/views/detail/MessageInfoPage.vue`: add the **"Not yet delivered"** list (`chat.participantIds` minus members with `deliveredAt`); rename "Read by"→"Seen by"; render an avatar stack (cap 5 + "+N") for each tier, reusing `contactMap`/`nameFor`/`avatarFor`/`initialsAvatar`.
 
 **Checkpoint**: full per-member detail.
 

--- a/src/components/QuickReactBar.vue
+++ b/src/components/QuickReactBar.vue
@@ -14,7 +14,7 @@
     >
       <emoji :emoji="e" />
     </button>
-    <button type="button" class="qr-emoji qr-more" aria-label="More emoji" @click="choose('more')">
+    <button v-if="!atEmojiCap" type="button" class="qr-emoji qr-more" aria-label="More emoji" @click="choose('more')">
       <ion-icon :icon="addCircleOutline" />
     </button>
   </div>
@@ -29,11 +29,19 @@ import Emoji from '@/components/Emoji.vue';
 const props = defineProps<{
   myEmojis?: string[]; // the user's current reactions on this message (to highlight)
   quick?: string[]; // most-used-first quick-react set (from the caller)
+  existing?: string[]; // the distinct emojis already on this message
+  atEmojiCap?: boolean; // message at the distinct-emoji cap → offer only `existing`
 }>();
 
 // The 5 most-used emoji, all shown at once (no scroll). Falls back to a default set.
+// At the per-message distinct-emoji cap we instead show exactly the emojis already on
+// the message (≤ cap), so the only thing you can do is react with one of those.
 const DEFAULT_QUICK = ['👍', '❤️', '😂', '😮', '🙏'];
-const quickSet = computed(() => (props.quick && props.quick.length ? props.quick : DEFAULT_QUICK).slice(0, 5));
+const quickSet = computed(() =>
+  props.atEmojiCap && props.existing && props.existing.length
+    ? props.existing.slice(0, 5)
+    : (props.quick && props.quick.length ? props.quick : DEFAULT_QUICK).slice(0, 5),
+);
 
 const pick = (emoji: string) => void popoverController.dismiss({ action: 'react', emoji });
 const choose = (action: string) => void popoverController.dismiss({ action });

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -23,7 +23,7 @@ import {
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
 import { getChat, listChats, listMessages, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing } from '@/db/queries';
-import { checkDeliveries } from '@/services/api';
+import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
 import { runOwnSync, ownSyncQuiet } from '@/services/ownsync';
@@ -47,6 +47,13 @@ import { isInitialized, isUnlocked } from '@/services/crypto/identity';
 const syncState = ref<TransportState>('offline');
 let transport: Transport | null = null;
 let started = false;
+
+// Cached "Seen receipts" privacy preference (default on), the EMIT side of the
+// reciprocal gate (spec 1010 FR-008). When false, sendSeenReceipts is a no-op so
+// no seen confirmation ever leaves this device. Kept in sync by applySeenPref()
+// on start + on any settings change (mirrors 1009's activity-indicators flag). The
+// DISPLAY side of reciprocity lives in the chat/info views (they read the setting).
+let seenReceiptsEnabled = true;
 
 /* ---- presence ---- */
 
@@ -137,6 +144,37 @@ async function reconcileDeliveries(): Promise<void> {
   }
 }
 
+/**
+ * Reconcile durable SEEN receipts on reconnect (spec 1010), the symmetric twin of
+ * reconcileDeliveries. A member's live 'seen' receipt is dropped if the sender is
+ * offline at that instant, so "Seen X/N" would never reflect it. The server now
+ * records seen durably (the `seen` table); here we ask which of our still-
+ * unconfirmed outgoing messages have been seen and replay each as a synthetic
+ * `{status:'seen', from: recipient}` frame through the normal receipt path (so the
+ * group aggregation + monotonic clamp hold). Best-effort: retried on next reconnect.
+ */
+async function reconcileSeen(): Promise<void> {
+  if (!isUnlocked.value) return; // messages are unreadable while locked; nothing to reconcile
+  try {
+    const ids = await collectUnconfirmedOutgoing();
+    if (!ids.length) return;
+    const seen = await checkSeen(ids);
+    for (const s of seen) {
+      // `from` = the member who saw it → applyGroupReceipt stamps that member's seenAt
+      // (mirrors a live 'seen' receipt's shape).
+      await handleIncomingFrame({
+        t: 'receipt',
+        messageId: s.messageId,
+        status: 'seen',
+        at: s.at,
+        from: s.recipient,
+      });
+    }
+  } catch {
+    /* retried on next reconnect */
+  }
+}
+
 /** We count as "active" (online to peers) only when the app is foregrounded AND
  *  unlocked, so a device sitting at the passcode gate shows offline even though
  *  the relay is connected (for delivery receipts). */
@@ -201,6 +239,7 @@ function start(): void {
       cancelSessionCheck(); // the WS auth passed → our token is valid
       void drainOutbox(transport); // flush what queued offline
       void reconcileDeliveries(); // recover any 'delivered' receipt dropped while we were offline
+      void reconcileSeen(); // recover any 'seen' receipt dropped while we were offline (spec 1010)
       void sendDownloadedReceipts(); // confirm media we hold so senders can free the blobs
       void resumePendingMediaJobs(); // re-attempt any interrupted/failed-but-retryable media
       // Publish our bundle (so peers can start sessions), then top up the
@@ -346,8 +385,10 @@ function start(): void {
     void sendPresencePrefs();
     void applyPushPreference();
     void applyActivityPref(); // reflect the activity-indicators toggle (spec 1009)
+    void applySeenPref(); // reflect the seen-receipts toggle (spec 1010)
   });
   void applyActivityPref(); // apply the saved toggle once at startup
+  void applySeenPref(); // apply the saved seen-receipts toggle once at startup
 
   // Back up own data (contacts/chats + profile/prefs snapshot) shortly after any
   // change, not only on reconnect. Debounced so a burst of writes coalesces.
@@ -432,22 +473,28 @@ function start(): void {
   );
 }
 
-// Message ids we've already sent a read receipt for (avoid resending on every
-// chat open). In-memory is fine, a duplicate read receipt is idempotent.
-const readReceiptsSent = new Set<string>();
+// Message ids we've already sent a seen receipt for (avoid resending on every
+// chat open). In-memory is fine, a duplicate seen receipt is idempotent.
+const seenReceiptsSent = new Set<string>();
 
 /**
- * Send 'read' receipts for the incoming messages of a chat (called when the user
+ * Send 'seen' receipts for the incoming messages of a chat (called when the user
  * opens it). The server routes each receipt to its target and stamps `from` = the
- * reader, advancing that message's status to 'read' on the sender's side.
+ * viewer, advancing that message's status to 'seen' on the sender's side, and
+ * durably records it so "Seen X/N" survives the sender being offline (spec 1010).
+ *
+ * Privacy emit gate (FR-008): when "Seen receipts" is off this is a NO-OP — you
+ * can't leak what you don't send, so the server never relays or records it and
+ * the sender keeps you counted as merely delivered. Mirrors sendActivity (1009).
  *
  * 1:1: every unseen message goes to the single peer. Group: each message is
  * addressed to its OWN author (m.senderId); a group has N independent 1:1 relay
  * paths, not one peer, so the original sender's per-recipient receipt for us is
- * the one that gets stamped read (see applyReceipt's group aggregation).
+ * the one that gets stamped seen (see applyReceipt's group aggregation).
  */
-export async function sendReadReceipts(chatId: string): Promise<void> {
+export async function sendSeenReceipts(chatId: string): Promise<void> {
   if (!transport || transport.state !== 'online') return;
+  if (!seenReceiptsEnabled) return; // privacy: off ⇒ never send a seen confirmation
   const chat = await getChat(chatId);
   if (!chat) return;
   const peerUserId = chat.isGroup ? null : chat.participantIds[0];
@@ -455,15 +502,15 @@ export async function sendReadReceipts(chatId: string): Promise<void> {
 
   const msgs = await listMessages(chatId, '');
   for (const m of msgs) {
-    if (m.outgoing || readReceiptsSent.has(m.id)) continue;
+    if (m.outgoing || seenReceiptsSent.has(m.id)) continue;
     // In a group the recipient is the message's author; in 1:1 it's the peer.
     const to = chat.isGroup ? m.senderId : peerUserId;
     if (!to || to === 'me') continue;
-    readReceiptsSent.add(m.id);
+    seenReceiptsSent.add(m.id);
     try {
-      await transport.send({ t: 'receipt', messageId: m.id, status: 'read', at: Date.now(), to });
+      await transport.send({ t: 'receipt', messageId: m.id, status: 'seen', at: Date.now(), to });
     } catch {
-      readReceiptsSent.delete(m.id); // retry next time if the send failed
+      seenReceiptsSent.delete(m.id); // retry next time if the send failed
     }
   }
 }
@@ -473,7 +520,7 @@ const downloadedReceiptsSent = new Set<string>();
 
 /**
  * Tell the SENDER we now hold an incoming media message's bytes (status 'downloaded'), so
- * they can delete the server blob once every recipient has it. Distinct from 'read': it's
+ * they can delete the server blob once every recipient has it. Distinct from 'seen': it's
  * about having the file on-device, not having opened it, and never affects the UI ticks.
  * Scans incoming messages whose media we've downloaded (mediaId set). Best-effort and
  * idempotent; cleanup falls back to the server's age sweep if these never arrive.
@@ -588,6 +635,17 @@ export async function sendGroupActivity(opts: {
  */
 export async function applyActivityPref(): Promise<void> {
   setActivityIndicatorsEnabled(await getSetting<boolean>('privacy.activityIndicators', true));
+}
+
+/**
+ * Reflect the `privacy.seenReceipts` toggle (default on) into the emit gate (spec
+ * 1010 FR-008/010). When off, the client sends no seen confirmation (the server
+ * never learns the preference and never holds an opted-out seen). The reciprocity
+ * DISPLAY gate (not rendering others' seen on your own messages) is enforced in the
+ * views. Applied on start and on any settings change (mirrors applyActivityPref).
+ */
+export async function applySeenPref(): Promise<void> {
+  seenReceiptsEnabled = await getSetting<boolean>('privacy.seenReceipts', true);
 }
 
 // Poll redeemed invitations only when there's something to resolve (outstanding

--- a/src/db/idb.migration.test.ts
+++ b/src/db/idb.migration.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { migrateMessageToV6 } from './idb';
+
+// The DB_VERSION 5→6 forward transform (spec 1010): read → seen on every stored
+// message. Tested as a pure function (no IndexedDB needed); the onupgradeneeded
+// cursor applies it inside the versionchange transaction, so a throw here aborts
+// the whole upgrade atomically (data intact at v5, retried next open).
+
+describe('migrateMessageToV6 (read → seen forward migration)', () => {
+  it('maps a 1:1 message status read→seen and readAt→seenAt, preserving all else', () => {
+    const row = {
+      id: 'm1',
+      chatId: 'c1',
+      senderId: 'me',
+      body: 'hi',
+      kind: 'text',
+      status: 'read',
+      timestamp: 1000,
+      sentAt: 1001,
+      deliveredAt: 1002,
+      readAt: 1003,
+      outgoing: true,
+      updatedAt: 2000,
+    };
+    const out = migrateMessageToV6(row)!;
+    expect(out.status).toBe('seen');
+    expect(out.seenAt).toBe(1003);
+    expect('readAt' in out).toBe(false);
+    // Everything else is preserved untouched.
+    expect(out.deliveredAt).toBe(1002);
+    expect(out.sentAt).toBe(1001);
+    expect(out.body).toBe('hi');
+    expect(out.timestamp).toBe(1000);
+    expect(out.updatedAt).toBe(2000);
+  });
+
+  it('maps each receipts[].readAt→seenAt on a group message', () => {
+    const row = {
+      id: 'g1',
+      status: 'read',
+      receipts: [
+        { contactId: 'a', deliveredAt: 10, readAt: 20 },
+        { contactId: 'b', deliveredAt: 11 },
+        { contactId: 'c', deliveredAt: 12, readAt: 22 },
+      ],
+      readAt: 22,
+    };
+    const out = migrateMessageToV6(row)!;
+    expect(out.status).toBe('seen');
+    expect(out.seenAt).toBe(22);
+    const recs = out.receipts as Array<Record<string, unknown>>;
+    expect(recs[0]).toEqual({ contactId: 'a', deliveredAt: 10, seenAt: 20 });
+    expect(recs[1]).toEqual({ contactId: 'b', deliveredAt: 11 }); // no read → unchanged
+    expect(recs[2]).toEqual({ contactId: 'c', deliveredAt: 12, seenAt: 22 });
+    expect(recs.every((r) => !('readAt' in r))).toBe(true);
+  });
+
+  it('does not regress status: a delivered/sent/pending message is left as-is (null)', () => {
+    expect(migrateMessageToV6({ id: 'm', status: 'delivered', deliveredAt: 5 })).toBeNull();
+    expect(migrateMessageToV6({ id: 'm', status: 'sent', sentAt: 5 })).toBeNull();
+    expect(migrateMessageToV6({ id: 'm', status: 'pending' })).toBeNull();
+  });
+
+  it('is idempotent: an already-migrated (seen) row needs no rewrite (null)', () => {
+    expect(
+      migrateMessageToV6({ id: 'm', status: 'seen', seenAt: 30, receipts: [{ contactId: 'a', seenAt: 30 }] }),
+    ).toBeNull();
+  });
+
+  it('migrates a group row whose status is not "read" but whose receipts still carry readAt', () => {
+    // e.g. an outgoing group message still at 'delivered' with one member's readAt set.
+    const out = migrateMessageToV6({
+      id: 'g',
+      status: 'delivered',
+      receipts: [{ contactId: 'a', deliveredAt: 10, readAt: 20 }, { contactId: 'b', deliveredAt: 11 }],
+    })!;
+    expect(out.status).toBe('delivered'); // unchanged
+    expect((out.receipts as Array<Record<string, unknown>>)[0]).toEqual({
+      contactId: 'a',
+      deliveredAt: 10,
+      seenAt: 20,
+    });
+  });
+
+  it('never mutates the input row (so an aborted upgrade leaves data intact)', () => {
+    const row = { id: 'm', status: 'read', readAt: 5, receipts: [{ contactId: 'a', readAt: 9 }] };
+    const snapshot = JSON.parse(JSON.stringify(row));
+    migrateMessageToV6(row);
+    expect(row).toEqual(snapshot); // input object untouched
+  });
+
+  it('handles malformed / empty input without throwing', () => {
+    expect(migrateMessageToV6(null)).toBeNull();
+    expect(migrateMessageToV6(undefined)).toBeNull();
+    expect(migrateMessageToV6({})).toBeNull();
+  });
+});

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -26,15 +26,61 @@ export const STORES = [
 export type StoreName = (typeof STORES)[number];
 
 const DB_NAME = 'ring';
-const DB_VERSION = 5;
+const DB_VERSION = 6;
 
 let dbPromise: Promise<IDBDatabase> | null = null;
+
+/**
+ * Pure forward transform for the v5→v6 "read → seen" rename (spec 1010): a stored
+ * message row gets `status 'read'→'seen'`, the scalar `readAt→seenAt`, and each
+ * `receipts[].readAt→seenAt`. Every other field is preserved and status never
+ * regresses ('read' and 'seen' share the same rank). Returns a NEW row when it
+ * changed anything, or `null` when the row already speaks "seen" (so the migration
+ * skips a needless write) — never mutates the input. Exported so it's unit-tested
+ * without an IndexedDB (see idb.migration.test.ts); the onupgradeneeded cursor
+ * below applies it inside the versionchange transaction.
+ */
+export function migrateMessageToV6(
+  row: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (!row || typeof row !== 'object') return null;
+  let changed = false;
+  const next: Record<string, unknown> = { ...row };
+
+  if (row.status === 'read') {
+    next.status = 'seen';
+    changed = true;
+  }
+  if (Object.prototype.hasOwnProperty.call(row, 'readAt')) {
+    if (row.readAt !== undefined) next.seenAt = row.readAt;
+    delete next.readAt;
+    changed = true;
+  }
+  if (Array.isArray(row.receipts)) {
+    let recChanged = false;
+    const recs = (row.receipts as Array<Record<string, unknown>>).map((r) => {
+      if (r && typeof r === 'object' && Object.prototype.hasOwnProperty.call(r, 'readAt')) {
+        recChanged = true;
+        const nr: Record<string, unknown> = { ...r };
+        if (r.readAt !== undefined) nr.seenAt = r.readAt;
+        delete nr.readAt;
+        return nr;
+      }
+      return r;
+    });
+    if (recChanged) {
+      next.receipts = recs;
+      changed = true;
+    }
+  }
+  return changed ? next : null;
+}
 
 export function openDB(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise;
   dbPromise = new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onupgradeneeded = () => {
+    req.onupgradeneeded = (event) => {
       const db = req.result;
       if (!db.objectStoreNames.contains('contacts'))
         db.createObjectStore('contacts', { keyPath: 'id' });
@@ -61,6 +107,27 @@ export function openDB(): Promise<IDBDatabase> {
       // v5: user-defined chat filter lists.
       if (!db.objectStoreNames.contains('chatlists'))
         db.createObjectStore('chatlists', { keyPath: 'id' });
+      // v6 (spec 1010): rename "read" → "seen" on every stored message
+      // (status 'read'→'seen', readAt→seenAt, receipts[].readAt→seenAt). Runs inside
+      // THIS versionchange transaction over the existing rows: a cursor rewrites each
+      // row via the pure migrateMessageToV6 transform. It's a no-op on a fresh DB (the
+      // store was just created empty). Crucially, any cursor/update error bubbles to
+      // the transaction, which aborts the whole upgrade atomically — leaving existing
+      // message data intact at v5 and retried on the next open (Edge: upgrade failure),
+      // never partially migrated.
+      if (event.oldVersion > 0 && event.oldVersion < 6 && db.objectStoreNames.contains('messages')) {
+        const tx = req.transaction; // the active versionchange transaction
+        const cursorReq = tx?.objectStore('messages').openCursor();
+        if (cursorReq) {
+          cursorReq.onsuccess = () => {
+            const cursor = cursorReq.result;
+            if (!cursor) return;
+            const migrated = migrateMessageToV6(cursor.value as Record<string, unknown>);
+            if (migrated) cursor.update(migrated); // an update error aborts the upgrade txn
+            cursor.continue();
+          };
+        }
+      }
     };
     req.onsuccess = () => {
       const db = req.result;

--- a/src/db/outbox.ts
+++ b/src/db/outbox.ts
@@ -6,7 +6,7 @@
  * At-least-once delivery: an entry is NOT removed when it's written to the socket
  * (a write only means the bytes left this device; the server may still crash /
  * restart before durably queuing it). It's removed only when the server confirms
- * receipt (a 'sent'/'delivered'/'read' receipt → removeByFrameId), and re-sent on
+ * receipt (a 'sent'/'delivered'/'seen' receipt → removeByFrameId), and re-sent on
  * reconnect until then. The relay's EnqueueRelay is idempotent on
  * (recipient, msg_id), so re-sends never duplicate.
  */

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -415,6 +415,11 @@ async function sendGroupCard(members: string[], card: GroupCard): Promise<void> 
 /** Up to 3 reactions per person on a single message (Teams-style). */
 export const MAX_REACTIONS_PER_USER = 3;
 
+/** Cap on how many DIFFERENT emojis a single message can carry across everyone. Once
+ *  a message has this many distinct emojis, no one can introduce a new one — they can
+ *  only pile onto an existing emoji. Keeps a message's reaction set bounded/sane. */
+export const MAX_DISTINCT_REACTIONS = 5;
+
 /** Apply a reaction change to a message in place (shared by local + inbound).
  *  Up to MAX_REACTIONS_PER_USER per user, toggled per emoji; `at` resolves
  *  out-of-order updates so a stale frame can't override a newer choice. */
@@ -447,13 +452,23 @@ function applyReaction(
 export async function reactToMessage(
   messageId: string,
   emoji: string,
-): Promise<'added' | 'removed' | 'limit'> {
+): Promise<'added' | 'removed' | 'limit' | 'limit-emojis'> {
   const message = await getMessage(messageId);
   if (!message) return 'removed';
   const self = getSelfUserId() ?? '';
   const mine = (message.reactions ?? []).filter((r) => r.userId === self);
   const has = mine.some((r) => r.emoji === emoji);
-  if (!has && mine.length >= MAX_REACTIONS_PER_USER) return 'limit'; // already at the cap
+  if (!has) {
+    // Adding (not toggling off): enforce both caps client-side at the emit site.
+    if (mine.length >= MAX_REACTIONS_PER_USER) return 'limit'; // your own 3-reaction cap
+    // Per-message distinct-emoji cap: a brand-new emoji is blocked once the message
+    // already carries MAX_DISTINCT_REACTIONS different ones; piling onto an existing
+    // emoji is always allowed. Every up-to-date client gates its own user this way,
+    // so nobody contributes a 6th distinct emoji (kept as an emit gate, not an
+    // inbound drop, so reaction state stays convergent across devices).
+    const distinct = new Set((message.reactions ?? []).map((r) => r.emoji));
+    if (!distinct.has(emoji) && distinct.size >= MAX_DISTINCT_REACTIONS) return 'limit-emojis';
+  }
   const remove = has; // tapping one of your existing emoji clears just that one
   const at = now();
   applyReaction(message, self, emoji, remove, at);
@@ -1594,7 +1609,7 @@ export async function retryAllFailed(): Promise<void> {
 export async function markSendFailed(messageId: string): Promise<void> {
   const m = await getMessage(messageId);
   if (!m || !m.outgoing) return;
-  if (m.status === 'sent' || m.status === 'delivered' || m.status === 'read') return;
+  if (m.status === 'sent' || m.status === 'delivered' || m.status === 'seen') return;
   m.status = 'failed';
   m.updatedAt = now();
   await put('messages', m);
@@ -2084,7 +2099,7 @@ async function resendRecentOutgoing(chatId: string): Promise<void> {
   if (!chat || chat.isGroup) return;
   const peerId = chat.participantIds[0];
   const recent = (await getByIndex<Message>('messages', 'chatId', chatId))
-    .filter((m) => m.outgoing && m.status !== 'read')
+    .filter((m) => m.outgoing && m.status !== 'seen')
     .sort((x, y) => x.timestamp - y.timestamp)
     .slice(-REKEY_RESEND_LIMIT);
   for (const m of recent) {
@@ -2101,11 +2116,12 @@ const RECONCILE_WINDOW_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
 const RECONCILE_ID_CAP = 500;
 
 /**
- * Collect the ids of our recent OUTGOING messages whose delivery isn't confirmed
- * yet - 1:1 messages still at 'sent', and group messages with any member not yet
- * 'delivered'. On reconnect these are handed to the server (checkDeliveries) so a
- * 'delivered' receipt that was dropped because WE were offline when the recipient
- * acked is recovered. Bounded by a recency window + a hard cap so the check is cheap.
+ * Collect the ids of our recent OUTGOING messages whose delivery/seen isn't
+ * confirmed yet - 1:1 messages still at 'sent', and group messages with any member
+ * not yet 'delivered' OR not yet 'seen'. On reconnect these are handed to the
+ * server (checkDeliveries + checkSeen, spec 1010) so a 'delivered'/'seen' receipt
+ * that was dropped because WE were offline when the recipient acked/opened it is
+ * recovered. Bounded by a recency window + a hard cap so the check is cheap.
  */
 export async function collectUnconfirmedOutgoing(): Promise<string[]> {
   const since = now() - RECONCILE_WINDOW_MS;
@@ -2115,7 +2131,9 @@ export async function collectUnconfirmedOutgoing(): Promise<string[]> {
     if (!m.outgoing || m.timestamp < since) continue;
     const recs = m.receipts;
     if (recs && recs.length) {
-      if (recs.some((r) => !r.deliveredAt)) ids.push(m.id);
+      // Group: any member not yet delivered (→ checkDeliveries) or not yet seen
+      // (→ checkSeen) keeps this message in the reconcile set.
+      if (recs.some((r) => !r.deliveredAt || !r.seenAt)) ids.push(m.id);
     } else if (m.status === 'sent') {
       ids.push(m.id);
     }
@@ -3405,7 +3423,7 @@ export async function logCallToChat(chatId: string, log: CallLog): Promise<void>
     kind: 'call',
     timestamp: ts,
     outgoing: log.direction === 'outgoing',
-    status: 'read', // informational; never enqueued, no receipts
+    status: 'seen', // informational; never enqueued, no receipts
     callLog: log,
     updatedAt: ts,
   };

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -176,16 +176,16 @@ export interface SharedContact {
  *  - compressing: media is being (re-)compressed in the background, not yet sealed
  *  - pending:     sealed + queued for relay, awaiting the server's 'sent' ack
  *  - sent:        the server accepted it (the real "sent" time → sentAt)
- *  - delivered / read: peer receipts
+ *  - delivered / seen: peer receipts
  *  - failed:      the background job failed its retry budget → shows a retry button
  */
-export type MessageStatus = 'compressing' | 'pending' | 'sent' | 'delivered' | 'read' | 'failed';
+export type MessageStatus = 'compressing' | 'pending' | 'sent' | 'delivered' | 'seen' | 'failed';
 
-/** Per-recipient receipt, drives group "Read by" / "Delivered to" info. */
+/** Per-recipient receipt, drives group "Seen by" / "Delivered to" info. */
 export interface Receipt {
   contactId: string;
   deliveredAt?: number;
-  readAt?: number;
+  seenAt?: number;
   downloadedAt?: number; // when this member confirmed it has the media bytes (blob cleanup)
 }
 
@@ -227,7 +227,7 @@ export interface Message {
   jobAttempts?: number; // background-job (compress + seal/upload) failure count
   failReason?: 'too-large'; // why a send failed permanently (drives a specific toast)
   deliveredAt?: number; // 1:1: when the peer's device confirmed delivery
-  readAt?: number; // 1:1: when the peer opened/read it
+  seenAt?: number; // 1:1: when the peer opened/saw it
   receipts?: Receipt[]; // group messages only
   reactions?: Reaction[]; // emoji reactions, by user
   replyTo?: ReplyRef; // the message this one is a reply to

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -335,6 +335,30 @@ export async function checkDeliveries(ids: string[]): Promise<DeliveredEntry[]> 
   return ((await res.json()) as { delivered?: DeliveredEntry[] }).delivered ?? [];
 }
 
+/** One reconciled seen receipt: a message we sent was seen by `recipient` (a group
+ *  message reports one entry per member who saw it). */
+export interface SeenEntry {
+  messageId: string;
+  recipient: string;
+  at: number;
+}
+
+/**
+ * Reconcile our seen state on reconnect (spec 1010): ask the server which of the
+ * given message ids it has recorded as seen (so a 'seen' receipt dropped while we
+ * were offline is recovered). Mirrors checkDeliveries. Returns the seen entries.
+ */
+export async function checkSeen(ids: string[]): Promise<SeenEntry[]> {
+  if (!ids.length) return [];
+  const res = await fetch(`${apiBaseUrl()}/v1/seen/check`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ ids }),
+  });
+  if (!res.ok) throw new Error(`seen check failed: ${res.status}`);
+  return ((await res.json()) as { seen?: SeenEntry[] }).seen ?? [];
+}
+
 /* ---- connect-request lifecycle (directory-initiated 1:1 connections) ---- */
 
 export interface ConnReq {

--- a/src/services/message-status.test.ts
+++ b/src/services/message-status.test.ts
@@ -7,6 +7,7 @@ import {
   applyGroupReceipt,
   applyStatusReceipt,
   applyDownloadedReceipt,
+  groupProgress,
 } from './message-status';
 
 // Minimal outgoing-message factory. The reducers only read status/receipts/*At/
@@ -31,18 +32,18 @@ function recipients(ids: string[]): Receipt[] {
 }
 
 describe('STATUS_ORDER', () => {
-  it('ranks pre-send states below sent and read at the top, and excludes downloaded', () => {
+  it('ranks pre-send states below sent and seen at the top, and excludes downloaded', () => {
     expect(statusRank('pending')).toBeLessThan(statusRank('sent'));
     expect(statusRank('compressing')).toBeLessThan(statusRank('sent'));
     expect(statusRank('failed')).toBeLessThan(statusRank('sent'));
     expect(statusRank('sent')).toBeLessThan(statusRank('delivered'));
-    expect(statusRank('delivered')).toBeLessThan(statusRank('read'));
+    expect(statusRank('delivered')).toBeLessThan(statusRank('seen'));
     expect('downloaded' in STATUS_ORDER).toBe(false);
   });
 });
 
 describe('applyScalarReceipt (1:1)', () => {
-  it('advances pending → sent → delivered → read and stamps timeline', () => {
+  it('advances pending → sent → delivered → seen and stamps timeline', () => {
     let m = msg({ status: 'pending' });
     m = applyScalarReceipt(m, 'sent', 10);
     expect(m.status).toBe('sent');
@@ -50,24 +51,24 @@ describe('applyScalarReceipt (1:1)', () => {
     m = applyScalarReceipt(m, 'delivered', 20);
     expect(m.status).toBe('delivered');
     expect(m.deliveredAt).toBe(20);
-    m = applyScalarReceipt(m, 'read', 30);
-    expect(m.status).toBe('read');
-    expect(m.readAt).toBe(30);
-    expect(m.deliveredAt).toBe(20); // unchanged by read
+    m = applyScalarReceipt(m, 'seen', 30);
+    expect(m.status).toBe('seen');
+    expect(m.seenAt).toBe(30);
+    expect(m.deliveredAt).toBe(20); // unchanged by seen
   });
 
-  it('read implies delivered when delivered was skipped', () => {
-    const m = applyScalarReceipt(msg({ status: 'sent' }), 'read', 30);
-    expect(m.status).toBe('read');
+  it('seen implies delivered when delivered was skipped', () => {
+    const m = applyScalarReceipt(msg({ status: 'sent' }), 'seen', 30);
+    expect(m.status).toBe('seen');
     expect(m.deliveredAt).toBe(30);
-    expect(m.readAt).toBe(30);
+    expect(m.seenAt).toBe(30);
   });
 
   it('never regresses and returns the SAME reference on a no-op', () => {
-    const m = msg({ status: 'read', readAt: 30, deliveredAt: 20, sentAt: 10 });
+    const m = msg({ status: 'seen', seenAt: 30, deliveredAt: 20, sentAt: 10 });
     expect(applyScalarReceipt(m, 'delivered', 99)).toBe(m); // same ref → no write
     expect(applyScalarReceipt(m, 'sent', 99)).toBe(m);
-    expect(applyScalarReceipt(m, 'read', 99).status).toBe('read');
+    expect(applyScalarReceipt(m, 'seen', 99).status).toBe('seen');
   });
 
   it('does not mutate the input', () => {
@@ -90,13 +91,13 @@ describe('applyGroupReceipt', () => {
     expect(m.deliveredAt).toBe(12);
   });
 
-  it('does not reach read until EVERY member has read', () => {
+  it('does not reach seen until EVERY member has seen', () => {
     let m = msg({ status: 'delivered', sentAt: 5, receipts: recipients(['a', 'b']) });
-    m = applyGroupReceipt(m, 'read', 20, 'a');
+    m = applyGroupReceipt(m, 'seen', 20, 'a');
     expect(m.status).toBe('delivered');
-    m = applyGroupReceipt(m, 'read', 21, 'b');
-    expect(m.status).toBe('read');
-    expect(m.readAt).toBe(21);
+    m = applyGroupReceipt(m, 'seen', 21, 'b');
+    expect(m.status).toBe('seen');
+    expect(m.seenAt).toBe(21);
   });
 
   it('is order-independent: any permutation yields the same aggregate', () => {
@@ -104,39 +105,39 @@ describe('applyGroupReceipt', () => {
     const inOrder = [
       ['delivered', 10, 'a'],
       ['delivered', 11, 'b'],
-      ['read', 20, 'a'],
-      ['read', 21, 'b'],
+      ['seen', 20, 'a'],
+      ['seen', 21, 'b'],
     ] as const;
     const shuffled = [
-      ['read', 21, 'b'],
+      ['seen', 21, 'b'],
       ['delivered', 10, 'a'],
-      ['read', 20, 'a'],
+      ['seen', 20, 'a'],
       ['delivered', 11, 'b'],
     ] as const;
     const run = (steps: readonly (readonly [string, number, string])[]) =>
       steps.reduce((m, [s, at, who]) => applyGroupReceipt(m, s as never, at, who), base());
     const A = run(inOrder);
     const B = run(shuffled);
-    // Terminal status and the all-read time are order-independent. (The aggregate
-    // deliveredAt can differ when a member reads before it delivers — "read implies
-    // delivered" stamps that member's deliveredAt to the read time — which is the
+    // Terminal status and the all-seen time are order-independent. (The aggregate
+    // deliveredAt can differ when a member sees before it delivers — "seen implies
+    // delivered" stamps that member's deliveredAt to the seen time — which is the
     // existing, intentional behavior; we only guarantee monotonic, stable status.)
-    expect(A.status).toBe('read');
-    expect(B.status).toBe('read');
-    expect(A.readAt).toBe(B.readAt);
-    expect(A.readAt).toBe(21);
+    expect(A.status).toBe('seen');
+    expect(B.status).toBe('seen');
+    expect(A.seenAt).toBe(B.seenAt);
+    expect(A.seenAt).toBe(21);
     expect(A.deliveredAt).toBeDefined();
     expect(B.deliveredAt).toBeDefined();
   });
 
-  it('a late member delivered never regresses an all-read message', () => {
-    let m = msg({ status: 'read', sentAt: 5, receipts: recipients(['a', 'b']) });
+  it('a late member delivered never regresses an all-seen message', () => {
+    let m = msg({ status: 'seen', sentAt: 5, receipts: recipients(['a', 'b']) });
     m.receipts = [
-      { contactId: 'a', deliveredAt: 10, readAt: 20 },
-      { contactId: 'b', deliveredAt: 11, readAt: 21 },
+      { contactId: 'a', deliveredAt: 10, seenAt: 20 },
+      { contactId: 'b', deliveredAt: 11, seenAt: 21 },
     ];
     const out = applyGroupReceipt(m, 'delivered', 99, 'a');
-    expect(out.status).toBe('read'); // clamped
+    expect(out.status).toBe('seen'); // clamped
   });
 
   it('returns the SAME reference when a receipt adds nothing', () => {
@@ -160,19 +161,19 @@ describe('applyDownloadedReceipt — status independence (the bug)', () => {
     expect(out.status).toBe('sent'); // UNCHANGED
     expect(out.sentAt).toBe(10);
     expect(out.deliveredAt).toBeUndefined();
-    expect(out.readAt).toBeUndefined();
+    expect(out.seenAt).toBeUndefined();
     expect(out.downloadedBy).toEqual(['peer']);
   });
 
   it('group: allDownloaded only once every member confirms; status untouched', () => {
-    let m = msg({ status: 'read', sentBlobId: 'blob1', receipts: recipients(['a', 'b']) });
+    let m = msg({ status: 'seen', sentBlobId: 'blob1', receipts: recipients(['a', 'b']) });
     let r = applyDownloadedReceipt(m, 'a', 50);
     expect(r.allDownloaded).toBe(false);
-    expect(r.msg.status).toBe('read');
+    expect(r.msg.status).toBe('seen');
     m = r.msg;
     r = applyDownloadedReceipt(m, 'b', 51);
     expect(r.allDownloaded).toBe(true);
-    expect(r.msg.status).toBe('read'); // STILL untouched
+    expect(r.msg.status).toBe('seen'); // STILL untouched
     expect(r.msg.receipts?.every((x) => x.downloadedAt)).toBe(true);
   });
 
@@ -184,7 +185,7 @@ describe('applyDownloadedReceipt — status independence (the bug)', () => {
   });
 
   it('does not mutate the input message or its receipts', () => {
-    const m = msg({ status: 'read', receipts: recipients(['a', 'b']) });
+    const m = msg({ status: 'seen', receipts: recipients(['a', 'b']) });
     applyDownloadedReceipt(m, 'a', 50);
     expect(m.receipts?.find((x) => x.contactId === 'a')?.downloadedAt).toBeUndefined();
   });
@@ -200,5 +201,62 @@ describe('applyStatusReceipt dispatch', () => {
       'a',
     );
     expect(g.status).toBe('sent'); // group: not all delivered yet
+  });
+});
+
+describe('groupProgress (complete-the-tier counter, spec 1010 FR-004/005)', () => {
+  // Build a roster of N recipients with the given delivered/seen flags.
+  function roster(specs: Array<{ d?: boolean; s?: boolean }>): Receipt[] {
+    return specs.map((x, i) => ({
+      contactId: String.fromCharCode(97 + i),
+      deliveredAt: x.d ? 10 + i : undefined,
+      seenAt: x.s ? 20 + i : undefined,
+    }));
+  }
+
+  it('returns null for a non-group message (no receipts roster)', () => {
+    expect(groupProgress(msg({}))).toBeNull();
+    expect(groupProgress(msg({ receipts: [] }))).toBeNull();
+  });
+
+  it('N from the roster: 0 delivered → Sent tier, no fraction', () => {
+    const p = groupProgress(msg({ receipts: roster([{}, {}, {}]) }));
+    expect(p).toEqual({ tier: 'sent', label: null });
+  });
+
+  it('partial delivered → "Delivered X/N"', () => {
+    const p = groupProgress(msg({ receipts: roster([{ d: true }, {}, {}]) }));
+    expect(p).toEqual({ tier: 'delivered', label: '1/3' });
+  });
+
+  it('all delivered, none seen → delivered tier, no fraction', () => {
+    const p = groupProgress(msg({ receipts: roster([{ d: true }, { d: true }]) }));
+    expect(p).toEqual({ tier: 'delivered', label: null });
+  });
+
+  it('all delivered, partial seen → "Seen X/N"', () => {
+    const p = groupProgress(msg({ receipts: roster([{ d: true, s: true }, { d: true }, { d: true }]) }));
+    expect(p).toEqual({ tier: 'seen', label: '1/3' });
+  });
+
+  it('all seen → "Seen", no fraction', () => {
+    const p = groupProgress(msg({ receipts: roster([{ d: true, s: true }, { d: true, s: true }]) }));
+    expect(p).toEqual({ tier: 'seen', label: null });
+  });
+
+  it('N=1 never shows a fraction (renders like a 1:1)', () => {
+    expect(groupProgress(msg({ receipts: roster([{ d: true }]) }))).toEqual({ tier: 'delivered', label: null });
+    expect(groupProgress(msg({ receipts: roster([{ d: true, s: true }]) }))).toEqual({ tier: 'seen', label: null });
+  });
+
+  it('reciprocity: seenEnabled=false caps at the delivered tier (seen ignored)', () => {
+    const m = msg({ receipts: roster([{ d: true, s: true }, { d: true, s: true }]) });
+    // With seen on, this is fully seen; with it off it must cap at delivered.
+    expect(groupProgress(m, true)).toEqual({ tier: 'seen', label: null });
+    expect(groupProgress(m, false)).toEqual({ tier: 'delivered', label: null });
+    // A partially-seen group with seen off shows the delivered tier (here all
+    // delivered → plain), never a "Seen X/N".
+    const partial = msg({ receipts: roster([{ d: true, s: true }, { d: true }]) });
+    expect(groupProgress(partial, false)).toEqual({ tier: 'delivered', label: null });
   });
 });

--- a/src/services/message-status.ts
+++ b/src/services/message-status.ts
@@ -27,7 +27,7 @@ export const STATUS_ORDER: Record<Message['status'], number> = {
   pending: 0,
   sent: 1,
   delivered: 2,
-  read: 3,
+  seen: 3,
 };
 
 export function statusRank(s: Message['status']): number {
@@ -37,7 +37,7 @@ export function statusRank(s: Message['status']): number {
 /** Statuses a receipt can carry for the *displayed* timeline. `downloaded` is
  *  handled by a separate reducer and is intentionally excluded here, so the
  *  compiler prevents it from ever being assigned to `Message.status`. */
-export type ReceiptStatus = Extract<Message['status'], 'sent' | 'delivered' | 'read'>;
+export type ReceiptStatus = Extract<Message['status'], 'sent' | 'delivered' | 'seen'>;
 
 /** Apply a status receipt to a message, dispatching on whether it's a group
  *  message (has a per-member `receipts[]` roster) or a 1:1 message. Returns the
@@ -59,11 +59,11 @@ export function applyScalarReceipt(msg: Message, status: ReceiptStatus, at: numb
   const next: Message = { ...msg, status };
   // The real "sent" time is when the server accepted it (not when composed).
   if (status === 'sent') next.sentAt ??= at;
-  // Record when delivery/read happened so Message info can show a timeline.
+  // Record when delivery/seen happened so Message info can show a timeline.
   if (status === 'delivered') next.deliveredAt ??= at;
-  if (status === 'read') {
+  if (status === 'seen') {
     next.deliveredAt ??= at;
-    next.readAt = at;
+    next.seenAt = at;
   }
   return next;
 }
@@ -71,9 +71,9 @@ export function applyScalarReceipt(msg: Message, status: ReceiptStatus, at: numb
 /** Group message: every fan-out copy is confirmed independently and the server
  *  stamps each receipt with the member who confirmed it (`recipient`). Record
  *  ONLY that member's row, then derive the message-level status from the whole
- *  roster, WhatsApp-style: delivered only once every member's device has it, read
+ *  roster, WhatsApp-style: delivered only once every member's device has it, seen
  *  only once every member has opened it. (The pre-fix code marked everyone
- *  delivered/read on a single member's receipt.) Returns the same reference when
+ *  delivered/seen on a single member's receipt.) Returns the same reference when
  *  nothing changes. */
 export function applyGroupReceipt(
   msg: Message,
@@ -90,17 +90,17 @@ export function applyGroupReceipt(
     sentAt = at;
     touched = true;
   }
-  if (recipient && (status === 'delivered' || status === 'read')) {
+  if (recipient && (status === 'delivered' || status === 'seen')) {
     const r = recs.find((x) => x.contactId === recipient);
     if (r) {
       if (status === 'delivered' && r.deliveredAt == null) {
         r.deliveredAt = at;
         touched = true;
       }
-      if (status === 'read') {
+      if (status === 'seen') {
         if (r.deliveredAt == null) r.deliveredAt = at;
-        if (r.readAt !== at) {
-          r.readAt = at;
+        if (r.seenAt !== at) {
+          r.seenAt = at;
           touched = true;
         }
       }
@@ -108,30 +108,30 @@ export function applyGroupReceipt(
   }
 
   const allDelivered = recs.length > 0 && recs.every((r) => r.deliveredAt);
-  const allRead = recs.length > 0 && recs.every((r) => r.readAt);
+  const allSeen = recs.length > 0 && recs.every((r) => r.seenAt);
 
   let deliveredAt = msg.deliveredAt;
-  let readAt = msg.readAt;
+  let seenAt = msg.seenAt;
   // Message-level timestamps only once the WHOLE group reaches that state.
   if (allDelivered && deliveredAt == null) deliveredAt = Math.max(...recs.map((r) => r.deliveredAt ?? 0));
-  if (allRead && readAt == null) readAt = Math.max(...recs.map((r) => r.readAt ?? 0));
+  if (allSeen && seenAt == null) seenAt = Math.max(...recs.map((r) => r.seenAt ?? 0));
 
-  const agg: Message['status'] = allRead ? 'read' : allDelivered ? 'delivered' : sentAt ? 'sent' : msg.status;
+  const agg: Message['status'] = allSeen ? 'seen' : allDelivered ? 'delivered' : sentAt ? 'sent' : msg.status;
   // Monotonic clamp: a late member's 'delivered' must never regress an already-
-  // all-read message, and an out-of-order frame can only raise status.
+  // all-seen message, and an out-of-order frame can only raise status.
   const nextStatus = STATUS_ORDER[agg] > STATUS_ORDER[msg.status] ? agg : msg.status;
 
   if (
     !touched &&
     nextStatus === msg.status &&
     deliveredAt === msg.deliveredAt &&
-    readAt === msg.readAt &&
+    seenAt === msg.seenAt &&
     sentAt === msg.sentAt
   ) {
     return msg; // nothing changed
   }
 
-  return { ...msg, receipts: recs, status: nextStatus, sentAt, deliveredAt, readAt };
+  return { ...msg, receipts: recs, status: nextStatus, sentAt, deliveredAt, seenAt };
 }
 
 /** A recipient confirmed they hold our media's bytes. Stamps the cleanup
@@ -158,4 +158,40 @@ export function applyDownloadedReceipt(
   if (already) return { msg, allDownloaded: true };
   const downloadedBy = [...new Set([...(msg.downloadedBy ?? []), recipient])];
   return { msg: { ...msg, downloadedBy }, allDownloaded: true };
+}
+
+/** Which tier's icon/colour a group bubble shows. `sent` = single tick; `delivered`
+ *  and `seen` = the double tick (seen tinted "seen-blue"). */
+export type GroupTier = 'sent' | 'delivered' | 'seen';
+
+/** Derived progress of an outgoing GROUP message, for the compact bubble counter
+ *  (spec 1010 FR-004/005). `complete-the-tier`: N = the recipient roster (the
+ *  embedded `receipts[]`, which already excludes the sender); the indicator climbs
+ *  "Delivered X/N" until all N delivered, then "Seen X/N" until all N seen, then
+ *  settles to a plain "Seen". The fraction (`label`) is shown ONLY while a tier is
+ *  partial (1 ≤ X < N) — so an N=1 group never shows one (it renders like a 1:1).
+ *
+ *  `seenEnabled` is the local reciprocity gate (privacy.seenReceipts): when off,
+ *  the caller doesn't get to see others' seen state on their own messages, so the
+ *  seen tier is suppressed and the indicator caps at delivered.
+ *
+ *  Returns `null` for a non-group message (no `receipts[]`) — the caller renders
+ *  the plain 1:1 tick. Pre-send states (compressing/pending/failed) are the
+ *  caller's concern; here `delivered == 0` simply yields the `sent` tier. */
+export function groupProgress(
+  msg: Pick<Message, 'receipts'>,
+  seenEnabled = true,
+): { tier: GroupTier; label: string | null } | null {
+  const recs = msg.receipts;
+  if (!recs || recs.length === 0) return null;
+  const n = recs.length;
+  const delivered = recs.reduce((acc, r) => acc + (r.deliveredAt ? 1 : 0), 0);
+  const seen = seenEnabled ? recs.reduce((acc, r) => acc + (r.seenAt ? 1 : 0), 0) : 0;
+
+  if (delivered === 0) return { tier: 'sent', label: null };
+  if (delivered < n) return { tier: 'delivered', label: `${delivered}/${n}` };
+  // All delivered → the seen tier governs from here.
+  if (seen === 0) return { tier: 'delivered', label: null };
+  if (seen < n) return { tier: 'seen', label: `${seen}/${n}` };
+  return { tier: 'seen', label: null };
 }

--- a/src/services/showcase-seed.ts
+++ b/src/services/showcase-seed.ts
@@ -79,7 +79,7 @@ function message(
     kind: 'text',
     timestamp: Date.now() - ageMs,
     outgoing,
-    status: 'read',
+    status: 'seen',
     updatedAt: Date.now(),
     ...extra,
   };
@@ -126,12 +126,12 @@ export async function seedShowcase(): Promise<void> {
   const aliceImg = message('sc-alice', 'me', 'Sunrise from the hike this morning ⛰️', 40 * MIN, {
     kind: 'image',
     mediaId: photoId,
-    status: 'read',
+    status: 'seen',
     reactions: [{ userId: 'sc-alice', emoji: '❤️', at: now - 35 * MIN }],
   });
   messages.push(
     message('sc-alice', 'sc-alice', 'Morning! Did you try the new Ring update? 🎉', 2 * HOUR),
-    message('sc-alice', 'me', 'Yes! The "What’s new" sheet is such a nice touch', 110 * MIN, { status: 'read' }),
+    message('sc-alice', 'me', 'Yes! The "What’s new" sheet is such a nice touch', 110 * MIN, { status: 'seen' }),
     message('sc-alice', 'sc-alice', 'Voice message', 90 * MIN, { kind: 'voice', mediaId: voiceId, durationSec: 12 }),
     aliceImg,
     message('sc-alice', 'sc-alice', 'Gorgeous! Where is this?', 30 * MIN, {
@@ -160,7 +160,7 @@ export async function seedShowcase(): Promise<void> {
   // --- Group: Weekend Trip ---
   const groupMembers = ['sc-alice', 'sc-daniel', 'sc-sofia'];
   const myMsg = message('sc-trip', 'me', "Perfect, I’ll bring snacks 🍫", 4 * HOUR, {
-    status: 'read',
+    status: 'seen',
     reactions: [{ userId: 'sc-sofia', emoji: '👍', at: now - 3.5 * HOUR }],
   });
   messages.push(

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -31,7 +31,7 @@ export function setSyncCursor(cursor: string): Promise<void> {
 /* ---- push ---- */
 
 let draining = false;
-// An outbox entry stays until the server CONFIRMS it (a 'sent'/'delivered'/'read'
+// An outbox entry stays until the server CONFIRMS it (a 'sent'/'delivered'/'seen'
 // receipt removes it). Until then it's re-sent on reconnect and on a periodic
 // grace tick; re-sends are idempotent server-side (relay_queue is unique on
 // recipient,msg_id). This is what closes the loss window where the server received
@@ -56,7 +56,7 @@ export async function drainOutbox(transport: Transport): Promise<number> {
       if (entry.sentAt && now - entry.sentAt < ACK_GRACE_MS) continue;
       // Sent repeatedly but never confirmed → give up so the user sees it failed.
       // (Idempotency means no duplicate was created; if it HAD reached the server, a
-      // later delivered/read receipt advances it past 'failed' on its own.)
+      // later delivered/seen receipt advances it past 'failed' on its own.)
       if (entry.attempts >= MAX_SENDS) {
         if (entry.frame.t === 'msg' && entry.frame.id) await markSendFailed(entry.frame.id);
         await removeOutbox(entry.id);
@@ -122,7 +122,7 @@ export async function handleIncomingFrame(frame: Frame): Promise<void> {
       return;
     case 'msg':
       // Inbound relayed message: decrypt + store under the SENDER's message id
-      // (so read receipts we send back correlate on their side). The ack (which
+      // (so seen receipts we send back correlate on their side). The ack (which
       // clears the server queue and triggers the sender's delivered receipt) is
       // sent by useSync after this resolves.
       await receiveIncoming(frame.from ?? '', frame.id, frame.ciphertext);
@@ -181,7 +181,7 @@ async function applyReceipt(
   // Scoped to `recipient` so one group member's receipt never evicts the still-unsent
   // copies addressed to the other members. Done before the local-message lookup so it
   // still fires for a message row that's since been pruned locally.
-  if (status === 'sent' || status === 'delivered' || status === 'read') {
+  if (status === 'sent' || status === 'delivered' || status === 'seen') {
     await removeOutboxByFrameId(messageId, recipient);
   }
   // Status derivation is a pure reducer (see message-status.ts, fully unit-tested);

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -10,7 +10,7 @@
 import { register, getSelfUserId, getSelfUsername } from '@/services/auth';
 import { syncDirectory, importDirectoryUser, searchDirectory, publishOwnProfile } from '@/services/directory';
 import { previewPending } from '@/services/sw-inbox';
-import { disconnectTransport, nudgeReconnect, forceReconnect, sendDownloadedReceipts } from '@/composables/useSync';
+import { disconnectTransport, nudgeReconnect, forceReconnect, sendDownloadedReceipts, sendSeenReceipts, applySeenPref } from '@/composables/useSync';
 import {
   ensureIdentity,
   isUnlocked,
@@ -315,6 +315,17 @@ export function installTestHook(): void {
         preview: m.body || m.kind,
       });
     },
+    /* ---- seen receipts (spec 1010) ---- */
+    /** Send 'seen' receipts for a chat's incoming messages (what the UI does when the
+     *  chat is viewed). A no-op when the "Seen receipts" privacy toggle is off. */
+    markSeen: (chatId: string) => sendSeenReceipts(chatId),
+    /** Re-read the privacy.seenReceipts toggle into the emit gate (deterministic
+     *  alternative to waiting for the settings-change reaction in tests). */
+    applySeenPref: () => applySeenPref(),
+    /** A message's per-member receipts roster {contactId, deliveredAt, seenAt,
+     *  downloadedAt}, for asserting "Seen X/N" group progress + the info-page lists. */
+    messageReceipts: async (messageId: string) => (await dbGetMessage(messageId))?.receipts ?? [],
+
     /** Add/toggle the local user's emoji reaction on a message. */
     reactToMessage: (messageId: string, emoji: string) => dbReactToMessage(messageId, emoji),
     /** The most-used-first quick-react set (the menu's emoji row order). Lets e2e

--- a/src/services/transport.ts
+++ b/src/services/transport.ts
@@ -27,11 +27,11 @@ export interface MsgFrame {
 export interface ReceiptFrame {
   t: 'receipt';
   messageId: string;
-  // 'downloaded' is recipient-originated like 'read', but signals the media bytes are on
+  // 'downloaded' is recipient-originated like 'seen', but signals the media bytes are on
   // their device (not a UI tick) so the sender can delete the server blob.
-  status: 'sent' | 'delivered' | 'read' | 'downloaded';
+  status: 'sent' | 'delivered' | 'seen' | 'downloaded';
   at: number;
-  to?: string; // recipient (for client-originated read receipts; routed by the server)
+  to?: string; // recipient (for client-originated seen receipts; routed by the server)
   from?: string; // server 'sent'/'delivered' receipts: WHICH recipient confirmed it
   // (scopes the sender's outbox removal: a group message has one copy per member,
   // all sharing the message id, so a receipt must only clear the confirmed copy).
@@ -365,7 +365,7 @@ export class MockTransport implements Transport {
       // removal works if this loopback is ever swapped back in for the real transport.
       this.schedule(SENT_MS, () => this.emit({ t: 'receipt', messageId: frame.id, status: 'sent', at: Date.now(), from: frame.to }));
       this.schedule(DELIVERED_MS, () => this.emit({ t: 'receipt', messageId: frame.id, status: 'delivered', at: Date.now(), from: frame.to }));
-      this.schedule(READ_MS, () => this.emit({ t: 'receipt', messageId: frame.id, status: 'read', at: Date.now(), from: frame.to }));
+      this.schedule(READ_MS, () => this.emit({ t: 'receipt', messageId: frame.id, status: 'seen', at: Date.now(), from: frame.to }));
     } else if (frame.t === 'tombstone') {
       this.emit({ t: 'ack', refId: `${frame.store}:${frame.recordId}` });
     } else if (frame.t === 'pull') {

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -258,9 +258,9 @@ export const SETTINGS: Record<string, SettingNode> = {
         footer: 'Start new chats with disappearing messages set to your timer.',
       },
       {
-        items: [{ type: 'toggle', title: 'Read receipts', key: 'privacy.readReceipts', default: true }],
+        items: [{ type: 'toggle', title: 'Seen receipts', key: 'privacy.seenReceipts', default: true }],
         footer:
-          'If you turn off read receipts, you won’t be able to see read receipts from other people. Read receipts are always sent for group chats.',
+          'If you turn off seen receipts, you won’t send them and you won’t see when other people have seen your messages either. This applies to both one-to-one and group chats.',
       },
       {
         items: [

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -401,12 +401,19 @@
                 </button>
                 <span class="time">
                   <span v-if="m.editedAt" class="edited">edited</span>
+                  <!-- Group "X/N" sits to the LEFT of the clock so it grows/shrinks into the
+                       footer's floating edge (like the "edited" tag) — the clock + tick stay a
+                       stable right-anchored unit and never slide as the count appears/disappears. -->
+                  <span
+                    v-if="m.outgoing && m.status !== 'failed' && m.receipts && m.receipts.length > 1"
+                    class="tick-count"
+                  >{{ tickInfo(m).fraction }}</span>
                   {{ formatClock(m.sentAt ?? m.timestamp) }}
                   <ion-icon
                     v-if="m.outgoing && m.status !== 'failed'"
                     class="tick"
-                    :class="{ read: m.status === 'read' }"
-                    :icon="statusIcon(m.status)"
+                    :class="{ seen: tickInfo(m).seen }"
+                    :icon="tickInfo(m).icon"
                   />
                 </span>
               </div>
@@ -539,12 +546,17 @@
                   <ion-icon :icon="happyOutline" />
                 </button>
                 <span class="time">
+                  <!-- Count to the LEFT of the clock so the clock + tick stay put as it toggles. -->
+                  <span
+                    v-if="item.messages[0].outgoing && item.messages[item.messages.length - 1].status !== 'failed' && item.messages[item.messages.length - 1].receipts && item.messages[item.messages.length - 1].receipts!.length > 1"
+                    class="tick-count"
+                  >{{ tickInfo(item.messages[item.messages.length - 1]).fraction }}</span>
                   {{ formatClock(item.messages[item.messages.length - 1].timestamp) }}
                   <ion-icon
-                    v-if="item.messages[0].outgoing"
+                    v-if="item.messages[0].outgoing && item.messages[item.messages.length - 1].status !== 'failed'"
                     class="tick"
-                    :class="{ read: item.messages[item.messages.length - 1].status === 'read' }"
-                    :icon="statusIcon(item.messages[item.messages.length - 1].status)"
+                    :class="{ seen: tickInfo(item.messages[item.messages.length - 1]).seen }"
+                    :icon="tickInfo(item.messages[item.messages.length - 1]).icon"
                   />
                 </span>
               </div>
@@ -846,12 +858,13 @@ import {
   reactToMessage, deleteMessage, softDeleteMessage, deleteMessageForEveryone, editMessage,
   toggleFavorite, setCaption, forwardMessage,
   quickReactEmojis,
-  MAX_REACTIONS_PER_USER,
+  MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS,
   retryMediaMessage, resumePendingMediaJobs, downloadMessageMedia,
   sendLocation, sendPoll, sendContact, votePoll, messageSharedContact,
   unblockContact, detectTerminated, firstMessageOnOrAfter, countUnread,
-  CAPTION_MAX,
+  CAPTION_MAX, getSetting,
 } from '@/db/queries';
+import { groupProgress } from '@/services/message-status';
 import { getSelfUserId } from '@/services/auth';
 import MessageActions from '@/components/MessageActions.vue';
 import QuickReactBar from '@/components/QuickReactBar.vue';
@@ -893,7 +906,7 @@ import {
   type AudioTrackMeta,
 } from '@/composables/useAudioPlayer';
 import { isUnlocked, isUnlockedNow } from '@/services/crypto/identity';
-import { sendReadReceipts, sendDownloadedReceipts, sendActivity, sendGroupActivity } from '@/composables/useSync';
+import { sendSeenReceipts, sendDownloadedReceipts, sendActivity, sendGroupActivity } from '@/composables/useSync';
 import { peerPresence, presenceLabel } from '@/composables/usePresence';
 import { activityFor, activityKindLabel, coalescedActivityLabel } from '@/composables/useTyping';
 import { ACTIVITY, type ActivityKind, type ActivityState } from '@/services/transport';
@@ -1050,7 +1063,37 @@ function jobPct(id: string, phase: 'compress' | 'upload'): string {
 function statusIcon(status: MessageStatus) {
   if (status === 'compressing' || status === 'pending') return timeOutline;
   if (status === 'sent') return checkmark;
-  return checkmarkDone; // delivered & read
+  return checkmarkDone; // delivered & seen
+}
+
+// The "Seen receipts" privacy preference (default on), reactive. Drives the
+// reciprocity DISPLAY gate (spec 1010 FR-009): when off we don't render the seen
+// tier on our own sent messages (it caps at delivered), mirroring the emit gate in
+// useSync.
+const seenReceiptsOn = useLiveQuery(
+  () => getSetting<boolean>('privacy.seenReceipts', true),
+  ['settings'],
+  true,
+);
+
+// Compact per-bubble status for an outgoing message: the tick icon, whether to
+// tint it "seen-blue", and the optional GROUP "X/N" fraction (spec 1010 FR-004/005).
+// Groups derive complete-the-tier progress from receipts[] (N = recipients); 1:1
+// shows the plain tick. The fraction appears only while a tier is partial — so a
+// fully-seen group, an N=1 group, and every 1:1 render with no fraction.
+function tickInfo(m: Message): { icon: string; seen: boolean; fraction: string | null } {
+  if (m.status === 'compressing' || m.status === 'pending') {
+    return { icon: timeOutline, seen: false, fraction: null };
+  }
+  if (chat.value?.isGroup && m.receipts?.length) {
+    const p = groupProgress(m, seenReceiptsOn.value);
+    return {
+      icon: p && p.tier === 'sent' ? checkmark : checkmarkDone,
+      seen: p?.tier === 'seen',
+      fraction: p?.label ?? null,
+    };
+  }
+  return { icon: statusIcon(m.status), seen: seenReceiptsOn.value && m.status === 'seen', fraction: null };
 }
 
 const selfId = getSelfUserId() ?? '';
@@ -1080,9 +1123,13 @@ const myEmojisFor = (m: Message) =>
 
 // React, surfacing the 3-reaction cap if it's hit (tapping a chip or a quick emoji).
 async function onReact(messageId: string, emoji: string): Promise<void> {
-  if ((await reactToMessage(messageId, emoji)) === 'limit') {
+  const result = await reactToMessage(messageId, emoji);
+  if (result === 'limit' || result === 'limit-emojis') {
     const t = await toastController.create({
-      message: 'You can add up to 3 reactions.',
+      message:
+        result === 'limit-emojis'
+          ? `This message already has ${MAX_DISTINCT_REACTIONS} different reactions — tap one of those instead.`
+          : `You can add up to ${MAX_REACTIONS_PER_USER} reactions.`,
       duration: 1600,
       position: 'top',
     });
@@ -1271,10 +1318,15 @@ const popoverSide = (ev: Event): 'top' | 'bottom' =>
 // Tap on the reaction button → a transient popover of the 7 most-used emoji + "+".
 async function openQuickReact(m: Message, ev: Event): Promise<void> {
   await dismissOpenPopovers();
+  // When the message is at the distinct-emoji cap, offer ONLY its existing emojis
+  // (and drop the "+ more" picker) — you can react with what's there but can't add a
+  // new one (spec: max MAX_DISTINCT_REACTIONS different emojis per message).
+  const existing = [...new Set((m.reactions ?? []).map((r) => r.emoji))];
+  const atEmojiCap = existing.length >= MAX_DISTINCT_REACTIONS;
   const popover = await popoverController.create({
     component: QuickReactBar,
     cssClass: 'reaction-popover quick-react-popover',
-    componentProps: { myEmojis: myEmojisFor(m), quick: await quickReactEmojis(5) },
+    componentProps: { myEmojis: myEmojisFor(m), quick: await quickReactEmojis(5), existing, atEmojiCap },
     event: ev,
     reference: 'event',
     side: popoverSide(ev),
@@ -1943,7 +1995,7 @@ const peerGhosted = computed(
 const peerBlocked = computed(() => peerContact.value?.blocked === true);
 
 // Opening the conversation clears its unread count (and the Chats badge) and
-// sends 'read' receipts to the sender (the blue "seen" checks on their side).
+// sends 'seen' receipts to the sender (the blue "seen" checks on their side).
 // viewActive tracks whether the chat is actually on-screen, so we only mark
 // messages seen while it's visible (Ionic keeps pages alive in the background).
 const viewActive = ref(false);
@@ -2002,15 +2054,16 @@ onUnmounted(() => {
   clearTimeout(listReadyFallback);
   resizeObs?.disconnect();
 });
-// Send 'read' ("seen") receipts ONLY when the user is genuinely looking at this
-// chat: its view is the active one AND the app is foregrounded (document visible).
-// A message that arrives via push while the app is backgrounded (screen off /
-// another app) must NOT be marked seen just because the chat view is still mounted
-// so the sender would see a false "seen". The receipt is sent instead when the user
-// returns to the foregrounded chat (onVisibilityChange) or opens it.
+// Send 'seen' receipts ONLY when the user is genuinely looking at this chat: its
+// view is the active one AND the app is foregrounded (document visible). A message
+// that arrives via push while the app is backgrounded (screen off / another app)
+// must NOT be marked seen just because the chat view is still mounted, or the
+// sender would see a false "seen". The receipt is sent instead when the user
+// returns to the foregrounded chat (onVisibilityChange) or opens it. (sendSeenReceipts
+// is itself a no-op when the "Seen receipts" privacy toggle is off.)
 function markChatSeenIfVisible(): void {
   if (viewActive.value && document.visibilityState === 'visible') {
-    void sendReadReceipts(chatId);
+    void sendSeenReceipts(chatId);
     void sendDownloadedReceipts(chatId); // free server blobs once we hold the media
   }
 }
@@ -3260,6 +3313,15 @@ function cancelRecording() {
 .bubble.out {
   background: var(--app-bubble-out);
 }
+/* Reserve a minimum bubble width that fits ~3 reaction pills side by side, so a
+   short message NEVER (a) shrinks when the react button hides at the 3-reaction cap,
+   nor (b) ends up narrower than its own reactions row (which would overhang to the
+   side). Applies to every text bubble regardless of content length; media / video-
+   note bubbles size to their media and are excluded. Logical prop → RTL-correct. A
+   long message exceeds this floor, so it's unaffected. */
+.bubble:not(.bubble-media):not(.bubble-plain) {
+  min-inline-size: 9.75rem;
+}
 /* A round video note has no chat bubble behind it; instead the circle gets a
    thin frame ring and its timestamp sits in a small pill, both matching the
    in/out bubble colour. */
@@ -3910,8 +3972,28 @@ function cancelRecording() {
   font-size: 16px;
 }
 /* WhatsApp-style blue "seen" double-check. */
-.tick.read {
+.tick.seen {
   color: #34b7f1;
+}
+/* Compact group progress count ("3/5") (spec 1010). Rendered just to the inline-start
+   of the timestamp (not between clock and tick): the clock + tick form a stable
+   right-anchored unit, and the count — like the "edited" tag — grows into the footer's
+   floating edge, so it can appear/disappear without ever shifting the timestamp.
+
+   The slot is RESERVED (min-inline-size) on every group-with-≥2-recipients outgoing
+   message for its whole lifecycle, even when the fraction is absent (sent / all-
+   delivered / all-seen). That keeps the footer — and therefore a short bubble whose
+   width the footer drives — a CONSTANT width, so the bubble doesn't resize as the
+   count toggles. text-align:end keeps the digits hugging the timestamp; the reserved
+   blank sits to their inline-start. tabular-nums steadies a given count's width;
+   logical properties mirror in RTL. */
+.tick-count {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+  margin-inline-end: 2px;
+  min-inline-size: 2.6em; /* fits up to ~2-digit "NN/NN" so the bubble never jumps */
+  text-align: end;
 }
 .bubble-image {
   /* Fills the fixed media frame (cropped to cover). */

--- a/src/views/detail/MessageInfoPage.vue
+++ b/src/views/detail/MessageInfoPage.vue
@@ -20,55 +20,82 @@
             <ion-icon
               class="tick"
               :icon="statusIcon(message.status)"
-              :color="message.status === 'read' ? 'primary' : undefined"
+              :color="seenReceiptsOn && message.status === 'seen' ? 'primary' : undefined"
             />
           </ion-note>
         </ion-item>
       </ion-list>
 
-      <!-- Group: per-recipient read / delivered lists -->
+      <!-- Group: per-member Seen by / Delivered / Not yet delivered, covering every
+           member of the roster (spec 1010 FR-006). Each tier shows a capped avatar
+           stack (5 + "+N") plus the members' names. -->
       <template v-if="isGroup">
-        <ion-list :inset="true">
+        <!-- Seen by — suppressed entirely when "Seen receipts" is off (reciprocity:
+             you don't get to see others' seen on your own messages). -->
+        <ion-list :inset="true" v-if="seenReceiptsOn">
           <ion-list-header>
             <ion-icon :icon="checkmarkDone" color="primary" />
-            <ion-label>Read by</ion-label>
+            <ion-label>Seen by</ion-label>
           </ion-list-header>
-          <ion-item v-for="r in readBy" :key="r.contactId">
-            <ion-avatar slot="start">
-              <img :src="avatarFor(r.contactId)" :alt="nameFor(r.contactId)" />
-            </ion-avatar>
-            <ion-label>{{ nameFor(r.contactId) }}</ion-label>
-            <ion-note slot="end">{{ formatTime(r.readAt!) }}</ion-note>
-          </ion-item>
-          <ion-item v-if="readBy.length === 0" lines="none">
-            <ion-note>No one yet</ion-note>
+          <ion-item lines="none">
+            <div class="tier" v-if="seenByIds.length">
+              <div class="avatar-stack">
+                <ion-avatar v-for="id in stackIds(seenByIds)" :key="id">
+                  <img :src="avatarFor(id)" :alt="nameFor(id)" />
+                </ion-avatar>
+                <span v-if="overflowCount(seenByIds)" class="stack-more">+{{ overflowCount(seenByIds) }}</span>
+              </div>
+              <ion-label class="ion-text-wrap names">{{ namesLine(seenByIds) }}</ion-label>
+            </div>
+            <ion-note v-else>No one yet</ion-note>
           </ion-item>
         </ion-list>
 
         <ion-list :inset="true">
           <ion-list-header>
             <ion-icon :icon="checkmarkDone" />
-            <ion-label>Delivered to</ion-label>
+            <ion-label>Delivered</ion-label>
           </ion-list-header>
-          <ion-item v-for="r in deliveredTo" :key="r.contactId">
-            <ion-avatar slot="start">
-              <img :src="avatarFor(r.contactId)" :alt="nameFor(r.contactId)" />
-            </ion-avatar>
-            <ion-label>{{ nameFor(r.contactId) }}</ion-label>
-            <ion-note slot="end">{{ formatTime(r.deliveredAt!) }}</ion-note>
+          <ion-item lines="none">
+            <div class="tier" v-if="deliveredIds.length">
+              <div class="avatar-stack">
+                <ion-avatar v-for="id in stackIds(deliveredIds)" :key="id">
+                  <img :src="avatarFor(id)" :alt="nameFor(id)" />
+                </ion-avatar>
+                <span v-if="overflowCount(deliveredIds)" class="stack-more">+{{ overflowCount(deliveredIds) }}</span>
+              </div>
+              <ion-label class="ion-text-wrap names">{{ namesLine(deliveredIds) }}</ion-label>
+            </div>
+            <ion-note v-else>No one yet</ion-note>
           </ion-item>
-          <ion-item v-if="deliveredTo.length === 0" lines="none">
-            <ion-note>No one yet</ion-note>
+        </ion-list>
+
+        <ion-list :inset="true">
+          <ion-list-header>
+            <ion-icon :icon="checkmark" />
+            <ion-label>Not yet delivered</ion-label>
+          </ion-list-header>
+          <ion-item lines="none">
+            <div class="tier" v-if="notDeliveredIds.length">
+              <div class="avatar-stack">
+                <ion-avatar v-for="id in stackIds(notDeliveredIds)" :key="id">
+                  <img :src="avatarFor(id)" :alt="nameFor(id)" />
+                </ion-avatar>
+                <span v-if="overflowCount(notDeliveredIds)" class="stack-more">+{{ overflowCount(notDeliveredIds) }}</span>
+              </div>
+              <ion-label class="ion-text-wrap names">{{ namesLine(notDeliveredIds) }}</ion-label>
+            </div>
+            <ion-note v-else>Everyone has it</ion-note>
           </ion-item>
         </ion-list>
       </template>
 
       <!-- 1:1: simple status timeline -->
       <ion-list :inset="true" v-else-if="message">
-        <ion-item v-if="reached('read')">
+        <ion-item v-if="seenReceiptsOn && reached('seen')">
           <ion-icon slot="start" :icon="checkmarkDone" color="primary" />
-          <ion-label>Read</ion-label>
-          <ion-note v-if="message.readAt" slot="end">{{ formatTime(message.readAt) }}</ion-note>
+          <ion-label>Seen</ion-label>
+          <ion-note v-if="message.seenAt" slot="end">{{ formatTime(message.seenAt) }}</ion-note>
         </ion-item>
         <ion-item v-if="reached('delivered')">
           <ion-icon slot="start" :icon="checkmarkDone" />
@@ -93,8 +120,8 @@ import {
   IonContent, IonList, IonListHeader, IonItem, IonAvatar, IonLabel,
   IonNote, IonIcon,
 } from '@ionic/vue';
-import { timeOutline, checkmark, checkmarkDone } from 'ionicons/icons';
-import { getMessage, getChat, listContacts } from '@/db/queries';
+import { checkmark, checkmarkDone, timeOutline } from 'ionicons/icons';
+import { getMessage, getChat, listContacts, getSetting } from '@/db/queries';
 import { initialsAvatar } from '@/db/avatars';
 import type { Chat, Contact, Message, MessageStatus } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
@@ -112,9 +139,18 @@ const message = useLiveQuery<Message | undefined>(
 const chat = useLiveQuery<Chat | undefined>(() => getChat(chatId), ['chats'], undefined);
 const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
 
-// Per-recipient (Read by / Delivered to) lists are a group concept; branch on the
-// chat being a group rather than on the message carrying a receipts array, so the
-// right panel shows even for an edge-case row and never shows for a stray 1:1 one.
+// "Seen receipts" privacy preference (default on), reactive. Reciprocity DISPLAY
+// gate (spec 1010 FR-009): when off, we don't render the seen tier on our own
+// messages — seen members fall back into "Delivered" and the top tick isn't blue.
+const seenReceiptsOn = useLiveQuery(
+  () => getSetting<boolean>('privacy.seenReceipts', true),
+  ['settings'],
+  true,
+);
+
+// Per-member lists are a group concept; branch on the chat being a group rather
+// than on the message carrying a receipts array, so the right panel shows even for
+// an edge-case row and never shows for a stray 1:1 one.
 const isGroup = computed(() => chat.value?.isGroup === true && !!message.value?.receipts);
 
 const contactMap = computed(
@@ -125,18 +161,47 @@ const nameFor = (id: string) => contactMap.value.get(id)?.name ?? 'Unknown';
 // members whose contact row was pruned (e.g. someone who left the group).
 const avatarFor = (id: string) => contactMap.value.get(id)?.avatar || initialsAvatar(nameFor(id));
 
-const readBy = computed(() =>
-  (message.value?.receipts ?? [])
-    .filter((r) => r.readAt)
-    .sort((a, b) => (a.readAt ?? 0) - (b.readAt ?? 0)),
+const receipts = computed(() => message.value?.receipts ?? []);
+const participantIds = computed(() => chat.value?.participantIds ?? []);
+
+// Seen by — only when seen receipts are on (otherwise the tier is suppressed and
+// these members show as merely Delivered). Sorted by when they saw it.
+const seenByIds = computed(() =>
+  seenReceiptsOn.value
+    ? receipts.value
+        .filter((r) => r.seenAt)
+        .sort((a, b) => (a.seenAt ?? 0) - (b.seenAt ?? 0))
+        .map((r) => r.contactId)
+    : [],
 );
-const deliveredTo = computed(() =>
-  (message.value?.receipts ?? [])
-    .filter((r) => r.deliveredAt && !r.readAt)
-    .sort((a, b) => (a.deliveredAt ?? 0) - (b.deliveredAt ?? 0)),
+// Delivered but not (shown as) seen. With seen receipts off, every delivered
+// member lands here (the seen tier is hidden).
+const deliveredIds = computed(() =>
+  receipts.value
+    .filter((r) => r.deliveredAt && !(seenReceiptsOn.value && r.seenAt))
+    .sort((a, b) => (a.deliveredAt ?? 0) - (b.deliveredAt ?? 0))
+    .map((r) => r.contactId),
+);
+// Not yet delivered = every roster member with no delivered receipt (FR-011), so
+// the three tiers together account for every member.
+const notDeliveredIds = computed(() =>
+  participantIds.value.filter(
+    (id) => !receipts.value.some((r) => r.contactId === id && r.deliveredAt),
+  ),
 );
 
-const order: MessageStatus[] = ['pending', 'sent', 'delivered', 'read'];
+// Capped avatar stack (FR-006 / large-group edge case): show up to 5 avatars then
+// a "+N" overflow, with the names listed alongside.
+const STACK_CAP = 5;
+const stackIds = (ids: string[]): string[] => ids.slice(0, STACK_CAP);
+const overflowCount = (ids: string[]): number => Math.max(0, ids.length - STACK_CAP);
+const namesLine = (ids: string[]): string => {
+  const shown = ids.slice(0, STACK_CAP).map(nameFor);
+  const extra = ids.length - shown.length;
+  return extra > 0 ? `${shown.join(', ')} +${extra} more` : shown.join(', ');
+};
+
+const order: MessageStatus[] = ['pending', 'sent', 'delivered', 'seen'];
 const reached = (s: MessageStatus) =>
   !!message.value && order.indexOf(message.value.status) >= order.indexOf(s);
 
@@ -160,5 +225,36 @@ function mediaLabel(kind: Message['kind']) {
   font-size: 15px;
   vertical-align: -2px;
   margin-inline-start: 3px;
+}
+/* Overlapping avatar stack for each per-member tier; logical margins so it mirrors
+   correctly in RTL. */
+.tier {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 4px 0;
+}
+.avatar-stack {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.avatar-stack ion-avatar {
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--ion-background-color, #fff);
+  margin-inline-start: -8px;
+}
+.avatar-stack ion-avatar:first-child {
+  margin-inline-start: 0;
+}
+.stack-more {
+  margin-inline-start: 6px;
+  font-size: 13px;
+  opacity: 0.7;
+}
+.names {
+  font-size: 14px;
 }
 </style>


### PR DESCRIPTION
## Spec 1010 — Group "Seen" Receipts (durable, private, counted)

Makes group receipts complete and correct on top of the existing receipt/relay machinery.

### What's in it
- **Rename read → seen** end-to-end (UI, status enum, wire value) with a one-time **IndexedDB `DB_VERSION 5 → 6`** forward migration (`status`/`readAt`/`receipts[].readAt` → `seen`/`seenAt`), preserving history with no status regression.
- **Durable per-member seen**: a new server `seen` table + store + `POST /v1/seen/check` + reconnect reconcile, mirroring the `deliveries` machinery, so **"Seen X/N" survives the sender being offline**. Same age-sweep/retention as `deliveries`.
- **Reciprocal "Seen receipts" privacy toggle** (default on), enforced **entirely client-side**: emit gate (off ⇒ never send) + reciprocity display gate (off ⇒ don't render others' seen). The server is never told the preference.
- **Group progress counter** on the bubble — complete-the-tier `Delivered X/N → Seen X/N → Seen` (recipients-only N, partial-only) — and **Seen by / Delivered / Not-yet-delivered** member lists with avatars in message info.

### Zero-knowledge
The `seen` store holds the same `(sender, recipient, msg_id, seen_at)` metadata shape already stored for `deliveries` — **no new class of server-visible metadata, no message content**, no preference column.

### Polish added during review (verified live in mobile emulation)
- The counter renders to the inline-start of the timestamp and **reserves its slot**, so it never shifts the timestamp or resizes the bubble as it toggles.
- A **minimum bubble width** so the react button hiding (at the 3-reaction cap) doesn't shrink the bubble and reactions never overhang it.
- **Cap a message at 5 distinct emoji reactions** — once reached you can pile onto an existing emoji but not add a new one (the quick-react picker offers only the existing emojis at the cap).

### Tests / gates (all green locally)
`npm run build` · `go build/vet/test ./...` · `vitest` (147) · `npm run test:e2e` (`group-seen-receipts.spec.ts`: counter climb, offline durability, toggle reciprocity, 1:1 unchanged) + reactions/quick-react/groups specs.

### Notes
- The reaction polish + 5-distinct cap were maintainer-directed refinements added alongside this spec.
- Marking spec 1010 **shipped** + roadmap regen will follow as a separate docs PR (per the spec-1009 precedent).

Closes #101
Closes #102
Closes #103
Closes #104
Closes #105
Closes #106
Closes #107
Closes #108
Closes #109
Closes #110
Closes #111
Closes #112
Closes #113
Closes #114
Closes #115
Closes #116
Closes #117
Closes #118
Closes #119
Closes #120
Closes #121
Closes #122
Closes #123
Closes #124
Closes #125
Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
