### PR TITLE
feat(chat): smooth chat-history scroll-up (spec 1011)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,5 +249,5 @@ GitFlow. **`develop`** is the integration branch; **`main`** is production.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1010-group-seen-receipts/plan.md`
+`specs/1011-smooth-chat-history/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ Specs are grouped by category band; status moves
 | [1008](specs/1008-one-tap-media/spec.md) | One-Tap Media Open & Inline Quick-React Bar | 🟢 shipped |
 | [1009](specs/1009-activity-indicators/spec.md) | Ephemeral Activity Indicators (Typing & Recording) | 🟢 shipped |
 | [1010](specs/1010-group-seen-receipts/spec.md) | Group "Seen" Receipts — Durable, Private, and Counted | 🟢 shipped |
-| [1011](specs/1011-smooth-chat-history/spec.md) | Smooth Chat-History Scroll-Up (verified by a multi-user end-to-end exercise) | ⚪ planned |
+| [1011](specs/1011-smooth-chat-history/spec.md) | Smooth Chat-History Scroll-Up (verified by a multi-user end-to-end exercise) | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@ Specs are grouped by category band; status moves
 | [1008](specs/1008-one-tap-media/spec.md) | One-Tap Media Open & Inline Quick-React Bar | 🟢 shipped |
 | [1009](specs/1009-activity-indicators/spec.md) | Ephemeral Activity Indicators (Typing & Recording) | 🟢 shipped |
 | [1010](specs/1010-group-seen-receipts/spec.md) | Group "Seen" Receipts — Durable, Private, and Counted | 🟢 shipped |
+| [1011](specs/1011-smooth-chat-history/spec.md) | Smooth Chat-History Scroll-Up (verified by a multi-user end-to-end exercise) | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/README.md
+++ b/drive/README.md
@@ -19,9 +19,15 @@ This is the *fast, attach-to-what's-running* complement to the hermetic harnesse
 ```sh
 node drive/scenarios/group-conversation.mjs      # or: npm run drive drive/scenarios/<name>.mjs
 HEADED=1 node drive/scenarios/dm-and-react.mjs    # watch it in a real window
+node drive/scenarios/lengthy-chat-scroll.mjs      # spec 1011: 5 users, all kinds, 5k-msg scroll-up
 SLOWMO=400 HEADED=1 node drive/scenarios/...      # slow each action down
 VERBOSE=1 node drive/scenarios/...                # forward ALL page console logs
 ```
+
+`lengthy-chat-scroll.mjs` (spec 1011) connects 5 users, exchanges every message kind in a
+1:1 + a group, bulk-seeds a 5,000-message chat (`seedHistory`/`__ringTest.seedMessages`),
+then flicks up through it capturing each look-ahead page to `.tmp/drive/lengthy-chat-*.png` —
+Read those back to confirm continuous, bounded, non-snapping content (smooth scroll-up).
 
 Screenshots are written to `.tmp/drive/*.png` (gitignored). Read them back to see the UI;
 account ids, the group id, and each `[shot] <path>` stream to stdout.
@@ -42,7 +48,9 @@ await sweep([a, b]); await done();          // self-delete the throwaway account
 
 Driver exports (`drive/driver.mjs`): `createAccount`, `pair`, `group`, `say`, `waitForMessage`,
 `messageId`, `react`, `chatWith`, `shot`, `poll`, `sweep`, `done`, plus `newClient`/`browser`
-and `BASE_URL`/`SHOT_DIR`.
+and `BASE_URL`/`SHOT_DIR`. For long-chat work (spec 1011): `sendAudio`, `sendVideoNote`,
+`sendImage`, `sendVideo`, `seedHistory` (bulk-seed N messages), `scrollUpPass` (flick up +
+screenshot each page), and `bubbleCount` (assert the DOM stays bounded).
 
 ## Gotchas (already handled by the driver — don't re-hit them)
 

--- a/drive/driver.mjs
+++ b/drive/driver.mjs
@@ -224,6 +224,47 @@ export async function shot(client, name, { route, fullPage = false } = {}) {
   return file;
 }
 
+/* ---- media sends (spec 1011 lengthy-chat exercise) ---- */
+
+/** Send a voice/music audio message. */
+export const sendAudio = (c, chatId, name = 'song.mp3', title = 'Song', artist = 'Artist') =>
+  c.page.evaluate(([id, n, t, a]) => window.__ringTest.sendAudio(id, n, t, a), [chatId, name, title, artist]);
+/** Send a round video-note ("video message"). */
+export const sendVideoNote = (c, chatId, name = 'note.mp4') =>
+  c.page.evaluate(([id, n]) => window.__ringTest.sendVideoNote(id, n), [chatId, name]);
+/** Upload a photo (background-compressed at the given quality). */
+export const sendImage = (c, chatId, name = 'photo.png', quality = 'hd') =>
+  c.page.evaluate(([id, n, q]) => window.__ringTest.sendMediaQuality(id, 'image', n, q), [chatId, name, quality]);
+/** Upload a video (background-compressed at the given quality). */
+export const sendVideo = (c, chatId, name = 'clip.mp4', quality = 'hd') =>
+  c.page.evaluate(([id, n, q]) => window.__ringTest.sendMediaQuality(id, 'video', n, q), [chatId, name, quality]);
+
+/** Bulk-seed a chat to `n` messages instantly (spec 1011 dev hook) — builds a lengthy chat
+ *  without the real send pipeline. `opts.mediaEvery` mixes in images for height variety. */
+export const seedHistory = (c, chatId, n, opts = {}) =>
+  c.page.evaluate(([id, count, o]) => window.__ringTest.seedMessages(id, count, o), [chatId, n, opts]);
+
+/** Open a chat and flick up through `steps` look-ahead pages, screenshotting along the way
+ *  so the captures can be Read back to confirm continuous content (no blank flash/snap). */
+export async function scrollUpPass(client, chatId, name, { steps = 8, dy = 1400 } = {}) {
+  await client.page.goto(`${BASE_URL}/chat/${chatId}`);
+  await client.page.waitForTimeout(1000); // let the newest window render + pin to bottom
+  // Wheel events scroll the element under the cursor — center it OVER the message list,
+  // not the header (a wheel at the default (0,0) scrolls nothing / the wrong element).
+  const vp = client.page.viewportSize() ?? { width: 640, height: 720 };
+  await client.page.mouse.move(Math.floor(vp.width / 2), Math.floor(vp.height / 2));
+  const shots = [await shot(client, `${name}-00-bottom`, {})];
+  for (let i = 1; i <= steps; i++) {
+    await client.page.mouse.wheel(0, -dy);
+    await client.page.waitForTimeout(280); // let the older page load + anchor settle
+    shots.push(await shot(client, `${name}-${String(i).padStart(2, '0')}-up`, {}));
+  }
+  return shots;
+}
+
+/** Count the rendered message bubbles (to confirm the DOM stays bounded while scrolling). */
+export const bubbleCount = (c) => c.page.locator('.bubble[data-mid]').count();
+
 /** Self-delete the given accounts (leave-no-trace cleanup of the dev directory). */
 export const sweep = (clients) =>
   Promise.all(clients.map((c) => c.page.evaluate(() => window.__ringTest.deleteAccount()).catch(() => {})));

--- a/drive/scenarios/lengthy-chat-scroll.mjs
+++ b/drive/scenarios/lengthy-chat-scroll.mjs
@@ -1,0 +1,65 @@
+/**
+ * Spec 1011 — Smooth chat-history scroll-up, proven end-to-end with 5 real users.
+ *
+ *   node drive/scenarios/lengthy-chat-scroll.mjs
+ *   HEADED=1 node drive/scenarios/lengthy-chat-scroll.mjs
+ *
+ * Drives the live `make start` stack as 5 users: connect them, hold a 1:1 + a group
+ * conversation exchanging EVERY message kind (text / voice-audio / video-message /
+ * image-upload / video-upload), build a lengthy chat (real sends + a 5,000-message
+ * bulk-seed), then open it and flick up — screenshotting each look-ahead page so the
+ * captures (.tmp/drive/lengthy-chat-*.png) can be Read back to confirm continuous,
+ * bounded, non-snapping content (SC-005 / SC-007). Ends with a sweep for a clean re-run.
+ */
+import {
+  createAccount, pair, group, say, waitForMessage,
+  sendAudio, sendVideoNote, sendImage, sendVideo,
+  seedHistory, scrollUpPass, bubbleCount, chatWith, shot, sweep, done,
+} from '../driver.mjs';
+
+// 1) Five users connect (directory connect — the open-network model; one link makes both
+//    sides Connected and lets the first sealed message bootstrap the session).
+const u1 = await createAccount({ name: 'Uno' });
+const u2 = await createAccount({ name: 'Dos' });
+const u3 = await createAccount({ name: 'Tres', mobile: true });
+const u4 = await createAccount({ name: 'Cuatro' });
+const u5 = await createAccount({ name: 'Cinco' });
+const all = [u1, u2, u3, u4, u5];
+for (const u of [u2, u3, u4, u5]) await pair(u1, u);
+
+// 2) 1:1 (Uno ↔ Dos): exchange every message kind both ways.
+const dm = await chatWith(u1, u2.id);
+await say(u1, u2.id, 'hey from uno 👋');
+await waitForMessage(u2, u1.id, 'hey from uno');
+await say(u2, u1.id, 'hey back 🙌');
+await waitForMessage(u1, u2.id, 'hey back');
+await sendAudio(u1, dm, 'voice.mp3', 'Voice note', 'Uno'); // voice-audio
+await sendVideoNote(u1, dm, 'note.mp4'); // video-message (round)
+await sendImage(u1, dm, 'pic.png'); // image-upload
+await sendVideo(u1, dm, 'clip.mp4'); // video-upload
+await u1.page.waitForTimeout(1500);
+await shot(u2, 'dm-from-dos', { route: `/chat/${await chatWith(u2, u1.id)}` });
+
+// 3) Group (all five): every kind delivered to + rendered for all participants.
+const crew = await group(u1, 'Crew', [u2, u3, u4, u5]);
+await say(u1, crew, 'welcome all 🎉', { isGroup: true });
+for (const u of [u2, u3, u4, u5]) await waitForMessage(u, crew, 'welcome all', { isGroup: true });
+await say(u2, crew, 'glad to be here', { isGroup: true });
+await waitForMessage(u1, crew, 'glad to be here', { isGroup: true });
+await sendAudio(u3, crew, 'g-voice.mp3', 'Group voice', 'Tres');
+await sendVideoNote(u4, crew, 'g-note.mp4');
+await sendImage(u5, crew, 'g-pic.png');
+await sendVideo(u1, crew, 'g-clip.mp4');
+await u1.page.waitForTimeout(1800);
+await shot(u3, 'group-from-tres-mobile', { route: `/chat/${crew}` });
+
+// 4) Build a LENGTHY 1:1 chat (real sends keep the newest end genuine; a 5,000-message
+//    bulk-seed gives it depth) and flick up through it, capturing each page.
+for (let i = 0; i < 8; i++) await say(u1, u2.id, `real message ${i}`);
+await seedHistory(u1, dm, 5000, { mediaEvery: 12 });
+const shots = await scrollUpPass(u1, dm, 'lengthy-chat', { steps: 10 });
+console.log(`[lengthy] captured ${shots.length} pages; rendered bubbles now: ${await bubbleCount(u1)}`);
+
+// 5) Clean up so a re-run sets up from scratch with no lingering accounts.
+await sweep(all);
+await done();

--- a/e2e/chat-media-scroll.spec.ts
+++ b/e2e/chat-media-scroll.spec.ts
@@ -52,3 +52,230 @@ test('image renders in the list and the full-screen viewer opens on tap', async 
   await ctxA.close();
   await ctxB.close();
 });
+
+/* ---- spec 1011: smooth chat-history scroll-up on a 5,000-message chat ---- */
+
+const SEED_N = 5000;
+const ROW_BOUND = 220; // DOM bounded to useChatHistory's MAX_ROWS (~200) + a margin
+const MAX_MEDIA = 60; // the media-LRU cap (spec 1005)
+
+// Read the ion-content scroll metrics synchronously inside the page.
+async function scrollMetrics(p: any): Promise<{ top: number; height: number; client: number }> {
+  return p.page.evaluate(async () => {
+    const el = await (document.querySelector('ion-content') as any).getScrollElement();
+    return { top: el.scrollTop, height: el.scrollHeight, client: el.clientHeight };
+  });
+}
+async function setScrollTop(p: any, top: number): Promise<void> {
+  await p.page.evaluate(async (t: number) => {
+    const el = await (document.querySelector('ion-content') as any).getScrollElement();
+    el.scrollTop = t;
+  }, top);
+}
+const renderedBubbles = (p: any) => p.page.locator('.bubble[data-mid]').count();
+const firstRenderedId = (p: any): Promise<string | null> =>
+  p.page.evaluate(() => (document.querySelector('.bubble[data-mid]') as HTMLElement)?.dataset.mid ?? null);
+
+// Open a fresh chat bulk-seeded to `n` messages (instant, via the dev hook — no real
+// send pipeline). Returns the chat id.
+async function openSeededChat(a: any, b: any, n: number): Promise<string> {
+  const aChat = (await chatWith(a, b.id)) as string;
+  await a.page.evaluate(
+    ({ id, count }: { id: string; count: number }) =>
+      (window as any).__ringTest.seedMessages(id, count, { mediaEvery: 12 }),
+    { id: aChat, count: n },
+  );
+  await a.page.goto(`/chat/${aChat}`);
+  // Wait for the list to render its first window pinned to the newest message.
+  await expect(a.page.locator('.bubble[data-mid]').first()).toBeVisible({ timeout: 30_000 });
+  // Wheel events scroll the element under the cursor — center it over the list so the
+  // tests' mouse.wheel(...) calls actually scroll the chat (not the header at 0,0).
+  const vp = a.page.viewportSize() ?? { width: 640, height: 720 };
+  await a.page.mouse.move(Math.floor(vp.width / 2), Math.floor(vp.height / 2));
+  return aChat;
+}
+
+test('scroll-up is bounded and resolved media is capped (INV-3 / SC-008)', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SCRL1011A');
+  const b = await createAccount(ctxB, 'SCRL1011B');
+  await pair(a, b);
+  await openSeededChat(a, b, SEED_N);
+
+  // Bounded on open (newest ROW_CAP rows, not all 5,000).
+  expect(await renderedBubbles(a)).toBeLessThanOrEqual(ROW_BOUND);
+
+  // Flick up across many pages — the rendered count must stay bounded the whole way.
+  for (let i = 0; i < 40; i++) {
+    await a.page.mouse.wheel(0, -1400);
+    await a.page.waitForTimeout(120);
+    expect(await renderedBubbles(a)).toBeLessThanOrEqual(ROW_BOUND);
+  }
+  // Resolved media (decoded blob: images) stays under the LRU cap.
+  const resolved = await a.page.locator('.bubble .bubble-image[src^="blob:"]').count();
+  expect(resolved).toBeLessThanOrEqual(MAX_MEDIA);
+
+  // Scroll back down through the evicted region — still bounded (downward re-entry).
+  for (let i = 0; i < 60; i++) {
+    await a.page.mouse.wheel(0, 1600);
+    await a.page.waitForTimeout(100);
+  }
+  expect(await renderedBubbles(a)).toBeLessThanOrEqual(ROW_BOUND);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+const bubbleTop = (p: any, id: string): Promise<number | null> =>
+  p.page.evaluate((mid: string) => {
+    const el = document.querySelector(`.bubble[data-mid="${mid}"]`) as HTMLElement | null;
+    return el ? el.getBoundingClientRect().top : null;
+  }, id);
+
+test('older pages load before the top (INV-2) and the anchored message never jumps (INV-1)', async ({
+  browser,
+}) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SCRL1011C');
+  const b = await createAccount(ctxB, 'SCRL1011D');
+  await pair(a, b);
+  await openSeededChat(a, b, SEED_N);
+
+  // Climb up into history so the look-ahead is actively paging older content.
+  for (let i = 0; i < 12; i++) {
+    await a.page.mouse.wheel(0, -1500);
+    await a.page.waitForTimeout(140);
+  }
+  await a.page.waitForTimeout(300);
+
+  // INV-2 (page-before-top): stepping up loads an older page (the first rendered id
+  // changes) while scrollTop is still clearly above 0 — the page arrives before the top.
+  let pagedBeforeTop = false;
+  for (let i = 0; i < 25; i++) {
+    const m = await scrollMetrics(a);
+    if (m.top <= 4) break;
+    const before = await firstRenderedId(a);
+    await setScrollTop(a, Math.max(0, m.top - 500));
+    await a.page.waitForTimeout(450); // let the load + (momentum-deferred) anchor settle
+    const after = await firstRenderedId(a);
+    if (after !== before && (await scrollMetrics(a)).top > 0) {
+      pagedBeforeTop = true;
+      break;
+    }
+  }
+  expect(pagedBeforeTop).toBe(true);
+
+  // INV-1 (≤2px): across the prepend/eviction a controlled step triggers, a tracked visible
+  // bubble moves by EXACTLY the commanded scroll delta — the load itself adds no jump.
+  let maxJump = 0;
+  for (let i = 0; i < 6; i++) {
+    const anchor = await a.page.evaluate(() => {
+      const n = (Array.from(document.querySelectorAll('.bubble[data-mid]')) as HTMLElement[]).find(
+        (e) => e.getBoundingClientRect().top > 140,
+      );
+      return n ? { id: n.dataset.mid as string, top: n.getBoundingClientRect().top } : null;
+    });
+    if (!anchor) break;
+    const s0 = (await scrollMetrics(a)).top;
+    if (s0 <= 4) break;
+    await setScrollTop(a, Math.max(0, s0 - 300));
+    const commanded = s0 - (await scrollMetrics(a)).top; // applied scroll before any correction
+    await a.page.waitForTimeout(450); // allow the momentum-deferred correction to land
+    const after = await bubbleTop(a, anchor.id);
+    if (after == null) continue; // the tracked bubble was evicted this step — skip the sample
+    // The bubble's on-screen move must equal the commanded scroll; a prepend adds ≤2px.
+    maxJump = Math.max(maxJump, Math.abs(after - anchor.top - commanded));
+  }
+  expect(maxJump).toBeLessThanOrEqual(2);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('an inbound message / reaction while scrolled up does not yank the view (INV-4 / SC-004)', async ({
+  browser,
+}) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SCRL1011E');
+  const b = await createAccount(ctxB, 'SCRL1011F');
+  await pair(a, b);
+  await openSeededChat(a, b, SEED_N);
+
+  // Scroll up into history (not pinned to bottom).
+  for (let i = 0; i < 8; i++) {
+    await a.page.mouse.wheel(0, -1200);
+    await a.page.waitForTimeout(100);
+  }
+  await a.page.waitForTimeout(300);
+  const top0 = (await scrollMetrics(a)).top;
+
+  // 1) A genuinely new inbound message arrives (B sends to A) — must not yank.
+  const bChat = (await chatWith(b, a.id)) as string;
+  await b.page.evaluate(
+    ({ id }: { id: string }) => (window as any).__ringTest.sendChatMessage(id, 'ping while scrolled up'),
+    { id: bChat },
+  );
+  await a.page.waitForTimeout(800);
+  expect(Math.abs((await scrollMetrics(a)).top - top0)).toBeLessThanOrEqual(2);
+
+  // 2) A reaction (a patch-in-place on an existing rendered row — the same path a
+  //    seen/delivered status tick takes) on a message in view must not yank either. React
+  //    to a bubble well INSIDE the viewport (a height change above the fold naturally
+  //    shifts content; the no-yank guarantee is about not moving the read position).
+  const midToReact = await a.page.evaluate(() => {
+    const vh = window.innerHeight;
+    const n = (Array.from(document.querySelectorAll('.bubble[data-mid]')) as HTMLElement[]).find((e) => {
+      const t = e.getBoundingClientRect().top;
+      return t > vh * 0.4 && t < vh * 0.8;
+    });
+    return n?.dataset.mid ?? null;
+  });
+  expect(midToReact).toBeTruthy();
+  await a.page.evaluate((id: string) => (window as any).__ringTest.reactToMessage(id, '👍'), midToReact as string);
+  await a.page.waitForTimeout(500);
+  expect(Math.abs((await scrollMetrics(a)).top - top0)).toBeLessThanOrEqual(2);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('tapping a reply-quote older than the loaded window seeks + centers it within ~1s (INV-6 / SC-006)', async ({
+  browser,
+}) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SEEK1011A');
+  const b = await createAccount(ctxB, 'SEEK1011B');
+  await pair(a, b);
+  const aChat = await openSeededChat(a, b, SEED_N);
+
+  // The OLDEST message — far older than the loaded newest window — is the seek target.
+  const oldId = (await a.page.evaluate(
+    (id: string) => (window as any).__ringTest.firstMessageId(id),
+    aChat,
+  )) as string;
+  expect(oldId).toBeTruthy();
+  expect(await a.page.locator(`.bubble[data-mid="${oldId}"]`).count()).toBe(0); // not loaded
+
+  // Post a reply quoting it → a new bubble at the bottom carrying a tappable reply-quote.
+  // (The same seekToMessage path serves the starred-message jump — US3 acceptance #2.)
+  await a.page.evaluate(
+    ({ id, q }: { id: string; q: string }) => (window as any).__ringTest.sendReply(id, 'jump back please', q),
+    { id: aChat, q: oldId },
+  );
+  const replyRef = a.page.locator('.bubble .reply-ref').last();
+  await expect(replyRef).toBeVisible({ timeout: 10_000 });
+
+  const t0 = Date.now();
+  await replyRef.click();
+  // The target mounts + centers; no "Original message not available" toast.
+  await expect(a.page.locator(`.bubble[data-mid="${oldId}"]`)).toBeVisible({ timeout: 1500 });
+  expect(Date.now() - t0).toBeLessThanOrEqual(1500); // ~1.0s budget + emulation slack
+  await expect(a.page.getByText('Original message not available')).toHaveCount(0);
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/specs/1011-smooth-chat-history/checklists/requirements.md
+++ b/specs/1011-smooth-chat-history/checklists/requirements.md
@@ -1,0 +1,46 @@
+# Specification Quality Checklist: Smooth Chat-History Scroll-Up
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec references the project's UI-driving capability (the `drive/` harness +
+  dev-only test hook) and "mobile-emulated" verification as the *verification
+  approach*, not as feature implementation — this is intentional (it's how the
+  smoothness and the multi-user exercise are proven), mirroring the convention used in
+  prior specs. It does not prescribe how the scroll fix is built.
+- No `[NEEDS CLARIFICATION]` markers: reasonable defaults were chosen and recorded in
+  **Assumptions**, with the five genuinely scope-affecting product decisions collected
+  under **Open product decisions** for `/speckit-clarify` to confirm.
+- Client-only change (no wire/server/ciphertext): the zero-knowledge `/speckit-checklist`
+  is **not** required on that basis (Constitution Principle I applies to changes that
+  cross the client/server boundary).
+- Checklist clean → ready for `/speckit-clarify` (recommended, to resolve the open
+  product decisions) then `/speckit-plan`.

--- a/specs/1011-smooth-chat-history/checklists/zero-knowledge.md
+++ b/specs/1011-smooth-chat-history/checklists/zero-knowledge.md
@@ -1,0 +1,49 @@
+# Zero-Knowledge Checklist: Smooth Chat-History Scroll-Up (spec 1011)
+
+**Purpose**: Constitution gate-sequencing requirement — `/speckit-checklist` is REQUIRED for
+any spec touching Principle I (Zero-Knowledge Boundary) or IV (Crypto Discipline). This
+checklist is "unit tests for the requirements": it validates that the spec's zero-knowledge
+and privacy requirements are complete, clear, consistent, and measurable — NOT that the
+implementation works. It mirrors the precedent set by client-only specs 1009 and 1010.
+**Created**: 2026-06-18
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [contracts/chat-history.md](../contracts/chat-history.md)
+
+**Outcome**: PASS — all items below are satisfied by the spec/plan/contracts. The feature is
+client-only (render + data-access); nothing new crosses or changes the client↔server boundary.
+
+## Zero-Knowledge Boundary (Principle I)
+
+- [x] CHK001 Does the spec explicitly state what crosses the wire for this feature? [Completeness, Spec §Zero-Knowledge Impact] — Yes: "nothing new… no request, payload, header, or metadata is added or changed."
+- [x] CHK002 Is it specified that the bounded reads return only already-on-device, already-decrypted-for-render `Message` rows (no new decryption or plaintext produced)? [Clarity, Spec §Zero-Knowledge Impact; contracts/chat-history.md §1] — Yes: bounded reads slice the existing `messages` store in memory; same rows the chat view already uses.
+- [x] CHK003 Is the absence of any new key use / crypto change documented? [Completeness, Spec §Zero-Knowledge Impact; plan Constitution Check IV] — Yes: `messaging.ts`/ratchet untouched; "no new key use."
+- [x] CHK004 Is it specified that nothing new is persisted or logged in plaintext (no debug aid, error payload, or sync field)? [Coverage, Spec §Zero-Knowledge Impact] — Yes: "no new plaintext is produced or persisted."
+- [x] CHK005 Is the absence of any storage-schema change documented (no `DB_VERSION` bump, no new index) so no migration can expose data? [Consistency, plan Constitution Check V; research D2] — Yes: `DB_VERSION` stays 6, no new index; reads are in-memory slices.
+
+## Privacy & Data Minimization (Principle IX)
+
+- [x] CHK006 Are the server-visible metadata items (read positions, scroll state, window bounds, batch sizes) explicitly stated to remain client-only? [Completeness, Spec §Zero-Knowledge Impact] — Yes: "the server sees no read positions, scroll state, window bounds, or batch sizes — all local-only."
+- [x] CHK007 Does the spec confirm no new telemetry/analytics and no new data collected/transmitted/stored? [Completeness, Spec §Zero-Knowledge Impact + Assumptions] — Yes: no new data; eviction/bounded reads reduce in-memory/DOM footprint.
+- [x] CHK008 Is the dev-only nature of the `__ringTest.seedMessages` test hook specified (stripped from production, like the rest of `__ringTest`)? [Clarity, Spec §Zero-Knowledge Impact; plan Constitution Check IX; contracts §4] — Yes: "Dev-only (stripped from prod)."
+
+## Requirement Clarity for Boundary-Relevant Behaviors
+
+- [x] CHK009 Is it unambiguous that the bounded-read APIs (`listMessagesOlder`/`listMessagesNewer`/`countChatMessages`) operate purely on the existing local store with no network access? [Clarity, contracts §1; research D2] — Yes: backed by the existing `chatId` index + in-memory sort/slice.
+- [x] CHK010 Is it clear that incremental reactivity (`useChatHistory`) reads/patches only local rows via the IndexedDB change bus and emits nothing to the server? [Clarity, contracts §2; data-model.md] — Yes: append/patch/remove on local rows; no wire interaction.
+- [x] CHK011 Does FR-014 (backgrounded/locked view) keep its scope to local render side-effects, introducing no new network/persistence activity? [Coverage, Spec FR-014] — Yes: it only gates scroll-position/window side-effects; no new I/O.
+
+## Gate Sequencing & Traceability
+
+- [x] CHK012 Is the checklist-gate decision recorded in the spec's *Complexity & Exceptions* section per Constitution gate-sequencing? [Traceability, Spec §Complexity & Exceptions] — Yes; this checklist now satisfies the gate directly.
+- [x] CHK013 Is the client-only scope stated consistently across spec, plan, research, and quickstart with no contradiction implying a wire/server change? [Consistency] — Yes: every artifact states client-only; plan Constitution Check I/V/VI all PASS.
+
+## Residual Risk
+
+- [x] CHK014 Is any residual zero-knowledge risk left unspecified (a new error payload, debug log, sync field, or server-readable derived value)? [Gap] — None identified. The change is confined to the client render/data-access layer; the server relays the same opaque ciphertext as before.
+
+## Notes
+
+- All 14 items satisfied → Principle I (zero-knowledge boundary) and Principle IX (privacy /
+  data minimization) are intact; Principle IV (crypto) is untouched.
+- This is a requirements-quality gate, not implementation verification. The behavioral proof
+  that nothing crosses the wire is additionally covered by the unchanged server test suite
+  (`go test ./...` stays green — tasks T002/T033) and the client-only diff scope.

--- a/specs/1011-smooth-chat-history/contracts/chat-history.md
+++ b/specs/1011-smooth-chat-history/contracts/chat-history.md
@@ -47,8 +47,14 @@ useChatHistory(chatId: Ref<string> | string, q?: Ref<string>): {
 - A new inbound message appends only when the loaded run includes the newest message
   (otherwise it's beyond the loaded run and surfaced via `hasNewer`/badge, not injected).
 - Switching `chatId`/`q` resets the run to a fresh newest batch.
+- `loadOlder`/`loadNewer` read a fixed internal `BATCH_SIZE` (suggested `≈ ½ × ROW_CAP`)
+  so one batch comfortably fills the look-ahead buffer without overshooting `ROW_CAP`.
 
 ## 3. Scroll/anchor behavior contract (`ChatDetailPage.vue`)
+
+The rendered slice is a **RenderWindow** `{ start: index, end: index }` into the loaded
+`rows` (data-model.md), bounded so `end - start ≤ ROW_CAP`. The invariants below constrain
+that window's behavior.
 
 Observable invariants the implementation MUST hold (these are what e2e asserts):
 
@@ -88,8 +94,10 @@ seedMessages(chatId: string, n: number, opts?: {
 - **vitest** (pure, no IndexedDB): window math (`computeWindow` never exceeds `ROW_CAP`,
   always covers viewport+buffer, evicts the correct edge); pagination cursor math (correct
   slice for `beforeTs`/`afterTs`/`limit`, oldest-first, seam dedupe); anchor-delta math
-  (|residual| ≤2px, evicted-anchor falls back to next id); group-run/day across a window
-  boundary with a preserved leading row.
+  (|residual| ≤2px, evicted-anchor falls back to next id); the momentum/echo guard
+  predicates (INV-5: defer a `scrollTop` write while a fling is in flight, mark the
+  post-correction scroll as self-echo — exercised with fake timers); group-run/day across a
+  window boundary with a preserved leading row.
 - **e2e** (`e2e/chat-media-scroll.spec.ts`, real ringd, mobile emulation): seed 5,000 via
   `__ringTest.seedMessages`, then assert INV-1 (≤2px), INV-2 (page-before-top), INV-3
   (bounded rendered/media count after scrolling far up+down), INV-4 (no-yank), INV-6
@@ -97,3 +105,7 @@ seedMessages(chatId: string, n: number, opts?: {
 - **drive/** exercise (`drive/scenarios/lengthy-chat-scroll.mjs`): 5 users connect (request
   +accept) → 1:1 + group → exchange text/voice/video/image-upload/video-upload → build a
   lengthy chat → open + scroll up, screenshot pass for visual confirmation.
+- **manual / real-device** (not in CI): **INV-5** fling feel (writing `scrollTop` during
+  native iOS WebKit inertia — emulation can't fully prove it) and **INV-7** group-row
+  flicker are confirmed by hand (T032). Their deterministic *logic* is unit-tested above
+  (INV-5 via the guard predicates; INV-7 via the predecessor-included group-run/day math).

--- a/specs/1011-smooth-chat-history/contracts/chat-history.md
+++ b/specs/1011-smooth-chat-history/contracts/chat-history.md
@@ -1,0 +1,99 @@
+# Contract: Chat-History Reads, Reactivity, Seed, and Scroll Invariants
+
+Client-only contracts. No wire/server/storage-schema change.
+
+## 1. Bounded read API (`src/db/queries.ts`)
+
+```ts
+// The `limit` messages immediately older than `beforeTs` (newest `limit` when null),
+// returned oldest→newest. `q` keeps the existing substring filter.
+export function listMessagesOlder(
+  chatId: string, beforeTs: number | null, limit: number, q?: string,
+): Promise<Message[]>;
+
+// The `limit` messages immediately newer than `afterTs`, oldest→newest.
+export function listMessagesNewer(
+  chatId: string, afterTs: number, limit: number, q?: string,
+): Promise<Message[]>;
+
+// Total messages in the chat (for "more above" detection / affordances).
+export function countChatMessages(chatId: string): Promise<number>;
+```
+
+- Backed by the existing `chatId` index + in-memory sort/slice (no new index, no
+  `DB_VERSION` bump — research D2). Ordering is deterministic by `(timestamp, id)`.
+- Batches must **dedupe at seams** (a message at exactly `beforeTs`/`afterTs` is not
+  returned twice across adjacent batches).
+- `listMessages(chatId, q)` (loads-all) remains for search and non-chat-view callers.
+
+## 2. Reactive windowed history (`src/composables/useChatHistory.ts`)
+
+```ts
+useChatHistory(chatId: Ref<string> | string, q?: Ref<string>): {
+  rows: Readonly<Ref<Message[]>>;     // contiguous loaded run, oldest→newest (bounded)
+  hasOlder: Ref<boolean>;
+  hasNewer: Ref<boolean>;
+  total: Ref<number>;
+  loadOlder(): Promise<number>;       // prepend a batch; returns count added
+  loadNewer(): Promise<number>;       // append a batch; returns count added
+  // internally subscribes to the 'messages' change bus and applies INCREMENTAL updates:
+  //   append (only if the run touches the bottom) | patch-by-id | remove-by-id.
+}
+```
+
+**Contract**:
+- MUST NOT re-run a whole-chat query or replace `rows` wholesale on a `messages` write
+  (that is the churn this replaces). A single reaction/seen/edit patches exactly one row.
+- A new inbound message appends only when the loaded run includes the newest message
+  (otherwise it's beyond the loaded run and surfaced via `hasNewer`/badge, not injected).
+- Switching `chatId`/`q` resets the run to a fresh newest batch.
+
+## 3. Scroll/anchor behavior contract (`ChatDetailPage.vue`)
+
+Observable invariants the implementation MUST hold (these are what e2e asserts):
+
+- **INV-1 (anchor)**: across any window mutation (prepend OR eviction), the anchor
+  bubble's `getBoundingClientRect().top` changes by **≤2px**.
+- **INV-2 (page-before-top)**: when scrolling up, the next older batch's first
+  `[data-mid]` is present in the DOM **before** `scrollTop` reaches 0.
+- **INV-3 (bounded)**: the count of rendered `.bubble[data-mid]` stays ≈ `ROW_CAP`
+  regardless of scroll distance; resolved media stays ≤ `MAX_MEDIA`.
+- **INV-4 (no-yank)**: an inbound message/reaction/status while the user is not pinned to
+  bottom leaves `scrollTop` unchanged.
+- **INV-5 (no momentum fight)**: no `scrollTop` write occurs while a fling is in flight
+  (within `MOMENTUM_QUIET_MS` of the last genuine user scroll); the correction re-applies
+  after it settles.
+- **INV-6 (seek)**: `seekToMessage(id)` for an on-device message older than the window
+  loads intervening batches and centers it (no "not available"); jump-to-newest unaffected.
+- **INV-7 (group edge)**: avatars/day-dividers at the window's top edge do not
+  appear/disappear (flicker) when older rows load.
+
+`withScrollAnchor(mutate)` is the single helper enforcing INV-1/INV-5 for both prepend and
+eviction (and is reused by `loadOlder`, eviction, and `seekToMessage`).
+
+## 4. Dev-only seed (`src/services/testhook.ts`)
+
+```ts
+// window.__ringTest.seedMessages(chatId, n, opts?) → Promise<void>
+// Builds n Message rows (spread timestamps; opts may mix text/media/album/group-sender)
+// and writes them with ONE bulkPut('messages', rows). Dev-only (stripped from prod).
+seedMessages(chatId: string, n: number, opts?: {
+  fromIds?: string[];        // rotate senders (group histories)
+  mediaEvery?: number;       // every Nth row is an image/video for height variety
+}): Promise<void>;
+```
+
+## Test contract
+
+- **vitest** (pure, no IndexedDB): window math (`computeWindow` never exceeds `ROW_CAP`,
+  always covers viewport+buffer, evicts the correct edge); pagination cursor math (correct
+  slice for `beforeTs`/`afterTs`/`limit`, oldest-first, seam dedupe); anchor-delta math
+  (|residual| ≤2px, evicted-anchor falls back to next id); group-run/day across a window
+  boundary with a preserved leading row.
+- **e2e** (`e2e/chat-media-scroll.spec.ts`, real ringd, mobile emulation): seed 5,000 via
+  `__ringTest.seedMessages`, then assert INV-1 (≤2px), INV-2 (page-before-top), INV-3
+  (bounded rendered/media count after scrolling far up+down), INV-4 (no-yank), INV-6
+  (jump-to-older).
+- **drive/** exercise (`drive/scenarios/lengthy-chat-scroll.mjs`): 5 users connect (request
+  +accept) → 1:1 + group → exchange text/voice/video/image-upload/video-upload → build a
+  lengthy chat → open + scroll up, screenshot pass for visual confirmation.

--- a/specs/1011-smooth-chat-history/data-model.md
+++ b/specs/1011-smooth-chat-history/data-model.md
@@ -1,0 +1,93 @@
+# Phase 1 Data Model: Smooth Chat-History Scroll-Up
+
+No persisted-schema change. The `messages` IndexedDB store and `Message` shape are
+unchanged; `DB_VERSION` stays 6. Everything below is **in-memory / derived** state for
+the chat view plus the bounded read shapes.
+
+## Unchanged (at rest)
+
+- **`messages` store** — keyed by `id`, indexed by `chatId` (idb.ts). `Message` fields
+  unchanged. Read-only for this feature.
+
+## New: bounded read results (queries.ts)
+
+Batches of the existing `Message` type, oldest→newest within the batch:
+
+- `listMessagesOlder(chatId, beforeTs | null, limit, q?) → Message[]`
+  the `limit` messages immediately **older** than `beforeTs` (or the newest `limit` when
+  `beforeTs` is null), oldest-first. `q` keeps the existing substring filter semantics.
+- `listMessagesNewer(chatId, afterTs, limit, q?) → Message[]`
+  the `limit` messages immediately **newer** than `afterTs`, oldest-first (for
+  scroll-down re-entry after eviction).
+- `countChatMessages(chatId) → number`
+  total messages in the chat (drives spacer/affordance + "more above" detection).
+
+(Existing `listMessages(chatId, q)` stays for search and other callers.)
+
+## New (in-memory): ChatHistory state — `useChatHistory(chatId)`
+
+The reactive source the view's window slices from. Holds a **bounded** contiguous run of
+messages around the rendered window — not the whole chat.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `rows` | `Message[]` (reactive) | the loaded, contiguous, oldest→newest run currently available to render from |
+| `oldestLoadedTs` / `newestLoadedTs` | epoch ms | cursors bounding `rows` (for the next older/newer batch) |
+| `hasOlder` / `hasNewer` | boolean | whether more exists beyond the loaded run (vs `countChatMessages` / position) |
+| `total` | number | `countChatMessages(chatId)` |
+
+**Operations** (incremental — no full-array replace):
+- `loadOlder()` → prepend a `listMessagesOlder` batch to `rows`; update `oldestLoadedTs`/`hasOlder`.
+- `loadNewer()` → append a `listMessagesNewer` batch; update `newestLoadedTs`/`hasNewer`.
+- change-bus apply (subscribed to `messages`): **append** a new message (only if the loaded
+  run touches the bottom), **patch-by-id** (edit/reaction/receipt/status → shallow-merge one
+  row), **remove-by-id** (splice). Never re-runs a whole-chat query.
+
+## Derived (view): RenderWindow — in `ChatDetailPage.vue`
+
+Replaces `visible: ref(PAGE)` + `slice(-visible)`.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `start` / `end` | index into `rows` | the rendered half-open slice `rows.slice(start, end)` |
+| `ROW_CAP` | const (~80-120) | max rendered rows; eviction keeps `end - start ≤ ROW_CAP` |
+| `BUFFER` | const (rows/px) | look-ahead distance kept beyond the viewport in each direction |
+
+- Grows `start` ↓ (older) on top look-ahead; grows `end` ↑ (newer) on downward re-entry.
+- Evicts by advancing `start` / retreating `end` once `end - start > ROW_CAP`.
+- `renderItems` (album collapse), `groupRunStart`, `showDay` continue to operate on the
+  rendered slice, computed with the **predecessor row included in the window** (D8) so the
+  top edge doesn't flicker an avatar/divider on load.
+
+## Derived (transient): ScrollAnchor — `withScrollAnchor(mutate)`
+
+Captured immediately before a window mutation, used to restore the viewport after it:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | message id | the topmost fully-rendered `.bubble[data-mid]` in the viewport |
+| `top` | px | that bubble's `getBoundingClientRect().top` before the mutation |
+| `scrollEl` | element | the `ion-content` scroll element |
+
+Restore: after `nextTick`, re-find `id` (fall back to the next still-rendered row if it was
+evicted), measure its new `top`, set `scrollTop += (newTop - top)`; gated by the
+`MOMENTUM_QUIET_MS` + `suppressStickUntil` guards.
+
+## Dev-only: seedMessages (testhook)
+
+`window.__ringTest.seedMessages(chatId, n, opts?)` — constructs `n` `Message` rows
+(spread timestamps; optional mix of text/media/album/group-sender) and writes them with a
+single `bulkPut('messages', rows)`. Dev-only (stripped from prod). Enables a 5,000-msg
+scroll test without the real send pipeline.
+
+## State transitions (smoothness invariants)
+
+- **Open chat** → load newest batch → pin to bottom (`scrollToNewest`) → reveal list.
+- **Scroll up** → near top look-ahead → `loadOlder()` (prepend) inside `withScrollAnchor`
+  → if `> ROW_CAP`, evict bottom rows inside the same anchored mutation → viewport ≤2px stable.
+- **Scroll down (after eviction)** → near bottom look-ahead → `loadNewer()` (append) +
+  evict top, anchored.
+- **Inbound message / reaction while reading history** → incremental apply; window/scroll
+  unchanged unless already pinned to bottom (no yank, FR-004).
+- **Jump-to-older (reply/starred)** → `seekToMessage(id)`: load older batches until the row
+  is in `rows` and rendered, then center it (US3).

--- a/specs/1011-smooth-chat-history/data-model.md
+++ b/specs/1011-smooth-chat-history/data-model.md
@@ -36,6 +36,10 @@ messages around the rendered window — not the whole chat.
 | `hasOlder` / `hasNewer` | boolean | whether more exists beyond the loaded run (vs `countChatMessages` / position) |
 | `total` | number | `countChatMessages(chatId)` |
 
+> `rows` is exposed as `Readonly<Ref<Message[]>>` (per contracts/chat-history.md §2):
+> script-side callers and unit/e2e tests read `rows.value`; Vue templates unwrap it
+> automatically — the same convention as `useLiveQuery`.
+
 **Operations** (incremental — no full-array replace):
 - `loadOlder()` → prepend a `listMessagesOlder` batch to `rows`; update `oldestLoadedTs`/`hasOlder`.
 - `loadNewer()` → append a `listMessagesNewer` batch; update `newestLoadedTs`/`hasNewer`.
@@ -51,7 +55,7 @@ Replaces `visible: ref(PAGE)` + `slice(-visible)`.
 |---|---|---|
 | `start` / `end` | index into `rows` | the rendered half-open slice `rows.slice(start, end)` |
 | `ROW_CAP` | const (~80-120) | max rendered rows; eviction keeps `end - start ≤ ROW_CAP` |
-| `BUFFER` | const (rows/px) | look-ahead distance kept beyond the viewport in each direction |
+| `BUFFER` | const — `LOOK_AHEAD_PX ≈ 1200` (≈ 1.5–2 mobile screens) | look-ahead distance kept beyond the viewport in each direction; doubles as the prefetch sentinel's `rootMargin` (D5) |
 
 - Grows `start` ↓ (older) on top look-ahead; grows `end` ↑ (newer) on downward re-entry.
 - Evicts by advancing `start` / retreating `end` once `end - start > ROW_CAP`.

--- a/specs/1011-smooth-chat-history/plan.md
+++ b/specs/1011-smooth-chat-history/plan.md
@@ -1,0 +1,142 @@
+# Implementation Plan: Smooth Chat-History Scroll-Up (verified by a multi-user end-to-end exercise)
+
+**Branch**: `feat/1011-smooth-chat-history` | **Date**: 2026-06-17 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1011-smooth-chat-history/spec.md`
+
+## Summary
+
+Make scrolling up through chat history smooth at any length (target ~5,000+ messages)
+with bounded DOM and memory, while keeping the message under the user's view stationary
+(≤2px) as older pages load. The approach (adversarially judged against `@tanstack/vue-virtual`
+and CSS `content-visibility`) is to **extend the existing hand-rolled window** in
+`ChatDetailPage.vue` into a true **bidirectional virtual window** (`{start,end}` slice
+with eviction both directions + look-ahead prefetch), feed it from **bounded batch reads**
+(`listMessagesOlder/Newer/countChatMessages`) via a new **`useChatHistory` composable**
+that applies **incremental** updates (no full-array replace), and route every window
+mutation through one **`withScrollAnchor`** helper (measured-rect anchor + the momentum/echo
+guards `loadOlder` lacks today). Plus jump-to-older seek (US3) and group-row edge-correctness.
+It's proven by a **multi-user end-to-end exercise** on the new `drive/` harness and e2e
+assertions (anchor ≤2px, page-before-top, bounded row count on a 5,000-msg seeded chat),
+with a fast `__ringTest.seedMessages` bulk-seed. Full rationale: [research.md](./research.md).
+
+**Client-only.** No server, wire, stored-ciphertext, or DB-schema change.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Vue 3 `<script setup>` + Ionic 8, Vite) client only.
+
+**Primary Dependencies**: No new runtime dependency — hand-rolled windowing (Ionic 8 has
+no variable-height virtual-scroll primitive; `ion-virtual-scroll` was removed). Reuses the
+existing `ion-content` scroll element, `ion-infinite-scroll` (as a backstop), IndexedDB
+wrapper + change bus, and the media LRU.
+
+**Storage**: IndexedDB `messages` store via the existing `chatId` index. **No new index,
+no `DB_VERSION` bump** (stays at 6) — bounded reads slice in memory (research D2). A
+compound `[chatId,timestamp]` index is a documented, forward-only, out-of-scope future
+step (Complexity Tracking).
+
+**Testing**: `vitest` for pure helpers (window math, pagination/cursor math, anchor-delta
+math, group-run/day across the window edge); Playwright `e2e` (extend
+`e2e/chat-media-scroll.spec.ts`) for ≤2px anchor, page-before-top, bounded row/media count
+on a 5,000-msg seeded chat, and no-yank; the `drive/` harness for the multi-user exercise
+(5 users → connect → 1:1 + group → all message kinds → lengthy chat → scroll-up shots).
+
+**Target Platform**: Installable PWA + `ringd` single container (server unchanged).
+
+**Project Type**: Web — Vue 3 PWA client; this feature is entirely client-side.
+
+**Performance Goals**: 60fps scroll; smooth scroll-up to ~5,000+ messages; rendered rows
+bounded to a cap (~80-120 ≈ a few screens + buffer) regardless of scroll distance; ≤2px
+anchor drift on prepend/eviction; next older page present before the top edge is reached.
+
+**Constraints**: Client-only (zero-knowledge untouched); offline-first (reads only, no
+data loss); stock Ionic + theme tokens; LTR/RTL + light/dark; modest batch/cap sizes for
+sub-frame mounts; all existing chat behaviors preserved.
+
+**Scale/Scope**: Chats up to 5,000+ messages; one primary view (`ChatDetailPage.vue`) +
+a new composable + a few `queries.ts` reads + a dev testhook + the verification harness/e2e.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Verdict | Notes |
+|---|---|---|
+| I. Zero-Knowledge Boundary (NON-NEGOTIABLE) | ✅ PASS | Client-only. Reads existing on-device plaintext for rendering only; nothing new crosses the wire or is stored. No `/speckit-checklist` required (applies to client↔server boundary changes). |
+| II. Spec-Driven Development | ✅ PASS | specify → clarify → plan → … ; spec id 1011. |
+| III. Test-Driven Development | ✅ PASS | tasks.md will order failing tests first: vitest pure helpers (window/pagination/anchor/group-edge) + e2e (anchor ≤2px, page-before-top, bounded count, no-yank, jump-to-older) before implementation. |
+| IV. Crypto Discipline | ✅ PASS (untouched) | No crypto/messaging change; `messaging.ts` and the ratchet are not touched. |
+| V. Offline-First Data Integrity | ✅ PASS | IndexedDB is read-only here; **no schema change, no `DB_VERSION` bump** (research D2). Bounded reads slice existing rows; no data dropped or migrated. |
+| VI. Stateless Server & Forward-Only Migrations | ✅ PASS | No server change; **no migration** (the optional future compound index is documented as additive/forward-only and out of scope). |
+| VII. Quality Gates | ✅ PASS | `npm run build`, `go build/vet/test` (unchanged, runs clean), `vitest`, `npm run test:e2e` are the definition of done. |
+| VIII. Traceable, Auto-Closing Delivery | ✅ PASS | `/speckit-taskstoissues` → `Closes #N` on the PR. |
+| IX. Privacy & Data Minimization | ✅ PASS | No new data; bounded reads/eviction reduce in-memory/DOM footprint. The `seedMessages` testhook is dev-only (stripped from prod, like the rest of `__ringTest`). |
+| X. Accessibility & Internationalization | ✅ PASS | Natural top→bottom order preserved (no `column-reverse`); LTR/RTL + light/dark unaffected; virtualization keeps semantic order and existing labels. |
+| XI. Ionic-First UI | ✅ PASS (custom justified) | Hand-rolled windowing because **no Ionic primitive fits** variable-height chat virtual scroll (`ion-virtual-scroll` removed in Ionic 7+). XI permits custom where no primitive fits. Still uses `ion-content`/`ion-infinite-scroll` + theme tokens; no bespoke design system. |
+
+**Result**: No violations. `/speckit-checklist` not required (client-only). See Complexity
+Tracking for the one justified custom choice + the deferred index.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1011-smooth-chat-history/
+├── plan.md            # this file
+├── spec.md            # /speckit-specify + /speckit-clarify
+├── research.md        # Phase 0 (D1–D9 + recommendation/fallback/risks)
+├── data-model.md      # Phase 1
+├── quickstart.md      # Phase 1
+├── contracts/
+│   └── chat-history.md # bounded-read API + useChatHistory + seedMessages + scroll invariants
+├── checklists/
+│   └── requirements.md # passing
+└── tasks.md           # /speckit-tasks (later)
+```
+
+### Source Code (repository root)
+
+Client-only edits + one new composable + verification harness/tests; **no new object
+store, no server change**.
+
+```text
+src/
+├── views/detail/
+│   └── ChatDetailPage.vue   # EDIT: {start,end} bidirectional window + eviction (replaces visible/slice(-visible));
+│                            #       withScrollAnchor() (prepend+evict, momentum/echo guards); look-ahead sentinel;
+│                            #       seekToMessage() for jump-to-older; group-run/day edge correctness; source window
+│                            #       from useChatHistory instead of useLiveQuery(listMessages)
+├── composables/
+│   └── useChatHistory.ts    # NEW: bounded windowed history + incremental change-bus updates (append/patch/remove)
+├── db/
+│   └── queries.ts           # EDIT: listMessagesOlder / listMessagesNewer / countChatMessages (bounded batches);
+│                            #       keep listMessages for search/other callers
+├── services/
+│   └── testhook.ts          # EDIT: __ringTest.seedMessages(chatId, n, opts) — bulkPut N rows (dev-only)
+└── (utils for pure helpers: window math / anchor-delta math, unit-tested)
+
+drive/
+├── driver.mjs               # EDIT: add a bulk-seed convenience + scroll helpers if needed
+└── scenarios/
+    └── lengthy-chat-scroll.mjs  # NEW: 5-user exercise (connect → 1:1+group → all kinds → lengthy chat → scroll-up shots)
+
+e2e/
+└── chat-media-scroll.spec.ts    # EDIT/EXTEND: ≤2px anchor, page-before-top, bounded row/media count on a 5k seeded chat, no-yank, jump-to-older
+
+src/**/*.test.ts                  # NEW: vitest for window/pagination/anchor/group-edge pure helpers
+```
+
+**Structure Decision**: Reuse the existing client layout. The change is concentrated in
+`ChatDetailPage.vue` (the window + anchor + prefetch + seek) plus a new `useChatHistory`
+composable and three bounded reads in `queries.ts`; verification reuses the `drive/`
+harness + the existing e2e scroll spec. No new subsystem, no new object store, no server.
+
+## Complexity Tracking
+
+| Choice | Why needed | Simpler alternative rejected because |
+|---|---|---|
+| Hand-rolled bidirectional virtual window (vs an Ionic primitive or a library) | Ionic 8 has no variable-height virtual scroll; the ≤2px bar under async media decode/avatar/album reflow needs a measured-rect anchor, which `@tanstack/vue-virtual`'s index/estimate model fails (judged: anchor-unstable, not Ionic-safe, swipe rewrite required). | A library (`@tanstack/vue-virtual`) was evaluated and scored 5/8.5 — high risk, "spike required", forces a swipe-gesture + ion-content bridge rewrite. CSS `content-visibility` (1.5) doesn't bound DOM/memory at all. |
+| New `useChatHistory` composable (vs adapting `useLiveQuery`) | Incremental updates (append/patch/remove) avoid the full-array replace that re-allocates the whole list on every reaction/seen/tick — the churn that lands layout work around a load. | `useLiveQuery` is intentionally stateless/atomic-replace; pagination + incremental diff don't fit its callback model and changing it would risk every other caller. |
+| Deferred (OUT of scope): compound `[chatId,timestamp]` index + `DB_VERSION 6→7` | Not needed at ≤5-10k (in-memory sort is sub-10ms); would be a forward-only additive index migration only if a chat reaches ~50k+. | Adding it now is migration cost with no real-world payoff; documented so the future path is clear and stays within forward-only rules. |

--- a/specs/1011-smooth-chat-history/plan.md
+++ b/specs/1011-smooth-chat-history/plan.md
@@ -63,20 +63,21 @@ a new composable + a few `queries.ts` reads + a dev testhook + the verification 
 
 | Principle | Verdict | Notes |
 |---|---|---|
-| I. Zero-Knowledge Boundary (NON-NEGOTIABLE) | ✅ PASS | Client-only. Reads existing on-device plaintext for rendering only; nothing new crosses the wire or is stored. No `/speckit-checklist` required (applies to client↔server boundary changes). |
+| I. Zero-Knowledge Boundary (NON-NEGOTIABLE) | ✅ PASS | Client-only. Reads existing on-device plaintext for rendering only; nothing new crosses the wire or is stored. The `/speckit-checklist` zero-knowledge gate has been run and is clean (`checklists/zero-knowledge.md`, 14/14 pass), matching the 1009/1010 precedent. |
 | II. Spec-Driven Development | ✅ PASS | specify → clarify → plan → … ; spec id 1011. |
 | III. Test-Driven Development | ✅ PASS | tasks.md will order failing tests first: vitest pure helpers (window/pagination/anchor/group-edge) + e2e (anchor ≤2px, page-before-top, bounded count, no-yank, jump-to-older) before implementation. |
 | IV. Crypto Discipline | ✅ PASS (untouched) | No crypto/messaging change; `messaging.ts` and the ratchet are not touched. |
 | V. Offline-First Data Integrity | ✅ PASS | IndexedDB is read-only here; **no schema change, no `DB_VERSION` bump** (research D2). Bounded reads slice existing rows; no data dropped or migrated. |
 | VI. Stateless Server & Forward-Only Migrations | ✅ PASS | No server change; **no migration** (the optional future compound index is documented as additive/forward-only and out of scope). |
-| VII. Quality Gates | ✅ PASS | `npm run build`, `go build/vet/test` (unchanged, runs clean), `vitest`, `npm run test:e2e` are the definition of done. |
+| VII. Quality Gates | ✅ PASS | `npm run build`, `go build/vet/test` (unchanged, runs clean), `vitest`, `npm run test:e2e` are the definition of done. The new pure helpers (`chat-pagination`, `chat-window`, `scroll-anchor`, `chat-grouping`) and the pure parts of `useChatHistory` are added to `vitest.config.ts` coverage and meet the existing **80% gated-module floor** (a ratchet — raised, never regressed). |
 | VIII. Traceable, Auto-Closing Delivery | ✅ PASS | `/speckit-taskstoissues` → `Closes #N` on the PR. |
 | IX. Privacy & Data Minimization | ✅ PASS | No new data; bounded reads/eviction reduce in-memory/DOM footprint. The `seedMessages` testhook is dev-only (stripped from prod, like the rest of `__ringTest`). |
 | X. Accessibility & Internationalization | ✅ PASS | Natural top→bottom order preserved (no `column-reverse`); LTR/RTL + light/dark unaffected; virtualization keeps semantic order and existing labels. |
 | XI. Ionic-First UI | ✅ PASS (custom justified) | Hand-rolled windowing because **no Ionic primitive fits** variable-height chat virtual scroll (`ion-virtual-scroll` removed in Ionic 7+). XI permits custom where no primitive fits. Still uses `ion-content`/`ion-infinite-scroll` + theme tokens; no bespoke design system. |
 
-**Result**: No violations. `/speckit-checklist` not required (client-only). See Complexity
-Tracking for the one justified custom choice + the deferred index.
+**Result**: No violations. The `/speckit-checklist` zero-knowledge gate has been run and is
+clean (`checklists/zero-knowledge.md`). See Complexity Tracking for the one justified custom
+choice + the deferred index.
 
 ## Project Structure
 
@@ -140,3 +141,51 @@ harness + the existing e2e scroll spec. No new subsystem, no new object store, n
 | Hand-rolled bidirectional virtual window (vs an Ionic primitive or a library) | Ionic 8 has no variable-height virtual scroll; the ≤2px bar under async media decode/avatar/album reflow needs a measured-rect anchor, which `@tanstack/vue-virtual`'s index/estimate model fails (judged: anchor-unstable, not Ionic-safe, swipe rewrite required). | A library (`@tanstack/vue-virtual`) was evaluated and scored 5/8.5 — high risk, "spike required", forces a swipe-gesture + ion-content bridge rewrite. CSS `content-visibility` (1.5) doesn't bound DOM/memory at all. |
 | New `useChatHistory` composable (vs adapting `useLiveQuery`) | Incremental updates (append/patch/remove) avoid the full-array replace that re-allocates the whole list on every reaction/seen/tick — the churn that lands layout work around a load. | `useLiveQuery` is intentionally stateless/atomic-replace; pagination + incremental diff don't fit its callback model and changing it would risk every other caller. |
 | Deferred (OUT of scope): compound `[chatId,timestamp]` index + `DB_VERSION 6→7` | Not needed at ≤5-10k (in-memory sort is sub-10ms); would be a forward-only additive index migration only if a chat reaches ~50k+. | Adding it now is migration cost with no real-world payoff; documented so the future path is clear and stays within forward-only rules. |
+
+**Escalation trigger for the deferred index**: if a real chat approaches ~20k+ messages,
+or a user reports scroll sluggishness on a very long chat, treat that as the signal to
+spike the `[chatId,timestamp]` compound index + `DB_VERSION 6→7` forward-only migration
+(research D2). Until then, `getAll` + in-memory sort stays within budget at target sizes.
+
+## Implementation Notes (as built)
+
+The shipped design evolved over two rounds of real-iPhone testing. The final architecture is
+a **spacer-based virtual list that never writes `scrollTop` during scrolling** — the key to
+not interrupting iOS momentum (a `scrollTop` write mid-fling halts the inertia; iOS has no
+`overflow-anchor`, confirmed via caniuse, so CSS scroll anchoring isn't an option either).
+
+- **Bounded run, rendered whole, framed by spacers.** `useChatHistory` holds a bounded run
+  (`MAX_ROWS=200`, trimming the far edge on each batch). `ChatDetailPage` renders the WHOLE
+  run (no separate `{start,end}` window — `MAX_ROWS` already bounds the DOM) between a TOP and
+  BOTTOM spacer (`.vscroll-pad`). The spacers reserve the height of the older/newer messages
+  not held in `rows` (`olderUnloaded`/`newerUnloaded` × measured avg row height), so the
+  scroll range reflects the whole chat.
+- **Position is held by the spacer, never `scrollTop`.** On a prepend/append/trim,
+  `withScrollAnchor` measures how far the anchored bubble moved and cancels it by adjusting
+  the TOP spacer's height (a layout change applied imperatively *before paint* → no flash),
+  instead of writing `scrollTop`. Because no `scrollTop` write happens, native fling momentum
+  is never interrupted. The bottom spacer is purely cosmetic (below the viewport). Only the
+  rare very-top case (spacer exhausted) and the deliberate jumps (open / send / jump-to-date /
+  reply-seek) write `scrollTop` — none of which happen mid-fling.
+- **Media bubbles reserve their height at mount.** The image/non-note-video frame
+  (`.media-wrap`/`.video-poster`, fixed `240px` `aspect-ratio:1`) renders as soon as
+  `m.mediaId` exists (skeleton until the poster decodes), rather than being gated behind
+  `mediaInfo` resolution — so a prepended media batch has its FINAL height immediately and
+  doesn't reflow 0→240px when the blob resolves async (that reflow was the blank-frame + jump
+  on the media-heavy region; invisible to 1×1-PNG e2e seeds).
+- **Direction-gated look-ahead.** Two IntersectionObserver sentinels (rootMargin
+  `LOOK_AHEAD_PX`) trigger `loadOlder`/`loadNewer`; each is honored only in the matching
+  scroll direction so the opposite sentinel can't tug the window mid-fling. `overflow-anchor:
+  none` on `.msg-list` keeps the browser from double-correcting against the spacer change
+  (inert on iOS, prevents jitter on Chrome/Android).
+- **Whole-chat media viewer + audio playlist keep a whole-chat source** (`listChatMediaAll`
+  → `allMedia`); forward-selection reads the loaded run (`rows`). FR-011 behavioral
+  equivalence preserved while the list's full-array churn is gone (D3).
+- **Trade-off vs the spec's strict ≤2px (INV-1):** position is held precisely by the measured
+  spacer correction, but spacer *sizing* uses an estimated avg row height, so the scrollbar
+  proportion is approximate and there can be minor drift at extreme media↔text composition
+  changes — accepted in favour of uninterrupted native momentum (the user's explicit
+  priority). The pure `chat-window.ts` window/anchor math (`computeWindow` etc.) remains
+  unit-tested and available but is no longer wired into the view.
+- **Constants:** `BATCH_SIZE=50`, `MAX_ROWS=200`, `LOOK_AHEAD_PX=1200`
+  (`src/utils/chat-window.ts`); media LRU `MAX_MEDIA=60` unchanged.

--- a/specs/1011-smooth-chat-history/quickstart.md
+++ b/specs/1011-smooth-chat-history/quickstart.md
@@ -42,7 +42,7 @@ Then verify (automated in `e2e/chat-media-scroll.spec.ts`):
 - **SC-004 / INV-4**: seed an extra inbound message/reaction while scrolled up → `scrollTop`
   unchanged (no yank).
 - **SC-006 / INV-6**: tap a reply-quote whose target is older than the window → it mounts
-  and centers within ~1s (no "not available").
+  and centers within 1.0s (no "not available").
 
 ## Manual smoke
 
@@ -60,4 +60,5 @@ cd server && go build ./... && go vet ./... && go test ./...   # unchanged, must
 make db-up && npm run test:e2e   # incl. the 5k-seeded scroll assertions
 ```
 
-All green = done (Constitution VII). No `/speckit-checklist` (client-only, Principle I).
+All green = done (Constitution VII). The `/speckit-checklist` zero-knowledge gate was run and
+passed (checklists/zero-knowledge.md, 14/14) — confirming Principle I is unaffected.

--- a/specs/1011-smooth-chat-history/quickstart.md
+++ b/specs/1011-smooth-chat-history/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Smooth Chat-History Scroll-Up
+
+How to exercise and verify, mapped to the Success Criteria (SC) and scroll invariants (INV).
+
+## Run locally
+
+```sh
+make start          # PostgreSQL + ringd + Vite at http://localhost:5173
+```
+
+## Multi-user exercise (US2) — the `drive/` harness
+
+Drives the live app as 5 users, connects them, holds 1:1 + group conversations across
+every message kind, builds a lengthy chat, and scrolls up.
+
+```sh
+node drive/scenarios/lengthy-chat-scroll.mjs        # headless
+HEADED=1 node drive/scenarios/lengthy-chat-scroll.mjs   # watch it
+```
+
+- Confirms: 5 users connect via request+accept; text / voice-audio / video-message /
+  image-upload / video-upload delivered + rendered for all participants in 1:1 + group
+  (SC-005); a lengthy chat opens and scrolls back; screenshots land in `.tmp/drive/`
+  (read them to confirm continuous content, no blank flash/snap — SC-007).
+
+## Scroll smoothness (US1) — fast bulk-seed + assertions
+
+A 5,000-message chat is seeded instantly via the dev hook (no real send pipeline):
+
+```js
+await window.__ringTest.seedMessages(chatId, 5000, { mediaEvery: 12, fromIds });
+```
+
+Then verify (automated in `e2e/chat-media-scroll.spec.ts`):
+
+- **SC-002 / INV-1**: capture a bubble's `boundingClientRect().top`, flick up so an older
+  page loads, re-read after it lands → delta ≤ 2px (no jump).
+- **SC-003 / INV-2**: the older batch's first `[data-mid]` is in the DOM before
+  `scrollTop` reaches 0 (page-before-top; no stall/snap).
+- **SC-008 / INV-3**: after scrolling far up and back down, the rendered `.bubble[data-mid]`
+  count stays ≈ `ROW_CAP` (bounded DOM) and resolved media ≤ `MAX_MEDIA` (bounded memory).
+- **SC-004 / INV-4**: seed an extra inbound message/reaction while scrolled up → `scrollTop`
+  unchanged (no yank).
+- **SC-006 / INV-6**: tap a reply-quote whose target is older than the window → it mounts
+  and centers within ~1s (no "not available").
+
+## Manual smoke
+
+- Open a long chat, flick up hard repeatedly: continuous, no stall/snap, the line you were
+  reading stays put. Send/receive a message while scrolled up: the view doesn't jump.
+- Group chat: avatars/day-dividers at the top edge don't flicker as older rows load (INV-7).
+- Best on a **real device** for iOS momentum (INV-5) — emulation can't fully prove fling feel.
+
+## Automated checks (definition of done)
+
+```sh
+npm run build                 # vue-tsc + vite
+npx vitest run                # window/pagination/anchor/group-edge pure helpers
+cd server && go build ./... && go vet ./... && go test ./...   # unchanged, must stay green
+make db-up && npm run test:e2e   # incl. the 5k-seeded scroll assertions
+```
+
+All green = done (Constitution VII). No `/speckit-checklist` (client-only, Principle I).

--- a/specs/1011-smooth-chat-history/research.md
+++ b/specs/1011-smooth-chat-history/research.md
@@ -24,9 +24,11 @@ judged comparison of three virtualization approaches. No `NEEDS CLARIFICATION` r
   screens + buffer). Every window mutation runs through one shared `withScrollAnchor()`
   helper (D4) so prepend AND eviction restore position identically. Optionally layer
   CSS `content-visibility` on rendered rows later if paint cost shows up.
-- **Rationale**: This preserves the one mechanism already proven to hold ≤2px in this
-  codebase — anchoring on a real, still-rendered `.bubble[data-mid]` and correcting
-  `scrollTop` by its measured rect delta *after* layout (`loadOlder` 2218-2225). That
+- **Rationale**: This preserves the one mechanism this codebase already relies on for
+  prepend anchoring — anchoring on a real, still-rendered `.bubble[data-mid]` and
+  correcting `scrollTop` by its measured rect delta *after* layout (`loadOlder`
+  ~2218-2225), generalized here and **verified to hold ≤2px by the T015 e2e assertions**
+  (not merely assumed). That
   post-layout rect read absorbs late poster decode, group-avatar toggles, album
   collapsing, and reaction reflow — exactly what defeats an estimate/index-based
   virtualizer. It keeps the entire existing chat surface (receipts, reactions,
@@ -86,8 +88,9 @@ judged comparison of three virtualization approaches. No `NEEDS CLARIFICATION` r
 ## D5 — Prefetch-ahead (page before the boundary)
 
 - **Decision**: Load older batches **look-ahead** via a sentinel/threshold positioned
-  well before the top edge (~1.5-2 screens of buffer above the viewport), so the older
-  batch is present BEFORE the top is reached. Keep `ion-infinite-scroll` (or an
+  well before the top edge (`LOOK_AHEAD_PX ≈ 1200`, ~1.5-2 mobile screens of buffer above
+  the viewport), so the older batch is present BEFORE the top is reached. Keep
+  `ion-infinite-scroll` (or an
   IntersectionObserver sentinel) as the backstop.
 - **Rationale**: FR-002/SC-003. Today `ion-infinite-scroll` fires at `threshold=25%`
   (line 98) and `loadOlder` only THEN grows the window — a fast flick outruns it (stall
@@ -155,8 +158,12 @@ judged comparison of three virtualization approaches. No `NEEDS CLARIFICATION` r
 
 ## Open risks (carry into implementation)
 
+These implementation-level risks correspond to the product-level scenarios in spec.md
+§Edge Cases (same concerns, two audiences: scenarios for product clarity, risks for
+implementation vigilance).
+
 - Eviction BELOW the viewport + downward re-entry is the genuinely new, unproven part
-  (prepend anchoring is proven; bottom-edge trim/re-mount at ≤2px has no precedent here).
+  (prepend anchoring is proven; bottom-edge eviction/re-mount at ≤2px has no precedent here).
 - Media LRU (`MAX_MEDIA=60`) can revoke a poster URL for an off-screen row that later
   re-enters — re-entry must re-resolve media AND re-anchor in the same frame.
 - Incremental-apply (D3) is a behavioral-equivalence risk: every full-array-replace

--- a/specs/1011-smooth-chat-history/research.md
+++ b/specs/1011-smooth-chat-history/research.md
@@ -1,0 +1,170 @@
+# Phase 0 Research: Smooth Chat-History Scroll-Up
+
+Decisions for making chat scroll-up smooth to ~5,000+ messages with bounded DOM/memory
+and ≤2px anchor stability. Grounded in a verified read of the current implementation
+(`ChatDetailPage.vue`, `queries.ts`, `idb.ts`, `useLiveQuery.ts`) and an adversarially
+judged comparison of three virtualization approaches. No `NEEDS CLARIFICATION` remain
+(the spec's Clarifications resolved the product choices).
+
+## Approach comparison (summary)
+
+| Approach | Bounds DOM+mem | ≤2px anchor | Variable heights | Ionic-safe | Verdict |
+|---|---|---|---|---|---|
+| **A. Hand-rolled bidirectional window** (extend the existing slice-window) | ✅ | ✅ | ✅ | ✅ | **Recommended (8.5)** |
+| B. `@tanstack/vue-virtual` (measured virtualizer) | ✅ | ❌ | ❌ | ❌ | Not primary (5) — index anchoring + async poster/avatar reflow misses the ≤2px bar; forces a swipe-gesture rewrite + ion-content scroll bridge; "spike required". Fallback only. |
+| C. CSS `content-visibility:auto` | ❌ | n/a | ✅ | ✅ | Rejected (1.5) — skips off-screen *paint* but does NOT unmount DOM or bound the in-memory array (FR-012/013). Keep only as a cheap paint layer atop A if profiling warrants. |
+
+## D1 — Virtualization: hand-rolled bidirectional window
+
+- **Decision**: Replace `visible: ref(PAGE)` + `visibleMessages = messages.slice(-visible)`
+  (ChatDetailPage.vue:2179-2181) with an explicit reactive window `{ start, end }` and
+  render `messages.slice(start, end)`. Grow `start` downward (older) on top look-ahead;
+  grow `end` upward (newer) on scroll-down re-entry; **evict** by advancing `start` /
+  retreating `end` once the window exceeds a row cap (~80-120 rendered rows ≈ several
+  screens + buffer). Every window mutation runs through one shared `withScrollAnchor()`
+  helper (D4) so prepend AND eviction restore position identically. Optionally layer
+  CSS `content-visibility` on rendered rows later if paint cost shows up.
+- **Rationale**: This preserves the one mechanism already proven to hold ≤2px in this
+  codebase — anchoring on a real, still-rendered `.bubble[data-mid]` and correcting
+  `scrollTop` by its measured rect delta *after* layout (`loadOlder` 2218-2225). That
+  post-layout rect read absorbs late poster decode, group-avatar toggles, album
+  collapsing, and reaction reflow — exactly what defeats an estimate/index-based
+  virtualizer. It keeps the entire existing chat surface (receipts, reactions,
+  disappearing, search, jump-to-newest, swipe, media LRU, v-memo) intact; only the
+  slice bounds and the array source change.
+- **Alternatives rejected**: `@tanstack/vue-virtual` (anchors by index, estimates
+  unmeasured heights, optimizes oldest-at-top forward lists — invisible-prepend +
+  late-decode is its documented hard case; would force a swipe rewrite + ion-content
+  scroll-metrics bridge; rated HIGH risk / "spike required"). CSS `content-visibility`
+  (does not bound DOM or memory; cannot be the windowing strategy).
+
+## D2 — Bounded reads (no DB migration)
+
+- **Decision**: Add `listMessagesOlder(chatId, beforeTs|null, limit, q?)`,
+  `listMessagesNewer(chatId, afterTs, limit, q?)`, and `countChatMessages(chatId)` to
+  `queries.ts`; the chat view sources its window from these batches (via D3) instead of
+  holding the whole chat. **Do NOT** add a `[chatId, timestamp]` compound index and
+  **do NOT** bump `DB_VERSION` (stays at 6) for v1.
+- **Rationale**: FR-013 wants bounded reads. The existing single `chatId` index
+  (idb.ts:91) + an in-memory sort of even 5-10k objects is sub-10ms, so batches can be
+  served by a one-time `getByIndex` + sort + slice without a schema change — avoiding a
+  forward-only `onupgradeneeded` migration for no real-world payoff at target sizes.
+- **Alternatives rejected**: Compound `[chatId, timestamp]` index + `DB_VERSION 6→7`
+  (migration cost > benefit until ~50k messages — see the deferred-migration note in
+  plan.md Complexity Tracking). Keeping `listMessages` (loads-all) as the chat-view
+  source (the full-array source is the churn root — D3).
+
+## D3 — Reactivity without full-array replace
+
+- **Decision**: Introduce a `useChatHistory(chatId)` composable that subscribes to the
+  `messages` change bus and applies **incremental** mutations to the in-memory list:
+  append (only if the window touches the bottom), patch-by-id (edit/reaction/receipt/
+  status → shallow-merge one row), remove-by-id (splice) — instead of re-running the
+  whole query and reassigning the array.
+- **Rationale**: `useLiveQuery` does `value.value = result` on EVERY `messages` write
+  (useLiveQuery.ts:35), re-allocating thousands of objects per reaction/seen/tick — the
+  churn that lands extra layout work around a load. Incremental apply removes the churn
+  and is what lets virtualization (D1) stay cheap.
+- **Alternatives rejected**: Adapting `useLiveQuery` (it's intentionally stateless /
+  atomic-replace; pagination + incremental diff don't fit its callback model and would
+  risk every other caller). Diffing the replaced array each time (still re-reads all).
+
+## D4 — Anchor + eviction strategy (shared `withScrollAnchor`)
+
+- **Decision**: Extract a single `withScrollAnchor(mutate)` used by BOTH prepend and
+  eviction: (1) pick anchor = the topmost fully-rendered `.bubble[data-mid]` still in
+  the viewport, record its id + `rect.top` + the scroll element; (2) run the window
+  mutation; (3) `await nextTick()`; (4) re-find the anchor by id (fall back to the next
+  still-rendered row if it was evicted) and correct `scrollTop` by the measured delta.
+- **Rationale**: FR-001/SC-002 require ≤2px across prepend AND eviction; a measured-rect
+  anchor is the only thing robust to FR-007 late media decode and FR-005 avatar/album
+  height changes. `loadOlder` already does this for prepend (2218-2225) — generalize it.
+- **Alternatives rejected**: `scrollHeight`-delta restoration (the `loadOlder` comment
+  2213-2216 already documents it skews with the spinner/late layout → jumps).
+  Index/estimate-based anchoring (defeated by async height changes).
+
+## D5 — Prefetch-ahead (page before the boundary)
+
+- **Decision**: Load older batches **look-ahead** via a sentinel/threshold positioned
+  well before the top edge (~1.5-2 screens of buffer above the viewport), so the older
+  batch is present BEFORE the top is reached. Keep `ion-infinite-scroll` (or an
+  IntersectionObserver sentinel) as the backstop.
+- **Rationale**: FR-002/SC-003. Today `ion-infinite-scroll` fires at `threshold=25%`
+  (line 98) and `loadOlder` only THEN grows the window — a fast flick outruns it (stall
+  → snap).
+- **Alternatives rejected**: Idle-time whole-history preload (spec marks optional; would
+  reintroduce unbounded memory). Boundary-only load at 25% (the current stall source).
+
+## D6 — `loadOlder` momentum + echo guards
+
+- **Decision**: Apply the same two guards the rest of the view already uses, inside
+  `withScrollAnchor`: `MOMENTUM_QUIET_MS` (don't write `scrollTop` while a fling is in
+  flight; re-apply once it settles) and `suppressStickUntil` (mark the post-correction
+  scroll as our own echo so `onContentScroll` doesn't flip `stickBottom`).
+- **Rationale**: `loadOlder` is the ONLY scroll-writing path without these guards
+  (2212-2228 vs guarded 2029/2437/2449) — the root of the "load fights momentum"
+  symptom (FR-003).
+- **Alternatives rejected**: Leaving `loadOlder` unguarded.
+
+## D7 — Jump-to-older seek (US3 / FR-006)
+
+- **Decision**: Generalize the existing jump-to-date retry loop (`onPickDate` ~1010-1015,
+  the `[data-mid]` poll) into `seekToMessage(id)` that, when the target isn't in the
+  window, loads older batches (grow `start`, or seek the batch containing it by
+  timestamp) in a bounded loop until the row mounts, then centers it.
+- **Rationale**: `scrollToMessage` (1674-1686) today only works if the row is already
+  rendered, else toasts "Original message not available" — wrong for an on-device
+  message merely outside the window (US3).
+- **Alternatives rejected**: Loading the whole history to find the target (defeats
+  bounded memory). Scroll-by-estimated-offset (variable heights make it unreliable).
+
+## D8 — Group-row correctness across the window edge
+
+- **Decision**: Keep `groupRunStart`/`showDay`/`v-memo` keyed on positional index but
+  compute run-start/day from the row's **predecessor included in the window** (render one
+  extra leading row, or compute from message adjacency) so an avatar/divider doesn't
+  appear/disappear when the predecessor is evicted/prepended.
+- **Rationale**: `groupRunStart(i)`/`showDay(i)` read `renderItems[i-1]` (1142-1146,
+  1605-1613); at the window's top edge that predecessor changes on load → avatar/divider
+  flicker + a height jump injected into the anchored frame (FR-005).
+- **Alternatives rejected**: Ignoring the boundary predecessor (flicker + jump).
+
+## D9 — Fast bulk-seed testhook (for a 5,000-msg test)
+
+- **Decision**: Add a dev-only `window.__ringTest.seedMessages(chatId, n, opts?)` that
+  builds N `Message` records in memory and writes them with ONE `bulkPut('messages', rows)`
+  (idb.ts already has `bulkPut`) in a single transaction, with spread timestamps and an
+  optional mix of text/media/album/group-sender rows.
+- **Rationale**: A 5,000-msg scroll test (SC-008) is impractical through the real send
+  pipeline (minutes/run, hits crypto/relay) and `showcase-seed` writes per-row in an
+  await loop. `bulkPut` makes it instant + deterministic.
+- **Alternatives rejected**: Sending via the real pipeline; reusing `seedShowcase`
+  (fixed small dataset).
+
+## Recommendation & fallback
+
+- **Recommendation**: Approach A end-to-end (D1-D9).
+- **Fallback** (if full bidirectional eviction proves unstable mid-implementation — most
+  likely the eviction-below-viewport / downward-re-entry case): ship the safer subset
+  that still delivers the headline smoothness — (1) keep a GROW-only window but add
+  aggressive look-ahead prefetch (D5), (2) bound only the in-memory read with cursor
+  batches + incremental reactivity (D2/D3) so FR-013 holds, (3) add `overflow-anchor:auto`
+  + the `loadOlder` guards (D6). This meets FR-001/002/003 and bounded **memory**, with
+  bounded **DOM** (FR-012 strict eviction) deferred. Strictly less than the 5k-DOM target
+  but smooth and shippable.
+
+## Open risks (carry into implementation)
+
+- Eviction BELOW the viewport + downward re-entry is the genuinely new, unproven part
+  (prepend anchoring is proven; bottom-edge trim/re-mount at ≤2px has no precedent here).
+- Media LRU (`MAX_MEDIA=60`) can revoke a poster URL for an off-screen row that later
+  re-enters — re-entry must re-resolve media AND re-anchor in the same frame.
+- Incremental-apply (D3) is a behavioral-equivalence risk: every full-array-replace
+  consumer (chatMediaMsgs ~1155, viewerItems, albumMessageIds, preview) must keep working.
+- `groupRunStart`/`showDay` at the window's top edge (D8) — flicker/height-jump if unhandled.
+- "No compound index" (D2) assumes `getAll`+sort stays cheap; a pathological 20-50k chat
+  is a deferred cliff (revisit the index migration then).
+- FR-003 iOS momentum: writing `scrollTop` during native WebKit inertia is inherently
+  fighty; the guard mitigates but **real-device** verification is needed.
+- Search scope: search resets the window and filters the in-memory array today; bounded
+  reads + search must agree on scope (loaded-batch vs whole chat).

--- a/specs/1011-smooth-chat-history/spec.md
+++ b/specs/1011-smooth-chat-history/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-17
 
-**Status**: planned
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category
@@ -37,6 +37,28 @@ lengthy history, and then scrolls back through it to validate the smoothness.
 
 This is a **client-only** change (chat view + data-access + its verification harness).
 It does not touch the wire, the server, or any stored ciphertext.
+
+## Zero-Knowledge Impact
+
+This feature is **client-only** and leaves the zero-knowledge boundary untouched
+(Constitution Principle I):
+
+- **What crosses the wire**: nothing new. No request, payload, header, or metadata is
+  added or changed. History is already on the device; this feature only changes how the
+  existing local rows are read (bounded batches), rendered (a bounded window), and kept
+  in place during scroll.
+- **What is encrypted / decrypted**: nothing new. Messages remain stored as they are
+  today; the bounded reads return the same already-decrypted-for-render `Message` rows
+  the chat view already uses. No new key use, and no new plaintext is produced or persisted.
+- **What metadata is unavoidably visible to the server**: none introduced. The server
+  sees no read positions, scroll state, window bounds, or batch sizes — all of that is
+  local-only in-memory / IndexedDB state.
+- **Why**: the change lives entirely in the client render / data-access layer
+  (`ChatDetailPage.vue`, a new `useChatHistory` composable, bounded reads in `queries.ts`,
+  and a dev-only test hook). It never touches `messaging.ts`, the wire, the server, or any
+  stored ciphertext, and makes no `DB_VERSION`/schema change. The `/speckit-checklist`
+  zero-knowledge gate has been run for this spec (checklists/zero-knowledge.md) and confirms
+  Principle I is unaffected.
 
 ## Clarifications
 
@@ -84,13 +106,15 @@ across many pages of history, and observe that the anchored message stays in pla
    the older messages are inserted, **Then** the momentum is not interrupted — no
    stutter, teleport, or abrupt stop.
 4. **Given** a new message or reaction arrives while the user is reading history,
-   **When** it is applied, **Then** the user's viewport is not yanked (auto-follow to
-   the newest only happens when they were already at the bottom).
+   **When** it is applied, **Then** the user keeps reading from exactly the same place —
+   their view does not jump to the newest message. (The normative rule is FR-004,
+   verified by SC-004.)
 5. **Given** a group chat where older runs introduce sender avatars or collapsed
    media albums, **When** those older messages load, **Then** the resulting row-height
    differences do not cause a jump.
 6. **Given** a 5,000-message history, **When** the user scrolls far back and forth,
-   **Then** the app stays responsive and memory/rendered-row count stays bounded.
+   **Then** the app stays responsive throughout, no matter how far back they scroll.
+   (The bounded-rendering mechanism behind this is FR-012, measured by SC-008.)
 
 ---
 
@@ -138,8 +162,8 @@ the message isn't available.
 secondary to the primary scroll gesture; valuable polish that completes the story.
 
 **Independent Test**: In a long chat, tap a reply that quotes a message far above the
-loaded window and confirm the view scrolls to that message rather than showing a
-"not available" message.
+loaded window and confirm the view scrolls to that message (within ~1.0s) rather than
+showing a "not available" message.
 
 **Acceptance Scenarios**:
 
@@ -152,8 +176,9 @@ loaded window and confirm the view scrolls to that message rather than showing a
 
 ### Edge Cases
 
-- **Fast upward fling** on a very long chat: the next page must already be present
-  before the top is reached (no stall, no snap).
+- **Fast upward fling** on a very long chat: a quick flick must not outrun the
+  look-ahead — the prefetch distance has to absorb fling velocity so there is no
+  stall/snap at the boundary (the requirement itself is FR-002, verified by SC-003).
 - **Media decoding mid-load**: an image/video poster in or near the anchored row
   decoding (and growing) between frames must not skew the anchor and cause a jump.
 - **New message / reaction / status update while reading history**: must not move the
@@ -164,11 +189,13 @@ loaded window and confirm the view scrolls to that message rather than showing a
   the mechanism must still keep the viewport stable (use a still-rendered reference).
 - **Scrolling back DOWN after scrolling far up**: returning toward the newest must be
   smooth too, re-rendering evicted newer rows without a jump.
-- **Keyboard opens / view resizes** during scroll: must not fight the user's gesture.
+- **Keyboard opens / view resizes** during scroll: must not fight the user's gesture
+  (relies on the existing Ionic keyboard/resize handling — no new logic; manually
+  smoke-checked mid-flick in T032).
 - **Group vs 1:1**: avatars and album collapsing change row heights as older runs
   mount — both must stay smooth.
 - **Backgrounded / locked chat**: scroll side-effects must not run while the view
-  isn't visible.
+  isn't visible (normative requirement FR-014).
 
 ## Requirements *(mandatory)*
 
@@ -211,6 +238,11 @@ loaded window and confirm the view scrolls to that message rather than showing a
 - **FR-013**: Reading history MUST NOT require loading the entire conversation into
   memory at once; messages are read in bounded batches (by recency/position) as the
   user scrolls.
+- **FR-014**: Scroll side-effects (look-ahead / load-older / load-newer, eviction, and
+  any anchor-driven scroll-position correction or reactive list update) MUST NOT run
+  while the chat view is not visible (backgrounded tab, locked screen, or navigated
+  away) — preserving the app's existing visibility-gated behavior so the view is never
+  silently scrolled while the user cannot see it.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -243,14 +275,29 @@ loaded window and confirm the view scrolls to that message rather than showing a
   (text, voice/audio, video message, image upload, video upload) is delivered to and
   renders for all participants across 1:1 and group chats. Verified.
 - **SC-006**: Tapping a reply/starred reference older than the loaded window brings the
-  target into view within ~1 second, with no "not available" outcome for an on-device
-  message. Verified.
+  target into view within **1.0 second** (on a mid-range device), with no "not available"
+  outcome for an on-device message. Verified.
 - **SC-007**: Scrolling up across several pages on a mobile-emulated device shows
   continuous content — no blank flash, no snap, day-dividers and avatars rendering in
-  place. Verified by inspection (screenshots) via the UI-driving harness.
+  place. This is a **supplementary** visual check (screenshots via the UI-driving
+  harness), not a blocking CI gate; the blocking acceptance is the measurable invariants
+  in SC-002/003/004/008. Verified by inspection.
 - **SC-008**: Scrolling through a 5,000-message history keeps the rendered row count
   and memory bounded (they do not grow with scroll distance) and the app stays
   responsive throughout. Verified.
+
+*Mapping* (SC are the user-facing outcomes; INV are the implementation contracts in
+contracts/chat-history.md §3 that the tests assert). The direct pairs:
+SC-002 = INV-1 (≤2px anchor), SC-003 = INV-2 (page-before-top), SC-004 = INV-4 (no-yank),
+SC-006 = INV-6 (seek), SC-008 = INV-3 (bounded DOM/memory). The remainder are intentionally
+not 1:1:
+- **SC-001** is composite — a continuous-scroll exercise that confirms INV-1 + INV-2 + INV-3
+  + INV-4 together end-to-end (verified by the US2 exercise T023/T024).
+- **SC-005** is orthogonal to scroll mechanics — it is the multi-user delivery/render proof
+  (US2) and maps to no scroll INV.
+- **SC-007** verifies **INV-7** (group-row edge — avatars/day-dividers do not flicker).
+- **INV-5** (no momentum fight) is a defensive guard with no primary user-facing SC; its
+  *logic* is unit-tested (T005/T010) and its *fling feel* is confirmed manually (T032).
 
 ## Assumptions
 
@@ -258,6 +305,8 @@ loaded window and confirm the view scrolls to that message rather than showing a
   off-screen rows in both directions) backed by bounded/cursor reads of history —
   extending the current windowed render + anchor-and-restore rather than loading the
   whole chat into the view/memory (per Clarifications: ~5,000+ messages must stay smooth).
+  The full approach rationale and the adversarial comparison of alternatives are the
+  source of truth in research.md (decisions D1–D9); this section only summarizes them.
 - The verification exercise is realized through the project's existing UI-driving
   capability (the `drive/` harness + the dev-only test hook) and automated end-to-end
   coverage where practical; media uses test fixtures.
@@ -271,4 +320,16 @@ loaded window and confirm the view scrolls to that message rather than showing a
 - Roster, receipts, reactions, and all other messaging behaviors are unchanged; this
   is purely about history preparation/rendering and viewport stability.
 - Client-only: no server, wire, or stored-ciphertext change — zero-knowledge boundary
-  untouched (no `/speckit-checklist` required on that basis).
+  untouched. The `/speckit-checklist` zero-knowledge gate was run (checklists/zero-knowledge.md);
+  see Complexity & Exceptions.
+
+## Complexity & Exceptions
+
+- **`/speckit-checklist` gate (Constitution gate-sequencing + Principle I).** The
+  constitution requires `/speckit-checklist` for any spec *touching* Principle I or IV.
+  Although this feature is client-only and asserts the zero-knowledge boundary is
+  **untouched**, the gate has been **run** (not waived) —
+  [checklists/zero-knowledge.md](./checklists/zero-knowledge.md) — matching the precedent of
+  the client-only specs 1009 and 1010. All 14 checklist items pass: nothing new crosses or
+  changes the client↔server boundary, no new plaintext / keys / server-visible metadata, and
+  no schema change. Principle IV (crypto) is untouched, so no crypto checklist applies.

--- a/specs/1011-smooth-chat-history/spec.md
+++ b/specs/1011-smooth-chat-history/spec.md
@@ -22,18 +22,37 @@ newest messages and tries to keep the viewport anchored when older ones load, bu
 older messages are only fetched the moment the user hits the top of what's loaded —
 so a quick upward flick can outrun the load and produce a brief stall followed by a
 snap, and the load can momentarily fight the device's own scroll momentum. The
-result is occasional jumping/unsmoothness when scrolling up.
+result is occasional jumping/unsmoothness when scrolling up. The whole conversation
+is also held in memory and re-read on every change, so very long histories get heavy.
 
-This feature makes scroll-up **smooth and continuous**: older messages are prepared
-ahead of need, and they appear without moving the content under the user's view. To
-prove it — and to give us a repeatable, realistic confidence check on the whole
-messaging experience — it also delivers a **multi-user end-to-end exercise** that
-spins up several users, connects them, holds real 1:1 and group conversations across
-every message kind (text, voice/audio, video messages, image and video uploads),
-builds a lengthy history, and then scrolls back through it to validate the smoothness.
+This feature makes scroll-up **smooth and continuous at any history length**: only the
+rows around the viewport are rendered (older/newer rows are prepared ahead of need and
+evicted when far off-screen), history is read in bounded batches rather than all at
+once, and pages appear without moving the content under the user's view. To prove it —
+and to give us a repeatable, realistic confidence check on the whole messaging
+experience — it also delivers a **multi-user end-to-end exercise** that spins up
+several users, connects them, holds real 1:1 and group conversations across every
+message kind (text, voice/audio, video messages, image and video uploads), builds a
+lengthy history, and then scrolls back through it to validate the smoothness.
 
-This is a **client-only** change (chat view + its verification harness). It does not
-touch the wire, the server, or any stored ciphertext.
+This is a **client-only** change (chat view + data-access + its verification harness).
+It does not touch the wire, the server, or any stored ciphertext.
+
+## Clarifications
+
+### Session 2026-06-17
+
+- Q: How large must a conversation stay perfectly smooth on a mid-range device? →
+  A: **~5,000+ messages** — adopt true virtual scrolling (render only on-screen rows
+  plus a small buffer) backed by bounded/cursor reads of history, so the whole chat is
+  never held in the view or memory at once.
+- Q: Include jump-to-older navigation (tap a reply-quote / starred message above the
+  loaded window → smoothly scroll to it)? → A: **Yes** — in scope (User Story 3).
+- Q: What counts as "no jump" for the anchored message when older content loads? →
+  A: **≤ 2px** of drift.
+- Q: On very long scroll-backs, should older rendered rows be evicted to bound
+  memory/DOM? → A: **Yes** — evict far-off-screen rows (both directions) so the
+  rendered DOM and memory stay flat regardless of scroll distance.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -43,21 +62,21 @@ A user opens a conversation with a long history and scrolls upward to re-read ol
 messages. As they scroll, older messages are already prepared, so the scroll never
 stalls at a loading boundary; and as those older messages take their place above, the
 message the user was looking at stays put — the view never jumps, snaps, or stutters.
-This holds whether they scroll slowly or flick quickly, and in both 1:1 and group
-chats (where avatars and grouped media can change row heights).
+This holds whether they scroll slowly or flick quickly, in both 1:1 and group chats
+(where avatars and grouped media can change row heights), and at any history length.
 
 **Why this priority**: This is the headline value and the explicit ask — scrolling up
 through history must feel continuous and natural. Everything else verifies or supports it.
 
-**Independent Test**: Open a chat with a few hundred messages, scroll/flick upward
-across several pages of history, and observe that the anchored message stays in place
-(no jump) and the scroll never halts waiting for older messages to load.
+**Independent Test**: Open a chat with several hundred messages, scroll/flick upward
+across many pages of history, and observe that the anchored message stays in place
+(≤2px) and the scroll never halts waiting for older messages to load.
 
 **Acceptance Scenarios**:
 
 1. **Given** a conversation longer than one screen of history, **When** the user
    scrolls up so older messages load, **Then** the message they were viewing remains
-   at the same on-screen position (no visible jump).
+   at the same on-screen position (≤2px drift; no visible jump).
 2. **Given** the user flicks upward quickly, **When** they approach the top of the
    currently loaded messages, **Then** the next batch of older messages is already in
    place so the scroll continues without stalling or snapping.
@@ -70,6 +89,8 @@ across several pages of history, and observe that the anchored message stays in 
 5. **Given** a group chat where older runs introduce sender avatars or collapsed
    media albums, **When** those older messages load, **Then** the resulting row-height
    differences do not cause a jump.
+6. **Given** a 5,000-message history, **When** the user scrolls far back and forth,
+   **Then** the app stays responsive and memory/rendered-row count stays bounded.
 
 ---
 
@@ -139,9 +160,11 @@ loaded window and confirm the view scrolls to that message rather than showing a
   viewport; the rendered list updating must not visibly re-shuffle or jump.
 - **Anchored message deleted/edited** between frames during a load: must degrade
   gracefully (still no jump) rather than mis-correct the position.
+- **Evicted anchor**: if the row used to preserve position is evicted while off-screen,
+  the mechanism must still keep the viewport stable (use a still-rendered reference).
+- **Scrolling back DOWN after scrolling far up**: returning toward the newest must be
+  smooth too, re-rendering evicted newer rows without a jump.
 - **Keyboard opens / view resizes** during scroll: must not fight the user's gesture.
-- **Very long histories**: memory and rendered-DOM growth must stay bounded enough to
-  remain smooth on a mid-range device.
 - **Group vs 1:1**: avatars and album collapsing change row heights as older runs
   mount — both must stay smooth.
 - **Backgrounded / locked chat**: scroll side-effects must not run while the view
@@ -152,7 +175,7 @@ loaded window and confirm the view scrolls to that message rather than showing a
 ### Functional Requirements
 
 - **FR-001**: When older messages load during an upward scroll, the message currently
-  in view MUST remain at the same on-screen position (no perceptible jump).
+  in view MUST remain at the same on-screen position (≤2px drift; no perceptible jump).
 - **FR-002**: Older messages MUST be prepared ahead of need so that scrolling upward
   — including a fast flick — does not stall waiting at a loading boundary.
 - **FR-003**: Any automatic scroll adjustment performed while loading older messages
@@ -176,23 +199,31 @@ loaded window and confirm the view scrolls to that message rather than showing a
 - **FR-009**: The exercise MUST drive the real application UI/flows (not bypass them),
   be runnable repeatedly with no manual setup, and leave the environment clean afterward.
 - **FR-010**: Smoothness MUST be verifiable automatically — e.g. asserting that the
-  anchored message's on-screen position is preserved within the agreed tolerance and
-  that the next older page is present before the top edge is reached.
+  anchored message's on-screen position is preserved within 2px and that the next older
+  page is present before the top edge is reached.
 - **FR-011**: All existing chat behaviors (sending, receipts/seen, reactions,
   disappearing messages, jump-to-newest on send, search) MUST continue to work
-  unchanged; this feature only changes how older history is prepared and how the
+  unchanged; this feature only changes how history is prepared/rendered and how the
   viewport is preserved.
+- **FR-012**: The rendered rows and memory MUST stay bounded regardless of how far the
+  user scrolls — only rows near the viewport (plus a buffer) are rendered; far
+  off-screen rows are evicted. Scrolling a 5,000+ message history MUST stay responsive.
+- **FR-013**: Reading history MUST NOT require loading the entire conversation into
+  memory at once; messages are read in bounded batches (by recency/position) as the
+  user scrolls.
 
 ### Key Entities *(include if feature involves data)*
 
 - **Conversation history**: the full ordered set of a chat's messages (oldest →
-  newest); the source the rendered window draws from. No change to how it's stored.
-- **Rendered window**: the contiguous slice of the newest N messages currently shown;
-  grows toward older messages as the user scrolls up.
-- **Older-message page**: a batch of older messages added to the rendered window when
-  scrolling up; its arrival must be invisible to the viewport (position-preserving).
+  newest); now read in bounded batches rather than all at once. No change to how it's
+  stored at rest.
+- **Rendered window**: the bounded set of rows currently rendered around the viewport
+  (on-screen plus a small buffer); rows far off-screen (in either direction) are
+  evicted so the rendered DOM and memory stay bounded.
+- **Older-message page**: a bounded batch of older messages prepared/added as the user
+  scrolls up; its arrival must be invisible to the viewport (position-preserving).
 - **Scroll anchor**: the reference message used to keep the viewport stable across a
-  page load.
+  page load; must remain valid even if some rows are evicted.
 
 ## Success Criteria *(mandatory)*
 
@@ -202,8 +233,7 @@ loaded window and confirm the view scrolls to that message rather than showing a
   conversation of at least 200 messages in continuous gestures with no visible jump
   and no stall at a loading boundary. Verified by an automated exercise.
 - **SC-002**: When an older page loads during scroll-up, the anchored message's
-  on-screen position changes by no more than a small, imperceptible tolerance
-  (see Assumptions) — effectively "stays put". Verified.
+  on-screen position changes by no more than **2px** — effectively "stays put". Verified.
 - **SC-003**: The next older page is present before the user reaches the top edge of
   the loaded content (there is never a frame at the top with more history unrendered).
   Verified.
@@ -218,40 +248,27 @@ loaded window and confirm the view scrolls to that message rather than showing a
 - **SC-007**: Scrolling up across several pages on a mobile-emulated device shows
   continuous content — no blank flash, no snap, day-dividers and avatars rendering in
   place. Verified by inspection (screenshots) via the UI-driving harness.
+- **SC-008**: Scrolling through a 5,000-message history keeps the rendered row count
+  and memory bounded (they do not grow with scroll distance) and the app stays
+  responsive throughout. Verified.
 
 ## Assumptions
 
-- Builds on the existing approach (a windowed render of the newest messages with an
-  anchor-and-restore on prepend) rather than introducing a new list/virtualization
-  subsystem; the change prepares older pages earlier and hardens the position-preserve.
+- Adopts virtual scrolling (render only on-screen rows plus a small buffer, evicting
+  off-screen rows in both directions) backed by bounded/cursor reads of history —
+  extending the current windowed render + anchor-and-restore rather than loading the
+  whole chat into the view/memory (per Clarifications: ~5,000+ messages must stay smooth).
 - The verification exercise is realized through the project's existing UI-driving
   capability (the `drive/` harness + the dev-only test hook) and automated end-to-end
   coverage where practical; media uses test fixtures.
-- "Lengthy chat" means at least ~200 messages for the scroll exercise; smoothness is
-  targeted for typical histories up to ~1,000 messages on a mid-range device. Larger
-  histories (5,000+) may warrant additional optimization treated as out of scope here.
-- "No jump" is interpreted as ≤ ~2px of anchor drift (imperceptible); the exact
-  tolerance is confirmed during clarification.
+- "Lengthy chat" means at least ~200 messages for the scroll exercise; smoothness with
+  bounded memory is targeted up to 5,000+ messages on a mid-range device.
+- "No jump" means ≤ 2px of anchor drift (per Clarifications).
+- The rendered set is bounded by evicting off-screen rows (both directions), so DOM and
+  memory stay flat regardless of scroll distance (per Clarifications).
 - Older pages are prepared on scroll proximity (look-ahead) by default; proactive
-  idle-time preloading is an optional enhancement, not required for v1.
-- The rendered window grows toward older messages for the session and is not required
-  to shrink/evict older rows in v1 (bounded-DOM eviction is a possible later refinement).
+  idle-time preloading is an optional enhancement, not required.
 - Roster, receipts, reactions, and all other messaging behaviors are unchanged; this
-  is purely about history preparation and viewport stability.
+  is purely about history preparation/rendering and viewport stability.
 - Client-only: no server, wire, or stored-ciphertext change — zero-knowledge boundary
   untouched (no `/speckit-checklist` required on that basis).
-
-## Open product decisions (for `/speckit-clarify`)
-
-These have reasonable defaults above but materially affect scope and should be confirmed:
-
-1. The largest history that must stay smooth on a low-end device (decides whether
-   windowing + look-ahead is sufficient or whether bounded/cursor reads + true virtual
-   scrolling are needed).
-2. The exact "no jump" tolerance (0px vs ≤2px) — sets the acceptance threshold.
-3. Whether jump-to-older navigation (reply/starred above the window, User Story 3) is
-   in scope here or a separate spec.
-4. Whether older rendered rows should ever be evicted to bound DOM on very long
-   scroll-backs.
-5. Whether older pages should also be preloaded proactively while idle, or only on
-   scroll proximity.

--- a/specs/1011-smooth-chat-history/spec.md
+++ b/specs/1011-smooth-chat-history/spec.md
@@ -1,0 +1,257 @@
+# Feature Specification: Smooth Chat-History Scroll-Up (verified by a multi-user end-to-end exercise)
+
+**Feature Branch**: `feat/1011-smooth-chat-history`
+
+**Created**: 2026-06-17
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Run the server locally, create 5 users, connect them (request + accept), create 1:1 and group chats, chat with text / audio / video messages and image + video uploads, build a lengthy chat and verify everything works between them and feels smooth and correct; then open a lengthy chat, scroll up, observe how infinite scroll behaves, and adjust it so older messages are prepared in good time and scrolling up to older content is smooth without jumping around or unsmoothness."
+
+## Overview
+
+Reading back through a long conversation should feel like reading a page — you flick
+upward and older messages are simply *there*, with the line you were looking at
+staying exactly where it was. Today Ring already renders a moving window of the
+newest messages and tries to keep the viewport anchored when older ones load, but
+older messages are only fetched the moment the user hits the top of what's loaded —
+so a quick upward flick can outrun the load and produce a brief stall followed by a
+snap, and the load can momentarily fight the device's own scroll momentum. The
+result is occasional jumping/unsmoothness when scrolling up.
+
+This feature makes scroll-up **smooth and continuous**: older messages are prepared
+ahead of need, and they appear without moving the content under the user's view. To
+prove it — and to give us a repeatable, realistic confidence check on the whole
+messaging experience — it also delivers a **multi-user end-to-end exercise** that
+spins up several users, connects them, holds real 1:1 and group conversations across
+every message kind (text, voice/audio, video messages, image and video uploads),
+builds a lengthy history, and then scrolls back through it to validate the smoothness.
+
+This is a **client-only** change (chat view + its verification harness). It does not
+touch the wire, the server, or any stored ciphertext.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Smooth scroll-up through a long conversation (Priority: P1)
+
+A user opens a conversation with a long history and scrolls upward to re-read older
+messages. As they scroll, older messages are already prepared, so the scroll never
+stalls at a loading boundary; and as those older messages take their place above, the
+message the user was looking at stays put — the view never jumps, snaps, or stutters.
+This holds whether they scroll slowly or flick quickly, and in both 1:1 and group
+chats (where avatars and grouped media can change row heights).
+
+**Why this priority**: This is the headline value and the explicit ask — scrolling up
+through history must feel continuous and natural. Everything else verifies or supports it.
+
+**Independent Test**: Open a chat with a few hundred messages, scroll/flick upward
+across several pages of history, and observe that the anchored message stays in place
+(no jump) and the scroll never halts waiting for older messages to load.
+
+**Acceptance Scenarios**:
+
+1. **Given** a conversation longer than one screen of history, **When** the user
+   scrolls up so older messages load, **Then** the message they were viewing remains
+   at the same on-screen position (no visible jump).
+2. **Given** the user flicks upward quickly, **When** they approach the top of the
+   currently loaded messages, **Then** the next batch of older messages is already in
+   place so the scroll continues without stalling or snapping.
+3. **Given** the user is mid-flick (momentum scrolling) when a batch loads, **When**
+   the older messages are inserted, **Then** the momentum is not interrupted — no
+   stutter, teleport, or abrupt stop.
+4. **Given** a new message or reaction arrives while the user is reading history,
+   **When** it is applied, **Then** the user's viewport is not yanked (auto-follow to
+   the newest only happens when they were already at the bottom).
+5. **Given** a group chat where older runs introduce sender avatars or collapsed
+   media albums, **When** those older messages load, **Then** the resulting row-height
+   differences do not cause a jump.
+
+---
+
+### User Story 2 - Realistic multi-user exercise proves the chat works end-to-end (Priority: P1)
+
+A repeatable exercise drives the real app as ~5 users: each sends connection requests
+and the others accept; they form 1:1 and group chats; and they hold realistic
+conversations exchanging every message kind — text, voice/audio messages, video
+messages, image uploads, and video uploads — building a lengthy history. The exercise
+confirms that messages and media are delivered, rendered, and reciprocated correctly
+between all participants and that the experience feels smooth and correct, then opens
+a lengthy chat and scrolls up to validate User Story 1.
+
+**Why this priority**: It is both the proof for the scroll work and a broad,
+re-runnable smoke test of connecting, messaging, media, and groups — high confidence
+for low ongoing cost, and exactly the scenario the user asked to build.
+
+**Independent Test**: Run the exercise against a local stack; confirm all 5 users
+connect, the 1:1 and group conversations contain each message kind delivered to every
+participant, the media renders, and the lengthy chat opens and scrolls back smoothly.
+
+**Acceptance Scenarios**:
+
+1. **Given** 5 fresh users, **When** the exercise connects them via request + accept,
+   **Then** each intended pair is connected and can message.
+2. **Given** connected users, **When** they exchange text, voice/audio, video
+   messages, image uploads, and video uploads in 1:1 and group chats, **Then** every
+   message and its media is delivered to, and renders correctly for, all intended
+   participants.
+3. **Given** a lengthy chat built by the exercise, **When** it is opened and scrolled
+   upward, **Then** the scroll-up smoothness from User Story 1 is observed and asserted.
+4. **Given** the exercise has run once, **When** it is run again, **Then** it sets up
+   from scratch with no manual steps and leaves the environment clean afterward.
+
+---
+
+### User Story 3 - Jumping to older-than-loaded content stays smooth (Priority: P2)
+
+A user taps a reply-quote (or opens a starred message) whose original is older than
+the currently loaded window. The app brings that older message into view smoothly —
+loading whatever history is needed to reach it — instead of failing or reporting that
+the message isn't available.
+
+**Why this priority**: It's a real "scroll up to older content" smoothness gap, but
+secondary to the primary scroll gesture; valuable polish that completes the story.
+
+**Independent Test**: In a long chat, tap a reply that quotes a message far above the
+loaded window and confirm the view scrolls to that message rather than showing a
+"not available" message.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reply whose quoted message is older than what's loaded, **When** the
+   user taps the quote, **Then** the older message is brought into view smoothly.
+2. **Given** a starred message older than the loaded window, **When** the user jumps
+   to it, **Then** it is reached without an error.
+
+---
+
+### Edge Cases
+
+- **Fast upward fling** on a very long chat: the next page must already be present
+  before the top is reached (no stall, no snap).
+- **Media decoding mid-load**: an image/video poster in or near the anchored row
+  decoding (and growing) between frames must not skew the anchor and cause a jump.
+- **New message / reaction / status update while reading history**: must not move the
+  viewport; the rendered list updating must not visibly re-shuffle or jump.
+- **Anchored message deleted/edited** between frames during a load: must degrade
+  gracefully (still no jump) rather than mis-correct the position.
+- **Keyboard opens / view resizes** during scroll: must not fight the user's gesture.
+- **Very long histories**: memory and rendered-DOM growth must stay bounded enough to
+  remain smooth on a mid-range device.
+- **Group vs 1:1**: avatars and album collapsing change row heights as older runs
+  mount — both must stay smooth.
+- **Backgrounded / locked chat**: scroll side-effects must not run while the view
+  isn't visible.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When older messages load during an upward scroll, the message currently
+  in view MUST remain at the same on-screen position (no perceptible jump).
+- **FR-002**: Older messages MUST be prepared ahead of need so that scrolling upward
+  — including a fast flick — does not stall waiting at a loading boundary.
+- **FR-003**: Any automatic scroll adjustment performed while loading older messages
+  MUST NOT interrupt or fight the user's in-progress momentum scroll (no stutter,
+  teleport, or abrupt stop).
+- **FR-004**: While the user is reading history (not at the bottom), a newly arriving
+  message, reaction, or status update MUST NOT move their viewport; the view follows
+  the newest message only when the user is already at the bottom.
+- **FR-005**: Scroll-up smoothness MUST hold for both 1:1 and group conversations,
+  including where sender avatars and collapsed media albums change row heights.
+- **FR-006**: Tapping a reply-quote or opening a starred message that is older than the
+  currently loaded window MUST bring that message into view (loading the intervening
+  history as needed) rather than failing.
+- **FR-007**: Media (images, videos, voice/video messages) MUST render correctly for
+  every recipient and MUST NOT cause the scroll position to drift when it decodes.
+- **FR-008**: The project MUST provide a repeatable exercise that creates ~5 users,
+  connects them via request + accept, forms 1:1 and group chats, exchanges text,
+  voice/audio, video messages, image uploads, and video uploads, builds a lengthy
+  chat, and verifies correct delivery, rendering, and reciprocation between all
+  participants.
+- **FR-009**: The exercise MUST drive the real application UI/flows (not bypass them),
+  be runnable repeatedly with no manual setup, and leave the environment clean afterward.
+- **FR-010**: Smoothness MUST be verifiable automatically — e.g. asserting that the
+  anchored message's on-screen position is preserved within the agreed tolerance and
+  that the next older page is present before the top edge is reached.
+- **FR-011**: All existing chat behaviors (sending, receipts/seen, reactions,
+  disappearing messages, jump-to-newest on send, search) MUST continue to work
+  unchanged; this feature only changes how older history is prepared and how the
+  viewport is preserved.
+
+### Key Entities *(include if feature involves data)*
+
+- **Conversation history**: the full ordered set of a chat's messages (oldest →
+  newest); the source the rendered window draws from. No change to how it's stored.
+- **Rendered window**: the contiguous slice of the newest N messages currently shown;
+  grows toward older messages as the user scrolls up.
+- **Older-message page**: a batch of older messages added to the rendered window when
+  scrolling up; its arrival must be invisible to the viewport (position-preserving).
+- **Scroll anchor**: the reference message used to keep the viewport stable across a
+  page load.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can scroll from the newest message back to the start of a
+  conversation of at least 200 messages in continuous gestures with no visible jump
+  and no stall at a loading boundary. Verified by an automated exercise.
+- **SC-002**: When an older page loads during scroll-up, the anchored message's
+  on-screen position changes by no more than a small, imperceptible tolerance
+  (see Assumptions) — effectively "stays put". Verified.
+- **SC-003**: The next older page is present before the user reaches the top edge of
+  the loaded content (there is never a frame at the top with more history unrendered).
+  Verified.
+- **SC-004**: A new message, reaction, or status update arriving while the user reads
+  history never moves the viewport. Verified.
+- **SC-005**: The multi-user exercise runs end-to-end and confirms every message kind
+  (text, voice/audio, video message, image upload, video upload) is delivered to and
+  renders for all participants across 1:1 and group chats. Verified.
+- **SC-006**: Tapping a reply/starred reference older than the loaded window brings the
+  target into view within ~1 second, with no "not available" outcome for an on-device
+  message. Verified.
+- **SC-007**: Scrolling up across several pages on a mobile-emulated device shows
+  continuous content — no blank flash, no snap, day-dividers and avatars rendering in
+  place. Verified by inspection (screenshots) via the UI-driving harness.
+
+## Assumptions
+
+- Builds on the existing approach (a windowed render of the newest messages with an
+  anchor-and-restore on prepend) rather than introducing a new list/virtualization
+  subsystem; the change prepares older pages earlier and hardens the position-preserve.
+- The verification exercise is realized through the project's existing UI-driving
+  capability (the `drive/` harness + the dev-only test hook) and automated end-to-end
+  coverage where practical; media uses test fixtures.
+- "Lengthy chat" means at least ~200 messages for the scroll exercise; smoothness is
+  targeted for typical histories up to ~1,000 messages on a mid-range device. Larger
+  histories (5,000+) may warrant additional optimization treated as out of scope here.
+- "No jump" is interpreted as ≤ ~2px of anchor drift (imperceptible); the exact
+  tolerance is confirmed during clarification.
+- Older pages are prepared on scroll proximity (look-ahead) by default; proactive
+  idle-time preloading is an optional enhancement, not required for v1.
+- The rendered window grows toward older messages for the session and is not required
+  to shrink/evict older rows in v1 (bounded-DOM eviction is a possible later refinement).
+- Roster, receipts, reactions, and all other messaging behaviors are unchanged; this
+  is purely about history preparation and viewport stability.
+- Client-only: no server, wire, or stored-ciphertext change — zero-knowledge boundary
+  untouched (no `/speckit-checklist` required on that basis).
+
+## Open product decisions (for `/speckit-clarify`)
+
+These have reasonable defaults above but materially affect scope and should be confirmed:
+
+1. The largest history that must stay smooth on a low-end device (decides whether
+   windowing + look-ahead is sufficient or whether bounded/cursor reads + true virtual
+   scrolling are needed).
+2. The exact "no jump" tolerance (0px vs ≤2px) — sets the acceptance threshold.
+3. Whether jump-to-older navigation (reply/starred above the window, User Story 3) is
+   in scope here or a separate spec.
+4. Whether older rendered rows should ever be evicted to bound DOM on very long
+   scroll-backs.
+5. Whether older pages should also be preloaded proactively while idle, or only on
+   scroll proximity.

--- a/specs/1011-smooth-chat-history/tasks.md
+++ b/specs/1011-smooth-chat-history/tasks.md
@@ -1,0 +1,235 @@
+---
+description: "Task list for Smooth Chat-History Scroll-Up (spec 1011)"
+---
+
+# Tasks: Smooth Chat-History Scroll-Up (verified by a multi-user end-to-end exercise)
+
+**Input**: Design documents from `/specs/1011-smooth-chat-history/`
+
+**Prerequisites**: plan.md, spec.md, research.md (D1–D9), data-model.md, contracts/chat-history.md, quickstart.md
+
+**Tests**: REQUIRED. Constitution III (TDD) is non-negotiable — failing tests (vitest pure
+helpers + Playwright e2e) are authored before the implementation they cover.
+
+**Scope**: **Client-only.** No server, wire, stored-ciphertext, or DB-schema change
+(`DB_VERSION` stays 6, no new index — research D2). There are NO server/migration tasks.
+
+**Organization**: By user story (US1 smooth scroll-up P1 = MVP, US2 multi-user exercise P1,
+US3 jump-to-older P2). A Foundational phase delivers the shared, unit-tested building blocks
+every story needs (bounded reads + `useChatHistory` + window math + `withScrollAnchor` +
+`seedMessages`) so the stories layer cleanly on top.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, Polish carry no story label)
+- Exact file paths are in each description.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Stand up the client unit-test runner the TDD phases need and capture a green
+baseline (the server gates must stay green untouched throughout — Constitution VII).
+
+- [X] T001 Verify the existing client unit-test runner covers the new specs — vitest `^3.2.6` + `test:unit` / `test:unit:watch` scripts + `vitest.config.ts` **already exist** (env `node`, `include: src/**/*.test.ts`, `@/` → `src/` alias, an 80% gated `coverage.include` floor). Confirm `npx vitest run` is green; the new pure-helper specs and the `useChatHistory` spec run under the existing `node` env (Vue refs + a mocked change bus need no DOM — happy-dom NOT required). No new runner/config is added. As the helpers land, append `src/utils/chat-pagination.ts`, `chat-window.ts`, `scroll-anchor.ts`, `chat-grouping.ts` to `vitest.config.ts` `coverage.include` so the 80% floor ratchets onto them (Constitution VII).
+- [X] T002 [P] Capture the baseline green gates before any change: `npm run build` (vue-tsc + vite) and `cd server && go build ./... && go vet ./... && go test ./...`. These must stay green for the whole feature; record that they pass now so regressions are attributable.
+
+**Checkpoint**: `vitest` runs; baseline build/server gates green.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The reusable, independently-tested core — bounded batch reads, the pure window /
+anchor / pagination / group-edge math, the incremental `useChatHistory` composable, and the
+dev-only bulk-seed hook. Everything here is consumed by US1/US2/US3.
+
+**⚠️ CRITICAL**: No user-story work begins until this phase is complete.
+
+**⚠️ TDD**: T003–T007 (tests) are written FIRST and MUST FAIL (the modules they import don't
+exist yet) before the matching implementations T008–T013.
+
+### Tests (write first — must fail)
+
+- [X] T003 [P] Write failing vitest for pagination/cursor math in `src/utils/chat-pagination.test.ts`: `sliceOlder(sortedAsc, beforeTs|null, limit)` returns the `limit` rows immediately older than `beforeTs` oldest-first (newest `limit` when `null`); `sliceNewer(sortedAsc, afterTs, limit)` returns the `limit` rows immediately newer than `afterTs` oldest-first; deterministic `(timestamp, id)` ordering; **seam dedupe** (a row exactly at the cursor is not returned by both adjacent batches).
+- [X] T004 [P] Write failing vitest for window/eviction math in `src/utils/chat-window.test.ts`: `computeWindow` never exceeds `ROW_CAP` (~80–120), always covers viewport + `BUFFER` (derived from `LOOK_AHEAD_PX ≈ 1200`, ~1.5–2 mobile screens) in both directions, grows `start` ↓ on top look-ahead, grows `end` ↑ on downward re-entry, and evicts the correct edge (advance `start` / retreat `end`) once `end - start > ROW_CAP`.
+- [X] T005 [P] Write failing vitest for anchor-delta math in `src/utils/scroll-anchor.test.ts`: given an anchor id + recorded `top` and a post-mutation set of measured rects, the residual correction is computed so |residual| ≤ 2px (INV-1); when the recorded anchor id was evicted, it falls back to the next still-rendered row. ALSO cover the **momentum/echo guard predicates** (INV-5) with fake timers: `shouldDeferScrollWrite(now, lastUserScrollAt, MOMENTUM_QUIET_MS)` defers a correction while a fling is in flight and permits it once quiet; `isSelfEcho(scrollTs, suppressStickUntil)` marks the post-correction scroll as our own.
+- [X] T006 [P] Write failing vitest for group-run/day boundary math in `src/utils/chat-grouping.test.ts`: `isRunStart(prev, cur)` / `showDay(prev, cur)` computed from the **predecessor included in the window** stay correct across a window boundary with a preserved leading row (D8) — no avatar/divider toggling when the predecessor is prepended/evicted.
+- [X] T007 [P] Write failing vitest for the `useChatHistory` composable in `src/composables/useChatHistory.test.ts` (mock `queries` reads + the `idb` change bus): `loadOlder()` prepends a batch and updates `oldestLoadedTs`/`hasOlder`; `loadNewer()` appends; change-bus **append** fires only when the run touches the bottom; **patch-by-id** shallow-merges exactly one row (reaction/seen/edit); **remove-by-id** splices; it NEVER reassigns/replaces the whole `rows` array; switching `chatId`/`q` resets to a fresh newest batch.
+
+### Implementation (make the tests pass)
+
+- [X] T008 [P] Implement `sliceOlder`/`sliceNewer` pure helpers in `src/utils/chat-pagination.ts` to pass T003 (no IndexedDB — operate on a sorted array).
+- [X] T009 [P] Implement `computeWindow` + eviction math in `src/utils/chat-window.ts` (`ROW_CAP` ~80–120, `BUFFER` look-ahead constant) to pass T004.
+- [X] T010 [P] Implement the anchor helpers in `src/utils/scroll-anchor.ts` (`pickAnchor(rendered, scrollTop)` → topmost fully-rendered `[data-mid]`; `resolveAnchorDelta(anchor, measured)` with evicted-anchor fallback) **plus the pure momentum/echo guard predicates** `shouldDeferScrollWrite` / `isSelfEcho` (INV-5) consumed by `withScrollAnchor`, to pass T005.
+- [X] T011 [P] Implement `isRunStart`/`showDay` (predecessor-included) in `src/utils/chat-grouping.ts` to pass T006.
+- [X] T012 Implement bounded reads in `src/db/queries.ts` — `listMessagesOlder(chatId, beforeTs|null, limit, q?)`, `listMessagesNewer(chatId, afterTs, limit, q?)`, `countChatMessages(chatId)` — backed by the existing `chatId` index (`getByIndex` + in-memory sort) + the T008 slice helpers; keep `q` substring filter semantics; **keep `listMessages(chatId, q)` (loads-all) for search/other callers**; NO new index, NO `DB_VERSION` bump (D2). (depends on T008)
+- [X] T013 Implement the `useChatHistory(chatId, q?)` composable in `src/composables/useChatHistory.ts` — bounded contiguous `rows` (oldest→newest), `hasOlder`/`hasNewer`/`total`, `loadOlder`/`loadNewer`, and the incremental change-bus apply (append-if-bottom / patch-by-id / remove-by-id), per contracts/chat-history.md §2. No full-array replace. (depends on T007, T012)
+- [X] T014 [P] Add the dev-only `__ringTest.seedMessages(chatId, n, opts?)` hook in `src/services/testhook.ts`: build `n` `Message` rows (spread timestamps; `opts.fromIds` rotates senders, `opts.mediaEvery` makes every Nth row image/video for height variety) and write them with ONE `bulkPut('messages', rows)` (idb.ts already exposes `bulkPut`). Stripped from prod like the rest of `__ringTest`.
+
+**Checkpoint**: `npx vitest run` green (pagination/window/anchor/group-edge/composable); bounded
+reads + `useChatHistory` + `seedMessages` exist and are tested. User stories can begin.
+
+---
+
+## Phase 3: User Story 1 - Smooth scroll-up through a long conversation (Priority: P1) 🎯 MVP
+
+**Goal**: Scrolling up through history is continuous at any length — older pages are prepared
+ahead of need, the anchored message stays put (≤2px), DOM/memory stay bounded, and existing
+chat behaviors are unchanged.
+
+**Independent Test**: Open a 5,000-msg seeded chat, flick up across many pages → anchored
+`[data-mid]` drifts ≤2px, the next older page is in the DOM before the top is reached, rendered
+row + resolved-media counts stay bounded, and an inbound message while scrolled up doesn't yank.
+
+### Tests for User Story 1 (write first — must fail)
+
+- [X] T015 [P] [US1] Extend `e2e/chat-media-scroll.spec.ts` with failing assertions on a chat seeded to 5,000 via `__ringTest.seedMessages`: **INV-1/SC-002** anchored bubble `getBoundingClientRect().top` delta ≤ 2px across an older-page load; **INV-2/SC-003** the older batch's first `[data-mid]` is in the DOM before `scrollTop` reaches 0 (page-before-top); **INV-3/SC-008** after scrolling far up then back down, rendered `.bubble[data-mid]` count stays ≈ `ROW_CAP` (per data-model.md / T009, ~80–120) and resolved media ≤ `MAX_MEDIA` (the existing media-LRU cap, 60); **INV-4/SC-004** seeding an extra inbound message, a reaction, AND a status update (e.g. a seen/delivered tick) while scrolled up each leaves `scrollTop` unchanged (all three cases per FR-004).
+
+### Implementation for User Story 1
+
+- [X] T016 [US1] In `src/views/detail/ChatDetailPage.vue`, replace `visible: ref(PAGE)` + `visibleMessages = messages.slice(-visible)` (~2179-2181) with an explicit reactive `{ start, end }` window (render `rows.slice(start, end)`), and source `rows` from `useChatHistory` instead of `useLiveQuery(listMessages)` (D1/D3).
+- [X] T017 [US1] Extract and apply `withScrollAnchor(mutate)` in `ChatDetailPage.vue` (using `src/utils/scroll-anchor.ts`): capture anchor → run mutation → `await nextTick()` → re-find by id (evicted-anchor fallback) → correct `scrollTop` by measured delta. Route `loadOlder`'s prepend through it and add the `MOMENTUM_QUIET_MS` + `suppressStickUntil` guards the load path lacks today (D4/D6; `loadOlder` ~2212-2228). The `scrollTop` correction MUST also respect the existing `viewActive` / `document.visibilityState === 'visible'` guard so no correction runs while the view is backgrounded/locked (FR-014).
+- [X] T018 [US1] Implement bidirectional eviction + downward re-entry in `ChatDetailPage.vue`: once `end - start > ROW_CAP`, evict the far edge inside the SAME anchored mutation; grow `end` ↑ and `loadNewer()` (append) when scrolling back down after eviction — all via `withScrollAnchor` so position stays ≤2px (D1, uses `computeWindow`).
+- [X] T019 [US1] Add look-ahead prefetch in `ChatDetailPage.vue`: an IntersectionObserver sentinel with `rootMargin` = `LOOK_AHEAD_PX` (≈ 1200px, ~1.5–2 screens above the viewport) triggers `loadOlder` BEFORE the top edge is reached; keep `ion-infinite-scroll position="top"` as the backstop (D5; replaces the stall-prone boundary-only `threshold=25%` load).
+- [X] T020 [US1] Wire group-row edge correctness into `ChatDetailPage.vue`: feed `renderItems`/`groupRunStart`/`showDay` (~1142-1146, 1605-1613) from the predecessor-included helper (`src/utils/chat-grouping.ts`) so avatars/day-dividers at the window's top edge don't flicker or inject a height jump on load (D8 / INV-7 / FR-005).
+- [X] T021 [US1] Verify and preserve all existing chat behaviors against the new windowed/incremental source in `ChatDetailPage.vue`: receipts/seen (spec 1010), reactions, disappearing messages, jump-to-newest on send, search, swipe-to-reply transforms, media LRU (`MAX_MEDIA`), and `v-memo`; confirm the full-array consumers (`chatMediaMsgs` ~1155, `viewerItems`, `albumMessageIds`, preview) still compute correctly from incremental `rows` (FR-011). Also confirm the existing `viewActive` / visibility gate is applied to every new scroll-writing and window-mutation path (look-ahead, `loadOlder`/`loadNewer`, eviction, `withScrollAnchor`) so none run while the view is backgrounded/locked (FR-014).
+
+**Checkpoint**: T015 e2e assertions pass; US1 is independently demoable (MVP) — smooth, bounded,
+behavior-preserving scroll-up.
+
+---
+
+## Phase 4: User Story 2 - Realistic multi-user exercise proves the chat works end-to-end (Priority: P1)
+
+**Goal**: A repeatable `drive/` exercise that drives the real app as 5 users — connect via
+request+accept, form 1:1 + group, exchange every message kind, build a lengthy chat, scroll up —
+proving US1 and broadly smoke-testing messaging/media/groups.
+
+**Independent Test**: `node drive/scenarios/lengthy-chat-scroll.mjs` against `make start` →
+5 users connect, every kind delivered/rendered for all participants in 1:1 + group, lengthy chat
+opens and scrolls back, screenshots in `.tmp/drive/` show continuous content; a re-run is clean.
+
+**Depends on**: US1 (the scroll-up portion exercises US1) + Foundational `seedMessages` (T014).
+
+- [X] T022 [US2] Add bulk-seed + scroll/screenshot helpers to `drive/driver.mjs` as needed: a convenience that calls `__ringTest.seedMessages(chatId, n, opts)` to build a lengthy chat fast, a scroll-up pass helper, and a screenshot sweep (reuse existing `createAccount`/`pair`/`group`/`say`/`shot`/`sweep`/`preflight`).
+- [X] T023 [US2] Create `drive/scenarios/lengthy-chat-scroll.mjs`: 5 users connect via request+accept → form 1:1 + a group → exchange text / voice-audio / video-message / image-upload / video-upload in both → build a lengthy chat (real sends + bulk-seed for length) → open it and scroll up with a screenshot pass to `.tmp/drive/` (SC-005, SC-007); end with `sweep` for a clean re-run (FR-009).
+- [X] T024 [US2] Run `node drive/scenarios/lengthy-chat-scroll.mjs` against the local `make start` stack; confirm all 5 connect, every message kind is delivered to + renders for all intended participants across 1:1 + group, the lengthy chat scrolls back smoothly, and read the `.tmp/drive/*.png` screenshots to confirm continuous content (no blank flash/snap); verify a second run sets up from scratch and leaves no lingering accounts.
+
+**Checkpoint**: The end-to-end exercise passes and visually confirms US1 on a real lengthy chat.
+
+---
+
+## Phase 5: User Story 3 - Jumping to older-than-loaded content stays smooth (Priority: P2)
+
+**Goal**: Tapping a reply-quote / starred message older than the loaded window brings it into
+view (loading intervening history) instead of "not available".
+
+**Independent Test**: In a long chat, tap a reply quoting a message far above the window → it
+mounts and centers within ~1s, no error; jump-to-newest unaffected.
+
+**Depends on**: US1 (window + `withScrollAnchor` + bounded reads).
+
+### Tests for User Story 3 (write first — must fail)
+
+- [X] T025 [P] [US3] Add a failing e2e to `e2e/chat-media-scroll.spec.ts` (INV-6 / SC-006): on a 5,000-msg seeded chat, tap a reply-quote whose target is older than the loaded window → the target `[data-mid]` mounts and is centered within **1.0s**, with no "Original message not available" toast.
+
+### Implementation for User Story 3
+
+- [X] T026 [US3] Implement `seekToMessage(id)` in `ChatDetailPage.vue` by generalizing the existing jump-to-date retry/poll loop (`onPickDate` ~1010-1015) and `scrollToMessage` (~1674-1686): when the target isn't in `rows`, load older batches (grow `start` / seek the batch containing it by timestamp) in a bounded loop until the row mounts, then center it via `withScrollAnchor`; keep jump-to-newest behavior unchanged (D7).
+
+**Checkpoint**: All three stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns (research open-risks + gates)
+
+**Purpose**: Verify the genuinely-new/risky parts, the behavioral-equivalence risks called out
+in research, and run the definition-of-done gates.
+
+- [X] T027 [P] Verify the riskiest path — eviction BELOW the viewport + downward re-entry stability — on a 5,000-msg seeded chat (scroll far up, then back down through evicted regions): position stays ≤2px and rows re-mount without a jump. If unstable, apply the documented fallback (grow-only window + aggressive look-ahead + bounded reads + `loadOlder` guards; bounds memory, defers strict DOM eviction) and note it in plan.md. (`ChatDetailPage.vue`)
+- [X] T028 [P] Verify media LRU re-resolve on re-entry. **Scenario**: seed a 5,000-msg chat with `mediaEvery` so more than `MAX_MEDIA` posters exist; scroll far up until the LRU revokes a tracked media row's poster URL and that row is evicted; then scroll back down so the row re-enters. **Assert**: the poster re-resolves AND the anchor delta stays ≤2px in the same frame the media re-decodes (no flash, no drift — INV-1 holds through re-decode). (`ChatDetailPage.vue` media LRU path)
+- [X] T029 [P] Verify incremental-apply behavioral equivalence for every full-array consumer (`chatMediaMsgs`, `viewerItems`, `albumMessageIds`, message preview) against the `useChatHistory` incremental `rows` vs the old full-array source. (`ChatDetailPage.vue`)
+- [X] T030 [P] Verify search scope agreement: search must use a consistent scope (whole-chat via `listMessages(chatId, q)`) and resetting/clearing search returns to a correct newest window — bounded reads + search agree, no missing results. (`ChatDetailPage.vue` + `src/db/queries.ts`)
+- [X] T031 [P] Update `drive/README.md` (and the CLAUDE.md "Driving the dev app" note if needed) to list the `lengthy-chat-scroll.mjs` scenario and how to run/read it.
+- [X] T032 Run the quickstart manual smoke (specs/1011-smooth-chat-history/quickstart.md): long chat hard flick-up (continuous, no stall/snap, line stays put), send/receive while scrolled up (no jump), group day-divider/avatar no-flicker at top edge (INV-7); and open the keyboard / resize the view mid-flick and confirm the scroll gesture is not fought (no stutter/teleport — relies on existing Ionic handling, no new logic). The INV-5 guard *logic* (MOMENTUM_QUIET_MS / suppressStickUntil) is unit-covered by T005/T010; this task additionally confirms iOS momentum *fling feel* on a **real device** — emulation can't fully prove it.
+- [X] T033 Definition-of-done gate (Constitution VII): `npm run build`; `cd server && go build ./... && go vet ./... && go test ./...` (unchanged, must stay green); `npx vitest run`; `make db-up && npm run test:e2e` (incl. the 5k-seeded scroll assertions). All green = done.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (P1)** → no deps; start immediately.
+- **Foundational (P2)** → depends on Setup; **BLOCKS all user stories**.
+- **US1 (P3)** → depends on Foundational. **MVP.**
+- **US2 (P4)** → depends on Foundational + US1 (exercises the smooth scroll).
+- **US3 (P5)** → depends on Foundational + US1 (reuses window/anchor/bounded reads).
+- **Polish (P6)** → depends on the user stories it verifies.
+
+### Key within-phase dependencies
+
+- Foundational tests T003–T007 before impls T008–T013. T012 needs T008; T013 needs T007 + T012.
+- US1: T015 (e2e, fails first) → T016 → T017 → T018 → T019 → T020 → T021 (all same file `ChatDetailPage.vue`, so largely sequential).
+- US2: T022 before T023 before T024.
+- US3: T025 (fails first) → T026.
+
+### Parallel opportunities
+
+- **Setup**: T002 ∥ T001.
+- **Foundational tests** T003 ∥ T004 ∥ T005 ∥ T006 ∥ T007 (distinct files).
+- **Foundational impls** T008 ∥ T009 ∥ T010 ∥ T011 ∥ T014 (distinct files); T012/T013 follow their deps.
+- **US1 vs US3 e2e authoring** (T015, T025) both extend `e2e/chat-media-scroll.spec.ts`: **T015 lands first** (US1, INV-1/2/3/4), **T025 appends** (US3, INV-6) — author sequentially in that order to avoid merge conflicts (not [P]).
+- **Polish** T027 ∥ T028 ∥ T029 ∥ T030 ∥ T031 (distinct concerns/files).
+
+---
+
+## Parallel Example: Foundational phase
+
+```bash
+# Author all foundational failing tests together (distinct files):
+vitest: src/utils/chat-pagination.test.ts      # T003
+vitest: src/utils/chat-window.test.ts          # T004
+vitest: src/utils/scroll-anchor.test.ts        # T005
+vitest: src/utils/chat-grouping.test.ts        # T006
+vitest: src/composables/useChatHistory.test.ts # T007
+
+# Then implement the independent pure helpers together:
+src/utils/chat-pagination.ts   # T008
+src/utils/chat-window.ts       # T009
+src/utils/scroll-anchor.ts     # T010
+src/utils/chat-grouping.ts     # T011
+src/services/testhook.ts       # T014 (seedMessages)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (US1 only)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (CRITICAL — blocks stories) → 3. Phase 3 US1 →
+4. **STOP & VALIDATE**: T015 e2e green on a 5k-seeded chat (anchor ≤2px, page-before-top,
+bounded, no-yank) → 5. Demo. This alone delivers the headline ask.
+
+### Incremental delivery
+
+- Setup + Foundational → foundation ready.
+- + US1 → smooth bounded scroll-up (MVP).
+- + US2 → repeatable 5-user proof + broad smoke test.
+- + US3 → jump-to-older polish.
+- + Polish → risk verification + all gates green.
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete-task dependency. Most US1 tasks share
+  `ChatDetailPage.vue` → sequential by necessity.
+- TDD: verify each test FAILS before implementing (Constitution III).
+- Client-only — no server/migration/wire tasks (Principle I untouched; no `/speckit-checklist`).
+- `DB_VERSION` stays 6; no new index (research D2). The compound `[chatId,timestamp]` index is a
+  documented, forward-only, out-of-scope future step (plan.md Complexity Tracking).
+- Commit after each task or logical group; each story is an independently testable increment.

--- a/src/composables/useChatHistory.test.ts
+++ b/src/composables/useChatHistory.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// useChatHistory reads bounded batches from queries.ts and subscribes to the idb
+// 'messages' change bus. Mock both so the windowing + incremental-apply logic is tested
+// in isolation (node env, no IndexedDB). `subscribe` captures the change callback so a
+// test can fire a "messages changed" notification and assert the incremental reconcile.
+const h = vi.hoisted(() => ({
+  older: vi.fn(),
+  newer: vi.fn(),
+  count: vi.fn(),
+  subscribe: vi.fn(),
+  changeCb: null as null | (() => void),
+}));
+
+vi.mock('@/db/queries', () => ({
+  listMessagesOlder: h.older,
+  listMessagesNewer: h.newer,
+  countChatMessages: h.count,
+}));
+vi.mock('@/db/idb', () => ({
+  subscribe: (_stores: string[], cb: () => void) => {
+    h.subscribe(_stores, cb);
+    h.changeCb = cb;
+    return () => {};
+  },
+}));
+
+import { effectScope, ref, nextTick } from 'vue';
+import { useChatHistory } from './useChatHistory';
+import type { Message } from '@/db/types';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+// Minimal Message factory — only the fields the composable touches.
+function msg(id: string, ts: number, over: Partial<Message> = {}): Message {
+  return { id, chatId: 'c1', timestamp: ts, updatedAt: ts, body: id, status: 'sent', ...over } as Message;
+}
+
+// Fire the captured change-bus callback and let the async reconcile settle.
+async function fireChange() {
+  h.changeCb?.();
+  await flush();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.changeCb = null;
+  h.count.mockResolvedValue(0);
+  h.older.mockResolvedValue([]);
+  h.newer.mockResolvedValue([]);
+});
+
+describe('useChatHistory — initial load', () => {
+  it('loads the newest batch oldest→newest and subscribes to messages once', async () => {
+    h.older.mockResolvedValueOnce([msg('m3', 30), msg('m4', 40), msg('m5', 50)]);
+    h.count.mockResolvedValue(5);
+    const scope = effectScope();
+    let ch!: ReturnType<typeof useChatHistory>;
+    scope.run(() => (ch = useChatHistory('c1', undefined, { batchSize: 3, maxRows: 8 })));
+    await flush();
+
+    expect(h.older).toHaveBeenCalledWith('c1', null, 3, '');
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['m3', 'm4', 'm5']);
+    expect(ch.hasOlder.value).toBe(true); // total 5 > 3 loaded
+    expect(ch.hasNewer.value).toBe(false); // newest batch → at the bottom
+    expect(ch.total.value).toBe(5);
+    expect(h.subscribe).toHaveBeenCalledTimes(1);
+    expect(h.subscribe.mock.calls[0][0]).toEqual(['messages']);
+    scope.stop();
+  });
+});
+
+describe('useChatHistory — loadOlder / loadNewer', () => {
+  it('loadOlder prepends a batch and updates oldestLoadedTs/hasOlder', async () => {
+    h.older.mockResolvedValueOnce([msg('m3', 30), msg('m4', 40), msg('m5', 50)]); // initial
+    h.count.mockResolvedValue(5);
+    const scope = effectScope();
+    let ch!: ReturnType<typeof useChatHistory>;
+    scope.run(() => (ch = useChatHistory('c1', undefined, { batchSize: 3, maxRows: 8 })));
+    await flush();
+    const arr = ch.rows.value; // capture array identity
+
+    h.older.mockResolvedValueOnce([msg('m1', 10), msg('m2', 20)]); // older than ts 30
+    const added = await ch.loadOlder();
+
+    expect(added).toBe(2);
+    expect(h.older).toHaveBeenLastCalledWith('c1', 30, 3, '');
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4', 'm5']);
+    expect(ch.oldestLoadedTs.value).toBe(10);
+    expect(ch.hasOlder.value).toBe(false); // batch (2) < batchSize (3) → start reached
+    expect(ch.rows.value).toBe(arr); // never reassigned the array
+    scope.stop();
+  });
+
+  it('trims the newest tail past maxRows (sets hasNewer) and loadNewer re-appends', async () => {
+    // Initial newest batch of 2; maxRows 4 so a second prepend overflows by 1.
+    h.older.mockResolvedValueOnce([msg('m5', 50), msg('m6', 60)]);
+    h.count.mockResolvedValue(6);
+    const scope = effectScope();
+    let ch!: ReturnType<typeof useChatHistory>;
+    scope.run(() => (ch = useChatHistory('c1', undefined, { batchSize: 3, maxRows: 4 })));
+    await flush();
+
+    // Initial: 2 loaded of 6 total → 4 older unloaded, 0 newer.
+    expect(ch.olderUnloaded.value).toBe(4);
+    expect(ch.newerUnloaded.value).toBe(0);
+
+    h.older.mockResolvedValueOnce([msg('m2', 20), msg('m3', 30), msg('m4', 40)]); // +3 → 5 rows
+    await ch.loadOlder();
+    // 5 > maxRows 4 → trim 1 from the newest tail (m6); now at [m2,m3,m4,m5]
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['m2', 'm3', 'm4', 'm5']);
+    expect(ch.hasNewer.value).toBe(true);
+    expect(ch.newestLoadedTs.value).toBe(50);
+    // The trimmed m6 is now "newer-unloaded"; older dropped by the 3 we prepended → 1 left.
+    expect(ch.newerUnloaded.value).toBe(1);
+    expect(ch.olderUnloaded.value).toBe(1); // 6 total - 4 loaded - 1 newer
+    expect(ch.olderUnloaded.value + ch.rows.value.length + ch.newerUnloaded.value).toBe(6); // invariant
+
+    h.newer.mockResolvedValueOnce([msg('m6', 60)]); // newer than ts 50
+    const added = await ch.loadNewer();
+    expect(added).toBe(1);
+    expect(h.newer).toHaveBeenLastCalledWith('c1', 50, 3, '');
+    expect(ch.rows.value.map((m) => m.id)).toContain('m6');
+    expect(ch.newerUnloaded.value).toBe(0); // consumed the trimmed m6 back
+    scope.stop();
+  });
+});
+
+describe('useChatHistory — incremental change-bus apply', () => {
+  async function setup(initial: Message[], total = initial.length) {
+    h.older.mockResolvedValueOnce(initial);
+    h.count.mockResolvedValue(total);
+    const scope = effectScope();
+    let ch!: ReturnType<typeof useChatHistory>;
+    scope.run(() => (ch = useChatHistory('c1', undefined, { batchSize: 3, maxRows: 8 })));
+    await flush();
+    return { ch, scope };
+  }
+
+  it('patch-by-id shallow-merges exactly one row (reaction/seen/edit), array kept', async () => {
+    const { ch, scope } = await setup([msg('m1', 10), msg('m2', 20), msg('m3', 30)]);
+    const arr = ch.rows.value;
+    const row2Before = ch.rows.value[1];
+
+    // The reconcile re-reads the loaded window; m2 now seen (status + updatedAt changed).
+    h.newer.mockResolvedValueOnce([
+      msg('m1', 10),
+      msg('m2', 20, { status: 'seen', updatedAt: 999 }),
+      msg('m3', 30),
+    ]);
+    await fireChange();
+
+    expect(ch.rows.value[1].status).toBe('seen');
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['m1', 'm2', 'm3']); // no add/remove
+    expect(ch.rows.value).toBe(arr); // array not reassigned
+    expect(ch.rows.value[1]).toBe(row2Before); // same row object, merged in place
+    expect(ch.rows.value[0].status).toBe('sent'); // untouched rows unchanged
+    scope.stop();
+  });
+
+  it('remove-by-id splices a deleted row out', async () => {
+    const { ch, scope } = await setup([msg('m1', 10), msg('m2', 20), msg('m3', 30)]);
+    const arr = ch.rows.value;
+    h.newer.mockResolvedValueOnce([msg('m1', 10), msg('m3', 30)]); // m2 gone
+    await fireChange();
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['m1', 'm3']);
+    expect(ch.rows.value).toBe(arr);
+    scope.stop();
+  });
+
+  it('appends a new inbound message only when the run touches the bottom', async () => {
+    const { ch, scope } = await setup([msg('m1', 10), msg('m2', 20), msg('m3', 30)]);
+    expect(ch.hasNewer.value).toBe(false); // at the bottom
+    h.newer.mockResolvedValueOnce([msg('m1', 10), msg('m2', 20), msg('m3', 30), msg('m4', 40)]);
+    await fireChange();
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    scope.stop();
+  });
+
+  it('does NOT append a newer message when the run is not at the bottom', async () => {
+    const { ch, scope } = await setup([msg('m1', 10), msg('m2', 20), msg('m3', 30)]);
+    // Force "not at bottom": simulate a prior tail-trim having set hasNewer.
+    h.older.mockResolvedValueOnce([msg('x0', 5)]);
+    // (batchSize 3, maxRows 8 — no trim here; instead drive hasNewer directly is not
+    //  exposed, so emulate by loading older to keep at bottom=false is N/A.)
+    // Use the reconcile path with hasNewer already false but assert the inverse via a
+    // separate not-at-bottom fixture below.
+    scope.stop();
+
+    // Dedicated not-at-bottom fixture: maxRows tiny so the first loadOlder trims tail.
+    h.older.mockReset();
+    h.older.mockResolvedValueOnce([msg('m5', 50), msg('m6', 60)]); // initial newest
+    h.count.mockResolvedValue(6);
+    const scope2 = effectScope();
+    let ch2!: ReturnType<typeof useChatHistory>;
+    scope2.run(() => (ch2 = useChatHistory('c1', undefined, { batchSize: 3, maxRows: 4 })));
+    await flush();
+    h.older.mockResolvedValueOnce([msg('m2', 20), msg('m3', 30), msg('m4', 40)]);
+    await ch2.loadOlder(); // trims m6 → hasNewer true (not at bottom)
+    expect(ch2.hasNewer.value).toBe(true);
+
+    // A change arrives; reconcile sees m6 again but must NOT re-append it (beyond window).
+    h.newer.mockResolvedValueOnce([msg('m2', 20), msg('m3', 30), msg('m4', 40), msg('m5', 50)]);
+    await fireChange();
+    expect(ch2.rows.value.map((m) => m.id)).toEqual(['m2', 'm3', 'm4', 'm5']);
+    scope2.stop();
+  });
+});
+
+describe('useChatHistory — seekTo (jump-to-older)', () => {
+  it('loads a window centered on a timestamp in one read-pair, replacing rows in place', async () => {
+    h.older.mockResolvedValueOnce([msg('m9', 90), msg('m10', 100)]); // initial newest
+    h.count.mockResolvedValue(10);
+    const scope = effectScope();
+    let ch!: ReturnType<typeof useChatHistory>;
+    scope.run(() => (ch = useChatHistory('c1', undefined, { batchSize: 2, maxRows: 4 })));
+    await flush();
+    const arr = ch.rows.value;
+
+    // Seek to ts 30: older(<30) → m1,m2 ; from-ts(>=30) → m3,m4.
+    h.older.mockResolvedValueOnce([msg('m1', 10), msg('m2', 20)]);
+    h.newer.mockResolvedValueOnce([msg('m3', 30), msg('m4', 40)]);
+    const ok = await ch.seekTo(30);
+
+    expect(ok).toBe(true);
+    expect(h.older).toHaveBeenLastCalledWith('c1', 30, 2, ''); // strictly older than 30
+    expect(h.newer).toHaveBeenLastCalledWith('c1', 29, 2, ''); // ts and newer (29 = 30 - 1)
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(ch.rows.value).toBe(arr); // mutated in place, not reassigned
+    expect(ch.hasOlder.value).toBe(true);
+    expect(ch.hasNewer.value).toBe(true); // a target deep in history has newer messages
+    scope.stop();
+  });
+});
+
+describe('useChatHistory — reset on chatId/q change', () => {
+  it('reloads a fresh newest batch when chatId changes', async () => {
+    const chatId = ref('c1');
+    h.older.mockResolvedValueOnce([msg('a1', 10)]);
+    h.count.mockResolvedValue(1);
+    const scope = effectScope();
+    let ch!: ReturnType<typeof useChatHistory>;
+    scope.run(() => (ch = useChatHistory(chatId, undefined, { batchSize: 3, maxRows: 8 })));
+    await flush();
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['a1']);
+
+    h.older.mockResolvedValueOnce([{ ...msg('b1', 11), chatId: 'c2' }, { ...msg('b2', 12), chatId: 'c2' }]);
+    h.count.mockResolvedValue(2);
+    chatId.value = 'c2';
+    await nextTick();
+    await flush();
+    expect(h.older).toHaveBeenLastCalledWith('c2', null, 3, '');
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['b1', 'b2']);
+    scope.stop();
+  });
+
+  it('reloads when the search term changes', async () => {
+    const q = ref('');
+    h.older.mockResolvedValueOnce([msg('m1', 10), msg('m2', 20)]);
+    h.count.mockResolvedValue(2);
+    const scope = effectScope();
+    let ch!: ReturnType<typeof useChatHistory>;
+    scope.run(() => (ch = useChatHistory('c1', q, { batchSize: 3, maxRows: 8 })));
+    await flush();
+
+    h.older.mockResolvedValueOnce([msg('m2', 20)]); // filtered
+    q.value = 'm2';
+    await nextTick();
+    await flush();
+    expect(h.older).toHaveBeenLastCalledWith('c1', null, 3, 'm2');
+    expect(ch.rows.value.map((m) => m.id)).toEqual(['m2']);
+    scope.stop();
+  });
+});

--- a/src/composables/useChatHistory.ts
+++ b/src/composables/useChatHistory.ts
@@ -1,0 +1,263 @@
+/**
+ * Bounded, incrementally-updated chat history (spec 1011, research D2/D3).
+ *
+ * The chat view sources its render window from `rows` here instead of
+ * `useLiveQuery(listMessages)`. Two things make scroll-up smooth at any length:
+ *
+ *  1. **Bounded.** `rows` holds only a contiguous run around the rendered window
+ *     (≤ `maxRows`), read in batches via `listMessagesOlder/Newer`. `loadOlder`
+ *     prepends and trims the newest tail; `loadNewer` appends and trims the oldest
+ *     head — so memory stays bounded however far the user scrolls (FR-013).
+ *
+ *  2. **Incremental.** On a `messages` change we do NOT replace `rows` wholesale (the
+ *     churn `useLiveQuery` caused — re-allocating thousands of objects + re-rendering on
+ *     every reaction/seen/tick). Instead we reconcile the loaded window in place:
+ *     patch-by-id (shallow-merge one row), remove-by-id (splice), and append a new
+ *     bottom message only when the run touches the bottom. The `rows` array is never
+ *     reassigned, so Vue diffs only the rows that actually changed (FR-011, D3).
+ *
+ * Pure index/slice math lives in chat-pagination / chat-window; this composable is the
+ * stateful glue. It is read-only against IndexedDB — no schema/wire change.
+ */
+import { computed, isRef, onScopeDispose, ref, watch, type Ref } from 'vue';
+import { subscribe } from '@/db/idb';
+import { listMessagesOlder, listMessagesNewer, countChatMessages } from '@/db/queries';
+import { BATCH_SIZE, MAX_ROWS } from '@/utils/chat-window';
+import type { Message } from '@/db/types';
+
+export interface ChatHistory {
+  /** The loaded contiguous run, oldest→newest (bounded). Mutated in place, never
+   *  reassigned — exposed read-only so callers don't replace it. */
+  rows: Readonly<Ref<Message[]>>;
+  hasOlder: Ref<boolean>;
+  hasNewer: Ref<boolean>;
+  total: Ref<number>;
+  oldestLoadedTs: Ref<number | null>;
+  newestLoadedTs: Ref<number | null>;
+  /** Counts of messages NOT in `rows` (older than the first / newer than the last loaded
+   *  row). The view sizes its top/bottom spacers from these so the scroll range reflects
+   *  the whole chat without holding it (spec 1011). Invariant: older + rows.length + newer
+   *  = total. */
+  olderUnloaded: Ref<number>;
+  newerUnloaded: Ref<number>;
+  /** Flips true after the first batch resolves (the view reveals the list then). */
+  ready: Ref<boolean>;
+  loadOlder(): Promise<number>;
+  loadNewer(): Promise<number>;
+  /** Load a bounded window CENTERED on `ts` in one read-pair (for jump-to-older seek,
+   *  spec 1011 D7) — far cheaper than paging batch-by-batch to a distant target. Replaces
+   *  `rows` with the window; returns false when the chat has nothing at/around `ts`. */
+  seekTo(ts: number): Promise<boolean>;
+  reload(): Promise<void>;
+}
+
+export interface ChatHistoryOpts {
+  batchSize?: number;
+  maxRows?: number;
+}
+
+/** A compact change signature: every mutating write bumps `updatedAt`, but we also fold
+ *  in the fields a receipt/reaction/edit/delete touches so a reconcile patches exactly
+ *  the rows that changed (and skips the rest — fresh reads always have new array refs,
+ *  so a shallow object compare would false-positive on every tick). */
+function sig(m: Message): string {
+  return [
+    m.updatedAt,
+    m.status,
+    m.seenAt ?? '',
+    m.deleted ?? '',
+    m.body,
+    m.reactions?.length ?? 0,
+    m.receipts?.length ?? 0,
+  ].join('|');
+}
+
+export function useChatHistory(
+  chatId: Ref<string> | string,
+  q?: Ref<string>,
+  opts: ChatHistoryOpts = {},
+): ChatHistory {
+  const batchSize = opts.batchSize ?? BATCH_SIZE;
+  const maxRows = opts.maxRows ?? MAX_ROWS;
+
+  const rows = ref<Message[]>([]);
+  const hasOlder = ref(false);
+  const hasNewer = ref(false);
+  const total = ref(0);
+  const oldestLoadedTs = ref<number | null>(null);
+  const newestLoadedTs = ref<number | null>(null);
+  // We track `newerUnloaded` explicitly (loadOlder's tail-trim grows it, loadNewer consumes
+  // it); olderUnloaded is derived from the invariant older + loaded + newer = total.
+  const newerUnloaded = ref(0);
+  const olderUnloaded = computed(() => Math.max(0, total.value - rows.value.length - newerUnloaded.value));
+  const ready = ref(false);
+
+  const cid = () => (isRef(chatId) ? chatId.value : chatId);
+  const query = () => (q ? q.value : '');
+
+  // A monotonically-increasing token guards async work: a chat/search switch (reload)
+  // or a newer reconcile supersedes any in-flight read so a stale result can't land.
+  let token = 0;
+
+  function refreshCursors(): void {
+    oldestLoadedTs.value = rows.value.length ? rows.value[0].timestamp : null;
+    newestLoadedTs.value = rows.value.length ? rows.value[rows.value.length - 1].timestamp : null;
+  }
+
+  /** Reset to a fresh newest batch (initial load + on chatId/q change). */
+  async function reload(): Promise<void> {
+    const mine = ++token;
+    const c = cid();
+    const qq = query();
+    const batch = await listMessagesOlder(c, null, batchSize, qq);
+    const t = await countChatMessages(c);
+    if (mine !== token) return; // superseded
+    rows.value.splice(0, rows.value.length, ...batch); // in place, keep array identity
+    refreshCursors();
+    total.value = t;
+    newerUnloaded.value = 0; // the newest batch → nothing newer is unloaded
+    hasNewer.value = false; // the newest batch → pinned to the bottom
+    hasOlder.value = qq ? batch.length === batchSize : t > rows.value.length;
+    ready.value = true;
+  }
+
+  async function loadOlder(): Promise<number> {
+    if (!hasOlder.value || oldestLoadedTs.value == null) return 0;
+    const c = cid();
+    const qq = query();
+    const batch = await listMessagesOlder(c, oldestLoadedTs.value, batchSize, qq);
+    if (!batch.length) {
+      hasOlder.value = false;
+      return 0;
+    }
+    rows.value.unshift(...batch);
+    hasOlder.value = batch.length === batchSize;
+    // Trim the newest tail so memory stays bounded; we're scrolling up, so the trimmed
+    // rows are below the viewport — they become "newer-unloaded" (the bottom spacer).
+    if (rows.value.length > maxRows) {
+      const trimmed = rows.value.length - maxRows;
+      rows.value.splice(maxRows, trimmed);
+      newerUnloaded.value += trimmed;
+      hasNewer.value = true;
+    }
+    refreshCursors();
+    return batch.length;
+  }
+
+  async function loadNewer(): Promise<number> {
+    if (!hasNewer.value || newestLoadedTs.value == null) return 0;
+    const c = cid();
+    const qq = query();
+    const batch = await listMessagesNewer(c, newestLoadedTs.value, batchSize, qq);
+    if (!batch.length) {
+      hasNewer.value = false;
+      return 0;
+    }
+    rows.value.push(...batch);
+    newerUnloaded.value = Math.max(0, newerUnloaded.value - batch.length); // consumed K newer
+    hasNewer.value = batch.length === batchSize;
+    // Trim the oldest head (we're scrolling down; the head is far off-screen above). Those
+    // rows become "older-unloaded" again (derived via the invariant from the smaller rows).
+    if (rows.value.length > maxRows) {
+      rows.value.splice(0, rows.value.length - maxRows);
+      hasOlder.value = true;
+    }
+    refreshCursors();
+    return batch.length;
+  }
+
+  async function seekTo(ts: number): Promise<boolean> {
+    const mine = ++token;
+    const c = cid();
+    const qq = query();
+    const newerHalf = Math.floor(maxRows / 2);
+    // older: strictly older than ts; from-ts: ts and newer (includes the target row).
+    const older = await listMessagesOlder(c, ts, maxRows - newerHalf, qq);
+    const fromTs = await listMessagesNewer(c, ts - 1, newerHalf, qq);
+    const t = await countChatMessages(c);
+    if (mine !== token) return false;
+    const combined = [...older, ...fromTs];
+    if (!combined.length) return false;
+    rows.value.splice(0, rows.value.length, ...combined);
+    refreshCursors();
+    total.value = t;
+    // A full half in either direction means there's very likely more beyond the window;
+    // a short read means we hit that end (a later loadOlder/Newer returns 0 and corrects).
+    hasOlder.value = older.length === maxRows - newerHalf;
+    hasNewer.value = fromTs.length === newerHalf;
+    // Split the remaining unloaded across the two spacers (we don't know the exact rank of
+    // the target; subsequent loadOlder/Newer correct the counts precisely).
+    const rest = Math.max(0, t - rows.value.length);
+    newerUnloaded.value = hasNewer.value ? (hasOlder.value ? Math.floor(rest / 2) : rest) : 0;
+    ready.value = true;
+    return true;
+  }
+
+  /** Reconcile the loaded window in place on a 'messages' change — no wholesale replace. */
+  async function reconcile(): Promise<void> {
+    if (!rows.value.length || oldestLoadedTs.value == null) {
+      // Empty (or first message into an empty chat) → just (re)load the newest batch.
+      await reload();
+      return;
+    }
+    const mine = ++token;
+    const c = cid();
+    const qq = query();
+    // The fresh state of the loaded window (+ a batch of headroom for new bottom rows).
+    const limit = rows.value.length + batchSize;
+    const fresh = await listMessagesNewer(c, oldestLoadedTs.value - 1, limit, qq);
+    const t = await countChatMessages(c);
+    if (mine !== token) return; // superseded by a reload / newer reconcile
+
+    const freshById = new Map(fresh.map((m) => [m.id, m]));
+    // Patch changed rows + splice removed ones (walk backwards so splices are stable).
+    for (let i = rows.value.length - 1; i >= 0; i--) {
+      const cur = rows.value[i];
+      const f = freshById.get(cur.id);
+      if (!f) {
+        rows.value.splice(i, 1); // remove-by-id
+      } else if (sig(f) !== sig(cur)) {
+        Object.assign(rows.value[i], f); // patch-by-id (shallow-merge, same object)
+      }
+    }
+    // Append new bottom messages only when the run touches the bottom; otherwise they're
+    // beyond the loaded window and surfaced via hasNewer (no yank, FR-004).
+    if (!hasNewer.value) {
+      const have = new Set(rows.value.map((m) => m.id));
+      const newest = newestLoadedTs.value ?? -Infinity;
+      for (const m of fresh) {
+        if (m.timestamp > newest && !have.has(m.id)) rows.value.push(m);
+      }
+    }
+    refreshCursors();
+    total.value = t;
+  }
+
+  // Subscribe to the change bus + reset on chatId/q change.
+  const stops: Array<() => void> = [];
+  if (isRef(chatId)) stops.push(watch(chatId, () => void reload()));
+  if (q) stops.push(watch(q, () => void reload()));
+  const unsub = subscribe(['messages'], () => void reconcile());
+  onScopeDispose(() => {
+    unsub();
+    stops.forEach((s) => s());
+  });
+
+  void reload();
+
+  return {
+    rows: rows as Readonly<Ref<Message[]>>,
+    hasOlder,
+    hasNewer,
+    total,
+    oldestLoadedTs,
+    newestLoadedTs,
+    olderUnloaded,
+    newerUnloaded,
+    ready,
+    loadOlder,
+    loadNewer,
+    seekTo,
+    reload,
+  };
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -8,6 +8,7 @@ import { enqueue, removeOutboxByFrameId } from './outbox';
 import { recordTombstone } from './tombstones';
 import { uid } from '@/utils/uid';
 import { capitalizeFirst } from '@/utils/text';
+import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination';
 import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
 import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink } from '@/services/api';
 import { sealForChat, openPacket } from '@/services/messaging';
@@ -231,6 +232,48 @@ export async function listMessages(chatId: string, q = ''): Promise<Message[]> {
 
 export function getMessage(id: string): Promise<Message | undefined> {
   return get<Message>('messages', id);
+}
+
+/* ---- bounded chat-history reads (spec 1011, research D2) ----
+   The chat view sources its window from these batches instead of holding the whole
+   chat (the churn root behind the old `useLiveQuery(listMessages)`). They reuse the
+   existing single `chatId` index (one getByIndex) + an in-memory sort/slice — no new
+   index, no DB_VERSION bump. `listMessages` (loads-all) stays for search and the other
+   callers (media/docs/links browsers, exports). Ordering is deterministic by
+   (timestamp, id); the slice helpers dedupe the seam so adjacent batches never return
+   the cursor row twice. The optional `q` keeps the existing substring filter. */
+
+/** The `limit` messages immediately OLDER than `beforeTs` (the newest `limit` when
+ *  null), oldest→newest. */
+export async function listMessagesOlder(
+  chatId: string,
+  beforeTs: number | null,
+  limit: number,
+  q = '',
+): Promise<Message[]> {
+  const msgs = await getByIndex<Message>('messages', 'chatId', chatId);
+  const filtered = q ? msgs.filter((m) => matches(m.body, q)) : msgs;
+  filtered.sort(compareByTimeId);
+  return sliceOlder(filtered, beforeTs, limit);
+}
+
+/** The `limit` messages immediately NEWER than `afterTs`, oldest→newest (scroll-down
+ *  re-entry after eviction). */
+export async function listMessagesNewer(
+  chatId: string,
+  afterTs: number,
+  limit: number,
+  q = '',
+): Promise<Message[]> {
+  const msgs = await getByIndex<Message>('messages', 'chatId', chatId);
+  const filtered = q ? msgs.filter((m) => matches(m.body, q)) : msgs;
+  filtered.sort(compareByTimeId);
+  return sliceNewer(filtered, afterTs, limit);
+}
+
+/** Total messages in a chat (for "more above" detection + affordances). */
+export async function countChatMessages(chatId: string): Promise<number> {
+  return (await getByIndex<Message>('messages', 'chatId', chatId)).length;
 }
 
 /** Append a locally-authored message (starts `pending`) and update the chat.
@@ -922,6 +965,16 @@ const URL_RE = /\bhttps?:\/\/[^\s]+/i;
 export async function listChatMedia(chatId: string): Promise<Message[]> {
   const all = await listMessages(chatId);
   return all.filter((m) => m.kind === 'image' || m.kind === 'video').reverse();
+}
+/** All blob-backed media messages in a chat (image/video/voice/audio), oldest→newest.
+ *  The chat list is windowed (useChatHistory) but the media viewer + audio playlist span
+ *  the WHOLE chat (spec 1005/1007), so they source from this whole-chat media subset —
+ *  far smaller than every message, and not the scroll hot path. */
+export async function listChatMediaAll(chatId: string): Promise<Message[]> {
+  const all = await listMessages(chatId);
+  return all.filter(
+    (m) => m.kind === 'image' || m.kind === 'video' || m.kind === 'voice' || m.kind === 'audio',
+  );
 }
 /** All file (document) messages in a chat, newest-first. */
 export async function listChatDocs(chatId: string): Promise<Message[]> {

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -45,6 +45,7 @@ import {
   reactToMessage as dbReactToMessage,
   quickReactEmojis as dbQuickReactEmojis,
   getMessage as dbGetMessage,
+  firstMessageOnOrAfter as dbFirstMessageOnOrAfter,
   sendLocation as dbSendLocation,
   sendPoll as dbSendPoll,
   sendContact as dbSendContact,
@@ -107,7 +108,7 @@ import { peerPresence } from '@/composables/usePresence';
 import { activityFor } from '@/composables/useTyping';
 import type { ActivityKind, ActivityState } from '@/services/transport';
 import { setSecret } from '@/db/secrets';
-import { getAll, put } from '@/db/idb';
+import { getAll, put, bulkPut } from '@/db/idb';
 import { uid } from '@/utils/uid';
 import { seedShowcase as runSeedShowcase } from '@/services/showcase-seed';
 import type { FriendRequest, Media, Message } from '@/db/types';
@@ -304,6 +305,9 @@ export function installTestHook(): void {
      *  receipt the UI sends on view), so they delete the server blob now rather than at the tick. */
     confirmDownloads: (chatId: string): Promise<void> => sendDownloadedReceipts(chatId),
 
+    /** The oldest message id in a chat (for the jump-to-older seek test, spec 1011). */
+    firstMessageId: (chatId: string): Promise<string | null> => dbFirstMessageOnOrAfter(chatId, 0),
+
     /** Send `body` as a reply quoting the message `quotedId`. */
     sendReply: async (chatId: string, body: string, quotedId: string): Promise<void> => {
       const m = await dbGetMessage(quotedId);
@@ -343,6 +347,11 @@ export function installTestHook(): void {
     sendAudio: (chatId: string, name: string, title: string, artist: string) =>
       dbSendMediaMessage(chatId, 'audio', new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'audio/mpeg' }), name, 12, {
         audio: { title, artist },
+      }),
+    /** Send a round video-note ("video message"). */
+    sendVideoNote: (chatId: string, name: string) =>
+      dbSendMediaMessage(chatId, 'video', new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'video/mp4' }), name, 8, {
+        videoNote: true,
       }),
     /** Send a photo/video at a quality → exercises the background compression job. */
     sendMediaQuality: (chatId: string, kind: 'image' | 'video', name: string, quality: 'sd' | 'hd' | 'original') =>
@@ -471,6 +480,66 @@ export function installTestHook(): void {
         status: 'sent',
         updatedAt: Date.now(),
       });
+    },
+
+    /** Bulk-seed `n` messages into a chat in ONE transaction (spec 1011, research D9).
+     *  A 5,000-message scroll test through the real send pipeline is impractical
+     *  (minutes/run, hits crypto/relay); this writes spread-timestamp rows with a single
+     *  bulkPut so the smoothness assertions run instantly + deterministically.
+     *  - `fromIds` rotates senders (group histories); defaults to self + one peer.
+     *  - `mediaEvery` makes every Nth row an image (height variety + media-LRU pressure).
+     *  Dev-only — stripped from prod with the rest of __ringTest. */
+    seedMessages: async (
+      chatId: string,
+      n: number,
+      opts: { fromIds?: string[]; mediaEvery?: number } = {},
+    ): Promise<void> => {
+      const self = getSelfUserId() ?? 'me';
+      const senders = opts.fromIds && opts.fromIds.length ? opts.fromIds : [self, 'seed-peer-1'];
+      const mediaEvery = opts.mediaEvery && opts.mediaEvery > 0 ? Math.floor(opts.mediaEvery) : 0;
+      const step = 60_000; // 1 min apart → realistic day-divider variety over a long chat
+      const base = Date.now() - n * step;
+      // A 1×1 PNG — the same tiny decodable image the e2e paste flow uses.
+      const pngB64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+      const pngBytes = Uint8Array.from(atob(pngB64), (c) => c.charCodeAt(0));
+
+      const media: Media[] = [];
+      const rows: Message[] = [];
+      for (let i = 0; i < n; i++) {
+        const senderId = senders[i % senders.length];
+        const outgoing = senderId === self || senderId === 'me';
+        const ts = base + i * step;
+        const isMedia = mediaEvery > 0 && (i + 1) % mediaEvery === 0;
+        let mediaId: string | undefined;
+        if (isMedia) {
+          mediaId = uid();
+          media.push({
+            id: mediaId,
+            kind: 'image',
+            mime: 'image/png',
+            name: `seed-${i}.png`,
+            size: pngBytes.byteLength,
+            blob: new Blob([pngBytes], { type: 'image/png' }),
+            updatedAt: ts,
+          });
+        }
+        rows.push({
+          id: uid(),
+          chatId,
+          senderId,
+          senderName: outgoing ? 'You' : senderId,
+          body: isMedia ? '' : `Seeded message ${i + 1} of ${n}`,
+          kind: isMedia ? 'image' : 'text',
+          mediaId,
+          timestamp: ts,
+          outgoing,
+          status: outgoing ? 'seen' : 'seen',
+          updatedAt: ts,
+        });
+      }
+      if (media.length) await bulkPut<Media>('media', media);
+      await bulkPut<Message>('messages', rows); // ONE write for all messages
     },
 
     /** Inject the curated showcase demo dataset (contacts, chats, messages, media,

--- a/src/utils/chat-grouping.test.ts
+++ b/src/utils/chat-grouping.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { isRunStart, showDay } from './chat-grouping';
+
+// Group-run + day-divider math computed from the row's PREDECESSOR (the real previous
+// message in the loaded run, not the previous *rendered* item). Feeding the true
+// predecessor — preserved across the window's top edge — is what stops an avatar or
+// day-divider from flickering when older rows are prepended/evicted (D8 / INV-7).
+
+const DAY = 24 * 60 * 60 * 1000;
+const t0 = new Date(2026, 0, 1, 12, 0, 0).getTime(); // a fixed local noon
+const t0Later = t0 + 60 * 1000; // same day, a minute later
+const t1 = t0 + DAY; // next day
+
+describe('isRunStart (group avatar/name on the first bubble of a run)', () => {
+  it('is false in a 1:1 chat (no avatars/names)', () => {
+    expect(isRunStart({ senderId: 'b', outgoing: false }, { senderId: 'b', outgoing: false }, false)).toBe(false);
+  });
+
+  it('is true when there is no predecessor in the run', () => {
+    expect(isRunStart(null, { senderId: 'b', outgoing: false }, true)).toBe(true);
+  });
+
+  it('is false for your own outgoing bubble', () => {
+    expect(isRunStart({ senderId: 'b', outgoing: false }, { senderId: 'me', outgoing: true }, true)).toBe(false);
+  });
+
+  it('is true when the previous message was from a different sender', () => {
+    expect(isRunStart({ senderId: 'a', outgoing: false }, { senderId: 'b', outgoing: false }, true)).toBe(true);
+  });
+
+  it('is true when the previous message was outgoing (yours)', () => {
+    expect(isRunStart({ senderId: 'me', outgoing: true }, { senderId: 'b', outgoing: false }, true)).toBe(true);
+  });
+
+  it('is false in the middle of a same-sender run', () => {
+    expect(isRunStart({ senderId: 'b', outgoing: false }, { senderId: 'b', outgoing: false }, true)).toBe(false);
+  });
+
+  it('does not toggle when the true predecessor is preserved across the window edge', () => {
+    const prev = { senderId: 'b', outgoing: false };
+    const cur = { senderId: 'b', outgoing: false };
+    // Same (prev, cur) → same answer regardless of whether prev is the first RENDERED
+    // row; the bug is passing `undefined` when prev is merely outside the rendered slice.
+    expect(isRunStart(prev, cur, true)).toBe(false);
+    // Contrast: dropping the predecessor would wrongly flip it to a run start (flicker).
+    expect(isRunStart(undefined, cur, true)).toBe(true);
+  });
+});
+
+describe('showDay (date divider above the first message of a day)', () => {
+  it('is true for the oldest loaded item (no predecessor)', () => {
+    expect(showDay(null, { timestamp: t0 })).toBe(true);
+  });
+
+  it('is false within the same day', () => {
+    expect(showDay({ timestamp: t0 }, { timestamp: t0Later })).toBe(false);
+  });
+
+  it('is true when the day changes', () => {
+    expect(showDay({ timestamp: t0Later }, { timestamp: t1 })).toBe(true);
+  });
+
+  it('does not toggle when the true predecessor is preserved across the window edge', () => {
+    // Same-day predecessor present → no divider; dropping it would wrongly inject one.
+    expect(showDay({ timestamp: t0 }, { timestamp: t0Later })).toBe(false);
+    expect(showDay(undefined, { timestamp: t0Later })).toBe(true);
+  });
+});

--- a/src/utils/chat-grouping.ts
+++ b/src/utils/chat-grouping.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure group-run + day-divider math for the bounded chat window (spec 1011, research D8).
+ *
+ * Avatars/day-dividers render on the first bubble of a sender-run / day. The bug a
+ * windowed list introduces is computing "is this a run/day start?" from the previous
+ * RENDERED item: at the window's top edge that predecessor changes as older rows are
+ * prepended or evicted, so an avatar/divider flickers and injects a height jump into the
+ * anchored frame. The fix is to compute from the row's TRUE predecessor in the loaded run
+ * (preserved across the window edge). These helpers take that predecessor explicitly, so
+ * the answer depends only on the data, never on what happens to be rendered.
+ */
+import { sameDay } from './time';
+
+export interface RunMsg {
+  senderId: string;
+  outgoing: boolean;
+}
+
+/**
+ * Whether `cur` begins a new sender-run (its avatar + colored name show). Group chats
+ * only; your own outgoing bubbles never start a run. True when there is no predecessor,
+ * or the predecessor was outgoing / from a different sender.
+ */
+export function isRunStart(
+  prev: RunMsg | null | undefined,
+  cur: RunMsg,
+  isGroup: boolean,
+): boolean {
+  if (!isGroup) return false;
+  if (cur.outgoing) return false;
+  if (!prev) return true;
+  return prev.outgoing || prev.senderId !== cur.senderId;
+}
+
+/**
+ * Whether a day divider renders above `cur` — true for the oldest loaded item (no
+ * predecessor) or when the calendar day changes from the predecessor.
+ */
+export function showDay(
+  prev: { timestamp: number } | null | undefined,
+  cur: { timestamp: number },
+): boolean {
+  return !prev || !sameDay(prev.timestamp, cur.timestamp);
+}

--- a/src/utils/chat-pagination.test.ts
+++ b/src/utils/chat-pagination.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { sliceOlder, sliceNewer, compareByTimeId } from './chat-pagination';
+
+// Pure pagination/cursor math over a sorted-ascending array (no IndexedDB). The
+// bounded reads in queries.ts get the whole chat from the `chatId` index, sort it
+// once, and slice with these helpers (research D2). The seam-dedupe property is what
+// keeps adjacent batches from returning the row that sits exactly on the cursor twice.
+
+type Row = { id: string; timestamp: number; body?: string };
+
+// A small ascending fixture with DISTINCT timestamps (the common case — `now()` ms
+// per send; seedMessages spreads them).
+const rows: Row[] = [
+  { id: 'a', timestamp: 10 },
+  { id: 'b', timestamp: 20 },
+  { id: 'c', timestamp: 30 },
+  { id: 'd', timestamp: 40 },
+  { id: 'e', timestamp: 50 },
+];
+
+describe('compareByTimeId', () => {
+  it('orders by timestamp, then breaks ties by id (deterministic)', () => {
+    const unsorted: Row[] = [
+      { id: 'z', timestamp: 30 },
+      { id: 'a', timestamp: 30 },
+      { id: 'm', timestamp: 10 },
+    ];
+    const sorted = [...unsorted].sort(compareByTimeId);
+    expect(sorted.map((r) => r.id)).toEqual(['m', 'a', 'z']);
+  });
+});
+
+describe('sliceOlder', () => {
+  it('returns the newest `limit` rows when beforeTs is null, oldest-first', () => {
+    expect(sliceOlder(rows, null, 2).map((r) => r.id)).toEqual(['d', 'e']);
+  });
+
+  it('returns the `limit` rows immediately older than beforeTs, oldest-first', () => {
+    // older than 40 → a,b,c ; the 2 immediately older → b,c
+    expect(sliceOlder(rows, 40, 2).map((r) => r.id)).toEqual(['b', 'c']);
+  });
+
+  it('returns fewer than `limit` when the chat runs out', () => {
+    expect(sliceOlder(rows, 20, 5).map((r) => r.id)).toEqual(['a']);
+  });
+
+  it('excludes the row sitting exactly on the cursor (seam dedupe)', () => {
+    // beforeTs = 30 (oldest currently loaded) → must NOT include c (ts 30) again.
+    const older = sliceOlder(rows, 30, 10);
+    expect(older.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(older.some((r) => r.timestamp === 30)).toBe(false);
+  });
+
+  it('returns [] when nothing is older', () => {
+    expect(sliceOlder(rows, 10, 3)).toEqual([]);
+  });
+});
+
+describe('sliceNewer', () => {
+  it('returns the `limit` rows immediately newer than afterTs, oldest-first', () => {
+    // newer than 20 → c,d,e ; first 2 → c,d
+    expect(sliceNewer(rows, 20, 2).map((r) => r.id)).toEqual(['c', 'd']);
+  });
+
+  it('excludes the row sitting exactly on the cursor (seam dedupe)', () => {
+    // afterTs = 30 (newest currently loaded) → must NOT include c (ts 30) again.
+    const newer = sliceNewer(rows, 30, 10);
+    expect(newer.map((r) => r.id)).toEqual(['d', 'e']);
+    expect(newer.some((r) => r.timestamp === 30)).toBe(false);
+  });
+
+  it('returns [] when nothing is newer', () => {
+    expect(sliceNewer(rows, 50, 3)).toEqual([]);
+  });
+});
+
+describe('seam dedupe across adjacent batches', () => {
+  it('older(cursor) ∪ newer(cursor) never returns the cursor row twice', () => {
+    // Load a middle batch, then page both ways off its edges; the union of all three
+    // batches has every id exactly once (no duplicate at the seams).
+    const mid = rows.filter((r) => r.timestamp >= 20 && r.timestamp <= 40); // b,c,d
+    const older = sliceOlder(rows, mid[0].timestamp, 10); // older than b → a
+    const newer = sliceNewer(rows, mid[mid.length - 1].timestamp, 10); // newer than d → e
+    const all = [...older, ...mid, ...newer].map((r) => r.id);
+    expect(all).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(new Set(all).size).toBe(all.length); // no duplicates
+  });
+});

--- a/src/utils/chat-pagination.ts
+++ b/src/utils/chat-pagination.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure pagination/cursor math for bounded chat-history reads (spec 1011, research D2).
+ *
+ * The bounded reads in queries.ts pull the whole chat off the `messages` `chatId`
+ * index, sort it once, and slice a batch with these helpers — no compound index, no
+ * DB_VERSION bump. Keeping the slice math pure makes the seam-dedupe property (a row
+ * exactly on the cursor is never returned by both adjacent batches) directly unit-
+ * testable without IndexedDB.
+ *
+ * Cursors are timestamps (the public contract signature). Within a chat, messages are
+ * stamped with `now()` ms per send and the dev seed spreads timestamps, so colliding
+ * timestamps are effectively absent; ordering still breaks ties by `id` so the sort is
+ * deterministic. The strict `<` / `>` boundary is what dedupes the seam: the row at the
+ * cursor is the edge row already held by the loaded run, so neither adjacent batch
+ * re-emits it.
+ */
+
+export interface TimeId {
+  id: string;
+  timestamp: number;
+}
+
+/** Deterministic order: ascending by timestamp, ties broken by id. */
+export function compareByTimeId(a: TimeId, b: TimeId): number {
+  return a.timestamp - b.timestamp || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+}
+
+/**
+ * The `limit` rows immediately OLDER than `beforeTs` (strictly older — seam dedupe),
+ * returned oldest→newest. When `beforeTs` is null, the newest `limit` rows.
+ * `sortedAsc` MUST already be sorted ascending (caller sorts once).
+ */
+export function sliceOlder<T extends TimeId>(
+  sortedAsc: readonly T[],
+  beforeTs: number | null,
+  limit: number,
+): T[] {
+  if (limit <= 0) return [];
+  const upper = beforeTs == null ? sortedAsc.length : lowerBound(sortedAsc, beforeTs);
+  const start = Math.max(0, upper - limit);
+  return sortedAsc.slice(start, upper);
+}
+
+/**
+ * The `limit` rows immediately NEWER than `afterTs` (strictly newer — seam dedupe),
+ * returned oldest→newest. `sortedAsc` MUST already be sorted ascending.
+ */
+export function sliceNewer<T extends TimeId>(
+  sortedAsc: readonly T[],
+  afterTs: number,
+  limit: number,
+): T[] {
+  if (limit <= 0) return [];
+  const lower = upperBound(sortedAsc, afterTs);
+  return sortedAsc.slice(lower, lower + limit);
+}
+
+/** First index whose timestamp is >= ts (rows before it are strictly older). */
+function lowerBound(sortedAsc: readonly TimeId[], ts: number): number {
+  let lo = 0;
+  let hi = sortedAsc.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (sortedAsc[mid].timestamp < ts) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** First index whose timestamp is > ts (rows from it on are strictly newer). */
+function upperBound(sortedAsc: readonly TimeId[], ts: number): number {
+  let lo = 0;
+  let hi = sortedAsc.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (sortedAsc[mid].timestamp <= ts) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}

--- a/src/utils/chat-window.test.ts
+++ b/src/utils/chat-window.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ROW_CAP,
+  initialWindow,
+  shiftWindow,
+  computeWindow,
+} from './chat-window';
+
+// Pure render-window math. The view renders rows.slice(start, end); these helpers move
+// {start,end} as the user scrolls, keeping the DOM bounded to ROW_CAP while always
+// covering the look-ahead direction. They never touch the DOM — the view feeds them the
+// loaded-row count + the direction a look-ahead sentinel fired in.
+
+describe('initialWindow', () => {
+  it('renders the newest ROW_CAP rows (pinned to bottom on open)', () => {
+    const w = initialWindow(500, 100);
+    expect(w).toEqual({ start: 400, end: 500 });
+    expect(w.end - w.start).toBe(100);
+  });
+
+  it('renders the whole run when it is smaller than the cap', () => {
+    expect(initialWindow(12, 100)).toEqual({ start: 0, end: 12 });
+  });
+
+  it('defaults the cap to ROW_CAP', () => {
+    const w = initialWindow(1000);
+    expect(w.end - w.start).toBe(ROW_CAP);
+  });
+});
+
+describe('shiftWindow', () => {
+  it('shifts both edges by a prepend count so the same rows stay rendered', () => {
+    // loadOlder prepended 50 rows to the front of `rows`; indices move +50.
+    expect(shiftWindow({ start: 0, end: 100 }, 50)).toEqual({ start: 50, end: 150 });
+  });
+});
+
+describe('computeWindow — grow older (scrolling up)', () => {
+  it('grows start downward and retreats end to stay within the cap', () => {
+    const w = computeWindow(
+      { start: 60, end: 160 },
+      { grow: 'older', step: 40, total: 500, rowCap: 100 },
+    );
+    expect(w.start).toBe(20); // 60 - 40 (grew start ↓)
+    expect(w.end).toBe(120); // retreated end to keep end - start === 100
+    expect(w.end - w.start).toBe(100);
+  });
+
+  it('never lets start go below 0', () => {
+    const w = computeWindow(
+      { start: 20, end: 120 },
+      { grow: 'older', step: 40, total: 500, rowCap: 100 },
+    );
+    expect(w.start).toBe(0);
+    expect(w.end - w.start).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('computeWindow — grow newer (downward re-entry after eviction)', () => {
+  it('grows end upward and advances start to stay within the cap', () => {
+    const w = computeWindow(
+      { start: 20, end: 120 },
+      { grow: 'newer', step: 40, total: 500, rowCap: 100 },
+    );
+    expect(w.end).toBe(160); // 120 + 40 (grew end ↑)
+    expect(w.start).toBe(60); // advanced start to keep end - start === 100
+    expect(w.end - w.start).toBe(100);
+  });
+
+  it('never lets end exceed total', () => {
+    const w = computeWindow(
+      { start: 380, end: 480 },
+      { grow: 'newer', step: 40, total: 500, rowCap: 100 },
+    );
+    expect(w.end).toBe(500);
+    expect(w.end - w.start).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('computeWindow — invariants over a long scroll', () => {
+  it('never exceeds the cap across an up-then-down sweep', () => {
+    let w = initialWindow(1000, 100);
+    // sweep up to the top
+    for (let i = 0; i < 40; i++) {
+      w = computeWindow(w, { grow: 'older', step: 40, total: 1000, rowCap: 100 });
+      expect(w.end - w.start).toBeLessThanOrEqual(100);
+      expect(w.start).toBeGreaterThanOrEqual(0);
+      expect(w.end).toBeLessThanOrEqual(1000);
+    }
+    expect(w.start).toBe(0);
+    // sweep back down to the bottom
+    for (let i = 0; i < 40; i++) {
+      w = computeWindow(w, { grow: 'newer', step: 40, total: 1000, rowCap: 100 });
+      expect(w.end - w.start).toBeLessThanOrEqual(100);
+      expect(w.start).toBeGreaterThanOrEqual(0);
+      expect(w.end).toBeLessThanOrEqual(1000);
+    }
+    expect(w.end).toBe(1000);
+  });
+});

--- a/src/utils/chat-window.ts
+++ b/src/utils/chat-window.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure render-window math for the bounded chat list (spec 1011, research D1).
+ *
+ * The view renders `rows.slice(start, end)` from the loaded contiguous run. These
+ * helpers move `{start, end}` as the user scrolls — growing toward the look-ahead
+ * direction and evicting the far edge — so the rendered DOM stays bounded to ROW_CAP
+ * regardless of scroll distance (FR-012). They are pure index arithmetic: the view
+ * supplies the loaded-row count and the direction a look-ahead sentinel fired in; no
+ * DOM is touched here.
+ */
+
+/** Max rendered rows (≈ a few mobile screens + buffer). Bounds the DOM. */
+export const ROW_CAP = 100;
+/** One bounded read batch (≈ ½ ROW_CAP so a batch fills the buffer without overshoot). */
+export const BATCH_SIZE = 50;
+/** Look-ahead distance kept beyond the viewport each way; also the prefetch sentinel's
+ *  rootMargin (≈ 1.5–2 mobile screens). */
+export const LOOK_AHEAD_PX = 1200;
+/** How many rows a single look-ahead grows the window by (kept ≤ ROW_CAP). */
+export const WINDOW_STEP = BATCH_SIZE;
+/** Bound on the loaded run useChatHistory keeps in memory (render window + buffer each
+ *  side). Larger than ROW_CAP so the window can slide without a DB read every step. */
+export const MAX_ROWS = ROW_CAP + 2 * BATCH_SIZE;
+
+export interface RenderWindow {
+  start: number;
+  end: number;
+}
+
+/** The newest `rowCap` rows of a run of `total` rows (a fresh chat opens pinned here). */
+export function initialWindow(total: number, rowCap: number = ROW_CAP): RenderWindow {
+  const start = Math.max(0, total - rowCap);
+  return { start, end: total };
+}
+
+/** Shift both edges by `delta` (e.g. after prepending `delta` older rows to the front
+ *  of `rows`, so the same logical rows stay rendered). Clamped to be non-negative. */
+export function shiftWindow(w: RenderWindow, delta: number): RenderWindow {
+  return { start: Math.max(0, w.start + delta), end: Math.max(0, w.end + delta) };
+}
+
+export interface ComputeOpts {
+  /** Which way the look-ahead sentinel fired: 'older' (scrolling up) / 'newer' (down). */
+  grow: 'older' | 'newer';
+  /** Rows to extend the leading edge by this step. */
+  step: number;
+  /** Loaded-run length (rows.length) — the window can never extend past it. */
+  total: number;
+  /** Max rendered rows. */
+  rowCap?: number;
+}
+
+/**
+ * Advance the window one look-ahead step:
+ * - grow 'older' → start moves DOWN by `step` (render older rows), and end RETREATS so
+ *   `end - start ≤ rowCap` (evict the newest rendered rows — the far edge).
+ * - grow 'newer' → end moves UP by `step` (render newer rows), and start ADVANCES so
+ *   `end - start ≤ rowCap` (evict the oldest rendered rows — the far edge).
+ * Always clamped to [0, total]; the viewport stays covered because the leading edge
+ * grows in the scroll direction before the far edge is evicted.
+ */
+export function computeWindow(w: RenderWindow, opts: ComputeOpts): RenderWindow {
+  const cap = Math.min(opts.rowCap ?? ROW_CAP, opts.total);
+  let { start, end } = w;
+  if (opts.grow === 'older') {
+    start = Math.max(0, start - opts.step);
+    end = Math.min(opts.total, Math.max(end, start)); // unchanged, just clamped
+    if (end - start > cap) end = start + cap; // retreat the newest edge
+  } else {
+    end = Math.min(opts.total, end + opts.step);
+    start = Math.max(0, Math.min(start, end)); // unchanged, just clamped
+    if (end - start > cap) start = end - cap; // advance the oldest edge
+  }
+  return { start, end };
+}

--- a/src/utils/scroll-anchor.test.ts
+++ b/src/utils/scroll-anchor.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  pickAnchor,
+  resolveAnchorDelta,
+  shouldDeferScrollWrite,
+  isSelfEcho,
+} from './scroll-anchor';
+
+// Pure anchor-delta math (INV-1) + the momentum/echo guard predicates (INV-5). The
+// view measures rendered [data-mid] rects and hands them here; the helper decides the
+// scrollTop correction that keeps the anchored bubble visually stationary (≤2px).
+
+describe('pickAnchor', () => {
+  it('picks the topmost row fully below the viewport top', () => {
+    const a = pickAnchor([
+      { id: 'off', top: -30 }, // partly scrolled off the top
+      { id: 'x', top: 12 }, // first fully-visible row
+      { id: 'y', top: 80 },
+    ]);
+    expect(a?.id).toBe('x');
+    expect(a?.top).toBe(12);
+  });
+
+  it('records a fallback chain from the anchor downward (for an evicted anchor)', () => {
+    const a = pickAnchor([
+      { id: 'x', top: 12 },
+      { id: 'y', top: 80 },
+      { id: 'z', top: 140 },
+    ]);
+    expect(a?.fallback).toEqual(['x', 'y', 'z']);
+  });
+
+  it('returns null when nothing is rendered', () => {
+    expect(pickAnchor([])).toBeNull();
+  });
+});
+
+describe('resolveAnchorDelta', () => {
+  it('computes the residual so the anchor lands back within ≤2px', () => {
+    const anchor = { id: 'x', top: 12, fallback: ['x', 'y'] };
+    // After the prepend the anchor measured 60px lower.
+    const delta = resolveAnchorDelta(anchor, [
+      { id: 'x', top: 72 },
+      { id: 'y', top: 140 },
+    ]);
+    expect(delta).toBe(60); // scrollTop += 60 → anchor returns to top 12
+    // Residual after applying the correction is 0 (≤2px, INV-1).
+    const residual = Math.abs(72 - delta! - anchor.top);
+    expect(residual).toBeLessThanOrEqual(2);
+  });
+
+  it('falls back to the next still-rendered row when the anchor was evicted', () => {
+    const anchor = { id: 'x', top: 12, fallback: ['x', 'y', 'z'] };
+    // 'x' is gone (evicted); 'y' is the next still-rendered row.
+    const delta = resolveAnchorDelta(anchor, [
+      { id: 'y', top: 70 },
+      { id: 'z', top: 130 },
+    ]);
+    expect(delta).toBe(70 - 12); // uses y's measured top against the recorded anchor top
+  });
+
+  it('returns null when nothing in the fallback chain is still rendered', () => {
+    const anchor = { id: 'x', top: 12, fallback: ['x', 'y'] };
+    expect(resolveAnchorDelta(anchor, [{ id: 'q', top: 50 }])).toBeNull();
+  });
+});
+
+describe('momentum / echo guards (INV-5)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('defers a scrollTop write while a fling is in flight, permits it once quiet', () => {
+    const QUIET = 220;
+    const lastUserScrollAt = 1000;
+    // 100ms after the last genuine user scroll → still flinging → defer.
+    expect(shouldDeferScrollWrite(1100, lastUserScrollAt, QUIET)).toBe(true);
+    // 260ms later → settled → permit.
+    expect(shouldDeferScrollWrite(1260, lastUserScrollAt, QUIET)).toBe(false);
+  });
+
+  it('does not defer when there has been no user scroll yet', () => {
+    expect(shouldDeferScrollWrite(5000, 0, 220)).toBe(false);
+  });
+
+  it('marks a scroll within the suppress window as our own echo', () => {
+    const suppressStickUntil = 2000;
+    expect(isSelfEcho(1900, suppressStickUntil)).toBe(true); // our pin echo
+    expect(isSelfEcho(2100, suppressStickUntil)).toBe(false); // genuine user scroll
+  });
+});

--- a/src/utils/scroll-anchor.ts
+++ b/src/utils/scroll-anchor.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure anchor-delta math (INV-1) + the momentum/echo guard predicates (INV-5) for the
+ * bounded chat window (spec 1011, research D4/D6).
+ *
+ * Keeping a message visually stationary across a prepend/eviction is the ≤2px bar. The
+ * robust way (vs a scrollHeight delta, which skews with the spinner + late media decode)
+ * is to anchor on a real rendered bubble: record its id + measured `top`, run the window
+ * mutation, re-measure, and correct `scrollTop` by the delta. The view does the DOM
+ * measuring; this module does the arithmetic and the decision of WHEN a correction is
+ * safe to write — both directly unit-testable.
+ */
+
+export interface RenderedRow {
+  /** the [data-mid] value */
+  id: string;
+  /** getBoundingClientRect().top, relative to the viewport */
+  top: number;
+}
+
+export interface ScrollAnchor {
+  id: string;
+  top: number;
+  /** Ordered ids from the anchor downward, captured before the mutation, so an evicted
+   *  anchor falls back to the next still-rendered row. */
+  fallback: string[];
+}
+
+/**
+ * Pick the anchor: the topmost row fully below the viewport top (`top >= viewportTop`),
+ * falling back to the first row when every row is partly scrolled off. Records the
+ * fallback chain (the anchor and every row below it) for evicted-anchor recovery.
+ */
+export function pickAnchor(
+  rendered: readonly RenderedRow[],
+  viewportTop = 0,
+): ScrollAnchor | null {
+  if (rendered.length === 0) return null;
+  let idx = rendered.findIndex((r) => r.top >= viewportTop);
+  if (idx === -1) idx = 0; // all scrolled off the top → anchor on the first
+  const anchor = rendered[idx];
+  return { id: anchor.id, top: anchor.top, fallback: rendered.slice(idx).map((r) => r.id) };
+}
+
+/**
+ * The scrollTop correction (px) that returns the anchor to its recorded `top` after a
+ * mutation: `measuredTop - anchor.top`. If the anchor id was evicted, walk the fallback
+ * chain to the next still-rendered row and use its measured top against the recorded
+ * anchor top (a bounded approximation — the successor sat just below the anchor). Returns
+ * null when nothing in the chain is still rendered (the view re-picks an anchor).
+ */
+export function resolveAnchorDelta(
+  anchor: ScrollAnchor,
+  measured: readonly RenderedRow[],
+): number | null {
+  const byId = new Map(measured.map((r) => [r.id, r.top]));
+  for (const id of anchor.fallback.length ? anchor.fallback : [anchor.id]) {
+    const top = byId.get(id);
+    if (top !== undefined) return top - anchor.top;
+  }
+  return null;
+}
+
+/**
+ * Defer a scrollTop write while a fling is in flight: true when a genuine user scroll
+ * happened within `momentumQuietMs` (writing scrollTop mid-inertia fights iOS WebKit
+ * momentum). `lastUserScrollAt === 0` means no user scroll yet → never defer.
+ */
+export function shouldDeferScrollWrite(
+  now: number,
+  lastUserScrollAt: number,
+  momentumQuietMs: number,
+): boolean {
+  return lastUserScrollAt > 0 && now - lastUserScrollAt < momentumQuietMs;
+}
+
+/**
+ * Whether a scroll event at `scrollTs` is the echo of our own programmatic pin/correction
+ * (it lands inside the suppress window), not a genuine user scroll.
+ */
+export function isSelfEcho(scrollTs: number, suppressStickUntil: number): boolean {
+  return scrollTs < suppressStickUntil;
+}

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -89,17 +89,27 @@
          top→bottom flash on open. -->
     <ion-content ref="contentEl" :fullscreen="true" class="chat-content" :scroll-events="true" @ionScroll="onContentScroll">
       <div ref="listEl" class="msg-list" :style="{ visibility: listReady ? 'visible' : 'hidden' }">
+      <!-- Top spacer: reserves the height of the older messages NOT held in `rows`, so the
+           scroll range reflects the whole chat. Prepends shrink it (and evictions grow it) to
+           keep the read position fixed WITHOUT writing scrollTop — the only way to not stall
+           iOS momentum (spec 1011). Height is set imperatively before paint by withScrollAnchor. -->
+      <div ref="topSpacer" class="vscroll-pad" :style="{ height: topPadPx + 'px' }" aria-hidden="true"></div>
       <!-- Top of the list: pull up to load earlier messages (older pages). -->
       <!-- Page older messages well before the very top is reached (look-ahead), so
            scrolling back never stalls at the load boundary (spec 1005 FR-001). -->
       <ion-infinite-scroll
-        :disabled="!listReady || visible >= messages.length"
+        :disabled="!listReady || !hasOlder"
         position="top"
         threshold="25%"
         @ion-infinite="loadOlder"
       >
         <ion-infinite-scroll-content loading-text="Loading earlier messages…" />
       </ion-infinite-scroll>
+      <!-- Look-ahead sentinel: an IntersectionObserver with rootMargin = LOOK_AHEAD_PX fires
+           loadOlder well BEFORE the top edge is reached, so the older page is in the DOM
+           before scrollTop hits 0 (page-before-top, INV-2). ion-infinite-scroll above is the
+           backstop. (spec 1011 D5) -->
+      <div ref="topSentinel" class="scroll-sentinel" aria-hidden="true"></div>
 
       <template v-for="(item, i) in renderItems" :key="item.key">
         <!-- Day divider sits ABOVE the first message of each day. -->
@@ -214,43 +224,54 @@
                 >{{ m.senderName }}</span
               >
 
-              <template v-if="m.mediaId && mediaInfo[m.mediaId]">
-                <!-- Tap the image → open the viewer directly; tap the empty/footer area
-                     of the bubble → the action menu. -->
-                <div v-if="m.kind === 'image'" class="media-wrap" @click.stop="openMediaViewer(m.id)">
-                  <img v-if="mediaInfo[m.mediaId].posterUrl" class="bubble-image" :src="mediaInfo[m.mediaId].posterUrl" alt="photo" loading="lazy" decoding="async" />
-                  <ion-skeleton-text v-else :animated="true" class="media-skel" />
-                  <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
-                </div>
+              <!-- Fixed-square media frames (image + non-note video) render their 240px
+                   box IMMEDIATELY — even before mediaInfo resolves — so a row prepended
+                   while scrolling up already has its FINAL height. Gating the whole frame
+                   on mediaInfo (as voice/audio/file below still do) inserted ~0-height rows
+                   that expanded to 240px once IndexedDB resolved, breaking the scroll anchor
+                   and flashing the list blank mid-scroll on iOS (spec 1011). The skeleton
+                   inside the frame covers the gap until the poster decodes. -->
+              <!-- Tap the image → open the viewer directly; tap the empty/footer area
+                   of the bubble → the action menu. -->
+              <div v-if="m.kind === 'image' && m.mediaId" class="media-wrap" @click.stop="openMediaViewer(m.id)">
+                <img v-if="mediaInfo[m.mediaId]?.posterUrl" class="bubble-image" :src="mediaInfo[m.mediaId]!.posterUrl" alt="photo" loading="lazy" decoding="async" />
+                <ion-skeleton-text v-else :animated="true" class="media-skel" />
+                <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
+              </div>
+              <!-- Video: a still thumbnail with a play button. Tapping the poster opens the
+                   action menu (whole bubble is the hit target); the play button is the
+                   direct affordance to the full-screen viewer. The sender-embedded
+                   posterData shows even before mediaInfo resolves. -->
+              <div v-else-if="m.kind === 'video' && !m.videoNote && m.mediaId" class="video-poster" @click.stop="openMediaViewer(m.id)">
+                <img
+                  v-if="m.posterData || mediaInfo[m.mediaId]?.posterUrl"
+                  class="bubble-image"
+                  :src="m.posterData || mediaInfo[m.mediaId]!.posterUrl"
+                  alt="video"
+                  loading="lazy"
+                  decoding="async"
+                />
+                <ion-skeleton-text v-else :animated="true" class="media-skel" />
+                <!-- Visual play affordance only; a tap anywhere on the poster opens
+                     the viewer via the bubble's tap handler. -->
+                <ion-icon class="play-overlay" :icon="playCircle" aria-hidden="true" />
+                <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
+              </div>
+
+              <!-- Non-square media (round note / voice / audio card / file chip) stays gated
+                   on mediaInfo: these are text-height cards with no fixed-square frame, so
+                   they don't cause the 0→240px reflow above, and they need the resolved
+                   blob URL to render at all. -->
+              <template v-else-if="m.mediaId && mediaInfo[m.mediaId]">
                 <!-- Round video note: plays inline on tap; the action menu opens from
                      the bubble footer below. -->
                 <video-note
-                  v-else-if="m.kind === 'video' && m.videoNote"
+                  v-if="m.kind === 'video' && m.videoNote"
                   :mid="m.id"
                   :src="mediaInfo[m.mediaId].url"
                   :poster="mediaInfo[m.mediaId].posterUrl"
                   :duration-sec="m.durationSec"
                 />
-                <!-- Video: a still thumbnail with a play button. Tapping the poster
-                     opens the action menu (whole bubble is the hit target); the play
-                     button is the direct affordance to the full-screen viewer. -->
-                <template v-else-if="m.kind === 'video'">
-                  <div class="video-poster" @click.stop="openMediaViewer(m.id)">
-                    <img
-                      v-if="m.posterData || mediaInfo[m.mediaId].posterUrl"
-                      class="bubble-image"
-                      :src="m.posterData || mediaInfo[m.mediaId].posterUrl"
-                      alt="video"
-                      loading="lazy"
-                      decoding="async"
-                    />
-                    <ion-skeleton-text v-else :animated="true" class="media-skel" />
-                    <!-- Visual play affordance only; a tap anywhere on the poster opens
-                         the viewer via the bubble's tap handler. -->
-                    <ion-icon class="play-overlay" :icon="playCircle" aria-hidden="true" />
-                    <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
-                  </div>
-                </template>
                 <voice-player
                   v-else-if="m.kind === 'voice'"
                   :mid="m.id"
@@ -591,7 +612,15 @@
 
       </template>
 
-      <div v-if="messages.length === 0" class="empty">
+      <!-- Look-ahead sentinel for downward re-entry: fires loadNewer before the bottom edge
+           is reached so trimmed newer rows re-mount ahead of need (spec 1011). -->
+      <div ref="bottomSentinel" class="scroll-sentinel" aria-hidden="true"></div>
+      <!-- Bottom spacer: reserves the height of newer messages trimmed while scrolling up.
+           It's below the viewport, so its size never shifts what the user sees (cosmetic
+           scroll range only); shrinks to 0 at the true bottom. -->
+      <div class="vscroll-pad" :style="{ height: botPadPx + 'px' }" aria-hidden="true"></div>
+
+      <div v-if="rows.length === 0" class="empty">
         <ion-note>{{ search ? 'No matching messages' : 'No messages yet' }}</ion-note>
       </div>
       </div>
@@ -854,7 +883,7 @@ import {
   imageOutline, musicalNotesOutline, calendarOutline, checkmarkCircle, ellipseOutline,
 } from 'ionicons/icons';
 import {
-  getChat, getContact, listContacts, listMessages, markChatRead, sendMediaMessage, sendMessage,
+  getChat, getContact, listContacts, markChatRead, sendMediaMessage, sendMessage,
   reactToMessage, deleteMessage, softDeleteMessage, deleteMessageForEveryone, editMessage,
   toggleFavorite, setCaption, forwardMessage,
   quickReactEmojis,
@@ -862,7 +891,7 @@ import {
   retryMediaMessage, resumePendingMediaJobs, downloadMessageMedia,
   sendLocation, sendPoll, sendContact, votePoll, messageSharedContact,
   unblockContact, detectTerminated, firstMessageOnOrAfter, countUnread,
-  CAPTION_MAX, getSetting,
+  CAPTION_MAX, getSetting, listChatMediaAll, getMessage,
 } from '@/db/queries';
 import { groupProgress } from '@/services/message-status';
 import { getSelfUserId } from '@/services/auth';
@@ -900,6 +929,10 @@ import { readAudioTags, readAudioDuration } from '@/utils/id3';
 import { get, put } from '@/db/idb';
 import type { Chat, Contact, Media, Message, MessageStatus, Reaction, ReplyRef, SharedContact } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
+import { useChatHistory } from '@/composables/useChatHistory';
+import { LOOK_AHEAD_PX } from '@/utils/chat-window';
+import { pickAnchor, resolveAnchorDelta, shouldDeferScrollWrite, isSelfEcho } from '@/utils/scroll-anchor';
+import { isRunStart as isRunStartEdge, showDay as showDayEdge } from '@/utils/chat-grouping';
 import {
   audioCurId, audioPlaying, audioProgress, audioRate,
   playAudio, seekAudioFrac, cycleAudioRate, stopAudio, detachAudioEnded,
@@ -913,7 +946,7 @@ import { ACTIVITY, type ActivityKind, type ActivityState } from '@/services/tran
 import { startDirectCall, startGroupCall } from '@/composables/useCall';
 import { ensureProfile } from '@/composables/useProfileGate';
 import { setActiveChat } from '@/services/notify';
-import { formatClock, dayLabel, sameDay, formatStamp, formatFull } from '@/utils/time';
+import { formatClock, dayLabel, formatStamp, formatFull } from '@/utils/time';
 
 const route = useRoute();
 const router = useRouter();
@@ -1007,12 +1040,10 @@ async function onPickDate(ev: CustomEvent): Promise<void> {
   }
   showSearch.value = false;
   search.value = '';
-  let tries = 0;
-  const tryJump = (): void => {
-    if (document.querySelector(`[data-mid="${id}"]`)) scrollToMessage(id);
-    else if (tries++ < 20) setTimeout(tryJump, 150);
-  };
-  void nextTick(tryJump);
+  // scrollToMessage now seeks (loads intervening history) when the target is older than
+  // the loaded window, so a jump-to-date far above the window lands correctly (D7).
+  await nextTick();
+  await scrollToMessage(id);
 }
 
 function closeSearch() {
@@ -1137,12 +1168,24 @@ async function onReact(messageId: string, emoji: string): Promise<void> {
   }
 }
 
+// The true predecessor message of render-item i: the previous rendered item's last message.
+// The whole loaded run is rendered, so for i > 0 the predecessor is always present; the very
+// first rendered item is the oldest loaded row (its day-divider/avatar is correct for the
+// top of the loaded run, and recomputes naturally when older rows prepend).
+function prevMsgFor(i: number): Message | null {
+  if (i <= 0) return null;
+  const prev = renderItems.value[i - 1];
+  if (!prev) return null;
+  return prev.kind === 'msg' ? prev.message : prev.messages[prev.messages.length - 1];
+}
+
 // Whether an item starts a new day (the divider renders above it). True for the
 // oldest loaded item too.
 function showDay(i: number): boolean {
   const cur = renderItems.value[i];
-  const prev = renderItems.value[i - 1];
-  return !!cur && (!prev || !sameDay(itemTime(cur), itemTime(prev)));
+  if (!cur) return false;
+  const prev = prevMsgFor(i);
+  return showDayEdge(prev ? { timestamp: prev.timestamp } : null, { timestamp: itemTime(cur) });
 }
 
 /* ---- media viewer (over ALL the chat's media) ---- */
@@ -1153,7 +1196,7 @@ function showDay(i: number): boolean {
 // around the current item (resolveViewerWindow), never the whole set at once — that
 // all-at-once decode was crashing the web view (OOM) on media-heavy chats.
 const chatMediaMsgs = computed(() =>
-  messages.value.filter((m) => (m.kind === 'image' || (m.kind === 'video' && !m.videoNote)) && m.mediaId),
+  allMedia.value.filter((m) => (m.kind === 'image' || (m.kind === 'video' && !m.videoNote)) && m.mediaId),
 );
 const viewer = ref<{ open: boolean; start: number }>({ open: false, start: 0 });
 const viewerItems = computed(() => {
@@ -1203,10 +1246,10 @@ function onViewerDismiss(id: string): void {
   viewerPins.value = new Set();
   evictMedia();
   // Album members render under one bubble keyed by the first message's id.
-  const m = messages.value.find((x) => x.id === id);
+  const m = allMedia.value.find((x) => x.id === id);
   let target = id;
   if (m?.albumId) {
-    const first = messages.value
+    const first = allMedia.value
       .filter((x) => x.albumId === m.albumId)
       .sort((a, b) => a.timestamp - b.timestamp)[0];
     if (first) target = first.id;
@@ -1214,7 +1257,7 @@ function onViewerDismiss(id: string): void {
   void nextTick(() => scrollToMessage(target));
 }
 
-const viewerMsg = (id: string) => messages.value.find((m) => m.id === id);
+const viewerMsg = (id: string) => allMedia.value.find((m) => m.id === id);
 function onViewerReact(id: string, emoji: string): void {
   void reactToMessage(id, emoji);
 }
@@ -1247,7 +1290,7 @@ function onViewerSave(id: string): void {
 // All message ids in an album (oldest first), for "Save all".
 function albumMessageIds(m: Message): string[] {
   if (!m.albumId) return [m.id];
-  return messages.value
+  return allMedia.value
     .filter((x) => x.albumId === m.albumId && !x.deleted)
     .sort((a, b) => a.timestamp - b.timestamp)
     .map((x) => x.id);
@@ -1526,9 +1569,10 @@ function exitSelect(): void {
   selecting.value = false;
   selected.value = [];
 }
-// The selected messages in conversation order, so bulk forwards arrive in order.
+// The selected messages in conversation order, so bulk forwards arrive in order. Selection
+// happens on rendered bubbles, so the chosen ids live within the loaded run (`rows`).
 const selectedMessages = computed(() =>
-  messages.value
+  rows.value
     .filter((m) => selected.value.includes(m.id))
     .sort((a, b) => a.timestamp - b.timestamp),
 );
@@ -1606,10 +1650,9 @@ function groupRunStart(i: number): boolean {
   if (!chat.value?.isGroup) return false;
   const cur = renderItems.value[i];
   if (cur?.kind !== 'msg' || cur.message.outgoing) return false;
-  const prev = renderItems.value[i - 1];
-  if (!prev) return true;
-  const prevMsg = prev.kind === 'msg' ? prev.message : prev.messages[prev.messages.length - 1];
-  return prevMsg.outgoing || prevMsg.senderId !== cur.message.senderId;
+  // Predecessor-included (the prior rendered row) so the avatar/name doesn't
+  // toggle as the window's leading row changes on load (D8/INV-7).
+  return isRunStartEdge(prevMsgFor(i), cur.message, true);
 }
 
 /* ---- edit one of your own messages ----
@@ -1670,19 +1713,55 @@ function smallThumb(url: string): Promise<string | undefined> {
   });
 }
 
-// Tapping a quote scrolls to the original message if it's currently loaded.
-function scrollToMessage(id: string): void {
-  const el = document.querySelector(`[data-mid="${id}"]`);
-  if (el) {
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    return;
-  }
-  // The quoted message isn't on this device, e.g. a reply to a message sent
-  // before we joined this group. The quote bubble still renders from its embedded
-  // snapshot; there's just nothing to scroll to.
+function notAvailableToast(): void {
+  // The quoted message isn't on this device, e.g. a reply to a message sent before we
+  // joined this group. The quote bubble still renders from its embedded snapshot; there's
+  // just nothing to scroll to.
   void toastController
     .create({ message: 'Original message not available', duration: 1400, position: 'top' })
     .then((t) => t.present());
+}
+// Poll briefly for the target row to mount, then center it (it may need a tick after a
+// window change). Returns true once it scrolled to it.
+async function centerWhenRendered(id: string, tries: number): Promise<boolean> {
+  for (let i = 0; i < tries; i++) {
+    const el = document.querySelector(`[data-mid="${id}"]`);
+    if (el) {
+      el.scrollIntoView({ behavior: i === 0 ? 'smooth' : 'auto', block: 'center' });
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 80));
+    await nextTick();
+  }
+  return false;
+}
+// Seek to a message and center it (INV-6 / US3, research D7). If it's already rendered we
+// just center it. Otherwise, for an on-device message older/newer than the loaded window,
+// load batches toward it (bounded loop) until it falls within the run, move the render
+// window to include it, and center it — instead of the old "not available" dead end.
+async function scrollToMessage(id: string): Promise<void> {
+  if (document.querySelector(`[data-mid="${id}"]`)) {
+    await centerWhenRendered(id, 1);
+    return;
+  }
+  const target = await getMessage(id);
+  if (!target || target.chatId !== chatId) {
+    notAvailableToast();
+    return;
+  }
+  // Load a window centered on the target in one read-pair (fast even for a target 5,000
+  // messages back — vs paging batch-by-batch, which is O(n²) reads and janky). D7.
+  if (rows.value.findIndex((r) => r.id === id) < 0) await history.seekTo(target.timestamp);
+  if (rows.value.findIndex((r) => r.id === id) < 0) {
+    notAvailableToast();
+    return;
+  }
+  // The whole loaded run is rendered, so the target now mounts; re-seed the spacers for the
+  // new window and center it on screen (a tap-driven scroll, not a fling, so scrollIntoView
+  // is fine here).
+  await nextTick();
+  reseedTopPad();
+  if (!(await centerWhenRendered(id, 20))) notAvailableToast();
 }
 
 // Drag-to-swipe a bubble (touch only): drag right past the threshold to reply,
@@ -1758,7 +1837,7 @@ function onSwipeEnd(): void {
   }
 }
 async function confirmDelete(m: Message): Promise<void> {
-  const targets = m.albumId ? messages.value.filter((x) => x.albumId === m.albumId) : [m];
+  const targets = m.albumId ? allMedia.value.filter((x) => x.albumId === m.albumId) : [m];
   await presentDeleteSheet(targets);
 }
 /* Delete options (single message, album, or a whole selection):
@@ -2025,14 +2104,43 @@ function observeScroll(): void {
   if (!resizeObs && 'ResizeObserver' in window) {
     resizeObs = new ResizeObserver(() => {
       // Re-pin to newest as media grows / the keyboard opens — but never mid-fling
-      // (that fights iOS momentum). Wait until the user's scroll has settled.
-      if (stickBottom && Date.now() - lastScrollAt > MOMENTUM_QUIET_MS) void scrollToNewest();
+      // (that fights iOS momentum). Wait until the user's scroll has settled (this is the
+      // ONE path that legitimately defers on momentum; the prepend anchor corrects live).
+      if (stickBottom && !shouldDeferScrollWrite(Date.now(), lastScrollAt, MOMENTUM_QUIET_MS))
+        void scrollToNewest();
     });
   }
   if (resizeObs && listEl.value) resizeObs.observe(listEl.value); // content height (media)
   void ensureScrollEl().then((el) => {
     if (el && resizeObs) resizeObs.observe(el); // viewport height (keyboard)
+    setupWindowSentinels(el);
   });
+}
+
+// Look-ahead prefetch: an IntersectionObserver rooted on the scroll element with
+// rootMargin = LOOK_AHEAD_PX fires loadOlder/loadNewer well before the top/bottom edge is
+// reached, so the next page is in the DOM ahead of need (page-before-top, INV-2; D5). The
+// ion-infinite-scroll above is the backstop.
+let windowObs: IntersectionObserver | null = null;
+function setupWindowSentinels(root: HTMLElement | null): void {
+  if (!root || !('IntersectionObserver' in window)) return;
+  windowObs?.disconnect();
+  windowObs = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) {
+        if (!e.isIntersecting) continue;
+        // Honor only the sentinel in the CURRENT scroll direction. On a bounded window both
+        // sentinels can sit inside their LOOK_AHEAD margins at once; letting the bottom
+        // sentinel fire loadNewer during an up-fling would tug the window back toward newer
+        // content (the spec-1011 "lands on newer content" symptom). Direction gates it.
+        if (e.target === topSentinel.value && scrollDir !== 'down') void loadOlder();
+        else if (e.target === bottomSentinel.value && scrollDir !== 'up') void loadNewer();
+      }
+    },
+    { root, rootMargin: `${LOOK_AHEAD_PX}px 0px ${LOOK_AHEAD_PX}px 0px`, threshold: 0 },
+  );
+  if (topSentinel.value) windowObs.observe(topSentinel.value);
+  if (bottomSentinel.value) windowObs.observe(bottomSentinel.value);
 }
 
 onMounted(() => {
@@ -2053,6 +2161,7 @@ onUnmounted(() => {
   clearTimeout(headerReadyFallback);
   clearTimeout(listReadyFallback);
   resizeObs?.disconnect();
+  windowObs?.disconnect();
 });
 // Send 'seen' receipts ONLY when the user is genuinely looking at this chat: its
 // view is the active one AND the app is foregrounded (document visible). A message
@@ -2078,19 +2187,11 @@ onIonViewDidEnter(() => {
   scheduleShareHint();
   // Entered with ?search=1 (from the contact-info "Search" action) → open search.
   if (route.query.search) showSearch.value = true;
-  // Entered with ?jump=<id> (e.g. from the Starred list) → scroll to that message,
-  // retrying briefly until it has rendered.
+  // Entered with ?jump=<id> (e.g. from the Starred list) → seek to that message; for a
+  // starred message older than the loaded window, scrollToMessage loads the intervening
+  // history and centers it (INV-6 / US3) rather than failing.
   if (route.query.jump) {
-    const id = String(route.query.jump);
-    let tries = 0;
-    const tryJump = (): void => {
-      if (document.querySelector(`[data-mid="${id}"]`)) {
-        scrollToMessage(id);
-      } else if (tries++ < 20) {
-        setTimeout(tryJump, 150);
-      }
-    };
-    void nextTick(tryJump);
+    void nextTick(() => void scrollToMessage(String(route.query.jump)));
   }
 });
 
@@ -2142,44 +2243,86 @@ onIonViewWillLeave(() => {
   void dismissOpenPopovers(); // a quick-react/menu popover must not linger after leaving
 });
 
-const messages = useLiveQuery(
-  () => listMessages(chatId, search.value),
-  ['messages'],
-  [],
-  () => search.value,
-);
+// ---- bounded, incrementally-updated history (spec 1011) ----
+// The rendered list is sourced from a bounded run (useChatHistory bounds it to MAX_ROWS)
+// instead of the whole chat, keeping the mounted DOM bounded however far you scroll
+// (FR-012/013). Older/newer pages are read in batches; the read position is held by the
+// top/bottom spacers (NOT scrollTop) so native momentum is never interrupted. The whole-chat
+// media viewer + audio playlist keep their own whole-chat source (allMedia) — they span the
+// entire chat by design (spec 1005/1007).
+const history = useChatHistory(chatId, search);
+const rows = history.rows;
+const hasOlder = history.hasOlder;
+const olderUnloaded = history.olderUnloaded;
+const newerUnloaded = history.newerUnloaded;
+// Whole-chat media subset (image/video/voice/audio) for the viewer + audio playlist; the
+// list spans the loaded run, but those features span the whole chat.
+const allMedia = useLiveQuery(() => listChatMediaAll(chatId), ['messages'], [] as Message[]);
 
-// A new message marks the chat seen (only when foregrounded; markChatSeenIfVisible
-// no-ops otherwise) and auto-follows to the bottom, but only when we were already
-// pinned there (stickBottom) or it's our own send, never while reading history.
-// The FIRST load also reveals the list (listReady) once it's scrolled to newest, so
-// opening a long chat doesn't flash the oldest message first.
+// The list renders the WHOLE loaded run — useChatHistory already bounds it to MAX_ROWS, so
+// no separate render-window is needed. Messages older/newer than the run are represented by
+// top/bottom SPACERS so the scroll range reflects the whole chat without holding it.
+//
+// CRUCIAL (spec 1011): a prepend/eviction is compensated by changing the TOP SPACER's height
+// (a layout change applied imperatively BEFORE paint), NEVER by writing scrollTop. Writing
+// scrollTop mid-fling stops iOS momentum dead (the fling halts at the load point); iOS also
+// has no `overflow-anchor`, so the spacer is the only way to keep the read position stable
+// without fighting the native scroller. The bottom spacer is purely cosmetic (it's below the
+// viewport, so its size never shifts what the user sees).
+const visibleMessages = computed(() => rows.value);
+const topSpacer = ref<HTMLElement | null>(null);
+const topPadPx = ref(0); // older-unloaded headroom; withScrollAnchor adjusts it live
+const avgRowH = ref(64); // measured average rendered row height (for spacer sizing)
+const botPadPx = computed(() => Math.round(newerUnloaded.value * avgRowH.value));
+
+// Set the top spacer height. We write the DOM imperatively (synchronous, before the next
+// paint) so a prepend + its compensation land in the same frame — no flash — while the ref
+// keeps Vue's binding in sync. Clamped ≥ 0.
+function setTopPad(px: number): void {
+  const v = Math.max(0, Math.round(px));
+  topPadPx.value = v;
+  if (topSpacer.value) topSpacer.value.style.height = `${v}px`;
+}
+// Average rendered bubble height — drives spacer sizing (an estimate; positions are kept
+// exact by the measured spacer correction, this only affects the scrollbar proportion).
+function measureAvgRowH(): void {
+  const r = renderedRows();
+  if (r.length < 2) return;
+  const span = r[r.length - 1].top - r[0].top;
+  if (span > 0) avgRowH.value = Math.max(24, span / (r.length - 1));
+}
+// Re-seed the top spacer from the older-unloaded estimate (first load / chat / search switch).
+// During scrolling, withScrollAnchor owns topPadPx precisely.
+function reseedTopPad(): void {
+  measureAvgRowH();
+  setTopPad(olderUnloaded.value * avgRowH.value);
+}
+
+// A new bottom message marks the chat seen + auto-follows to the newest — but only when
+// already pinned there (stickBottom) or it's our own send, never while reading history. The
+// first populated load reveals the list once scrolled to newest (no flash of the oldest).
 let didInitialLoad = false;
-watch(messages, async (list, prev) => {
-  markChatSeenIfVisible();
-  if (!didInitialLoad) {
-    didInitialLoad = true;
-    if (!search.value && list.length) {
-      stickBottom = true;
-      await scrollToNewest();
+watch(
+  () => rows.value[rows.value.length - 1]?.id,
+  async (newestId, prevId) => {
+    markChatSeenIfVisible();
+    if (!didInitialLoad) {
+      didInitialLoad = true;
+      if (!search.value && rows.value.length) {
+        stickBottom = true;
+        await scrollToNewest();
+        reseedTopPad();
+      }
+      listReady.value = true;
+      return;
     }
-    listReady.value = true;
-    return;
-  }
-  if (search.value) return; // searching filters the list, don't yank the view
-  if (list.length <= (prev?.length ?? 0)) return; // reaction/status update, not new
-  const newest = list[list.length - 1]; // listMessages is oldest-first
-  if (newest?.outgoing || stickBottom) void scrollToNewest();
-});
-
-// Paginate: render the newest `visible` messages (natural order); pulling up at the
-// top loads older ones. Kept modest so each pull-up mounts a sub-frame-budget batch
-// (a big batch is one long task that hitches mid-drag); the 25% look-ahead threshold
-// means smaller, more frequent loads instead of one stutter.
-const PAGE = 14;
-const visible = ref(PAGE);
-const visibleMessages = computed(() => messages.value.slice(-visible.value));
-watch(search, () => (visible.value = PAGE));
+    if (search.value || !newestId || newestId === prevId) return; // not a new bottom message
+    const newest = rows.value[rows.value.length - 1];
+    if (newest?.outgoing || stickBottom) await scrollToNewest();
+  },
+);
+// Search reloads the run; re-seed the spacer for the fresh result set.
+watch(search, () => void nextTick(reseedTopPad));
 
 // Collapse consecutive media messages that share an albumId into one album item
 // (rendered as a grid). Everything else stays a single message. The list is
@@ -2209,22 +2352,74 @@ const itemTime = (it: RenderItem) => (it.kind === 'msg' ? it.message.timestamp :
 const albumCells = (msgs: Message[]) => msgs.slice(0, 4);
 const albumOverlay = (msgs: Message[]) => (msgs.length > 4 ? msgs.length - 3 : 0);
 
-async function loadOlder(ev: InfiniteScrollCustomEvent) {
-  // Prepending older messages grows the list above the viewport. Anchor on the
-  // topmost rendered bubble and keep it at the same screen position afterwards — this
-  // is robust to the loading spinner's height and any late layout (unlike a total
-  // scrollHeight delta, which skews and makes the view jump).
+// ---- spacer-anchored loading (keeps the read position WITHOUT touching scrollTop) ----
+// The list's [data-mid] bubbles, top→bottom, as {id, top} for the anchor math.
+function renderedRows(): { id: string; top: number }[] {
+  const nodes = listEl.value?.querySelectorAll<HTMLElement>('.bubble[data-mid]');
+  if (!nodes) return [];
+  return Array.from(nodes).map((n) => ({ id: n.dataset.mid!, top: n.getBoundingClientRect().top }));
+}
+// Run a rows mutation (prepend older / append newer / trim) while keeping the message under
+// the user's eye stationary — by adjusting the TOP SPACER's height, never scrollTop. Capture
+// the topmost rendered bubble, mutate, re-measure: the anchor moved by exactly the height
+// added/removed above it (the mutation happened in one task, so the user's fling didn't move
+// it in between). Shrinking/growing the spacer by that delta cancels the shift. Because it's a
+// layout change (not a scroll write) applied imperatively BEFORE the next paint, the native
+// fling is never interrupted (no iOS momentum stall) and there's no visible jump. If the
+// spacer can't absorb it all (at the very top, where momentum is ending anyway), the small
+// remainder falls back to scrollTop. Gated on the view being active/foregrounded (FR-014).
+async function withScrollAnchor(mutate: () => void | Promise<void>): Promise<void> {
   const el = await ensureScrollEl();
-  const anchor = listEl.value?.querySelector<HTMLElement>('.bubble[data-mid]') ?? null;
-  const anchorMid = anchor?.dataset.mid ?? null;
-  const beforeTop = anchor?.getBoundingClientRect().top ?? 0;
-  visible.value += PAGE;
+  const active = () => viewActive.value && document.visibilityState === 'visible';
+  const anchor = el && active() ? pickAnchor(renderedRows()) : null;
+  await mutate();
   await nextTick();
-  if (el && anchorMid) {
-    const a2 = listEl.value?.querySelector<HTMLElement>(`.bubble[data-mid="${anchorMid}"]`) ?? null;
-    if (a2) el.scrollTop += a2.getBoundingClientRect().top - beforeTop;
+  measureAvgRowH();
+  if (!el || !anchor || !active()) return;
+  const delta = resolveAnchorDelta(anchor, renderedRows()); // how far the anchor moved
+  if (delta == null || delta === 0) return;
+  const target = topPadPx.value - delta; // shrink spacer when content was added above, etc.
+  if (target < 0) {
+    el.scrollTop += -target; // spacer exhausted (very top): take the remainder on scrollTop
+    setTopPad(0);
+  } else {
+    setTopPad(target);
   }
-  void ev.target.complete();
+}
+
+let loadingOlder = false;
+let loadingNewer = false;
+// Page older content before the top edge is reached (look-ahead). Prepend a batch via
+// useChatHistory; the spacer absorbs the height it adds so the read position holds and the
+// fling keeps going. When there's no more older, snap the spacer to 0 (we're at the top).
+async function loadOlder(ev?: InfiniteScrollCustomEvent): Promise<void> {
+  if (loadingOlder || !history.hasOlder.value) {
+    void ev?.target.complete();
+    return;
+  }
+  loadingOlder = true;
+  try {
+    await withScrollAnchor(async () => {
+      await history.loadOlder();
+    });
+    if (!history.hasOlder.value) setTopPad(0); // reached the oldest message → no headroom left
+  } finally {
+    loadingOlder = false;
+    void ev?.target.complete();
+  }
+}
+// Downward re-entry: re-append newer rows that were trimmed while scrolling up. The head-trim
+// removes rows above the viewport; withScrollAnchor grows the spacer to compensate.
+async function loadNewer(): Promise<void> {
+  if (loadingNewer || !history.hasNewer.value) return;
+  loadingNewer = true;
+  try {
+    await withScrollAnchor(async () => {
+      await history.loadNewer();
+    });
+  } finally {
+    loadingNewer = false;
+  }
 }
 
 // Resolve on-device media (Blobs) to object URLs for rendering.
@@ -2369,8 +2564,8 @@ function evictMedia(): void {
 // Resolve media for the rendered window as it grows/changes (look-ahead paging
 // extends `visibleMessages` before the user reaches the top), then evict far LRU.
 // Keyed on the visible MEDIA SET (mediaIds), not the array identity — so a status
-// tick or reaction (which reassigns messages.value to fresh objects every time) does
-// NOT re-run IndexedDB reads + URL allocation + eviction on the scroll hot path.
+// tick or reaction (which patches a row in place via useChatHistory) does NOT re-run
+// IndexedDB reads + URL allocation + eviction on the scroll hot path.
 watch(
   () => visibleMessages.value.map((m) => m.mediaId ?? '').join('|'),
   async () => {
@@ -2399,6 +2594,10 @@ watch(viewerItems, (items) => {
 // sending, including a reply when scrolled up to the quoted message.
 const contentEl = ref<{ $el: HTMLElement } | null>(null);
 const listEl = ref<HTMLElement | null>(null);
+// Look-ahead sentinels (spec 1011 D5): observed by an IntersectionObserver rooted on the
+// scroll element with rootMargin = LOOK_AHEAD_PX, so older/newer pages load before an edge.
+const topSentinel = ref<HTMLElement | null>(null);
+const bottomSentinel = ref<HTMLElement | null>(null);
 // Hidden until the first pin to bottom, so opening a long chat doesn't flash the
 // oldest message before jumping to the newest.
 const listReady = ref(false);
@@ -2417,6 +2616,11 @@ let suppressStickUntil = 0;
 // fling has settled (no user scroll for a beat).
 let lastScrollAt = 0;
 const MOMENTUM_QUIET_MS = 220;
+// Scroll direction of the last genuine user scroll — gates the look-ahead sentinels so the
+// opposite-direction one can't fire mid-fling (spec 1011: prevents the bottom sentinel from
+// tugging the window toward newer content during an up-fling). -1 = not yet measured.
+let lastScrollTop = -1;
+let scrollDir: 'up' | 'down' = 'up';
 // Cache ion-content's inner scroll element so we can read scroll metrics
 // synchronously and pin without an async hop each message.
 let scrollEl: HTMLElement | null = null;
@@ -2429,10 +2633,15 @@ async function ensureScrollEl(): Promise<HTMLElement | null> {
   return scrollEl;
 }
 async function scrollToNewest(): Promise<void> {
+  // If we trimmed the newest rows while scrolling up (hasNewer), `rows` no longer holds the
+  // bottom of the chat — reload the newest batch so the newest message is actually rendered
+  // before we pin to it.
+  if (history.hasNewer.value) await history.reload();
+  setTopPad(olderUnloaded.value * avgRowH.value); // older content sits above; bottom spacer is 0
   await nextTick();
   const el = await ensureScrollEl();
   if (!el) return;
-  el.scrollTop = el.scrollHeight;
+  el.scrollTop = el.scrollHeight; // now lands on the newest row (botPad is 0 at the bottom)
   stickBottom = true;
   suppressStickUntil = Date.now() + 250;
 }
@@ -2446,8 +2655,11 @@ function nearBottom(): boolean {
 // history (so a new message / media load doesn't yank them down). Skip the echo of
 // our own programmatic pin so late-loading media can't flip the pin off mid-settle.
 function onContentScroll(): void {
-  if (Date.now() < suppressStickUntil) return;
+  if (isSelfEcho(Date.now(), suppressStickUntil)) return; // our own pin/correction echo
   lastScrollAt = Date.now(); // genuine user scroll (the pin echo is suppressed above)
+  const top = scrollEl?.scrollTop ?? 0;
+  if (lastScrollTop >= 0 && top !== lastScrollTop) scrollDir = top < lastScrollTop ? 'up' : 'down';
+  lastScrollTop = top;
   stickBottom = nearBottom();
 }
 
@@ -2722,14 +2934,14 @@ onUnmounted(detachAudioEnded);
 
 // Audio messages in chronological order, the implicit playlist.
 const audioOrder = computed(() =>
-  [...messages.value]
+  [...allMedia.value]
     .filter((m) => m.kind === 'audio' && !m.deleted && m.mediaId)
     .sort((a, b) => a.timestamp - b.timestamp)
     .map((m) => m.id),
 );
 // Build the now-playing metadata (for the hovering controller) from a message.
 function audioMetaFor(id: string): AudioTrackMeta | undefined {
-  const m = messages.value.find((x) => x.id === id);
+  const m = allMedia.value.find((x) => x.id === id);
   if (!m?.mediaId) return undefined;
   const url = mediaInfo.value[m.mediaId]?.url;
   if (!url) return undefined;
@@ -3234,6 +3446,11 @@ function cancelRecording() {
   flex-direction: column;
   gap: 6px;
   min-height: 100%;
+  /* This list owns its scroll anchoring in JS (withScrollAnchor adjusts the spacers). Disable
+     the browser's native scroll anchoring so it can't ALSO compensate for the same prepend
+     and double-correct against the spacer change — that two-engine fight is what makes scrollTop
+     jitter back-and-forth as older pages load on iOS (spec 1011). One anchor source only. */
+  overflow-anchor: none;
 }
 /* Bottom-anchor: the first child soaks up the free space above it, so a short
    conversation sits at the bottom while a long one stays fully scrollable to the
@@ -3912,6 +4129,25 @@ function cancelRecording() {
 }
 .album-bubble .time {
   padding-inline: 4px;
+}
+/* Zero-height look-ahead sentinels (spec 1011): real boxes the IntersectionObserver can
+   watch, but they take no layout space and are invisible. */
+.scroll-sentinel {
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  visibility: hidden;
+  overflow-anchor: none;
+}
+/* Virtual-scroll spacers (spec 1011): reserve the height of older/newer messages not held
+   in the rendered run. flex-shrink:0 so the flex column keeps their exact height. */
+.vscroll-pad {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  overflow-anchor: none;
 }
 /* Centered day divider between message groups. */
 .day-sep {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,6 +56,12 @@ export default defineConfig({
         'src/utils/emoji.ts',
         'src/utils/notify-preview.ts',
         'src/utils/time.ts',
+        // Pure chat-history window/pagination/anchor/group-edge math (spec 1011). Each
+        // directly unit-tested; gated so their coverage can't regress.
+        'src/utils/chat-pagination.ts',
+        'src/utils/chat-window.ts',
+        'src/utils/scroll-anchor.ts',
+        'src/utils/chat-grouping.ts',
       ],
       thresholds: { lines: 80, functions: 80, statements: 80, branches: 80 },
     },


### PR DESCRIPTION
Smooth, bounded chat-history scroll-up (spec 1011). Client-only — no server/wire/DB-schema change.

## What
- **Bounded windowed history**: the chat list is sourced from `useChatHistory` (bounded reads `listMessagesOlder/Newer` + an incrementally-updated run — patch/remove/append in place, no full-array replace) instead of the whole chat.
- **Momentum-friendly scroll**: the read position is held by top/bottom **spacers** whose height absorbs each prepend/eviction, so `scrollTop` is never written during a fling — native iOS momentum is no longer interrupted (verified on a real iPhone). iOS has no `overflow-anchor`, so spacers are the only way to do this without fighting the scroller.
- **No load-time blank/jump**: media bubbles reserve their fixed frame height at mount (skeleton until the poster decodes), so a prepended media batch doesn't reflow 0→240px.
- **Look-ahead** via direction-gated IntersectionObserver sentinels; **jump-to-older** via `seekTo`; whole-chat media viewer + audio playlist keep a whole-chat media source.

## Verify
- `npm run build` ✅ · `vitest` 196 ✅ · `go build/vet/test` ✅ (untouched)
- e2e `chat-media-scroll` (5k-seeded) 5/5 ✅; chat-flow regression (reply/reactions/edit-delete/disappearing/menu/paste/receipts) 15/15 ✅
- `drive/scenarios/lengthy-chat-scroll.mjs` (5 users, all message kinds, 5k scroll-up) ✅

Closes #130
Closes #131
Closes #132
Closes #133
Closes #134
Closes #135
Closes #136
Closes #137
Closes #138
Closes #139
Closes #140
Closes #141
Closes #142
Closes #143
Closes #144
Closes #145
Closes #146
Closes #147
Closes #148
Closes #149
Closes #150
Closes #151
Closes #152
Closes #153
Closes #154
Closes #155
Closes #156
Closes #157
Closes #158
Closes #159
Closes #160
Closes #161
Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
