### PR TITLE
docs(spec): mark 1010 shipped; regen roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ Specs are grouped by category band; status moves
 | [1007](specs/1007-media-playback-and/spec.md) | Media Playback & Embedded Thumbnails | 🟢 shipped |
 | [1008](specs/1008-one-tap-media/spec.md) | One-Tap Media Open & Inline Quick-React Bar | 🟢 shipped |
 | [1009](specs/1009-activity-indicators/spec.md) | Ephemeral Activity Indicators (Typing & Recording) | 🟢 shipped |
-| [1010](specs/1010-group-seen-receipts/spec.md) | Group "Seen" Receipts — Durable, Private, and Counted | ⚪ planned |
+| [1010](specs/1010-group-seen-receipts/spec.md) | Group "Seen" Receipts — Durable, Private, and Counted | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1010-group-seen-receipts/spec.md
+++ b/specs/1010-group-seen-receipts/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-17
 
-**Status**: planned
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Marks spec **1010 — Group "Seen" Receipts** as `shipped` now that the implementation has merged to `develop` (#127), and regenerates `ROADMAP.md` accordingly. Docs-only; follows the spec-1009 precedent (#100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)