### PR TITLE
docs(spec): mark 1012–1015 shipped + regenerate roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,10 +31,10 @@ Specs are grouped by category band; status moves
 | [1009](specs/1009-activity-indicators/spec.md) | Ephemeral Activity Indicators (Typing & Recording) | 🟢 shipped |
 | [1010](specs/1010-group-seen-receipts/spec.md) | Group "Seen" Receipts — Durable, Private, and Counted | 🟢 shipped |
 | [1011](specs/1011-smooth-chat-history/spec.md) | Smooth Chat-History Scroll-Up (verified by a multi-user end-to-end exercise) | 🟢 shipped |
-| [1012](specs/1012-scroll-to-bottom-button/spec.md) | Hovering "Scroll to Latest" Button in Chat | ⚪ planned |
-| [1013](specs/1013-jump-pill-seen-receipts/spec.md) | Expanding "Jump to Latest" Pill + Visibility-Driven Seen Receipts | ⚪ planned |
-| [1014](specs/1014-image-thumbnails-album/spec.md) | Multi-Size Image Thumbnails + Album-View Overhaul | 🔵 in-review |
-| [1015](specs/1015-reliable-push-notifications/spec.md) | Reliable Push & Redesigned In-App Notifications | 🟡 in-progress |
+| [1012](specs/1012-scroll-to-bottom-button/spec.md) | Hovering "Scroll to Latest" Button in Chat | 🟢 shipped |
+| [1013](specs/1013-jump-pill-seen-receipts/spec.md) | Expanding "Jump to Latest" Pill + Visibility-Driven Seen Receipts | 🟢 shipped |
+| [1014](specs/1014-image-thumbnails-album/spec.md) | Multi-Size Image Thumbnails + Album-View Overhaul | 🟢 shipped |
+| [1015](specs/1015-reliable-push-notifications/spec.md) | Reliable Push & Redesigned In-App Notifications | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1012-scroll-to-bottom-button/spec.md
+++ b/specs/1012-scroll-to-bottom-button/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-18
 
-**Status**: planned
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1013-jump-pill-seen-receipts/spec.md
+++ b/specs/1013-jump-pill-seen-receipts/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-19
 
-**Status**: planned
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1014-image-thumbnails-album/spec.md
+++ b/specs/1014-image-thumbnails-album/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-19
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1015-reliable-push-notifications/spec.md
+++ b/specs/1015-reliable-push-notifications/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-20
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Specs 1012, 1013, 1014 are already merged to `develop` (their feature commits are in the history) but their authors left the **Status** lines at planned/in-review; 1015 just merged. This bumps all four to `shipped` and regenerates the generated `ROADMAP.md` so the "Roadmap up to date" guard stays green.

Doc-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)