### PR TITLE
feat: zero-knowledge social Wall + version-announcement push (spec 0003)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,5 +249,5 @@ GitFlow. **`develop`** is the integration branch; **`main`** is production.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1015-reliable-push-notifications/plan.md`
+`specs/0003-zero-knowledge-social/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@ Specs are grouped by category band; status moves
 |------|-------|--------|
 | [0001](specs/0001-show-what-changed/spec.md) | Show what changed in the update toast (release-note delta) | 🟢 shipped |
 | [0002](specs/0002-connections-and-friendship/spec.md) | Connections & Friendship | 🟢 shipped |
+| [0003](specs/0003-zero-knowledge-social/spec.md) | Zero-Knowledge Social Wall | ⚪ planned |
 
 ## ⚡ Ad-hoc (1001–1999)
 

--- a/drive/scenarios/chat-enter-send.mjs
+++ b/drive/scenarios/chat-enter-send.mjs
@@ -1,0 +1,46 @@
+/**
+ * Desktop Enter-to-send in the chat composer. Alice types into the message composer
+ * and presses Enter (no shift); the message must send (Bob receives it). Then she
+ * types a line, presses Shift+Enter, and the draft must keep a newline (not send).
+ *
+ *   node drive/scenarios/chat-enter-send.mjs
+ */
+import { createAccount, pair, chatWith, waitForMessage, sweep, done } from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+const aliceChat = await chatWith(alice, bob.id);
+await alice.page.goto(`/chat/${aliceChat}`);
+await alice.page.waitForSelector('ion-textarea.composer', { timeout: 15_000 });
+await alice.page.waitForTimeout(400);
+
+// Type a message and press Enter (desktop → should SEND).
+await alice.page.locator('ion-textarea.composer').click();
+await alice.page.keyboard.type('hello via enter key');
+await alice.page.waitForTimeout(200);
+await alice.page.keyboard.press('Enter');
+
+await waitForMessage(bob, alice.id, 'hello via enter key');
+console.log('[bob] received the Enter-sent message ✓');
+
+// Shift+Enter must NOT send — it inserts a newline and leaves a draft.
+await alice.page.locator('ion-textarea.composer').click();
+await alice.page.keyboard.type('first line');
+await alice.page.keyboard.down('Shift');
+await alice.page.keyboard.press('Enter');
+await alice.page.keyboard.up('Shift');
+await alice.page.keyboard.type('second line');
+await alice.page.waitForTimeout(200);
+const draft = await alice.page.evaluate(() => {
+  const ta = document.querySelector('ion-textarea.composer');
+  return ta ? ta.value : null;
+});
+if (!draft || !draft.includes('\n') || !draft.includes('first line') || !draft.includes('second line')) {
+  throw new Error(`Shift+Enter did not keep a multi-line draft: ${JSON.stringify(draft)}`);
+}
+console.log('[alice] Shift+Enter kept a multi-line draft ✓');
+
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/wall-close-friend-revoke.mjs
+++ b/drive/scenarios/wall-close-friend-revoke.mjs
@@ -1,0 +1,66 @@
+/**
+ * Spec 0003 revocation: removing someone from close friends revokes your close-only
+ * posts from them. Alice posts a close-friends-only post; Bob (a close friend) receives
+ * it; Alice un-close-friends Bob; Bob's local copy must disappear.
+ *
+ *   node drive/scenarios/wall-close-friend-revoke.mjs
+ *   HEADED=1 node drive/scenarios/wall-close-friend-revoke.mjs
+ *
+ * Drives the live `queries` module directly (Vite serves the same singleton the app
+ * uses) since there is no __ringTest wall helper.
+ */
+import { createAccount, pair, poll, sweep, done } from '../driver.mjs';
+
+const Q = '/src/db/queries.ts';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+
+// Friends + Alice marks Bob a CLOSE friend.
+await pair(alice, bob);
+await alice.page.evaluate(async ([mod, id]) => {
+  const q = await import(mod);
+  await q.setCloseFriend(id, true);
+}, [Q, bob.id]);
+
+// Alice posts a close-friends-only post.
+const postId = await alice.page.evaluate(async ([mod]) => {
+  const q = await import(mod);
+  const p = await q.createPost({ body: 'secret for close friends 🤫', audience: 'close', lifetime: '24h' });
+  return p.id;
+}, [Q]);
+console.log('[alice] posted close-only', postId);
+
+// Bob pulls and should see it.
+await poll(
+  () => bob.page.evaluate(async ([mod]) => {
+    const q = await import(mod);
+    await q.syncPosts();
+    return (await q.listWallPosts()).length;
+  }, [Q]),
+  (n) => n >= 1,
+  { label: 'bob receives the close-only post' },
+);
+console.log('[bob] sees the post ✓');
+
+// Alice removes Bob from close friends → revokes the post from him.
+await alice.page.evaluate(async ([mod, id]) => {
+  const q = await import(mod);
+  await q.setCloseFriend(id, false);
+}, [Q, bob.id]);
+console.log('[alice] un-close-friended bob');
+
+// Bob's local copy must vanish (live post-revoke nudge, with a syncPosts fallback).
+await poll(
+  () => bob.page.evaluate(async ([mod]) => {
+    const q = await import(mod);
+    await q.syncPosts();
+    return (await q.listWallPosts()).length;
+  }, [Q]),
+  (n) => n === 0,
+  { label: 'bob loses the revoked post' },
+);
+console.log('[bob] post revoked ✓');
+
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/wall-swipe-style.mjs
+++ b/drive/scenarios/wall-swipe-style.mjs
@@ -1,0 +1,62 @@
+/**
+ * Visual check for the restyled swipe actions (rounded, inset, revealed from behind
+ * the card/row). Opens the sliding items programmatically and screenshots them.
+ *
+ *   HEADED=1 node drive/scenarios/wall-swipe-style.mjs
+ * Screenshots land in .tmp/drive/.
+ */
+import path from 'node:path';
+import { createAccount, pair, poll, sweep, done, SHOT_DIR } from '../driver.mjs';
+
+const Q = '/src/db/queries.ts';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+// Alice posts; Bob comments so we have a comment to swipe.
+const postId = await alice.page.evaluate(async ([mod]) => {
+  const q = await import(mod);
+  const p = await q.createPost({ body: 'a sunny afternoon walk 🌞', audience: 'friends', lifetime: '24h' });
+  return p.id;
+}, [Q]);
+
+await poll(
+  () => bob.page.evaluate(async ([mod, id]) => {
+    const q = await import(mod);
+    await q.syncPosts();
+    return !!(await q.getPost(id));
+  }, [Q, postId]),
+  Boolean,
+  { label: 'bob has the post' },
+);
+await bob.page.evaluate(async ([mod, id]) => {
+  const q = await import(mod);
+  await q.commentOnPost(id, 'looks lovely!');
+}, [Q, postId]);
+
+// Open a sliding item to the given side and screenshot.
+async function shotOpen(client, route, side, name) {
+  await client.page.goto(route);
+  await client.page.waitForSelector('ion-item-sliding', { timeout: 15_000 });
+  await client.page.waitForTimeout(400);
+  await client.page.evaluate(async (s) => {
+    const el = document.querySelector('ion-item-sliding');
+    if (el && el.open) await el.open(s);
+  }, side);
+  await client.page.waitForTimeout(500);
+  const file = path.join(SHOT_DIR, `${name}.png`);
+  await client.page.screenshot({ path: file });
+  console.log('shot', file);
+}
+
+// Alice's own post → swipe end reveals Delete.
+await shotOpen(alice, '/tabs/wall', 'end', 'swipe-own-delete');
+// Bob viewing Alice's post → swipe start reveals Mute, end reveals Hide.
+await shotOpen(bob, '/tabs/wall', 'end', 'swipe-other-hide');
+await shotOpen(bob, '/tabs/wall', 'start', 'swipe-other-mute');
+// Bob's comment on the detail page → swipe end reveals Delete.
+await shotOpen(bob, `/wall/post/${postId}`, 'end', 'swipe-comment-delete');
+
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/wall-voice-post.mjs
+++ b/drive/scenarios/wall-voice-post.mjs
@@ -1,0 +1,44 @@
+/**
+ * Spec 0003: voice posts. Alice shares a voice post; Bob (a friend) receives it and
+ * his Wall renders it as a voice item. Exercises the createPost(kind:'voice') →
+ * upload → receivePost → render path the new composer recorder feeds into (the mic UI
+ * itself can't run headless, so we hand createPost a synthetic audio blob).
+ *
+ *   node drive/scenarios/wall-voice-post.mjs
+ */
+import { createAccount, pair, poll, sweep, done } from '../driver.mjs';
+
+const Q = '/src/db/queries.ts';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+// Alice shares a voice post (synthetic audio blob stands in for a recording).
+const postId = await alice.page.evaluate(async ([mod]) => {
+  const q = await import(mod);
+  const blob = new Blob([new Uint8Array(4096)], { type: 'audio/webm' });
+  const p = await q.createPost({
+    audience: 'friends',
+    lifetime: '24h',
+    media: { blob, kind: 'voice', name: 'voice.webm', durationSec: 3 },
+  });
+  return p.id;
+}, [Q]);
+console.log('[alice] shared voice post', postId);
+
+// Bob receives it and it is a voice-kind post.
+await poll(
+  () => bob.page.evaluate(async ([mod, id]) => {
+    const q = await import(mod);
+    await q.syncPosts();
+    const p = await q.getPost(id);
+    return p ? p.kind : null;
+  }, [Q, postId]),
+  (k) => k === 'voice',
+  { label: 'bob receives the voice post' },
+);
+console.log('[bob] sees a voice post ✓');
+
+await sweep([alice, bob]);
+await done();

--- a/server/cmd/ringd/main.go
+++ b/server/cmd/ringd/main.go
@@ -363,7 +363,7 @@ func run() error {
 
 	handler := api.NewRouter(&api.Handlers{
 		Store: st, Directory: st, Contacts: st, Connections: st, Blocks: st, Keys: st, Relay: st, Hub: hub, Blobs: st, Sync: st, Push: st,
-		Invites: st, Notifier: notifier, RequireConnection: cfg.RequireConnection,
+		Invites: st, Posts: st, Notifier: notifier, RequireConnection: cfg.RequireConnection,
 		PublicURL: cfg.PublicURL, VapidPublicKey: secs.VapidPublicKey, MaxBlobBytes: cfg.MaxBlobBytes,
 		Version:      version,
 		ReleaseNotes: decodeReleaseNotes(releaseNotesB64),

--- a/server/cmd/ringd/main.go
+++ b/server/cmd/ringd/main.go
@@ -99,6 +99,43 @@ func devProxy(cfg config.Config) string {
 	return ""
 }
 
+// lastAnnouncedVersionKey is the app_meta key holding the version we last broadcast a
+// "what's new" push for.
+const lastAnnouncedVersionKey = "last_announced_version"
+
+// announceVersionIfChanged broadcasts a version-announcement push when the running
+// build's version differs from the one we last announced, then records the new version.
+// It is deliberately conservative about WHEN it actually pushes:
+//   - skip the local `dev` build (no real release to announce);
+//   - skip when there is no previously recorded version (fresh DB / first run after this
+//     feature ships) — record a baseline instead, so we never blast on a rollout deploy;
+//   - skip an unchanged version (a plain restart);
+// otherwise record the new version and fan the tickle out in the background (never
+// blocking boot). Best-effort: a metadata error just logs and skips the broadcast.
+func announceVersionIfChanged(ctx context.Context, st *store.Store, notifier *push.Notifier, version string) {
+	if version == "" || version == "dev" || notifier == nil {
+		return
+	}
+	prev, err := st.GetAppMeta(ctx, lastAnnouncedVersionKey)
+	if err != nil {
+		slog.Warn("version announce: read last-announced failed", "err", err)
+		return
+	}
+	if prev == version {
+		return // same version (restart) → nothing to announce
+	}
+	if err := st.SetAppMeta(ctx, lastAnnouncedVersionKey, version); err != nil {
+		slog.Warn("version announce: record version failed", "err", err)
+		return
+	}
+	if prev == "" {
+		slog.Info("version announce: recording baseline (no broadcast on first run)", "version", version)
+		return
+	}
+	slog.Info("version announce: new version deployed, broadcasting", "from", prev, "to", version)
+	go notifier.BroadcastVersion(context.Background())
+}
+
 // ensureBootstrapInvite guarantees an empty system can onboard its first user.
 // When there are no accounts, it reuses an existing claimable invitation code or
 // mints one, and surfaces it in the logs. The code lives in the invitations
@@ -279,6 +316,15 @@ func run() error {
 		push.NewSender(secs.VapidPublicKey, secs.VapidPrivateKey, cfg.VapidSubject),
 		st,
 	)
+
+	// Version-announcement push: when a freshly-deployed binary boots with a version
+	// different from the one we last announced, fan a content-free "new version" tickle
+	// out to every subscription. The SW turns it into a user-friendly "what's new" from
+	// the public /v1/config. Deduped via app_meta so a plain restart (same version)
+	// stays silent; skipped on the very first run after this feature ships (no recorded
+	// previous version → we can't claim a "change", and don't want to blast on the
+	// rollout deploy itself) and for local `dev` builds.
+	announceVersionIfChanged(ctx, st, notifier, version)
 
 	// Embedded TURN/STUN relay for WebRTC calls. Media is relayed opaquely (the
 	// server never sees DTLS keys). In dev it runs plaintext on TurnListen; in

--- a/server/internal/api/connections_handlers_test.go
+++ b/server/internal/api/connections_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -27,31 +28,48 @@ func (f *fakeConnNotifier) NotifyConn(_ context.Context, userID string) {
 	f.conn = append(f.conn, userID)
 }
 func (f *fakeConnNotifier) woke(userID string) bool {
+	return f.wokeCount(userID) > 0
+}
+func (f *fakeConnNotifier) wokeCount(userID string) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	n := 0
 	for _, u := range f.conn {
 		if u == userID {
-			return true
+			n++
 		}
 	}
-	return false
+	return n
 }
 
 // fakeConn is a minimal in-memory ConnectionsStore for handler tests. It records
 // the last withdraw so the test can assert the handler called the store correctly.
 type fakeConn struct {
 	withdrawn map[[2]string]bool // (requester,target) -> true
+	rejected  map[[2]string]bool // (requester,target) declined → suppressed (FR-007)
 }
 
-func newFakeConn() *fakeConn { return &fakeConn{withdrawn: map[[2]string]bool{}} }
+func newFakeConn() *fakeConn {
+	return &fakeConn{withdrawn: map[[2]string]bool{}, rejected: map[[2]string]bool{}}
+}
 
-func (c *fakeConn) Connected(_ context.Context, _, _ string) (bool, error)          { return false, nil }
-func (c *fakeConn) ConnectionState(_ context.Context, _, _ string) (string, error)  { return "", nil }
-func (c *fakeConn) RequestConnection(_ context.Context, _, _ string) (string, error) {
+func (c *fakeConn) Connected(_ context.Context, _, _ string) (bool, error)         { return false, nil }
+func (c *fakeConn) ConnectionState(_ context.Context, _, _ string) (string, error) { return "", nil }
+
+// RequestConnection models FR-007: once requester→target was declined it stays
+// "rejected" (the cooldown is always "active" in tests since no wall-clock passes), so
+// the handler won't re-notify the target. Otherwise it's a fresh pending request.
+func (c *fakeConn) RequestConnection(_ context.Context, requester, target string) (string, error) {
+	if c.rejected[[2]string{requester, target}] {
+		return "rejected", nil
+	}
 	return "pending", nil
 }
-func (c *fakeConn) AcceptConnection(_ context.Context, _, _ string) error        { return nil }
-func (c *fakeConn) RejectConnection(_ context.Context, _, _ string, _ bool) error { return nil }
+func (c *fakeConn) AcceptConnection(_ context.Context, _, _ string) error { return nil }
+func (c *fakeConn) RejectConnection(_ context.Context, target, requester string, _ bool) error {
+	c.rejected[[2]string{requester, target}] = true
+	return nil
+}
 func (c *fakeConn) WithdrawConnection(_ context.Context, requester, target string) error {
 	c.withdrawn[[2]string{requester, target}] = true
 	return nil
@@ -134,6 +152,39 @@ func TestRejectWakesRequester(t *testing.T) {
 	}
 	if !notif.woke(aliceID) {
 		t.Errorf("reject: expected alice (%s) to be woken via NotifyConn", aliceID)
+	}
+}
+
+// TestFriendRequestSuppressedAfterDecline verifies FR-007: once a request is declined,
+// a repeat request from the same sender is suppressed (state stays "rejected") and the
+// target is NOT notified again, so a declined sender cannot harass via re-requests.
+func TestFriendRequestSuppressedAfterDecline(t *testing.T) {
+	notif := &fakeConnNotifier{}
+	srv, _, _ := newConnTestServerN(newFakeConn(), notif)
+
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+
+	// alice → request bob (pending): bob is woken once.
+	if rr := do(t, srv, http.MethodPost, "/v1/connections/request", tokA, `{"target":"`+bobID+`"}`); rr.Code != http.StatusOK {
+		t.Fatalf("request status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	// bob declines alice (no block).
+	if rr := do(t, srv, http.MethodPost, "/v1/connections/reject", tokB, `{"requester":"`+aliceID+`"}`); rr.Code != http.StatusNoContent {
+		t.Fatalf("reject status = %d, want 204; body=%s", rr.Code, rr.Body.String())
+	}
+	wokeBefore := notif.wokeCount(bobID)
+
+	// alice re-requests bob: suppressed → state "rejected", bob NOT woken again.
+	rr := do(t, srv, http.MethodPost, "/v1/connections/request", tokA, `{"target":"`+bobID+`"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-request status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Body.String(); !strings.Contains(got, `"rejected"`) {
+		t.Errorf("re-request after decline: state = %s, want rejected (suppressed)", got)
+	}
+	if after := notif.wokeCount(bobID); after != wokeBefore {
+		t.Errorf("re-request after decline woke bob again (%d → %d); FR-007 expects suppression", wokeBefore, after)
 	}
 }
 

--- a/server/internal/api/connections_handlers_test.go
+++ b/server/internal/api/connections_handlers_test.go
@@ -20,6 +20,7 @@ type fakeConnNotifier struct {
 
 func (f *fakeConnNotifier) Notify(context.Context, string)     {}
 func (f *fakeConnNotifier) NotifyCall(context.Context, string) {}
+func (f *fakeConnNotifier) NotifyPost(context.Context, string) {}
 func (f *fakeConnNotifier) NotifyConn(_ context.Context, userID string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -38,6 +38,17 @@ const maxPostEnvelopes = 1024
 // server-side regardless of the client (spec 0003, FR-012).
 const maxPostLifetime = 72 * time.Hour
 
+// FR-008 anti-flood volume limits. Enforced using ONLY routing metadata the server
+// already holds (counts of recent rows by author / actor / post) — never by reading
+// content. The windows are deliberately generous: a real person never hits them, but
+// a script that tries to flood a Wall or a viewer is throttled with 429.
+const (
+	rateWindowSec            = 60 // sliding window for all three caps
+	maxPostsPerWindow        = 20 // posts a single author may create per window
+	maxEngagementsPerWindow  = 60 // reactions+comments a single actor may submit per window
+	maxCommentsPerPostWindow = 10 // comments one actor may add to ONE post per window
+)
+
 // notifyPost sends a content-free "a post is waiting" nudge to a recipient: a live WS
 // frame if connected, and an offline push tickle otherwise. Carries no content — the
 // client reconciles via GET /v1/posts — preserving the zero-knowledge boundary.
@@ -85,6 +96,12 @@ func (h *Handlers) createPost(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		envs = append(envs, store.NewPostEnvelope{Recipient: e.Recipient, WrappedKey: e.WrappedKey})
+	}
+	// FR-008 per-author post-rate limit (anti-flood) — counts only the author's own
+	// recent posts, no content involved.
+	if n, err := h.Posts.RecentPostCount(r.Context(), uid, rateWindowSec); err == nil && n >= maxPostsPerWindow {
+		httpx.Error(w, http.StatusTooManyRequests, "posting too fast, please slow down")
+		return
 	}
 	// Wall posts are ALWAYS ephemeral: clamp the expiry to at most 72h from now,
 	// whatever the client sent (including "no expiry"). This guarantees the
@@ -243,6 +260,21 @@ func (h *Handlers) submitEngagement(w http.ResponseWriter, r *http.Request) {
 	if !canSee {
 		httpx.Error(w, http.StatusForbidden, "not in this post's audience")
 		return
+	}
+	// FR-008 anti-flood volume limits (skip tombstones — removing your own item is not
+	// flooding). Per-actor engagement rate guards a viewer against being spammed; the
+	// per-post comment rate guards a single Wall thread. Counts only, never content.
+	if !tombstone {
+		if n, err := h.Posts.RecentEngagementCount(r.Context(), uid, rateWindowSec); err == nil && n >= maxEngagementsPerWindow {
+			httpx.Error(w, http.StatusTooManyRequests, "engaging too fast, please slow down")
+			return
+		}
+		if req.Kind == "comment" {
+			if n, err := h.Posts.RecentCommentCount(r.Context(), postID, uid, rateWindowSec); err == nil && n >= maxCommentsPerPostWindow {
+				httpx.Error(w, http.StatusTooManyRequests, "commenting too fast, please slow down")
+				return
+			}
+		}
 	}
 	// Moderation: only the original author of the targeted engagement, or the POST's
 	// author, may tombstone it (FR-034).

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -47,7 +47,7 @@ func (h *Handlers) notifyPost(ctx context.Context, recipient, author string) {
 		}
 	}
 	if h.Notifier != nil {
-		h.Notifier.Notify(ctx, recipient)
+		h.Notifier.NotifyPost(ctx, recipient)
 	}
 }
 

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -33,6 +33,10 @@ type createPostReq struct {
 // maxPostEnvelopes bounds a single post's fan-out (a sanity cap, not a privacy gate).
 const maxPostEnvelopes = 1024
 
+// maxPostLifetime is the hard ceiling on how long any post lives, enforced
+// server-side regardless of the client (spec 0003, FR-012).
+const maxPostLifetime = 72 * time.Hour
+
 // notifyPost sends a content-free "a post is waiting" nudge to a recipient: a live WS
 // frame if connected, and an offline push tickle otherwise. Carries no content — the
 // client reconciles via GET /v1/posts — preserving the zero-knowledge boundary.
@@ -81,13 +85,18 @@ func (h *Handlers) createPost(w http.ResponseWriter, r *http.Request) {
 		}
 		envs = append(envs, store.NewPostEnvelope{Recipient: e.Recipient, WrappedKey: e.WrappedKey})
 	}
-	var expires *time.Time
+	// Wall posts are ALWAYS ephemeral: clamp the expiry to at most 72h from now,
+	// whatever the client sent (including "no expiry"). This guarantees the
+	// 72-hour ceiling server-side, independent of the client (FR-012).
+	maxExpiry := time.Now().Add(maxPostLifetime)
+	expires := maxExpiry
 	if req.ExpiresAt > 0 {
-		t := time.UnixMilli(req.ExpiresAt)
-		expires = &t
+		if t := time.UnixMilli(req.ExpiresAt); t.Before(maxExpiry) {
+			expires = t
+		}
 	}
 	if err := h.Posts.CreatePost(r.Context(), store.NewPost{
-		ID: req.ID, Author: uid, BlobID: req.BlobID, Size: req.Size, ExpiresAt: expires, Envelopes: envs,
+		ID: req.ID, Author: uid, BlobID: req.BlobID, Size: req.Size, ExpiresAt: &expires, Envelopes: envs,
 	}); err != nil {
 		httpx.Error(w, http.StatusInternalServerError, "could not create post")
 		return

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -150,8 +150,9 @@ func (h *Handlers) listPosts(w http.ResponseWriter, r *http.Request) {
 
 type engagementReq struct {
 	ID      string `json:"id"`
-	Kind    string `json:"kind"`    // reaction | comment | tombstone
-	Payload string `json:"payload"` // opaque, sealed under K_post
+	Kind    string `json:"kind"`             // reaction | comment | tombstone
+	Payload string `json:"payload"`          // opaque, sealed under K_post
+	Target  string `json:"target,omitempty"` // tombstone: the engagement id being removed
 }
 
 func validEngagementKind(k string) bool {
@@ -173,8 +174,17 @@ func (h *Handlers) submitEngagement(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req engagementReq
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil ||
-		!uuidRE.MatchString(req.ID) || !validEngagementKind(req.Kind) || req.Payload == "" {
+	tombstone := false
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err == nil {
+		tombstone = req.Kind == "tombstone"
+	} else {
+		httpx.Error(w, http.StatusBadRequest, "invalid engagement")
+		return
+	}
+	// A tombstone removes a target engagement and needs no payload; reaction/comment
+	// carry a sealed payload.
+	if !uuidRE.MatchString(req.ID) || !validEngagementKind(req.Kind) ||
+		(!tombstone && req.Payload == "") || (tombstone && !uuidRE.MatchString(req.Target)) {
 		httpx.Error(w, http.StatusBadRequest, "invalid engagement")
 		return
 	}
@@ -187,7 +197,27 @@ func (h *Handlers) submitEngagement(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusForbidden, "not in this post's audience")
 		return
 	}
-	if err := h.Posts.SubmitEngagement(r.Context(), postID, req.ID, uid, req.Kind, req.Payload); err != nil {
+	// Moderation: only the original author of the targeted engagement, or the POST's
+	// author, may tombstone it (FR-034).
+	if tombstone {
+		postAuthor, err1 := h.Posts.PostAuthor(r.Context(), postID)
+		engActor, err2 := h.Posts.EngagementActor(r.Context(), postID, req.Target)
+		if err1 != nil || err2 != nil {
+			httpx.Error(w, http.StatusInternalServerError, "could not authorize")
+			return
+		}
+		if uid != postAuthor && uid != engActor {
+			httpx.Error(w, http.StatusForbidden, "cannot remove this item")
+			return
+		}
+	}
+	// A tombstone carries its (cleartext) target engagement id in place of a sealed
+	// payload, so recipients know which item to remove.
+	payload := req.Payload
+	if tombstone {
+		payload = req.Target
+	}
+	if err := h.Posts.SubmitEngagement(r.Context(), postID, req.ID, uid, req.Kind, payload); err != nil {
 		httpx.Error(w, http.StatusInternalServerError, "could not submit engagement")
 		return
 	}
@@ -250,6 +280,74 @@ func (h *Handlers) listEngagement(w http.ResponseWriter, r *http.Request) {
 		items = append(items, engagementOut{ID: e.ID, Actor: e.Actor, Kind: e.Kind, Payload: e.Payload, CreatedAt: e.CreatedMs})
 	}
 	httpx.JSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
+// recordView (POST /v1/posts/{id}/view) records that the caller viewed a post,
+// delivered to the author only. The caller sends this ONLY when their seen-receipts
+// setting is on (client-gated). Must be in the post's audience.
+func (h *Handlers) recordView(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	postID := r.PathValue("id")
+	if !uuidRE.MatchString(postID) {
+		httpx.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	canSee, err := h.Posts.CanSeePost(r.Context(), postID, uid)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not authorize")
+		return
+	}
+	if !canSee {
+		httpx.Error(w, http.StatusForbidden, "not in this post's audience")
+		return
+	}
+	if err := h.Posts.RecordView(r.Context(), postID, uid); err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not record view")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type viewOut struct {
+	Viewer   string `json:"viewer"`
+	ViewedAt int64  `json:"viewedAt"`
+}
+
+// listViews (GET /v1/posts/{id}/views) returns who viewed a post — author-only.
+func (h *Handlers) listViews(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	postID := r.PathValue("id")
+	if !uuidRE.MatchString(postID) {
+		httpx.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	author, err := h.Posts.PostAuthor(r.Context(), postID)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not authorize")
+		return
+	}
+	if author == "" || author != uid {
+		httpx.Error(w, http.StatusForbidden, "only the author can see views")
+		return
+	}
+	rows, err := h.Posts.ListViews(r.Context(), postID)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not list views")
+		return
+	}
+	views := make([]viewOut, 0, len(rows))
+	for _, v := range rows {
+		views = append(views, viewOut{Viewer: v.Viewer, ViewedAt: v.ViewedMs})
+	}
+	httpx.JSON(w, http.StatusOK, map[string]any{"views": views})
 }
 
 // deletePost (DELETE /v1/posts/{id}) deletes the caller's own post (author-only; the

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -27,6 +27,7 @@ type createPostReq struct {
 	BlobID    string            `json:"blobId"`
 	Size      int               `json:"size"`
 	ExpiresAt int64             `json:"expiresAt"` // epoch ms; 0/absent = keep
+	TtlMs     int64             `json:"ttlMs"`     // per-post lifetime window
 	Envelopes []postEnvelopeReq `json:"envelopes"`
 }
 
@@ -95,8 +96,13 @@ func (h *Handlers) createPost(w http.ResponseWriter, r *http.Request) {
 			expires = t
 		}
 	}
+	// Clamp the per-post window to (0, 72h]; default 72h.
+	ttl := req.TtlMs
+	if ttl <= 0 || ttl > maxPostLifetime.Milliseconds() {
+		ttl = maxPostLifetime.Milliseconds()
+	}
 	if err := h.Posts.CreatePost(r.Context(), store.NewPost{
-		ID: req.ID, Author: uid, BlobID: req.BlobID, Size: req.Size, ExpiresAt: &expires, Envelopes: envs,
+		ID: req.ID, Author: uid, BlobID: req.BlobID, Size: req.Size, ExpiresAt: &expires, TtlMs: ttl, Envelopes: envs,
 	}); err != nil {
 		httpx.Error(w, http.StatusInternalServerError, "could not create post")
 		return
@@ -114,6 +120,7 @@ type postOut struct {
 	Size       int    `json:"size"`
 	CreatedAt  int64  `json:"createdAt"`
 	ExpiresAt  int64  `json:"expiresAt,omitempty"`
+	TtlMs      int64  `json:"ttlMs,omitempty"`
 	WrappedKey string `json:"wrappedKey,omitempty"`
 }
 
@@ -139,7 +146,7 @@ func (h *Handlers) listPosts(w http.ResponseWriter, r *http.Request) {
 	for _, p := range rows {
 		posts = append(posts, postOut{
 			ID: p.ID, Author: p.Author, BlobID: p.BlobID, Size: p.Size,
-			CreatedAt: p.CreatedMs, ExpiresAt: p.ExpiresMs, WrappedKey: p.WrappedKey,
+			CreatedAt: p.CreatedMs, ExpiresAt: p.ExpiresMs, TtlMs: p.TtlMs, WrappedKey: p.WrappedKey,
 		})
 		if p.CreatedMs > cursor {
 			cursor = p.CreatedMs

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -148,6 +148,110 @@ func (h *Handlers) listPosts(w http.ResponseWriter, r *http.Request) {
 	httpx.JSON(w, http.StatusOK, map[string]any{"posts": posts, "cursor": cursor})
 }
 
+type engagementReq struct {
+	ID      string `json:"id"`
+	Kind    string `json:"kind"`    // reaction | comment | tombstone
+	Payload string `json:"payload"` // opaque, sealed under K_post
+}
+
+func validEngagementKind(k string) bool {
+	return k == "reaction" || k == "comment" || k == "tombstone"
+}
+
+// submitEngagement (POST /v1/posts/{id}/engagement) records one opaque engagement item
+// and nudges everyone who can see the post to pull it. Only audience members (or the
+// author) may engage; the server never reads the payload.
+func (h *Handlers) submitEngagement(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	postID := r.PathValue("id")
+	if !uuidRE.MatchString(postID) {
+		httpx.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	var req engagementReq
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil ||
+		!uuidRE.MatchString(req.ID) || !validEngagementKind(req.Kind) || req.Payload == "" {
+		httpx.Error(w, http.StatusBadRequest, "invalid engagement")
+		return
+	}
+	canSee, err := h.Posts.CanSeePost(r.Context(), postID, uid)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not authorize")
+		return
+	}
+	if !canSee {
+		httpx.Error(w, http.StatusForbidden, "not in this post's audience")
+		return
+	}
+	if err := h.Posts.SubmitEngagement(r.Context(), postID, req.ID, uid, req.Kind, req.Payload); err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not submit engagement")
+		return
+	}
+	// Nudge everyone who can see the post (content-free) to pull the new engagement.
+	if aud, err := h.Posts.PostAudience(r.Context(), postID); err == nil {
+		for _, u := range aud {
+			if u == uid {
+				continue
+			}
+			if h.Hub != nil {
+				if b, e := json.Marshal(map[string]any{"t": "post-engagement", "post": postID}); e == nil {
+					h.Hub.Send(u, b)
+				}
+			}
+			if h.Notifier != nil {
+				h.Notifier.Notify(r.Context(), u)
+			}
+		}
+	}
+	httpx.JSON(w, http.StatusCreated, map[string]any{"id": req.ID})
+}
+
+type engagementOut struct {
+	ID        string `json:"id"`
+	Actor     string `json:"actor"`
+	Kind      string `json:"kind"`
+	Payload   string `json:"payload"`
+	CreatedAt int64  `json:"createdAt"`
+}
+
+// listEngagement (GET /v1/posts/{id}/engagement) returns the opaque engagement on a
+// post the caller can see; the client decrypts under K_post.
+func (h *Handlers) listEngagement(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	postID := r.PathValue("id")
+	if !uuidRE.MatchString(postID) {
+		httpx.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	canSee, err := h.Posts.CanSeePost(r.Context(), postID, uid)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not authorize")
+		return
+	}
+	if !canSee {
+		httpx.Error(w, http.StatusForbidden, "not in this post's audience")
+		return
+	}
+	rows, err := h.Posts.ListEngagement(r.Context(), postID)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not list engagement")
+		return
+	}
+	items := make([]engagementOut, 0, len(rows))
+	for _, e := range rows {
+		items = append(items, engagementOut{ID: e.ID, Actor: e.Actor, Kind: e.Kind, Payload: e.Payload, CreatedAt: e.CreatedMs})
+	}
+	httpx.JSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
 // deletePost (DELETE /v1/posts/{id}) deletes the caller's own post (author-only; the
 // store guards on author so a non-author delete is a no-op). Idempotent.
 func (h *Handlers) deletePost(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"ring/server/internal/auth"
+	"ring/server/internal/httpx"
+	"ring/server/internal/store"
+)
+
+// Social Wall handlers (spec 0003). A post is opaque ciphertext (the K_post-sealed
+// payload, uploaded as a blob) plus one wrapped-key envelope per audience member. The
+// server enforces that every recipient is an accepted friend of the author (and not
+// blocked) — but it never sees content, media keys, the audience tier, or the
+// close-friends subset. Engagement + views are added with US4/US7.
+
+type postEnvelopeReq struct {
+	Recipient  string `json:"recipient"`
+	WrappedKey string `json:"wrappedKey"`
+}
+type createPostReq struct {
+	ID        string            `json:"id"`
+	BlobID    string            `json:"blobId"`
+	Size      int               `json:"size"`
+	ExpiresAt int64             `json:"expiresAt"` // epoch ms; 0/absent = keep
+	Envelopes []postEnvelopeReq `json:"envelopes"`
+}
+
+// maxPostEnvelopes bounds a single post's fan-out (a sanity cap, not a privacy gate).
+const maxPostEnvelopes = 1024
+
+// notifyPost sends a content-free "a post is waiting" nudge to a recipient: a live WS
+// frame if connected, and an offline push tickle otherwise. Carries no content — the
+// client reconciles via GET /v1/posts — preserving the zero-knowledge boundary.
+func (h *Handlers) notifyPost(ctx context.Context, recipient, author string) {
+	if h.Hub != nil {
+		if b, err := json.Marshal(map[string]any{"t": "post-new", "from": author}); err == nil {
+			h.Hub.Send(recipient, b)
+		}
+	}
+	if h.Notifier != nil {
+		h.Notifier.Notify(ctx, recipient)
+	}
+}
+
+// createPost (POST /v1/posts) records a post + its per-recipient envelopes. Every
+// recipient MUST be an accepted connection of the author (Connected() also excludes
+// blocked pairs); otherwise the post is rejected.
+func (h *Handlers) createPost(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var req createPostReq
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 256<<10)).Decode(&req); err != nil ||
+		!uuidRE.MatchString(req.ID) || req.BlobID == "" || len(req.Envelopes) == 0 ||
+		len(req.Envelopes) > maxPostEnvelopes {
+		httpx.Error(w, http.StatusBadRequest, "invalid post")
+		return
+	}
+	envs := make([]store.NewPostEnvelope, 0, len(req.Envelopes))
+	for _, e := range req.Envelopes {
+		if !uuidRE.MatchString(e.Recipient) || e.Recipient == uid || e.WrappedKey == "" {
+			httpx.Error(w, http.StatusBadRequest, "invalid recipient")
+			return
+		}
+		// Audience must be friends-only: an accepted connection, not blocked.
+		connected, err := h.Connections.Connected(r.Context(), uid, e.Recipient)
+		if err != nil {
+			httpx.Error(w, http.StatusInternalServerError, "could not verify audience")
+			return
+		}
+		if !connected {
+			httpx.Error(w, http.StatusForbidden, "recipient is not a friend")
+			return
+		}
+		envs = append(envs, store.NewPostEnvelope{Recipient: e.Recipient, WrappedKey: e.WrappedKey})
+	}
+	var expires *time.Time
+	if req.ExpiresAt > 0 {
+		t := time.UnixMilli(req.ExpiresAt)
+		expires = &t
+	}
+	if err := h.Posts.CreatePost(r.Context(), store.NewPost{
+		ID: req.ID, Author: uid, BlobID: req.BlobID, Size: req.Size, ExpiresAt: expires, Envelopes: envs,
+	}); err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not create post")
+		return
+	}
+	for _, e := range envs {
+		h.notifyPost(r.Context(), e.Recipient, uid)
+	}
+	httpx.JSON(w, http.StatusCreated, map[string]any{"id": req.ID})
+}
+
+type postOut struct {
+	ID         string `json:"id"`
+	Author     string `json:"author"`
+	BlobID     string `json:"blobId"`
+	Size       int    `json:"size"`
+	CreatedAt  int64  `json:"createdAt"`
+	ExpiresAt  int64  `json:"expiresAt,omitempty"`
+	WrappedKey string `json:"wrappedKey,omitempty"`
+}
+
+// listPosts (GET /v1/posts?since=) returns the caller's own posts + posts addressed
+// to them, newest-first, with the caller's wrapped K_post envelope.
+func (h *Handlers) listPosts(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var since int64
+	if s := r.URL.Query().Get("since"); s != "" {
+		since, _ = strconv.ParseInt(s, 10, 64)
+	}
+	rows, err := h.Posts.ListPosts(r.Context(), uid, since)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not list posts")
+		return
+	}
+	posts := make([]postOut, 0, len(rows))
+	var cursor int64 = since
+	for _, p := range rows {
+		posts = append(posts, postOut{
+			ID: p.ID, Author: p.Author, BlobID: p.BlobID, Size: p.Size,
+			CreatedAt: p.CreatedMs, ExpiresAt: p.ExpiresMs, WrappedKey: p.WrappedKey,
+		})
+		if p.CreatedMs > cursor {
+			cursor = p.CreatedMs
+		}
+	}
+	httpx.JSON(w, http.StatusOK, map[string]any{"posts": posts, "cursor": cursor})
+}
+
+// deletePost (DELETE /v1/posts/{id}) deletes the caller's own post (author-only; the
+// store guards on author so a non-author delete is a no-op). Idempotent.
+func (h *Handlers) deletePost(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	id := r.PathValue("id")
+	if !uuidRE.MatchString(id) {
+		httpx.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	if err := h.Posts.DeletePost(r.Context(), uid, id); err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not delete post")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -152,7 +152,47 @@ func (h *Handlers) listPosts(w http.ResponseWriter, r *http.Request) {
 			cursor = p.CreatedMs
 		}
 	}
-	httpx.JSON(w, http.StatusOK, map[string]any{"posts": posts, "cursor": cursor})
+	// Revocations: posts the caller was removed from (e.g. dropped from close friends)
+	// so the client deletes its local copies. Idempotent.
+	revoked, _ := h.Posts.ListRevocations(r.Context(), uid)
+	httpx.JSON(w, http.StatusOK, map[string]any{"posts": posts, "cursor": cursor, "revoked": revoked})
+}
+
+// removePostRecipient (DELETE /v1/posts/{id}/recipient/{userId}) drops a recipient from
+// one of the caller's own posts (author-only) and signals them to remove their copy —
+// used when un-close-friending someone to revoke close-only posts.
+func (h *Handlers) removePostRecipient(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	postID := r.PathValue("id")
+	recipient := r.PathValue("userId")
+	if !uuidRE.MatchString(postID) || !uuidRE.MatchString(recipient) {
+		httpx.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	owns, err := h.Posts.RemovePostRecipient(r.Context(), postID, uid, recipient)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not revoke")
+		return
+	}
+	if !owns {
+		httpx.Error(w, http.StatusForbidden, "not your post")
+		return
+	}
+	// Signal the removed recipient: a live frame to delete it now, and a push so an
+	// offline device picks up the revocation on its next sync.
+	if h.Hub != nil {
+		if b, e := json.Marshal(map[string]any{"t": "post-revoke", "post": postID}); e == nil {
+			h.Hub.Send(recipient, b)
+		}
+	}
+	if h.Notifier != nil {
+		h.Notifier.NotifyPost(r.Context(), recipient)
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 type engagementReq struct {

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"ring/server/internal/store"
+	"ring/server/internal/ws"
+)
+
+// fakePostConn is a ConnectionStore whose Connected() answers from an explicit
+// friendship set, so post-audience authorization can be exercised.
+type fakePostConn struct{ friends map[[2]string]bool }
+
+func newFakePostConn() *fakePostConn { return &fakePostConn{friends: map[[2]string]bool{}} }
+func (c *fakePostConn) befriend(a, b string) {
+	c.friends[[2]string{a, b}] = true
+	c.friends[[2]string{b, a}] = true
+}
+func (c *fakePostConn) Connected(_ context.Context, a, b string) (bool, error) {
+	return c.friends[[2]string{a, b}], nil
+}
+func (c *fakePostConn) ConnectionState(context.Context, string, string) (string, error) {
+	return "", nil
+}
+func (c *fakePostConn) RequestConnection(context.Context, string, string) (string, error) {
+	return "pending", nil
+}
+func (c *fakePostConn) AcceptConnection(context.Context, string, string) error        { return nil }
+func (c *fakePostConn) RejectConnection(context.Context, string, string, bool) error  { return nil }
+func (c *fakePostConn) WithdrawConnection(context.Context, string, string) error      { return nil }
+func (c *fakePostConn) IncomingRequests(context.Context, string) ([]store.ConnectionReq, error) {
+	return nil, nil
+}
+func (c *fakePostConn) OutgoingRequests(context.Context, string) ([]store.ConnectionReq, error) {
+	return nil, nil
+}
+
+// fakePostStore is an in-memory PostStore for handler tests.
+type fakePostStore struct{ posts map[string]store.NewPost }
+
+func newFakePostStore() *fakePostStore { return &fakePostStore{posts: map[string]store.NewPost{}} }
+func (f *fakePostStore) CreatePost(_ context.Context, p store.NewPost) error {
+	f.posts[p.ID] = p
+	return nil
+}
+func (f *fakePostStore) ListPosts(_ context.Context, recipient string, _ int64) ([]store.PostForRecipient, error) {
+	var out []store.PostForRecipient
+	for _, p := range f.posts {
+		if p.Author == recipient {
+			out = append(out, store.PostForRecipient{ID: p.ID, Author: p.Author, BlobID: p.BlobID, Size: p.Size})
+			continue
+		}
+		for _, e := range p.Envelopes {
+			if e.Recipient == recipient {
+				out = append(out, store.PostForRecipient{ID: p.ID, Author: p.Author, BlobID: p.BlobID, WrappedKey: e.WrappedKey})
+			}
+		}
+	}
+	return out, nil
+}
+func (f *fakePostStore) DeletePost(_ context.Context, author, id string) error {
+	if p, ok := f.posts[id]; ok && p.Author == author {
+		delete(f.posts, id)
+	}
+	return nil
+}
+
+func newPostTestServer(conn ConnectionStore, posts PostStore) http.Handler {
+	as := newFakeStore()
+	return NewRouter(&Handlers{
+		Store: as, Directory: as, Contacts: as, Blocks: as, Relay: as,
+		Connections: conn, Posts: posts, Hub: ws.NewHub(),
+		Keys: newFakeKeysStore(), Blobs: newFakeBlobStore(), Sync: newFakeSyncStore(),
+		Push: newFakePushStore(), Invites: as,
+		PublicURL: "https://ring.example", VapidPublicKey: "VAPID_PUB",
+	}, []string{"http://localhost:5173"})
+}
+
+const postID = "11111111-1111-1111-1111-111111111111"
+
+func listPostIDs(t *testing.T, srv http.Handler, tok string) []string {
+	t.Helper()
+	rr := do(t, srv, http.MethodGet, "/v1/posts", tok, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Posts []struct {
+			ID         string `json:"id"`
+			WrappedKey string `json:"wrappedKey"`
+		} `json:"posts"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	ids := make([]string, 0, len(resp.Posts))
+	for _, p := range resp.Posts {
+		ids = append(ids, p.ID)
+	}
+	return ids
+}
+
+// TestCreatePostRejectsNonFriendRecipient: a post addressed to someone who is not an
+// accepted friend is rejected (FR-013).
+func TestCreatePostRejectsNonFriendRecipient(t *testing.T) {
+	srv := newPostTestServer(newFakePostConn(), newFakePostStore()) // no friendships
+	tokA, _, _ := registerNamed(t, srv, "alice")
+	_, bobID, _ := registerNamed(t, srv, "bob")
+
+	body := `{"id":"` + postID + `","blobId":"cap1","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("create-to-non-friend status = %d, want 403; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestCreatePostDeliversToAudienceOnly: a friends post is delivered to its audience
+// (with the wrapped key) and to no one else (FR-013, SC-002).
+func TestCreatePostDeliversToAudienceOnly(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	tokC, _, _ := registerNamed(t, srv, "carol")
+	conn.befriend(aliceID, bobID) // carol is NOT a friend
+
+	body := `{"id":"` + postID + `","blobId":"cap1","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+
+	if ids := listPostIDs(t, srv, tokB); len(ids) != 1 || ids[0] != postID {
+		t.Errorf("bob (audience) sees %v, want [%s]", ids, postID)
+	}
+	if ids := listPostIDs(t, srv, tokC); len(ids) != 0 {
+		t.Errorf("carol (non-audience) sees %v, want []", ids)
+	}
+	if ids := listPostIDs(t, srv, tokA); len(ids) != 1 || ids[0] != postID {
+		t.Errorf("alice (author) sees %v, want [%s]", ids, postID)
+	}
+}
+
+// TestDeletePostAuthorOnly: only the author can delete; a non-author delete is a
+// no-op (FR-015).
+func TestDeletePostAuthorOnly(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	body := `{"id":"` + postID + `","blobId":"cap1","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Bob (not the author) attempts delete → 204 but the post survives.
+	if rr := do(t, srv, http.MethodDelete, "/v1/posts/"+postID, tokB, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("non-author delete status = %d, want 204", rr.Code)
+	}
+	if ids := listPostIDs(t, srv, tokB); len(ids) != 1 {
+		t.Errorf("after non-author delete, bob sees %v, want the post to survive", ids)
+	}
+
+	// Alice (the author) deletes → gone.
+	if rr := do(t, srv, http.MethodDelete, "/v1/posts/"+postID, tokA, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("author delete status = %d, want 204", rr.Code)
+	}
+	if ids := listPostIDs(t, srv, tokB); len(ids) != 0 {
+		t.Errorf("after author delete, bob sees %v, want []", ids)
+	}
+}

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -157,6 +158,39 @@ func (f *fakePostStore) RemovePostRecipient(_ context.Context, postID, author, r
 }
 func (f *fakePostStore) ListRevocations(_ context.Context, recipient string) ([]string, error) {
 	return f.revoked[recipient], nil
+}
+
+// Rate-limit counts (FR-008). The fake ignores the time window and counts everything
+// the author/actor has done in the test — each test uses a fresh store, so this is
+// enough to exercise the handler's cap logic.
+func (f *fakePostStore) RecentPostCount(_ context.Context, author string, _ int) (int, error) {
+	n := 0
+	for _, p := range f.posts {
+		if p.Author == author {
+			n++
+		}
+	}
+	return n, nil
+}
+func (f *fakePostStore) RecentEngagementCount(_ context.Context, actor string, _ int) (int, error) {
+	n := 0
+	for _, rows := range f.eng {
+		for _, e := range rows {
+			if e.Actor == actor {
+				n++
+			}
+		}
+	}
+	return n, nil
+}
+func (f *fakePostStore) RecentCommentCount(_ context.Context, postID, actor string, _ int) (int, error) {
+	n := 0
+	for _, e := range f.eng[postID] {
+		if e.Actor == actor && e.Kind == "comment" {
+			n++
+		}
+	}
+	return n, nil
 }
 
 func newPostTestServer(conn ConnectionStore, posts PostStore) http.Handler {
@@ -424,5 +458,82 @@ func TestRemovePostRecipientAuthorOnly(t *testing.T) {
 	}
 	if len(resp.Revoked) != 1 || resp.Revoked[0] != postID {
 		t.Errorf("revoked = %v, want [%s]", resp.Revoked, postID)
+	}
+}
+
+// pid builds a distinct valid UUID for the i-th post/engagement in a loop.
+func pid(prefix int, i int) string {
+	return fmt.Sprintf("%08x-%04x-1111-1111-111111111111", prefix, i)
+}
+
+// TestCreatePostRateLimited: FR-008 per-author post-rate limit — once an author exceeds
+// maxPostsPerWindow recent posts, further creates are rejected with 429.
+func TestCreatePostRateLimited(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	_, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	for i := 0; i < maxPostsPerWindow; i++ {
+		body := `{"id":"` + pid(1, i) + `","blobId":"cap","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+		if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+			t.Fatalf("post %d status = %d, want 201; body=%s", i, rr.Code, rr.Body.String())
+		}
+	}
+	// One past the cap → throttled.
+	body := `{"id":"` + pid(1, maxPostsPerWindow) + `","blobId":"cap","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("over-cap post status = %d, want 429; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestEngagementRateLimited: FR-008 per-user engagement-rate limit — once an actor
+// exceeds maxEngagementsPerWindow recent items, further engagement is rejected with 429.
+func TestEngagementRateLimited(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	body := `{"id":"` + postID + `","blobId":"cap","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d", rr.Code)
+	}
+	for i := 0; i < maxEngagementsPerWindow; i++ {
+		eng := `{"id":"` + pid(2, i) + `","kind":"reaction","payload":"SEALED"}`
+		if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, eng); rr.Code != http.StatusCreated {
+			t.Fatalf("engagement %d status = %d, want 201; body=%s", i, rr.Code, rr.Body.String())
+		}
+	}
+	eng := `{"id":"` + pid(2, maxEngagementsPerWindow) + `","kind":"reaction","payload":"SEALED"}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, eng); rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("over-cap engagement status = %d, want 429; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestCommentRateLimitedPerPost: FR-008 per-post comment-rate limit — one actor can add
+// at most maxCommentsPerPostWindow comments to a single post per window.
+func TestCommentRateLimitedPerPost(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	body := `{"id":"` + postID + `","blobId":"cap","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d", rr.Code)
+	}
+	for i := 0; i < maxCommentsPerPostWindow; i++ {
+		eng := `{"id":"` + pid(3, i) + `","kind":"comment","payload":"SEALED"}`
+		if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, eng); rr.Code != http.StatusCreated {
+			t.Fatalf("comment %d status = %d, want 201; body=%s", i, rr.Code, rr.Body.String())
+		}
+	}
+	eng := `{"id":"` + pid(3, maxCommentsPerPostWindow) + `","kind":"comment","payload":"SEALED"}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, eng); rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("over-cap comment status = %d, want 429; body=%s", rr.Code, rr.Body.String())
 	}
 }

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -40,16 +40,18 @@ func (c *fakePostConn) OutgoingRequests(context.Context, string) ([]store.Connec
 
 // fakePostStore is an in-memory PostStore for handler tests.
 type fakePostStore struct {
-	posts map[string]store.NewPost
-	eng   map[string][]store.PostEngagementRow
-	views map[string][]string
+	posts   map[string]store.NewPost
+	eng     map[string][]store.PostEngagementRow
+	views   map[string][]string
+	revoked map[string][]string
 }
 
 func newFakePostStore() *fakePostStore {
 	return &fakePostStore{
-		posts: map[string]store.NewPost{},
-		eng:   map[string][]store.PostEngagementRow{},
-		views: map[string][]string{},
+		posts:   map[string]store.NewPost{},
+		eng:     map[string][]store.PostEngagementRow{},
+		views:   map[string][]string{},
+		revoked: map[string][]string{},
 	}
 }
 func (f *fakePostStore) PostAuthor(_ context.Context, postID string) (string, error) {
@@ -136,6 +138,25 @@ func (f *fakePostStore) DeletePost(_ context.Context, author, id string) error {
 		delete(f.posts, id)
 	}
 	return nil
+}
+func (f *fakePostStore) RemovePostRecipient(_ context.Context, postID, author, recipient string) (bool, error) {
+	p, ok := f.posts[postID]
+	if !ok || p.Author != author {
+		return false, nil
+	}
+	envs := p.Envelopes[:0:0]
+	for _, e := range p.Envelopes {
+		if e.Recipient != recipient {
+			envs = append(envs, e)
+		}
+	}
+	p.Envelopes = envs
+	f.posts[postID] = p
+	f.revoked[recipient] = append(f.revoked[recipient], postID)
+	return true, nil
+}
+func (f *fakePostStore) ListRevocations(_ context.Context, recipient string) ([]string, error) {
+	return f.revoked[recipient], nil
 }
 
 func newPostTestServer(conn ConnectionStore, posts PostStore) http.Handler {
@@ -362,5 +383,46 @@ func TestDeletePostAuthorOnly(t *testing.T) {
 	}
 	if ids := listPostIDs(t, srv, tokB); len(ids) != 0 {
 		t.Errorf("after author delete, bob sees %v, want []", ids)
+	}
+}
+
+// TestRemovePostRecipientAuthorOnly: dropping a recipient is author-only, removes the
+// post from that recipient's feed, and surfaces in their `revoked` list so an offline
+// device can prune it (the un-close-friend revocation path).
+func TestRemovePostRecipientAuthorOnly(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	body := `{"id":"` + postID + `","blobId":"cap1","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Bob (not the author) cannot revoke his own membership for someone else's post.
+	if rr := do(t, srv, http.MethodDelete, "/v1/posts/"+postID+"/recipient/"+aliceID, tokB, ""); rr.Code != http.StatusForbidden {
+		t.Fatalf("non-author revoke status = %d, want 403", rr.Code)
+	}
+
+	// Alice (the author) removes Bob from the audience → 204, and Bob no longer sees it.
+	if rr := do(t, srv, http.MethodDelete, "/v1/posts/"+postID+"/recipient/"+bobID, tokA, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("author revoke status = %d, want 204", rr.Code)
+	}
+	if ids := listPostIDs(t, srv, tokB); len(ids) != 0 {
+		t.Errorf("after revoke, bob sees %v, want []", ids)
+	}
+
+	// The revocation surfaces in Bob's list response so an offline device prunes it.
+	rr := do(t, srv, http.MethodGet, "/v1/posts", tokB, "")
+	var resp struct {
+		Revoked []string `json:"revoked"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(resp.Revoked) != 1 || resp.Revoked[0] != postID {
+		t.Errorf("revoked = %v, want [%s]", resp.Revoked, postID)
 	}
 }

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -39,12 +39,50 @@ func (c *fakePostConn) OutgoingRequests(context.Context, string) ([]store.Connec
 }
 
 // fakePostStore is an in-memory PostStore for handler tests.
-type fakePostStore struct{ posts map[string]store.NewPost }
+type fakePostStore struct {
+	posts map[string]store.NewPost
+	eng   map[string][]store.PostEngagementRow
+}
 
-func newFakePostStore() *fakePostStore { return &fakePostStore{posts: map[string]store.NewPost{}} }
+func newFakePostStore() *fakePostStore {
+	return &fakePostStore{posts: map[string]store.NewPost{}, eng: map[string][]store.PostEngagementRow{}}
+}
 func (f *fakePostStore) CreatePost(_ context.Context, p store.NewPost) error {
 	f.posts[p.ID] = p
 	return nil
+}
+func (f *fakePostStore) CanSeePost(_ context.Context, postID, user string) (bool, error) {
+	p, ok := f.posts[postID]
+	if !ok {
+		return false, nil
+	}
+	if p.Author == user {
+		return true, nil
+	}
+	for _, e := range p.Envelopes {
+		if e.Recipient == user {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+func (f *fakePostStore) PostAudience(_ context.Context, postID string) ([]string, error) {
+	p, ok := f.posts[postID]
+	if !ok {
+		return nil, nil
+	}
+	out := []string{p.Author}
+	for _, e := range p.Envelopes {
+		out = append(out, e.Recipient)
+	}
+	return out, nil
+}
+func (f *fakePostStore) SubmitEngagement(_ context.Context, postID, id, actor, kind, payload string) error {
+	f.eng[postID] = append(f.eng[postID], store.PostEngagementRow{ID: id, Actor: actor, Kind: kind, Payload: payload})
+	return nil
+}
+func (f *fakePostStore) ListEngagement(_ context.Context, postID string) ([]store.PostEngagementRow, error) {
+	return f.eng[postID], nil
 }
 func (f *fakePostStore) ListPosts(_ context.Context, recipient string, _ int64) ([]store.PostForRecipient, error) {
 	var out []store.PostForRecipient
@@ -140,6 +178,54 @@ func TestCreatePostDeliversToAudienceOnly(t *testing.T) {
 	}
 	if ids := listPostIDs(t, srv, tokA); len(ids) != 1 || ids[0] != postID {
 		t.Errorf("alice (author) sees %v, want [%s]", ids, postID)
+	}
+}
+
+// TestEngagementAudienceOnly: only the post's audience (or author) may submit/read
+// engagement; outsiders are rejected (FR-035/FR-036).
+func TestEngagementAudienceOnly(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	tokC, _, _ := registerNamed(t, srv, "carol")
+	conn.befriend(aliceID, bobID)
+
+	body := `{"id":"` + postID + `","blobId":"cap1","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d", rr.Code)
+	}
+
+	const engID = "22222222-2222-2222-2222-222222222222"
+	eng := `{"id":"` + engID + `","kind":"reaction","payload":"SEALED"}`
+
+	// Bob (audience) may react.
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, eng); rr.Code != http.StatusCreated {
+		t.Fatalf("bob react status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+	// Carol (not audience) may NOT react or read.
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokC, eng); rr.Code != http.StatusForbidden {
+		t.Errorf("carol react status = %d, want 403", rr.Code)
+	}
+	if rr := do(t, srv, http.MethodGet, "/v1/posts/"+postID+"/engagement", tokC, ""); rr.Code != http.StatusForbidden {
+		t.Errorf("carol list status = %d, want 403", rr.Code)
+	}
+	// Alice (author) reads the engagement.
+	rr := do(t, srv, http.MethodGet, "/v1/posts/"+postID+"/engagement", tokA, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("alice list status = %d, want 200", rr.Code)
+	}
+	var resp struct {
+		Items []struct {
+			Actor   string `json:"actor"`
+			Payload string `json:"payload"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].Actor != bobID || resp.Items[0].Payload != "SEALED" {
+		t.Errorf("engagement = %+v, want one from bob with opaque payload", resp.Items)
 	}
 }
 

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -42,10 +42,42 @@ func (c *fakePostConn) OutgoingRequests(context.Context, string) ([]store.Connec
 type fakePostStore struct {
 	posts map[string]store.NewPost
 	eng   map[string][]store.PostEngagementRow
+	views map[string][]string
 }
 
 func newFakePostStore() *fakePostStore {
-	return &fakePostStore{posts: map[string]store.NewPost{}, eng: map[string][]store.PostEngagementRow{}}
+	return &fakePostStore{
+		posts: map[string]store.NewPost{},
+		eng:   map[string][]store.PostEngagementRow{},
+		views: map[string][]string{},
+	}
+}
+func (f *fakePostStore) PostAuthor(_ context.Context, postID string) (string, error) {
+	return f.posts[postID].Author, nil
+}
+func (f *fakePostStore) EngagementActor(_ context.Context, postID, engID string) (string, error) {
+	for _, e := range f.eng[postID] {
+		if e.ID == engID {
+			return e.Actor, nil
+		}
+	}
+	return "", nil
+}
+func (f *fakePostStore) RecordView(_ context.Context, postID, viewer string) error {
+	for _, v := range f.views[postID] {
+		if v == viewer {
+			return nil
+		}
+	}
+	f.views[postID] = append(f.views[postID], viewer)
+	return nil
+}
+func (f *fakePostStore) ListViews(_ context.Context, postID string) ([]store.PostView, error) {
+	out := make([]store.PostView, 0, len(f.views[postID]))
+	for _, v := range f.views[postID] {
+		out = append(out, store.PostView{Viewer: v})
+	}
+	return out, nil
 }
 func (f *fakePostStore) CreatePost(_ context.Context, p store.NewPost) error {
 	f.posts[p.ID] = p
@@ -226,6 +258,79 @@ func TestEngagementAudienceOnly(t *testing.T) {
 	}
 	if len(resp.Items) != 1 || resp.Items[0].Actor != bobID || resp.Items[0].Payload != "SEALED" {
 		t.Errorf("engagement = %+v, want one from bob with opaque payload", resp.Items)
+	}
+}
+
+// TestCommentTombstoneAuthz: a commenter may remove their own comment and the post
+// author may remove any, but a third audience member may not (FR-034).
+func TestCommentTombstoneAuthz(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice") // post author
+	tokB, bobID, _ := registerNamed(t, srv, "bob")      // commenter
+	tokC, carolID, _ := registerNamed(t, srv, "carol")  // other audience member
+	conn.befriend(aliceID, bobID)
+	conn.befriend(aliceID, carolID)
+
+	post := `{"id":"` + postID + `","blobId":"cap1","envelopes":[` +
+		`{"recipient":"` + bobID + `","wrappedKey":"WK"},{"recipient":"` + carolID + `","wrappedKey":"WK2"}]}`
+	do(t, srv, http.MethodPost, "/v1/posts", tokA, post)
+
+	const commentID = "33333333-3333-3333-3333-333333333333"
+	do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB,
+		`{"id":"`+commentID+`","kind":"comment","payload":"SEALED"}`)
+
+	tomb := func(tok, id string) int {
+		return do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tok,
+			`{"id":"`+id+`","kind":"tombstone","target":"`+commentID+`"}`).Code
+	}
+	// Carol (neither the commenter nor the post author) may NOT remove Bob's comment.
+	if code := tomb(tokC, "44444444-4444-4444-4444-444444444444"); code != http.StatusForbidden {
+		t.Errorf("carol tombstone = %d, want 403", code)
+	}
+	// Bob (the commenter) may remove his own comment.
+	if code := tomb(tokB, "55555555-5555-5555-5555-555555555555"); code != http.StatusCreated {
+		t.Errorf("bob tombstone own = %d, want 201", code)
+	}
+	// Alice (the post author) may remove any comment.
+	if code := tomb(tokA, "66666666-6666-6666-6666-666666666666"); code != http.StatusCreated {
+		t.Errorf("alice tombstone any = %d, want 201", code)
+	}
+}
+
+// TestPostViewsAuthorOnly: a viewer's view is recorded and only the author can read
+// the view list (FR-037).
+func TestPostViewsAuthorOnly(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	do(t, srv, http.MethodPost, "/v1/posts", tokA,
+		`{"id":"`+postID+`","blobId":"cap1","envelopes":[{"recipient":"`+bobID+`","wrappedKey":"WK"}]}`)
+
+	// Bob views the post.
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/view", tokB, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("view status = %d, want 204", rr.Code)
+	}
+	// Bob (not the author) cannot read the view list.
+	if rr := do(t, srv, http.MethodGet, "/v1/posts/"+postID+"/views", tokB, ""); rr.Code != http.StatusForbidden {
+		t.Errorf("bob list views = %d, want 403", rr.Code)
+	}
+	// Alice (the author) sees Bob in the list.
+	rr := do(t, srv, http.MethodGet, "/v1/posts/"+postID+"/views", tokA, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("alice list views = %d, want 200", rr.Code)
+	}
+	var resp struct {
+		Views []struct {
+			Viewer string `json:"viewer"`
+		} `json:"views"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if len(resp.Views) != 1 || resp.Views[0].Viewer != bobID {
+		t.Errorf("views = %+v, want [bob]", resp.Views)
 	}
 }
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -119,6 +119,9 @@ type PostStore interface {
 	DeletePost(ctx context.Context, author, id string) error
 	RemovePostRecipient(ctx context.Context, postID, author, recipient string) (bool, error)
 	ListRevocations(ctx context.Context, recipient string) ([]string, error)
+	RecentPostCount(ctx context.Context, author string, withinSec int) (int, error)
+	RecentEngagementCount(ctx context.Context, actor string, withinSec int) (int, error)
+	RecentCommentCount(ctx context.Context, postID, actor string, withinSec int) (int, error)
 	CanSeePost(ctx context.Context, postID, user string) (bool, error)
 	PostAudience(ctx context.Context, postID string) ([]string, error)
 	PostAuthor(ctx context.Context, postID string) (string, error)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -119,8 +119,12 @@ type PostStore interface {
 	DeletePost(ctx context.Context, author, id string) error
 	CanSeePost(ctx context.Context, postID, user string) (bool, error)
 	PostAudience(ctx context.Context, postID string) ([]string, error)
+	PostAuthor(ctx context.Context, postID string) (string, error)
 	SubmitEngagement(ctx context.Context, postID, id, actor, kind, payload string) error
+	EngagementActor(ctx context.Context, postID, engID string) (string, error)
 	ListEngagement(ctx context.Context, postID string) ([]store.PostEngagementRow, error)
+	RecordView(ctx context.Context, postID, viewer string) error
+	ListViews(ctx context.Context, postID string) ([]store.PostView, error)
 }
 
 // Handlers carries the dependencies the HTTP handlers need.
@@ -234,6 +238,8 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	mux.Handle("DELETE /v1/posts/{id}", authMW(http.HandlerFunc(h.deletePost)))
 	mux.Handle("POST /v1/posts/{id}/engagement", authMW(http.HandlerFunc(h.submitEngagement)))
 	mux.Handle("GET /v1/posts/{id}/engagement", authMW(http.HandlerFunc(h.listEngagement)))
+	mux.Handle("POST /v1/posts/{id}/view", authMW(http.HandlerFunc(h.recordView)))
+	mux.Handle("GET /v1/posts/{id}/views", authMW(http.HandlerFunc(h.listViews)))
 
 	// Public in-network directory: discover any member, fetch one profile, update
 	// your own profile, and (legacy) claim a username. The literal /me/* patterns

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -117,6 +117,8 @@ type PostStore interface {
 	CreatePost(ctx context.Context, p store.NewPost) error
 	ListPosts(ctx context.Context, recipient string, sinceMs int64) ([]store.PostForRecipient, error)
 	DeletePost(ctx context.Context, author, id string) error
+	RemovePostRecipient(ctx context.Context, postID, author, recipient string) (bool, error)
+	ListRevocations(ctx context.Context, recipient string) ([]string, error)
 	CanSeePost(ctx context.Context, postID, user string) (bool, error)
 	PostAudience(ctx context.Context, postID string) ([]string, error)
 	PostAuthor(ctx context.Context, postID string) (string, error)
@@ -236,6 +238,7 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	mux.Handle("POST /v1/posts", authMW(http.HandlerFunc(h.createPost)))
 	mux.Handle("GET /v1/posts", authMW(http.HandlerFunc(h.listPosts)))
 	mux.Handle("DELETE /v1/posts/{id}", authMW(http.HandlerFunc(h.deletePost)))
+	mux.Handle("DELETE /v1/posts/{id}/recipient/{userId}", authMW(http.HandlerFunc(h.removePostRecipient)))
 	mux.Handle("POST /v1/posts/{id}/engagement", authMW(http.HandlerFunc(h.submitEngagement)))
 	mux.Handle("GET /v1/posts/{id}/engagement", authMW(http.HandlerFunc(h.listEngagement)))
 	mux.Handle("POST /v1/posts/{id}/view", authMW(http.HandlerFunc(h.recordView)))

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -110,6 +110,15 @@ type InviteStore interface {
 	MintInvite(ctx context.Context) (string, error)
 }
 
+// PostStore is the social-Wall persistence (spec 0003): opaque post ciphertext +
+// per-recipient wrapped-key envelopes. *store.Store satisfies it. Engagement + view
+// methods are added with US4/US7.
+type PostStore interface {
+	CreatePost(ctx context.Context, p store.NewPost) error
+	ListPosts(ctx context.Context, recipient string, sinceMs int64) ([]store.PostForRecipient, error)
+	DeletePost(ctx context.Context, author, id string) error
+}
+
 // Handlers carries the dependencies the HTTP handlers need.
 type Handlers struct {
 	Store       AuthStore
@@ -124,6 +133,7 @@ type Handlers struct {
 	Sync      SyncStore
 	Push      PushStore
 	Invites   InviteStore
+	Posts     PostStore
 	Notifier  ws.Notifier // sends push tickles when a relayed message can't be delivered live
 	// Public, non-secret config advertised at GET /v1/config.
 	PublicURL      string
@@ -213,6 +223,11 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	mux.Handle("POST /v1/connections/reject", authMW(http.HandlerFunc(h.rejectConnection)))
 	mux.Handle("POST /v1/connections/withdraw", authMW(http.HandlerFunc(h.withdrawConnection)))
 	mux.Handle("POST /v1/connections/link", authMW(http.HandlerFunc(h.linkConnection)))
+
+	// Social Wall (spec 0003): posts are opaque ciphertext + per-recipient envelopes.
+	mux.Handle("POST /v1/posts", authMW(http.HandlerFunc(h.createPost)))
+	mux.Handle("GET /v1/posts", authMW(http.HandlerFunc(h.listPosts)))
+	mux.Handle("DELETE /v1/posts/{id}", authMW(http.HandlerFunc(h.deletePost)))
 
 	// Public in-network directory: discover any member, fetch one profile, update
 	// your own profile, and (legacy) claim a username. The literal /me/* patterns

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -117,6 +117,10 @@ type PostStore interface {
 	CreatePost(ctx context.Context, p store.NewPost) error
 	ListPosts(ctx context.Context, recipient string, sinceMs int64) ([]store.PostForRecipient, error)
 	DeletePost(ctx context.Context, author, id string) error
+	CanSeePost(ctx context.Context, postID, user string) (bool, error)
+	PostAudience(ctx context.Context, postID string) ([]string, error)
+	SubmitEngagement(ctx context.Context, postID, id, actor, kind, payload string) error
+	ListEngagement(ctx context.Context, postID string) ([]store.PostEngagementRow, error)
 }
 
 // Handlers carries the dependencies the HTTP handlers need.
@@ -228,6 +232,8 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	mux.Handle("POST /v1/posts", authMW(http.HandlerFunc(h.createPost)))
 	mux.Handle("GET /v1/posts", authMW(http.HandlerFunc(h.listPosts)))
 	mux.Handle("DELETE /v1/posts/{id}", authMW(http.HandlerFunc(h.deletePost)))
+	mux.Handle("POST /v1/posts/{id}/engagement", authMW(http.HandlerFunc(h.submitEngagement)))
+	mux.Handle("GET /v1/posts/{id}/engagement", authMW(http.HandlerFunc(h.listEngagement)))
 
 	// Public in-network directory: discover any member, fetch one profile, update
 	// your own profile, and (legacy) claim a username. The literal /me/* patterns

--- a/server/internal/db/migrations/0021_posts.sql
+++ b/server/internal/db/migrations/0021_posts.sql
@@ -1,0 +1,49 @@
+-- Social Wall (spec 0003): end-to-end-encrypted status posts shared to a chosen
+-- audience of friends. The server stores ONLY opaque ciphertext + per-recipient
+-- wrapped-key envelopes + coarse routing metadata — never post content, media keys,
+-- reaction/comment text, the close-friends tier, or who is in the "close" subset.
+-- A post is sealed under a per-post content key (K_post); that key is wrapped to each
+-- audience member and stored as one envelope row. The recipient set in
+-- post_envelopes is the audience the relay addresses (and reuses to fan engagement
+-- out); it does NOT reveal the tier (friends vs close) — the server sees a set either
+-- way.
+
+CREATE TABLE posts (
+    id         text PRIMARY KEY,                       -- client-generated uuid
+    author     uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    blob_id    text NOT NULL,                          -- opaque capability: K_post-sealed payload
+    size       int  NOT NULL DEFAULT 0,                -- coarse size (routing/quotas)
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz                             -- NULL = keep; coarse lifetime
+);
+CREATE INDEX posts_author_idx ON posts (author, created_at DESC);
+
+-- Per-recipient wrapped K_post. This is the post's audience; the relay delivers the
+-- post (and, later, engagement on it) to exactly this set.
+CREATE TABLE post_envelopes (
+    post_id     text NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    recipient   uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    wrapped_key text NOT NULL,                          -- opaque (b64url WrappedPostKey)
+    PRIMARY KEY (post_id, recipient)
+);
+CREATE INDEX post_envelopes_recipient_idx ON post_envelopes (recipient);
+
+-- Audience-visible engagement (reactions/comments) + tombstones, sealed under K_post.
+-- Fanned out to the post's post_envelopes set. Wired by US4/US6.
+CREATE TABLE post_engagement (
+    id         text PRIMARY KEY,                       -- client-generated uuid
+    post_id    text NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    actor      uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    kind       text NOT NULL,                          -- reaction | comment | tombstone
+    payload    text NOT NULL,                          -- opaque, sealed under K_post
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX post_engagement_post_idx ON post_engagement (post_id, created_at);
+
+-- Author-only "who viewed" receipts (seen-receipts-gated client-side). Wired by US7.
+CREATE TABLE post_views (
+    post_id   text NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    viewer    uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    viewed_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (post_id, viewer)
+);

--- a/server/internal/db/migrations/0022_post_ttl.sql
+++ b/server/internal/db/migrations/0022_post_ttl.sql
@@ -1,0 +1,6 @@
+-- Per-post lifetime window (spec 0003). The author picks how long a post stays after
+-- the LAST activity (1h / 24h / 72h). Keep-alive resets the expiry to now + this
+-- window on every reaction/comment, so the chosen value is respected (a 1h post never
+-- outlives 1h of silence) while active posts roll forward. Coarse timing metadata, the
+-- same privacy class as expires_at. Existing rows default to 72h.
+ALTER TABLE posts ADD COLUMN ttl_ms bigint NOT NULL DEFAULT 259200000; -- 72h

--- a/server/internal/db/migrations/0023_post_revocations.sql
+++ b/server/internal/db/migrations/0023_post_revocations.sql
@@ -1,0 +1,13 @@
+-- Per-recipient post revocations (spec 0003). When an author removes someone from
+-- their close friends, the author drops that person from each close-only post's
+-- audience (their envelope is deleted) and records a revocation here so the person's
+-- device removes its local copy on the next sync — even if they were offline when the
+-- live signal fired. Best-effort like any E2EE deletion (a copy already on-device is
+-- removed on signal; nothing is recoverable from the server regardless).
+CREATE TABLE post_revocations (
+    post_id    text NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    recipient  uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (post_id, recipient)
+);
+CREATE INDEX post_revocations_recipient_idx ON post_revocations (recipient, created_at);

--- a/server/internal/db/migrations/0024_app_meta.sql
+++ b/server/internal/db/migrations/0024_app_meta.sql
@@ -1,0 +1,10 @@
+-- Small server-side key/value table for the server's own (non-user, non-secret)
+-- operational metadata. First use: remember the last app version we announced to
+-- users, so a redeploy that changes the version fires a one-time "what's new" push
+-- broadcast while a plain restart (same version) does not (spec: version-announce push).
+-- This holds NO user data and NO secrets — only the app's own public version string.
+CREATE TABLE app_meta (
+    key        text PRIMARY KEY,
+    value      text NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -37,6 +37,13 @@ var (
 	// is closed and nudges a live page to pull + show the rich "X shared a photo"
 	// in-app banner. Same zero-knowledge class as msg/conn.
 	ticklePost = []byte(`{"t":"post"}`)
+	// tickleVersion wakes every device after a new app version is deployed. It carries
+	// NO payload: the SW fetches the PUBLIC, non-sensitive release info from
+	// GET /v1/config (version + user-friendly notes) and shows a "what's new"
+	// notification. Even though that info isn't secret, keeping the push payload
+	// content-free preserves the single, auditable invariant that the server NEVER puts
+	// content in a push — the same zero-knowledge class as every other tickle.
+	tickleVersion = []byte(`{"t":"version"}`)
 )
 
 const (
@@ -76,6 +83,17 @@ const (
 	postTTL   = 7 * 24 * 60 * 60 // 604800s
 	postTopic = "ring-post"
 
+	// versionTTL / versionTopic: a "new version" announcement is worth holding a few
+	// days so a device offline over a weekend still learns of it, but a weeks-stale
+	// announcement is noise (the SW reads the CURRENT version from /v1/config on wake).
+	// Collapsed per subscription so multiple deploys while offline yield ONE wake.
+	versionTTL   = 3 * 24 * 60 * 60 // 259200s
+	versionTopic = "ring-version"
+
+	// broadcastConcurrency bounds in-flight deliveries during an all-users broadcast,
+	// so a fan-out to the whole subscription base can't open thousands of sockets at once.
+	broadcastConcurrency = 16
+
 	// sendBudget bounds one subscription's whole delivery attempt (incl. retries),
 	// so one slow/hung endpoint can't starve a user's other devices.
 	sendBudget = 10 * time.Second
@@ -104,11 +122,17 @@ var (
 	postParams = func() pushParams {
 		return pushParams{payload: ticklePost, ttl: postTTL, urgency: webpush.UrgencyHigh, topic: postTopic}
 	}
+	versionParams = func() pushParams {
+		// Low urgency: an announcement should never preempt battery-saving like a
+		// message/call wake does.
+		return pushParams{payload: tickleVersion, ttl: versionTTL, urgency: webpush.UrgencyLow, topic: versionTopic}
+	}
 )
 
 // SubStore is the subscription persistence the notifier needs.
 type SubStore interface {
 	SubscriptionsFor(ctx context.Context, userID string) ([]store.PushSubscription, error)
+	AllSubscriptions(ctx context.Context) ([]store.PushSubscription, error)
 	DeleteSubscriptionByEndpoint(ctx context.Context, endpoint string) error
 }
 
@@ -188,6 +212,41 @@ func (n *Notifier) NotifyConn(ctx context.Context, userID string) {
 // + show the rich in-app banner. Carries no identity.
 func (n *Notifier) NotifyPost(ctx context.Context, userID string) {
 	n.notify(ctx, userID, postParams())
+}
+
+// BroadcastVersion sends a content-free version-announcement tickle to EVERY push
+// subscription (a new app version was deployed). The SW renders the user-friendly
+// "what's new" from the public /v1/config. Deliveries are bounded by
+// broadcastConcurrency; dead endpoints are pruned and failures logged. Safe to call in
+// a goroutine — a panic is recovered, so a bad broadcast can never crash the server.
+func (n *Notifier) BroadcastVersion(ctx context.Context) {
+	defer recoverLog("push: broadcast")
+	subs, err := n.store.AllSubscriptions(ctx)
+	if err != nil {
+		slog.Error("push: load all subscriptions for broadcast", "err", err)
+		return
+	}
+	if len(subs) == 0 {
+		return
+	}
+	slog.Info("push: broadcasting version announcement", "subscriptions", len(subs))
+	p := versionParams()
+	sem := make(chan struct{}, broadcastConcurrency)
+	var wg sync.WaitGroup
+	for _, sub := range subs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(sub store.PushSubscription) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer recoverLog("push: broadcast deliver")
+			sctx, cancel := context.WithTimeout(ctx, sendBudget)
+			defer cancel()
+			n.deliver(sctx, sub, p)
+		}(sub)
+	}
+	wg.Wait()
+	slog.Info("push: version broadcast complete", "subscriptions", len(subs))
 }
 
 func (n *Notifier) notify(ctx context.Context, userID string, p pushParams) {

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -32,6 +32,11 @@ var (
 	// service only learns "a connection event occurred for this endpoint", the same
 	// privacy class as msg/call).
 	tickleConn = []byte(`{"t":"conn"}`)
+	// ticklePost wakes a device for a new Wall post addressed to it (spec 0003). It
+	// carries NO content; the SW shows a generic "new post" notification when the app
+	// is closed and nudges a live page to pull + show the rich "X shared a photo"
+	// in-app banner. Same zero-knowledge class as msg/conn.
+	ticklePost = []byte(`{"t":"post"}`)
 )
 
 const (
@@ -66,6 +71,11 @@ const (
 	// never collapsed away by a message burst (and vice versa).
 	connTopic = "ring-conn"
 
+	// postTTL / postTopic: a Wall post wake is worth holding until the device next
+	// comes online (like a message), collapsed per subscription so a burst is one wake.
+	postTTL   = 7 * 24 * 60 * 60 // 604800s
+	postTopic = "ring-post"
+
 	// sendBudget bounds one subscription's whole delivery attempt (incl. retries),
 	// so one slow/hung endpoint can't starve a user's other devices.
 	sendBudget = 10 * time.Second
@@ -90,6 +100,9 @@ var (
 	}
 	connParams = func() pushParams {
 		return pushParams{payload: tickleConn, ttl: connTTL, urgency: webpush.UrgencyHigh, topic: connTopic}
+	}
+	postParams = func() pushParams {
+		return pushParams{payload: ticklePost, ttl: postTTL, urgency: webpush.UrgencyHigh, topic: postTopic}
 	}
 )
 
@@ -167,6 +180,14 @@ func (n *Notifier) NotifyCall(ctx context.Context, userID string) {
 // reconciles the actual state from GET /v1/connections. Carries no identity.
 func (n *Notifier) NotifyConn(ctx context.Context, userID string) {
 	n.notify(ctx, userID, connParams())
+}
+
+// NotifyPost pushes a content-free WALL-POST tickle (spec 0003): long-ish lived +
+// collapsible like a message, so an offline device still learns of it on wake; the SW
+// then shows a generic "new post" notification (closed) or nudges a live page to pull
+// + show the rich in-app banner. Carries no identity.
+func (n *Notifier) NotifyPost(ctx context.Context, userID string) {
+	n.notify(ctx, userID, postParams())
 }
 
 func (n *Notifier) notify(ctx context.Context, userID string, p pushParams) {

--- a/server/internal/push/push_test.go
+++ b/server/internal/push/push_test.go
@@ -30,6 +30,16 @@ func (m *memSubStore) SubscriptionsFor(_ context.Context, userID string) ([]stor
 	return append([]store.PushSubscription(nil), m.subs[userID]...), nil
 }
 
+func (m *memSubStore) AllSubscriptions(_ context.Context) ([]store.PushSubscription, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []store.PushSubscription
+	for _, subs := range m.subs {
+		out = append(out, subs...)
+	}
+	return out, nil
+}
+
 func (m *memSubStore) DeleteSubscriptionByEndpoint(_ context.Context, endpoint string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -261,6 +271,9 @@ type panicSubStore struct{}
 func (panicSubStore) SubscriptionsFor(context.Context, string) ([]store.PushSubscription, error) {
 	panic("boom: SubscriptionsFor")
 }
+func (panicSubStore) AllSubscriptions(context.Context) ([]store.PushSubscription, error) {
+	panic("boom: AllSubscriptions")
+}
 func (panicSubStore) DeleteSubscriptionByEndpoint(context.Context, string) error { return nil }
 
 // A panic in push delivery must never escape Notify - it runs in a bare goroutine
@@ -281,4 +294,66 @@ func TestNotifyRecoversPanicInFanout(t *testing.T) {
 	}}
 	n := NewNotifier(nil, st)
 	n.Notify(context.Background(), "u1") // returns only if the fan-out recover holds
+}
+
+// TestBroadcastVersionHeaders verifies the version-announcement push is a content-free
+// tickle that is low-urgency, a few days long, and collapsible under its own topic.
+func TestBroadcastVersionHeaders(t *testing.T) {
+	cap := &capturedReq{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.record(r)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	p256dh, auth := newSubKeys(t)
+	st := &memSubStore{subs: map[string][]store.PushSubscription{
+		"u1": {{Endpoint: srv.URL, P256dh: p256dh, Auth: auth}},
+	}}
+	n := newNotifier(t, st)
+
+	n.BroadcastVersion(context.Background())
+	if cap.ttl != "259200" {
+		t.Errorf("version TTL = %q, want 259200 (3d)", cap.ttl)
+	}
+	if cap.urgency != "low" {
+		t.Errorf("version Urgency = %q, want low", cap.urgency)
+	}
+	if cap.topic != "ring-version" {
+		t.Errorf("version Topic = %q, want ring-version", cap.topic)
+	}
+}
+
+// TestBroadcastVersionReachesEveryDevice verifies the broadcast fans out to EVERY
+// subscription across ALL users (not just one user's devices).
+func TestBroadcastVersionReachesEveryDevice(t *testing.T) {
+	cap := &capturedReq{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.record(r)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	mk := func() store.PushSubscription {
+		p256dh, auth := newSubKeys(t)
+		return store.PushSubscription{Endpoint: srv.URL, P256dh: p256dh, Auth: auth}
+	}
+	st := &memSubStore{subs: map[string][]store.PushSubscription{
+		"u1": {mk(), mk()}, // two devices
+		"u2": {mk()},
+		"u3": {mk()},
+	}}
+	n := newNotifier(t, st)
+
+	n.BroadcastVersion(context.Background())
+	if got := atomic.LoadInt32(&cap.hits); got != 4 {
+		t.Errorf("broadcast reached %d subscriptions, want 4 (all devices of all users)", got)
+	}
+}
+
+// TestBroadcastVersionRecoversPanic asserts a panic while loading subscriptions can't
+// escape the broadcast (it runs in a goroutine off boot).
+func TestBroadcastVersionRecoversPanic(t *testing.T) {
+	n := NewNotifier(nil, panicSubStore{})
+	n.BroadcastVersion(context.Background()) // AllSubscriptions panics; recover must contain it
 }

--- a/server/internal/store/connections.go
+++ b/server/internal/store/connections.go
@@ -57,15 +57,31 @@ func (s *Store) RequestConnection(ctx context.Context, requester, target string)
 	} else if connected {
 		return "accepted", nil
 	}
+	// FR-007 anti-harassment: a request that was REJECTED stays rejected during a
+	// cooldown, so a declined sender cannot re-open (and re-notify) by spamming new
+	// requests. After the cooldown a fresh request is allowed again. updated_at is NOT
+	// bumped while suppressed, so repeated attempts don't extend the window — it expires
+	// rejectCooldownSecs after the actual rejection. An accepted pair stays accepted.
 	var state string
 	err := s.pool.QueryRow(ctx,
 		`INSERT INTO connections (requester, target, state) VALUES ($1, $2, 'pending')
 		 ON CONFLICT (requester, target) DO UPDATE SET
-		     state = CASE WHEN connections.state = 'accepted' THEN 'accepted' ELSE 'pending' END,
-		     updated_at = now()
-		 RETURNING state`, requester, target).Scan(&state)
+		     state = CASE
+		         WHEN connections.state = 'accepted' THEN 'accepted'
+		         WHEN connections.state = 'rejected'
+		              AND connections.updated_at > now() - make_interval(secs => $3) THEN 'rejected'
+		         ELSE 'pending' END,
+		     updated_at = CASE
+		         WHEN connections.state = 'rejected'
+		              AND connections.updated_at > now() - make_interval(secs => $3) THEN connections.updated_at
+		         ELSE now() END
+		 RETURNING state`, requester, target, rejectCooldownSecs).Scan(&state)
 	return state, err
 }
+
+// rejectCooldownSecs is how long a declined request is suppressed before the same
+// sender may try again (FR-007). 24 hours.
+const rejectCooldownSecs = 24 * 60 * 60
 
 // AcceptConnection marks the request requester->target accepted (target accepts).
 func (s *Store) AcceptConnection(ctx context.Context, target, requester string) error {

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -25,6 +25,7 @@ type NewPost struct {
 	BlobID    string // opaque capability of the K_post-sealed payload
 	Size      int
 	ExpiresAt *time.Time // nil = keep
+	TtlMs     int64      // per-post lifetime window (keep-alive resets to now+ttl)
 	Envelopes []NewPostEnvelope
 }
 
@@ -37,6 +38,7 @@ type PostForRecipient struct {
 	Size       int
 	CreatedMs  int64
 	ExpiresMs  int64  // 0 = no expiry
+	TtlMs      int64  // per-post lifetime window
 	WrappedKey string // "" for own posts
 }
 
@@ -47,9 +49,13 @@ func (s *Store) CreatePost(ctx context.Context, p NewPost) error {
 		return err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+	ttl := p.TtlMs
+	if ttl <= 0 {
+		ttl = 72 * 60 * 60 * 1000
+	}
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO posts (id, author, blob_id, size, expires_at) VALUES ($1, $2, $3, $4, $5)`,
-		p.ID, p.Author, p.BlobID, p.Size, p.ExpiresAt); err != nil {
+		`INSERT INTO posts (id, author, blob_id, size, expires_at, ttl_ms) VALUES ($1, $2, $3, $4, $5, $6)`,
+		p.ID, p.Author, p.BlobID, p.Size, p.ExpiresAt, ttl); err != nil {
 		return err
 	}
 	for _, e := range p.Envelopes {
@@ -71,6 +77,7 @@ func (s *Store) ListPosts(ctx context.Context, recipient string, sinceMs int64) 
 		`SELECT p.id, p.author::text, p.blob_id, p.size,
 		        (extract(epoch from p.created_at)*1000)::bigint,
 		        COALESCE((extract(epoch from p.expires_at)*1000)::bigint, 0),
+		        p.ttl_ms,
 		        COALESCE(e.wrapped_key, '')
 		   FROM posts p
 		   LEFT JOIN post_envelopes e ON e.post_id = p.id AND e.recipient::text = $1
@@ -86,7 +93,7 @@ func (s *Store) ListPosts(ctx context.Context, recipient string, sinceMs int64) 
 	var out []PostForRecipient
 	for rows.Next() {
 		var p PostForRecipient
-		if err := rows.Scan(&p.ID, &p.Author, &p.BlobID, &p.Size, &p.CreatedMs, &p.ExpiresMs, &p.WrappedKey); err != nil {
+		if err := rows.Scan(&p.ID, &p.Author, &p.BlobID, &p.Size, &p.CreatedMs, &p.ExpiresMs, &p.TtlMs, &p.WrappedKey); err != nil {
 			return nil, err
 		}
 		out = append(out, p)
@@ -151,9 +158,10 @@ func (s *Store) SubmitEngagement(ctx context.Context, postID, id, actor, kind, p
 		id, postID, actor, kind, payload); err != nil {
 		return err
 	}
+	// Keep-alive: extend to now + the post's OWN window (never shorten).
 	if _, err := tx.Exec(ctx,
-		`UPDATE posts SET expires_at = now() + interval '72 hours'
-		  WHERE id = $1 AND (expires_at IS NULL OR expires_at < now() + interval '72 hours')`,
+		`UPDATE posts SET expires_at = GREATEST(expires_at, now() + (ttl_ms * interval '1 millisecond'))
+		  WHERE id = $1`,
 		postID); err != nil {
 		return err
 	}

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -1,0 +1,99 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// Social Wall persistence (spec 0003). The server holds only opaque ciphertext +
+// per-recipient wrapped-key envelopes + coarse routing metadata. This file covers
+// post create/list/delete (US2); engagement + views are added with US4/US7.
+
+// NewPostEnvelope is one recipient's wrapped K_post.
+type NewPostEnvelope struct {
+	Recipient  string
+	WrappedKey string // opaque
+}
+
+// NewPost is an authored post plus its per-recipient envelopes (its audience).
+type NewPost struct {
+	ID        string
+	Author    string
+	BlobID    string // opaque capability of the K_post-sealed payload
+	Size      int
+	ExpiresAt *time.Time // nil = keep
+	Envelopes []NewPostEnvelope
+}
+
+// PostForRecipient is a post as delivered to one caller: the caller's wrapped key is
+// included (empty for the caller's own posts, which they can already open).
+type PostForRecipient struct {
+	ID         string
+	Author     string
+	BlobID     string
+	Size       int
+	CreatedMs  int64
+	ExpiresMs  int64  // 0 = no expiry
+	WrappedKey string // "" for own posts
+}
+
+// CreatePost stores a post and its envelopes atomically.
+func (s *Store) CreatePost(ctx context.Context, p NewPost) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO posts (id, author, blob_id, size, expires_at) VALUES ($1, $2, $3, $4, $5)`,
+		p.ID, p.Author, p.BlobID, p.Size, p.ExpiresAt); err != nil {
+		return err
+	}
+	for _, e := range p.Envelopes {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO post_envelopes (post_id, recipient, wrapped_key) VALUES ($1, $2, $3)
+			 ON CONFLICT (post_id, recipient) DO NOTHING`,
+			p.ID, e.Recipient, e.WrappedKey); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// ListPosts returns posts the caller can see — their own plus those addressed to
+// them — created after sinceMs, newest first, excluding expired ones (lazy prune).
+// The caller's envelope (wrapped K_post) rides along for received posts.
+func (s *Store) ListPosts(ctx context.Context, recipient string, sinceMs int64) ([]PostForRecipient, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT p.id, p.author::text, p.blob_id, p.size,
+		        (extract(epoch from p.created_at)*1000)::bigint,
+		        COALESCE((extract(epoch from p.expires_at)*1000)::bigint, 0),
+		        COALESCE(e.wrapped_key, '')
+		   FROM posts p
+		   LEFT JOIN post_envelopes e ON e.post_id = p.id AND e.recipient::text = $1
+		  WHERE (p.author::text = $1 OR e.recipient::text = $1)
+		    AND (extract(epoch from p.created_at)*1000)::bigint > $2
+		    AND (p.expires_at IS NULL OR p.expires_at > now())
+		  ORDER BY p.created_at DESC
+		  LIMIT 200`, recipient, sinceMs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PostForRecipient
+	for rows.Next() {
+		var p PostForRecipient
+		if err := rows.Scan(&p.ID, &p.Author, &p.BlobID, &p.Size, &p.CreatedMs, &p.ExpiresMs, &p.WrappedKey); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// DeletePost removes a post (and, via cascade, its envelopes/engagement/views). The
+// author-only guard is the `author` predicate, so a non-author delete is a no-op.
+func (s *Store) DeletePost(ctx context.Context, author, id string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM posts WHERE id = $1 AND author::text = $2`, id, author)
+	return err
+}

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -137,12 +137,27 @@ func (s *Store) PostAudience(ctx context.Context, postID string) ([]string, erro
 
 // SubmitEngagement records one opaque engagement item (reaction/comment/tombstone) on a
 // post. The payload is sealed under K_post; the server stores it without reading it.
+// Keep-alive (rolling 72h of inactivity): any engagement extends the post's expiry to
+// now+72h, so an actively-engaged post stays alive (mirrors the client bump).
 func (s *Store) SubmitEngagement(ctx context.Context, postID, id, actor, kind, payload string) error {
-	_, err := s.pool.Exec(ctx,
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx,
 		`INSERT INTO post_engagement (id, post_id, actor, kind, payload) VALUES ($1, $2, $3, $4, $5)
 		 ON CONFLICT (id) DO NOTHING`,
-		id, postID, actor, kind, payload)
-	return err
+		id, postID, actor, kind, payload); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE posts SET expires_at = now() + interval '72 hours'
+		  WHERE id = $1 AND (expires_at IS NULL OR expires_at < now() + interval '72 hours')`,
+		postID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 // PostEngagementRow is one opaque engagement item delivered to an audience member.

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -108,6 +108,57 @@ func (s *Store) DeletePost(ctx context.Context, author, id string) error {
 	return err
 }
 
+// RemovePostRecipient drops `recipient` from a post's audience (author-only): it
+// deletes their wrapped-key envelope (so they can't re-fetch the key) and records a
+// revocation so their device removes the local copy on next sync. Returns true if the
+// caller authored the post (the operation applied).
+func (s *Store) RemovePostRecipient(ctx context.Context, postID, author, recipient string) (bool, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var owns bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM posts WHERE id = $1 AND author::text = $2)`, postID, author).Scan(&owns); err != nil {
+		return false, err
+	}
+	if !owns {
+		return false, nil
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM post_envelopes WHERE post_id = $1 AND recipient::text = $2`, postID, recipient); err != nil {
+		return false, err
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO post_revocations (post_id, recipient) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+		postID, recipient); err != nil {
+		return false, err
+	}
+	return true, tx.Commit(ctx)
+}
+
+// ListRevocations returns post ids recently revoked for `recipient` (bounded window),
+// so their client can delete those local copies. Idempotent for the client.
+func (s *Store) ListRevocations(ctx context.Context, recipient string) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT post_id FROM post_revocations
+		  WHERE recipient::text = $1 AND created_at > now() - interval '30 days'`, recipient)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
 /* ---- engagement (reactions/comments) — US4 ---- */
 
 // CanSeePost reports whether `user` is in a post's audience (has an envelope) or is its

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -2,7 +2,10 @@ package store
 
 import (
 	"context"
+	"errors"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // Social Wall persistence (spec 0003). The server holds only opaque ciphertext +
@@ -149,6 +152,69 @@ type PostEngagementRow struct {
 	Kind      string
 	Payload   string
 	CreatedMs int64
+}
+
+// PostAuthor returns a post's author id (or "" if the post is gone).
+func (s *Store) PostAuthor(ctx context.Context, postID string) (string, error) {
+	var author string
+	err := s.pool.QueryRow(ctx, `SELECT author::text FROM posts WHERE id = $1`, postID).Scan(&author)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return author, nil
+}
+
+// EngagementActor returns who authored a given engagement item on a post (or "" if not
+// found) — used to authorize a tombstone (a commenter may delete their own comment).
+func (s *Store) EngagementActor(ctx context.Context, postID, engID string) (string, error) {
+	var actor string
+	err := s.pool.QueryRow(ctx,
+		`SELECT actor::text FROM post_engagement WHERE id = $1 AND post_id = $2`, engID, postID).Scan(&actor)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return actor, nil
+}
+
+// RecordView records that `viewer` saw a post (idempotent), delivered to the author
+// only. Gated client-side by the viewer's seen-receipts setting.
+func (s *Store) RecordView(ctx context.Context, postID, viewer string) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO post_views (post_id, viewer) VALUES ($1, $2) ON CONFLICT (post_id, viewer) DO NOTHING`,
+		postID, viewer)
+	return err
+}
+
+// PostView is one viewer of a post (author-only).
+type PostView struct {
+	Viewer   string
+	ViewedMs int64
+}
+
+// ListViews returns a post's viewers (the handler restricts this to the post author).
+func (s *Store) ListViews(ctx context.Context, postID string) ([]PostView, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT viewer::text, (extract(epoch from viewed_at)*1000)::bigint
+		   FROM post_views WHERE post_id = $1 ORDER BY viewed_at DESC`, postID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PostView
+	for rows.Next() {
+		var v PostView
+		if err := rows.Scan(&v.Viewer, &v.ViewedMs); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
 }
 
 // ListEngagement returns all engagement on a post, oldest-first (the caller must

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -159,6 +159,42 @@ func (s *Store) ListRevocations(ctx context.Context, recipient string) ([]string
 	return out, rows.Err()
 }
 
+/* ---- FR-008 anti-flood counts (routing metadata only, never content) ---- */
+
+// RecentPostCount returns how many posts `author` created within the last withinSec
+// seconds — the input to the per-author post-rate limit.
+func (s *Store) RecentPostCount(ctx context.Context, author string, withinSec int) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM posts
+		  WHERE author::text = $1 AND created_at > now() - make_interval(secs => $2)`,
+		author, withinSec).Scan(&n)
+	return n, err
+}
+
+// RecentEngagementCount returns how many engagement items `actor` submitted (any post)
+// within the last withinSec seconds — the input to the per-user engagement-rate limit.
+func (s *Store) RecentEngagementCount(ctx context.Context, actor string, withinSec int) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM post_engagement
+		  WHERE actor::text = $1 AND created_at > now() - make_interval(secs => $2)`,
+		actor, withinSec).Scan(&n)
+	return n, err
+}
+
+// RecentCommentCount returns how many comments `actor` added to ONE post within the
+// last withinSec seconds — the input to the per-post comment-rate limit.
+func (s *Store) RecentCommentCount(ctx context.Context, postID, actor string, withinSec int) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM post_engagement
+		  WHERE post_id = $1 AND actor::text = $2 AND kind = 'comment'
+		    AND created_at > now() - make_interval(secs => $3)`,
+		postID, actor, withinSec).Scan(&n)
+	return n, err
+}
+
 /* ---- engagement (reactions/comments) — US4 ---- */
 
 // CanSeePost reports whether `user` is in a post's audience (has an envelope) or is its

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -97,3 +97,77 @@ func (s *Store) DeletePost(ctx context.Context, author, id string) error {
 	_, err := s.pool.Exec(ctx, `DELETE FROM posts WHERE id = $1 AND author::text = $2`, id, author)
 	return err
 }
+
+/* ---- engagement (reactions/comments) — US4 ---- */
+
+// CanSeePost reports whether `user` is in a post's audience (has an envelope) or is its
+// author — the gate for both submitting and reading engagement.
+func (s *Store) CanSeePost(ctx context.Context, postID, user string) (bool, error) {
+	var ok bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM posts WHERE id = $1 AND author::text = $2)
+		     OR EXISTS (SELECT 1 FROM post_envelopes WHERE post_id = $1 AND recipient::text = $2)`,
+		postID, user).Scan(&ok)
+	return ok, err
+}
+
+// PostAudience returns the post's recipient set plus its author (used to nudge everyone
+// who can see a post when engagement arrives).
+func (s *Store) PostAudience(ctx context.Context, postID string) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT recipient::text FROM post_envelopes WHERE post_id = $1
+		 UNION SELECT author::text FROM posts WHERE id = $1`, postID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var u string
+		if err := rows.Scan(&u); err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+// SubmitEngagement records one opaque engagement item (reaction/comment/tombstone) on a
+// post. The payload is sealed under K_post; the server stores it without reading it.
+func (s *Store) SubmitEngagement(ctx context.Context, postID, id, actor, kind, payload string) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO post_engagement (id, post_id, actor, kind, payload) VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (id) DO NOTHING`,
+		id, postID, actor, kind, payload)
+	return err
+}
+
+// PostEngagementRow is one opaque engagement item delivered to an audience member.
+type PostEngagementRow struct {
+	ID        string
+	Actor     string
+	Kind      string
+	Payload   string
+	CreatedMs int64
+}
+
+// ListEngagement returns all engagement on a post, oldest-first (the caller must
+// already be authorized via CanSeePost).
+func (s *Store) ListEngagement(ctx context.Context, postID string) ([]PostEngagementRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, actor::text, kind, payload, (extract(epoch from created_at)*1000)::bigint
+		   FROM post_engagement WHERE post_id = $1 ORDER BY created_at ASC`, postID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PostEngagementRow
+	for rows.Next() {
+		var e PostEngagementRow
+		if err := rows.Scan(&e.ID, &e.Actor, &e.Kind, &e.Payload, &e.CreatedMs); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/server/internal/store/push.go
+++ b/server/internal/store/push.go
@@ -1,6 +1,11 @@
 package store
 
-import "context"
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+)
 
 // PushSubscription is a browser Web Push subscription.
 type PushSubscription struct {
@@ -36,8 +41,18 @@ func (s *Store) DeleteSubscriptionByEndpoint(ctx context.Context, endpoint strin
 
 // SubscriptionsFor returns all of a user's push subscriptions.
 func (s *Store) SubscriptionsFor(ctx context.Context, userID string) ([]PushSubscription, error) {
-	rows, err := s.pool.Query(ctx,
+	return s.querySubscriptions(ctx,
 		`SELECT endpoint, p256dh, auth FROM push_subscriptions WHERE user_id = $1`, userID)
+}
+
+// AllSubscriptions returns every push subscription across all users — used for the
+// version-announcement broadcast (the only fan-out that isn't addressed to one user).
+func (s *Store) AllSubscriptions(ctx context.Context) ([]PushSubscription, error) {
+	return s.querySubscriptions(ctx, `SELECT endpoint, p256dh, auth FROM push_subscriptions`)
+}
+
+func (s *Store) querySubscriptions(ctx context.Context, q string, args ...any) ([]PushSubscription, error) {
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -51,4 +66,26 @@ func (s *Store) SubscriptionsFor(ctx context.Context, userID string) ([]PushSubs
 		out = append(out, sub)
 	}
 	return out, rows.Err()
+}
+
+// GetAppMeta reads a server-side metadata value (empty string if the key is absent).
+func (s *Store) GetAppMeta(ctx context.Context, key string) (string, error) {
+	var v string
+	err := s.pool.QueryRow(ctx, `SELECT value FROM app_meta WHERE key = $1`, key).Scan(&v)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return v, nil
+}
+
+// SetAppMeta upserts a server-side metadata value.
+func (s *Store) SetAppMeta(ctx context.Context, key, value string) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO app_meta (key, value) VALUES ($1, $2)
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
+		key, value)
+	return err
 }

--- a/server/internal/ws/hub.go
+++ b/server/internal/ws/hub.go
@@ -99,6 +99,7 @@ type Notifier interface {
 	Notify(ctx context.Context, userID string)
 	NotifyCall(ctx context.Context, userID string)
 	NotifyConn(ctx context.Context, userID string)
+	NotifyPost(ctx context.Context, userID string)
 }
 
 // frame is the wire shape. The relay only reads t/id/to/from/refId/messageId;

--- a/server/internal/ws/relay_test.go
+++ b/server/internal/ws/relay_test.go
@@ -418,6 +418,7 @@ type fakeNotifier struct{ ch chan string }
 func (f *fakeNotifier) Notify(_ context.Context, userID string)     { f.ch <- userID }
 func (f *fakeNotifier) NotifyCall(_ context.Context, userID string) { f.ch <- userID }
 func (f *fakeNotifier) NotifyConn(_ context.Context, userID string) { f.ch <- userID }
+func (f *fakeNotifier) NotifyPost(_ context.Context, userID string) { f.ch <- userID }
 
 func TestRelayPushesWhenRecipientOffline(t *testing.T) {
 	relay := newMemRelay()

--- a/specs/0003-zero-knowledge-social/checklists/crypto-zk.md
+++ b/specs/0003-zero-knowledge-social/checklists/crypto-zk.md
@@ -1,0 +1,71 @@
+# Crypto / Zero-Knowledge Checklist: Zero-Knowledge Social Wall
+
+**Purpose**: Validate that the spec/plan's cryptography and zero-knowledge requirements are complete,
+clear, consistent, and adversarially scoped — BEFORE implementation. Required by constitution
+Principle I (Zero-Knowledge) and Principle IV (Crypto Discipline). This tests the **requirements**, not
+the code; each item asks whether something is adequately *specified*.
+**Created**: 2026-06-21
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [research.md](../research.md) · [data-model.md](../data-model.md)
+
+## Server-Plaintext Exclusion (Principle I)
+
+- [ ] CHK001 Are the exact data classes that MUST remain unreadable by the server enumerated (post body, media, media keys, reaction emoji, comment text, view list, close-friends membership)? [Completeness, Spec §Zero-Knowledge Impact]
+- [ ] CHK002 Is it specified that every new server column/field holding user content is opaque ciphertext or a capability id (no plaintext columns)? [Clarity, Data-model §Server, Spec §FR-014]
+- [x] CHK003 Are requirements stated that no log line, metric, error payload, or migration may expose post/engagement plaintext to the server? [Resolved, Spec §NFR-ZK-3]
+- [ ] CHK004 Is the post-payload encryption requirement unambiguous about WHAT is sealed (type, text, AND the media-ref/file key inside the sealed payload)? [Clarity, Research §R3/§R4]
+- [ ] CHK005 Is it specified that the per-file media key never appears outside the K_post-sealed payload? [Completeness, Research §R4]
+
+## New-Crypto Correctness & Adversarial Robustness (Principle IV)
+
+- [ ] CHK006 Is the per-post content key (K_post) generation requirement specified (fresh, random, per post)? [Completeness, Research §R3]
+- [ ] CHK007 Is the per-recipient K_post wrapping requirement specified as reuse of the existing Double Ratchet session (not a new scheme)? [Clarity, Research §R3, Constitution IV]
+- [ ] CHK008 Are adversarial cases REQUIRED as acceptance criteria for the new crypto: forgery (non-member key), replay, out-of-order delivery, and skipped-key? [Coverage, Spec §NFR-ZK-2, Constitution IV]
+- [ ] CHK009 Is the "only audience members can produce valid engagement ciphertext" property stated as a requirement (engagement sealed under K_post which non-members lack)? [Clarity, Spec §FR-035, Research §R5]
+- [ ] CHK010 Are reaction conflict-resolution (last-write-wins per actor) and reaction caps specified as requirements, reusing existing semantics? [Consistency, Spec §FR-032, Research §R5]
+- [ ] CHK011 Is comment ordering defined deterministically (timestamp + tiebreak) so independent devices converge? [Clarity, Data-model §PostEngagement]
+- [ ] CHK012 Is it required that the new crypto lives in pure, IndexedDB-free helpers (`crypto/post.ts`) with `posts.ts` crypto-only and the `queries.ts → posts.ts` dependency one-directional (no cycle)? [Consistency, Plan §Structure, Constitution IV]
+
+## Audience-Membership Privacy
+
+- [ ] CHK013 Is it required that the server CANNOT distinguish the "all friends" vs "close friends" tier (it sees only a recipient set)? [Clarity, Data-model §ZK invariant 2, Spec §Zero-Knowledge Impact]
+- [ ] CHK014 Is the requirement that an engager never learns the audience roster stated and measurable (SC-010)? [Measurability, Spec §SC-010, §FR-035]
+- [ ] CHK015 Is it specified that the close-friend flag never crosses the client/server boundary (client-only, rides encrypted own-sync)? [Completeness, Spec §FR-041, Research §R2]
+- [ ] CHK016 Is "audience frozen at post time" specified, including the consequence that later friend/close-friend changes affect only future posts? [Consistency, Spec §Edge Cases, Data-model §lifecycle]
+- [ ] CHK017 Is the residual disclosure to the audience (co-engagers become visible; author sees viewers) explicitly bounded and distinguished from server disclosure? [Clarity, Spec §Zero-Knowledge Impact]
+
+## Authorization & Access Control
+
+- [ ] CHK018 Is it required that only members of a post's audience (or the author) may submit engagement, with the server enforcing membership? [Coverage, Spec §FR-035, Contracts §engagement]
+- [ ] CHK019 Are blocked-user interactions specified across all new paths (no post delivery, no engagement, request suppression)? [Coverage, Spec §FR-036/§FR-005]
+- [ ] CHK020 Is the author-only constraint on the view list specified (non-authors cannot read who viewed)? [Clarity, Spec §FR-037, Contracts §views]
+- [ ] CHK021 Is author-only post deletion specified, including best-effort tombstone propagation and the no-clawback limitation? [Completeness, Spec §FR-015, §Edge Cases]
+- [ ] CHK022 Is the seen-receipts reciprocity for view receipts specified precisely (receipts-off viewer is never listed AND receives no view lists)? [Clarity, Spec §FR-038, Research §R6]
+
+## Metadata Minimization (Principle IX)
+
+- [ ] CHK023 Is the metadata the server unavoidably learns enumerated and justified as the minimum to relay (author, recipient set, coarse size/expiry, that engagement occurred)? [Completeness, Spec §Zero-Knowledge Impact]
+- [ ] CHK024 Is it required that new WS frames (`post-new`, `post-engagement`) are content-free nudges that only trigger a sync (no identity/content payload)? [Clarity, Contracts §WS, Constitution I]
+- [ ] CHK025 Is coarse expiry (not exact-to-the-second timing) the specified granularity for server-side post lifetime? [Clarity, Data-model §posts, Spec §FR-012]
+- [x] CHK026 Are quotas/abuse limits specified without introducing identity-revealing telemetry? [Resolved, Spec §FR-008, §NFR-ZK-3]
+
+## Reuse, Consistency & Testability (Principles III, IV, VI)
+
+- [ ] CHK027 Is it explicitly required that NO new cryptographic primitive or key-exchange/ratchet scheme is introduced (reuse libsodium core + existing patterns only)? [Consistency, Constitution IV, Research §R3]
+- [ ] CHK028 Is the requirement to add unit tests for the new crypto (seal/open round-trip + the adversarial set) stated, with TDD ordering (red→green)? [Coverage, Constitution III, Spec §NFR-ZK-2]
+- [ ] CHK029 Are server-handler authorization tests (audience/block/author-only) required against the in-memory fake store (no DB)? [Coverage, Constitution VI, Contracts]
+- [ ] CHK030 Is the forward-only migration requirement stated (new `0021_posts.sql`, no edits to shipped migrations) with no `SECRETS_KEY` impact? [Consistency, Constitution VI, Plan §Structure]
+- [ ] CHK031 Is the IndexedDB change (DB_VERSION bump + forward `onupgradeneeded` preserving data) specified for the new stores and the `closeFriend` field? [Completeness, Constitution V, Data-model §Client]
+
+## Ambiguities & Conflicts to Resolve Before Implementation
+
+- [ ] CHK032 Is there any conflict between "engager never learns roster" (SC-010) and any requirement that would require the client to address the audience directly? [Conflict, Spec §SC-010 vs §FR-013]
+- [ ] CHK033 Is the meaning of "friend" defined consistently as an accepted connection (reusing `connections`), avoiding a second competing relationship model? [Consistency, Research §R1]
+- [ ] CHK034 Is the security-review requirement (Principle IV) explicitly called out as a gate before `/speckit-implement`? [Traceability, Constitution IV, Spec §NFR-ZK-2]
+- [ ] CHK035 Are the post-engagement tombstone semantics (who may delete what, and that delivered copies cannot be cryptographically recalled) unambiguous? [Ambiguity, Spec §FR-034, §Edge Cases]
+
+## Notes
+
+- Items are requirement-quality questions ("is X specified?"), not implementation tests. Resolve any
+  unchecked item by amending spec/plan/research before `/speckit-tasks` → `/speckit-implement`.
+- This checklist, plus a maintainer security review of the eventual crypto diff, satisfies the
+  constitution's Principle I & IV gate for this spec.

--- a/specs/0003-zero-knowledge-social/checklists/requirements.md
+++ b/specs/0003-zero-knowledge-social/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: Zero-Knowledge Social Wall
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Ring-specific
+
+- [x] Zero-Knowledge Impact section present and answers what crosses the boundary and what metadata leaks (constitution Principle I)
+- [x] Crypto/zero-knowledge checklist flagged as required (constitution Principle IV) — to be produced via /speckit-checklist
+
+## Notes
+
+- All three open questions were resolved in the 2026-06-21 clarify session (see spec.md
+  "Clarifications"): reactions are audience-visible, audience-visible comment threads are in scope,
+  and the author sees a per-post view list (seen-receipts-gated). The spec was updated accordingly
+  (US4/US6/US7, FR-031/FR-033–FR-038, ZK Impact, Success Criteria) and no markers remain.
+- Spec is ready for `/speckit-plan`. A crypto/zero-knowledge checklist (`/speckit-checklist`) is
+  still required before implementation per constitution Principle IV — note the expanded engagement
+  surface (author-relay re-broadcast of reactions/comments) that the checklist must cover.

--- a/specs/0003-zero-knowledge-social/contracts/http-api.md
+++ b/specs/0003-zero-knowledge-social/contracts/http-api.md
@@ -1,0 +1,104 @@
+# Phase 1 Contracts: HTTP / WS API
+
+New endpoints for posts + engagement. All bodies carry **ciphertext or capability ids only** (no
+plaintext). Auth is the existing bearer token on `/v1/*`; the WS authenticates via `?token=`.
+Friendship reuses the **existing** `/v1/connections/*` endpoints unchanged (see research R1).
+
+Conventions: stdlib `net/http` method+pattern routes; handlers depend on a new small `PostStore`
+interface defined in `router.go` and satisfied by `*store.Store`; unit-tested against the fake store.
+
+## Posts
+
+### `POST /v1/posts`
+Create a post. Server stores the opaque payload reference + per-recipient envelopes and addresses
+delivery to the recipients.
+
+Request:
+```json
+{
+  "id": "uuid",
+  "blobId": "cap-id-of-Kpost-sealed-payload",
+  "size": 12345,
+  "expiresAt": 1750000000000,        // optional; omit = keep
+  "envelopes": [
+    { "recipient": "userId", "wrappedKey": "b64url" }
+  ]
+}
+```
+Response: `201 Created` `{ "id": "uuid" }`.
+Server MUST: verify each `recipient` is an accepted connection of the author and not blocked; reject
+otherwise. Server MUST NOT learn the audience tier (it only sees a recipient set).
+
+### `GET /v1/posts?since=<cursor>`
+Pull posts addressed to the caller (envelopes where `recipient = me`) plus the caller's own posts,
+newest-first, with a cursor.
+
+Response:
+```json
+{
+  "posts": [
+    { "id": "uuid", "author": "userId", "blobId": "cap", "size": 123,
+      "createdAt": 1750000000000, "expiresAt": 1750086400000,
+      "wrappedKey": "b64url" }                 // the caller's envelope (omitted for own posts)
+  ],
+  "cursor": "opaque"
+}
+```
+
+### `DELETE /v1/posts/{id}`
+Author deletes their post. Server removes the post, its envelopes, and engagement, and signals
+recipients (best-effort tombstone). Only the author may delete.
+
+## Engagement (reactions / comments / tombstones)
+
+### `POST /v1/posts/{id}/engagement`
+Submit one engagement item; the server fans it out to the post's stored audience.
+
+Request:
+```json
+{
+  "id": "uuid",
+  "kind": "reaction | comment | tombstone",
+  "payload": "b64url-Kpost-sealed"   // emoji / comment text / delete-target, sealed under K_post
+}
+```
+Response: `201 Created`.
+Server MUST: verify the submitter ∈ (post audience ∪ author) and not blocked; deliver the opaque
+`payload` to every `post_envelopes.recipient` of `{id}` (plus the author). Server MUST NOT read
+`payload`. Reaction caps + LWW-per-actor are enforced **client-side** (the server only relays).
+
+### `GET /v1/posts/{id}/engagement?since=<cursor>`
+Pull engagement for a post the caller is in the audience of (or authored). Returns opaque items the
+client decrypts under `K_post`.
+
+## Views (author-only receipts)
+
+### `POST /v1/posts/{id}/view`
+Record that the caller viewed the post (delivered to the author only). Caller sends this **only if**
+their `privacy.seenReceipts` is on (client-gated). Idempotent per (post, viewer).
+Response: `204 No Content`.
+
+### `GET /v1/posts/{id}/views`
+Author-only: list viewers of the author's own post. `403` if caller is not the author.
+```json
+{ "views": [ { "viewer": "userId", "viewedAt": 1750000000000 } ] }
+```
+
+## WS frames (live nudges; reconcile via GET)
+
+Reuse the existing content-free tickle pattern (`connect-req`/`connect-update`). Add:
+- `post-new` `{ "t": "post-new", "from": "authorId" }` — a post addressed to you arrived; client pulls
+  `GET /v1/posts`.
+- `post-engagement` `{ "t": "post-engagement", "post": "postId" }` — engagement on a post you can see;
+  client pulls `GET /v1/posts/{id}/engagement`.
+
+Frames carry **no content** — only a nudge to sync, consistent with Principle I and the existing
+connection/notification model.
+
+## Zero-knowledge contract checks (for tests)
+
+- No endpoint accepts or returns post/comment/reaction **plaintext** or media keys outside a sealed
+  `blobId`/`payload`.
+- `POST /v1/posts` envelopes reveal a recipient set but **not** the tier (friends vs close).
+- `POST /v1/posts/{id}/engagement` is rejected for non-audience submitters and blocked users.
+- `GET /v1/posts/{id}/views` is author-only.

--- a/specs/0003-zero-knowledge-social/data-model.md
+++ b/specs/0003-zero-knowledge-social/data-model.md
@@ -1,0 +1,111 @@
+# Phase 1 Data Model: Zero-Knowledge Social Wall
+
+Entities for the client (IndexedDB, source of truth) and server (Postgres, opaque ciphertext only).
+All user content is encrypted client-side; server columns marked **opaque** hold ciphertext or
+capability ids.
+
+## Client (IndexedDB) — `src/db/idb.ts` `DB_VERSION` 8 → 9
+
+### Contact (EDIT existing `contacts` store)
+Add one author-private field; rides existing own-data sync (LWW on `updatedAt`).
+
+| Field | Type | Notes |
+|---|---|---|
+| `closeFriend` | `boolean` (default false) | Curated close-friends membership. Client-only; never sent to server. Distinct from `Chat.favorite`. |
+
+"Friends" are not a new field: a friend = an **accepted connection** (`connectedPeers` ledger /
+`Connected()`); add a `listFriends()` query helper that returns contacts whose peer is connected.
+
+### Post (NEW store `posts`, keyPath `id`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string (uuid) | Stable post id. |
+| `author` | string (userId) | Self for own posts; peer for received. |
+| `kind` | `'text' \| 'voice' \| 'video' \| 'image'` | Post media type. |
+| `body` | string? | Decrypted text/caption (plaintext in IDB; encrypted at rest by the keystore as today). |
+| `mediaId` | string? | Local media record id (reuses existing `media` store) for voice/video/image. |
+| `audience` | `'friends' \| 'close'` | Author's chosen tier (own posts). Display-only for received posts. |
+| `expiresAt` | number? | Epoch ms; absent = "keep". Drives the sweep. |
+| `createdAt` | number | Author timestamp; feed ordering. |
+| `outgoing` | boolean | True for self-authored. |
+| `updatedAt` | number | For reactive bus / dedup. |
+
+### PostEngagement (NEW store `postEngagement`, keyPath `id`)
+Reactions, comments, and view receipts, all keyed by `postId`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | `${postId}:${type}:${actor}` for reaction/view (LWW per actor); uuid for comment. |
+| `postId` | string | The post engaged with. |
+| `type` | `'reaction' \| 'comment' \| 'view'` | Engagement kind. |
+| `actor` | string (userId) | Who reacted/commented/viewed (profile resolved from contacts/directory). |
+| `emoji` | string? | For reactions. |
+| `text` | string? | For comments (decrypted). |
+| `at` | number | Actor timestamp; LWW per actor for reactions; ordering for comments. |
+| `deleted` | boolean? | Tombstone (own comment deleted, author-moderated, or post deleted). |
+| `updatedAt` | number | Reactive bus. |
+
+Caps: reactions reuse existing per-item reaction caps + LWW-per-actor. Views are author-only
+(present only in the author's store).
+
+## Server (Postgres) — migration `0021_posts.sql` (all content **opaque**)
+
+### `posts`
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `author` | uuid | FK users; the only identity the server needs. |
+| `blob_id` | text | **opaque** — capability id of the `K_post`-sealed post payload. |
+| `size` | int | Coarse size (routing/quotas). |
+| `created_at` | timestamptz | |
+| `expires_at` | timestamptz NULL | Coarse expiry; NULL = keep. Pruned when past. |
+
+### `post_envelopes`
+| Column | Type | Notes |
+|---|---|---|
+| `post_id` | uuid | FK posts (cascade). |
+| `recipient` | uuid | Audience member. **This is the audience the server addresses + reuses to fan out engagement.** |
+| `wrapped_key` | bytea | **opaque** — `K_post` wrapped to the recipient's session. |
+| PK | `(post_id, recipient)` | |
+| index | `(recipient)` | Fast "posts addressed to me" pull. |
+
+### `post_engagement`
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `post_id` | uuid | FK posts. |
+| `actor` | uuid | Submitter; server verifies actor ∈ post_envelopes.recipient ∪ {author} and not blocked. |
+| `kind` | text | `'reaction' \| 'comment' \| 'tombstone'`. |
+| `payload` | bytea | **opaque** — sealed under `K_post` (emoji/comment-text/target). |
+| `created_at` | timestamptz | |
+| index | `(post_id)` | Fan-out + fetch by post. |
+
+Delivery: a new engagement row is fanned out to `post_envelopes.recipient` for `post_id` (same set as
+the post). The server never reads `payload`.
+
+### `post_views`
+| Column | Type | Notes |
+|---|---|---|
+| `post_id` | uuid | FK posts. |
+| `viewer` | uuid | Author-only view receipt; delivered to the post's author only. |
+| `viewed_at` | timestamptz | |
+| PK | `(post_id, viewer)` | One per viewer (gated by viewer's seen-receipts setting client-side). |
+
+## State & lifecycle
+
+- **Friendship**: `none → pending(out/in) → accepted` (existing connections) ; `accepted →` ended by
+  block/withdraw. Audience "friends" = accepted set at post time.
+- **Post**: `draft(local) → queued(offline) → published(envelopes delivered) → expired/deleted`
+  (swept locally + pruned server-side). Audience frozen at publish.
+- **Engagement**: `submitted → fanned-out → (optionally) tombstoned`. Reactions LWW per actor; comments
+  appended + deletable by commenter or post author.
+- **View**: recorded once per viewer when a post is opened, iff the viewer has seen-receipts on.
+
+## Zero-knowledge invariants (assert in tests)
+
+1. No `posts`/`post_engagement` row exposes plaintext content or media keys (all `bytea`/blob ids).
+2. `post_envelopes.recipient` is the *only* place audience membership lives server-side; **close-friend
+   vs all-friend tier is indistinguishable** to the server (it sees a recipient set either way).
+3. `closeFriend` never appears in any request body or server table.
+4. View lists exist only for the author; a seen-receipts-off viewer produces no `post_views` row.

--- a/specs/0003-zero-knowledge-social/plan.md
+++ b/specs/0003-zero-knowledge-social/plan.md
@@ -1,0 +1,172 @@
+# Implementation Plan: Zero-Knowledge Social Wall
+
+**Branch**: `feat/0003-zero-knowledge-social` | **Date**: 2026-06-21 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/0003-zero-knowledge-social/spec.md`
+
+## Summary
+
+Add a **Wall**: end-to-end-encrypted status posts (text / voice / video / image) shared to a chosen
+audience of **all friends** or an author-private **close-friends** subset, with author-chosen
+lifetime, plus audience-visible **reactions** and **comments** and an author-only **view list**.
+
+The key technical insight from the codebase audit: **friendship already exists**. The `connections`
+subsystem (server `0017_connections.sql` + `connections_handlers.go` + `store/connections.go`; client
+`src/services/connections.ts`, the `requests` IndexedDB store, and the Contacts-page request UI) is a
+complete request→accept/decline/withdraw handshake with E2EE-gating and block interplay. **User Story
+1 is therefore mostly satisfied today** — this feature *reuses* it (treating an accepted connection as
+a "friend") and adds only a small **close-friends** tier on top.
+
+The genuinely new surface is **posts + engagement**, built to preserve zero-knowledge by reusing
+existing crypto primitives:
+
+- A post is encrypted once under a fresh **per-post content key**; that key is wrapped per audience
+  member over their existing 1:1 Double Ratchet session (the same per-recipient key-distribution
+  pattern `senderkeys.ts` already uses). Media reuses the existing per-file AES-GCM blob transfer,
+  with the file key carried *inside* the sealed post payload.
+- The server stores only **opaque post ciphertext + per-recipient key envelopes + coarse expiry**,
+  and addresses each post to its recipient set — exactly today's message trust model.
+- **Engagement (reactions/comments)** is encrypted under the *same post content key* (which every
+  audience member already holds) and submitted to the relay, which **fans it out to the post's stored
+  audience**. The engager never learns the roster (the server addresses it), only audience members
+  can produce valid ciphertext, and delivery does not depend on the author being online. **View
+  receipts** are 1:1 viewer→author signals gated by the existing seen-receipts setting.
+
+Lifetime/expiry reuses the existing disappearing-message TTL + sweep. Settings reuse the declarative
+`schema.ts` (re-introducing *real*, wired post/Wall controls where dead "Status" placeholders were
+removed in a separate cleanup).
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES modules, Vue 3 `<script setup>` + Ionic) on the client; Go 1.26
+(stdlib `net/http`) on the server.
+
+**Primary Dependencies**: client — libsodium-wrappers-sumo (existing crypto core: X3DH, Double
+Ratchet, sender keys), Ionic/Vue, IndexedDB via `src/db/idb.ts`; server — `pgx` v5, embedded SQL
+migrations, existing WS hub + push.
+
+**Storage**: client IndexedDB (source of truth, bump `DB_VERSION` 8 → 9, add `posts` +
+`postEngagement` stores; extend `contacts` with a close-friend flag). Server PostgreSQL (new
+forward-only migration `0021_posts.sql`).
+
+**Testing**: client — vitest unit tests for the pure crypto/post helpers + Playwright e2e under
+`e2e/`; server — `go test ./...` against the in-memory fake store (one `_test.go` per handler/store).
+
+**Target Platform**: installable PWA (mobile + desktop) + the single `ringd` container.
+
+**Project Type**: web (Vue PWA client + Go server in one repo, one image).
+
+**Performance Goals**: Wall feed renders incrementally and stays reactive via `useLiveQuery`; posting
+and engagement feel instant locally (offline-first) and converge on next sync. No new polling.
+
+**Constraints**: NON-NEGOTIABLE zero-knowledge (Principle I) — server never sees post/media/reaction/
+comment plaintext, media keys, view-list, or close-friends membership. Offline-first (Principle V).
+Reuse existing crypto only (Principle IV). Ionic-first UI (Principle XI). Single image + WS `?token=`
+auth (Domain Constraints).
+
+**Scale/Scope**: single Ring network instance; audiences bounded by a user's friend count (tens to
+low hundreds); per-post fan-out is N envelopes like a group message today.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0 and re-checked after Phase 1.*
+
+| Principle | Gate | Status |
+|---|---|---|
+| I. Zero-Knowledge (NON-NEGOTIABLE) | No server plaintext; spec has Zero-Knowledge Impact; metadata minimized | **PASS (by design)** — posts/engagement are ciphertext + per-recipient envelopes; server learns only author, recipient set (as today), coarse size/expiry, and that engagement occurred. Close-friends membership and view-list never leave the device readable. A dedicated crypto/ZK checklist is REQUIRED (Principle IV + Gate sequencing) and is produced via `/speckit-checklist`. |
+| II. Spec-Driven | specify→clarify→plan→tasks→analyze→issues→implement | **ON TRACK** — specify ✓, clarify ✓, plan (this), tasks next. |
+| III. TDD | failing tests before impl; crypto/store/handler unit tests; e2e for behavior | **PLANNED** — tasks.md will order red→green; new crypto (post seal/open, engagement) gets forgery/replay/out-of-order/skipped-key tests; new handlers get fake-store tests; new user flows get an `e2e/` spec. |
+| IV. Crypto Discipline | reuse libsodium core; pure functions; `messaging.ts` crypto-only; AEAD-at-rest | **PASS** — reuse per-recipient key wrapping (à la `senderkeys.ts`) + per-file AEAD blobs; new pure helpers (`crypto/post.ts`) testable without IndexedDB; no new primitives/schemes. Checklist required. |
+| V. Offline-First | IndexedDB source of truth; bump `DB_VERSION`; reactive; LWW own-sync | **PASS** — new `posts`/`postEngagement` stores + `DB_VERSION` 8→9 forward migration; `useLiveQuery`-backed Wall; close-friend flag rides own-data sync (LWW on `updatedAt`). |
+| VI. Stateless Server & Forward-Only | new numbered migration; stdlib handlers; small interfaces; fake-store tests | **PASS** — add `0021_posts.sql`; new `PostStore` interface at the call site; no `SECRETS_KEY` impact. |
+| VII. Quality Gates | typecheck+build, go build/vet/test, vitest+floors, e2e | **PLANNED** — part of Definition of Done. |
+| VIII. Traceable Delivery | issues per task; `Closes #N`; ROADMAP generated | **ON TRACK** — `taskstoissues` step; ROADMAP row `0003` already generated. |
+| IX. Privacy & Data Minimization | minimum metadata; AGPL | **PASS** — server stores no new identity-revealing plaintext; engagement metadata is the minimum to route (submitter + post id). |
+| X. a11y / i18n | Ionic schema settings; bidi text | **PASS** — post text surfaces reuse the bidi-aware composer approach; Wall built from Ionic. |
+| XI. Ionic-First UI | stock Ionic + `--ring-*` tokens; settings = schema edit | **PASS** — Wall/feed, composer, request/engagement UIs compose `ion-*`; post/Wall settings are a `schema.ts` data edit. Any bespoke media-post tile is composed from Ionic + existing media components and reasoned in research.md. |
+
+**Result: PASS.** No principle requires a waiver. One mandatory follow-up: the crypto/ZK **checklist**
+(Principle I & IV) before `/speckit-implement`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/0003-zero-knowledge-social/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions & rationale
+├── data-model.md        # Phase 1 — entities (client + server)
+├── quickstart.md        # Phase 1 — how to exercise the feature
+├── contracts/
+│   └── http-api.md      # Phase 1 — new HTTP/WS contracts
+├── checklists/
+│   └── requirements.md  # spec-quality checklist (done) + crypto/ZK checklist (via /speckit-checklist)
+└── tasks.md             # Phase 2 — /speckit-tasks (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/                                  # Vue PWA client
+├── services/
+│   ├── crypto/
+│   │   ├── post.ts                   # NEW: pure post seal/open + engagement seal/open (per-post key wrap)
+│   │   └── senderkeys.ts             # REUSE: per-recipient key-distribution pattern
+│   ├── posts.ts                      # NEW: post orchestration (crypto-only, like messaging.ts; no store writes)
+│   ├── media-transfer.ts             # REUSE: per-file AEAD blob up/download
+│   ├── connections.ts                # REUSE/EXTEND: friendship (already request/accept/withdraw)
+│   └── directory.ts                  # REUSE: public profile (avatar/name/username) on posts
+├── db/
+│   ├── idb.ts                        # EDIT: DB_VERSION 8→9; add 'posts','postEngagement' stores; close-friend
+│   ├── types.ts                      # EDIT: Post, PostEngagement, ViewReceipt; Contact.closeFriend
+│   └── queries.ts                    # EDIT: post/engagement orchestration (queries.ts → posts.ts, one-way)
+├── composables/
+│   └── useWall.ts                    # NEW: reactive Wall feed + per-post engagement (useLiveQuery)
+├── views/
+│   ├── tabs/WallPage.vue             # NEW: the Wall feed tab (or surfaced where the team prefers)
+│   └── detail/
+│       ├── PostComposerPage.vue      # NEW: compose text/voice/video/image + audience + lifetime
+│       ├── PostDetailPage.vue        # NEW: full-screen post + reactions + comments + (author) views
+│       └── CloseFriendsPage.vue      # NEW: curate the close-friends list
+├── components/                       # NEW post tiles/reaction bar/comment list — composed from ion-*
+├── settings/schema.ts               # EDIT: real post/Wall settings (default audience, post notifications)
+└── sw.ts / services/notify*         # EDIT: post/engagement notifications via existing model
+
+server/                               # ringd
+├── internal/db/migrations/0021_posts.sql   # NEW: posts, post_envelopes, post_engagement, post_views
+├── internal/store/posts.go                 # NEW: PostStore impl (+ posts_test via fake store)
+├── internal/api/posts_handlers.go          # NEW: create/list/delete posts; submit/list engagement; views
+├── internal/api/router.go                  # EDIT: PostStore interface + routes
+└── internal/api/connections_handlers.go    # REUSE: friendship handshake unchanged
+
+e2e/                                  # NEW Playwright spec: friend→post→view→react→comment→expire
+```
+
+**Structure Decision**: single repo / single image (web). The feature is additive: new client
+services/stores/views + one server migration/store/handler set, all following existing conventions
+(`queries.ts → {posts.ts, messaging.ts}` one-directional; stdlib handlers on small interfaces; embedded
+forward-only migration). Friendship is **reuse**, not new.
+
+## Phasing (delivery order, mirrors spec priorities)
+
+1. **P1 — Friendship reuse + close-friends tier**: confirm/connect the existing connections flow as
+   "friends"; add `Contact.closeFriend` + `CloseFriendsPage`. (Small; unblocks audiences.)
+2. **P1 — Posts MVP**: `crypto/post.ts` + `posts.ts` + `posts` store + `0021_posts.sql` +
+   `posts_handlers` (create/list/delete) + composer + Wall feed (text first, then media reuse) +
+   lifetime/expiry via existing sweep.
+3. **P2 — Reactions (audience-visible)** + **close-friends audience** end-to-end.
+4. **P3 — Comments thread** + **view receipts** (seen-receipts-gated) + post/engagement notifications
+   + settings.
+
+Each slice is independently testable (spec's Independent Test per story).
+
+## Complexity Tracking
+
+No constitution violations requiring a waiver. Notable complexity, justified:
+
+| Item | Why needed | Simpler alternative rejected because |
+|---|---|---|
+| Per-post content key wrapped per recipient (vs. a ratcheting sender key per author) | Posts are independent items with per-post audiences and per-post lifetime; a fresh per-post key gives clean per-post access control + revocation-by-expiry | A long-lived author sender key would entangle all posts under one key and complicate per-post audience/expiry and close-friends scoping |
+| Server fan-out of engagement to the post's stored audience | Keeps the close-friends roster author-private while letting any audience member engage and not depend on the author being online | Author-relay re-broadcast adds an author-online dependency; direct viewer→audience addressing would leak the roster to the engager |
+| New `postEngagement` store + `post_engagement` table | Reactions/comments/views have different lifecycle + query patterns than messages | Overloading the `messages`/`requests` stores would blur the chat vs. wall domains and complicate sweeps |

--- a/specs/0003-zero-knowledge-social/quickstart.md
+++ b/specs/0003-zero-knowledge-social/quickstart.md
@@ -1,0 +1,50 @@
+# Quickstart: Zero-Knowledge Social Wall
+
+How to exercise the feature once implemented — for reviewers and the e2e author. Uses the existing dev
+stack and the `drive/` harness (live `make start`) or the hermetic `npm run test:e2e`.
+
+## Prerequisites
+- `make start` (Vite :5173 → ringd :8080), or the isolated e2e stack.
+- Two+ test accounts via the `window.__ringTest` hook (the `drive/` driver mints them).
+
+## Happy path (the MVP loop)
+1. **Befriend**: Account A sends a friend request to B (existing connections flow); B accepts. They
+   are now friends. *(Reuses today's request/accept — no new mechanism.)*
+2. **Close friends**: A opens the close-friends list and marks B as a close friend.
+3. **Post to all friends**: A composes a **text** post, audience = "all friends", lifetime = 24h, and
+   shares. B sees it on the Wall with A's avatar/name/username.
+4. **Post media to close friends**: A composes an **image** (then **voice**, **video**) post,
+   audience = "close friends". Only close friends (B) receive it; a non-close friend C sees nothing
+   and no indication it exists.
+5. **React (audience-visible)**: B reacts 👍. A **and** every other audience member see B's reaction +
+   identity. B changes/removes it; everyone updates.
+6. **Comment (audience-visible)**: B comments. A and the audience see the comment attributed to B,
+   ordered. B deletes their comment; it disappears for the audience. A removes a comment as the post
+   author.
+7. **Views**: A opens the post's view list and sees B (because B has seen receipts on). A viewer with
+   seen receipts off does not appear, and gets no view list on their own posts.
+8. **Expiry**: after 24h (or via the test clock), the post disappears for A and all viewers.
+
+## Zero-knowledge spot-checks (reviewer)
+- Inspect server Postgres: `posts.blob_id` and `post_engagement.payload` are opaque; no plaintext
+  text/emoji columns; `post_views` exists only for the author.
+- Confirm `post_envelopes` shows a recipient set but no tier; the close-friends flag never appears in
+  any request body or table.
+- Confirm a non-audience account cannot fetch a post or submit engagement (403/empty).
+
+## Automated coverage to add
+- **Unit (vitest)**: `crypto/post.ts` seal/open round-trip; per-recipient `K_post` wrap/unwrap;
+  engagement forgery (non-member key), replay, out-of-order, skipped-key; reaction caps + LWW.
+- **Server (`go test`)**: `posts_handlers`/`posts.go` against the fake store — create/list/delete,
+  engagement fan-out to the audience, audience+block authorization, author-only views.
+- **e2e (`e2e/`)**: the full happy path above across real accounts (friend → post each media type →
+  view → react → comment → expire), including the close-friends isolation and the non-audience
+  negative case.
+
+## Commands
+```sh
+npm run build                 # client typecheck + build
+cd server && go test ./...     # server unit tests (fake store, no DB)
+npm run test:e2e               # Playwright (needs make db-up)
+node drive/scenarios/<wall>.mjs  # interactive drive against make start
+```

--- a/specs/0003-zero-knowledge-social/research.md
+++ b/specs/0003-zero-knowledge-social/research.md
@@ -1,0 +1,169 @@
+# Phase 0 Research: Zero-Knowledge Social Wall
+
+Decisions that resolve the unknowns in the plan's Technical Context. Each is **Decision /
+Rationale / Alternatives considered**, grounded in the existing codebase.
+
+## R1 — Friendship: reuse the existing `connections` subsystem
+
+**Decision**: Treat an **accepted connection** as a **friend**. Do not build a new friend-request
+system. Reuse: server `connections` table + `/v1/connections/{request,accept,reject,withdraw,link}` +
+`GET /v1/connections` (`server/internal/api/connections_handlers.go`, `store/connections.go`,
+`migrations/0017_connections.sql`); client `src/services/connections.ts`, the `requests` IndexedDB
+store + `FriendRequest` type (`src/db/types.ts`), the `connectedPeers` ledger / `markContactConnected`
+(`src/db/queries.ts`), and the Contacts-page request UI (`src/views/tabs/ContactsPage.vue`).
+
+**Rationale**: This already implements spec US1 / FR-001…FR-006 end-to-end: directed
+request→accept/decline/withdraw, block interplay (`Connected()` checks both directions and blocks),
+E2EE gating (prekey-bundle fetch blocked until accepted), and content-free offline tickles
+(zero-knowledge). The Wall's "all friends" audience = the set of accepted connections.
+
+**Gaps to close (small)**:
+- **Mutual semantics**: `Connected(a,b)` is true if *either* side accepted. For the Wall this is the
+  right "are we friends" predicate; no change needed. FR-006 (crossing requests) is already handled
+  (`RequestConnection` returns `accepted` when the reverse request exists).
+- **Friend enumeration for audience building**: the client needs "my friends" = accepted connections.
+  Derive from `connectedPeers` ledger + contacts; add a `listFriends()` query helper if not present.
+- **FR-007 anti-harassment**: confirm/add rate-limiting on repeated `request` after decline/block
+  (server already drops requests from blocked users; add a cooldown on repeat requests).
+
+**Alternatives considered**: a brand-new `friendships` table — rejected (duplicates a working,
+zero-knowledge-correct mechanism and fragments the social graph).
+
+## R2 — Close-friends list: client-only, per-contact flag
+
+**Decision**: Add `Contact.closeFriend: boolean` (default false), curated on a new `CloseFriendsPage`.
+It rides the existing **own-data sync** (contacts are already in `SYNCED`, LWW on `updatedAt`), so it
+restores across devices **encrypted** and is **never sent to the server in the clear**.
+
+**Rationale**: FR-040/FR-041 require the close-friends set to be author-private (not disclosed to
+others or the server). Keeping it a client-side flag on the already-encrypted contact record
+satisfies this for free. Distinct from the per-**chat** favorite/pin (`Chat.favorite`) — different
+intent, different record.
+
+**Alternatives considered**: a server-side "close friends" group — rejected (would leak the roster to
+the server, violating FR-041 and Principle I).
+
+## R3 — Post encryption: fresh per-post content key, wrapped per recipient
+
+**Decision**: For each post, generate a random symmetric **content key** `K_post`. Seal the post
+payload (type, text, and the media-ref including the per-file media key) with `K_post` via the
+existing AEAD (`crypto/envelope.ts`). Distribute `K_post` to each audience member by wrapping it over
+that member's existing **1:1 Double Ratchet session** — the same per-recipient distribution pattern
+`crypto/senderkeys.ts` already uses to hand out a sender key. The post **ciphertext blob** is uploaded
+once (reusing `media-transfer.ts` / blob storage); the server stores it plus **one envelope per
+recipient** (the wrapped `K_post`).
+
+**Rationale**: Posts are discrete items with **per-post audiences and per-post lifetimes**. A fresh
+key per post gives clean per-post access control and "revocation by expiry" without entangling posts.
+Reuses only existing primitives (Principle IV). The new pure helpers live in `crypto/post.ts`
+(testable without IndexedDB); orchestration in `posts.ts` stays crypto-only (mirrors `messaging.ts`;
+`queries.ts → posts.ts` one-directional, no cycle).
+
+**Alternatives considered**:
+- A long-lived **author sender key** (ratchet) reused across posts — rejected: per-post audience +
+  expiry + close-friends scoping would fight a single evolving key; forward secrecy across unrelated
+  posts adds complexity without benefit.
+- **MLS / new group scheme** — rejected (Principle IV: no new key-exchange schemes).
+
+## R4 — Media: reuse the per-file AEAD blob transfer
+
+**Decision**: Voice/video/image posts reuse `media-transfer.ts`: client generates a random file key,
+AES-GCM-encrypts the file, uploads ciphertext to `POST /v1/blobs` (opaque, capability id), and embeds
+the `{blobId, fileKey}` media-ref **inside** the `K_post`-sealed payload. Viewers extract the ref,
+download the blob, decrypt locally. Multi-size image thumbnails reuse spec 1014's pipeline.
+
+**Rationale**: Zero new media path; the server already stores blob ciphertext it cannot read. The file
+key never appears outside the sealed post payload.
+
+**Alternatives considered**: a separate "post media" store — rejected (blobs already are
+capability-addressed and content-blind).
+
+## R5 — Engagement (reactions/comments): encrypt under `K_post`, relay fans out to the post's audience
+
+**Decision**: A reaction/comment is sealed under the **same `K_post`** (every audience member already
+holds it) and submitted to the relay referencing **only the post id**. The server **fans the
+engagement ciphertext out to the post's stored recipient set** (the envelopes it already has), after
+checking the submitter is in that audience and not blocked. Each recipient stores it in the new
+`postEngagement` store; the Wall renders reactions/comments reactively. Reactions reuse the existing
+**reaction caps + last-write-wins-per-user** semantics (`queries.ts`). Comment ordering is by author
+timestamp with id tiebreak. Deletions (own comment, or author moderating, or post deletion) are
+tombstone engagement records fanned out the same way.
+
+**Rationale**: Satisfies FR-030…FR-036 + SC-010 (engager never learns the roster — the **server**
+addresses the fan-out from the set it already stores), keeps everything E2EE under a key the server
+lacks, and removes any author-online dependency. Only audience members can produce valid `K_post`
+ciphertext, so non-members can't forge engagement.
+
+**Server learns**: that submitter X engaged with post P (and the post's audience, already known). It
+does **not** learn the emoji, comment text, or who is in the close-friends tier. This is the minimum
+routing metadata (Principle IX) and is consistent with today's addressed-message model.
+
+**Alternatives considered**:
+- **Author re-broadcast** (viewer→author, author→audience) — rejected: adds an author-online
+  dependency for engagement to appear; no ZK benefit over server fan-out (server learns the same).
+- **Viewer addresses the audience directly** — rejected: the viewer doesn't know (and must not learn)
+  the roster, especially close friends (FR-041).
+
+## R6 — View receipts: 1:1 viewer→author, gated by seen-receipts
+
+**Decision**: When an audience member opens a post, the client sends a **view signal to the author
+only** (over the 1:1 session), recorded in the author's `postEngagement` as a view. It is gated by the
+existing `privacy.seenReceipts` setting **reciprocally**: a viewer with receipts off sends none and is
+shown no view lists on their own posts (mirrors the chat seen-receipt reciprocity in `useSync.ts`).
+
+**Rationale**: FR-037/FR-038 + SC-008. Reuses the established seen-receipt privacy contract rather
+than inventing a new visibility rule. View lists are author-only, so no fan-out is needed.
+
+**Alternatives considered**: fanning views to the whole audience — rejected (the spec makes views
+author-only; broader disclosure would be a privacy regression).
+
+## R7 — Lifetime/expiry: reuse the disappearing-message TTL + sweep
+
+**Decision**: A post carries `expiresAt` (author chooses 24h / 7d / keep). Reuse the existing
+disappearing-message sweep (the `useSync.ts` expiry sweep over `expiresAt`) extended to the `posts` +
+`postEngagement` stores; the server stores a coarse expiry on the post row and prunes expired posts +
+envelopes + engagement on a periodic job (or lazily on fetch).
+
+**Rationale**: FR-012/FR-023 + SC-005; one mechanism for "disappearing", consistent UX, no new timer
+infrastructure.
+
+**Alternatives considered**: a bespoke post-expiry timer — rejected (duplicates existing sweep).
+
+## R8 — Server storage shape
+
+**Decision**: New forward-only migration `0021_posts.sql`:
+- `posts(id, author, blob_id, size, created_at, expires_at)` — opaque; `blob_id` is the post-payload
+  ciphertext capability.
+- `post_envelopes(post_id, recipient, wrapped_key)` — per-recipient `K_post` envelope (the audience
+  addressing the server uses to deliver + to fan out engagement).
+- `post_engagement(id, post_id, author, blob_or_inline, kind, created_at)` — opaque engagement
+  ciphertext (reaction/comment/tombstone) fanned out to the post's audience.
+- `post_views(post_id, viewer, viewed_at)` — author-only view receipts (only rows the author can read;
+  stored as opaque/min-metadata, author aggregates client-side).
+
+All content is ciphertext or capability ids; no plaintext columns. Handlers are stdlib `net/http` on a
+new `PostStore` interface at the call site, tested against the in-memory fake store (Principle VI).
+
+**Rationale**: Mirrors existing `blobs` + addressed-delivery patterns; minimal, content-blind schema.
+
+**Alternatives considered**: storing post content in a column — rejected (Principle I).
+
+## R9 — UI: Ionic-first
+
+**Decision**: Wall feed = `ion-content` + `ion-list`/cards composed from `ion-*` and existing media
+components (image/video/voice bubbles reused). Composer reuses the bidi-aware textarea approach and the
+existing media-capture/attach flows. Audience + lifetime pickers are `ion-segment`/`ion-select`.
+Post/Wall **settings** are a **data edit to `src/settings/schema.ts`** (real, wired controls replacing
+the removed placeholder "Status" rows), not bespoke components.
+
+**Rationale**: Principles X & XI. Any custom post tile is composed from Ionic + `--ring-*` tokens and
+reasoned here; no hand-rolled primitives.
+
+## Open risks (carry into tasks/checklist)
+
+- **Crypto/ZK checklist is mandatory** (Principles I & IV) — must cover post seal/open, per-recipient
+  `K_post` wrap, engagement forgery/replay/out-of-order, and that no plaintext/roster leaks server-side.
+- **Audience-change semantics**: audience is frozen at post time (envelopes are fixed); removing a
+  friend affects future posts only — already in spec Edge Cases; tests must assert it.
+- **Fan-out cost**: per-post + per-engagement fan-out is O(audience), like group messages today;
+  acceptable at the stated scale.

--- a/specs/0003-zero-knowledge-social/spec.md
+++ b/specs/0003-zero-knowledge-social/spec.md
@@ -277,8 +277,11 @@ list. A viewer with seen receipts off opens the post; the author does not see th
   image.
 - **FR-011**: For each post, the author MUST choose an audience of either **all friends** or **close
   friends**.
-- **FR-012**: For each post, the author MUST choose a lifetime (at minimum: 24 hours, 7 days, and
-  "keep"); the chosen lifetime governs automatic disappearance.
+- **FR-012**: Every post is ephemeral with a **hard maximum lifetime of 72 hours**, regardless of
+  type (text/photo/video/voice). The author chooses a lifetime up to that ceiling (e.g. 1 hour, 24
+  hours, 72 hours); there is no "keep"/permanent option. The 72-hour ceiling MUST be enforced
+  server-side (the server clamps any longer or absent expiry), not just in the UI, so no post can
+  outlive it.
 - **FR-013**: A post MUST be delivered only to its chosen audience as of post time; non-audience users
   MUST receive nothing and MUST NOT be able to infer the post exists.
 - **FR-014**: Post content and media MUST be end-to-end encrypted such that only audience members can

--- a/specs/0003-zero-knowledge-social/spec.md
+++ b/specs/0003-zero-knowledge-social/spec.md
@@ -1,0 +1,447 @@
+# Feature Specification: Zero-Knowledge Social Wall
+
+**Feature Branch**: `feat/0003-zero-knowledge-social`
+
+**Created**: 2026-06-20
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Bring a social 'Wall' into Ring: let people post status updates
+(text, voice, video, or image) visible to their friends or a favorite-friends subset, with the
+author in control of who can see each post. Viewers see the author's profile (avatar, name,
+username), can react, and the author can see who reacted. People can request friendship in either
+direction. Posts must stay private — the network's zero-knowledge guarantee holds."
+
+## Overview
+
+Ring is a private, end-to-end-encrypted messenger. This feature adds a **Wall**: a place to share
+short status posts with people you are connected to, without weakening the zero-knowledge
+guarantee. Two new capabilities underpin it: a real **friendship** relationship (mutual,
+request-and-accept) replacing today's one-way "add a contact", and **posts** that the author shares
+to a chosen audience of friends.
+
+Crucially, there is **no public, server-readable feed**. Post content (text, voice, video, image)
+is always end-to-end encrypted to its chosen audience. Strangers on the network can still find your
+public profile and send you a friend request, but they can never see your posts unless you accept
+them and include them in the audience.
+
+Engagement is social and audience-visible: audience members can **react** and add **comments** that
+the whole audience sees, and the author sees a **per-post view list**. Because a post's audience —
+especially the close-friends subset — is known only to the author, engagement must reach everyone
+without any engager learning who else is in the audience. The system delivers each reaction/comment
+to the post's audience (the same recipient set the post was sent to) end-to-end encrypted, while the
+engager only ever addresses "this post" — never a roster. Audience membership therefore stays
+author-private while reactions and comments still appear for everyone.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Build a friends list with requests (Priority: P1)
+
+A person finds someone on the network (by username/profile) and sends a **friend request**. The
+other person sees an incoming request and can **accept** or **decline**. Either side can **cancel**
+a still-pending outgoing request. Once accepted, the two are **friends** (mutual), which is the
+basis for everything else on the Wall. Blocking someone removes/forbids the friendship.
+
+**Why this priority**: Friendship is the foundation — without a mutual relationship there is no
+audience to post to. It also delivers standalone value: a curated, consent-based connection model
+that today's unilateral "add contact" lacks.
+
+**Independent Test**: Two accounts; one sends a request, the other accepts; both now list each other
+as friends. Decline, cancel, and block paths each reach the correct end state. Fully testable
+without any posting feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** Bob's public profile, **When** Alice sends a friend request, **Then** Bob sees a
+   pending incoming request and Alice sees a pending outgoing request.
+2. **Given** a pending incoming request, **When** Bob accepts, **Then** Alice and Bob are friends and
+   both see the other in their friends list.
+3. **Given** a pending incoming request, **When** Bob declines, **Then** the request disappears for
+   both and neither becomes a friend; Alice is not told whether it was declined or merely unseen.
+4. **Given** a pending outgoing request, **When** Alice cancels it, **Then** it disappears for both.
+5. **Given** Alice and Bob are friends, **When** either blocks the other, **Then** the friendship
+   ends and no new request can be sent while the block stands.
+6. **Given** Bob already sent Alice a request, **When** Alice sends Bob a request, **Then** the two
+   are reconciled into a single accepted friendship rather than two crossing requests.
+
+---
+
+### User Story 2 - Compose and share a post to friends (Priority: P1)
+
+A friend opens a composer, creates a post that is **text, a voice clip, a video, or an image**,
+chooses **who can see it** (all friends, or close friends only), chooses **how long it lasts**
+(e.g. 24 hours, 7 days, or keep), and shares it. The post is delivered, end-to-end encrypted, only
+to the chosen audience.
+
+**Why this priority**: This is the headline value — sharing moments privately. Together with US1 and
+US3 it forms the MVP.
+
+**Independent Test**: With an existing friendship, the author posts each media type with an audience
+and a lifetime; only audience members receive it; the server never holds readable content.
+
+**Acceptance Scenarios**:
+
+1. **Given** Alice has friends, **When** she posts text to "all friends", **Then** every current
+   friend can see it and no one else can.
+2. **Given** Alice posts an image/voice/video, **When** an audience member opens it, **Then** the
+   media is fetched and decrypted on their device and plays/renders correctly.
+3. **Given** Alice chooses "close friends", **When** she posts, **Then** only her close-friends
+   subset receives it; other friends receive nothing and see no indication a post exists.
+4. **Given** Alice sets a 24-hour lifetime, **When** 24 hours pass, **Then** the post disappears for
+   both Alice and all viewers (lifetime/expiry per FR-012 and FR-023).
+5. **Given** the device is offline, **When** Alice creates a post, **Then** it is queued locally and
+   sent when connectivity returns (offline-first).
+
+---
+
+### User Story 3 - View friends' posts in a Wall feed (Priority: P1)
+
+A person opens the Wall and sees recent posts from their friends, each labelled with the author's
+**avatar, name, and username**, newest first, with media rendered inline. Tapping a post opens it
+full-screen.
+
+**Why this priority**: Posting has no value if no one can see it; viewing completes the MVP loop.
+
+**Independent Test**: Given posts addressed to a viewer, the viewer's Wall lists exactly those posts
+with correct author identity and content, and excludes posts they are not in the audience for.
+
+**Acceptance Scenarios**:
+
+1. **Given** friends have posted, **When** the viewer opens the Wall, **Then** they see those posts
+   newest-first with author avatar/name/username.
+2. **Given** a post the viewer is NOT in the audience for, **When** the Wall loads, **Then** that
+   post does not appear and its existence is not revealed.
+3. **Given** a new post arrives while the Wall is open, **When** it is received, **Then** it appears
+   without a manual refresh (reactive update).
+4. **Given** an author's profile photo is hidden by their privacy settings, **When** their post
+   shows, **Then** it respects that setting consistently with the rest of the app.
+
+---
+
+### User Story 4 - React to posts; the audience sees reactions (Priority: P2)
+
+A viewer reacts to a post with an emoji. The reaction is visible to the **whole audience** (each
+reactor's identity and emoji), not just the author — like reactions in a group chat. A reactor can
+change or remove their reaction.
+
+**Why this priority**: Reactions are the core lightweight engagement. Making them audience-visible
+(the author's choice) gives the Wall a social feel; it is possible because everyone in the audience
+is a friend of the author, who relays reactions out to the audience.
+
+**Independent Test**: A viewer reacts; the author and every other audience member see that reactor
+and emoji; removing the reaction updates everyone's view.
+
+**Acceptance Scenarios**:
+
+1. **Given** a post, **When** an audience member reacts, **Then** the author and all other audience
+   members see that reactor's identity and emoji.
+2. **Given** a reaction exists, **When** the reactor removes or changes it, **Then** the audience's
+   reaction list updates accordingly (last-write-wins per reactor).
+3. **Given** the per-item reaction caps already used elsewhere in Ring, **When** reactions exceed
+   them, **Then** the same caps apply to posts.
+4. **Given** the author is briefly offline, **When** a viewer reacts, **Then** the reaction still
+   reaches the rest of the audience (delivery does not depend on the author being online).
+
+---
+
+### User Story 5 - Curate a close-friends list (Priority: P2)
+
+A person maintains a **close friends** list — a curated subset of their friends — and can post to it
+as a distinct, more private audience. This is separate from any chat pinning/favorite.
+
+**Why this priority**: Enables the "favorite friends only" audience that the author asked to control
+per post. Lower than posting itself because "all friends" alone is already a usable MVP audience.
+
+**Independent Test**: Add/remove friends to the close-friends list; a "close friends" post reaches
+exactly that set and no other friend.
+
+**Acceptance Scenarios**:
+
+1. **Given** a friends list, **When** the author marks some as close friends, **Then** those friends
+   form the close-friends audience.
+2. **Given** a close friend is later removed from the list, **When** the author posts to close
+   friends, **Then** that person no longer receives new close-friends posts.
+3. **Given** the close-friends list, **When** anyone other than the author tries to learn its
+   membership, **Then** it is not disclosed (including to the server).
+
+---
+
+### User Story 6 - Comment on a post (audience-visible thread) (Priority: P3)
+
+An audience member adds a short **text comment** to a post. Comments form a thread that the whole
+audience can read, each labelled with the commenter's profile. A commenter can delete their own
+comment; the author can remove any comment on their post (and deleting the post removes its thread).
+
+**Why this priority**: Comments deepen engagement beyond reactions but are not needed for the MVP
+loop (friends → post → view → react). They share the same author-relay fan-out as reactions.
+
+**Independent Test**: A viewer comments; the author and other audience members see the comment with
+the commenter's identity; the commenter deletes it and it disappears for everyone.
+
+**Acceptance Scenarios**:
+
+1. **Given** a post, **When** an audience member comments, **Then** the comment appears for the author
+   and all audience members, attributed to the commenter, in a consistent order.
+2. **Given** a comment, **When** its author (the commenter) deletes it, **Then** it disappears for the
+   whole audience (best-effort per the E2EE limitation).
+3. **Given** a comment on her post, **When** the post author removes it, **Then** it disappears for the
+   audience.
+4. **Given** a blocked user, **When** they attempt to comment, **Then** the comment is not delivered.
+
+---
+
+### User Story 7 - See who viewed a post (Priority: P3)
+
+The author opens one of their posts and sees a **list of who has viewed it**, respecting Ring's
+existing seen-receipts privacy control: a viewer who has turned seen receipts off is not reported as
+having viewed, and correspondingly cannot see view lists on their own posts.
+
+**Why this priority**: A nice-to-have insight (story-style) layered on top of the core loop; it must
+honor existing reciprocal seen-receipt privacy, so it is lower priority and gated by that setting.
+
+**Independent Test**: A viewer with seen receipts on opens a post; the author sees them in the view
+list. A viewer with seen receipts off opens the post; the author does not see them.
+
+**Acceptance Scenarios**:
+
+1. **Given** a viewer with seen receipts enabled, **When** they view a post, **Then** the author sees
+   them in that post's view list.
+2. **Given** a viewer with seen receipts disabled, **When** they view a post, **Then** the author does
+   NOT see them, and that viewer does not get view lists on their own posts (reciprocity).
+3. **Given** an expired post, **When** the author opens it before it is swept, **Then** the view list
+   reflects only views recorded while it was live.
+
+---
+
+### Edge Cases
+
+- **Unfriending / removal after delivery**: Content already delivered to a device cannot be
+  cryptographically recalled. Removing a friend (or from close friends) affects **future** posts
+  only; already-received posts may remain on that device until they expire or are deleted by their
+  lifetime. This limitation MUST be reflected honestly in UI copy.
+- **Deleting a post before expiry**: The author can delete a post; the system best-effort removes it
+  from the server and signals viewers to remove their copies, but cannot guarantee deletion from a
+  device that already downloaded it (same E2EE limitation).
+- **Audience membership timing**: A post's audience is the set chosen **at post time**; someone who
+  becomes a friend afterwards does not retroactively gain access to earlier posts.
+- **Friend-request spam**: A stranger repeatedly sending requests after being declined/blocked MUST
+  be rate-limited or suppressed so requests cannot be used to harass.
+- **Reacting/commenting after expiry/unfriend**: A reaction or comment on a post the author can no
+  longer fan out (expired/deleted, or the engager was unfriended) is dropped gracefully.
+- **Engagement does not depend on the author being online**: a reaction/comment is delivered to the
+  post's audience by the relay independently of the author; the engager sees their own action
+  immediately and the rest of the audience receives it on their next sync.
+- **Engagement reveals co-engagers**: Audience-visible reactions/comments inherently disclose, to the
+  audience, *which* audience members chose to react or comment (not the full audience roster). UI copy
+  MUST set this expectation, especially for close-friends posts.
+- **View-list privacy reciprocity**: A viewer with seen receipts disabled is never listed as a viewer
+  and never receives view lists on their own posts.
+- **Large media / unsupported codecs**: Oversized or unplayable media degrades to a clear error, not
+  a broken post.
+- **Account termination / ghosted author**: Posts from an author who deletes their account stop
+  appearing and stop being fetchable; their relayed threads stop updating.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Friendship**
+
+- **FR-001**: Users MUST be able to send a friend request to any discoverable network user who has
+  not blocked them.
+- **FR-002**: The recipient MUST be able to accept or decline an incoming request; the sender MUST be
+  able to cancel a pending outgoing request.
+- **FR-003**: A declined request MUST NOT reveal to the sender whether it was actively declined or
+  simply unseen.
+- **FR-004**: Acceptance MUST establish a **mutual** friendship that both parties see in a friends
+  list, and MUST establish/confirm a secure session between them.
+- **FR-005**: Blocking MUST end any friendship and prevent new requests for the duration of the
+  block; the existing block model is the basis.
+- **FR-006**: Crossing requests (each sends the other a request) MUST reconcile into one accepted
+  friendship without duplicate state.
+- **FR-007**: Repeated requests from the same sender after decline/block MUST be rate-limited or
+  suppressed to prevent harassment.
+- **FR-008**: Posting and engagement MUST be volume-limited (per-author post rate, per-post comment
+  rate, and per-user engagement rate) to prevent flooding a Wall or a viewer; limits MUST be enforced
+  using only routing metadata the server already holds (author/recipient/post id), never by inspecting
+  content. (Reaction caps per FR-032 are separate, content-level, and client-enforced.)
+
+**Posts & audience**
+
+- **FR-010**: Users MUST be able to create a post whose content is text, a voice clip, a video, or an
+  image.
+- **FR-011**: For each post, the author MUST choose an audience of either **all friends** or **close
+  friends**.
+- **FR-012**: For each post, the author MUST choose a lifetime (at minimum: 24 hours, 7 days, and
+  "keep"); the chosen lifetime governs automatic disappearance.
+- **FR-013**: A post MUST be delivered only to its chosen audience as of post time; non-audience users
+  MUST receive nothing and MUST NOT be able to infer the post exists.
+- **FR-014**: Post content and media MUST be end-to-end encrypted such that only audience members can
+  decrypt them; the server MUST never receive readable content or media keys.
+- **FR-015**: Authors MUST be able to delete their own post (best-effort propagation per the Edge
+  Cases limitation).
+- **FR-016**: Posts MUST be created and queued while offline and sent on reconnect; the local device
+  is the source of truth.
+
+**Wall / viewing**
+
+- **FR-020**: Viewers MUST see a Wall listing posts they are in the audience for, newest-first, each
+  showing the author's avatar, name, and username.
+- **FR-021**: New incoming posts MUST appear without a manual refresh.
+- **FR-022**: Author identity shown on a post MUST respect the author's existing profile-privacy
+  settings (e.g. hidden photo).
+- **FR-023**: Expired or deleted posts MUST disappear from the Wall.
+
+**Engagement — reactions, comments, views**
+
+- **FR-030**: Audience members MUST be able to react to a post with an emoji, and change or remove
+  their reaction.
+- **FR-031**: Reactions MUST be visible to the **whole audience** (each reactor's profile identity and
+  emoji), not only the author.
+- **FR-032**: Reactions MUST obey the same per-item reaction caps used elsewhere in Ring and resolve
+  conflicts last-write-wins per reactor.
+- **FR-033**: Audience members MUST be able to add a **text comment** to a post; comments MUST be
+  visible to the whole audience, attributed to the commenter's profile, in a consistent order.
+- **FR-034**: A commenter MUST be able to delete their own comment; the **post author** MUST be able to
+  remove any comment on their post; deleting a post MUST remove its comment thread (best-effort per
+  NFR, since delivered copies cannot be cryptographically recalled).
+- **FR-035**: Reactions and comments MUST be delivered to the post's audience without disclosing the
+  audience roster (including close friends) to the engager; only members of the post's audience may
+  engage with it.
+- **FR-036**: A blocked user's reactions and comments MUST NOT be delivered.
+- **FR-037**: The post author MUST be able to see a **per-post view list** of which audience members
+  have viewed it.
+- **FR-038**: View reporting MUST honor the existing seen-receipts privacy control reciprocally: a
+  viewer with seen receipts disabled MUST NOT be reported as a viewer and MUST NOT receive view lists
+  on their own posts.
+
+**Close friends**
+
+- **FR-040**: Users MUST be able to curate a close-friends list as a subset of their friends,
+  distinct from chat pin/favorite.
+- **FR-041**: Close-friends membership MUST be known only to the author; it MUST NOT be disclosed to
+  other users or to the server.
+
+**Settings & notifications**
+
+- **FR-050**: Users MUST be able to set a default post audience and manage post/Wall notifications
+  through settings. (These replace the previously-removed placeholder "Status" settings with real,
+  wired controls.)
+- **FR-051**: Users MUST be notified of relevant events (new friend request, accepted request, and —
+  per notification settings — new posts, reactions, and comments on their posts), consistent with
+  Ring's existing notification model and per-item privacy (preview/no-preview).
+
+### Zero-Knowledge Impact *(constitution-required)*
+
+- **What new data crosses the client/server boundary, and in what form**: post ciphertext blobs,
+  per-recipient encrypted key material, coarse post lifetime/expiry, friend-request signals, and
+  reaction/comment/view signals — all as **opaque ciphertext or minimal routing metadata**. No post
+  content, media plaintext, media keys, reaction emoji, comment text, view-list membership, or
+  close-friends membership ever leaves a device in readable form.
+- **Engagement routing**: a reaction/comment is encrypted to the post's audience and delivered to the
+  same recipient set the post itself was addressed to; the engager addresses only "this post" and
+  never learns the roster. (The plan realizes this by having the relay fan a submitted engagement
+  ciphertext out to the audience it already holds for that post — keeping the close-friends roster
+  author-private.) View receipts are encrypted viewer→author signals (gated by the seen-receipts
+  setting).
+- **What metadata the server necessarily learns**: that a user posted, the post's recipient set
+  (audience addressing, as with any addressed message today), coarse size and expiry, that a friend
+  request/acceptance occurred between two users (the contact graph is already server-readable by
+  design), and that engagement signals flow between an engager and an author. The server MUST NOT
+  learn audience *tier* names, close-friends membership, post/comment content, reaction emoji, or who
+  viewed.
+- **Residual disclosure to the audience (not the server)**: because reactions and comments are
+  audience-visible by design, audience members learn *which co-audience members chose to engage*
+  (those who react/comment), and the author learns who viewed (subject to seen-receipts). This is a
+  product choice, surfaced in UI copy; it never widens what the *server* can read.
+- **NFR-ZK-1**: The feature MUST NOT introduce any server endpoint or storage that requires reading
+  user plaintext. A design that cannot meet this is rejected, not shipped (constitution Principle I).
+- **NFR-ZK-2**: New crypto paths MUST reuse Ring's existing libsodium primitives and MUST include
+  tests for forgery, replay, out-of-order delivery, and skipped-key cases, and MUST receive a
+  security review (constitution Principle IV). A crypto/zero-knowledge **checklist** is required for
+  this spec.
+- **NFR-ZK-3**: No post/media/reaction/comment plaintext, media key, view-list entry, or close-friends
+  membership may appear in any server log line, metric, error payload, debug aid, or migration. New
+  server-side observability on these paths MUST be limited to the opaque routing metadata of
+  NFR-ZK-1 (e.g. counts, ids, sizes), never content.
+
+### Key Entities
+
+- **Friendship**: a mutual relationship between two users with a state — none, pending-outgoing,
+  pending-incoming, accepted, or blocked. Basis for all post audiences.
+- **Friend Request**: a directed, pending intent from one user to another, resolvable to accepted,
+  declined, or cancelled.
+- **Close-Friends List**: an author-private set of friends used as a narrower audience.
+- **Post**: an authored item with a type (text/voice/video/image), encrypted content/media, a chosen
+  audience (all friends / close friends), a lifetime/expiry, and a created time.
+- **Reaction**: an audience member's emoji response to a post, visible to the whole audience,
+  attributed by profile, last-write-wins per reactor.
+- **Comment**: an audience member's text response to a post, visible to the whole audience, attributed
+  by profile, ordered, deletable by its commenter or the post author.
+- **View Receipt**: a signal that an audience member viewed a post, shown to the author as a per-post
+  view list, gated by the viewer's seen-receipts setting.
+- **Profile (existing)**: avatar, name, username — already part of the public directory; shown on
+  posts, comments, reactions, and friend requests.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A friend request can be sent, received, and accepted such that both parties see a mutual
+  friendship, in under 30 seconds of network time end-to-end.
+- **SC-002**: A post shared to "all friends" is visible to 100% of the author's current friends and to
+  0% of non-friends and non-audience users.
+- **SC-003**: A "close friends" post reaches exactly the close-friends subset — 0 leakage to other
+  friends — in 100% of tests.
+- **SC-004**: Across all post types (text, voice, video, image), audience members can open and
+  render/play the content successfully on first attempt in at least 95% of cases.
+- **SC-005**: A post with a 24-hour lifetime is no longer visible to author or viewers after expiry in
+  100% of tests.
+- **SC-006**: Every audience member (not just the author) sees each reactor's identity and emoji on a
+  post, with reactor changes/removals reflected for the whole audience.
+- **SC-007**: A comment posted by any audience member appears for the author and all audience members,
+  correctly attributed and ordered, in at least 95% of cases; deletion by the commenter or post author
+  removes it for the audience.
+- **SC-008**: The author's per-post view list includes 100% of viewers who have seen receipts enabled
+  and 0% of viewers who have them disabled.
+- **SC-009**: Zero-knowledge holds: in inspection of server storage and traffic, no post content,
+  media plaintext, media key, reaction emoji, comment text, view-list membership, or close-friends
+  membership is recoverable — verified by the required checklist and security review.
+- **SC-010**: An engager never learns the audience roster: in tests, a reacting/commenting viewer
+  cannot enumerate other audience members beyond those who themselves publicly engaged.
+- **SC-011**: A declined or blocked sender cannot harass via repeated requests (requests are
+  rate-limited/suppressed) in 100% of tests.
+
+## Assumptions
+
+- **Discovery** reuses the existing public directory (search by username/profile); no new public
+  surface is introduced beyond what already exists.
+- **Secure sessions** between friends reuse Ring's existing session-establishment (X3DH); friendship
+  acceptance is the natural point to establish/confirm one.
+- **Audience is frozen at post time**; later friend/close-friend changes affect future posts only.
+- **Engagement is audience-visible** (clarified): reactions and comments are shown to the whole
+  audience and are delivered to the post's audience without disclosing the roster to the engager, so
+  close-friends membership stays author-private. Delivery does not depend on the author being online
+  (the relay fans engagement out to the post's audience).
+- **View receipts** (clarified): the author sees a per-post view list, gated reciprocally by the
+  existing seen-receipts privacy setting.
+- **Media reuse**: posts reuse Ring's existing per-file encrypted media-blob transfer; no new media
+  pipeline.
+- **Lifetime reuse**: post expiry reuses Ring's existing disappearing-message timer/sweep machinery.
+- **Single-network scope**: friendships and posts are within one Ring server/network instance.
+
+## Clarifications
+
+### Session 2026-06-21
+
+- **Q: Reaction visibility** → A: **Reactions are visible to the whole audience** (each reactor's
+  identity + emoji), not author-only. Drives FR-031 and the author-relay routing.
+- **Q: Replies/comments scope** → A: **Audience-visible comment threads are in scope for v1** (not
+  reactions-only). Drives User Story 6 and FR-033–FR-036.
+- **Q: Viewer/seen list** → A: **The author sees a per-post view list**, gated by the existing
+  seen-receipts privacy control. Drives User Story 7 and FR-037–FR-038.

--- a/specs/0003-zero-knowledge-social/tasks.md
+++ b/specs/0003-zero-knowledge-social/tasks.md
@@ -1,0 +1,273 @@
+---
+description: "Task list for feature implementation"
+---
+
+# Tasks: Zero-Knowledge Social Wall
+
+**Input**: Design documents from `/specs/0003-zero-knowledge-social/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/http-api.md
+
+**Tests**: REQUIRED. Constitution Principle III mandates TDD (failing tests before implementation) and
+Principle IV mandates forgery/replay/out-of-order/skipped-key tests for new crypto. Test tasks are
+ordered before the implementation they cover.
+
+**Organization**: Grouped by user story (spec priorities). US1 is largely *reuse* of the existing
+`connections` subsystem; the heavy lifting is US2–US7 (posts + engagement).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1–US7 (foundational/setup/polish carry no story label)
+
+## Path Conventions
+
+Web app, single repo/image: client `src/…`, server `server/internal/…`, e2e `e2e/…`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 Register lazy routes for the new pages in `src/router/index.ts` (`/wall`, `/wall/compose`, `/wall/post/:id`, `/settings/close-friends`) behind the auth gate, mirroring existing detail-route patterns.
+- [ ] T002 [P] Add a Wall entry point to navigation (tab or You-tab link) using stock Ionic, consistent with existing tabs; no behavior yet.
+- [ ] T003 [P] Create the e2e spec skeleton `e2e/wall.spec.ts` (describe blocks for friend→post→view→react→comment→expire, all `test.skip` initially).
+- [ ] T004 [P] Create the drive scenario skeleton `drive/scenarios/wall.mjs` for manual exercise against `make start`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ CRITICAL**: Blocks ALL user stories. Covers storage, the server skeleton, and the pure post-crypto core.
+
+### Client storage & types
+
+- [ ] T005 Bump `DB_VERSION` 8→9 and add `posts` + `postEngagement` object stores (keyPath `id`) in `src/db/idb.ts` `onupgradeneeded`, preserving existing data (Principle V).
+- [ ] T006 [P] Add `Post`, `PostEngagement`, and `ViewReceipt` types and extend `Contact` with `closeFriend?: boolean` in `src/db/types.ts` per data-model.md.
+- [ ] T007 [P] Add `posts`/`postEngagement` to any store-iteration lists (e.g. `clearStore`/`STORES` wipe sets, expiry-sweep store lists) so account-delete and sweeps include them.
+
+### Server schema & store skeleton
+
+- [ ] T008 Create forward-only migration `server/internal/db/migrations/0021_posts.sql` with tables `posts`, `post_envelopes`, `post_engagement`, `post_views` (opaque columns only) per data-model.md — no edits to shipped migrations (Principle VI).
+- [ ] T009 [P] Add the `PostStore` interface to `server/internal/api/router.go` (create/list/delete posts; submit/list engagement; record/list views; with audience+block authorization helpers) at the call site.
+- [ ] T010 Implement `PostStore` on `*store.Store` in `server/internal/store/posts.go` (queries against the new tables; fan-out reads `post_envelopes`).
+- [ ] T011 [P] Add a fake `PostStore` to the server test harness so handler tests need no DB (mirror existing fake-store pattern).
+
+### Pure post-crypto core (TDD — tests first)
+
+- [ ] T012 [P] Write FAILING unit tests `src/services/crypto/post.test.ts` for: post payload seal/open round-trip; per-recipient `K_post` wrap/unwrap over a Double-Ratchet session; tamper/forgery rejection; replay; out-of-order; skipped-key (Principle IV, Spec §NFR-ZK-2).
+- [ ] T013 Implement `src/services/crypto/post.ts` pure helpers (`sealPost`/`openPost`, `wrapPostKey`/`unwrapPostKey`) reusing existing libsodium primitives + the `senderkeys.ts` per-recipient pattern — no new schemes (Principle IV) — until T012 passes (green).
+- [ ] T014 [P] Create `src/services/posts.ts` orchestration skeleton (crypto-only; imports `crypto/post.ts`, `media-transfer.ts`; NO chats/contacts store writes — preserve the one-directional `queries.ts → posts.ts` dependency, Principle IV).
+
+**Checkpoint**: storage migrated, server skeleton routable, post-crypto green. User stories can begin.
+
+---
+
+## Phase 3: User Story 1 - Build a friends list with requests (Priority: P1) 🎯 MVP foundation
+
+**Goal**: A mutual friends list via request/accept, reusing the existing `connections` subsystem.
+
+**Independent Test**: A sends a request, B accepts → both list each other as friends; decline/cancel/
+block reach correct end states (spec US1).
+
+### Tests for US1
+
+- [ ] T015 [P] [US1] Extend `e2e/wall.spec.ts` with a friend-request acceptance + decline + block scenario (un-skip), asserting both sides' friend lists.
+- [ ] T016 [P] [US1] Add a server test in `server/internal/api/connections_handlers_test.go` for FR-007 repeat-request rate-limiting after decline/block.
+
+### Implementation for US1
+
+- [ ] T017 [US1] Add a `listFriends()` query in `src/db/queries.ts` returning contacts whose peer is an accepted connection (derive from `connectedPeers` ledger / `Connected`), as the audience source for posts.
+- [ ] T018 [US1] Enforce FR-007 repeat-request rate-limiting in `server/internal/store/connections.go` / `connections_handlers.go` using routing metadata only (no content) until T016 passes.
+- [ ] T019 [P] [US1] Confirm/adjust the Contacts-page friend-request UI copy in `src/views/tabs/ContactsPage.vue` to read as "friends" consistently (reuse existing accept/decline/cancel actions).
+
+**Checkpoint**: Friendship works end-to-end (mostly pre-existing); `listFriends()` available for audiences.
+
+---
+
+## Phase 4: User Story 2 - Compose and share a post to friends (Priority: P1) 🎯 MVP
+
+**Goal**: Author composes text/voice/video/image posts to "all friends" with a chosen lifetime; only
+the audience receives them, E2EE.
+
+**Independent Test**: With a friendship, author posts each media type; only audience members receive
+and decrypt; the server holds no readable content (spec US2).
+
+### Tests for US2
+
+- [ ] T020 [P] [US2] Write FAILING `server/internal/api/posts_handlers_test.go` (fake store): `POST /v1/posts` stores blob+envelopes and rejects non-friend/blocked recipients; `GET /v1/posts` returns the caller's envelope; `DELETE` is author-only.
+- [ ] T021 [P] [US2] Add a vitest for `src/services/posts.ts` create/open flow (audience envelope construction over `listFriends()`; media-ref sealed inside the payload).
+- [ ] T022 [P] [US2] Un-skip the e2e "post to all friends" path asserting audience-only delivery and a non-friend seeing nothing; cover **all four media types** (text, voice, video, image) rendering for the audience (Spec §SC-004).
+
+### Implementation for US2
+
+- [ ] T023 [US2] Implement `posts_handlers.go` (`POST /v1/posts`, `GET /v1/posts?since=`, `DELETE /v1/posts/{id}`) + routes per contracts/http-api.md, enforcing recipient∈friends and not-blocked, until T020 passes.
+- [ ] T024 [P] [US2] Add client API calls `createPost`/`listPosts`/`deletePost` in `src/services/api.ts` matching the contract.
+- [ ] T025 [US2] Implement post create in `src/services/posts.ts`: gen `K_post`, seal payload (text + media-ref), upload post blob via `media-transfer.ts`, wrap `K_post` per audience member, call `createPost` (until T021 passes).
+- [ ] T026 [US2] Implement post receive/open in `src/services/posts.ts`: unwrap `K_post` from the caller envelope, open payload, persist a `Post` (+ media via existing pipeline) through `src/db/queries.ts`.
+- [ ] T027 [US2] Add post orchestration to `src/db/queries.ts` (`createPost`, `receivePost`, `deletePost`) writing to the `posts` store and firing the change bus (queries.ts → posts.ts only). **Offline-first (Spec §FR-016)**: a created post is persisted + queued locally and flushed via the existing outbox/retry path on reconnect.
+- [ ] T028 [P] [US2] Add WS `post-new` content-free nudge handling: emit in `posts_handlers.go`; on the client, pull `listPosts` in `src/composables/useSync.ts` on receipt.
+- [ ] T029 [US2] Build `src/views/detail/PostComposerPage.vue` (Ionic): text + audience segment (all-friends/close) + lifetime select (24h/7d/keep) + reuse existing media capture/attach for voice/video/image; submit via queries. Text input is bidi-aware (`dir=auto`, reusing the chat-composer approach) per Principle X.
+- [ ] T030 [US2] Wire lifetime: set `expiresAt` on the post and extend the existing disappearing-message sweep (`useSync.ts`) to prune expired `posts`/`postEngagement`; add coarse server-side expiry pruning in `posts.go`; **add an e2e assertion that a 24h post disappears for author and viewers after expiry** (Spec §FR-012/FR-023/SC-005).
+- [ ] T031 [US2] Enforce FR-008 per-author post-rate limiting in `posts_handlers.go` using routing metadata only.
+
+**Checkpoint**: Posting to all friends works for all media types with lifetime; audience-only, E2EE.
+
+---
+
+## Phase 5: User Story 3 - View friends' posts in a Wall feed (Priority: P1) 🎯 MVP
+
+**Goal**: A reactive Wall feed of received posts with author profile, newest-first.
+
+**Independent Test**: Given posts addressed to the viewer, the Wall lists exactly those with correct
+author identity, excludes non-audience posts, updates live (spec US3).
+
+### Tests for US3
+
+- [ ] T032 [P] [US3] Un-skip the e2e Wall-view assertions: feed shows audience posts with author avatar/name/username, excludes non-audience, updates without manual refresh.
+
+### Implementation for US3
+
+- [ ] T033 [P] [US3] Create `src/composables/useWall.ts`: `useLiveQuery` over the `posts` store, newest-first, hydrating author profile from contacts/directory (respecting profile-privacy per FR-022).
+- [ ] T034 [US3] Build `src/views/tabs/WallPage.vue` (Ionic list/cards) rendering text + reused media bubbles; reactive via `useWall`.
+- [ ] T035 [US3] Build `src/views/detail/PostDetailPage.vue` shell (full-screen post; reaction/comment/view sections added in later stories).
+
+**Checkpoint**: MVP complete — friends → post → view loop works end-to-end.
+
+---
+
+## Phase 6: User Story 4 - React to posts; the audience sees reactions (Priority: P2)
+
+**Goal**: Audience-visible reactions via server fan-out to the post's audience.
+
+**Independent Test**: A viewer reacts; the author and all audience members see the reactor + emoji;
+change/remove updates everyone (spec US4).
+
+### Tests for US4
+
+- [ ] T036 [P] [US4] Write FAILING crypto tests in `src/services/crypto/post.test.ts` for engagement seal/open under `K_post`, incl. non-member-key forgery + replay + out-of-order.
+- [ ] T037 [P] [US4] Write FAILING `posts_handlers_test.go` engagement cases: fan-out to the post's `post_envelopes` set; reject non-audience/blocked submitters.
+- [ ] T038 [P] [US4] Un-skip e2e reaction scenario (audience-visible; offline-author still delivers).
+
+### Implementation for US4
+
+- [ ] T039 [US4] Add `sealEngagement`/`openEngagement` to `src/services/crypto/post.ts` (reuse `K_post`) until T036 passes.
+- [ ] T040 [US4] Implement `POST/GET /v1/posts/{id}/engagement` in `posts_handlers.go` with audience+block authz and fan-out to the post's recipient set; FR-008 per-user engagement-rate limit (until T037 passes).
+- [ ] T041 [P] [US4] Add client API `submitEngagement`/`listEngagement` in `src/services/api.ts`.
+- [ ] T042 [US4] Reaction orchestration in `src/db/queries.ts` + `posts.ts`: seal reaction under `K_post`, submit, persist to `postEngagement`; apply existing reaction caps + LWW-per-actor.
+- [ ] T043 [P] [US4] Add WS `post-engagement` nudge (emit server-side; pull `listEngagement` in `useSync.ts`).
+- [ ] T044 [US4] Reaction UI on `PostDetailPage.vue`/`WallPage.vue`: emoji react bar + reactor list (profiles), composed from Ionic.
+
+**Checkpoint**: Audience-visible reactions work, author-online-independent.
+
+---
+
+## Phase 7: User Story 5 - Curate a close-friends list (Priority: P2)
+
+**Goal**: An author-private close-friends subset usable as a narrower audience.
+
+**Independent Test**: Mark some friends close; a "close friends" post reaches exactly that set, no
+other friend; membership never leaves the device (spec US5).
+
+### Tests for US5
+
+- [ ] T045 [P] [US5] Un-skip e2e close-friends scenario: close post reaches only close friends; a non-close friend sees nothing; assert no `closeFriend` in any request body / server table; assert an engaging viewer **cannot enumerate the audience roster** beyond co-engagers (Spec §SC-010).
+
+### Implementation for US5
+
+- [ ] T046 [US5] Implement `setCloseFriend(id, bool)` + `listCloseFriends()` in `src/db/queries.ts` (writes `Contact.closeFriend`; rides existing encrypted own-sync — never sent to server).
+- [ ] T047 [P] [US5] Build `src/views/detail/CloseFriendsPage.vue` (Ionic toggles over the friends list).
+- [ ] T048 [US5] Wire the composer's "close friends" audience to encrypt to `listCloseFriends()` only (envelopes restricted to that subset).
+
+**Checkpoint**: Close-friends audience works and stays author-private.
+
+---
+
+## Phase 8: User Story 6 - Comment on a post (audience-visible thread) (Priority: P3)
+
+**Goal**: Audience-visible text comments with deletion by commenter or post author.
+
+**Independent Test**: A viewer comments; author + audience see it attributed/ordered; commenter and
+author can delete (spec US6).
+
+### Tests for US6
+
+- [ ] T049 [P] [US6] Extend `posts_handlers_test.go` for comment + tombstone fan-out and author/commenter delete authorization.
+- [ ] T050 [P] [US6] Un-skip e2e comment scenario (post + delete by commenter and by post author).
+
+### Implementation for US6
+
+- [ ] T051 [US6] Comment orchestration in `queries.ts` + `posts.ts`: seal comment under `K_post`, submit `kind:'comment'`, persist ordered (timestamp + id tiebreak); deletion as `kind:'tombstone'` by commenter or post author (until T049 passes).
+- [ ] T052 [US6] Comment thread UI on `PostDetailPage.vue` (Ionic): list + bidi-aware (`dir=auto`) input + per-comment delete affordances respecting authorization (Principle X).
+
+**Checkpoint**: Audience-visible comments with moderation work.
+
+---
+
+## Phase 9: User Story 7 - See who viewed a post (Priority: P3)
+
+**Goal**: Author-only per-post view list, gated reciprocally by seen-receipts.
+
+**Independent Test**: A receipts-on viewer appears in the author's view list; a receipts-off viewer
+does not and gets no view list on their own posts (spec US7).
+
+### Tests for US7
+
+- [ ] T053 [P] [US7] Add `posts_handlers_test.go` cases: `POST /view` records; `GET /views` is author-only (403 otherwise).
+- [ ] T054 [P] [US7] Un-skip e2e view-receipt scenario incl. the seen-receipts-off reciprocity.
+
+### Implementation for US7
+
+- [ ] T055 [US7] Implement `POST /v1/posts/{id}/view` + author-only `GET /v1/posts/{id}/views` in `posts_handlers.go` (until T053 passes).
+- [ ] T056 [US7] Client: on opening a post, if `privacy.seenReceipts` is on, send a view receipt; gate view-list display reciprocally (mirror `useSync.ts` seen-receipt reciprocity) in `posts.ts`/`useWall.ts`.
+- [ ] T057 [US7] View-list UI on `PostDetailPage.vue` for the author only (Ionic).
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+- [ ] T058 [P] Add real, wired post/Wall settings to `src/settings/schema.ts` (default post audience; post/reaction/comment notification toggles) replacing the removed placeholder "Status" rows (Spec §FR-050).
+- [ ] T059 Wire post/engagement notifications through the existing model (`src/services/notify*`, `src/sw.ts`) honoring per-item preview privacy and the new settings (Spec §FR-051).
+- [ ] T060 [P] Add unfriend/close-friend-removal + post-delete UI copy reflecting the no-clawback limitation (Spec §Edge Cases).
+- [ ] T061 Run the crypto/ZK checklist (`checklists/crypto-zk.md`) against the implementation and obtain the required security review (Constitution Principle IV).
+- [ ] T062 [P] Run `quickstart.md` validation (ZK spot-checks on Postgres; non-audience negative case).
+- [ ] T063 Quality gates: `npm run build`, `cd server && go build ./... && go vet ./... && go test ./...`, vitest + floors, `npm run test:e2e` green (Constitution VII).
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (P1)** → **Foundational (P2, BLOCKS all)** → user stories.
+- **US1 (P1)**: independent (reuse). **US2 (P1)**: needs Foundational. **US3 (P1)**: needs US2 (posts to view). **US4 (P2)**: needs US2. **US5 (P2)**: needs US2 (audience). **US6 (P3)**: needs US2 + US4 engagement infra. **US7 (P3)**: needs US2.
+- **Polish (P10)**: after the desired stories.
+
+### Within a story
+
+- Tests FIRST and FAILING before implementation (Principles III/IV).
+- Models/types → services/crypto → endpoints → UI → integration.
+
+### Parallel opportunities
+
+- Setup T002–T004 parallel. Foundational T006/T007, T009/T011, T012 parallel where files differ.
+- Per story, `[P]` test tasks run together; client API + server handler tasks for the same story can
+  proceed in parallel by different people.
+
+---
+
+## Implementation Strategy
+
+### MVP (Stories US1–US3)
+
+Setup → Foundational → US1 (friendship reuse) → US2 (posting) → US3 (Wall feed). STOP and validate the
+friends→post→view loop independently before P2/P3.
+
+### Incremental
+
+Add US4 (reactions) → US5 (close friends) → US6 (comments) → US7 (views), each independently testable,
+then Polish (settings/notifications/security review/gates).
+
+## Notes
+
+- `[P]` = different files, no incomplete dependency. `[Story]` = traceability to spec.
+- Commit after each task or logical group; keep `queries.ts → posts.ts` one-directional (no cycle).
+- Every crypto task carries the adversarial test set; every handler task carries fake-store authz tests.
+- The crypto/ZK checklist + maintainer security review (T061) gate `merge` per the constitution.

--- a/specs/0003-zero-knowledge-social/tasks.md
+++ b/specs/0003-zero-knowledge-social/tasks.md
@@ -28,10 +28,10 @@ Web app, single repo/image: client `src/…`, server `server/internal/…`, e2e 
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-- [ ] T001 Register lazy routes for the new pages in `src/router/index.ts` (`/wall`, `/wall/compose`, `/wall/post/:id`, `/settings/close-friends`) behind the auth gate, mirroring existing detail-route patterns.
-- [ ] T002 [P] Add a Wall entry point to navigation (tab or You-tab link) using stock Ionic, consistent with existing tabs; no behavior yet.
-- [ ] T003 [P] Create the e2e spec skeleton `e2e/wall.spec.ts` (describe blocks for friend→post→view→react→comment→expire, all `test.skip` initially).
-- [ ] T004 [P] Create the drive scenario skeleton `drive/scenarios/wall.mjs` for manual exercise against `make start`.
+- [ ] T001 (#250) Register lazy routes for the new pages in `src/router/index.ts` (`/wall`, `/wall/compose`, `/wall/post/:id`, `/settings/close-friends`) behind the auth gate, mirroring existing detail-route patterns.
+- [ ] T002 (#251) [P] Add a Wall entry point to navigation (tab or You-tab link) using stock Ionic, consistent with existing tabs; no behavior yet.
+- [ ] T003 (#252) [P] Create the e2e spec skeleton `e2e/wall.spec.ts` (describe blocks for friend→post→view→react→comment→expire, all `test.skip` initially).
+- [ ] T004 (#253) [P] Create the drive scenario skeleton `drive/scenarios/wall.mjs` for manual exercise against `make start`.
 
 ---
 
@@ -41,22 +41,22 @@ Web app, single repo/image: client `src/…`, server `server/internal/…`, e2e 
 
 ### Client storage & types
 
-- [ ] T005 Bump `DB_VERSION` 8→9 and add `posts` + `postEngagement` object stores (keyPath `id`) in `src/db/idb.ts` `onupgradeneeded`, preserving existing data (Principle V).
-- [ ] T006 [P] Add `Post`, `PostEngagement`, and `ViewReceipt` types and extend `Contact` with `closeFriend?: boolean` in `src/db/types.ts` per data-model.md.
-- [ ] T007 [P] Add `posts`/`postEngagement` to any store-iteration lists (e.g. `clearStore`/`STORES` wipe sets, expiry-sweep store lists) so account-delete and sweeps include them.
+- [ ] T005 (#254) Bump `DB_VERSION` 8→9 and add `posts` + `postEngagement` object stores (keyPath `id`) in `src/db/idb.ts` `onupgradeneeded`, preserving existing data (Principle V).
+- [ ] T006 (#255) [P] Add `Post`, `PostEngagement`, and `ViewReceipt` types and extend `Contact` with `closeFriend?: boolean` in `src/db/types.ts` per data-model.md.
+- [ ] T007 (#256) [P] Add `posts`/`postEngagement` to any store-iteration lists (e.g. `clearStore`/`STORES` wipe sets, expiry-sweep store lists) so account-delete and sweeps include them.
 
 ### Server schema & store skeleton
 
-- [ ] T008 Create forward-only migration `server/internal/db/migrations/0021_posts.sql` with tables `posts`, `post_envelopes`, `post_engagement`, `post_views` (opaque columns only) per data-model.md — no edits to shipped migrations (Principle VI).
-- [ ] T009 [P] Add the `PostStore` interface to `server/internal/api/router.go` (create/list/delete posts; submit/list engagement; record/list views; with audience+block authorization helpers) at the call site.
-- [ ] T010 Implement `PostStore` on `*store.Store` in `server/internal/store/posts.go` (queries against the new tables; fan-out reads `post_envelopes`).
-- [ ] T011 [P] Add a fake `PostStore` to the server test harness so handler tests need no DB (mirror existing fake-store pattern).
+- [ ] T008 (#257) Create forward-only migration `server/internal/db/migrations/0021_posts.sql` with tables `posts`, `post_envelopes`, `post_engagement`, `post_views` (opaque columns only) per data-model.md — no edits to shipped migrations (Principle VI).
+- [ ] T009 (#258) [P] Add the `PostStore` interface to `server/internal/api/router.go` (create/list/delete posts; submit/list engagement; record/list views; with audience+block authorization helpers) at the call site.
+- [ ] T010 (#259) Implement `PostStore` on `*store.Store` in `server/internal/store/posts.go` (queries against the new tables; fan-out reads `post_envelopes`).
+- [ ] T011 (#260) [P] Add a fake `PostStore` to the server test harness so handler tests need no DB (mirror existing fake-store pattern).
 
 ### Pure post-crypto core (TDD — tests first)
 
-- [ ] T012 [P] Write FAILING unit tests `src/services/crypto/post.test.ts` for: post payload seal/open round-trip; per-recipient `K_post` wrap/unwrap over a Double-Ratchet session; tamper/forgery rejection; replay; out-of-order; skipped-key (Principle IV, Spec §NFR-ZK-2).
-- [ ] T013 Implement `src/services/crypto/post.ts` pure helpers (`sealPost`/`openPost`, `wrapPostKey`/`unwrapPostKey`) reusing existing libsodium primitives + the `senderkeys.ts` per-recipient pattern — no new schemes (Principle IV) — until T012 passes (green).
-- [ ] T014 [P] Create `src/services/posts.ts` orchestration skeleton (crypto-only; imports `crypto/post.ts`, `media-transfer.ts`; NO chats/contacts store writes — preserve the one-directional `queries.ts → posts.ts` dependency, Principle IV).
+- [ ] T012 (#261) [P] Write FAILING unit tests `src/services/crypto/post.test.ts` for: post payload seal/open round-trip; per-recipient `K_post` wrap/unwrap over a Double-Ratchet session; tamper/forgery rejection; replay; out-of-order; skipped-key (Principle IV, Spec §NFR-ZK-2).
+- [ ] T013 (#262) Implement `src/services/crypto/post.ts` pure helpers (`sealPost`/`openPost`, `wrapPostKey`/`unwrapPostKey`) reusing existing libsodium primitives + the `senderkeys.ts` per-recipient pattern — no new schemes (Principle IV) — until T012 passes (green).
+- [ ] T014 (#263) [P] Create `src/services/posts.ts` orchestration skeleton (crypto-only; imports `crypto/post.ts`, `media-transfer.ts`; NO chats/contacts store writes — preserve the one-directional `queries.ts → posts.ts` dependency, Principle IV).
 
 **Checkpoint**: storage migrated, server skeleton routable, post-crypto green. User stories can begin.
 
@@ -71,14 +71,14 @@ block reach correct end states (spec US1).
 
 ### Tests for US1
 
-- [ ] T015 [P] [US1] Extend `e2e/wall.spec.ts` with a friend-request acceptance + decline + block scenario (un-skip), asserting both sides' friend lists.
-- [ ] T016 [P] [US1] Add a server test in `server/internal/api/connections_handlers_test.go` for FR-007 repeat-request rate-limiting after decline/block.
+- [ ] T015 (#264) [P] [US1] Extend `e2e/wall.spec.ts` with a friend-request acceptance + decline + block scenario (un-skip), asserting both sides' friend lists.
+- [ ] T016 (#265) [P] [US1] Add a server test in `server/internal/api/connections_handlers_test.go` for FR-007 repeat-request rate-limiting after decline/block.
 
 ### Implementation for US1
 
-- [ ] T017 [US1] Add a `listFriends()` query in `src/db/queries.ts` returning contacts whose peer is an accepted connection (derive from `connectedPeers` ledger / `Connected`), as the audience source for posts.
-- [ ] T018 [US1] Enforce FR-007 repeat-request rate-limiting in `server/internal/store/connections.go` / `connections_handlers.go` using routing metadata only (no content) until T016 passes.
-- [ ] T019 [P] [US1] Confirm/adjust the Contacts-page friend-request UI copy in `src/views/tabs/ContactsPage.vue` to read as "friends" consistently (reuse existing accept/decline/cancel actions).
+- [ ] T017 (#266) [US1] Add a `listFriends()` query in `src/db/queries.ts` returning contacts whose peer is an accepted connection (derive from `connectedPeers` ledger / `Connected`), as the audience source for posts.
+- [ ] T018 (#267) [US1] Enforce FR-007 repeat-request rate-limiting in `server/internal/store/connections.go` / `connections_handlers.go` using routing metadata only (no content) until T016 passes.
+- [ ] T019 (#268) [P] [US1] Confirm/adjust the Contacts-page friend-request UI copy in `src/views/tabs/ContactsPage.vue` to read as "friends" consistently (reuse existing accept/decline/cancel actions).
 
 **Checkpoint**: Friendship works end-to-end (mostly pre-existing); `listFriends()` available for audiences.
 
@@ -94,21 +94,21 @@ and decrypt; the server holds no readable content (spec US2).
 
 ### Tests for US2
 
-- [ ] T020 [P] [US2] Write FAILING `server/internal/api/posts_handlers_test.go` (fake store): `POST /v1/posts` stores blob+envelopes and rejects non-friend/blocked recipients; `GET /v1/posts` returns the caller's envelope; `DELETE` is author-only.
-- [ ] T021 [P] [US2] Add a vitest for `src/services/posts.ts` create/open flow (audience envelope construction over `listFriends()`; media-ref sealed inside the payload).
-- [ ] T022 [P] [US2] Un-skip the e2e "post to all friends" path asserting audience-only delivery and a non-friend seeing nothing; cover **all four media types** (text, voice, video, image) rendering for the audience (Spec §SC-004).
+- [ ] T020 (#269) [P] [US2] Write FAILING `server/internal/api/posts_handlers_test.go` (fake store): `POST /v1/posts` stores blob+envelopes and rejects non-friend/blocked recipients; `GET /v1/posts` returns the caller's envelope; `DELETE` is author-only.
+- [ ] T021 (#270) [P] [US2] Add a vitest for `src/services/posts.ts` create/open flow (audience envelope construction over `listFriends()`; media-ref sealed inside the payload).
+- [ ] T022 (#271) [P] [US2] Un-skip the e2e "post to all friends" path asserting audience-only delivery and a non-friend seeing nothing; cover **all four media types** (text, voice, video, image) rendering for the audience (Spec §SC-004).
 
 ### Implementation for US2
 
-- [ ] T023 [US2] Implement `posts_handlers.go` (`POST /v1/posts`, `GET /v1/posts?since=`, `DELETE /v1/posts/{id}`) + routes per contracts/http-api.md, enforcing recipient∈friends and not-blocked, until T020 passes.
-- [ ] T024 [P] [US2] Add client API calls `createPost`/`listPosts`/`deletePost` in `src/services/api.ts` matching the contract.
-- [ ] T025 [US2] Implement post create in `src/services/posts.ts`: gen `K_post`, seal payload (text + media-ref), upload post blob via `media-transfer.ts`, wrap `K_post` per audience member, call `createPost` (until T021 passes).
-- [ ] T026 [US2] Implement post receive/open in `src/services/posts.ts`: unwrap `K_post` from the caller envelope, open payload, persist a `Post` (+ media via existing pipeline) through `src/db/queries.ts`.
-- [ ] T027 [US2] Add post orchestration to `src/db/queries.ts` (`createPost`, `receivePost`, `deletePost`) writing to the `posts` store and firing the change bus (queries.ts → posts.ts only). **Offline-first (Spec §FR-016)**: a created post is persisted + queued locally and flushed via the existing outbox/retry path on reconnect.
-- [ ] T028 [P] [US2] Add WS `post-new` content-free nudge handling: emit in `posts_handlers.go`; on the client, pull `listPosts` in `src/composables/useSync.ts` on receipt.
-- [ ] T029 [US2] Build `src/views/detail/PostComposerPage.vue` (Ionic): text + audience segment (all-friends/close) + lifetime select (24h/7d/keep) + reuse existing media capture/attach for voice/video/image; submit via queries. Text input is bidi-aware (`dir=auto`, reusing the chat-composer approach) per Principle X.
-- [ ] T030 [US2] Wire lifetime: set `expiresAt` on the post and extend the existing disappearing-message sweep (`useSync.ts`) to prune expired `posts`/`postEngagement`; add coarse server-side expiry pruning in `posts.go`; **add an e2e assertion that a 24h post disappears for author and viewers after expiry** (Spec §FR-012/FR-023/SC-005).
-- [ ] T031 [US2] Enforce FR-008 per-author post-rate limiting in `posts_handlers.go` using routing metadata only.
+- [ ] T023 (#272) [US2] Implement `posts_handlers.go` (`POST /v1/posts`, `GET /v1/posts?since=`, `DELETE /v1/posts/{id}`) + routes per contracts/http-api.md, enforcing recipient∈friends and not-blocked, until T020 passes.
+- [ ] T024 (#273) [P] [US2] Add client API calls `createPost`/`listPosts`/`deletePost` in `src/services/api.ts` matching the contract.
+- [ ] T025 (#274) [US2] Implement post create in `src/services/posts.ts`: gen `K_post`, seal payload (text + media-ref), upload post blob via `media-transfer.ts`, wrap `K_post` per audience member, call `createPost` (until T021 passes).
+- [ ] T026 (#275) [US2] Implement post receive/open in `src/services/posts.ts`: unwrap `K_post` from the caller envelope, open payload, persist a `Post` (+ media via existing pipeline) through `src/db/queries.ts`.
+- [ ] T027 (#276) [US2] Add post orchestration to `src/db/queries.ts` (`createPost`, `receivePost`, `deletePost`) writing to the `posts` store and firing the change bus (queries.ts → posts.ts only). **Offline-first (Spec §FR-016)**: a created post is persisted + queued locally and flushed via the existing outbox/retry path on reconnect.
+- [ ] T028 (#277) [P] [US2] Add WS `post-new` content-free nudge handling: emit in `posts_handlers.go`; on the client, pull `listPosts` in `src/composables/useSync.ts` on receipt.
+- [ ] T029 (#278) [US2] Build `src/views/detail/PostComposerPage.vue` (Ionic): text + audience segment (all-friends/close) + lifetime select (24h/7d/keep) + reuse existing media capture/attach for voice/video/image; submit via queries. Text input is bidi-aware (`dir=auto`, reusing the chat-composer approach) per Principle X.
+- [ ] T030 (#279) [US2] Wire lifetime: set `expiresAt` on the post and extend the existing disappearing-message sweep (`useSync.ts`) to prune expired `posts`/`postEngagement`; add coarse server-side expiry pruning in `posts.go`; **add an e2e assertion that a 24h post disappears for author and viewers after expiry** (Spec §FR-012/FR-023/SC-005).
+- [ ] T031 (#280) [US2] Enforce FR-008 per-author post-rate limiting in `posts_handlers.go` using routing metadata only.
 
 **Checkpoint**: Posting to all friends works for all media types with lifetime; audience-only, E2EE.
 
@@ -123,13 +123,13 @@ author identity, excludes non-audience posts, updates live (spec US3).
 
 ### Tests for US3
 
-- [ ] T032 [P] [US3] Un-skip the e2e Wall-view assertions: feed shows audience posts with author avatar/name/username, excludes non-audience, updates without manual refresh.
+- [ ] T032 (#281) [P] [US3] Un-skip the e2e Wall-view assertions: feed shows audience posts with author avatar/name/username, excludes non-audience, updates without manual refresh.
 
 ### Implementation for US3
 
-- [ ] T033 [P] [US3] Create `src/composables/useWall.ts`: `useLiveQuery` over the `posts` store, newest-first, hydrating author profile from contacts/directory (respecting profile-privacy per FR-022).
-- [ ] T034 [US3] Build `src/views/tabs/WallPage.vue` (Ionic list/cards) rendering text + reused media bubbles; reactive via `useWall`.
-- [ ] T035 [US3] Build `src/views/detail/PostDetailPage.vue` shell (full-screen post; reaction/comment/view sections added in later stories).
+- [ ] T033 (#282) [P] [US3] Create `src/composables/useWall.ts`: `useLiveQuery` over the `posts` store, newest-first, hydrating author profile from contacts/directory (respecting profile-privacy per FR-022).
+- [ ] T034 (#283) [US3] Build `src/views/tabs/WallPage.vue` (Ionic list/cards) rendering text + reused media bubbles; reactive via `useWall`.
+- [ ] T035 (#284) [US3] Build `src/views/detail/PostDetailPage.vue` shell (full-screen post; reaction/comment/view sections added in later stories).
 
 **Checkpoint**: MVP complete — friends → post → view loop works end-to-end.
 
@@ -144,18 +144,18 @@ change/remove updates everyone (spec US4).
 
 ### Tests for US4
 
-- [ ] T036 [P] [US4] Write FAILING crypto tests in `src/services/crypto/post.test.ts` for engagement seal/open under `K_post`, incl. non-member-key forgery + replay + out-of-order.
-- [ ] T037 [P] [US4] Write FAILING `posts_handlers_test.go` engagement cases: fan-out to the post's `post_envelopes` set; reject non-audience/blocked submitters.
-- [ ] T038 [P] [US4] Un-skip e2e reaction scenario (audience-visible; offline-author still delivers).
+- [ ] T036 (#285) [P] [US4] Write FAILING crypto tests in `src/services/crypto/post.test.ts` for engagement seal/open under `K_post`, incl. non-member-key forgery + replay + out-of-order.
+- [ ] T037 (#286) [P] [US4] Write FAILING `posts_handlers_test.go` engagement cases: fan-out to the post's `post_envelopes` set; reject non-audience/blocked submitters.
+- [ ] T038 (#287) [P] [US4] Un-skip e2e reaction scenario (audience-visible; offline-author still delivers).
 
 ### Implementation for US4
 
-- [ ] T039 [US4] Add `sealEngagement`/`openEngagement` to `src/services/crypto/post.ts` (reuse `K_post`) until T036 passes.
-- [ ] T040 [US4] Implement `POST/GET /v1/posts/{id}/engagement` in `posts_handlers.go` with audience+block authz and fan-out to the post's recipient set; FR-008 per-user engagement-rate limit (until T037 passes).
-- [ ] T041 [P] [US4] Add client API `submitEngagement`/`listEngagement` in `src/services/api.ts`.
-- [ ] T042 [US4] Reaction orchestration in `src/db/queries.ts` + `posts.ts`: seal reaction under `K_post`, submit, persist to `postEngagement`; apply existing reaction caps + LWW-per-actor.
-- [ ] T043 [P] [US4] Add WS `post-engagement` nudge (emit server-side; pull `listEngagement` in `useSync.ts`).
-- [ ] T044 [US4] Reaction UI on `PostDetailPage.vue`/`WallPage.vue`: emoji react bar + reactor list (profiles), composed from Ionic.
+- [ ] T039 (#288) [US4] Add `sealEngagement`/`openEngagement` to `src/services/crypto/post.ts` (reuse `K_post`) until T036 passes.
+- [ ] T040 (#289) [US4] Implement `POST/GET /v1/posts/{id}/engagement` in `posts_handlers.go` with audience+block authz and fan-out to the post's recipient set; FR-008 per-user engagement-rate limit (until T037 passes).
+- [ ] T041 (#290) [P] [US4] Add client API `submitEngagement`/`listEngagement` in `src/services/api.ts`.
+- [ ] T042 (#291) [US4] Reaction orchestration in `src/db/queries.ts` + `posts.ts`: seal reaction under `K_post`, submit, persist to `postEngagement`; apply existing reaction caps + LWW-per-actor.
+- [ ] T043 (#292) [P] [US4] Add WS `post-engagement` nudge (emit server-side; pull `listEngagement` in `useSync.ts`).
+- [ ] T044 (#293) [US4] Reaction UI on `PostDetailPage.vue`/`WallPage.vue`: emoji react bar + reactor list (profiles), composed from Ionic.
 
 **Checkpoint**: Audience-visible reactions work, author-online-independent.
 
@@ -170,13 +170,13 @@ other friend; membership never leaves the device (spec US5).
 
 ### Tests for US5
 
-- [ ] T045 [P] [US5] Un-skip e2e close-friends scenario: close post reaches only close friends; a non-close friend sees nothing; assert no `closeFriend` in any request body / server table; assert an engaging viewer **cannot enumerate the audience roster** beyond co-engagers (Spec §SC-010).
+- [ ] T045 (#294) [P] [US5] Un-skip e2e close-friends scenario: close post reaches only close friends; a non-close friend sees nothing; assert no `closeFriend` in any request body / server table; assert an engaging viewer **cannot enumerate the audience roster** beyond co-engagers (Spec §SC-010).
 
 ### Implementation for US5
 
-- [ ] T046 [US5] Implement `setCloseFriend(id, bool)` + `listCloseFriends()` in `src/db/queries.ts` (writes `Contact.closeFriend`; rides existing encrypted own-sync — never sent to server).
-- [ ] T047 [P] [US5] Build `src/views/detail/CloseFriendsPage.vue` (Ionic toggles over the friends list).
-- [ ] T048 [US5] Wire the composer's "close friends" audience to encrypt to `listCloseFriends()` only (envelopes restricted to that subset).
+- [ ] T046 (#295) [US5] Implement `setCloseFriend(id, bool)` + `listCloseFriends()` in `src/db/queries.ts` (writes `Contact.closeFriend`; rides existing encrypted own-sync — never sent to server).
+- [ ] T047 (#296) [P] [US5] Build `src/views/detail/CloseFriendsPage.vue` (Ionic toggles over the friends list).
+- [ ] T048 (#297) [US5] Wire the composer's "close friends" audience to encrypt to `listCloseFriends()` only (envelopes restricted to that subset).
 
 **Checkpoint**: Close-friends audience works and stays author-private.
 
@@ -191,13 +191,13 @@ author can delete (spec US6).
 
 ### Tests for US6
 
-- [ ] T049 [P] [US6] Extend `posts_handlers_test.go` for comment + tombstone fan-out and author/commenter delete authorization.
-- [ ] T050 [P] [US6] Un-skip e2e comment scenario (post + delete by commenter and by post author).
+- [ ] T049 (#298) [P] [US6] Extend `posts_handlers_test.go` for comment + tombstone fan-out and author/commenter delete authorization.
+- [ ] T050 (#299) [P] [US6] Un-skip e2e comment scenario (post + delete by commenter and by post author).
 
 ### Implementation for US6
 
-- [ ] T051 [US6] Comment orchestration in `queries.ts` + `posts.ts`: seal comment under `K_post`, submit `kind:'comment'`, persist ordered (timestamp + id tiebreak); deletion as `kind:'tombstone'` by commenter or post author (until T049 passes).
-- [ ] T052 [US6] Comment thread UI on `PostDetailPage.vue` (Ionic): list + bidi-aware (`dir=auto`) input + per-comment delete affordances respecting authorization (Principle X).
+- [ ] T051 (#300) [US6] Comment orchestration in `queries.ts` + `posts.ts`: seal comment under `K_post`, submit `kind:'comment'`, persist ordered (timestamp + id tiebreak); deletion as `kind:'tombstone'` by commenter or post author (until T049 passes).
+- [ ] T052 (#301) [US6] Comment thread UI on `PostDetailPage.vue` (Ionic): list + bidi-aware (`dir=auto`) input + per-comment delete affordances respecting authorization (Principle X).
 
 **Checkpoint**: Audience-visible comments with moderation work.
 
@@ -212,25 +212,25 @@ does not and gets no view list on their own posts (spec US7).
 
 ### Tests for US7
 
-- [ ] T053 [P] [US7] Add `posts_handlers_test.go` cases: `POST /view` records; `GET /views` is author-only (403 otherwise).
-- [ ] T054 [P] [US7] Un-skip e2e view-receipt scenario incl. the seen-receipts-off reciprocity.
+- [ ] T053 (#302) [P] [US7] Add `posts_handlers_test.go` cases: `POST /view` records; `GET /views` is author-only (403 otherwise).
+- [ ] T054 (#303) [P] [US7] Un-skip e2e view-receipt scenario incl. the seen-receipts-off reciprocity.
 
 ### Implementation for US7
 
-- [ ] T055 [US7] Implement `POST /v1/posts/{id}/view` + author-only `GET /v1/posts/{id}/views` in `posts_handlers.go` (until T053 passes).
-- [ ] T056 [US7] Client: on opening a post, if `privacy.seenReceipts` is on, send a view receipt; gate view-list display reciprocally (mirror `useSync.ts` seen-receipt reciprocity) in `posts.ts`/`useWall.ts`.
-- [ ] T057 [US7] View-list UI on `PostDetailPage.vue` for the author only (Ionic).
+- [ ] T055 (#304) [US7] Implement `POST /v1/posts/{id}/view` + author-only `GET /v1/posts/{id}/views` in `posts_handlers.go` (until T053 passes).
+- [ ] T056 (#305) [US7] Client: on opening a post, if `privacy.seenReceipts` is on, send a view receipt; gate view-list display reciprocally (mirror `useSync.ts` seen-receipt reciprocity) in `posts.ts`/`useWall.ts`.
+- [ ] T057 (#306) [US7] View-list UI on `PostDetailPage.vue` for the author only (Ionic).
 
 ---
 
 ## Phase 10: Polish & Cross-Cutting Concerns
 
-- [ ] T058 [P] Add real, wired post/Wall settings to `src/settings/schema.ts` (default post audience; post/reaction/comment notification toggles) replacing the removed placeholder "Status" rows (Spec §FR-050).
-- [ ] T059 Wire post/engagement notifications through the existing model (`src/services/notify*`, `src/sw.ts`) honoring per-item preview privacy and the new settings (Spec §FR-051).
-- [ ] T060 [P] Add unfriend/close-friend-removal + post-delete UI copy reflecting the no-clawback limitation (Spec §Edge Cases).
-- [ ] T061 Run the crypto/ZK checklist (`checklists/crypto-zk.md`) against the implementation and obtain the required security review (Constitution Principle IV).
-- [ ] T062 [P] Run `quickstart.md` validation (ZK spot-checks on Postgres; non-audience negative case).
-- [ ] T063 Quality gates: `npm run build`, `cd server && go build ./... && go vet ./... && go test ./...`, vitest + floors, `npm run test:e2e` green (Constitution VII).
+- [ ] T058 (#307) [P] Add real, wired post/Wall settings to `src/settings/schema.ts` (default post audience; post/reaction/comment notification toggles) replacing the removed placeholder "Status" rows (Spec §FR-050).
+- [ ] T059 (#308) Wire post/engagement notifications through the existing model (`src/services/notify*`, `src/sw.ts`) honoring per-item preview privacy and the new settings (Spec §FR-051).
+- [ ] T060 (#309) [P] Add unfriend/close-friend-removal + post-delete UI copy reflecting the no-clawback limitation (Spec §Edge Cases).
+- [ ] T061 (#310) Run the crypto/ZK checklist (`checklists/crypto-zk.md`) against the implementation and obtain the required security review (Constitution Principle IV).
+- [ ] T062 (#311) [P] Run `quickstart.md` validation (ZK spot-checks on Postgres; non-audience negative case).
+- [ ] T063 (#312) Quality gates: `npm run build`, `cd server && go build ./... && go vet ./... && go test ./...`, vitest + floors, `npm run test:e2e` green (Constitution VII).
 
 ---
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -47,7 +47,7 @@ import { callState } from '@/composables/useCall';
 import { stopAudio } from '@/composables/useAudioPlayer';
 import { useSync, nudgeReconnect } from '@/composables/useSync';
 import { useAppUpdate } from '@/composables/useAppUpdate';
-import { countPendingRequests, listChats, listFailedMessages, retryAllFailed } from '@/db/queries';
+import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import type { Message } from '@/db/types';
 
@@ -169,6 +169,8 @@ function onServiceWorkerMessage(ev: MessageEvent): void {
   if (!data) return;
   if (data.type === 'ring:navigate') {
     void routeRelevant(data.url);
+  } else if (data.type === 'ring:posts') {
+    void syncPosts(); // a Wall-post push woke us → pull (the in-app banner fires on the WS frame)
   } else if (data.type === 'ring:drain') {
     nudgeReconnect(); // pull queued messages now
     // We're a live page: if we're UNLOCKED we'll surface the message in-app

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,7 +46,7 @@ import NotificationBanners from '@/components/NotificationBanners.vue';
 import { callState } from '@/composables/useCall';
 import { stopAudio } from '@/composables/useAudioPlayer';
 import { useSync, nudgeReconnect } from '@/composables/useSync';
-import { useAppUpdate } from '@/composables/useAppUpdate';
+import { useAppUpdate, checkForUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import type { Message } from '@/db/types';
@@ -171,6 +171,8 @@ function onServiceWorkerMessage(ev: MessageEvent): void {
     void routeRelevant(data.url);
   } else if (data.type === 'ring:posts') {
     void syncPosts(); // a Wall-post push woke us → pull (the in-app banner fires on the WS frame)
+  } else if (data.type === 'ring:checkupdate') {
+    checkForUpdate(true); // a version-announcement push woke us → check now (surfaces the update toast)
   } else if (data.type === 'ring:drain') {
     nudgeReconnect(); // pull queued messages now
     // We're a live page: if we're UNLOCKED we'll surface the message in-app

--- a/src/components/AnimatedEmoji.vue
+++ b/src/components/AnimatedEmoji.vue
@@ -9,10 +9,15 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 
 /**
- * An emoji that plays its Noto Lottie animation a few times when it scrolls into
- * view, then freezes. The Lottie is served from our own server's cached proxy
- * (/v1/emoji/...), never a third-party CDN. Falls back to the native glyph when
- * animation is off, the emoji has no Noto Lottie, or the server can't reach it.
+ * An emoji that plays its Noto Lottie animation in a continuous loop WHILE it is
+ * visible on screen, and PAUSES the moment it scrolls off — so a long feed full of
+ * animated emoji only ever animates the handful actually in view (bounded CPU). The
+ * Lottie is served from our own server's cached proxy (/v1/emoji/...), never a
+ * third-party CDN. Falls back to the native glyph when animation is off, the emoji has
+ * no Noto Lottie, or the server can't reach it.
+ *
+ * (`plays` is accepted but ignored — playback is now visibility-driven, not count-
+ * capped — so existing callers don't break.)
  */
 const props = withDefaults(
   defineProps<{ emoji: string; animate?: boolean; large?: boolean; plays?: number }>(),
@@ -26,15 +31,18 @@ const showNative = ref(true); // native glyph shows until (and unless) Lottie lo
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let anim: any = null;
 let observer: IntersectionObserver | null = null;
-let started = false;
+let loading = false;
+let visible = false;
 
 function codepoints(): string {
   return [...props.emoji].map((c) => (c.codePointAt(0) ?? 0).toString(16)).join('_');
 }
 
-async function play(): Promise<void> {
-  if (started || !props.animate || !anchor.value) return;
-  started = true;
+// Lazily load the Lottie on first visibility, then loop it. Subsequent visibility
+// changes just resume/pause the already-loaded animation.
+async function ensureLoaded(): Promise<void> {
+  if (anim || loading || !props.animate || !anchor.value) return;
+  loading = true;
   try {
     // Self-hosted: proxied + cached by our own server (never a third-party CDN).
     const res = await fetch(`/v1/emoji/${codepoints()}/lottie.json`);
@@ -46,37 +54,41 @@ async function play(): Promise<void> {
       container: anchor.value,
       renderer: 'svg',
       loop: true,
-      autoplay: true,
+      autoplay: false,
       animationData: data,
     });
     showNative.value = false;
-    let loops = 0;
-    anim.addEventListener('loopComplete', () => {
-      loops += 1;
-      if (loops >= props.plays) anim.pause(); // freeze on the final frame
-    });
+    if (visible) anim.play(); // it became (or stayed) visible while loading
   } catch {
     /* keep the native glyph */
+  } finally {
+    loading = false;
+  }
+}
+
+function setVisible(on: boolean): void {
+  visible = on;
+  if (on) {
+    void ensureLoaded();
+    anim?.play();
+  } else {
+    anim?.pause();
   }
 }
 
 onMounted(() => {
   if (!props.animate) return;
   if (!('IntersectionObserver' in window)) {
-    void play();
+    setVisible(true); // no IO → just play (rare/legacy)
     return;
   }
+  // Keep observing (don't disconnect) so the emoji pauses/resumes as it scrolls in
+  // and out of view, not just on the first appearance.
   observer = new IntersectionObserver(
     (entries) => {
-      for (const e of entries) {
-        if (e.isIntersecting) {
-          void play();
-          observer?.disconnect();
-          observer = null;
-        }
-      }
+      for (const e of entries) setVisible(e.isIntersecting);
     },
-    { threshold: 0.5 },
+    { threshold: 0.1 },
   );
   if (rootEl.value) observer.observe(rootEl.value);
 });

--- a/src/components/EmojiPickerModal.vue
+++ b/src/components/EmojiPickerModal.vue
@@ -1,0 +1,51 @@
+<template>
+  <ion-content class="emoji-picker-modal">
+    <div ref="host" class="picker-host"></div>
+  </ion-content>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { IonContent, modalController } from '@ionic/vue';
+
+/**
+ * The full emoji picker (the same `emoji-picker-element` web component the chat uses),
+ * wrapped in a sheet so the Wall can reuse it. Dismisses with `{ emoji }` on pick.
+ */
+const host = ref<HTMLElement | null>(null);
+let el: HTMLElement | null = null;
+
+function onPick(ev: Event): void {
+  const emoji = (ev as CustomEvent<{ unicode?: string }>).detail?.unicode;
+  void modalController.dismiss(emoji ? { emoji } : undefined);
+}
+
+onMounted(async () => {
+  await import('emoji-picker-element');
+  el = document.createElement('emoji-picker');
+  el.addEventListener('emoji-click', onPick as EventListener);
+  host.value?.appendChild(el);
+});
+
+onBeforeUnmount(() => {
+  el?.removeEventListener('emoji-click', onPick as EventListener);
+  el?.remove();
+  el = null;
+});
+</script>
+
+<style scoped>
+.emoji-picker-modal {
+  --background: transparent;
+}
+.picker-host {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+}
+.picker-host :deep(emoji-picker) {
+  width: 100%;
+  max-width: 420px;
+  height: 100%;
+}
+</style>

--- a/src/components/EmojiText.vue
+++ b/src/components/EmojiText.vue
@@ -1,0 +1,43 @@
+<template>
+  <!-- Renders a run of text with inline animated Noto emoji, the same way chat message
+       bodies do: split into plain-text + emoji segments and render each emoji with
+       <AnimatedEmoji>. Used for Wall post bodies and comments so their emoji match the
+       rest of the app (animated, self-hosted, animation-pref aware). -->
+  <span class="emoji-text" dir="auto" :class="{ 'emoji-only': isBig }"><template
+    v-for="(p, i) in parts"
+    :key="i"
+  ><animated-emoji
+      v-if="p.emoji"
+      :emoji="p.emoji"
+      :animate="animEmoji"
+      :large="isBig"
+    /><template v-else>{{ p.text }}</template></template></span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import AnimatedEmoji from '@/components/AnimatedEmoji.vue';
+import { segmentEmoji, emojiOnlyCount } from '@/utils/emoji';
+import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
+
+// `big`: when set, a text that is ONLY emoji (≤3) renders enlarged, matching how chat
+// renders short emoji-only messages. Off for compact contexts (feed rows, comments).
+const props = withDefaults(defineProps<{ text: string; big?: boolean }>(), { big: false });
+
+const { animEmoji } = useAnimationPrefs();
+const parts = computed(() => segmentEmoji(props.text));
+const isBig = computed(() => {
+  if (!props.big) return false;
+  const n = emojiOnlyCount(props.text);
+  return n > 0 && n <= 3;
+});
+</script>
+
+<style scoped>
+.emoji-text {
+  white-space: pre-wrap;
+}
+.emoji-text.emoji-only {
+  font-size: 2em;
+}
+</style>

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -21,7 +21,7 @@ import { watch } from 'vue';
 import { useRegisterSW } from 'virtual:pwa-register/vue';
 import { toastController, modalController } from '@ionic/vue';
 import { fetchServerConfig } from '@/services/api';
-import { computeDelta, displayVersion, type ReleaseNote } from '@/services/release-notes';
+import { computeDelta, userFacing, displayVersion, type ReleaseNote } from '@/services/release-notes';
 import WhatsNewSheet from '@/components/WhatsNewSheet.vue';
 
 /** Present the "What's new" sheet with the per-user delta. Resolves true when the
@@ -107,8 +107,10 @@ export function useAppUpdate(): void {
     const shown = displayVersion(version);
     const label = version && version !== running ? `Ring ${shown} is ready to install.` : 'A new version of Ring is ready.';
 
-    // Per-user delta: the changes the incoming build adds that this one didn't have.
-    const delta = computeDelta(incoming, __RELEASE_NOTES__ ?? []);
+    // Per-user delta: the changes the incoming build adds that this one didn't have,
+    // narrowed to what a regular user cares about (features/fixes, not CI/test/docs/
+    // chores) so "What's new" reads as improvements rather than a developer changelog.
+    const delta = userFacing(computeDelta(incoming, __RELEASE_NOTES__ ?? []));
 
     const buttons: { text: string; role?: 'cancel'; handler?: () => boolean | void }[] = [];
     if (delta.length) {

--- a/src/composables/useBadges.ts
+++ b/src/composables/useBadges.ts
@@ -15,6 +15,7 @@ import {
   countPendingRequests,
   countUnread,
   countUnresolvedAlerts,
+  wallUnreadCount,
 } from '@/db/queries';
 import { incomingRequests } from '@/services/connections';
 
@@ -41,12 +42,15 @@ export function useBadges() {
   const pendingDb = useLiveQuery(() => countPendingRequests(), ['requests'], 0);
   const contacts = computed(() => pendingDb.value + incomingRequests.value.length);
   const you = useLiveQuery(() => countUnresolvedAlerts(), ['alerts'], 0);
+  // Wall = unseen received posts (cleared when the Wall tab is open). Depends on both
+  // the posts store and settings (the last-seen marker + hidden-user ledger).
+  const wall = useLiveQuery(() => wallUnreadCount(), ['posts', 'settings'], 0);
 
   const total = computed(
-    () => chats.value + calls.value + contacts.value + you.value,
+    () => chats.value + calls.value + contacts.value + you.value + wall.value,
   );
 
   watch(total, (n) => setAppBadge(n), { immediate: true });
 
-  return { chats, calls, contacts, you, total };
+  return { chats, calls, contacts, you, wall, total };
 }

--- a/src/composables/useReactionPicker.ts
+++ b/src/composables/useReactionPicker.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared reaction picker so the Wall reacts exactly like chat: a quick-react popover
+ * (your 5 most-used emoji, via QuickReactBar) with a "+" that opens the full emoji
+ * picker. The caller supplies an `onPick(emoji)` callback. Keeps the "most-used at your
+ * fingertips" behavior consistent everywhere.
+ */
+import { popoverController, modalController } from '@ionic/vue';
+import QuickReactBar from '@/components/QuickReactBar.vue';
+import EmojiPickerModal from '@/components/EmojiPickerModal.vue';
+import { quickReactEmojis } from '@/db/queries';
+
+export interface QuickReactOpts {
+  myEmojis?: string[]; // the user's current reactions (highlighted)
+  existing?: string[]; // distinct emoji already on the item
+  atEmojiCap?: boolean; // item at the distinct-emoji cap → only `existing` offered
+  onPick: (emoji: string) => void | Promise<void>;
+}
+
+export function useReactionPicker() {
+  async function openQuick(ev: Event, opts: QuickReactOpts): Promise<void> {
+    const pop = await popoverController.create({
+      component: QuickReactBar,
+      cssClass: 'reaction-popover quick-react-popover',
+      componentProps: {
+        myEmojis: opts.myEmojis,
+        quick: await quickReactEmojis(5),
+        existing: opts.existing,
+        atEmojiCap: opts.atEmojiCap,
+      },
+      event: ev,
+      reference: 'event',
+      side: 'top',
+      alignment: 'center',
+      showBackdrop: false,
+    });
+    await pop.present();
+    const { data } = await pop.onWillDismiss();
+    if (!data) return;
+    if (data.action === 'react') {
+      await opts.onPick(data.emoji);
+    } else if (data.action === 'more') {
+      const modal = await modalController.create({
+        component: EmojiPickerModal,
+        cssClass: 'emoji-picker-sheet',
+        breakpoints: [0, 0.6, 0.95],
+        initialBreakpoint: 0.6,
+      });
+      await modal.present();
+      const res = await modal.onWillDismiss();
+      if (res.data?.emoji) await opts.onPick(res.data.emoji);
+    }
+  }
+
+  return { openQuick };
+}

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -22,7 +22,7 @@ import {
   type TransportState,
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
-import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement } from '@/db/queries';
+import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost } from '@/db/queries';
 import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
@@ -297,8 +297,12 @@ function start(): void {
     // Connect-request notifications: re-read the authoritative state, and alert on a
     // new incoming request (so it surfaces like a friend request).
     if (f.t === 'post-new') {
-      // A Wall post addressed to us arrived (spec 0003). Content-free nudge → pull.
-      void syncPosts();
+      // A Wall post addressed to us arrived (spec 0003). Content-free nudge → pull,
+      // then surface an in-app banner ("X shared a photo").
+      void (async () => {
+        await syncPosts();
+        if (f.from) await notifyNewPost(f.from);
+      })();
       return;
     }
     if (f.t === 'post-engagement') {

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -22,7 +22,7 @@ import {
   type TransportState,
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
-import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported } from '@/db/queries';
+import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts } from '@/db/queries';
 import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
@@ -296,6 +296,11 @@ function start(): void {
   transport.onMessage((f) => {
     // Connect-request notifications: re-read the authoritative state, and alert on a
     // new incoming request (so it surfaces like a friend request).
+    if (f.t === 'post-new') {
+      // A Wall post addressed to us arrived (spec 0003). Content-free nudge → pull.
+      void syncPosts();
+      return;
+    }
     if (f.t === 'connect-req') {
       void refreshConnections();
       // FR-012a: a brand-new requester isn't a contact yet → a generic, identity-safe
@@ -379,6 +384,11 @@ function start(): void {
   // vanish on both sides shortly after their timer elapses even mid-session.
   void sweepExpiredMessages();
   setInterval(() => void sweepExpiredMessages(), 30_000);
+  // Wall posts (spec 0003): pull any addressed to us, and sweep expired ones on the
+  // same cadence as disappearing messages so they vanish shortly after their timer.
+  void syncPosts();
+  void sweepExpiredPosts();
+  setInterval(() => void sweepExpiredPosts(), 30_000);
   // Periodically confirm downloaded media to senders (catches background auto-downloads in
   // chats we haven't opened), so they can free the blobs without waiting for a reconnect.
   setInterval(() => void sendDownloadedReceipts(), 30_000);
@@ -433,6 +443,7 @@ function start(): void {
         // connected flips to "Ghosted" on return (reconnect alone won't fire if
         // the socket stayed up). Cheap batch call; errors are swallowed.
         if (isUnlocked.value) void refreshContactStatuses();
+        if (isUnlocked.value) void syncPosts(); // catch Wall posts that arrived while away
         // Re-assert push on a warm reopen (no reconnect event fires), so a device
         // whose subscription silently lapsed while closed heals on foreground.
         // Throttled internally, so this is cheap to run every time.

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -22,7 +22,7 @@ import {
   type TransportState,
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
-import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost } from '@/db/queries';
+import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, pruneLocalPost } from '@/db/queries';
 import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
@@ -308,6 +308,12 @@ function start(): void {
     if (f.t === 'post-engagement') {
       // A reaction landed on a post we can see → pull that post's engagement.
       void syncEngagement(f.post);
+      return;
+    }
+    if (f.t === 'post-revoke') {
+      // The author revoked a post from us (e.g. dropped us from close friends) →
+      // remove our local copy immediately.
+      void pruneLocalPost(f.post);
       return;
     }
     if (f.t === 'connect-req') {

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -22,7 +22,7 @@ import {
   type TransportState,
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
-import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts } from '@/db/queries';
+import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement } from '@/db/queries';
 import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
@@ -299,6 +299,11 @@ function start(): void {
     if (f.t === 'post-new') {
       // A Wall post addressed to us arrived (spec 0003). Content-free nudge → pull.
       void syncPosts();
+      return;
+    }
+    if (f.t === 'post-engagement') {
+      // A reaction landed on a post we can see → pull that post's engagement.
+      void syncEngagement(f.post);
       return;
     }
     if (f.t === 'connect-req') {

--- a/src/composables/useWall.ts
+++ b/src/composables/useWall.ts
@@ -1,0 +1,43 @@
+/**
+ * Reactive Wall feed (spec 0003, US3). Live-queries the local `posts` store and
+ * hydrates each post's author identity (avatar/name/username) from contacts — "You"
+ * for own posts. Reactive via the idb change bus, so a newly received or composed
+ * post appears without a manual refresh.
+ */
+import { computed } from 'vue';
+import { useLiveQuery } from '@/composables/useLiveQuery';
+import { useSelfProfile } from '@/composables/useSelfProfile';
+import { listWallPosts, listContacts } from '@/db/queries';
+import { getSelfUserId } from '@/services/auth';
+import type { Post, Contact } from '@/db/types';
+
+export interface WallPost extends Post {
+  isOwn: boolean;
+  authorName: string;
+  authorAvatar: string;
+  authorUsername?: string;
+}
+
+export function useWall() {
+  const posts = useLiveQuery(() => listWallPosts(), ['posts'], [] as Post[]);
+  const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+  const self = useSelfProfile();
+  const selfId = getSelfUserId();
+
+  const wall = computed<WallPost[]>(() => {
+    const byId = new Map(contacts.value.map((c) => [c.id, c]));
+    return posts.value.map((p) => {
+      const isOwn = p.author === selfId;
+      const c = byId.get(p.author);
+      return {
+        ...p,
+        isOwn,
+        authorName: isOwn ? 'You' : c?.name ?? 'Unknown',
+        authorAvatar: isOwn ? self.avatar.value : c?.avatar ?? '',
+        authorUsername: isOwn ? undefined : c?.username,
+      };
+    });
+  });
+
+  return { wall };
+}

--- a/src/composables/useWall.ts
+++ b/src/composables/useWall.ts
@@ -9,7 +9,7 @@
 import { computed, ref, watch, onUnmounted } from 'vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useSelfProfile } from '@/composables/useSelfProfile';
-import { listWallPosts, listContacts, listAllPostEngagement, getMedia } from '@/db/queries';
+import { listWallPosts, listContacts, listAllPostEngagement, getMedia, getWallMutedUsers } from '@/db/queries';
 import { getSelfUserId } from '@/services/auth';
 import type { Post, Contact, PostEngagement } from '@/db/types';
 
@@ -22,6 +22,7 @@ export interface CommentView {
   id: string;
   actor: string;
   authorName: string;
+  authorAvatar: string;
   text: string;
   at: number;
 }
@@ -30,6 +31,7 @@ export interface WallPost extends Post {
   authorName: string;
   authorAvatar: string;
   authorUsername?: string;
+  muted: boolean; // author's Wall notifications are muted
   mediaUrl?: string;
   reactions: ReactionGroup[];
   myEmojis: string[];
@@ -42,6 +44,7 @@ export function useWall() {
   const posts = useLiveQuery(() => listWallPosts(), ['posts', 'settings'], [] as Post[]);
   const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
   const engagement = useLiveQuery(() => listAllPostEngagement(), ['postEngagement'], [] as PostEngagement[]);
+  const mutedUsers = useLiveQuery(() => getWallMutedUsers(), ['settings'], {} as Record<string, boolean>);
   const self = useSelfProfile();
   const selfId = getSelfUserId();
 
@@ -104,10 +107,18 @@ export function useWall() {
       const reactions = [...rmap.entries()].map(([emoji, g]) => ({ emoji, ...g }));
       const myEmojis = reactionRows.filter((r) => r.actor === selfId).map((r) => r.emoji!);
 
+      const avatarOf = (id: string) => (id === selfId ? self.avatar.value : byId.get(id)?.avatar ?? '');
       const comments = es
         .filter((e) => e.type === 'comment' && !e.deleted)
         .sort((a, b) => a.at - b.at || a.id.localeCompare(b.id))
-        .map((cm) => ({ id: cm.id, actor: cm.actor, authorName: nameOf(cm.actor), text: cm.text ?? '', at: cm.at }));
+        .map((cm) => ({
+          id: cm.id,
+          actor: cm.actor,
+          authorName: nameOf(cm.actor),
+          authorAvatar: avatarOf(cm.actor),
+          text: cm.text ?? '',
+          at: cm.at,
+        }));
 
       return {
         ...p,
@@ -115,6 +126,7 @@ export function useWall() {
         authorName: isOwn ? 'You' : c?.name ?? 'Unknown',
         authorAvatar: isOwn ? self.avatar.value : c?.avatar ?? '',
         authorUsername: isOwn ? undefined : c?.username,
+        muted: !!mutedUsers.value[p.author],
         mediaUrl: mediaUrls.value[p.id],
         reactions,
         myEmojis,

--- a/src/composables/useWall.ts
+++ b/src/composables/useWall.ts
@@ -1,13 +1,13 @@
 /**
  * Reactive Wall feed (spec 0003, US3). Live-queries the local `posts` store and
  * hydrates each post's author identity (avatar/name/username) from contacts — "You"
- * for own posts. Reactive via the idb change bus, so a newly received or composed
- * post appears without a manual refresh.
+ * for own posts — plus an object URL for any attached photo/video/voice. Reactive via
+ * the idb change bus, so a newly received or composed post appears without a refresh.
  */
-import { computed } from 'vue';
+import { computed, ref, watch, onUnmounted } from 'vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useSelfProfile } from '@/composables/useSelfProfile';
-import { listWallPosts, listContacts } from '@/db/queries';
+import { listWallPosts, listContacts, getMedia } from '@/db/queries';
 import { getSelfUserId } from '@/services/auth';
 import type { Post, Contact } from '@/db/types';
 
@@ -16,6 +16,7 @@ export interface WallPost extends Post {
   authorName: string;
   authorAvatar: string;
   authorUsername?: string;
+  mediaUrl?: string;
 }
 
 export function useWall() {
@@ -23,6 +24,33 @@ export function useWall() {
   const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
   const self = useSelfProfile();
   const selfId = getSelfUserId();
+
+  // Resolve media blobs → object URLs, keyed by post id. Reused across re-renders;
+  // URLs no longer referenced are revoked.
+  const mediaUrls = ref<Record<string, string>>({});
+  watch(
+    () => posts.value.map((p) => `${p.id}:${p.mediaId ?? ''}`).join('|'),
+    async () => {
+      const next: Record<string, string> = {};
+      for (const p of posts.value) {
+        if (!p.mediaId) continue;
+        if (mediaUrls.value[p.id]) {
+          next[p.id] = mediaUrls.value[p.id];
+          continue;
+        }
+        const md = await getMedia(p.mediaId);
+        if (md?.blob) next[p.id] = URL.createObjectURL(md.blob);
+      }
+      for (const [pid, url] of Object.entries(mediaUrls.value)) {
+        if (next[pid] !== url) URL.revokeObjectURL(url);
+      }
+      mediaUrls.value = next;
+    },
+    { immediate: true },
+  );
+  onUnmounted(() => {
+    for (const url of Object.values(mediaUrls.value)) URL.revokeObjectURL(url);
+  });
 
   const wall = computed<WallPost[]>(() => {
     const byId = new Map(contacts.value.map((c) => [c.id, c]));
@@ -35,6 +63,7 @@ export function useWall() {
         authorName: isOwn ? 'You' : c?.name ?? 'Unknown',
         authorAvatar: isOwn ? self.avatar.value : c?.avatar ?? '',
         authorUsername: isOwn ? undefined : c?.username,
+        mediaUrl: mediaUrls.value[p.id],
       };
     });
   });

--- a/src/composables/useWall.ts
+++ b/src/composables/useWall.ts
@@ -38,7 +38,8 @@ export interface WallPost extends Post {
 }
 
 export function useWall() {
-  const posts = useLiveQuery(() => listWallPosts(), ['posts'], [] as Post[]);
+  // Depends on settings too: listWallPosts excludes hidden users (a settings ledger).
+  const posts = useLiveQuery(() => listWallPosts(), ['posts', 'settings'], [] as Post[]);
   const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
   const engagement = useLiveQuery(() => listAllPostEngagement(), ['postEngagement'], [] as PostEngagement[]);
   const self = useSelfProfile();
@@ -123,5 +124,7 @@ export function useWall() {
     });
   });
 
-  return { wall, now };
+  // `loaded` flips true after the first query resolves, so the UI can avoid flashing
+  // the empty state / "New post" button before posts have loaded.
+  return { wall, now, loaded: posts.loaded };
 }

--- a/src/composables/useWall.ts
+++ b/src/composables/useWall.ts
@@ -1,32 +1,55 @@
 /**
- * Reactive Wall feed (spec 0003, US3). Live-queries the local `posts` store and
- * hydrates each post's author identity (avatar/name/username) from contacts — "You"
- * for own posts — plus an object URL for any attached photo/video/voice. Reactive via
- * the idb change bus, so a newly received or composed post appears without a refresh.
+ * Reactive Wall feed (spec 0003). One set of live queries (posts + contacts +
+ * engagement) drives the whole feed: each post is enriched with its author identity,
+ * an attachment object URL, grouped reactions, and its comments — so the feed can show
+ * inline reactions and a comment preview without diving in. A 30s clock tick keeps the
+ * "disappears in …" countdowns fresh. Ordering is by last activity (queries side), so
+ * new posts and newly-interacted posts both rise to the top.
  */
 import { computed, ref, watch, onUnmounted } from 'vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useSelfProfile } from '@/composables/useSelfProfile';
-import { listWallPosts, listContacts, getMedia } from '@/db/queries';
+import { listWallPosts, listContacts, listAllPostEngagement, getMedia } from '@/db/queries';
 import { getSelfUserId } from '@/services/auth';
-import type { Post, Contact } from '@/db/types';
+import type { Post, Contact, PostEngagement } from '@/db/types';
 
+export interface ReactionGroup {
+  emoji: string;
+  count: number;
+  mine: boolean;
+}
+export interface CommentView {
+  id: string;
+  actor: string;
+  authorName: string;
+  text: string;
+  at: number;
+}
 export interface WallPost extends Post {
   isOwn: boolean;
   authorName: string;
   authorAvatar: string;
   authorUsername?: string;
   mediaUrl?: string;
+  reactions: ReactionGroup[];
+  myEmojis: string[];
+  comments: CommentView[];
+  commentCount: number;
 }
 
 export function useWall() {
   const posts = useLiveQuery(() => listWallPosts(), ['posts'], [] as Post[]);
   const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+  const engagement = useLiveQuery(() => listAllPostEngagement(), ['postEngagement'], [] as PostEngagement[]);
   const self = useSelfProfile();
   const selfId = getSelfUserId();
 
-  // Resolve media blobs → object URLs, keyed by post id. Reused across re-renders;
-  // URLs no longer referenced are revoked.
+  // Live clock for the countdowns (cheap; 30s granularity is plenty for hours-scale).
+  const now = ref(Date.now());
+  const tick = setInterval(() => (now.value = Date.now()), 30_000);
+  onUnmounted(() => clearInterval(tick));
+
+  // Media object URLs by post id (created/revoked as posts come and go).
   const mediaUrls = ref<Record<string, string>>({});
   watch(
     () => posts.value.map((p) => `${p.id}:${p.mediaId ?? ''}`).join('|'),
@@ -54,9 +77,37 @@ export function useWall() {
 
   const wall = computed<WallPost[]>(() => {
     const byId = new Map(contacts.value.map((c) => [c.id, c]));
+    const nameOf = (id: string) => (id === selfId ? 'You' : byId.get(id)?.name ?? 'Someone');
+
+    // Group engagement by post in one pass.
+    const byPost = new Map<string, PostEngagement[]>();
+    for (const e of engagement.value) {
+      const list = byPost.get(e.postId) ?? [];
+      list.push(e);
+      byPost.set(e.postId, list);
+    }
+
     return posts.value.map((p) => {
       const isOwn = p.author === selfId;
       const c = byId.get(p.author);
+      const es = byPost.get(p.id) ?? [];
+
+      const reactionRows = es.filter((e) => e.type === 'reaction' && !e.deleted && e.emoji);
+      const rmap = new Map<string, { count: number; mine: boolean }>();
+      for (const r of reactionRows) {
+        const g = rmap.get(r.emoji!) ?? { count: 0, mine: false };
+        g.count += 1;
+        if (r.actor === selfId) g.mine = true;
+        rmap.set(r.emoji!, g);
+      }
+      const reactions = [...rmap.entries()].map(([emoji, g]) => ({ emoji, ...g }));
+      const myEmojis = reactionRows.filter((r) => r.actor === selfId).map((r) => r.emoji!);
+
+      const comments = es
+        .filter((e) => e.type === 'comment' && !e.deleted)
+        .sort((a, b) => a.at - b.at || a.id.localeCompare(b.id))
+        .map((cm) => ({ id: cm.id, actor: cm.actor, authorName: nameOf(cm.actor), text: cm.text ?? '', at: cm.at }));
+
       return {
         ...p,
         isOwn,
@@ -64,9 +115,13 @@ export function useWall() {
         authorAvatar: isOwn ? self.avatar.value : c?.avatar ?? '',
         authorUsername: isOwn ? undefined : c?.username,
         mediaUrl: mediaUrls.value[p.id],
+        reactions,
+        myEmojis,
+        comments,
+        commentCount: comments.length,
       };
     });
   });
 
-  return { wall };
+  return { wall, now };
 }

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -22,6 +22,10 @@ export const STORES = [
   'tombstones', // soft-delete markers so pull can't resurrect rows
   // v5: user-defined chat filter lists (Chats-tab "lists").
   'chatlists',
+  // v9 (spec 0003): the social Wall. `posts` = received/own posts; `postEngagement`
+  // = reactions/comments/view-receipts keyed by postId. Both keyPath 'id'.
+  'posts',
+  'postEngagement',
 ] as const;
 export type StoreName = (typeof STORES)[number];
 
@@ -30,7 +34,9 @@ const DB_NAME = 'ring';
 // are additive optional Blob fields on existing records — IndexedDB needs no per-row transform for
 // that, so the version bump alone (which documents the schema evolution) is the whole migration;
 // existing rows are preserved unchanged and the tiers are filled in by the background backfill.
-const DB_VERSION = 8;
+// v9 (spec 0003): add the social-Wall stores `posts` + `postEngagement` (additive
+// createObjectStore in onupgradeneeded; existing data untouched).
+const DB_VERSION = 9;
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 
@@ -133,6 +139,14 @@ export function openDB(): Promise<IDBDatabase> {
       // v5: user-defined chat filter lists.
       if (!db.objectStoreNames.contains('chatlists'))
         db.createObjectStore('chatlists', { keyPath: 'id' });
+      // v9 (spec 0003): social-Wall stores. `postEngagement` indexes by postId so a
+      // post's reactions/comments/views can be read in one range query.
+      if (!db.objectStoreNames.contains('posts'))
+        db.createObjectStore('posts', { keyPath: 'id' });
+      if (!db.objectStoreNames.contains('postEngagement')) {
+        const s = db.createObjectStore('postEngagement', { keyPath: 'id' });
+        s.createIndex('postId', 'postId');
+      }
       // Forward message migrations (v6: spec 1010 "read"→"seen" rename; v7: spec 1013
       // seen-reported backfill). They run in ONE cursor pass so a multi-version upgrade
       // (e.g. v5→v7) does not open two racing cursors on the same store that could clobber

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -31,7 +31,7 @@ import type {
 } from '@/services/crypto/message';
 import type {
   Alert, Call, CallLog, Chat, ChatList, Contact, FriendRequest, Media, Message, MessageKind, Reaction, ReplyRef,
-  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post,
+  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement,
 } from './types';
 
 // WhatsApp-style cap on pinned chats.
@@ -1978,13 +1978,16 @@ export async function setCloseFriend(id: string, value: boolean): Promise<void> 
 
 /* ---- spec 0003: Wall posts ---- */
 
-// Author-chosen post lifetime → ttl (ms); 'keep' = no expiry.
-const POST_TTL_MS: Record<string, number | undefined> = {
+// Author-chosen post lifetime → ttl (ms). Wall posts are ALWAYS ephemeral: nothing
+// lives longer than 72 hours, whatever its type (text/photo/video/voice). There is no
+// "keep" option, and the server independently clamps to MAX_POST_TTL_MS as a backstop.
+export const MAX_POST_TTL_MS = 72 * 60 * 60 * 1000;
+const POST_TTL_MS: Record<string, number> = {
+  '1h': 60 * 60 * 1000,
   '24h': 24 * 60 * 60 * 1000,
-  '7d': 7 * 24 * 60 * 60 * 1000,
-  keep: undefined,
+  '72h': MAX_POST_TTL_MS,
 };
-export type PostLifetime = 'keep' | '24h' | '7d';
+export type PostLifetime = '1h' | '24h' | '72h';
 
 // Cache each friend's X25519 identity public key (stable per account) so building a
 // post doesn't re-fetch (and re-consume a one-time prekey) for every post. Lazily
@@ -2006,12 +2009,17 @@ async function peerPostKey(userId: string): Promise<Uint8Array | null> {
  * ciphertext + the per-recipient envelope set.
  */
 export async function createPost(opts: {
-  payload: PostPayload;
+  body?: string;
   audience: 'friends' | 'close';
   lifetime: PostLifetime;
+  // Optional attachment (image/video/voice). When present, it is encrypted + uploaded
+  // and the media-ref rides sealed inside the post payload.
+  media?: { blob: Blob; kind: 'image' | 'video' | 'voice'; name: string; durationSec?: number };
 }): Promise<Post> {
   const self = getSelfUserId();
   if (!self) throw new Error('not signed in');
+  const body = opts.body?.trim() || undefined;
+  if (!body && !opts.media) throw new Error('Nothing to post.');
   const friends = opts.audience === 'close' ? await listCloseFriends() : await listFriends();
   if (!friends.length) throw new Error('No audience — add friends first.');
   const audience: AudienceMember[] = [];
@@ -2020,18 +2028,42 @@ export async function createPost(opts: {
     if (pub) audience.push({ userId: f.id, pubKey: pub });
   }
   if (!audience.length) throw new Error('No reachable audience for this post.');
-  const built = buildPost(opts.payload, audience);
+
+  // Encrypt + upload the attachment first (its key rides sealed in the payload), and
+  // keep a local Media copy so the author renders it immediately.
+  const kind: Post['kind'] = opts.media ? opts.media.kind : 'text';
+  let mediaId: string | undefined;
+  const payload: PostPayload = { kind, body };
+  if (opts.media) {
+    const ref = await prepareOutgoingMedia(opts.media.blob, opts.media.name, opts.media.durationSec);
+    payload.media = ref;
+    mediaId = uid();
+    await put<Media>('media', {
+      id: mediaId,
+      kind: opts.media.kind,
+      mime: ref.mime,
+      name: ref.name,
+      size: ref.size,
+      blob: opts.media.blob,
+      durationSec: ref.durationSec,
+      updatedAt: now(),
+    });
+  }
+
+  const built = buildPost(payload, audience);
   const blobId = await uploadBlob(new Blob([built.blob as BlobPart]));
   const id = uid();
   const createdAt = now();
-  const ttl = POST_TTL_MS[opts.lifetime];
-  const expiresAt = ttl ? createdAt + ttl : undefined;
+  // Always ephemeral, hard-capped at 72h (the server clamps too).
+  const ttl = Math.min(POST_TTL_MS[opts.lifetime] ?? MAX_POST_TTL_MS, MAX_POST_TTL_MS);
+  const expiresAt = createdAt + ttl;
   await apiCreatePost({ id, blobId, size: built.blob.length, expiresAt, envelopes: built.envelopes });
   const post: Post = {
     id,
     author: self,
-    kind: opts.payload.kind,
-    body: opts.payload.body,
+    kind,
+    body,
+    mediaId,
     audience: opts.audience,
     createdAt,
     expiresAt,
@@ -2057,11 +2089,31 @@ async function receivePost(sp: ServerPost): Promise<void> {
   } catch {
     return;
   }
+  // Pull + decrypt the attachment (if any) and store it as a local Media record so the
+  // Wall renders it like any other media.
+  let mediaId: string | undefined;
+  if (payload.media && payload.kind !== 'text') {
+    const mblob = await receiveIncomingMedia(payload.media).catch(() => null);
+    if (mblob) {
+      mediaId = uid();
+      await put<Media>('media', {
+        id: mediaId,
+        kind: payload.kind,
+        mime: payload.media.mime,
+        name: payload.media.name,
+        size: payload.media.size,
+        blob: mblob,
+        durationSec: payload.media.durationSec,
+        updatedAt: now(),
+      });
+    }
+  }
   await put<Post>('posts', {
     id: sp.id,
     author: sp.author,
     kind: payload.kind,
     body: payload.body,
+    mediaId,
     createdAt: sp.createdAt,
     expiresAt: sp.expiresAt,
     outgoing: false,
@@ -2094,6 +2146,11 @@ export async function listWallPosts(): Promise<Post[]> {
 /** A single Wall post by id (or null). */
 export async function getPost(id: string): Promise<Post | null> {
   return (await get<Post>('posts', id)) ?? null;
+}
+
+/** A media record by id (for rendering a post's photo/video/voice). */
+export async function getMedia(id: string): Promise<Media | null> {
+  return (await get<Media>('media', id)) ?? null;
 }
 
 /** Delete one of our own posts: best-effort server delete + remove the local copy. */

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2012,9 +2012,10 @@ export async function createPost(opts: {
   body?: string;
   audience: 'friends' | 'close';
   lifetime: PostLifetime;
-  // Optional attachment (image/video/voice). When present, it is encrypted + uploaded
-  // and the media-ref rides sealed inside the post payload.
-  media?: { blob: Blob; kind: 'image' | 'video' | 'voice'; name: string; durationSec?: number };
+  // Optional attachment (image/video/voice). When present, it is compressed to the
+  // chosen quality (SD or HD — never original), encrypted + uploaded, and the media-ref
+  // rides sealed inside the post payload.
+  media?: { blob: Blob; kind: 'image' | 'video' | 'voice'; name: string; durationSec?: number; quality?: 'sd' | 'hd' };
 }): Promise<Post> {
   const self = getSelfUserId();
   if (!self) throw new Error('not signed in');
@@ -2035,7 +2036,16 @@ export async function createPost(opts: {
   let mediaId: string | undefined;
   const payload: PostPayload = { kind, body };
   if (opts.media) {
-    const ref = await prepareOutgoingMedia(opts.media.blob, opts.media.name, opts.media.durationSec);
+    // Posts only ship SD or HD (never the original): compress images/videos to the
+    // chosen quality before upload; voice is left as-is.
+    const q = opts.media.quality ?? 'hd';
+    const toUpload =
+      opts.media.kind === 'image'
+        ? await compressImage(opts.media.blob, q)
+        : opts.media.kind === 'video'
+          ? await compressVideo(opts.media.blob, q)
+          : opts.media.blob;
+    const ref = await prepareOutgoingMedia(toUpload, opts.media.name, opts.media.durationSec, { quality: q });
     payload.media = ref;
     mediaId = uid();
     await put<Media>('media', {
@@ -2044,7 +2054,7 @@ export async function createPost(opts: {
       mime: ref.mime,
       name: ref.name,
       size: ref.size,
-      blob: opts.media.blob,
+      blob: toUpload,
       durationSec: ref.durationSec,
       updatedAt: now(),
     });
@@ -2054,10 +2064,11 @@ export async function createPost(opts: {
   const blobId = await uploadBlob(new Blob([built.blob as BlobPart]));
   const id = uid();
   const createdAt = now();
-  // Always ephemeral, hard-capped at 72h (the server clamps too).
-  const ttl = Math.min(POST_TTL_MS[opts.lifetime] ?? MAX_POST_TTL_MS, MAX_POST_TTL_MS);
-  const expiresAt = createdAt + ttl;
-  await apiCreatePost({ id, blobId, size: built.blob.length, expiresAt, envelopes: built.envelopes });
+  // The chosen window (1h/24h/72h), capped at 72h. Keep-alive later resets the expiry
+  // to now + this same window on each interaction.
+  const ttlMs = Math.min(POST_TTL_MS[opts.lifetime] ?? MAX_POST_TTL_MS, MAX_POST_TTL_MS);
+  const expiresAt = createdAt + ttlMs;
+  await apiCreatePost({ id, blobId, size: built.blob.length, expiresAt, ttlMs, envelopes: built.envelopes });
   const post: Post = {
     id,
     author: self,
@@ -2068,6 +2079,7 @@ export async function createPost(opts: {
     createdAt,
     lastActivityAt: createdAt,
     expiresAt,
+    ttlMs,
     outgoing: true,
     postKey: built.postKey,
     updatedAt: createdAt,
@@ -2121,6 +2133,7 @@ async function receivePost(sp: ServerPost): Promise<void> {
     createdAt: sp.createdAt,
     lastActivityAt: Math.max(prev?.lastActivityAt ?? 0, sp.createdAt),
     expiresAt: sp.expiresAt,
+    ttlMs: sp.ttlMs,
     outgoing: false,
     postKey,
     updatedAt: now(),
@@ -2163,6 +2176,12 @@ const notifiedPostIds = new Set<string>();
  *  `authorId` ("X shared a photo"). Called from the live `post-new` nudge, so it only
  *  fires for genuinely new posts (a recency guard backs that up). */
 export async function notifyNewPost(authorId: string): Promise<void> {
+  // Respect notification controls: master toggle, a temporary global mute, and a
+  // per-user mute/hide.
+  if (!(await getSetting<boolean>('notifications.wall.show', true))) return;
+  if (await isWallTempMuted()) return;
+  if (await isWallUserMuted(authorId)) return;
+  if (await isWallUserHidden(authorId)) return;
   const recent = (await getAll<Post>('posts'))
     .filter((p) => p.author === authorId && !p.outgoing && !notifiedPostIds.has(p.id))
     .sort((a, b) => b.createdAt - a.createdAt);
@@ -2179,13 +2198,75 @@ export async function notifyNewPost(authorId: string): Promise<void> {
   });
 }
 
+/* ---- Wall mute / hide controls (client-only ledgers) ---- */
+
+async function getWallLedger(key: string): Promise<Record<string, boolean>> {
+  return (await getSetting<Record<string, boolean>>(key, {})) ?? {};
+}
+async function setWallLedgerEntry(key: string, id: string, on: boolean): Promise<void> {
+  const map = await getWallLedger(key);
+  if (!!map[id] === on) return;
+  if (on) map[id] = true;
+  else delete map[id];
+  await setSetting(key, map);
+}
+
+/** Users whose posts are hidden from your Wall entirely. */
+export async function getWallHiddenUsers(): Promise<Record<string, boolean>> {
+  return getWallLedger('wall.hiddenUsers');
+}
+/** Users whose Wall notifications you've muted (their posts still show). */
+export async function getWallMutedUsers(): Promise<Record<string, boolean>> {
+  return getWallLedger('wall.mutedUsers');
+}
+export async function setWallUserHidden(id: string, hidden: boolean): Promise<void> {
+  await setWallLedgerEntry('wall.hiddenUsers', id, hidden);
+}
+export async function setWallUserMuted(id: string, muted: boolean): Promise<void> {
+  await setWallLedgerEntry('wall.mutedUsers', id, muted);
+}
+export async function isWallUserHidden(id: string): Promise<boolean> {
+  return !!(await getWallHiddenUsers())[id];
+}
+export async function isWallUserMuted(id: string): Promise<boolean> {
+  return !!(await getWallMutedUsers())[id];
+}
+
+/** Temporary global mute of Wall notifications until this epoch ms (0 = not muted). */
+export async function getWallMuteUntil(): Promise<number> {
+  return (await getSetting<number>('wall.muteUntil', 0)) ?? 0;
+}
+export async function setWallMuteUntil(ts: number): Promise<void> {
+  await setSetting('wall.muteUntil', ts);
+}
+export async function isWallTempMuted(): Promise<boolean> {
+  return (await getWallMuteUntil()) > now();
+}
+
+/** Mark the Wall as seen (clears the unread-post badge). Called when the Wall is open. */
+export async function markWallSeen(): Promise<void> {
+  await setSetting('wall.lastSeenAt', now());
+}
+
+/** Count of received (non-own), non-expired posts newer than the last time the Wall was
+ *  seen — drives the Wall tab + app icon badge. Hidden users are excluded. */
+export async function wallUnreadCount(): Promise<number> {
+  const since = (await getSetting<number>('wall.lastSeenAt', 0)) ?? 0;
+  const nowMs = now();
+  const hidden = await getWallHiddenUsers();
+  return (await getAll<Post>('posts')).filter(
+    (p) => !p.outgoing && p.createdAt > since && !hidden[p.author] && (!p.expiresAt || p.expiresAt > nowMs),
+  ).length;
+}
+
 /** All non-expired Wall posts on this device, ordered by last activity — so a brand-
  *  new post AND a post that just got a reaction/comment both rise to the top. */
 export async function listWallPosts(): Promise<Post[]> {
   const nowMs = now();
+  const hidden = await getWallHiddenUsers();
   const activity = (p: Post) => p.lastActivityAt ?? p.createdAt;
   return (await getAll<Post>('posts'))
-    .filter((p) => !p.expiresAt || p.expiresAt > nowMs)
+    .filter((p) => (!p.expiresAt || p.expiresAt > nowMs) && !hidden[p.author])
     .sort((a, b) => activity(b) - activity(a));
 }
 
@@ -2230,12 +2311,12 @@ interface ReactionData {
 // Keep-alive (rolling 72h of inactivity): any interaction extends the post's life to
 // (interaction time + 72h) and bumps its last-activity, so an actively-engaged post
 // stays alive and jumps to the top of the feed. Local mirror of the server bump.
-const POST_KEEPALIVE_MS = MAX_POST_TTL_MS;
 async function bumpPostActivity(postId: string, atMs: number): Promise<void> {
   const post = await get<Post>('posts', postId);
   if (!post) return;
+  const window = Math.min(post.ttlMs ?? MAX_POST_TTL_MS, MAX_POST_TTL_MS);
   const lastActivityAt = Math.max(post.lastActivityAt ?? post.createdAt, atMs);
-  const expiresAt = Math.max(post.expiresAt ?? 0, atMs + POST_KEEPALIVE_MS);
+  const expiresAt = Math.max(post.expiresAt ?? 0, atMs + window);
   if (lastActivityAt === (post.lastActivityAt ?? post.createdAt) && expiresAt === (post.expiresAt ?? 0)) return;
   await put<Post>('posts', { ...post, lastActivityAt, expiresAt, updatedAt: now() });
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2232,6 +2232,22 @@ export async function isWallUserMuted(id: string): Promise<boolean> {
   return !!(await getWallMutedUsers())[id];
 }
 
+/** Everyone you've muted or hidden on the Wall, with their profile, for the manage
+ *  screen (so a hidden user — whose posts no longer appear — can be un-hidden). */
+export async function listWallManagedUsers(): Promise<
+  { id: string; name: string; avatar: string; muted: boolean; hidden: boolean }[]
+> {
+  const hidden = await getWallHiddenUsers();
+  const muted = await getWallMutedUsers();
+  const ids = new Set([...Object.keys(hidden), ...Object.keys(muted)]);
+  const out: { id: string; name: string; avatar: string; muted: boolean; hidden: boolean }[] = [];
+  for (const id of ids) {
+    const c = await getContact(id);
+    out.push({ id, name: c?.name ?? 'Someone', avatar: c?.avatar ?? '', muted: !!muted[id], hidden: !!hidden[id] });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
 /** Temporary global mute of Wall notifications until this epoch ms (0 = not muted). */
 export async function getWallMuteUntil(): Promise<number> {
   return (await getSetting<number>('wall.muteUntil', 0)) ?? 0;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -10,11 +10,13 @@ import { uid } from '@/utils/uid';
 import { capitalizeFirst } from '@/utils/text';
 import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination';
 import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
-import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink } from '@/services/api';
+import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, type ServerPost } from '@/services/api';
 import { sealForChat, openPacket } from '@/services/messaging';
-import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob } from '@/services/media-transfer';
+import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
+import { buildPost, openReceivedPost, type AudienceMember, type PostPayload } from '@/services/posts';
+import { b64urlToBytes } from '@/services/crypto/envelope';
 import { getSecret, setSecret } from '@/db/secrets';
-import { isUnlockedNow } from '@/services/crypto/identity';
+import { isUnlockedNow, getIdentityKeys } from '@/services/crypto/identity';
 import { getSelfUserId, getSelfUsername } from '@/services/auth';
 import { notifyIncoming, isChatActive } from '@/services/notify';
 import { compressImage, compressVideo } from '@/services/media-encode';
@@ -29,7 +31,7 @@ import type {
 } from '@/services/crypto/message';
 import type {
   Alert, Call, CallLog, Chat, ChatList, Contact, FriendRequest, Media, Message, MessageKind, Reaction, ReplyRef,
-  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting,
+  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post,
 } from './types';
 
 // WhatsApp-style cap on pinned chats.
@@ -1972,6 +1974,141 @@ export async function setCloseFriend(id: string, value: boolean): Promise<void> 
   const c = await getContact(id);
   if (!c || !!c.closeFriend === value) return;
   await put<Contact>('contacts', { ...c, closeFriend: value, updatedAt: Date.now() });
+}
+
+/* ---- spec 0003: Wall posts ---- */
+
+// Author-chosen post lifetime → ttl (ms); 'keep' = no expiry.
+const POST_TTL_MS: Record<string, number | undefined> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  keep: undefined,
+};
+export type PostLifetime = 'keep' | '24h' | '7d';
+
+// Cache each friend's X25519 identity public key (stable per account) so building a
+// post doesn't re-fetch (and re-consume a one-time prekey) for every post. Lazily
+// filled from the peer bundle; this key is the wrap target for K_post.
+async function peerPostKey(userId: string): Promise<Uint8Array | null> {
+  const cache = (await getSetting<Record<string, string>>('postPeerKeys', {})) ?? {};
+  if (cache[userId]) return b64urlToBytes(cache[userId]);
+  const bundle = await fetchPeerBundle(userId).catch(() => null);
+  if (!bundle) return null;
+  cache[userId] = bundle.xPub;
+  await setSetting('postPeerKeys', cache);
+  return b64urlToBytes(bundle.xPub);
+}
+
+/**
+ * Create a Wall post: seal the payload under a fresh per-post key, wrap that key to
+ * each audience member, upload the opaque blob, register the post server-side, then
+ * persist it locally so the author sees it immediately. The server only ever holds
+ * ciphertext + the per-recipient envelope set.
+ */
+export async function createPost(opts: {
+  payload: PostPayload;
+  audience: 'friends' | 'close';
+  lifetime: PostLifetime;
+}): Promise<Post> {
+  const self = getSelfUserId();
+  if (!self) throw new Error('not signed in');
+  const friends = opts.audience === 'close' ? await listCloseFriends() : await listFriends();
+  if (!friends.length) throw new Error('No audience — add friends first.');
+  const audience: AudienceMember[] = [];
+  for (const f of friends) {
+    const pub = await peerPostKey(f.id);
+    if (pub) audience.push({ userId: f.id, pubKey: pub });
+  }
+  if (!audience.length) throw new Error('No reachable audience for this post.');
+  const built = buildPost(opts.payload, audience);
+  const blobId = await uploadBlob(new Blob([built.blob as BlobPart]));
+  const id = uid();
+  const createdAt = now();
+  const ttl = POST_TTL_MS[opts.lifetime];
+  const expiresAt = ttl ? createdAt + ttl : undefined;
+  await apiCreatePost({ id, blobId, size: built.blob.length, expiresAt, envelopes: built.envelopes });
+  const post: Post = {
+    id,
+    author: self,
+    kind: opts.payload.kind,
+    body: opts.payload.body,
+    audience: opts.audience,
+    createdAt,
+    expiresAt,
+    outgoing: true,
+    updatedAt: createdAt,
+  };
+  await put<Post>('posts', post);
+  return post;
+}
+
+// Persist a single received post: unwrap K_post with our identity key, open the
+// payload, store it. Own posts come back without an envelope (already local) and are
+// skipped; anything we can't open (not for us / tampered) is dropped silently.
+async function receivePost(sp: ServerPost): Promise<void> {
+  if (!sp.wrappedKey) return;
+  if (await get<Post>('posts', sp.id)) return;
+  const blob = await downloadBlob(sp.blobId);
+  if (!blob) return;
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let payload: PostPayload;
+  try {
+    payload = openReceivedPost(bytes, sp.wrappedKey, getIdentityKeys().x.privateKey);
+  } catch {
+    return;
+  }
+  await put<Post>('posts', {
+    id: sp.id,
+    author: sp.author,
+    kind: payload.kind,
+    body: payload.body,
+    createdAt: sp.createdAt,
+    expiresAt: sp.expiresAt,
+    outgoing: false,
+    updatedAt: now(),
+  });
+}
+
+/** Pull new posts addressed to us and persist them (called on app open, on the
+ *  `post-new` WS nudge, and on reconnect). No-op while locked. */
+export async function syncPosts(): Promise<void> {
+  if (!isUnlockedNow()) return;
+  const cursor = (await getSetting<number>('postsCursor', 0)) ?? 0;
+  try {
+    const { posts, cursor: next } = await apiListPosts(cursor);
+    for (const sp of posts) await receivePost(sp);
+    if (next > cursor) await setSetting('postsCursor', next);
+  } catch {
+    /* offline / transient — retried on the next nudge */
+  }
+}
+
+/** All non-expired Wall posts on this device, newest-first (the Wall feed source). */
+export async function listWallPosts(): Promise<Post[]> {
+  const nowMs = now();
+  return (await getAll<Post>('posts'))
+    .filter((p) => !p.expiresAt || p.expiresAt > nowMs)
+    .sort((a, b) => b.createdAt - a.createdAt);
+}
+
+/** A single Wall post by id (or null). */
+export async function getPost(id: string): Promise<Post | null> {
+  return (await get<Post>('posts', id)) ?? null;
+}
+
+/** Delete one of our own posts: best-effort server delete + remove the local copy. */
+export async function deletePost(id: string): Promise<void> {
+  await apiDeletePost(id).catch(() => {});
+  await remove('posts', id);
+}
+
+/** Remove posts (and, later, their engagement) whose lifetime has elapsed. Wired into
+ *  the existing disappearing-message sweep. */
+export async function sweepExpiredPosts(): Promise<void> {
+  const nowMs = now();
+  for (const p of await getAll<Post>('posts')) {
+    if (p.expiresAt && p.expiresAt <= nowMs) await remove('posts', p.id);
+  }
 }
 
 /* ---- account termination ("Ghosted") ---- */

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -10,7 +10,7 @@ import { uid } from '@/utils/uid';
 import { capitalizeFirst } from '@/utils/text';
 import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination';
 import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
-import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
+import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, removePostRecipient as apiRemovePostRecipient, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
 import { sealForChat, openPacket } from '@/services/messaging';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
 import { buildPost, openReceivedPost, sealPostEngagement, openPostEngagement, type AudienceMember, type PostPayload } from '@/services/posts';
@@ -1969,11 +1969,30 @@ export async function listCloseFriends(): Promise<Contact[]> {
   return (await listFriends()).filter((c) => c.closeFriend);
 }
 
-/** Set/clear the author-private close-friend flag on a contact (spec 0003, US5). */
+/** Set/clear the author-private close-friend flag on a contact (spec 0003, US5).
+ *  Demoting someone (close → not) revokes your close-only posts from them: their key
+ *  envelopes are dropped server-side and their device prunes the local copies, so a
+ *  removed close friend can no longer see posts that were meant only for close friends. */
 export async function setCloseFriend(id: string, value: boolean): Promise<void> {
   const c = await getContact(id);
   if (!c || !!c.closeFriend === value) return;
   await put<Contact>('contacts', { ...c, closeFriend: value, updatedAt: Date.now() });
+  if (!value) await revokeCloseFriendPosts(id);
+}
+
+/** Revoke every still-live close-only post we authored from `userId` (called when they
+ *  are removed from close friends). Best-effort + idempotent: the server drops their
+ *  envelope and records a revocation; a post they never received is a harmless no-op. */
+export async function revokeCloseFriendPosts(userId: string): Promise<void> {
+  const self = getSelfUserId();
+  if (!self) return;
+  const nowMs = now();
+  const closePosts = (await getAll<Post>('posts')).filter(
+    (p) => p.outgoing && p.audience === 'close' && (!p.expiresAt || p.expiresAt > nowMs),
+  );
+  for (const p of closePosts) {
+    await apiRemovePostRecipient(p.id, userId).catch(() => {});
+  }
 }
 
 /* ---- spec 0003: Wall posts ---- */
@@ -2158,11 +2177,24 @@ export async function syncPosts(): Promise<void> {
   if (!isUnlockedNow()) return;
   const cursor = (await getSetting<number>('postsCursor', 0)) ?? 0;
   try {
-    const { posts, cursor: next } = await apiListPosts(cursor);
+    const { posts, cursor: next, revoked } = await apiListPosts(cursor);
     for (const sp of posts) await receivePost(sp);
+    // Posts the author revoked from us (e.g. they dropped us from close friends) —
+    // prune any local copy. Idempotent: an id we never had is a harmless no-op.
+    for (const id of revoked) await pruneLocalPost(id);
     if (next > cursor) await setSetting('postsCursor', next);
   } catch {
     /* offline / transient — retried on the next nudge */
+  }
+}
+
+/** Remove a post and its engagement from this device only (no server call). Used by
+ *  the sweep, by revocation pulls, and by the live `post-revoke` nudge. Idempotent. */
+export async function pruneLocalPost(id: string): Promise<void> {
+  if (!(await get<Post>('posts', id))) return;
+  await remove('posts', id);
+  for (const e of await getByIndex<PostEngagement>('postEngagement', 'postId', id)) {
+    await remove('postEngagement', e.id);
   }
 }
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2034,6 +2034,8 @@ export async function createPost(opts: {
   // keep a local Media copy so the author renders it immediately.
   const kind: Post['kind'] = opts.media ? opts.media.kind : 'text';
   let mediaId: string | undefined;
+  let mediaW: number | undefined;
+  let mediaH: number | undefined;
   const payload: PostPayload = { kind, body };
   if (opts.media) {
     // Posts only ship SD or HD (never the original): compress images/videos to the
@@ -2045,7 +2047,10 @@ export async function createPost(opts: {
         : opts.media.kind === 'video'
           ? await compressVideo(opts.media.blob, q)
           : opts.media.blob;
-    const ref = await prepareOutgoingMedia(toUpload, opts.media.name, opts.media.durationSec, { quality: q });
+    // Dimensions → reserve an aspect-ratio box in the feed (no layout jump).
+    if (opts.media.kind === 'image') ({ width: mediaW, height: mediaH } = await readImageMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
+    else if (opts.media.kind === 'video') ({ width: mediaW, height: mediaH } = await readVideoMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
+    const ref = await prepareOutgoingMedia(toUpload, opts.media.name, opts.media.durationSec, { width: mediaW, height: mediaH, quality: q });
     payload.media = ref;
     mediaId = uid();
     await put<Media>('media', {
@@ -2075,6 +2080,8 @@ export async function createPost(opts: {
     kind,
     body,
     mediaId,
+    mediaW,
+    mediaH,
     audience: opts.audience,
     createdAt,
     lastActivityAt: createdAt,
@@ -2130,6 +2137,8 @@ async function receivePost(sp: ServerPost): Promise<void> {
     kind: payload.kind,
     body: payload.body,
     mediaId,
+    mediaW: payload.media?.width,
+    mediaH: payload.media?.height,
     createdAt: sp.createdAt,
     lastActivityAt: Math.max(prev?.lastActivityAt ?? 0, sp.createdAt),
     expiresAt: sp.expiresAt,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1952,6 +1952,28 @@ export async function markContactConnected(id: string): Promise<void> {
   await put<Setting<Record<string, boolean>>>('settings', { key: 'connectedPeers', value: map });
 }
 
+/** Accepted friends: contacts whose peer is in the connected-peers ledger (i.e. an
+ *  accepted connection), excluding blocked/ghosted peers. This is the audience source
+ *  for Wall posts (spec 0003) — "all friends". */
+export async function listFriends(): Promise<Contact[]> {
+  const connected = await getConnectedPeers();
+  const all = await getAll<Contact>('contacts');
+  return all.filter((c) => connected[c.id] && !c.blocked && !c.ghosted);
+}
+
+/** Close friends: the curated subset of friends flagged `closeFriend`. Author-private
+ *  (the flag never leaves the device); drives the "close friends" Wall audience. */
+export async function listCloseFriends(): Promise<Contact[]> {
+  return (await listFriends()).filter((c) => c.closeFriend);
+}
+
+/** Set/clear the author-private close-friend flag on a contact (spec 0003, US5). */
+export async function setCloseFriend(id: string, value: boolean): Promise<void> {
+  const c = await getContact(id);
+  if (!c || !!c.closeFriend === value) return;
+  await put<Contact>('contacts', { ...c, closeFriend: value, updatedAt: Date.now() });
+}
+
 /* ---- account termination ("Ghosted") ---- */
 
 const GHOST_NAME = 'Ghosted';

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -10,10 +10,10 @@ import { uid } from '@/utils/uid';
 import { capitalizeFirst } from '@/utils/text';
 import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination';
 import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
-import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, type ServerPost } from '@/services/api';
+import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, type ServerPost } from '@/services/api';
 import { sealForChat, openPacket } from '@/services/messaging';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
-import { buildPost, openReceivedPost, type AudienceMember, type PostPayload } from '@/services/posts';
+import { buildPost, openReceivedPost, sealPostEngagement, openPostEngagement, type AudienceMember, type PostPayload } from '@/services/posts';
 import { b64urlToBytes } from '@/services/crypto/envelope';
 import { getSecret, setSecret } from '@/db/secrets';
 import { isUnlockedNow, getIdentityKeys } from '@/services/crypto/identity';
@@ -2068,6 +2068,7 @@ export async function createPost(opts: {
     createdAt,
     expiresAt,
     outgoing: true,
+    postKey: built.postKey,
     updatedAt: createdAt,
   };
   await put<Post>('posts', post);
@@ -2084,8 +2085,9 @@ async function receivePost(sp: ServerPost): Promise<void> {
   if (!blob) return;
   const bytes = new Uint8Array(await blob.arrayBuffer());
   let payload: PostPayload;
+  let postKey: string;
   try {
-    payload = openReceivedPost(bytes, sp.wrappedKey, getIdentityKeys().x.privateKey);
+    ({ payload, postKey } = openReceivedPost(bytes, sp.wrappedKey, getIdentityKeys().x.privateKey));
   } catch {
     return;
   }
@@ -2117,8 +2119,11 @@ async function receivePost(sp: ServerPost): Promise<void> {
     createdAt: sp.createdAt,
     expiresAt: sp.expiresAt,
     outgoing: false,
+    postKey,
     updatedAt: now(),
   });
+  // Pull any engagement (reactions) that already exists on this post.
+  void syncEngagement(sp.id);
 }
 
 /** Pull new posts addressed to us and persist them (called on app open, on the
@@ -2159,13 +2164,88 @@ export async function deletePost(id: string): Promise<void> {
   await remove('posts', id);
 }
 
-/** Remove posts (and, later, their engagement) whose lifetime has elapsed. Wired into
- *  the existing disappearing-message sweep. */
+/** Remove posts (and their engagement) whose lifetime has elapsed. Wired into the
+ *  existing disappearing-message sweep. */
 export async function sweepExpiredPosts(): Promise<void> {
   const nowMs = now();
   for (const p of await getAll<Post>('posts')) {
-    if (p.expiresAt && p.expiresAt <= nowMs) await remove('posts', p.id);
+    if (p.expiresAt && p.expiresAt <= nowMs) {
+      await remove('posts', p.id);
+      for (const e of await getByIndex<PostEngagement>('postEngagement', 'postId', p.id)) {
+        await remove('postEngagement', e.id);
+      }
+    }
   }
+}
+
+/* ---- engagement: reactions (spec 0003, US4) ---- */
+
+interface ReactionData {
+  emoji: string;
+  at: number;
+  remove?: boolean;
+}
+
+/** React to a post (audience-visible). Toggles: tapping your current emoji removes it.
+ *  Sealed under the post's K_post and submitted; the server fans it out to the
+ *  audience, who each apply it last-write-wins per actor. */
+export async function reactToPost(postId: string, emoji: string): Promise<void> {
+  const self = getSelfUserId();
+  const post = await get<Post>('posts', postId);
+  if (!self || !post?.postKey) return;
+  const at = now();
+  const mineId = `${postId}:reaction:${self}`;
+  const mine = await get<PostEngagement>('postEngagement', mineId);
+  const removing = !!mine && !mine.deleted && mine.emoji === emoji;
+  const data: ReactionData = { emoji, at, remove: removing || undefined };
+  // Optimistic local apply.
+  await put<PostEngagement>('postEngagement', {
+    id: mineId, postId, type: 'reaction', actor: self, emoji, at,
+    deleted: removing || undefined, updatedAt: at,
+  });
+  try {
+    await apiSubmitEngagement(postId, {
+      id: uid(),
+      kind: 'reaction',
+      payload: sealPostEngagement(post.postKey, data),
+    });
+  } catch {
+    /* offline — the optimistic local row stands; a later sync reconciles */
+  }
+}
+
+/** Pull + decrypt engagement for a post and apply it (reactions only, LWW per actor). */
+export async function syncEngagement(postId: string): Promise<void> {
+  if (!isUnlockedNow()) return;
+  const post = await get<Post>('posts', postId);
+  if (!post?.postKey) return;
+  try {
+    const { items } = await apiListEngagement(postId);
+    for (const it of items) {
+      if (it.kind !== 'reaction') continue;
+      let data: ReactionData;
+      try {
+        data = openPostEngagement<ReactionData>(post.postKey, it.payload);
+      } catch {
+        continue; // not decryptable / tampered
+      }
+      const id = `${postId}:reaction:${it.actor}`;
+      const existing = await get<PostEngagement>('postEngagement', id);
+      if (existing && existing.at >= data.at) continue; // LWW
+      await put<PostEngagement>('postEngagement', {
+        id, postId, type: 'reaction', actor: it.actor, emoji: data.emoji, at: data.at,
+        deleted: data.remove || undefined, updatedAt: now(),
+      });
+    }
+  } catch {
+    /* offline / transient */
+  }
+}
+
+/** Live reactions on a post (non-removed), oldest-first. */
+export async function listPostReactions(postId: string): Promise<PostEngagement[]> {
+  const rows = await getByIndex<PostEngagement>('postEngagement', 'postId', postId);
+  return rows.filter((e) => e.type === 'reaction' && !e.deleted).sort((a, b) => a.at - b.at);
 }
 
 /* ---- account termination ("Ghosted") ---- */

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2066,6 +2066,7 @@ export async function createPost(opts: {
     mediaId,
     audience: opts.audience,
     createdAt,
+    lastActivityAt: createdAt,
     expiresAt,
     outgoing: true,
     postKey: built.postKey,
@@ -2110,6 +2111,7 @@ async function receivePost(sp: ServerPost): Promise<void> {
       });
     }
   }
+  const prev = await get<Post>('posts', sp.id);
   await put<Post>('posts', {
     id: sp.id,
     author: sp.author,
@@ -2117,12 +2119,14 @@ async function receivePost(sp: ServerPost): Promise<void> {
     body: payload.body,
     mediaId,
     createdAt: sp.createdAt,
+    lastActivityAt: Math.max(prev?.lastActivityAt ?? 0, sp.createdAt),
     expiresAt: sp.expiresAt,
     outgoing: false,
     postKey,
     updatedAt: now(),
   });
-  // Pull any engagement (reactions) that already exists on this post.
+  // Pull any engagement (reactions/comments) that already exists on this post (also
+  // applies keep-alive from past interactions).
   void syncEngagement(sp.id);
 }
 
@@ -2140,12 +2144,49 @@ export async function syncPosts(): Promise<void> {
   }
 }
 
-/** All non-expired Wall posts on this device, newest-first (the Wall feed source). */
+/** Human label for what was shared, used in notifications. */
+function postShareLabel(kind: Post['kind']): string {
+  return kind === 'image'
+    ? 'shared a photo'
+    : kind === 'video'
+      ? 'shared a video'
+      : kind === 'voice'
+        ? 'shared a voice message'
+        : 'shared a post';
+}
+
+// Posts we've already notified about this session (avoids a repeat banner if the
+// `post-new` nudge fires again for the same post).
+const notifiedPostIds = new Set<string>();
+
+/** Surface an in-app banner / system notification for a freshly-arrived post from
+ *  `authorId` ("X shared a photo"). Called from the live `post-new` nudge, so it only
+ *  fires for genuinely new posts (a recency guard backs that up). */
+export async function notifyNewPost(authorId: string): Promise<void> {
+  const recent = (await getAll<Post>('posts'))
+    .filter((p) => p.author === authorId && !p.outgoing && !notifiedPostIds.has(p.id))
+    .sort((a, b) => b.createdAt - a.createdAt);
+  const p = recent[0];
+  if (!p || now() - p.createdAt > 5 * 60_000) return;
+  notifiedPostIds.add(p.id);
+  const c = await getContact(authorId);
+  void notifyIncoming({
+    kind: 'system',
+    name: c?.name ?? 'Someone',
+    body: postShareLabel(p.kind),
+    avatar: c?.avatar,
+    url: '/tabs/wall',
+  });
+}
+
+/** All non-expired Wall posts on this device, ordered by last activity — so a brand-
+ *  new post AND a post that just got a reaction/comment both rise to the top. */
 export async function listWallPosts(): Promise<Post[]> {
   const nowMs = now();
+  const activity = (p: Post) => p.lastActivityAt ?? p.createdAt;
   return (await getAll<Post>('posts'))
     .filter((p) => !p.expiresAt || p.expiresAt > nowMs)
-    .sort((a, b) => b.createdAt - a.createdAt);
+    .sort((a, b) => activity(b) - activity(a));
 }
 
 /** A single Wall post by id (or null). */
@@ -2186,32 +2227,58 @@ interface ReactionData {
   remove?: boolean;
 }
 
-/** React to a post (audience-visible). Toggles: tapping your current emoji removes it.
- *  Sealed under the post's K_post and submitted; the server fans it out to the
- *  audience, who each apply it last-write-wins per actor. */
-export async function reactToPost(postId: string, emoji: string): Promise<void> {
+// Keep-alive (rolling 72h of inactivity): any interaction extends the post's life to
+// (interaction time + 72h) and bumps its last-activity, so an actively-engaged post
+// stays alive and jumps to the top of the feed. Local mirror of the server bump.
+const POST_KEEPALIVE_MS = MAX_POST_TTL_MS;
+async function bumpPostActivity(postId: string, atMs: number): Promise<void> {
+  const post = await get<Post>('posts', postId);
+  if (!post) return;
+  const lastActivityAt = Math.max(post.lastActivityAt ?? post.createdAt, atMs);
+  const expiresAt = Math.max(post.expiresAt ?? 0, atMs + POST_KEEPALIVE_MS);
+  if (lastActivityAt === (post.lastActivityAt ?? post.createdAt) && expiresAt === (post.expiresAt ?? 0)) return;
+  await put<Post>('posts', { ...post, lastActivityAt, expiresAt, updatedAt: now() });
+}
+
+/** React to a post (audience-visible), mirroring chat: up to MAX_REACTIONS_PER_USER
+ *  emoji per person and MAX_DISTINCT_REACTIONS distinct emoji per post; tapping your
+ *  own emoji again removes it. Sealed under K_post and fanned out; applied LWW per
+ *  (actor, emoji). Returns what happened so the UI can surface a cap. */
+export async function reactToPost(
+  postId: string,
+  emoji: string,
+): Promise<'added' | 'removed' | 'limit' | 'limit-emojis' | 'noop'> {
   const self = getSelfUserId();
   const post = await get<Post>('posts', postId);
-  if (!self || !post?.postKey) return;
+  if (!self || !post?.postKey) return 'noop';
+  const rows = (await getByIndex<PostEngagement>('postEngagement', 'postId', postId)).filter(
+    (e) => e.type === 'reaction' && !e.deleted,
+  );
+  const mine = rows.filter((r) => r.actor === self);
+  const has = mine.some((r) => r.emoji === emoji);
+  if (!has) {
+    if (mine.length >= MAX_REACTIONS_PER_USER) return 'limit';
+    const distinct = new Set(rows.map((r) => r.emoji));
+    if (!distinct.has(emoji) && distinct.size >= MAX_DISTINCT_REACTIONS) return 'limit-emojis';
+  }
+  const remove = has;
   const at = now();
-  const mineId = `${postId}:reaction:${self}`;
-  const mine = await get<PostEngagement>('postEngagement', mineId);
-  const removing = !!mine && !mine.deleted && mine.emoji === emoji;
-  const data: ReactionData = { emoji, at, remove: removing || undefined };
-  // Optimistic local apply.
   await put<PostEngagement>('postEngagement', {
-    id: mineId, postId, type: 'reaction', actor: self, emoji, at,
-    deleted: removing || undefined, updatedAt: at,
+    id: `${postId}:reaction:${self}:${emoji}`, postId, type: 'reaction', actor: self, emoji, at,
+    deleted: remove || undefined, updatedAt: at,
   });
+  if (!remove) void recordEmojiUse(emoji); // most-used drives the quick-react order
+  await bumpPostActivity(postId, at);
   try {
     await apiSubmitEngagement(postId, {
       id: uid(),
       kind: 'reaction',
-      payload: sealPostEngagement(post.postKey, data),
+      payload: sealPostEngagement(post.postKey, { emoji, at, remove } satisfies ReactionData),
     });
   } catch {
     /* offline — the optimistic local row stands; a later sync reconciles */
   }
+  return remove ? 'removed' : 'added';
 }
 
 interface CommentData {
@@ -2227,6 +2294,7 @@ export async function syncEngagement(postId: string): Promise<void> {
   if (!post?.postKey) return;
   try {
     const { items } = await apiListEngagement(postId);
+    let latestActivity = 0; // newest reaction/comment time seen → keep-alive
     for (const it of items) {
       if (it.kind === 'reaction') {
         let data: ReactionData;
@@ -2235,9 +2303,10 @@ export async function syncEngagement(postId: string): Promise<void> {
         } catch {
           continue;
         }
-        const id = `${postId}:reaction:${it.actor}`;
+        latestActivity = Math.max(latestActivity, data.at);
+        const id = `${postId}:reaction:${it.actor}:${data.emoji}`;
         const existing = await get<PostEngagement>('postEngagement', id);
-        if (existing && existing.at >= data.at) continue; // LWW
+        if (existing && existing.at >= data.at) continue; // LWW per (actor, emoji)
         await put<PostEngagement>('postEngagement', {
           id, postId, type: 'reaction', actor: it.actor, emoji: data.emoji, at: data.at,
           deleted: data.remove || undefined, updatedAt: now(),
@@ -2250,6 +2319,7 @@ export async function syncEngagement(postId: string): Promise<void> {
         } catch {
           continue;
         }
+        latestActivity = Math.max(latestActivity, data.at);
         await put<PostEngagement>('postEngagement', {
           id: it.id, postId, type: 'comment', actor: it.actor, text: data.text, at: data.at, updatedAt: now(),
         });
@@ -2261,6 +2331,7 @@ export async function syncEngagement(postId: string): Promise<void> {
         }
       }
     }
+    if (latestActivity) await bumpPostActivity(postId, latestActivity);
   } catch {
     /* offline / transient */
   }
@@ -2270,6 +2341,11 @@ export async function syncEngagement(postId: string): Promise<void> {
 export async function listPostReactions(postId: string): Promise<PostEngagement[]> {
   const rows = await getByIndex<PostEngagement>('postEngagement', 'postId', postId);
   return rows.filter((e) => e.type === 'reaction' && !e.deleted).sort((a, b) => a.at - b.at);
+}
+
+/** All engagement rows (for the feed, which groups them by post in one live query). */
+export async function listAllPostEngagement(): Promise<PostEngagement[]> {
+  return getAll<PostEngagement>('postEngagement');
 }
 
 /** Live comments on a post (non-deleted), oldest-first (timestamp then id tiebreak). */
@@ -2291,6 +2367,7 @@ export async function commentOnPost(postId: string, text: string): Promise<void>
   await put<PostEngagement>('postEngagement', {
     id: engId, postId, type: 'comment', actor: self, text: body, at, updatedAt: at,
   });
+  await bumpPostActivity(postId, at);
   try {
     await apiSubmitEngagement(postId, {
       id: engId,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -10,7 +10,7 @@ import { uid } from '@/utils/uid';
 import { capitalizeFirst } from '@/utils/text';
 import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination';
 import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
-import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, type ServerPost } from '@/services/api';
+import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
 import { sealForChat, openPacket } from '@/services/messaging';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
 import { buildPost, openReceivedPost, sealPostEngagement, openPostEngagement, type AudienceMember, type PostPayload } from '@/services/posts';
@@ -2214,7 +2214,13 @@ export async function reactToPost(postId: string, emoji: string): Promise<void> 
   }
 }
 
-/** Pull + decrypt engagement for a post and apply it (reactions only, LWW per actor). */
+interface CommentData {
+  text: string;
+  at: number;
+}
+
+/** Pull + decrypt a post's engagement and apply it: reactions (LWW per actor),
+ *  comments (append, keyed by engagement id), and tombstones (mark target removed). */
 export async function syncEngagement(postId: string): Promise<void> {
   if (!isUnlockedNow()) return;
   const post = await get<Post>('posts', postId);
@@ -2222,20 +2228,38 @@ export async function syncEngagement(postId: string): Promise<void> {
   try {
     const { items } = await apiListEngagement(postId);
     for (const it of items) {
-      if (it.kind !== 'reaction') continue;
-      let data: ReactionData;
-      try {
-        data = openPostEngagement<ReactionData>(post.postKey, it.payload);
-      } catch {
-        continue; // not decryptable / tampered
+      if (it.kind === 'reaction') {
+        let data: ReactionData;
+        try {
+          data = openPostEngagement<ReactionData>(post.postKey, it.payload);
+        } catch {
+          continue;
+        }
+        const id = `${postId}:reaction:${it.actor}`;
+        const existing = await get<PostEngagement>('postEngagement', id);
+        if (existing && existing.at >= data.at) continue; // LWW
+        await put<PostEngagement>('postEngagement', {
+          id, postId, type: 'reaction', actor: it.actor, emoji: data.emoji, at: data.at,
+          deleted: data.remove || undefined, updatedAt: now(),
+        });
+      } else if (it.kind === 'comment') {
+        if (await get<PostEngagement>('postEngagement', it.id)) continue; // already have it
+        let data: CommentData;
+        try {
+          data = openPostEngagement<CommentData>(post.postKey, it.payload);
+        } catch {
+          continue;
+        }
+        await put<PostEngagement>('postEngagement', {
+          id: it.id, postId, type: 'comment', actor: it.actor, text: data.text, at: data.at, updatedAt: now(),
+        });
+      } else if (it.kind === 'tombstone') {
+        // The tombstone's payload is the (cleartext) target engagement id.
+        const target = await get<PostEngagement>('postEngagement', it.payload);
+        if (target && !target.deleted) {
+          await put<PostEngagement>('postEngagement', { ...target, deleted: true, updatedAt: now() });
+        }
       }
-      const id = `${postId}:reaction:${it.actor}`;
-      const existing = await get<PostEngagement>('postEngagement', id);
-      if (existing && existing.at >= data.at) continue; // LWW
-      await put<PostEngagement>('postEngagement', {
-        id, postId, type: 'reaction', actor: it.actor, emoji: data.emoji, at: data.at,
-        deleted: data.remove || undefined, updatedAt: now(),
-      });
     }
   } catch {
     /* offline / transient */
@@ -2246,6 +2270,75 @@ export async function syncEngagement(postId: string): Promise<void> {
 export async function listPostReactions(postId: string): Promise<PostEngagement[]> {
   const rows = await getByIndex<PostEngagement>('postEngagement', 'postId', postId);
   return rows.filter((e) => e.type === 'reaction' && !e.deleted).sort((a, b) => a.at - b.at);
+}
+
+/** Live comments on a post (non-deleted), oldest-first (timestamp then id tiebreak). */
+export async function listPostComments(postId: string): Promise<PostEngagement[]> {
+  const rows = await getByIndex<PostEngagement>('postEngagement', 'postId', postId);
+  return rows
+    .filter((e) => e.type === 'comment' && !e.deleted)
+    .sort((a, b) => a.at - b.at || a.id.localeCompare(b.id));
+}
+
+/** Add an audience-visible comment to a post (sealed under K_post; fanned out). */
+export async function commentOnPost(postId: string, text: string): Promise<void> {
+  const self = getSelfUserId();
+  const post = await get<Post>('posts', postId);
+  const body = text.trim();
+  if (!self || !post?.postKey || !body) return;
+  const at = now();
+  const engId = uid(); // local id == server engagement id, so tombstones can target it
+  await put<PostEngagement>('postEngagement', {
+    id: engId, postId, type: 'comment', actor: self, text: body, at, updatedAt: at,
+  });
+  try {
+    await apiSubmitEngagement(postId, {
+      id: engId,
+      kind: 'comment',
+      payload: sealPostEngagement(post.postKey, { text: body, at } satisfies CommentData),
+    });
+  } catch {
+    /* offline — local stands; a later sync reconciles */
+  }
+}
+
+/** Remove a comment (the commenter's own, or any comment if you authored the post).
+ *  Best-effort propagation: delivered copies can't be cryptographically recalled. */
+export async function deleteComment(postId: string, commentId: string): Promise<void> {
+  const target = await get<PostEngagement>('postEngagement', commentId);
+  if (target) await put<PostEngagement>('postEngagement', { ...target, deleted: true, updatedAt: now() });
+  try {
+    await apiSubmitEngagement(postId, { id: uid(), kind: 'tombstone', target: commentId });
+  } catch {
+    /* offline — local stands; a later sync reconciles */
+  }
+}
+
+/* ---- view receipts (spec 0003, US7) ---- */
+
+/** Record that we viewed a post — only if our seen-receipts setting is on (reciprocal
+ *  with the chat setting) and it isn't our own post. */
+export async function recordPostView(postId: string): Promise<void> {
+  const post = await get<Post>('posts', postId);
+  if (!post || post.outgoing) return;
+  if (!(await getSetting<boolean>('privacy.seenReceipts', true))) return;
+  try {
+    await apiRecordPostView(postId);
+  } catch {
+    /* best effort */
+  }
+}
+
+/** Author-only view list for our own post, gated by our own seen-receipts setting
+ *  (reciprocity). Returns viewer ids (resolve names in the UI). */
+export async function listPostViews(postId: string): Promise<string[]> {
+  if (!(await getSetting<boolean>('privacy.seenReceipts', true))) return [];
+  try {
+    const { views } = await apiListPostViews(postId);
+    return views.map((v) => v.viewer);
+  } catch {
+    return [];
+  }
 }
 
 /* ---- account termination ("Ghosted") ---- */

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -352,6 +352,10 @@ export interface Post {
   kind: 'text' | 'voice' | 'video' | 'image';
   body?: string; // decrypted text / caption
   mediaId?: string; // local `media` store id for voice/video/image
+  // Pixel dimensions of the attachment, so the feed can reserve an aspect-ratio box
+  // (with a skeleton) before the media loads — no layout jump as it decodes.
+  mediaW?: number;
+  mediaH?: number;
   audience?: 'friends' | 'close'; // own posts only (display-only on received)
   createdAt: number; // author timestamp
   // Last activity = max(createdAt, latest reaction/comment). Drives feed ordering (a

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -26,6 +26,12 @@ export interface Contact {
   // list; the durable source is the `blockedPeers` settings ledger. Drives the
   // read-only/blocked chat UI; inbound from them is dropped, outbound disabled.
   blocked?: boolean;
+  // spec 0003: author-private "close friend" flag. A curated subset of friends used
+  // as the narrower Wall audience. Client-only — it rides encrypted own-data sync and
+  // is NEVER sent to the server (the server only ever sees a per-post recipient set,
+  // so it cannot tell the "all friends" tier from "close friends"). Distinct from the
+  // per-CHAT `Chat.favorite` pin.
+  closeFriend?: boolean;
   updatedAt: number;
 }
 
@@ -331,6 +337,51 @@ export interface FriendRequest {
   inviter?: string;
   memberPreview?: string;
   roster?: import('@/services/crypto/message').GroupMember[];
+}
+
+/* ---- spec 0003: social Wall ---- */
+
+/** A Wall post (status update). Stored decrypted on-device (the keystore wraps it
+ *  at rest like every other store); only the server-side copy is ciphertext. `body`
+ *  + optional `mediaId` are the decrypted content; `audience` is the author's chosen
+ *  tier (own posts only — received posts don't carry it). `expiresAt` drives the
+ *  disappearing-message sweep. */
+export interface Post {
+  id: string;
+  author: string; // userId; self for own posts, the peer for received
+  kind: 'text' | 'voice' | 'video' | 'image';
+  body?: string; // decrypted text / caption
+  mediaId?: string; // local `media` store id for voice/video/image
+  audience?: 'friends' | 'close'; // own posts only (display-only on received)
+  createdAt: number; // author timestamp; feed ordering
+  expiresAt?: number; // epoch ms; absent = keep
+  outgoing: boolean; // true for self-authored
+  updatedAt: number; // change-bus / dedup
+}
+
+/** Engagement on a post: a reaction, a comment, or a view receipt. Reactions and
+ *  views are one-per-actor (id `${postId}:${type}:${actor}`, last-write-wins);
+ *  comments are append-only with a uuid id. `deleted` tombstones a comment (removed
+ *  by its author or the post author) — content cannot be cryptographically recalled,
+ *  so this is best-effort propagation. */
+export interface PostEngagement {
+  id: string;
+  postId: string;
+  type: 'reaction' | 'comment' | 'view';
+  actor: string; // userId (profile resolved from contacts/directory)
+  emoji?: string; // reaction
+  text?: string; // comment (decrypted)
+  at: number; // actor timestamp; LWW for reaction/view, ordering for comment
+  deleted?: boolean; // comment tombstone
+  updatedAt: number;
+}
+
+/** Author-only view receipt, surfaced as a per-post "who viewed" list. Recorded only
+ *  when the viewer has seen-receipts enabled (reciprocal with the chat setting). */
+export interface ViewReceipt {
+  postId: string;
+  viewer: string;
+  at: number;
 }
 
 /** A "needs attention" item in the You tab, drives its badge. */

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -353,8 +353,12 @@ export interface Post {
   body?: string; // decrypted text / caption
   mediaId?: string; // local `media` store id for voice/video/image
   audience?: 'friends' | 'close'; // own posts only (display-only on received)
-  createdAt: number; // author timestamp; feed ordering
-  expiresAt?: number; // epoch ms; absent = keep
+  createdAt: number; // author timestamp
+  // Last activity = max(createdAt, latest reaction/comment). Drives feed ordering (a
+  // post with fresh interaction jumps to the top) and, with keep-alive, tracks the
+  // rolling 72h-of-inactivity window. Absent on legacy rows → treated as createdAt.
+  lastActivityAt?: number;
+  expiresAt?: number; // epoch ms; with keep-alive = last activity + 72h
   outgoing: boolean; // true for self-authored
   // The post's content key K_post (b64url). Every audience member holds it (the author
   // generated it; recipients unwrap it from their envelope) and uses it to seal/open

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -358,7 +358,8 @@ export interface Post {
   // post with fresh interaction jumps to the top) and, with keep-alive, tracks the
   // rolling 72h-of-inactivity window. Absent on legacy rows → treated as createdAt.
   lastActivityAt?: number;
-  expiresAt?: number; // epoch ms; with keep-alive = last activity + 72h
+  expiresAt?: number; // epoch ms; with keep-alive = last activity + ttlMs
+  ttlMs?: number; // the author's chosen lifetime window (keep-alive resets to now + this)
   outgoing: boolean; // true for self-authored
   // The post's content key K_post (b64url). Every audience member holds it (the author
   // generated it; recipients unwrap it from their envelope) and uses it to seal/open

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -356,6 +356,10 @@ export interface Post {
   createdAt: number; // author timestamp; feed ordering
   expiresAt?: number; // epoch ms; absent = keep
   outgoing: boolean; // true for self-authored
+  // The post's content key K_post (b64url). Every audience member holds it (the author
+  // generated it; recipients unwrap it from their envelope) and uses it to seal/open
+  // audience-visible engagement (reactions/comments). The server never sees it.
+  postKey?: string;
   updatedAt: number; // change-bus / dedup
 }
 

--- a/src/directives/enter-send.ts
+++ b/src/directives/enter-send.ts
@@ -1,0 +1,58 @@
+/**
+ * `v-enter-send` — on a physical keyboard (a device whose primary pointer is fine, i.e.
+ * a mouse/trackpad), plain Enter triggers the bound send callback and Shift+Enter
+ * inserts a newline; on touch the Return key keeps inserting line breaks. IME
+ * composition never sends. Bound on the NATIVE input/textarea (via getInputElement) —
+ * a keydown on the ion-* host doesn't fire reliably across the shadow boundary — so it
+ * works on both ion-input and ion-textarea, and in v-for lists.
+ *
+ * Usage: <ion-textarea v-enter-send="() => send(item)" />
+ */
+import type { Directive, DirectiveBinding } from 'vue';
+
+const desktopKeyboard =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(pointer: fine)')
+    : null;
+
+interface ElState {
+  native?: HTMLElement;
+  handler: (e: KeyboardEvent) => void;
+  cb: () => void;
+}
+
+type IonHost = HTMLElement & {
+  getInputElement?: () => Promise<HTMLElement>;
+  __enterSend?: ElState;
+};
+
+export const vEnterSend: Directive<IonHost, () => void> = {
+  mounted(el, binding: DirectiveBinding<() => void>) {
+    const state: ElState = {
+      cb: binding.value,
+      handler: (e: KeyboardEvent) => {
+        if (e.key !== 'Enter') return;
+        if (desktopKeyboard?.matches && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
+          e.preventDefault(); // swallow the newline the field would otherwise insert
+          state.cb?.();
+        }
+      },
+    };
+    el.__enterSend = state;
+    void el
+      .getInputElement?.()
+      .then((native) => {
+        state.native = native;
+        native.addEventListener('keydown', state.handler);
+      })
+      .catch(() => {});
+  },
+  updated(el, binding: DirectiveBinding<() => void>) {
+    if (el.__enterSend) el.__enterSend.cb = binding.value;
+  },
+  unmounted(el) {
+    const s = el.__enterSend;
+    if (s?.native) s.native.removeEventListener('keydown', s.handler);
+    delete el.__enterSend;
+  },
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -136,6 +136,23 @@ const routes: RouteRecordRaw[] = [
     path: '/settings/calls-declines',
     component: () => import('@/views/detail/CallsDeclinesPage.vue'),
   },
+  // Social Wall (spec 0003).
+  {
+    path: '/wall',
+    component: () => import('@/views/detail/WallPage.vue'),
+  },
+  {
+    path: '/wall/compose',
+    component: () => import('@/views/detail/PostComposerPage.vue'),
+  },
+  {
+    path: '/wall/post/:id',
+    component: () => import('@/views/detail/PostDetailPage.vue'),
+  },
+  {
+    path: '/settings/close-friends',
+    component: () => import('@/views/detail/CloseFriendsPage.vue'),
+  },
   {
     path: '/settings/:section',
     component: () => import('@/views/detail/SettingDetailPage.vue'),

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -152,6 +152,10 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/detail/PostDetailPage.vue'),
   },
   {
+    path: '/wall/muted',
+    component: () => import('@/views/detail/WallManagePage.vue'),
+  },
+  {
     path: '/settings/close-friends',
     component: () => import('@/views/detail/CloseFriendsPage.vue'),
   },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -38,6 +38,7 @@ const routes: RouteRecordRaw[] = [
       { path: '', redirect: '/tabs/chats' },
       { path: 'calls', component: CallsPage },
       { path: 'chats', component: ChatsPage },
+      { path: 'wall', component: () => import('@/views/tabs/WallPage.vue') },
       { path: 'contacts', component: ContactsPage },
       { path: 'settings', component: SettingsPage },
       // Backward-compat for old links/bookmarks to the former "You" tab.
@@ -136,10 +137,11 @@ const routes: RouteRecordRaw[] = [
     path: '/settings/calls-declines',
     component: () => import('@/views/detail/CallsDeclinesPage.vue'),
   },
-  // Social Wall (spec 0003).
+  // Social Wall (spec 0003). The feed lives in the bottom tab bar (/tabs/wall);
+  // compose + post detail push full-screen over it. Old /wall links redirect in.
   {
     path: '/wall',
-    component: () => import('@/views/detail/WallPage.vue'),
+    redirect: '/tabs/wall',
   },
   {
     path: '/wall/compose',

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -83,6 +83,7 @@ export async function createPost(req: {
   blobId: string;
   size: number;
   expiresAt?: number;
+  ttlMs?: number;
   envelopes: PostEnvelopeWire[];
 }): Promise<void> {
   const res = await fetch(`${apiBaseUrl()}/v1/posts`, {
@@ -102,6 +103,7 @@ export interface ServerPost {
   size: number;
   createdAt: number;
   expiresAt?: number;
+  ttlMs?: number;
   wrappedKey?: string;
 }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -126,7 +126,7 @@ export async function deletePost(id: string): Promise<void> {
  *  out to the post's audience. Only audience members (or the author) may engage. */
 export async function submitEngagement(
   postId: string,
-  req: { id: string; kind: string; payload: string },
+  req: { id: string; kind: string; payload?: string; target?: string },
 ): Promise<void> {
   const res = await fetch(`${apiBaseUrl()}/v1/posts/${encodeURIComponent(postId)}/engagement`, {
     method: 'POST',
@@ -134,6 +134,25 @@ export async function submitEngagement(
     body: JSON.stringify(req),
   });
   if (!res.ok) throw new Error(`submit engagement failed: ${res.status}`);
+}
+
+/** Record that the caller viewed a post (delivered to the author only). Sent only when
+ *  the caller's seen-receipts setting is on. Idempotent. */
+export async function recordPostView(postId: string): Promise<void> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts/${encodeURIComponent(postId)}/view`, {
+    method: 'POST',
+    headers: authHeaders(),
+  });
+  if (!res.ok && res.status !== 404) throw new Error(`record view failed: ${res.status}`);
+}
+
+/** Author-only: who viewed a post. */
+export async function listPostViews(postId: string): Promise<{ views: { viewer: string; viewedAt: number }[] }> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts/${encodeURIComponent(postId)}/views`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`list views failed: ${res.status}`);
+  return (await res.json()) as { views: { viewer: string; viewedAt: number }[] };
 }
 
 /** One opaque engagement item; `payload` is sealed under K_post (decrypted client-side). */

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -67,6 +67,61 @@ export async function fetchPeerBundle(userId: string): Promise<PeerBundleRespons
   return (await res.json()) as PeerBundleResponse;
 }
 
+/* ---- social Wall (spec 0003) ---- */
+
+/** A post envelope on the wire: a recipient + their wrapped K_post. */
+export interface PostEnvelopeWire {
+  recipient: string;
+  wrappedKey: string;
+}
+
+/** Create a post: opaque blob id + per-recipient wrapped-key envelopes + coarse
+ *  expiry. The server stores ciphertext only and addresses delivery to the envelopes;
+ *  it rejects (403) any recipient who isn't an accepted friend. */
+export async function createPost(req: {
+  id: string;
+  blobId: string;
+  size: number;
+  expiresAt?: number;
+  envelopes: PostEnvelopeWire[];
+}): Promise<void> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) throw new Error(`create post failed: ${res.status}`);
+}
+
+/** A post as delivered to the caller. `wrappedKey` is the caller's envelope (absent
+ *  for the caller's own posts). All content is in the opaque blob. */
+export interface ServerPost {
+  id: string;
+  author: string;
+  blobId: string;
+  size: number;
+  createdAt: number;
+  expiresAt?: number;
+  wrappedKey?: string;
+}
+
+/** Pull posts addressed to the caller (and their own) newer than `since`, newest
+ *  first, with a cursor to pass next time. */
+export async function listPosts(since = 0): Promise<{ posts: ServerPost[]; cursor: number }> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts?since=${since}`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`list posts failed: ${res.status}`);
+  return (await res.json()) as { posts: ServerPost[]; cursor: number };
+}
+
+/** Delete one of the caller's own posts (author-only server-side). Idempotent. */
+export async function deletePost(id: string): Promise<void> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+  if (!res.ok && res.status !== 404) throw new Error(`delete post failed: ${res.status}`);
+}
+
 /** Delete (terminate) the current account. The server wipes all per-user data
  *  (tokens, prekeys, relay queue, sync records, recovery wrap, push, blocks) but
  *  KEEPS the user row flipped to 'terminated' so the id can't be re-registered and

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -108,11 +108,15 @@ export interface ServerPost {
 }
 
 /** Pull posts addressed to the caller (and their own) newer than `since`, newest
- *  first, with a cursor to pass next time. */
-export async function listPosts(since = 0): Promise<{ posts: ServerPost[]; cursor: number }> {
+ *  first, with a cursor to pass next time. `revoked` lists post ids the caller was
+ *  removed from (e.g. dropped from close friends) so the client prunes local copies. */
+export async function listPosts(
+  since = 0,
+): Promise<{ posts: ServerPost[]; cursor: number; revoked: string[] }> {
   const res = await fetch(`${apiBaseUrl()}/v1/posts?since=${since}`, { headers: authHeaders() });
   if (!res.ok) throw new Error(`list posts failed: ${res.status}`);
-  return (await res.json()) as { posts: ServerPost[]; cursor: number };
+  const body = (await res.json()) as { posts: ServerPost[]; cursor: number; revoked?: string[] };
+  return { ...body, revoked: body.revoked ?? [] };
 }
 
 /** Delete one of the caller's own posts (author-only server-side). Idempotent. */
@@ -122,6 +126,17 @@ export async function deletePost(id: string): Promise<void> {
     headers: authHeaders(),
   });
   if (!res.ok && res.status !== 404) throw new Error(`delete post failed: ${res.status}`);
+}
+
+/** Remove one recipient from one of the caller's own posts (author-only). Used when
+ *  un-close-friending someone to revoke close-only posts: their key envelope is deleted
+ *  and a revocation is recorded so their device prunes the local copy. Idempotent. */
+export async function removePostRecipient(postId: string, userId: string): Promise<void> {
+  const res = await fetch(
+    `${apiBaseUrl()}/v1/posts/${encodeURIComponent(postId)}/recipient/${encodeURIComponent(userId)}`,
+    { method: 'DELETE', headers: authHeaders() },
+  );
+  if (!res.ok && res.status !== 404) throw new Error(`remove post recipient failed: ${res.status}`);
 }
 
 /** Submit one opaque engagement item (reaction/comment) on a post; the server fans it

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -122,6 +122,38 @@ export async function deletePost(id: string): Promise<void> {
   if (!res.ok && res.status !== 404) throw new Error(`delete post failed: ${res.status}`);
 }
 
+/** Submit one opaque engagement item (reaction/comment) on a post; the server fans it
+ *  out to the post's audience. Only audience members (or the author) may engage. */
+export async function submitEngagement(
+  postId: string,
+  req: { id: string; kind: string; payload: string },
+): Promise<void> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts/${encodeURIComponent(postId)}/engagement`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) throw new Error(`submit engagement failed: ${res.status}`);
+}
+
+/** One opaque engagement item; `payload` is sealed under K_post (decrypted client-side). */
+export interface ServerEngagement {
+  id: string;
+  actor: string;
+  kind: string;
+  payload: string;
+  createdAt: number;
+}
+
+/** Fetch the engagement on a post the caller can see. */
+export async function listEngagement(postId: string): Promise<{ items: ServerEngagement[] }> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts/${encodeURIComponent(postId)}/engagement`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`list engagement failed: ${res.status}`);
+  return (await res.json()) as { items: ServerEngagement[] };
+}
+
 /** Delete (terminate) the current account. The server wipes all per-user data
  *  (tokens, prekeys, relay queue, sync records, recovery wrap, push, blocks) but
  *  KEEPS the user row flipped to 'terminated' so the id can't be re-registered and

--- a/src/services/connections.ts
+++ b/src/services/connections.ts
@@ -113,10 +113,14 @@ export async function withdrawConnect(userId: string): Promise<void> {
   await refreshConnections();
 }
 
-/** Unilaterally connect to a group co-member (membership = consent). Best-effort. */
+/** Unilaterally connect to a group co-member (membership = consent). Best-effort. A
+ *  linked connection is accepted server-side, so mark the peer connected locally too —
+ *  otherwise the local connected-peers ledger (which drives e.g. the Wall friends
+ *  audience, spec 0003) misses them. */
 export async function linkConnect(userId: string): Promise<void> {
   try {
     await apiLink(userId);
+    await markContactConnected(userId);
   } catch {
     /* best effort; a later interaction retries */
   }

--- a/src/services/crypto/post.test.ts
+++ b/src/services/crypto/post.test.ts
@@ -16,7 +16,11 @@ beforeAll(async () => {
 });
 
 const textPost: PostPayload = { kind: 'text', body: 'hello wall' };
-const mediaPost: PostPayload = { kind: 'image', body: 'caption', media: { blobId: 'cap123', fileKey: 'AAAA' } };
+const mediaPost: PostPayload = {
+  kind: 'image',
+  body: 'caption',
+  media: { blobId: 'cap123', fileKey: 'AAAA', mime: 'image/jpeg', size: 1024, name: 'p.jpg' },
+};
 
 describe('post payload seal/open', () => {
   it('round-trips a text payload', () => {

--- a/src/services/crypto/post.test.ts
+++ b/src/services/crypto/post.test.ts
@@ -1,0 +1,88 @@
+// Unit tests for the post crypto (spec 0003). Posts use a fresh per-post content
+// key (K_post) sealed with the existing AEAD, and an ECIES wrap of K_post per
+// recipient (ephemeral X25519 → HKDF → AEAD). This is deliberately NOT a ratchet:
+// each post/engagement item carries its own independent key, so the ratchet-specific
+// failure modes (out-of-order, skipped-key) do not apply by construction. The
+// adversarial cases that DO apply — tamper/forgery (AEAD integrity) and a non-member
+// key (wrong recipient) — are covered here; replay is handled at the store layer
+// (id-based idempotency), not in crypto.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ready, x25519Keypair } from './primitives';
+import { genPostKey, sealPost, openPost, wrapPostKey, unwrapPostKey, type PostPayload } from './post';
+import { b64urlToBytes } from './envelope';
+
+beforeAll(async () => {
+  await ready();
+});
+
+const textPost: PostPayload = { kind: 'text', body: 'hello wall' };
+const mediaPost: PostPayload = { kind: 'image', body: 'caption', media: { blobId: 'cap123', fileKey: 'AAAA' } };
+
+describe('post payload seal/open', () => {
+  it('round-trips a text payload', () => {
+    const k = genPostKey();
+    const env = sealPost(k, textPost);
+    expect(openPost(k, env)).toEqual(textPost);
+  });
+
+  it('round-trips a media payload (media-ref sealed inside)', () => {
+    const k = genPostKey();
+    const env = sealPost(k, mediaPost);
+    expect(openPost(k, env)).toEqual(mediaPost);
+  });
+
+  it('rejects a tampered ciphertext (AEAD integrity / forgery)', () => {
+    const k = genPostKey();
+    const env = sealPost(k, textPost);
+    const ctBytes = b64urlToBytes(env.ct);
+    ctBytes[0] ^= 0xff;
+    const forged = { ...env, ct: Buffer.from(ctBytes).toString('base64url') };
+    expect(() => openPost(k, forged)).toThrow();
+  });
+
+  it('a different K_post cannot open the payload', () => {
+    const env = sealPost(genPostKey(), textPost);
+    expect(() => openPost(genPostKey(), env)).toThrow();
+  });
+});
+
+describe('per-recipient K_post wrap/unwrap (ECIES)', () => {
+  it('the intended recipient unwraps the exact K_post', () => {
+    const recipient = x25519Keypair();
+    const k = genPostKey();
+    const wrapped = wrapPostKey(k, recipient.publicKey);
+    const got = unwrapPostKey(wrapped, recipient.privateKey);
+    expect(Array.from(got)).toEqual(Array.from(k));
+    // and the unwrapped key actually opens a payload sealed under the original
+    const env = sealPost(k, textPost);
+    expect(openPost(got, env)).toEqual(textPost);
+  });
+
+  it('a non-member (wrong recipient key) cannot unwrap', () => {
+    const recipient = x25519Keypair();
+    const outsider = x25519Keypair();
+    const wrapped = wrapPostKey(genPostKey(), recipient.publicKey);
+    expect(() => unwrapPostKey(wrapped, outsider.privateKey)).toThrow();
+  });
+
+  it('a tampered wrap envelope is rejected', () => {
+    const recipient = x25519Keypair();
+    const wrapped = wrapPostKey(genPostKey(), recipient.publicKey);
+    const ctBytes = b64urlToBytes(wrapped.env.ct);
+    ctBytes[0] ^= 0xff;
+    const forged = { ...wrapped, env: { ...wrapped.env, ct: Buffer.from(ctBytes).toString('base64url') } };
+    expect(() => unwrapPostKey(forged, recipient.privateKey)).toThrow();
+  });
+
+  it('each wrap uses a fresh ephemeral key (distinct wraps for the same K_post)', () => {
+    const recipient = x25519Keypair();
+    const k = genPostKey();
+    const a = wrapPostKey(k, recipient.publicKey);
+    const b = wrapPostKey(k, recipient.publicKey);
+    expect(a.eph).not.toEqual(b.eph);
+    // both still unwrap to the same K_post
+    expect(Array.from(unwrapPostKey(a, recipient.privateKey))).toEqual(
+      Array.from(unwrapPostKey(b, recipient.privateKey)),
+    );
+  });
+});

--- a/src/services/crypto/post.ts
+++ b/src/services/crypto/post.ts
@@ -51,6 +51,19 @@ export function openPost(kPost: Uint8Array, env: Envelope): PostPayload {
   return openJson<PostPayload>(kPost, env);
 }
 
+/** Seal an engagement item (reaction/comment) under the post's K_post. Every audience
+ *  member holds K_post (they unwrapped it to read the post), so they can both seal
+ *  their own engagement and open everyone else's; the server, which lacks K_post,
+ *  cannot read the emoji or comment text. */
+export function sealEngagement(kPost: Uint8Array, value: unknown): Envelope {
+  return sealJson(kPost, value, 'posteng');
+}
+
+/** Open an engagement item sealed by {@link sealEngagement}. */
+export function openEngagement<T>(kPost: Uint8Array, env: Envelope): T {
+  return openJson<T>(kPost, env);
+}
+
 /** A per-recipient wrapped K_post: the ephemeral X25519 public key + the sealed key. */
 export interface WrappedPostKey {
   eph: string; // b64url ephemeral X25519 public key

--- a/src/services/crypto/post.ts
+++ b/src/services/crypto/post.ts
@@ -27,12 +27,13 @@ import {
   type Envelope,
 } from './envelope';
 
-/** Decrypted content carried inside a post, sealed under K_post. */
+/** Decrypted content carried inside a post, sealed under K_post. For non-text posts
+ *  the full media-ref (blob id + per-file key + mime/dimensions) rides sealed inside
+ *  the payload, so the server never sees it. */
 export interface PostPayload {
   kind: 'text' | 'voice' | 'video' | 'image';
   body?: string;
-  /** Media-ref for non-text posts: blob capability id + its per-file key (b64url). */
-  media?: { blobId: string; fileKey: string };
+  media?: import('./message').MediaRef;
 }
 
 /** Generate a fresh per-post content key. */

--- a/src/services/crypto/post.ts
+++ b/src/services/crypto/post.ts
@@ -1,0 +1,87 @@
+/**
+ * Post crypto (spec 0003).
+ *
+ * A Wall post is sealed once under a fresh per-post content key (K_post). That key
+ * is then wrapped to each audience member with a standard ECIES construction over
+ * their X25519 public key: ephemeral X25519 → HKDF → AEAD — the very primitives X3DH
+ * is built from, NOT a new scheme (constitution Principle IV). The server stores the
+ * sealed payload plus one wrapped-key envelope per recipient and never holds K_post
+ * or any plaintext.
+ *
+ * Deliberately NOT a ratchet: each post (and each engagement item) carries its own
+ * independent key, so there is no chain. Forward secrecy across posts comes from
+ * per-post keys + expiry, and the ratchet-specific failure modes (out-of-order,
+ * skipped-key) do not apply here by construction (see research.md R3). These are pure
+ * functions, fully testable without IndexedDB; the stateful wiring (fetching a
+ * recipient's public key, persistence) lives in services/posts.ts.
+ */
+import { randomBytes, x25519Keypair, x25519, hkdf, KEY_BYTES } from './primitives';
+import {
+  seal,
+  open,
+  sealJson,
+  openJson,
+  bytesToB64url,
+  b64urlToBytes,
+  utf8ToBytes,
+  type Envelope,
+} from './envelope';
+
+/** Decrypted content carried inside a post, sealed under K_post. */
+export interface PostPayload {
+  kind: 'text' | 'voice' | 'video' | 'image';
+  body?: string;
+  /** Media-ref for non-text posts: blob capability id + its per-file key (b64url). */
+  media?: { blobId: string; fileKey: string };
+}
+
+/** Generate a fresh per-post content key. */
+export function genPostKey(): Uint8Array {
+  return randomBytes(KEY_BYTES);
+}
+
+/** Seal a post payload under K_post → Envelope (uploaded as the post blob). */
+export function sealPost(kPost: Uint8Array, payload: PostPayload): Envelope {
+  return sealJson(kPost, payload, 'post');
+}
+
+/** Open a post payload sealed by {@link sealPost}. */
+export function openPost(kPost: Uint8Array, env: Envelope): PostPayload {
+  return openJson<PostPayload>(kPost, env);
+}
+
+/** A per-recipient wrapped K_post: the ephemeral X25519 public key + the sealed key. */
+export interface WrappedPostKey {
+  eph: string; // b64url ephemeral X25519 public key
+  env: Envelope; // K_post sealed under the ECDH-derived wrap key
+}
+
+// Domain-separated HKDF info + a fixed all-zero salt (the ephemeral DH already
+// provides the randomness; the salt is constant by design, as in the ratchet's KDF).
+const WRAP_INFO = utf8ToBytes('ring/post/keywrap/v1');
+const ZERO_SALT = new Uint8Array(32);
+
+function wrapKeyFrom(shared: Uint8Array): Uint8Array {
+  return hkdf(shared, KEY_BYTES, ZERO_SALT, WRAP_INFO);
+}
+
+/**
+ * Wrap K_post to a recipient's X25519 public key (ECIES). Pure: the caller supplies
+ * the recipient's published public key. A fresh ephemeral key per call means two
+ * wraps of the same K_post differ on the wire.
+ */
+export function wrapPostKey(kPost: Uint8Array, recipientPub: Uint8Array): WrappedPostKey {
+  const eph = x25519Keypair();
+  const shared = x25519(eph.privateKey, recipientPub);
+  const env = seal(wrapKeyFrom(shared), kPost, 'postkey');
+  return { eph: bytesToB64url(eph.publicKey), env };
+}
+
+/**
+ * Unwrap K_post with the recipient's X25519 private key. Throws if the wrap was for a
+ * different recipient or was tampered with (the AEAD tag fails to verify).
+ */
+export function unwrapPostKey(wrapped: WrappedPostKey, recipientPriv: Uint8Array): Uint8Array {
+  const shared = x25519(recipientPriv, b64urlToBytes(wrapped.eph));
+  return open(wrapKeyFrom(shared), wrapped.env);
+}

--- a/src/services/posts.test.ts
+++ b/src/services/posts.test.ts
@@ -11,7 +11,11 @@ beforeAll(async () => {
   await ready();
 });
 
-const payload: PostPayload = { kind: 'image', body: 'sunset', media: { blobId: 'cap9', fileKey: 'ZmtleQ' } };
+const payload: PostPayload = {
+  kind: 'image',
+  body: 'sunset',
+  media: { blobId: 'cap9', fileKey: 'ZmtleQ', mime: 'image/png', size: 99, name: 's.png' },
+};
 
 describe('buildPost / openReceivedPost', () => {
   it('an audience member recovers the exact payload', () => {

--- a/src/services/posts.test.ts
+++ b/src/services/posts.test.ts
@@ -3,7 +3,7 @@
 // no plaintext a non-member could read.
 import { describe, it, expect, beforeAll } from 'vitest';
 import { ready, x25519Keypair } from './crypto/primitives';
-import { buildPost, openReceivedPost } from './posts';
+import { buildPost, openReceivedPost, sealPostEngagement, openPostEngagement } from './posts';
 import { bytesToUtf8 } from './crypto/envelope';
 import type { PostPayload } from './crypto/post';
 
@@ -18,13 +18,14 @@ const payload: PostPayload = {
 };
 
 describe('buildPost / openReceivedPost', () => {
-  it('an audience member recovers the exact payload', () => {
+  it('an audience member recovers the exact payload + K_post', () => {
     const bob = x25519Keypair();
     const built = buildPost(payload, [{ userId: 'bob', pubKey: bob.publicKey }]);
     expect(built.envelopes).toHaveLength(1);
     expect(built.envelopes[0].recipient).toBe('bob');
     const got = openReceivedPost(built.blob, built.envelopes[0].wrappedKey, bob.privateKey);
-    expect(got).toEqual(payload);
+    expect(got.payload).toEqual(payload);
+    expect(got.postKey).toBe(built.postKey); // recipient derives the same K_post
   });
 
   it('each audience member gets a distinct wrapped key but recovers the same payload', () => {
@@ -35,8 +36,8 @@ describe('buildPost / openReceivedPost', () => {
       { userId: 'carol', pubKey: carol.publicKey },
     ]);
     expect(built.envelopes[0].wrappedKey).not.toEqual(built.envelopes[1].wrappedKey);
-    expect(openReceivedPost(built.blob, built.envelopes[0].wrappedKey, bob.privateKey)).toEqual(payload);
-    expect(openReceivedPost(built.blob, built.envelopes[1].wrappedKey, carol.privateKey)).toEqual(payload);
+    expect(openReceivedPost(built.blob, built.envelopes[0].wrappedKey, bob.privateKey).payload).toEqual(payload);
+    expect(openReceivedPost(built.blob, built.envelopes[1].wrappedKey, carol.privateKey).payload).toEqual(payload);
   });
 
   it('a non-member cannot open the post (wrong key)', () => {
@@ -44,6 +45,18 @@ describe('buildPost / openReceivedPost', () => {
     const outsider = x25519Keypair();
     const built = buildPost(payload, [{ userId: 'bob', pubKey: bob.publicKey }]);
     expect(() => openReceivedPost(built.blob, built.envelopes[0].wrappedKey, outsider.privateKey)).toThrow();
+  });
+
+  it('engagement seals under K_post: audience members read it, outsiders cannot', () => {
+    const bob = x25519Keypair();
+    const built = buildPost(payload, [{ userId: 'bob', pubKey: bob.publicKey }]);
+    const bobKey = openReceivedPost(built.blob, built.envelopes[0].wrappedKey, bob.privateKey).postKey;
+    // Bob (audience) reacts; the author (holds built.postKey) reads it back.
+    const wire = sealPostEngagement(bobKey, { emoji: '👍', at: 1 });
+    expect(wire).not.toContain('👍'); // sealed on the wire
+    expect(openPostEngagement<{ emoji: string }>(built.postKey, wire)).toEqual({ emoji: '👍', at: 1 });
+    // A wrong K_post (all-zero) cannot open it.
+    expect(() => openPostEngagement('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', wire)).toThrow();
   });
 
   it('the blob carries no plaintext (body is not present in the clear)', () => {

--- a/src/services/posts.test.ts
+++ b/src/services/posts.test.ts
@@ -1,0 +1,51 @@
+// Round-trip test for the post orchestration (spec 0003): a built post is openable
+// by an audience member with their X25519 private key, and the blob/envelopes carry
+// no plaintext a non-member could read.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ready, x25519Keypair } from './crypto/primitives';
+import { buildPost, openReceivedPost } from './posts';
+import { bytesToUtf8 } from './crypto/envelope';
+import type { PostPayload } from './crypto/post';
+
+beforeAll(async () => {
+  await ready();
+});
+
+const payload: PostPayload = { kind: 'image', body: 'sunset', media: { blobId: 'cap9', fileKey: 'ZmtleQ' } };
+
+describe('buildPost / openReceivedPost', () => {
+  it('an audience member recovers the exact payload', () => {
+    const bob = x25519Keypair();
+    const built = buildPost(payload, [{ userId: 'bob', pubKey: bob.publicKey }]);
+    expect(built.envelopes).toHaveLength(1);
+    expect(built.envelopes[0].recipient).toBe('bob');
+    const got = openReceivedPost(built.blob, built.envelopes[0].wrappedKey, bob.privateKey);
+    expect(got).toEqual(payload);
+  });
+
+  it('each audience member gets a distinct wrapped key but recovers the same payload', () => {
+    const bob = x25519Keypair();
+    const carol = x25519Keypair();
+    const built = buildPost(payload, [
+      { userId: 'bob', pubKey: bob.publicKey },
+      { userId: 'carol', pubKey: carol.publicKey },
+    ]);
+    expect(built.envelopes[0].wrappedKey).not.toEqual(built.envelopes[1].wrappedKey);
+    expect(openReceivedPost(built.blob, built.envelopes[0].wrappedKey, bob.privateKey)).toEqual(payload);
+    expect(openReceivedPost(built.blob, built.envelopes[1].wrappedKey, carol.privateKey)).toEqual(payload);
+  });
+
+  it('a non-member cannot open the post (wrong key)', () => {
+    const bob = x25519Keypair();
+    const outsider = x25519Keypair();
+    const built = buildPost(payload, [{ userId: 'bob', pubKey: bob.publicKey }]);
+    expect(() => openReceivedPost(built.blob, built.envelopes[0].wrappedKey, outsider.privateKey)).toThrow();
+  });
+
+  it('the blob carries no plaintext (body is not present in the clear)', () => {
+    const bob = x25519Keypair();
+    const built = buildPost(payload, [{ userId: 'bob', pubKey: bob.publicKey }]);
+    expect(bytesToUtf8(built.blob)).not.toContain('sunset');
+    expect(bytesToUtf8(built.blob)).not.toContain('cap9');
+  });
+});

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -1,0 +1,71 @@
+/**
+ * Post orchestration (spec 0003) — crypto-only, like messaging.ts.
+ *
+ * This layer turns a post payload + an audience (each member's X25519 public key)
+ * into the bytes the server stores: one sealed-payload blob + one wrapped-key envelope
+ * per recipient. It NEVER touches the chats/contacts/posts IndexedDB stores — the
+ * data layer (`queries.ts`) fetches the audience public keys, uploads the blob via
+ * `media-transfer.ts`, calls the API, and persists the resulting `Post`. The
+ * dependency stays one-directional (`queries.ts → posts.ts`), no cycle.
+ */
+import {
+  genPostKey,
+  sealPost,
+  openPost,
+  wrapPostKey,
+  unwrapPostKey,
+  type PostPayload,
+  type WrappedPostKey,
+} from './crypto/post';
+import { utf8ToBytes, bytesToUtf8, type Envelope } from './crypto/envelope';
+
+export type { PostPayload } from './crypto/post';
+
+/** An audience member: their id + published X25519 public key (to wrap K_post to). */
+export interface AudienceMember {
+  userId: string;
+  pubKey: Uint8Array;
+}
+
+/** One per-recipient envelope as carried on the wire (`wrappedKey` = JSON of the
+ *  {@link WrappedPostKey}). */
+export interface PostEnvelopeWire {
+  recipient: string;
+  wrappedKey: string;
+}
+
+export interface BuiltPost {
+  /** The K_post-sealed payload bytes — uploaded as the opaque post blob. */
+  blob: Uint8Array;
+  /** One wrapped-key envelope per audience member. */
+  envelopes: PostEnvelopeWire[];
+}
+
+/**
+ * Seal a post under a fresh per-post key and wrap that key to each audience member.
+ * Pure: the caller supplies the audience public keys. The returned blob is uploaded
+ * once; the envelopes are sent alongside so each recipient (and only they) can recover
+ * K_post.
+ */
+export function buildPost(payload: PostPayload, audience: AudienceMember[]): BuiltPost {
+  const k = genPostKey();
+  const sealed = sealPost(k, payload);
+  const blob = utf8ToBytes(JSON.stringify(sealed));
+  const envelopes = audience.map((m) => ({
+    recipient: m.userId,
+    wrappedKey: JSON.stringify(wrapPostKey(k, m.pubKey)),
+  }));
+  return { blob, envelopes };
+}
+
+/**
+ * Recover a received post: unwrap K_post from the caller's envelope, then open the
+ * sealed payload blob. Throws if the wrap was not for this recipient or anything was
+ * tampered with (AEAD verification).
+ */
+export function openReceivedPost(blob: Uint8Array, wrappedKey: string, selfPriv: Uint8Array): PostPayload {
+  const wrapped = JSON.parse(wrappedKey) as WrappedPostKey;
+  const k = unwrapPostKey(wrapped, selfPriv);
+  const env = JSON.parse(bytesToUtf8(blob)) as Envelope;
+  return openPost(k, env);
+}

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -14,10 +14,12 @@ import {
   openPost,
   wrapPostKey,
   unwrapPostKey,
+  sealEngagement,
+  openEngagement,
   type PostPayload,
   type WrappedPostKey,
 } from './crypto/post';
-import { utf8ToBytes, bytesToUtf8, type Envelope } from './crypto/envelope';
+import { utf8ToBytes, bytesToUtf8, bytesToB64url, b64urlToBytes, type Envelope } from './crypto/envelope';
 
 export type { PostPayload } from './crypto/post';
 
@@ -39,13 +41,15 @@ export interface BuiltPost {
   blob: Uint8Array;
   /** One wrapped-key envelope per audience member. */
   envelopes: PostEnvelopeWire[];
+  /** K_post (b64url) — the author keeps it so they can read + post engagement. */
+  postKey: string;
 }
 
 /**
  * Seal a post under a fresh per-post key and wrap that key to each audience member.
  * Pure: the caller supplies the audience public keys. The returned blob is uploaded
  * once; the envelopes are sent alongside so each recipient (and only they) can recover
- * K_post.
+ * K_post; `postKey` is kept locally for engagement.
  */
 export function buildPost(payload: PostPayload, audience: AudienceMember[]): BuiltPost {
   const k = genPostKey();
@@ -55,17 +59,33 @@ export function buildPost(payload: PostPayload, audience: AudienceMember[]): Bui
     recipient: m.userId,
     wrappedKey: JSON.stringify(wrapPostKey(k, m.pubKey)),
   }));
-  return { blob, envelopes };
+  return { blob, envelopes, postKey: bytesToB64url(k) };
 }
 
 /**
  * Recover a received post: unwrap K_post from the caller's envelope, then open the
- * sealed payload blob. Throws if the wrap was not for this recipient or anything was
- * tampered with (AEAD verification).
+ * sealed payload blob. Returns the payload AND K_post (b64url) — the recipient keeps
+ * the key to read + post engagement. Throws if the wrap was not for this recipient or
+ * anything was tampered with (AEAD verification).
  */
-export function openReceivedPost(blob: Uint8Array, wrappedKey: string, selfPriv: Uint8Array): PostPayload {
+export function openReceivedPost(
+  blob: Uint8Array,
+  wrappedKey: string,
+  selfPriv: Uint8Array,
+): { payload: PostPayload; postKey: string } {
   const wrapped = JSON.parse(wrappedKey) as WrappedPostKey;
   const k = unwrapPostKey(wrapped, selfPriv);
   const env = JSON.parse(bytesToUtf8(blob)) as Envelope;
-  return openPost(k, env);
+  return { payload: openPost(k, env), postKey: bytesToB64url(k) };
+}
+
+/** Seal an engagement value (e.g. `{emoji}`) under a post's K_post (b64url) → the
+ *  opaque wire payload string. */
+export function sealPostEngagement(postKeyB64: string, value: unknown): string {
+  return JSON.stringify(sealEngagement(b64urlToBytes(postKeyB64), value));
+}
+
+/** Open an engagement wire payload sealed by {@link sealPostEngagement}. */
+export function openPostEngagement<T>(postKeyB64: string, payload: string): T {
+  return openEngagement<T>(b64urlToBytes(postKeyB64), JSON.parse(payload) as Envelope);
 }

--- a/src/services/release-notes.test.ts
+++ b/src/services/release-notes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeDelta, prettify, displayVersion, type ReleaseNote } from './release-notes';
+import { computeDelta, userFacing, isUserFacing, prettify, displayVersion, type ReleaseNote } from './release-notes';
 
 const note = (sha: string, subject = 'feat: x'): ReleaseNote => ({ sha, subject });
 
@@ -46,6 +46,39 @@ describe('computeDelta', () => {
   });
 });
 
+describe('isUserFacing / userFacing', () => {
+  it('keeps features, fixes, perf, and non-conforming subjects', () => {
+    expect(isUserFacing(note('a', 'feat(wall): add voice posts'))).toBe(true);
+    expect(isUserFacing(note('b', 'fix(call): no echo'))).toBe(true);
+    expect(isUserFacing(note('c', 'perf: faster boot'))).toBe(true);
+    expect(isUserFacing(note('d', 'security: rotate keys'))).toBe(true); // unknown type → shown
+    expect(isUserFacing(note('e', 'just some words'))).toBe(true); // non-conforming → shown
+  });
+
+  it('drops build/CI/test/docs/chore/refactor/style/deps noise', () => {
+    for (const t of ['build', 'chore', 'ci', 'deps', 'docs', 'refactor', 'style', 'test']) {
+      expect(isUserFacing(note('x', `${t}(scope): whatever`))).toBe(false);
+      expect(isUserFacing(note('x', `${t}: whatever`))).toBe(false);
+    }
+  });
+
+  it('filters a mixed list down to the user-facing notes, order preserved', () => {
+    const notes = [
+      note('a', 'feat: shiny new thing'),
+      note('b', 'ci: bump actions'),
+      note('c', 'fix: a real bug'),
+      note('d', 'docs: update readme'),
+      note('e', 'chore: tidy'),
+    ];
+    expect(userFacing(notes).map((n) => n.sha)).toEqual(['a', 'c']);
+  });
+
+  it('is case-insensitive on the type', () => {
+    expect(isUserFacing(note('x', 'CI: uppercase noise'))).toBe(false);
+    expect(isUserFacing(note('y', 'Feat: uppercase feature'))).toBe(true);
+  });
+});
+
 describe('prettify', () => {
   it('drops the conventional-commit prefix and capitalizes', () => {
     expect(prettify('fix(sync): stabilize message status')).toBe('Stabilize message status');
@@ -55,6 +88,18 @@ describe('prettify', () => {
   it('handles a breaking-change marker and scopes', () => {
     expect(prettify('feat!: drop legacy API')).toBe('Drop legacy API');
     expect(prettify('refactor(call/sfu): simplify routing')).toBe('Simplify routing');
+  });
+
+  it('strips a trailing spec / issue / PR reference', () => {
+    expect(prettify('feat(notifications): reliable push + redesigned in-app notifications (spec 1015)')).toBe(
+      'Reliable push + redesigned in-app notifications',
+    );
+    expect(prettify('fix(media): correct thumbnails (#248)')).toBe('Correct thumbnails');
+    expect(prettify('feat: add search (gh-12)')).toBe('Add search');
+  });
+
+  it('keeps a meaningful trailing parenthetical that is not a reference', () => {
+    expect(prettify('feat: add dark mode (finally)')).toBe('Add dark mode (finally)');
   });
 
   it('passes a non-conforming subject through, just capitalized', () => {

--- a/src/services/release-notes.ts
+++ b/src/services/release-notes.ts
@@ -5,8 +5,9 @@
 // list as the compile-time constant `__RELEASE_NOTES__`; the incoming build's list
 // arrives via `/v1/config`. `computeDelta` is the per-user difference (what the
 // incoming build adds that the running one didn't have), keyed by commit SHA so it
-// is exact even when the "since last tag" base shifts at a release. `prettify`
-// turns a Conventional-Commit subject into user-facing text.
+// is exact even when the "since last tag" base shifts at a release. `userFacing`
+// drops changes a regular user doesn't care about (build/CI/test/docs/chores), and
+// `prettify` turns a Conventional-Commit subject into clean user-facing text.
 //
 // No DOM / IndexedDB / network here, so this is fully unit-testable in the Node env.
 
@@ -24,6 +25,33 @@ export function computeDelta(incoming: ReleaseNote[], running: ReleaseNote[]): R
   return incoming.filter((n) => !have.has(n.sha));
 }
 
+// Conventional-Commit types that are NOT worth telling a regular user about: build
+// plumbing, CI, chores, dependency bumps, tests, docs, pure refactors, and code style.
+// Everything else (feat, fix, perf, security, and any non-conforming subject) is treated
+// as a user-facing change worth surfacing. A denylist (rather than an allowlist) errs
+// toward SHOWING a genuine change we didn't anticipate the type of, never hiding one.
+const NOISE_TYPES = new Set(['build', 'chore', 'ci', 'deps', 'docs', 'refactor', 'style', 'test']);
+
+/** The Conventional-Commit type of a subject in lowercase (e.g. `feat`, `fix`), or
+ *  `null` when the subject doesn't start with a `type(scope): ` prefix. */
+function commitType(subject: string): string | null {
+  const m = /^([a-z]+)(\([^)]*\))?!?:/i.exec(subject.trim());
+  return m ? m[1].toLowerCase() : null;
+}
+
+/** Whether a note describes a change a regular user cares about (a new feature, fix,
+ *  or improvement) rather than internal plumbing. */
+export function isUserFacing(note: ReleaseNote): boolean {
+  const t = commitType(note.subject);
+  return t === null || !NOISE_TYPES.has(t);
+}
+
+/** Keep only the user-facing notes (drops build/CI/test/docs/chore/etc.), so the
+ *  "What's new" list reads as features and fixes, not a developer changelog. */
+export function userFacing(notes: ReleaseNote[]): ReleaseNote[] {
+  return notes.filter(isUserFacing);
+}
+
 /** A version for display: drop semver build metadata (the `+<sha>` the develop image
  *  stamps, e.g. `0.1.0-dev.127+3ddacbf…`), which is a long unbreakable token that
  *  wrecks toast/sheet layout. Keeps the pre-release part (`-dev.127`, `-rc.1`). */
@@ -34,11 +62,15 @@ export function displayVersion(v: string): string {
 // Conventional-Commit prefix: type, optional (scope), optional `!`, then `: `.
 const CC_PREFIX = /^[a-z]+(\([^)]*\))?!?:\s*/i;
 
-/** Turn a commit subject into user-facing text: drop the `type(scope):` prefix and
- *  upper-case the first letter. A non-conforming subject is passed through (just
- *  capitalized), never dropped. */
+// A trailing developer reference users don't need: `(spec 1015)`, `(#248)`, or a bare
+// PR/issue number like `(#248)` at the end of the subject. Stripped for display.
+const TRAILING_REF = /\s*\((?:spec\s*\d+|#\d+|gh-\d+)\)\s*$/i;
+
+/** Turn a commit subject into clean user-facing text: drop the `type(scope):` prefix,
+ *  strip a trailing spec/issue/PR reference, and upper-case the first letter. A
+ *  non-conforming subject is passed through (just trimmed + capitalized), never dropped. */
 export function prettify(subject: string): string {
-  const stripped = subject.replace(CC_PREFIX, '').trim();
+  const stripped = subject.replace(CC_PREFIX, '').replace(TRAILING_REF, '').trim();
   const text = stripped || subject.trim();
   return text.charAt(0).toUpperCase() + text.slice(1);
 }

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -97,7 +97,6 @@ import {
 import {
   createInvitation, deleteAccount, fetchPeerBundle,
   listConnections as apiListConnections,
-  connectLink as apiConnectLink,
 } from '@/services/api';
 import { runInviteSync } from '@/services/invites';
 import { notifyBanners } from '@/services/notify';
@@ -107,6 +106,7 @@ import {
   rejectConnect as storeRejectConnect, withdrawConnect as storeWithdrawConnect,
   refreshConnections as storeRefreshConnections,
   incomingRequests as storeIncomingRequests,
+  linkConnect as storeLinkConnect,
 } from '@/services/connections';
 import { subscribePresence, sendActivity } from '@/composables/useSync';
 import { peerPresence } from '@/composables/usePresence';
@@ -684,7 +684,7 @@ export function installTestHook(): void {
     // Drive the real client store actions (import + mark-connected + reconcile),
     // not the raw API, so e2e exercises the actual friend-request behavior.
     connectRequest: (target: string) => storeRequestConnect(target),
-    connectLink: (target: string) => apiConnectLink(target),
+    connectLink: (target: string) => storeLinkConnect(target),
     connectAccept: (requester: string) => storeAcceptConnect(requester),
     connectReject: (requester: string, block: boolean) => storeRejectConnect(requester, block),
     connectWithdraw: (target: string) => storeWithdrawConnect(target),

--- a/src/services/transport.ts
+++ b/src/services/transport.ts
@@ -285,6 +285,13 @@ export interface PostEngagementFrame {
   post: string;
 }
 
+/** Content-free nudge that the author revoked a post from us (e.g. they dropped us from
+ *  close friends); the client deletes its local copy of that post. */
+export interface PostRevokeFrame {
+  t: 'post-revoke';
+  post: string;
+}
+
 /* ---- ephemeral activity indicators (spec 1009): typing / recording ---- */
 
 /** What a peer is doing in a conversation right now (sealed on the wire). */
@@ -333,6 +340,7 @@ export type Frame =
   | ConnectUpdateFrame
   | PostNewFrame
   | PostEngagementFrame
+  | PostRevokeFrame
   | CallFrame;
 
 export interface Transport {

--- a/src/services/transport.ts
+++ b/src/services/transport.ts
@@ -271,6 +271,13 @@ export interface ConnectUpdateFrame {
   state: string; // 'accepted' | 'rejected'
 }
 
+/** Content-free nudge that a Wall post addressed to us arrived (spec 0003). Carries
+ *  only the author id; the client reconciles by pulling GET /v1/posts. */
+export interface PostNewFrame {
+  t: 'post-new';
+  from: string;
+}
+
 /* ---- ephemeral activity indicators (spec 1009): typing / recording ---- */
 
 /** What a peer is doing in a conversation right now (sealed on the wire). */
@@ -317,6 +324,7 @@ export type Frame =
   | ActivityFrame
   | ConnectReqFrame
   | ConnectUpdateFrame
+  | PostNewFrame
   | CallFrame;
 
 export interface Transport {

--- a/src/services/transport.ts
+++ b/src/services/transport.ts
@@ -278,6 +278,13 @@ export interface PostNewFrame {
   from: string;
 }
 
+/** Content-free nudge that engagement (a reaction) landed on a post we can see; the
+ *  client reconciles by pulling that post's engagement. */
+export interface PostEngagementFrame {
+  t: 'post-engagement';
+  post: string;
+}
+
 /* ---- ephemeral activity indicators (spec 1009): typing / recording ---- */
 
 /** What a peer is doing in a conversation right now (sealed on the wire). */
@@ -325,6 +332,7 @@ export type Frame =
   | ConnectReqFrame
   | ConnectUpdateFrame
   | PostNewFrame
+  | PostEngagementFrame
   | CallFrame;
 
 export interface Transport {

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -247,6 +247,7 @@ export const SETTINGS: Record<string, SettingNode> = {
           { type: 'link', id: 'privacy-profile-photo', title: 'Profile picture', icon: 'person' },
           { type: 'link', id: 'privacy-about', title: 'About', icon: 'info' },
           { type: 'link', id: 'privacy-groups', title: 'Groups', icon: 'people' },
+          { type: 'route', title: 'Close friends', path: '/settings/close-friends', icon: 'people' },
           { type: 'link', id: 'privacy-status', title: 'Status', icon: 'time' },
         ],
       },
@@ -541,6 +542,13 @@ export const SETTINGS: Record<string, SettingNode> = {
           { type: 'link', id: 'notifications-status-sound', title: 'Sound', icon: 'music' },
           { type: 'toggle', title: 'Reaction notifications', key: 'notifications.status.reactions', default: true },
         ],
+      },
+      {
+        header: 'Wall notifications',
+        items: [
+          { type: 'toggle', title: 'Show notifications', key: 'notifications.wall.show', default: true },
+        ],
+        footer: 'Get notified when a friend shares a new post on their Wall.',
       },
       {
         items: [{ type: 'toggle', title: 'Reminders', key: 'notifications.reminders', default: true }],

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -22,6 +22,7 @@ import {
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import { resubscribePush } from '@/services/sw-push';
+import { userFacing, prettify, displayVersion } from '@/services/release-notes';
 
 declare const self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: Array<string | { url: string; revision: string | null }>;
@@ -144,16 +145,50 @@ async function updateAppBadge(newCount: number): Promise<void> {
 /** Decode the content-free tickle's frame type ('call' shows a ring, 'conn' is a
  *  friend-request lifecycle event; anything else, including an unreadable/absent
  *  payload, is treated as a message). */
-function pushKind(event: PushEvent): 'call' | 'msg' | 'conn' | 'post' {
+function pushKind(event: PushEvent): 'call' | 'msg' | 'conn' | 'post' | 'version' {
   try {
     const data = event.data?.json() as { t?: string } | undefined;
     if (data?.t === 'call') return 'call';
     if (data?.t === 'conn') return 'conn';
     if (data?.t === 'post') return 'post';
+    if (data?.t === 'version') return 'version';
   } catch {
     /* not JSON → treat as a message */
   }
   return 'msg';
+}
+
+/** "What's new" notification after a new version is deployed. The version tickle is
+ *  content-free; the actual (public, non-secret) version + user-friendly notes come
+ *  from GET /v1/config, so nothing about the release rode through the push service.
+ *  Shown only when the app is fully closed; an open app gets the in-app update toast. */
+async function showVersionNotification(): Promise<void> {
+  let version = '';
+  let notes: { sha: string; subject: string }[] = [];
+  try {
+    const cfg = (await fetch('/v1/config', { cache: 'no-store' }).then((r) => r.json())) as {
+      version?: string;
+      notes?: { sha: string; subject: string }[];
+    };
+    version = cfg.version ?? '';
+    notes = cfg.notes ?? [];
+  } catch {
+    /* offline / unreachable → a generic announcement below still honors userVisibleOnly */
+  }
+  const friendly = userFacing(notes);
+  const items = friendly.slice(0, 3).map((n) => prettify(n.subject));
+  const shown = displayVersion(version);
+  const title = shown ? `Ring ${shown} is here` : 'Ring just got an update';
+  const body = items.length
+    ? `What's new: ${items.join(' · ')}${friendly.length > items.length ? ' …' : ''}`
+    : 'Tap to update and see what’s new.';
+  await self.registration.showNotification(title, {
+    body,
+    icon: ICON,
+    badge: ICON,
+    tag: 'ring:version',
+    data: { url: '/' },
+  });
 }
 
 /** Generic, identity-safe notification for a new Wall post (spec 0003). Shown only
@@ -384,6 +419,16 @@ self.addEventListener('push', (event) => {
         // fully CLOSED. Nudge any live client to pull the post.
         for (const client of clients) client.postMessage({ type: 'ring:posts' });
         if (!clients.length) await showPostNotification();
+        return;
+      }
+      if (kind === 'version') {
+        // A new app version was deployed. A live page owns the alert (useAppUpdate
+        // shows the in-app "what's new" update toast), so nudge any open client to
+        // check immediately and show the system "what's new" notification only when
+        // the app is fully CLOSED — mirroring the post/conn pattern and keeping the
+        // userVisibleOnly contract (exactly one visible notification when closed).
+        for (const client of clients) client.postMessage({ type: 'ring:checkupdate' });
+        if (!clients.length) await showVersionNotification();
         return;
       }
       // Let a live, unlocked page own the notification (avoids a duplicate); the SW

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -144,15 +144,29 @@ async function updateAppBadge(newCount: number): Promise<void> {
 /** Decode the content-free tickle's frame type ('call' shows a ring, 'conn' is a
  *  friend-request lifecycle event; anything else, including an unreadable/absent
  *  payload, is treated as a message). */
-function pushKind(event: PushEvent): 'call' | 'msg' | 'conn' {
+function pushKind(event: PushEvent): 'call' | 'msg' | 'conn' | 'post' {
   try {
     const data = event.data?.json() as { t?: string } | undefined;
     if (data?.t === 'call') return 'call';
     if (data?.t === 'conn') return 'conn';
+    if (data?.t === 'post') return 'post';
   } catch {
     /* not JSON → treat as a message */
   }
   return 'msg';
+}
+
+/** Generic, identity-safe notification for a new Wall post (spec 0003). Shown only
+ *  when the app is closed; a live page shows the rich "X shared a photo" banner via
+ *  the post-new WS frame, so the SW stays silent there to avoid a duplicate. */
+async function showPostNotification(): Promise<void> {
+  await self.registration.showNotification('Ring', {
+    body: 'New post on your Wall',
+    icon: ICON,
+    badge: ICON,
+    tag: 'ring:post',
+    data: { url: '/tabs/wall' },
+  });
 }
 
 /** Show the generic friend-request notifications (identity-safe; no decryption). */
@@ -362,6 +376,14 @@ self.addEventListener('push', (event) => {
         // avoiding a duplicate. Still nudge any live client to reconcile its lists.
         for (const client of clients) client.postMessage({ type: 'ring:conn' });
         if (!clients.length) await showConnNotification();
+        return;
+      }
+      if (kind === 'post') {
+        // New Wall post. A live page owns the rich in-app banner (post-new WS frame
+        // via useSync), so the SW shows a generic notification only when the app is
+        // fully CLOSED. Nudge any live client to pull the post.
+        for (const client of clients) client.postMessage({ type: 'ring:posts' });
+        if (!clients.length) await showPostNotification();
         return;
       }
       // Let a live, unlocked page own the notification (avoids a duplicate); the SW

--- a/src/utils/post-time.ts
+++ b/src/utils/post-time.ts
@@ -9,6 +9,26 @@ export function timeLeft(expiresAt: number | undefined, nowMs: number): string {
   return `${Math.floor(s / 86400)}d left`;
 }
 
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/** Day-of-month with an English ordinal suffix (1st, 2nd, 3rd, 13th, 21st). */
+function ordinal(n: number): string {
+  const v = n % 100;
+  const suffix = v >= 11 && v <= 13 ? 'th' : (['th', 'st', 'nd', 'rd'][n % 10] ?? 'th');
+  return `${n}${suffix}`;
+}
+
+/** A post's full date + time, e.g. "2026, January 13th - 20:59" (24-hour, local). */
+export function formatPostDateTime(ts: number): string {
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${d.getFullYear()}, ${MONTHS[d.getMonth()]} ${ordinal(d.getDate())} - ${hh}:${mm}`;
+}
+
 /** Compact relative time for a post/comment timestamp ("now", "5m", "3h", "2d"). */
 export function ago(ts: number, nowMs: number = Date.now()): string {
   const s = Math.max(0, Math.floor((nowMs - ts) / 1000));

--- a/src/utils/post-time.ts
+++ b/src/utils/post-time.ts
@@ -1,0 +1,20 @@
+/** Compact "time left before a post disappears" label, e.g. "2h left", "45m left".
+ *  Returns '' when there's no expiry, 'expiring…' once elapsed. */
+export function timeLeft(expiresAt: number | undefined, nowMs: number): string {
+  if (!expiresAt) return '';
+  const s = Math.floor((expiresAt - nowMs) / 1000);
+  if (s <= 0) return 'expiring…';
+  if (s < 3600) return `${Math.max(1, Math.floor(s / 60))}m left`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h left`;
+  return `${Math.floor(s / 86400)}d left`;
+}
+
+/** Compact relative time for a post/comment timestamp ("now", "5m", "3h", "2d"). */
+export function ago(ts: number, nowMs: number = Date.now()): string {
+  const s = Math.max(0, Math.floor((nowMs - ts) / 1000));
+  if (s < 60) return 'now';
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  if (s < 7 * 86400) return `${Math.floor(s / 86400)}d`;
+  return new Date(ts).toLocaleDateString();
+}

--- a/src/views/TabsPage.vue
+++ b/src/views/TabsPage.vue
@@ -24,6 +24,7 @@
         <ion-tab-button tab="wall" :selected="activeTab === 'wall'" @click="switchTab('/tabs/wall')">
           <ion-icon :icon="activeTab === 'wall' ? sparkles : sparklesOutline" />
           <ion-label>Wall</ion-label>
+          <ion-badge v-if="wall" color="primary">{{ wall }}</ion-badge>
         </ion-tab-button>
         <ion-tab-button tab="contacts" :selected="activeTab === 'contacts'" @click="switchTab('/tabs/contacts')">
           <ion-icon :icon="activeTab === 'contacts' ? people : peopleOutline" />
@@ -65,7 +66,7 @@ import { useRoute } from 'vue-router';
 import { useBadges } from '@/composables/useBadges';
 import { isAuthenticated } from '@/services/auth';
 
-const { chats, calls, contacts, you } = useBadges();
+const { chats, calls, contacts, you, wall } = useBadges();
 
 // Active tab derived from the URL; drives the filled-vs-outline icon swap.
 const route = useRoute();

--- a/src/views/TabsPage.vue
+++ b/src/views/TabsPage.vue
@@ -21,6 +21,10 @@
           <ion-label>Chats</ion-label>
           <ion-badge v-if="chats" color="primary">{{ chats }}</ion-badge>
         </ion-tab-button>
+        <ion-tab-button tab="wall" :selected="activeTab === 'wall'" @click="switchTab('/tabs/wall')">
+          <ion-icon :icon="activeTab === 'wall' ? sparkles : sparklesOutline" />
+          <ion-label>Wall</ion-label>
+        </ion-tab-button>
         <ion-tab-button tab="contacts" :selected="activeTab === 'contacts'" @click="switchTab('/tabs/contacts')">
           <ion-icon :icon="activeTab === 'contacts' ? people : peopleOutline" />
           <ion-label>Contacts</ion-label>
@@ -52,6 +56,7 @@ import {
 import {
   call, callOutline,
   chatbubbles, chatbubblesOutline,
+  sparkles, sparklesOutline,
   people, peopleOutline,
   settings, settingsOutline,
 } from 'ionicons/icons';

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -778,9 +778,12 @@
           <!-- Auto-growing multi-line textarea so long messages wrap and the box
                grows (capped in CSS, then scrolls). autocapitalize/autocorrect/
                spellcheck on → the OS keyboard offers predictive text & suggestions.
-               The Return key inserts a line break; send with the send button. -->
+               On a physical keyboard (desktop) Enter sends and Shift+Enter inserts a
+               line break (v-enter-send); on touch the Return key inserts a line break
+               and you send with the button. -->
           <ion-textarea
             ref="composerEl"
+            v-enter-send="send"
             class="composer"
             :value="draft"
             :placeholder="pendingImages.length ? 'Add a caption' : 'Message'"
@@ -959,6 +962,7 @@ import { resolutionLabel, fileSizeLabel, generateVideoPoster, generateImageThumb
 import { openExternal } from '@/utils/external';
 import { selectEvictions } from '@/utils/lru';
 import { normalizeOutgoing, capitalizeFirst } from '@/utils/text';
+import { vEnterSend } from '@/directives/enter-send';
 import { readAudioTags, readAudioDuration } from '@/utils/id3';
 import { get, put } from '@/db/idb';
 import type { Chat, Contact, Media, Message, MessageStatus, Reaction, ReplyRef, SharedContact } from '@/db/types';

--- a/src/views/detail/CloseFriendsPage.vue
+++ b/src/views/detail/CloseFriendsPage.vue
@@ -1,0 +1,99 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/settings/privacy" />
+        </ion-buttons>
+        <ion-title>Close friends</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <ion-header collapse="condense">
+        <ion-toolbar>
+          <ion-title size="large">Close friends</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <p class="hint">
+        Pick a smaller circle for posts you mark “Close friends”. This list is private —
+        it stays on your device and is never shared with anyone, including the server.
+      </p>
+
+      <div v-if="!friends.length" class="empty">Add some friends first to build a close-friends list.</div>
+
+      <ion-list v-else :inset="true">
+        <ion-item v-for="f in friends" :key="f.id">
+          <ion-avatar slot="start" class="avatar">
+            <img v-if="f.avatar" :src="f.avatar" :alt="f.name" />
+            <div v-else class="ph">{{ initial(f.name) }}</div>
+          </ion-avatar>
+          <ion-label>
+            {{ f.name }}
+            <p v-if="f.username">@{{ f.username }}</p>
+          </ion-label>
+          <ion-toggle
+            slot="end"
+            :checked="!!f.closeFriend"
+            @ion-change="toggle(f.id, $event)"
+          />
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import {
+  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonContent,
+  IonList, IonItem, IonAvatar, IonLabel, IonToggle, onIonViewWillEnter,
+} from '@ionic/vue';
+import { ref } from 'vue';
+import { listFriends, setCloseFriend } from '@/db/queries';
+import type { Contact } from '@/db/types';
+
+const friends = ref<Contact[]>([]);
+
+async function load(): Promise<void> {
+  friends.value = await listFriends();
+}
+onIonViewWillEnter(load);
+
+function initial(name: string): string {
+  return (name.trim()[0] ?? '?').toUpperCase();
+}
+async function toggle(id: string, e: CustomEvent): Promise<void> {
+  const checked = (e.detail as { checked?: boolean }).checked ?? false;
+  await setCloseFriend(id, checked);
+  const f = friends.value.find((c) => c.id === id);
+  if (f) f.closeFriend = checked;
+}
+</script>
+
+<style scoped>
+.hint {
+  margin: 4px 20px 8px;
+  font-size: 13px;
+  color: var(--app-text-muted, var(--ion-color-medium));
+}
+.empty {
+  padding: 40px 24px;
+  text-align: center;
+  color: var(--ion-color-medium);
+}
+.avatar {
+  width: 40px;
+  height: 40px;
+}
+.avatar .ph {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--ion-color-step-150, rgba(120, 120, 128, 0.2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+</style>

--- a/src/views/detail/CloseFriendsPage.vue
+++ b/src/views/detail/CloseFriendsPage.vue
@@ -7,39 +7,61 @@
         </ion-buttons>
         <ion-title>Close friends</ion-title>
       </ion-toolbar>
+      <ion-toolbar>
+        <ion-searchbar
+          :value="search"
+          placeholder="Search friends"
+          :debounce="120"
+          @ion-input="onSearch"
+        />
+      </ion-toolbar>
     </ion-header>
 
     <ion-content :fullscreen="true">
-      <ion-header collapse="condense">
-        <ion-toolbar>
-          <ion-title size="large">Close friends</ion-title>
-        </ion-toolbar>
-      </ion-header>
-
       <p class="hint">
-        Pick a smaller circle for posts you mark “Close friends”. This list is private —
-        it stays on your device and is never shared with anyone, including the server.
+        Pick a smaller circle for posts you mark “Close friends”. This list is private. It stays on
+        your device and is never shared with anyone, including the server.
       </p>
 
       <div v-if="!friends.length" class="empty">Add some friends first to build a close-friends list.</div>
 
-      <ion-list v-else :inset="true">
-        <ion-item v-for="f in friends" :key="f.id">
-          <ion-avatar slot="start" class="avatar">
-            <img v-if="f.avatar" :src="f.avatar" :alt="f.name" />
-            <div v-else class="ph">{{ initial(f.name) }}</div>
-          </ion-avatar>
-          <ion-label>
-            {{ f.name }}
-            <p v-if="f.username">@{{ f.username }}</p>
-          </ion-label>
-          <ion-toggle
-            slot="end"
-            :checked="!!f.closeFriend"
-            @ion-change="toggle(f.id, $event)"
-          />
-        </ion-item>
-      </ion-list>
+      <template v-else>
+        <!-- Close friends, shown first and highlighted. -->
+        <ion-list v-if="closeFriends.length" :inset="true" class="closelist">
+          <ion-list-header>
+            <ion-icon :icon="star" color="primary" />
+            <ion-label>Close friends · {{ closeFriends.length }}</ion-label>
+          </ion-list-header>
+          <ion-item v-for="f in closeFriends" :key="f.id" class="closeitem">
+            <ion-avatar slot="start" class="avatar">
+              <img v-if="f.avatar" :src="f.avatar" :alt="f.name" />
+              <div v-else class="ph">{{ initial(f.name) }}</div>
+            </ion-avatar>
+            <ion-label>
+              {{ f.name }}
+              <p v-if="f.username">@{{ f.username }}</p>
+            </ion-label>
+            <ion-toggle slot="end" :checked="true" @ion-change="toggle(f.id, $event)" />
+          </ion-item>
+        </ion-list>
+
+        <!-- Everyone else. -->
+        <ion-list :inset="true">
+          <ion-list-header><ion-label>Friends</ion-label></ion-list-header>
+          <ion-item v-for="f in otherFriends" :key="f.id">
+            <ion-avatar slot="start" class="avatar">
+              <img v-if="f.avatar" :src="f.avatar" :alt="f.name" />
+              <div v-else class="ph">{{ initial(f.name) }}</div>
+            </ion-avatar>
+            <ion-label>
+              {{ f.name }}
+              <p v-if="f.username">@{{ f.username }}</p>
+            </ion-label>
+            <ion-toggle slot="end" :checked="false" @ion-change="toggle(f.id, $event)" />
+          </ion-item>
+          <div v-if="!otherFriends.length && !closeFriends.length" class="empty">No friends match “{{ search }}”.</div>
+        </ion-list>
+      </template>
     </ion-content>
   </ion-page>
 </template>
@@ -47,24 +69,39 @@
 <script setup lang="ts">
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonContent,
-  IonList, IonItem, IonAvatar, IonLabel, IonToggle, onIonViewWillEnter,
+  IonList, IonListHeader, IonItem, IonAvatar, IonLabel, IonToggle, IonIcon, IonSearchbar,
+  onIonViewWillEnter,
 } from '@ionic/vue';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
+import { star } from 'ionicons/icons';
 import { listFriends, setCloseFriend } from '@/db/queries';
 import type { Contact } from '@/db/types';
 
 const friends = ref<Contact[]>([]);
+const search = ref('');
 
 async function load(): Promise<void> {
   friends.value = await listFriends();
 }
 onIonViewWillEnter(load);
 
+function onSearch(e: CustomEvent): void {
+  search.value = (e.detail as { value?: string | null }).value ?? '';
+}
+const matches = (f: Contact): boolean => {
+  const q = search.value.trim().toLowerCase();
+  return !q || f.name.toLowerCase().includes(q) || (f.username ?? '').toLowerCase().includes(q);
+};
+const closeFriends = computed(() => friends.value.filter((f) => f.closeFriend && matches(f)));
+const otherFriends = computed(() => friends.value.filter((f) => !f.closeFriend && matches(f)));
+
 function initial(name: string): string {
   return (name.trim()[0] ?? '?').toUpperCase();
 }
 async function toggle(id: string, e: CustomEvent): Promise<void> {
   const checked = (e.detail as { checked?: boolean }).checked ?? false;
+  // Removing a close friend revokes your close-only posts from them (handled in
+  // setCloseFriend); adding just sets the flag.
   await setCloseFriend(id, checked);
   const f = friends.value.find((c) => c.id === id);
   if (f) f.closeFriend = checked;
@@ -78,9 +115,22 @@ async function toggle(id: string, e: CustomEvent): Promise<void> {
   color: var(--app-text-muted, var(--ion-color-medium));
 }
 .empty {
-  padding: 40px 24px;
+  padding: 24px;
   text-align: center;
   color: var(--ion-color-medium);
+}
+ion-list-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.closelist {
+  border: 1px solid color-mix(in srgb, var(--ion-color-primary) 35%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--ion-color-primary) 6%, transparent);
+}
+.closeitem {
+  --background: transparent;
 }
 .avatar {
   width: 40px;

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -48,6 +48,16 @@
         @change="onFile"
       />
 
+      <ion-list v-if="media" :inset="true">
+        <ion-list-header>Quality</ion-list-header>
+        <ion-item lines="none">
+          <ion-segment :value="quality" @ion-change="onQuality">
+            <ion-segment-button value="sd"><ion-label>SD</ion-label></ion-segment-button>
+            <ion-segment-button value="hd"><ion-label>HD</ion-label></ion-segment-button>
+          </ion-segment>
+        </ion-item>
+      </ion-list>
+
       <ion-list :inset="true">
         <ion-list-header>Who can see this</ion-list-header>
         <ion-item lines="none">
@@ -70,8 +80,9 @@
       </ion-list>
 
       <p class="hint">
-        Posts are end-to-end encrypted and visible only to the audience you choose — never the
-        server or the wider network. Every post disappears within 72 hours.
+        Your post is end to end encrypted and only the audience you pick can see it, never the
+        server or the wider network. It disappears after the time you choose once there is no new
+        activity, and a fresh reaction or comment keeps it around a little longer.
       </p>
     </ion-content>
   </ion-page>
@@ -97,6 +108,7 @@ const sharing = ref(false);
 const fileInput = ref<HTMLInputElement | null>(null);
 const media = ref<File | null>(null);
 const mediaUrl = ref<string | undefined>(undefined);
+const quality = ref<'sd' | 'hd'>('hd');
 const mediaKind = computed<'image' | 'video'>(() =>
   media.value?.type.startsWith('video/') ? 'video' : 'image',
 );
@@ -111,6 +123,9 @@ function onAudience(e: CustomEvent): void {
 }
 function onLifetime(e: CustomEvent): void {
   lifetime.value = ((e.detail as { value?: string }).value as PostLifetime) ?? '72h';
+}
+function onQuality(e: CustomEvent): void {
+  quality.value = ((e.detail as { value?: string }).value as 'sd' | 'hd') ?? 'hd';
 }
 
 function pickMedia(): void {
@@ -142,7 +157,7 @@ async function share(): Promise<void> {
       audience: audience.value,
       lifetime: lifetime.value,
       media: media.value
-        ? { blob: media.value, kind: mediaKind.value, name: media.value.name || 'attachment' }
+        ? { blob: media.value, kind: mediaKind.value, name: media.value.name || 'attachment', quality: quality.value }
         : undefined,
     });
     router.back();

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -16,13 +16,36 @@
       <ion-textarea
         class="composer"
         :auto-grow="true"
-        :rows="4"
-        placeholder="Share something with your friends…"
+        :rows="3"
+        :placeholder="media ? 'Add a caption…' : 'Share something with your friends…'"
         autocapitalize="sentences"
         :spellcheck="true"
         dir="auto"
         :value="body"
         @ion-input="onInput"
+      />
+
+      <!-- Attachment preview -->
+      <div v-if="mediaUrl" class="preview">
+        <img v-if="mediaKind === 'image'" :src="mediaUrl" alt="Selected photo" />
+        <video v-else :src="mediaUrl" controls playsinline />
+        <ion-button class="remove" fill="solid" color="dark" size="small" @click="clearMedia">
+          <ion-icon slot="icon-only" :icon="closeOutline" />
+        </ion-button>
+      </div>
+
+      <ion-list v-else :inset="true">
+        <ion-item button :detail="false" @click="pickMedia">
+          <ion-icon slot="start" :icon="imageOutline" color="primary" />
+          <ion-label color="primary">Add photo or video</ion-label>
+        </ion-item>
+      </ion-list>
+      <input
+        ref="fileInput"
+        type="file"
+        accept="image/*,video/*"
+        style="display: none"
+        @change="onFile"
       />
 
       <ion-list :inset="true">
@@ -39,38 +62,46 @@
         <ion-list-header>Disappears after</ion-list-header>
         <ion-item lines="none">
           <ion-segment :value="lifetime" @ion-change="onLifetime">
+            <ion-segment-button value="1h"><ion-label>1 hour</ion-label></ion-segment-button>
             <ion-segment-button value="24h"><ion-label>24 hours</ion-label></ion-segment-button>
-            <ion-segment-button value="7d"><ion-label>7 days</ion-label></ion-segment-button>
-            <ion-segment-button value="keep"><ion-label>Keep</ion-label></ion-segment-button>
+            <ion-segment-button value="72h"><ion-label>72 hours</ion-label></ion-segment-button>
           </ion-segment>
         </ion-item>
       </ion-list>
 
       <p class="hint">
-        Your post is end-to-end encrypted and visible only to the audience you choose.
-        Only friends can see it — never the server or the wider network.
+        Posts are end-to-end encrypted and visible only to the audience you choose — never the
+        server or the wider network. Every post disappears within 72 hours.
       </p>
     </ion-content>
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, onUnmounted } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
   IonContent, IonTextarea, IonList, IonListHeader, IonItem, IonSegment, IonSegmentButton,
-  IonLabel, alertController,
+  IonLabel, IonIcon, alertController,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
+import { imageOutline, closeOutline } from 'ionicons/icons';
 import { createPost, type PostLifetime } from '@/db/queries';
 
 const router = useRouter();
 const body = ref('');
 const audience = ref<'friends' | 'close'>('friends');
-const lifetime = ref<PostLifetime>('24h');
+const lifetime = ref<PostLifetime>('72h');
 const sharing = ref(false);
 
-const canShare = computed(() => body.value.trim().length > 0);
+const fileInput = ref<HTMLInputElement | null>(null);
+const media = ref<File | null>(null);
+const mediaUrl = ref<string | undefined>(undefined);
+const mediaKind = computed<'image' | 'video'>(() =>
+  media.value?.type.startsWith('video/') ? 'video' : 'image',
+);
+
+const canShare = computed(() => body.value.trim().length > 0 || !!media.value);
 
 function onInput(e: CustomEvent): void {
   body.value = (e.detail as { value?: string | null }).value ?? '';
@@ -79,14 +110,41 @@ function onAudience(e: CustomEvent): void {
   audience.value = ((e.detail as { value?: string }).value as 'friends' | 'close') ?? 'friends';
 }
 function onLifetime(e: CustomEvent): void {
-  lifetime.value = ((e.detail as { value?: string }).value as PostLifetime) ?? '24h';
+  lifetime.value = ((e.detail as { value?: string }).value as PostLifetime) ?? '72h';
 }
+
+function pickMedia(): void {
+  fileInput.value?.click();
+}
+function onFile(e: Event): void {
+  const f = (e.target as HTMLInputElement).files?.[0];
+  if (!f) return;
+  clearMedia();
+  media.value = f;
+  mediaUrl.value = URL.createObjectURL(f);
+}
+function clearMedia(): void {
+  if (mediaUrl.value) URL.revokeObjectURL(mediaUrl.value);
+  mediaUrl.value = undefined;
+  media.value = null;
+  if (fileInput.value) fileInput.value.value = '';
+}
+onUnmounted(() => {
+  if (mediaUrl.value) URL.revokeObjectURL(mediaUrl.value);
+});
 
 async function share(): Promise<void> {
   if (!canShare.value || sharing.value) return;
   sharing.value = true;
   try {
-    await createPost({ payload: { kind: 'text', body: body.value.trim() }, audience: audience.value, lifetime: lifetime.value });
+    await createPost({
+      body: body.value,
+      audience: audience.value,
+      lifetime: lifetime.value,
+      media: media.value
+        ? { blob: media.value, kind: mediaKind.value, name: media.value.name || 'attachment' }
+        : undefined,
+    });
     router.back();
   } catch (err) {
     const a = await alertController.create({
@@ -107,6 +165,24 @@ async function share(): Promise<void> {
   --padding-end: 20px;
   font-size: 17px;
   margin-top: 8px;
+}
+.preview {
+  position: relative;
+  margin: 8px 16px;
+}
+.preview img,
+.preview video {
+  width: 100%;
+  max-height: 320px;
+  object-fit: cover;
+  border-radius: 14px;
+  background: #000;
+}
+.preview .remove {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  --border-radius: 50%;
 }
 .hint {
   margin: 8px 20px;

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -1,0 +1,116 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/wall" />
+        </ion-buttons>
+        <ion-title>New post</ion-title>
+        <ion-buttons slot="end">
+          <ion-button :strong="true" :disabled="!canShare || sharing" @click="share">Share</ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <ion-textarea
+        class="composer"
+        :auto-grow="true"
+        :rows="4"
+        placeholder="Share something with your friends…"
+        autocapitalize="sentences"
+        :spellcheck="true"
+        dir="auto"
+        :value="body"
+        @ion-input="onInput"
+      />
+
+      <ion-list :inset="true">
+        <ion-list-header>Who can see this</ion-list-header>
+        <ion-item lines="none">
+          <ion-segment :value="audience" @ion-change="onAudience">
+            <ion-segment-button value="friends"><ion-label>All friends</ion-label></ion-segment-button>
+            <ion-segment-button value="close"><ion-label>Close friends</ion-label></ion-segment-button>
+          </ion-segment>
+        </ion-item>
+      </ion-list>
+
+      <ion-list :inset="true">
+        <ion-list-header>Disappears after</ion-list-header>
+        <ion-item lines="none">
+          <ion-segment :value="lifetime" @ion-change="onLifetime">
+            <ion-segment-button value="24h"><ion-label>24 hours</ion-label></ion-segment-button>
+            <ion-segment-button value="7d"><ion-label>7 days</ion-label></ion-segment-button>
+            <ion-segment-button value="keep"><ion-label>Keep</ion-label></ion-segment-button>
+          </ion-segment>
+        </ion-item>
+      </ion-list>
+
+      <p class="hint">
+        Your post is end-to-end encrypted and visible only to the audience you choose.
+        Only friends can see it — never the server or the wider network.
+      </p>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import {
+  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
+  IonContent, IonTextarea, IonList, IonListHeader, IonItem, IonSegment, IonSegmentButton,
+  IonLabel, alertController,
+} from '@ionic/vue';
+import { useRouter } from 'vue-router';
+import { createPost, type PostLifetime } from '@/db/queries';
+
+const router = useRouter();
+const body = ref('');
+const audience = ref<'friends' | 'close'>('friends');
+const lifetime = ref<PostLifetime>('24h');
+const sharing = ref(false);
+
+const canShare = computed(() => body.value.trim().length > 0);
+
+function onInput(e: CustomEvent): void {
+  body.value = (e.detail as { value?: string | null }).value ?? '';
+}
+function onAudience(e: CustomEvent): void {
+  audience.value = ((e.detail as { value?: string }).value as 'friends' | 'close') ?? 'friends';
+}
+function onLifetime(e: CustomEvent): void {
+  lifetime.value = ((e.detail as { value?: string }).value as PostLifetime) ?? '24h';
+}
+
+async function share(): Promise<void> {
+  if (!canShare.value || sharing.value) return;
+  sharing.value = true;
+  try {
+    await createPost({ payload: { kind: 'text', body: body.value.trim() }, audience: audience.value, lifetime: lifetime.value });
+    router.back();
+  } catch (err) {
+    const a = await alertController.create({
+      header: 'Could not share',
+      message: err instanceof Error ? err.message : 'Please try again.',
+      buttons: ['OK'],
+    });
+    await a.present();
+  } finally {
+    sharing.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.composer {
+  --padding-start: 20px;
+  --padding-end: 20px;
+  font-size: 17px;
+  margin-top: 8px;
+}
+.hint {
+  margin: 8px 20px;
+  font-size: 13px;
+  color: var(--app-text-muted, var(--ion-color-medium));
+}
+</style>

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -7,7 +7,7 @@
         </ion-buttons>
         <ion-title>New post</ion-title>
         <ion-buttons slot="end">
-          <ion-button :strong="true" :disabled="!canShare || sharing" @click="share">Share</ion-button>
+          <ion-button :strong="true" :disabled="!canShare || sharing || recording" @click="share">Share</ion-button>
         </ion-buttons>
       </ion-toolbar>
     </ion-header>
@@ -29,16 +29,31 @@
       <!-- Attachment preview -->
       <div v-if="mediaUrl" class="preview">
         <img v-if="mediaKind === 'image'" :src="mediaUrl" alt="Selected photo" />
-        <video v-else :src="mediaUrl" controls playsinline />
+        <video v-else-if="mediaKind === 'video'" :src="mediaUrl" controls playsinline />
+        <audio v-else class="vpreview" :src="mediaUrl" controls />
         <ion-button class="remove" fill="solid" color="dark" size="small" @click="clearMedia">
           <ion-icon slot="icon-only" :icon="closeOutline" />
         </ion-button>
       </div>
 
+      <!-- Recording a voice post in progress -->
+      <ion-list v-else-if="recording" :inset="true">
+        <ion-item lines="none">
+          <ion-icon slot="start" :icon="micOutline" color="danger" class="recdot" />
+          <ion-label>Recording… {{ recElapsed }}</ion-label>
+          <ion-button slot="end" fill="solid" color="danger" @click="stopRecording">Stop</ion-button>
+        </ion-item>
+      </ion-list>
+
+      <!-- Attachment options: a photo/video file, or a recorded voice post -->
       <ion-list v-else :inset="true">
         <ion-item button :detail="false" @click="pickMedia">
           <ion-icon slot="start" :icon="imageOutline" color="primary" />
           <ion-label color="primary">Add photo or video</ion-label>
+        </ion-item>
+        <ion-item button :detail="false" @click="startRecording">
+          <ion-icon slot="start" :icon="micOutline" color="primary" />
+          <ion-label color="primary">Record voice</ion-label>
         </ion-item>
       </ion-list>
       <input
@@ -49,7 +64,8 @@
         @change="onFile"
       />
 
-      <ion-list v-if="media" :inset="true">
+      <!-- Quality applies to photos/videos only; voice is sent as recorded. -->
+      <ion-list v-if="media && mediaKind !== 'voice'" :inset="true">
         <ion-list-header>Quality</ion-list-header>
         <ion-item lines="none">
           <ion-segment :value="quality" @ion-change="onQuality">
@@ -97,7 +113,7 @@ import {
   IonLabel, IonIcon, alertController,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
-import { imageOutline, closeOutline } from 'ionicons/icons';
+import { imageOutline, closeOutline, micOutline } from 'ionicons/icons';
 import { vEnterSend } from '@/directives/enter-send';
 import { createPost, type PostLifetime } from '@/db/queries';
 
@@ -107,13 +123,16 @@ const audience = ref<'friends' | 'close'>('friends');
 const lifetime = ref<PostLifetime>('72h');
 const sharing = ref(false);
 
+// One attachment slot, shared by a picked photo/video file and a recorded voice clip.
+// `mediaKind` is set explicitly when the attachment is chosen (a recorded Blob has no
+// filename, so we can't derive the kind from a File like the picker can).
 const fileInput = ref<HTMLInputElement | null>(null);
-const media = ref<File | null>(null);
+const media = ref<Blob | null>(null);
 const mediaUrl = ref<string | undefined>(undefined);
+const mediaKind = ref<'image' | 'video' | 'voice'>('image');
+const mediaName = ref('attachment');
+const mediaDuration = ref<number | undefined>(undefined);
 const quality = ref<'sd' | 'hd'>('hd');
-const mediaKind = computed<'image' | 'video'>(() =>
-  media.value?.type.startsWith('video/') ? 'video' : 'image',
-);
 
 const canShare = computed(() => body.value.trim().length > 0 || !!media.value);
 
@@ -138,16 +157,81 @@ function onFile(e: Event): void {
   if (!f) return;
   clearMedia();
   media.value = f;
+  mediaKind.value = f.type.startsWith('video/') ? 'video' : 'image';
+  mediaName.value = f.name || 'attachment';
   mediaUrl.value = URL.createObjectURL(f);
 }
 function clearMedia(): void {
   if (mediaUrl.value) URL.revokeObjectURL(mediaUrl.value);
   mediaUrl.value = undefined;
   media.value = null;
+  mediaDuration.value = undefined;
   if (fileInput.value) fileInput.value.value = '';
 }
+
+/* ---- voice post recording (mirrors the chat voice recorder, minus the live
+   waveform/pause/preview — a post is a single take, kept simple) ---- */
+const recording = ref(false);
+const recElapsed = ref('0:00');
+let recorder: MediaRecorder | null = null;
+let recChunks: Blob[] = [];
+let recStream: MediaStream | null = null;
+let recStart = 0;
+let recTimer: number | undefined;
+
+async function startRecording(): Promise<void> {
+  try {
+    recStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const types = ['audio/webm', 'audio/mp4', 'audio/ogg'];
+    const mimeType = types.find((t) => MediaRecorder.isTypeSupported?.(t));
+    recorder = new MediaRecorder(recStream, mimeType ? { mimeType } : undefined);
+    recChunks = [];
+    recorder.ondataavailable = (ev) => { if (ev.data.size) recChunks.push(ev.data); };
+    recorder.onstop = finishRecording;
+    recorder.start();
+    recStart = Date.now();
+    recElapsed.value = '0:00';
+    recording.value = true;
+    recTimer = window.setInterval(() => {
+      const s = Math.floor((Date.now() - recStart) / 1000);
+      recElapsed.value = `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+    }, 250);
+  } catch {
+    const a = await alertController.create({
+      header: 'Microphone unavailable',
+      message: 'Allow microphone access to record a voice post.',
+      buttons: ['OK'],
+    });
+    await a.present();
+  }
+}
+
+function stopRecording(): void {
+  if (recorder && recorder.state !== 'inactive') recorder.stop();
+}
+
+function finishRecording(): void {
+  if (recTimer) { clearInterval(recTimer); recTimer = undefined; }
+  recording.value = false;
+  recStream?.getTracks().forEach((t) => t.stop());
+  recStream = null;
+  const mime = recorder?.mimeType || 'audio/webm';
+  recorder = null;
+  if (!recChunks.length) return;
+  const durationSec = Math.max(1, Math.round((Date.now() - recStart) / 1000));
+  const blob = new Blob(recChunks, { type: mime });
+  clearMedia();
+  media.value = blob;
+  mediaKind.value = 'voice';
+  mediaName.value = `voice.${mime.includes('mp4') ? 'm4a' : mime.includes('ogg') ? 'ogg' : 'webm'}`;
+  mediaDuration.value = durationSec;
+  mediaUrl.value = URL.createObjectURL(blob);
+}
+
 onUnmounted(() => {
   if (mediaUrl.value) URL.revokeObjectURL(mediaUrl.value);
+  if (recTimer) clearInterval(recTimer);
+  recStream?.getTracks().forEach((t) => t.stop());
 });
 
 async function share(): Promise<void> {
@@ -159,7 +243,7 @@ async function share(): Promise<void> {
       audience: audience.value,
       lifetime: lifetime.value,
       media: media.value
-        ? { blob: media.value, kind: mediaKind.value, name: media.value.name || 'attachment', quality: quality.value }
+        ? { blob: media.value, kind: mediaKind.value, name: mediaName.value, durationSec: mediaDuration.value, quality: quality.value }
         : undefined,
     });
     router.back();
@@ -200,6 +284,17 @@ async function share(): Promise<void> {
   top: 8px;
   right: 8px;
   --border-radius: 50%;
+}
+.vpreview {
+  width: 100%;
+}
+/* Pulse the mic glyph while a voice post is being recorded. */
+.recdot {
+  animation: recpulse 1.2s ease-in-out infinite;
+}
+@keyframes recpulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
 }
 .hint {
   margin: 8px 20px;

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -14,6 +14,7 @@
 
     <ion-content :fullscreen="true">
       <ion-textarea
+        v-enter-send="share"
         class="composer"
         :auto-grow="true"
         :rows="3"
@@ -97,6 +98,7 @@ import {
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
 import { imageOutline, closeOutline } from 'ionicons/icons';
+import { vEnterSend } from '@/directives/enter-send';
 import { createPost, type PostLifetime } from '@/db/queries';
 
 const router = useRouter();

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -3,7 +3,7 @@
     <ion-header :translucent="true">
       <ion-toolbar>
         <ion-buttons slot="start">
-          <ion-back-button default-href="/wall" />
+          <ion-back-button default-href="/tabs/wall" />
         </ion-buttons>
         <ion-title>New post</ion-title>
         <ion-buttons slot="end">

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -28,11 +28,11 @@
           </div>
         </div>
 
-        <div v-if="mediaUrl" class="media">
+        <div v-if="mediaUrl && (post.kind === 'image' || post.kind === 'video')" class="media" :style="mediaBoxStyle">
           <img v-if="post.kind === 'image'" :src="mediaUrl" :alt="post.body || 'Photo'" />
-          <video v-else-if="post.kind === 'video'" :src="mediaUrl" controls playsinline />
-          <audio v-else-if="post.kind === 'voice'" :src="mediaUrl" controls />
+          <video v-else :src="mediaUrl" controls playsinline />
         </div>
+        <audio v-else-if="mediaUrl && post.kind === 'voice'" class="vaudio" :src="mediaUrl" controls />
 
         <p v-if="post.body" class="body"><EmojiText :text="post.body" big /></p>
 
@@ -148,6 +148,12 @@ const authorAvatar = ref('');
 const authorUsername = ref<string | undefined>(undefined);
 const mediaUrl = ref<string | undefined>(undefined);
 const leftLabel = computed(() => (post.value?.expiresAt ? timeLeft(post.value.expiresAt, Date.now()) : ''));
+// Reserve the media's aspect ratio so the page doesn't reflow as it decodes.
+const mediaBoxStyle = computed(() =>
+  post.value?.mediaW && post.value?.mediaH
+    ? { aspectRatio: `${post.value.mediaW} / ${post.value.mediaH}` }
+    : {},
+);
 
 const reactions = useLiveQuery(() => listPostReactions(postId), ['postEngagement'], [] as PostEngagement[]);
 const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
@@ -334,17 +340,22 @@ async function confirmDelete(): Promise<void> {
 }
 .media {
   margin: 16px 0 0;
+  width: 100%;
+  max-height: 70vh;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
 }
 .media img,
 .media video {
   width: 100%;
-  max-height: 60vh;
-  border-radius: 14px;
+  height: 100%;
   object-fit: contain;
-  background: #000;
+  display: block;
 }
-.media audio {
+.vaudio {
   width: 100%;
+  margin: 16px 0 0;
 }
 .body {
   margin: 16px 0 0;

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -40,7 +40,27 @@
           Disappears {{ when(post.expiresAt) }}
         </p>
 
-        <!-- Reactions, comments and the viewer list arrive with US4/US6/US7. -->
+        <!-- Reactions (audience-visible). -->
+        <div class="reactions">
+          <div class="picker">
+            <button
+              v-for="e in EMOJIS"
+              :key="e"
+              class="emoji"
+              :class="{ mine: myEmoji === e }"
+              :aria-label="'React ' + e"
+              @click="react(e)"
+            >{{ e }}</button>
+          </div>
+          <ul v-if="grouped.length" class="rlist">
+            <li v-for="g in grouped" :key="g.emoji">
+              <span class="e">{{ g.emoji }}</span>
+              <span class="who">{{ g.who }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Comments and the viewer list arrive with US6/US7. -->
       </div>
       <div v-else class="missing">This post is no longer available.</div>
     </ion-content>
@@ -48,31 +68,59 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
-  IonContent, IonAvatar, IonIcon, onIonViewWillEnter, alertController,
+  IonContent, IonAvatar, IonIcon, onIonViewWillEnter, onIonViewWillLeave, alertController,
 } from '@ionic/vue';
 import { useRoute, useRouter } from 'vue-router';
 import { trashOutline } from 'ionicons/icons';
-import { onIonViewWillLeave } from '@ionic/vue';
-import { getPost, getContact, getMedia, deletePost } from '@/db/queries';
+import { useLiveQuery } from '@/composables/useLiveQuery';
+import {
+  getPost, getContact, getMedia, deletePost,
+  listPostReactions, reactToPost, syncEngagement, listContacts,
+} from '@/db/queries';
 import { getSelfUserId } from '@/services/auth';
 import { useSelfProfile } from '@/composables/useSelfProfile';
-import type { Post } from '@/db/types';
+import type { Post, PostEngagement, Contact } from '@/db/types';
 
 const route = useRoute();
 const router = useRouter();
 const self = useSelfProfile();
+const selfId = getSelfUserId();
+const postId = String(route.params.id);
 const post = ref<Post | null>(null);
 const authorName = ref('Unknown');
 const authorAvatar = ref('');
 const authorUsername = ref<string | undefined>(undefined);
 const mediaUrl = ref<string | undefined>(undefined);
 
+const EMOJIS = ['👍', '❤️', '😂', '😮', '😢', '🙏'];
+const reactions = useLiveQuery(() => listPostReactions(postId), ['postEngagement'], [] as PostEngagement[]);
+const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+
+const myEmoji = computed(() => reactions.value.find((r) => r.actor === selfId)?.emoji);
+// Group reactions by emoji with a human "who" label.
+const grouped = computed(() => {
+  const byId = new Map(contacts.value.map((c) => [c.id, c.name] as const));
+  const map = new Map<string, string[]>();
+  for (const r of reactions.value) {
+    if (!r.emoji) continue;
+    const who = r.actor === selfId ? 'You' : byId.get(r.actor) ?? 'Someone';
+    const list = map.get(r.emoji) ?? [];
+    list.push(who);
+    map.set(r.emoji, list);
+  }
+  return [...map.entries()].map(([emoji, names]) => ({ emoji, who: names.join(', ') }));
+});
+
+function react(emoji: string): void {
+  void reactToPost(postId, emoji);
+}
+
 onIonViewWillEnter(async () => {
-  const id = String(route.params.id);
-  post.value = await getPost(id);
+  void syncEngagement(postId); // refresh reactions from the server
+  post.value = await getPost(postId);
   if (!post.value) return;
   if (post.value.mediaId) {
     const md = await getMedia(post.value.mediaId);
@@ -180,6 +228,44 @@ async function confirmDelete(): Promise<void> {
   margin-top: 16px;
   font-size: 13px;
   color: var(--ion-color-medium);
+}
+.reactions {
+  margin-top: 20px;
+}
+.reactions .picker {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.reactions .emoji {
+  font-size: 22px;
+  line-height: 1;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 999px;
+  background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+  cursor: pointer;
+}
+.reactions .emoji.mine {
+  background: var(--ion-color-primary);
+}
+.reactions .rlist {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+}
+.reactions .rlist li {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 4px 0;
+}
+.reactions .rlist .e {
+  font-size: 18px;
+}
+.reactions .rlist .who {
+  color: var(--ion-color-medium);
+  font-size: 14px;
 }
 .missing {
   padding: 56px 24px;

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -89,9 +89,12 @@
           <p v-else class="empty">No comments yet.</p>
           <div class="cinput">
             <ion-textarea
+              v-enter-send="sendComment"
               :auto-grow="true"
               :rows="1"
               placeholder="Add a comment…"
+              autocapitalize="sentences"
+              :spellcheck="true"
               dir="auto"
               :value="commentText"
               @ion-input="onComment"
@@ -125,6 +128,7 @@ import { timeLeft, formatPostDateTime } from '@/utils/post-time';
 import { toastController } from '@ionic/vue';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
+import { vEnterSend } from '@/directives/enter-send';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useReactionPicker } from '@/composables/useReactionPicker';
 import {

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -50,11 +50,11 @@
               :class="{ mine: myEmoji === e }"
               :aria-label="'React ' + e"
               @click="react(e)"
-            >{{ e }}</button>
+            ><Emoji :emoji="e" /></button>
           </div>
           <ul v-if="grouped.length" class="rlist">
             <li v-for="g in grouped" :key="g.emoji">
-              <span class="e">{{ g.emoji }}</span>
+              <Emoji class="e" :emoji="g.emoji" />
               <span class="who">{{ g.who }}</span>
             </li>
           </ul>
@@ -108,6 +108,7 @@ import {
 } from '@ionic/vue';
 import { useRoute, useRouter } from 'vue-router';
 import { trashOutline } from 'ionicons/icons';
+import Emoji from '@/components/Emoji.vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import {
   getPost, getContact, getMedia, deletePost,
@@ -129,7 +130,9 @@ const authorAvatar = ref('');
 const authorUsername = ref<string | undefined>(undefined);
 const mediaUrl = ref<string | undefined>(undefined);
 
-const EMOJIS = ['👍', '❤️', '😂', '😮', '😢', '🙏'];
+// The same canonical quick-react set the chat uses (rendered via the Noto Emoji
+// component for visual + animation consistency).
+const EMOJIS = ['👍', '❤️', '😂', '😮', '🙏'];
 const reactions = useLiveQuery(() => listPostReactions(postId), ['postEngagement'], [] as PostEngagement[]);
 const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
 

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -28,7 +28,13 @@
           </div>
         </div>
 
-        <p class="body">{{ post.body }}</p>
+        <div v-if="mediaUrl" class="media">
+          <img v-if="post.kind === 'image'" :src="mediaUrl" :alt="post.body || 'Photo'" />
+          <video v-else-if="post.kind === 'video'" :src="mediaUrl" controls playsinline />
+          <audio v-else-if="post.kind === 'voice'" :src="mediaUrl" controls />
+        </div>
+
+        <p v-if="post.body" class="body">{{ post.body }}</p>
 
         <p v-if="post.expiresAt" class="expiry">
           Disappears {{ when(post.expiresAt) }}
@@ -49,7 +55,8 @@ import {
 } from '@ionic/vue';
 import { useRoute, useRouter } from 'vue-router';
 import { trashOutline } from 'ionicons/icons';
-import { getPost, getContact, deletePost } from '@/db/queries';
+import { onIonViewWillLeave } from '@ionic/vue';
+import { getPost, getContact, getMedia, deletePost } from '@/db/queries';
 import { getSelfUserId } from '@/services/auth';
 import { useSelfProfile } from '@/composables/useSelfProfile';
 import type { Post } from '@/db/types';
@@ -61,11 +68,16 @@ const post = ref<Post | null>(null);
 const authorName = ref('Unknown');
 const authorAvatar = ref('');
 const authorUsername = ref<string | undefined>(undefined);
+const mediaUrl = ref<string | undefined>(undefined);
 
 onIonViewWillEnter(async () => {
   const id = String(route.params.id);
   post.value = await getPost(id);
   if (!post.value) return;
+  if (post.value.mediaId) {
+    const md = await getMedia(post.value.mediaId);
+    if (md?.blob) mediaUrl.value = URL.createObjectURL(md.blob);
+  }
   if (post.value.author === getSelfUserId()) {
     authorName.value = 'You';
     authorAvatar.value = self.avatar.value;
@@ -75,6 +87,13 @@ onIonViewWillEnter(async () => {
     authorName.value = c?.name ?? 'Unknown';
     authorAvatar.value = c?.avatar ?? '';
     authorUsername.value = c?.username;
+  }
+});
+
+onIonViewWillLeave(() => {
+  if (mediaUrl.value) {
+    URL.revokeObjectURL(mediaUrl.value);
+    mediaUrl.value = undefined;
   }
 });
 
@@ -137,6 +156,20 @@ async function confirmDelete(): Promise<void> {
 .who .time {
   color: var(--ion-color-medium);
   font-size: 13px;
+}
+.media {
+  margin: 16px 0 0;
+}
+.media img,
+.media video {
+  width: 100%;
+  max-height: 60vh;
+  border-radius: 14px;
+  object-fit: contain;
+  background: #000;
+}
+.media audio {
+  width: 100%;
 }
 .body {
   margin: 16px 0 0;

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -62,21 +62,30 @@
           </ul>
         </div>
 
-        <!-- Comments (audience-visible thread). -->
+        <!-- Comments (audience-visible thread). Swipe a comment you can remove to the
+             left to delete it (with confirmation). -->
         <div class="comments">
           <h3>Comments</h3>
-          <ul v-if="comments.length" class="clist">
-            <li v-for="c in comments" :key="c.id">
-              <div class="cmeta">
-                <span class="cname">{{ nameOf(c.actor) }}</span>
-                <span class="ctime">{{ ago(c.at) }}</span>
-                <button v-if="canModerate(c)" class="cdel" aria-label="Delete comment" @click="removeComment(c)">
-                  <ion-icon :icon="trashOutline" />
-                </button>
-              </div>
-              <p class="ctext"><EmojiText :text="c.text || ''" /></p>
-            </li>
-          </ul>
+          <ion-list v-if="comments.length" class="clist">
+            <ion-item-sliding v-for="c in comments" :key="c.id">
+              <ion-item lines="none" class="citem">
+                <ion-avatar slot="start" class="cavatar">
+                  <img v-if="avatarOf(c.actor)" :src="avatarOf(c.actor)" :alt="nameOf(c.actor)" />
+                  <div v-else class="ph">{{ initial(nameOf(c.actor)) }}</div>
+                </ion-avatar>
+                <ion-label class="cwrap">
+                  <div class="cmeta">
+                    <span class="cname">{{ nameOf(c.actor) }}</span>
+                    <span class="ctime">{{ ago(c.at) }}</span>
+                  </div>
+                  <p class="ctext"><EmojiText :text="c.text || ''" /></p>
+                </ion-label>
+              </ion-item>
+              <ion-item-options v-if="canModerate(c)" side="end">
+                <ion-item-option color="danger" @click="confirmDeleteComment(c)">Delete</ion-item-option>
+              </ion-item-options>
+            </ion-item-sliding>
+          </ion-list>
           <p v-else class="empty">No comments yet.</p>
           <div class="cinput">
             <ion-textarea
@@ -106,11 +115,13 @@
 import { computed, ref } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
-  IonContent, IonAvatar, IonIcon, IonTextarea, onIonViewWillEnter, onIonViewWillLeave, alertController,
+  IonContent, IonAvatar, IonIcon, IonTextarea, IonList, IonItem, IonLabel,
+  IonItemSliding, IonItemOptions, IonItemOption,
+  onIonViewWillEnter, onIonViewWillLeave, alertController,
 } from '@ionic/vue';
 import { useRoute, useRouter } from 'vue-router';
 import { trashOutline, happyOutline, timeOutline } from 'ionicons/icons';
-import { timeLeft } from '@/utils/post-time';
+import { timeLeft, formatPostDateTime } from '@/utils/post-time';
 import { toastController } from '@ionic/vue';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
@@ -186,6 +197,10 @@ const nameOf = (actorId: string): string => {
   if (actorId === selfId) return 'You';
   return contacts.value.find((c) => c.id === actorId)?.name ?? 'Someone';
 };
+const avatarOf = (actorId: string): string => {
+  if (actorId === selfId) return self.avatar.value;
+  return contacts.value.find((c) => c.id === actorId)?.avatar ?? '';
+};
 
 // Comments thread.
 const comments = useLiveQuery(() => listPostComments(postId), ['postEngagement'], [] as PostEngagement[]);
@@ -202,8 +217,16 @@ async function sendComment(): Promise<void> {
 function canModerate(c: PostEngagement): boolean {
   return c.actor === selfId || !!post.value?.outgoing;
 }
-function removeComment(c: PostEngagement): void {
-  void deleteComment(postId, c.id);
+async function confirmDeleteComment(c: PostEngagement): Promise<void> {
+  const a = await alertController.create({
+    header: 'Delete comment',
+    message: 'This removes your comment for everyone in the audience.',
+    buttons: [
+      { text: 'Cancel', role: 'cancel' },
+      { text: 'Delete', role: 'destructive', handler: () => void deleteComment(postId, c.id) },
+    ],
+  });
+  await a.present();
 }
 
 // Author-only view list.
@@ -246,7 +269,7 @@ function initial(name: string): string {
   return (name.trim()[0] ?? '?').toUpperCase();
 }
 function when(ts: number): string {
-  return new Date(ts).toLocaleString();
+  return formatPostDateTime(ts);
 }
 function ago(ts: number): string {
   const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
@@ -401,17 +424,39 @@ async function confirmDelete(): Promise<void> {
   margin: 0 0 8px;
 }
 .comments .clist {
-  list-style: none;
   margin: 0 0 12px;
   padding: 0;
+  background: transparent;
 }
-.comments .clist li {
-  padding: 8px 0;
-  border-bottom: 1px solid var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+.comments .citem {
+  --background: transparent;
+  --padding-start: 0;
+  --inner-padding-end: 0;
+  --min-height: 0;
+  align-items: flex-start;
+}
+.comments .cavatar {
+  width: 32px;
+  height: 32px;
+  margin: 6px 10px 6px 0;
+}
+.comments .cavatar .ph {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--ion-color-step-150, rgba(120, 120, 128, 0.2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 13px;
+}
+.comments .cwrap {
+  margin: 6px 0;
 }
 .comments .cmeta {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 8px;
 }
 .comments .cname {
@@ -421,14 +466,6 @@ async function confirmDelete(): Promise<void> {
 .comments .ctime {
   color: var(--ion-color-medium);
   font-size: 12px;
-}
-.comments .cdel {
-  margin-left: auto;
-  border: none;
-  background: none;
-  color: var(--ion-color-medium);
-  cursor: pointer;
-  font-size: 16px;
 }
 .comments .ctext {
   margin: 2px 0 0;

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -444,11 +444,25 @@ async function confirmDelete(): Promise<void> {
   background: transparent;
 }
 .comments .citem {
-  --background: transparent;
+  /* Opaque tinted row surface (the app's standard row wash, matching the post card)
+     rather than transparent, so that as the row slides back it slides OVER the swipe
+     action and hides it — otherwise the action shows through the row and then blinks
+     out when the slider collapses. */
+  --background: var(--ion-item-background);
   --padding-start: 0;
   --inner-padding-end: 0;
   --min-height: 0;
   align-items: flex-start;
+}
+/* Match the swipe-to-delete action to the comment row: a rounded, vertically-inset
+   pill that's revealed from behind the row as it slides, not a tall square button. */
+.comments ion-item-option {
+  margin: 6px 0 6px 8px;
+  border-radius: 12px;
+  --border-radius: 12px;
+  overflow: hidden;
+  font-weight: 600;
+  min-width: 72px;
 }
 .comments .cavatar {
   width: 32px;

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -34,7 +34,7 @@
           <audio v-else-if="post.kind === 'voice'" :src="mediaUrl" controls />
         </div>
 
-        <p v-if="post.body" class="body">{{ post.body }}</p>
+        <p v-if="post.body" class="body"><EmojiText :text="post.body" big /></p>
 
         <p v-if="post.expiresAt" class="expiry">
           Disappears {{ when(post.expiresAt) }}
@@ -72,7 +72,7 @@
                   <ion-icon :icon="trashOutline" />
                 </button>
               </div>
-              <p class="ctext">{{ c.text }}</p>
+              <p class="ctext"><EmojiText :text="c.text || ''" /></p>
             </li>
           </ul>
           <p v-else class="empty">No comments yet.</p>
@@ -109,6 +109,7 @@ import {
 import { useRoute, useRouter } from 'vue-router';
 import { trashOutline } from 'ionicons/icons';
 import Emoji from '@/components/Emoji.vue';
+import EmojiText from '@/components/EmojiText.vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import {
   getPost, getContact, getMedia, deletePost,

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -3,7 +3,7 @@
     <ion-header :translucent="true">
       <ion-toolbar>
         <ion-buttons slot="start">
-          <ion-back-button default-href="/wall" />
+          <ion-back-button default-href="/tabs/wall" />
         </ion-buttons>
         <ion-title>Post</ion-title>
         <ion-buttons v-if="post?.outgoing" slot="end">

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -60,7 +60,40 @@
           </ul>
         </div>
 
-        <!-- Comments and the viewer list arrive with US6/US7. -->
+        <!-- Comments (audience-visible thread). -->
+        <div class="comments">
+          <h3>Comments</h3>
+          <ul v-if="comments.length" class="clist">
+            <li v-for="c in comments" :key="c.id">
+              <div class="cmeta">
+                <span class="cname">{{ nameOf(c.actor) }}</span>
+                <span class="ctime">{{ ago(c.at) }}</span>
+                <button v-if="canModerate(c)" class="cdel" aria-label="Delete comment" @click="removeComment(c)">
+                  <ion-icon :icon="trashOutline" />
+                </button>
+              </div>
+              <p class="ctext">{{ c.text }}</p>
+            </li>
+          </ul>
+          <p v-else class="empty">No comments yet.</p>
+          <div class="cinput">
+            <ion-textarea
+              :auto-grow="true"
+              :rows="1"
+              placeholder="Add a comment…"
+              dir="auto"
+              :value="commentText"
+              @ion-input="onComment"
+            />
+            <ion-button size="small" :disabled="!commentText.trim()" @click="sendComment">Post</ion-button>
+          </div>
+        </div>
+
+        <!-- Author-only: who viewed this post (seen-receipts gated). -->
+        <div v-if="post.outgoing && viewers.length" class="viewers">
+          <h3>Viewed by</h3>
+          <p>{{ viewers.map(nameOf).join(', ') }}</p>
+        </div>
       </div>
       <div v-else class="missing">This post is no longer available.</div>
     </ion-content>
@@ -71,7 +104,7 @@
 import { computed, ref } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
-  IonContent, IonAvatar, IonIcon, onIonViewWillEnter, onIonViewWillLeave, alertController,
+  IonContent, IonAvatar, IonIcon, IonTextarea, onIonViewWillEnter, onIonViewWillLeave, alertController,
 } from '@ionic/vue';
 import { useRoute, useRouter } from 'vue-router';
 import { trashOutline } from 'ionicons/icons';
@@ -79,6 +112,7 @@ import { useLiveQuery } from '@/composables/useLiveQuery';
 import {
   getPost, getContact, getMedia, deletePost,
   listPostReactions, reactToPost, syncEngagement, listContacts,
+  listPostComments, commentOnPost, deleteComment, recordPostView, listPostViews,
 } from '@/db/queries';
 import { getSelfUserId } from '@/services/auth';
 import { useSelfProfile } from '@/composables/useSelfProfile';
@@ -118,6 +152,33 @@ function react(emoji: string): void {
   void reactToPost(postId, emoji);
 }
 
+const nameOf = (actorId: string): string => {
+  if (actorId === selfId) return 'You';
+  return contacts.value.find((c) => c.id === actorId)?.name ?? 'Someone';
+};
+
+// Comments thread.
+const comments = useLiveQuery(() => listPostComments(postId), ['postEngagement'], [] as PostEngagement[]);
+const commentText = ref('');
+function onComment(e: CustomEvent): void {
+  commentText.value = (e.detail as { value?: string | null }).value ?? '';
+}
+async function sendComment(): Promise<void> {
+  const t = commentText.value.trim();
+  if (!t) return;
+  commentText.value = '';
+  await commentOnPost(postId, t);
+}
+function canModerate(c: PostEngagement): boolean {
+  return c.actor === selfId || !!post.value?.outgoing;
+}
+function removeComment(c: PostEngagement): void {
+  void deleteComment(postId, c.id);
+}
+
+// Author-only view list.
+const viewers = ref<string[]>([]);
+
 onIonViewWillEnter(async () => {
   void syncEngagement(postId); // refresh reactions from the server
   post.value = await getPost(postId);
@@ -136,6 +197,12 @@ onIonViewWillEnter(async () => {
     authorAvatar.value = c?.avatar ?? '';
     authorUsername.value = c?.username;
   }
+  // Views: record ours on someone else's post; load the list on our own.
+  if (post.value.outgoing) {
+    viewers.value = await listPostViews(postId);
+  } else {
+    void recordPostView(postId);
+  }
 });
 
 onIonViewWillLeave(() => {
@@ -150,6 +217,13 @@ function initial(name: string): string {
 }
 function when(ts: number): string {
   return new Date(ts).toLocaleString();
+}
+function ago(ts: number): string {
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (s < 60) return 'now';
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  return `${Math.floor(s / 86400)}d`;
 }
 
 async function confirmDelete(): Promise<void> {
@@ -266,6 +340,73 @@ async function confirmDelete(): Promise<void> {
 .reactions .rlist .who {
   color: var(--ion-color-medium);
   font-size: 14px;
+}
+.comments {
+  margin-top: 24px;
+}
+.comments h3,
+.viewers h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+.comments .clist {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+}
+.comments .clist li {
+  padding: 8px 0;
+  border-bottom: 1px solid var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+}
+.comments .cmeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.comments .cname {
+  font-weight: 600;
+  font-size: 14px;
+}
+.comments .ctime {
+  color: var(--ion-color-medium);
+  font-size: 12px;
+}
+.comments .cdel {
+  margin-left: auto;
+  border: none;
+  background: none;
+  color: var(--ion-color-medium);
+  cursor: pointer;
+  font-size: 16px;
+}
+.comments .ctext {
+  margin: 2px 0 0;
+  white-space: pre-wrap;
+}
+.comments .empty {
+  color: var(--ion-color-medium);
+  font-size: 14px;
+}
+.comments .cinput {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+.comments .cinput ion-textarea {
+  flex: 1;
+  --background: var(--ion-color-step-100, rgba(120, 120, 128, 0.1));
+  --padding-start: 12px;
+  --padding-end: 12px;
+  border-radius: 18px;
+}
+.viewers {
+  margin-top: 20px;
+  color: var(--ion-color-medium);
+  font-size: 14px;
+}
+.viewers p {
+  margin: 0;
 }
 .missing {
   padding: 56px 24px;

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -36,21 +36,23 @@
 
         <p v-if="post.body" class="body"><EmojiText :text="post.body" big /></p>
 
-        <p v-if="post.expiresAt" class="expiry">
-          Disappears {{ when(post.expiresAt) }}
+        <p v-if="post.expiresAt" class="expiry" :title="when(post.expiresAt)">
+          <ion-icon :icon="timeOutline" /> Disappears in {{ leftLabel }}
         </p>
 
-        <!-- Reactions (audience-visible). -->
+        <!-- Reactions (audience-visible): pills + the shared quick-react picker. -->
         <div class="reactions">
-          <div class="picker">
+          <div class="rrow">
             <button
-              v-for="e in EMOJIS"
-              :key="e"
-              class="emoji"
-              :class="{ mine: myEmoji === e }"
-              :aria-label="'React ' + e"
-              @click="react(e)"
-            ><Emoji :emoji="e" /></button>
+              v-for="g in grouped"
+              :key="g.emoji"
+              class="rpill"
+              :class="{ mine: g.mine }"
+              @click="react(g.emoji)"
+            ><Emoji :emoji="g.emoji" /><span class="rc">{{ g.count }}</span></button>
+            <button class="raddbtn" aria-label="React" @click="openPicker($event)">
+              <ion-icon :icon="happyOutline" />
+            </button>
           </div>
           <ul v-if="grouped.length" class="rlist">
             <li v-for="g in grouped" :key="g.emoji">
@@ -107,14 +109,18 @@ import {
   IonContent, IonAvatar, IonIcon, IonTextarea, onIonViewWillEnter, onIonViewWillLeave, alertController,
 } from '@ionic/vue';
 import { useRoute, useRouter } from 'vue-router';
-import { trashOutline } from 'ionicons/icons';
+import { trashOutline, happyOutline, timeOutline } from 'ionicons/icons';
+import { timeLeft } from '@/utils/post-time';
+import { toastController } from '@ionic/vue';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
+import { useReactionPicker } from '@/composables/useReactionPicker';
 import {
   getPost, getContact, getMedia, deletePost,
   listPostReactions, reactToPost, syncEngagement, listContacts,
   listPostComments, commentOnPost, deleteComment, recordPostView, listPostViews,
+  MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS,
 } from '@/db/queries';
 import { getSelfUserId } from '@/services/auth';
 import { useSelfProfile } from '@/composables/useSelfProfile';
@@ -130,30 +136,50 @@ const authorName = ref('Unknown');
 const authorAvatar = ref('');
 const authorUsername = ref<string | undefined>(undefined);
 const mediaUrl = ref<string | undefined>(undefined);
+const leftLabel = computed(() => (post.value?.expiresAt ? timeLeft(post.value.expiresAt, Date.now()) : ''));
 
-// The same canonical quick-react set the chat uses (rendered via the Noto Emoji
-// component for visual + animation consistency).
-const EMOJIS = ['👍', '❤️', '😂', '😮', '🙏'];
 const reactions = useLiveQuery(() => listPostReactions(postId), ['postEngagement'], [] as PostEngagement[]);
 const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+const { openQuick } = useReactionPicker();
 
-const myEmoji = computed(() => reactions.value.find((r) => r.actor === selfId)?.emoji);
-// Group reactions by emoji with a human "who" label.
+const myEmojis = computed(() => reactions.value.filter((r) => r.actor === selfId).map((r) => r.emoji ?? ''));
+// Reaction pills (emoji + count + whether I reacted), plus a "who reacted" line.
 const grouped = computed(() => {
   const byId = new Map(contacts.value.map((c) => [c.id, c.name] as const));
-  const map = new Map<string, string[]>();
+  const map = new Map<string, { who: string[]; count: number; mine: boolean }>();
   for (const r of reactions.value) {
     if (!r.emoji) continue;
-    const who = r.actor === selfId ? 'You' : byId.get(r.actor) ?? 'Someone';
-    const list = map.get(r.emoji) ?? [];
-    list.push(who);
-    map.set(r.emoji, list);
+    const g = map.get(r.emoji) ?? { who: [], count: 0, mine: false };
+    g.who.push(r.actor === selfId ? 'You' : byId.get(r.actor) ?? 'Someone');
+    g.count += 1;
+    if (r.actor === selfId) g.mine = true;
+    map.set(r.emoji, g);
   }
-  return [...map.entries()].map(([emoji, names]) => ({ emoji, who: names.join(', ') }));
+  return [...map.entries()].map(([emoji, g]) => ({ emoji, who: g.who.join(', '), count: g.count, mine: g.mine }));
 });
 
-function react(emoji: string): void {
-  void reactToPost(postId, emoji);
+async function react(emoji: string): Promise<void> {
+  const res = await reactToPost(postId, emoji);
+  if (res === 'limit' || res === 'limit-emojis') {
+    const t = await toastController.create({
+      message:
+        res === 'limit-emojis'
+          ? `This post already has ${MAX_DISTINCT_REACTIONS} different reactions — tap one of those instead.`
+          : `You can add up to ${MAX_REACTIONS_PER_USER} reactions.`,
+      duration: 1600,
+      position: 'top',
+    });
+    await t.present();
+  }
+}
+function openPicker(ev: Event): void {
+  const existing = grouped.value.map((g) => g.emoji);
+  void openQuick(ev, {
+    myEmojis: myEmojis.value,
+    existing,
+    atEmojiCap: existing.length >= MAX_DISTINCT_REACTIONS,
+    onPick: react,
+  });
 }
 
 const nameOf = (actorId: string): string => {
@@ -310,22 +336,42 @@ async function confirmDelete(): Promise<void> {
 .reactions {
   margin-top: 20px;
 }
-.reactions .picker {
+.reactions .rrow {
   display: flex;
+  align-items: center;
   gap: 6px;
   flex-wrap: wrap;
 }
-.reactions .emoji {
-  font-size: 22px;
-  line-height: 1;
-  padding: 6px 8px;
+.reactions .rpill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 16px;
+  padding: 4px 10px;
   border: none;
   border-radius: 999px;
   background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
   cursor: pointer;
 }
-.reactions .emoji.mine {
-  background: var(--ion-color-primary);
+.reactions .rpill.mine {
+  background: color-mix(in srgb, var(--ion-color-primary) 22%, transparent);
+}
+.reactions .rpill .rc {
+  font-size: 12px;
+  color: var(--ion-color-medium);
+}
+.reactions .raddbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 50%;
+  background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+  color: var(--ion-color-medium);
+  font-size: 20px;
+  cursor: pointer;
 }
 .reactions .rlist {
   list-style: none;

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -1,0 +1,156 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/wall" />
+        </ion-buttons>
+        <ion-title>Post</ion-title>
+        <ion-buttons v-if="post?.outgoing" slot="end">
+          <ion-button color="danger" aria-label="Delete post" @click="confirmDelete">
+            <ion-icon slot="icon-only" :icon="trashOutline" />
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <div v-if="post" class="wrap">
+        <div class="head">
+          <ion-avatar class="avatar">
+            <img v-if="authorAvatar" :src="authorAvatar" :alt="authorName" />
+            <div v-else class="ph">{{ initial(authorName) }}</div>
+          </ion-avatar>
+          <div class="who">
+            <div class="name">{{ authorName }}</div>
+            <div v-if="authorUsername" class="user">@{{ authorUsername }}</div>
+            <div class="time">{{ when(post.createdAt) }}</div>
+          </div>
+        </div>
+
+        <p class="body">{{ post.body }}</p>
+
+        <p v-if="post.expiresAt" class="expiry">
+          Disappears {{ when(post.expiresAt) }}
+        </p>
+
+        <!-- Reactions, comments and the viewer list arrive with US4/US6/US7. -->
+      </div>
+      <div v-else class="missing">This post is no longer available.</div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import {
+  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
+  IonContent, IonAvatar, IonIcon, onIonViewWillEnter, alertController,
+} from '@ionic/vue';
+import { useRoute, useRouter } from 'vue-router';
+import { trashOutline } from 'ionicons/icons';
+import { getPost, getContact, deletePost } from '@/db/queries';
+import { getSelfUserId } from '@/services/auth';
+import { useSelfProfile } from '@/composables/useSelfProfile';
+import type { Post } from '@/db/types';
+
+const route = useRoute();
+const router = useRouter();
+const self = useSelfProfile();
+const post = ref<Post | null>(null);
+const authorName = ref('Unknown');
+const authorAvatar = ref('');
+const authorUsername = ref<string | undefined>(undefined);
+
+onIonViewWillEnter(async () => {
+  const id = String(route.params.id);
+  post.value = await getPost(id);
+  if (!post.value) return;
+  if (post.value.author === getSelfUserId()) {
+    authorName.value = 'You';
+    authorAvatar.value = self.avatar.value;
+    authorUsername.value = undefined;
+  } else {
+    const c = await getContact(post.value.author);
+    authorName.value = c?.name ?? 'Unknown';
+    authorAvatar.value = c?.avatar ?? '';
+    authorUsername.value = c?.username;
+  }
+});
+
+function initial(name: string): string {
+  return (name.trim()[0] ?? '?').toUpperCase();
+}
+function when(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+async function confirmDelete(): Promise<void> {
+  if (!post.value) return;
+  const a = await alertController.create({
+    header: 'Delete post',
+    message:
+      'This removes the post for you and signals your audience to remove their copies. ' +
+      'Copies already downloaded can’t be guaranteed to disappear.',
+    buttons: [
+      { text: 'Cancel', role: 'cancel' },
+      {
+        text: 'Delete',
+        role: 'destructive',
+        handler: () => {
+          void deletePost(post.value!.id).then(() => router.back());
+        },
+      },
+    ],
+  });
+  await a.present();
+}
+</script>
+
+<style scoped>
+.wrap {
+  padding: 16px 20px;
+}
+.head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.avatar {
+  width: 48px;
+  height: 48px;
+}
+.avatar .ph {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--ion-color-step-150, rgba(120, 120, 128, 0.2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+.who .name {
+  font-weight: 600;
+}
+.who .user,
+.who .time {
+  color: var(--ion-color-medium);
+  font-size: 13px;
+}
+.body {
+  margin: 16px 0 0;
+  font-size: 17px;
+  white-space: pre-wrap;
+}
+.expiry {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--ion-color-medium);
+}
+.missing {
+  padding: 56px 24px;
+  text-align: center;
+  color: var(--ion-color-medium);
+}
+</style>

--- a/src/views/detail/WallManagePage.vue
+++ b/src/views/detail/WallManagePage.vue
@@ -1,0 +1,106 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/tabs/wall" />
+        </ion-buttons>
+        <ion-title>Hidden &amp; muted</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <ion-header collapse="condense">
+        <ion-toolbar>
+          <ion-title size="large">Hidden &amp; muted</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <p class="hint">
+        Turn off Hidden to see someone's posts again, or Muted to get their Wall notifications back.
+      </p>
+
+      <div v-if="!people.length" class="empty">You haven't hidden or muted anyone.</div>
+
+      <ion-list v-else :inset="true">
+        <ion-item v-for="u in people" :key="u.id">
+          <ion-avatar slot="start" class="avatar">
+            <img v-if="u.avatar" :src="u.avatar" :alt="u.name" />
+            <div v-else class="ph">{{ initial(u.name) }}</div>
+          </ion-avatar>
+          <ion-label>{{ u.name }}</ion-label>
+          <div class="toggles" slot="end">
+            <label class="t">
+              <span>Hidden</span>
+              <ion-toggle :checked="u.hidden" @ion-change="onHide(u.id, $event)" />
+            </label>
+            <label class="t">
+              <span>Muted</span>
+              <ion-toggle :checked="u.muted" @ion-change="onMute(u.id, $event)" />
+            </label>
+          </div>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import {
+  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonContent,
+  IonList, IonItem, IonAvatar, IonLabel, IonToggle,
+} from '@ionic/vue';
+import { useLiveQuery } from '@/composables/useLiveQuery';
+import { listWallManagedUsers, setWallUserHidden, setWallUserMuted } from '@/db/queries';
+
+const people = useLiveQuery(() => listWallManagedUsers(), ['settings', 'contacts'], []);
+
+function initial(name: string): string {
+  return (name.trim()[0] ?? '?').toUpperCase();
+}
+function onHide(id: string, e: CustomEvent): void {
+  void setWallUserHidden(id, (e.detail as { checked?: boolean }).checked ?? false);
+}
+function onMute(id: string, e: CustomEvent): void {
+  void setWallUserMuted(id, (e.detail as { checked?: boolean }).checked ?? false);
+}
+</script>
+
+<style scoped>
+.hint {
+  margin: 4px 20px 8px;
+  font-size: 13px;
+  color: var(--app-text-muted, var(--ion-color-medium));
+}
+.empty {
+  padding: 40px 24px;
+  text-align: center;
+  color: var(--ion-color-medium);
+}
+.avatar {
+  width: 40px;
+  height: 40px;
+}
+.avatar .ph {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--ion-color-step-150, rgba(120, 120, 128, 0.2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+.toggles {
+  display: flex;
+  gap: 14px;
+}
+.toggles .t {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  font-size: 11px;
+  color: var(--ion-color-medium);
+}
+</style>

--- a/src/views/detail/WallPage.vue
+++ b/src/views/detail/WallPage.vue
@@ -46,9 +46,15 @@
               <span v-if="p.authorUsername" class="user">@{{ p.authorUsername }}</span>
               <span class="time">{{ ago(p.createdAt) }}</span>
             </div>
-            <p class="body">
-              <ion-icon v-if="p.kind !== 'text'" :icon="kindIcon(p.kind)" class="kind" />
-              {{ p.body || kindLabel(p.kind) }}
+            <div v-if="p.mediaUrl" class="thumb">
+              <img v-if="p.kind === 'image'" :src="p.mediaUrl" :alt="p.body || 'Photo'" />
+              <video v-else-if="p.kind === 'video'" :src="p.mediaUrl" muted playsinline preload="metadata" />
+              <div v-else class="voice"><ion-icon :icon="micOutline" /> Voice message</div>
+              <ion-icon v-if="p.kind === 'video'" class="play" :icon="playCircleOutline" />
+            </div>
+            <p v-if="p.body || p.kind === 'text'" class="body">
+              <ion-icon v-if="p.kind !== 'text' && !p.mediaUrl" :icon="kindIcon(p.kind)" class="kind" />
+              {{ p.body || (p.mediaUrl ? '' : kindLabel(p.kind)) }}
             </p>
             <span v-if="p.audience === 'close'" class="badge">Close friends</span>
           </ion-label>
@@ -64,7 +70,7 @@ import {
   IonContent, IonList, IonItem, IonAvatar, IonLabel, IonIcon,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
-import { createOutline, sparklesOutline, imageOutline, videocamOutline, micOutline } from 'ionicons/icons';
+import { createOutline, sparklesOutline, imageOutline, videocamOutline, micOutline, playCircleOutline } from 'ionicons/icons';
 import { useWall } from '@/composables/useWall';
 import type { Post } from '@/db/types';
 
@@ -140,6 +146,33 @@ function ago(ts: number): string {
 }
 .post .time {
   margin-left: auto;
+}
+.post .thumb {
+  position: relative;
+  margin: 6px 0 2px;
+  max-width: 220px;
+}
+.post .thumb img,
+.post .thumb video {
+  width: 100%;
+  max-height: 220px;
+  border-radius: 12px;
+  object-fit: cover;
+  display: block;
+}
+.post .thumb .voice {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ion-color-medium);
+}
+.post .thumb .play {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  font-size: 44px;
+  color: rgba(255, 255, 255, 0.92);
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.5));
 }
 .post .body {
   margin: 2px 0 0;

--- a/src/views/detail/WallPage.vue
+++ b/src/views/detail/WallPage.vue
@@ -1,0 +1,160 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/tabs/chats" />
+        </ion-buttons>
+        <ion-title>Wall</ion-title>
+        <ion-buttons slot="end">
+          <ion-button aria-label="New post" @click="compose">
+            <ion-icon slot="icon-only" :icon="createOutline" />
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <ion-header collapse="condense">
+        <ion-toolbar>
+          <ion-title size="large">Wall</ion-title>
+        </ion-toolbar>
+      </ion-header>
+
+      <!-- Empty state -->
+      <div v-if="!wall.length" class="empty">
+        <ion-icon :icon="sparklesOutline" />
+        <p>No posts yet. Share a moment with your friends.</p>
+        <ion-button fill="solid" @click="compose">New post</ion-button>
+      </div>
+
+      <ion-list v-else :inset="true" lines="full">
+        <ion-item
+          v-for="p in wall"
+          :key="p.id"
+          button
+          :detail="false"
+          @click="open(p.id)"
+        >
+          <ion-avatar slot="start" class="avatar">
+            <img v-if="p.authorAvatar" :src="p.authorAvatar" :alt="p.authorName" />
+            <div v-else class="ph">{{ initial(p.authorName) }}</div>
+          </ion-avatar>
+          <ion-label class="post">
+            <div class="head">
+              <span class="name">{{ p.authorName }}</span>
+              <span v-if="p.authorUsername" class="user">@{{ p.authorUsername }}</span>
+              <span class="time">{{ ago(p.createdAt) }}</span>
+            </div>
+            <p class="body">
+              <ion-icon v-if="p.kind !== 'text'" :icon="kindIcon(p.kind)" class="kind" />
+              {{ p.body || kindLabel(p.kind) }}
+            </p>
+            <span v-if="p.audience === 'close'" class="badge">Close friends</span>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import {
+  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
+  IonContent, IonList, IonItem, IonAvatar, IonLabel, IonIcon,
+} from '@ionic/vue';
+import { useRouter } from 'vue-router';
+import { createOutline, sparklesOutline, imageOutline, videocamOutline, micOutline } from 'ionicons/icons';
+import { useWall } from '@/composables/useWall';
+import type { Post } from '@/db/types';
+
+const router = useRouter();
+const { wall } = useWall();
+
+function compose(): void {
+  void router.push('/wall/compose');
+}
+function open(id: string): void {
+  void router.push(`/wall/post/${id}`);
+}
+function initial(name: string): string {
+  return (name.trim()[0] ?? '?').toUpperCase();
+}
+function kindIcon(kind: Post['kind']): string {
+  return kind === 'image' ? imageOutline : kind === 'video' ? videocamOutline : micOutline;
+}
+function kindLabel(kind: Post['kind']): string {
+  return kind === 'image' ? 'Photo' : kind === 'video' ? 'Video' : kind === 'voice' ? 'Voice' : '';
+}
+// Compact relative time ("now", "5m", "3h", "2d", else a date).
+function ago(ts: number): string {
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (s < 60) return 'now';
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  if (s < 7 * 86400) return `${Math.floor(s / 86400)}d`;
+  return new Date(ts).toLocaleDateString();
+}
+</script>
+
+<style scoped>
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 56px 24px;
+  color: var(--app-text-muted, var(--ion-color-medium));
+  text-align: center;
+}
+.empty ion-icon {
+  font-size: 44px;
+  color: var(--ion-color-primary);
+}
+.avatar {
+  width: 40px;
+  height: 40px;
+}
+.avatar .ph {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--ion-color-step-150, rgba(120, 120, 128, 0.2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+.post .head {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.post .name {
+  font-weight: 600;
+}
+.post .user,
+.post .time {
+  color: var(--ion-color-medium);
+  font-size: 13px;
+}
+.post .time {
+  margin-left: auto;
+}
+.post .body {
+  margin: 2px 0 0;
+  white-space: normal;
+  color: var(--ion-text-color);
+}
+.post .kind {
+  vertical-align: -2px;
+  margin-right: 2px;
+  color: var(--ion-color-medium);
+}
+.post .badge {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--ion-color-primary);
+}
+</style>

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -4,6 +4,9 @@
       <ion-toolbar>
         <ion-title>Chats</ion-title>
         <ion-buttons slot="end">
+          <ion-button aria-label="Wall" @click="router.push('/wall')">
+            <ion-icon slot="icon-only" :icon="sparklesOutline" />
+          </ion-button>
           <ion-button aria-label="New chat" @click="newOpen = true">
             <ion-icon slot="icon-only" :icon="createOutline" />
           </ion-button>
@@ -155,7 +158,7 @@ import {
   IonLabel, IonNote, IonModal,
 } from '@ionic/vue';
 import {
-  createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline,
+  createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline, sparklesOutline,
 } from 'ionicons/icons';
 import ChatListItem from '@/components/ChatListItem.vue';
 import ChatActionsHost from '@/components/ChatActionsHost.vue';

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -4,9 +4,6 @@
       <ion-toolbar>
         <ion-title>Chats</ion-title>
         <ion-buttons slot="end">
-          <ion-button aria-label="Wall" @click="router.push('/wall')">
-            <ion-icon slot="icon-only" :icon="sparklesOutline" />
-          </ion-button>
           <ion-button aria-label="New chat" @click="newOpen = true">
             <ion-icon slot="icon-only" :icon="createOutline" />
           </ion-button>
@@ -158,7 +155,7 @@ import {
   IonLabel, IonNote, IonModal,
 } from '@ionic/vue';
 import {
-  createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline, sparklesOutline,
+  createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline,
 } from 'ionicons/icons';
 import ChatListItem from '@/components/ChatListItem.vue';
 import ChatActionsHost from '@/components/ChatActionsHost.vue';

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -2,9 +2,6 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-buttons slot="start">
-          <ion-back-button default-href="/tabs/chats" />
-        </ion-buttons>
         <ion-title>Wall</ion-title>
         <ion-buttons slot="end">
           <ion-button aria-label="New post" @click="compose">
@@ -66,7 +63,7 @@
 
 <script setup lang="ts">
 import {
-  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
+  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton,
   IonContent, IonList, IonItem, IonAvatar, IonLabel, IonIcon,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -249,7 +249,11 @@ async function openMuteMenu(): Promise<void> {
   if (muted.value) buttons.unshift({ text: 'Turn notifications back on', handler: () => void mute(0) });
   const sheet = await actionSheetController.create({
     header: 'Wall notifications',
-    buttons: [...buttons, { text: 'Cancel', role: 'cancel' }],
+    buttons: [
+      ...buttons,
+      { text: 'Hidden & muted people', handler: () => void router.push('/wall/muted') },
+      { text: 'Cancel', role: 'cancel' },
+    ],
   });
   await sheet.present();
 }

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -51,7 +51,8 @@
             </div>
             <p v-if="p.body || p.kind === 'text'" class="body">
               <ion-icon v-if="p.kind !== 'text' && !p.mediaUrl" :icon="kindIcon(p.kind)" class="kind" />
-              {{ p.body || (p.mediaUrl ? '' : kindLabel(p.kind)) }}
+              <EmojiText v-if="p.body" :text="p.body" />
+              <template v-else>{{ p.mediaUrl ? '' : kindLabel(p.kind) }}</template>
             </p>
             <span v-if="p.audience === 'close'" class="badge">Close friends</span>
           </ion-label>
@@ -68,6 +69,7 @@ import {
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
 import { createOutline, sparklesOutline, imageOutline, videocamOutline, micOutline, playCircleOutline } from 'ionicons/icons';
+import EmojiText from '@/components/EmojiText.vue';
 import { useWall } from '@/composables/useWall';
 import type { Post } from '@/db/types';
 

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -299,7 +299,7 @@ function tomorrow9am(): number {
 async function openMuteMenu(): Promise<void> {
   const buttons = [
     { text: 'Mute for 1 hour', handler: () => void mute(Date.now() + 60 * 60_000) },
-    { text: 'Mute for 8 hours', handler: () => void mute(Date.now() + 8 * 60 * 60_000) },
+    { text: 'Mute for 24 hours', handler: () => void mute(Date.now() + 24 * 60 * 60_000) },
     { text: 'Mute until 9 AM tomorrow', handler: () => void mute(tomorrow9am()) },
     { text: 'Mute until I turn it back on', handler: () => void mute(Number.MAX_SAFE_INTEGER) },
   ];

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -18,63 +18,109 @@
         </ion-toolbar>
       </ion-header>
 
-      <!-- Empty state -->
       <div v-if="!wall.length" class="empty">
         <ion-icon :icon="sparklesOutline" />
         <p>No posts yet. Share a moment with your friends.</p>
         <ion-button fill="solid" @click="compose">New post</ion-button>
       </div>
 
-      <ion-list v-else :inset="true" lines="full">
-        <ion-item
-          v-for="p in wall"
-          :key="p.id"
-          button
-          :detail="false"
-          @click="open(p.id)"
-        >
-          <ion-avatar slot="start" class="avatar">
+      <ion-card v-for="p in wall" :key="p.id" class="post">
+        <!-- Header: avatar + name + a subtle "disappears in …" countdown. -->
+        <div class="phead">
+          <ion-avatar class="avatar" @click="open(p.id)">
             <img v-if="p.authorAvatar" :src="p.authorAvatar" :alt="p.authorName" />
             <div v-else class="ph">{{ initial(p.authorName) }}</div>
           </ion-avatar>
-          <ion-label class="post">
-            <div class="head">
-              <span class="name">{{ p.authorName }}</span>
-              <span v-if="p.authorUsername" class="user">@{{ p.authorUsername }}</span>
-              <span class="time">{{ ago(p.createdAt) }}</span>
+          <div class="who" @click="open(p.id)">
+            <div class="name">
+              {{ p.authorName }}<span v-if="p.authorUsername" class="user"> @{{ p.authorUsername }}</span>
             </div>
-            <div v-if="p.mediaUrl" class="thumb">
-              <img v-if="p.kind === 'image'" :src="p.mediaUrl" :alt="p.body || 'Photo'" />
-              <video v-else-if="p.kind === 'video'" :src="p.mediaUrl" muted playsinline preload="metadata" />
-              <div v-else class="voice"><ion-icon :icon="micOutline" /> Voice message</div>
-              <ion-icon v-if="p.kind === 'video'" class="play" :icon="playCircleOutline" />
+            <div class="sub">
+              {{ ago(p.createdAt, now) }}<span v-if="p.audience === 'close'"> · Close friends</span>
             </div>
-            <p v-if="p.body || p.kind === 'text'" class="body">
-              <ion-icon v-if="p.kind !== 'text' && !p.mediaUrl" :icon="kindIcon(p.kind)" class="kind" />
-              <EmojiText v-if="p.body" :text="p.body" />
-              <template v-else>{{ p.mediaUrl ? '' : kindLabel(p.kind) }}</template>
-            </p>
-            <span v-if="p.audience === 'close'" class="badge">Close friends</span>
-          </ion-label>
-        </ion-item>
-      </ion-list>
+          </div>
+          <span v-if="left(p)" class="countdown" :title="'This post auto-deletes'">
+            <ion-icon :icon="timeOutline" />{{ left(p) }}
+          </span>
+        </div>
+
+        <!-- Media + body (tap → full post). -->
+        <div v-if="p.mediaUrl" class="thumb" @click="open(p.id)">
+          <img v-if="p.kind === 'image'" :src="p.mediaUrl" :alt="p.body || 'Photo'" />
+          <video v-else-if="p.kind === 'video'" :src="p.mediaUrl" muted playsinline preload="metadata" />
+          <div v-else class="voice"><ion-icon :icon="micOutline" /> Voice message</div>
+          <ion-icon v-if="p.kind === 'video'" class="play" :icon="playCircleOutline" />
+        </div>
+        <p v-if="p.body" class="body" @click="open(p.id)"><EmojiText :text="p.body" /></p>
+
+        <!-- Reactions: pills + a quick-react button opening the shared picker. -->
+        <div class="rrow">
+          <button
+            v-for="r in p.reactions"
+            :key="r.emoji"
+            class="rpill"
+            :class="{ mine: r.mine }"
+            @click="onReact(p, r.emoji)"
+          >
+            <Emoji :emoji="r.emoji" /><span class="rc">{{ r.count }}</span>
+          </button>
+          <button class="raddbtn" aria-label="React" @click="openPicker(p, $event)">
+            <ion-icon :icon="happyOutline" />
+          </button>
+        </div>
+
+        <!-- Comment preview: first comment → "view all" → last comment. -->
+        <div v-if="p.commentCount" class="cpreview">
+          <div class="crow">
+            <span class="cname">{{ p.comments[0].authorName }}</span>
+            <EmojiText :text="p.comments[0].text" />
+          </div>
+          <a v-if="p.commentCount > 2" class="more" @click="open(p.id)">
+            View all {{ p.commentCount }} comments
+          </a>
+          <div v-if="p.commentCount > 1" class="crow">
+            <span class="cname">{{ p.comments[p.commentCount - 1].authorName }}</span>
+            <EmojiText :text="p.comments[p.commentCount - 1].text" />
+          </div>
+        </div>
+
+        <!-- Quick comment from the feed. -->
+        <div class="cinput">
+          <ion-input
+            class="cfield"
+            :value="draft[p.id] || ''"
+            placeholder="Add a comment…"
+            @ion-input="onDraft(p.id, $event)"
+            @keyup.enter="sendComment(p)"
+          />
+          <ion-button size="small" fill="clear" :disabled="!(draft[p.id] || '').trim()" @click="sendComment(p)">
+            Post
+          </ion-button>
+        </div>
+      </ion-card>
     </ion-content>
   </ion-page>
 </template>
 
 <script setup lang="ts">
+import { reactive } from 'vue';
 import {
-  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton,
-  IonContent, IonList, IonItem, IonAvatar, IonLabel, IonIcon,
+  IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent,
+  IonCard, IonAvatar, IonIcon, IonInput, toastController,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
-import { createOutline, sparklesOutline, imageOutline, videocamOutline, micOutline, playCircleOutline } from 'ionicons/icons';
+import { createOutline, sparklesOutline, micOutline, playCircleOutline, happyOutline, timeOutline } from 'ionicons/icons';
+import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
-import { useWall } from '@/composables/useWall';
-import type { Post } from '@/db/types';
+import { useWall, type WallPost } from '@/composables/useWall';
+import { useReactionPicker } from '@/composables/useReactionPicker';
+import { reactToPost, commentOnPost, MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS } from '@/db/queries';
+import { timeLeft, ago } from '@/utils/post-time';
 
 const router = useRouter();
-const { wall } = useWall();
+const { wall, now } = useWall();
+const { openQuick } = useReactionPicker();
+const draft = reactive<Record<string, string>>({});
 
 function compose(): void {
   void router.push('/wall/compose');
@@ -85,20 +131,40 @@ function open(id: string): void {
 function initial(name: string): string {
   return (name.trim()[0] ?? '?').toUpperCase();
 }
-function kindIcon(kind: Post['kind']): string {
-  return kind === 'image' ? imageOutline : kind === 'video' ? videocamOutline : micOutline;
+const left = (p: WallPost): string => timeLeft(p.expiresAt, now.value);
+
+async function onReact(post: WallPost, emoji: string): Promise<void> {
+  const res = await reactToPost(post.id, emoji);
+  if (res === 'limit' || res === 'limit-emojis') {
+    const t = await toastController.create({
+      message:
+        res === 'limit-emojis'
+          ? `This post already has ${MAX_DISTINCT_REACTIONS} different reactions — tap one of those instead.`
+          : `You can add up to ${MAX_REACTIONS_PER_USER} reactions.`,
+      duration: 1600,
+      position: 'top',
+    });
+    await t.present();
+  }
 }
-function kindLabel(kind: Post['kind']): string {
-  return kind === 'image' ? 'Photo' : kind === 'video' ? 'Video' : kind === 'voice' ? 'Voice' : '';
+function openPicker(post: WallPost, ev: Event): void {
+  const existing = post.reactions.map((r) => r.emoji);
+  void openQuick(ev, {
+    myEmojis: post.myEmojis,
+    existing,
+    atEmojiCap: existing.length >= MAX_DISTINCT_REACTIONS,
+    onPick: (e) => onReact(post, e),
+  });
 }
-// Compact relative time ("now", "5m", "3h", "2d", else a date).
-function ago(ts: number): string {
-  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
-  if (s < 60) return 'now';
-  if (s < 3600) return `${Math.floor(s / 60)}m`;
-  if (s < 86400) return `${Math.floor(s / 3600)}h`;
-  if (s < 7 * 86400) return `${Math.floor(s / 86400)}d`;
-  return new Date(ts).toLocaleDateString();
+
+function onDraft(id: string, e: CustomEvent): void {
+  draft[id] = (e.detail as { value?: string | null }).value ?? '';
+}
+async function sendComment(post: WallPost): Promise<void> {
+  const t = (draft[post.id] || '').trim();
+  if (!t) return;
+  draft[post.id] = '';
+  await commentOnPost(post.id, t);
 }
 </script>
 
@@ -116,9 +182,20 @@ function ago(ts: number): string {
   font-size: 44px;
   color: var(--ion-color-primary);
 }
+.post {
+  margin: 12px;
+  border-radius: 16px;
+}
+.phead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px 8px;
+}
 .avatar {
   width: 40px;
   height: 40px;
+  cursor: pointer;
 }
 .avatar .ph {
   width: 100%;
@@ -130,63 +207,130 @@ function ago(ts: number): string {
   justify-content: center;
   font-weight: 600;
 }
-.post .head {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
+.who {
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
 }
-.post .name {
+.who .name {
   font-weight: 600;
 }
-.post .user,
-.post .time {
+.who .user {
   color: var(--ion-color-medium);
-  font-size: 13px;
+  font-weight: 400;
+  font-size: 14px;
 }
-.post .time {
-  margin-left: auto;
+.who .sub {
+  color: var(--ion-color-medium);
+  font-size: 12px;
 }
-.post .thumb {
+.countdown {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex: none;
+  font-size: 11px;
+  color: var(--ion-color-medium);
+  background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+  padding: 3px 8px;
+  border-radius: 999px;
+}
+.thumb {
   position: relative;
-  margin: 6px 0 2px;
-  max-width: 220px;
+  cursor: pointer;
 }
-.post .thumb img,
-.post .thumb video {
+.thumb img,
+.thumb video {
   width: 100%;
-  max-height: 220px;
-  border-radius: 12px;
+  max-height: 360px;
   object-fit: cover;
   display: block;
 }
-.post .thumb .voice {
+.thumb .voice {
   display: flex;
   align-items: center;
   gap: 6px;
+  padding: 14px;
   color: var(--ion-color-medium);
 }
-.post .thumb .play {
+.thumb .play {
   position: absolute;
   inset: 0;
   margin: auto;
-  font-size: 44px;
+  font-size: 52px;
   color: rgba(255, 255, 255, 0.92);
   filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.5));
 }
-.post .body {
-  margin: 2px 0 0;
+.body {
+  margin: 8px 14px;
   white-space: normal;
-  color: var(--ion-text-color);
+  cursor: pointer;
 }
-.post .kind {
-  vertical-align: -2px;
-  margin-right: 2px;
+.rrow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 12px 6px;
+}
+.rpill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  border-radius: 999px;
+  background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+  padding: 3px 9px;
+  font-size: 14px;
+  cursor: pointer;
+}
+.rpill.mine {
+  background: color-mix(in srgb, var(--ion-color-primary) 22%, transparent);
+}
+.rpill .rc {
   color: var(--ion-color-medium);
+  font-size: 12px;
 }
-.post .badge {
-  display: inline-block;
-  margin-top: 4px;
-  font-size: 11px;
-  color: var(--ion-color-primary);
+.raddbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 50%;
+  background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+  color: var(--ion-color-medium);
+  font-size: 18px;
+  cursor: pointer;
+}
+.cpreview {
+  padding: 2px 14px 4px;
+}
+.cpreview .crow {
+  font-size: 14px;
+  padding: 1px 0;
+}
+.cpreview .cname {
+  font-weight: 600;
+  margin-right: 6px;
+}
+.cpreview .more {
+  display: block;
+  color: var(--ion-color-medium);
+  font-size: 13px;
+  padding: 2px 0;
+  cursor: pointer;
+}
+.cinput {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px 8px 14px;
+}
+.cfield {
+  flex: 1;
+  --padding-start: 0;
+  font-size: 14px;
 }
 </style>

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -63,12 +63,34 @@
               </span>
             </div>
 
-            <!-- Media + body (tap → full post). -->
-            <div v-if="p.mediaUrl" class="thumb" @click="open(p.id)">
-              <img v-if="p.kind === 'image'" :src="p.mediaUrl" :alt="p.body || 'Photo'" />
-              <video v-else-if="p.kind === 'video'" :src="p.mediaUrl" muted playsinline preload="metadata" />
-              <div v-else class="voice"><ion-icon :icon="micOutline" /> Voice message</div>
-              <ion-icon v-if="p.kind === 'video'" class="play" :icon="playCircleOutline" />
+            <!-- Media + body (tap → full post). The image/video box reserves the
+                 media's aspect ratio with a skeleton so the feed doesn't jump as it
+                 decodes; a placeholder box also shows before the blob URL resolves. -->
+            <div
+              v-if="p.kind === 'image' || p.kind === 'video'"
+              class="thumb"
+              :class="{ loading: !mediaLoaded[p.id] }"
+              :style="mediaStyle(p)"
+              @click="open(p.id)"
+            >
+              <img
+                v-if="p.kind === 'image' && p.mediaUrl"
+                :src="p.mediaUrl"
+                :alt="p.body || 'Photo'"
+                @load="onMediaLoad(p.id)"
+              />
+              <video
+                v-else-if="p.kind === 'video' && p.mediaUrl"
+                :src="p.mediaUrl"
+                muted
+                playsinline
+                preload="metadata"
+                @loadeddata="onMediaLoad(p.id)"
+              />
+              <ion-icon v-if="p.kind === 'video' && p.mediaUrl" class="play" :icon="playCircleOutline" />
+            </div>
+            <div v-else-if="p.mediaUrl && p.kind === 'voice'" class="voice" @click="open(p.id)">
+              <ion-icon :icon="micOutline" /> Voice message
             </div>
             <p v-if="p.body" class="body" @click="open(p.id)"><EmojiText :text="p.body" /></p>
 
@@ -166,6 +188,16 @@ const router = useRouter();
 const { wall, now, loaded } = useWall();
 const { openQuick } = useReactionPicker();
 const draft = reactive<Record<string, string>>({});
+
+// Reserve the media's aspect ratio (fallback 4:3) so the card height is fixed before
+// the image/video decodes; track which have loaded to drop the skeleton shimmer.
+const mediaLoaded = reactive<Record<string, boolean>>({});
+function onMediaLoad(id: string): void {
+  mediaLoaded[id] = true;
+}
+function mediaStyle(p: WallPost): Record<string, string> {
+  return { aspectRatio: p.mediaW && p.mediaH ? `${p.mediaW} / ${p.mediaH}` : '4 / 3' };
+}
 
 // Search across a post's body, its comments, and the author's name/username.
 const search = ref('');
@@ -399,20 +431,38 @@ async function confirmDeletePost(post: WallPost): Promise<void> {
 .thumb {
   position: relative;
   cursor: pointer;
+  width: 100%;
+  max-height: 60vh;
+  overflow: hidden;
+  background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+}
+/* Skeleton shimmer while the media hasn't painted yet (box height is already
+   reserved by aspect-ratio, so nothing jumps when it loads). */
+.thumb.loading {
+  animation: thumb-pulse 1.4s ease-in-out infinite;
+}
+@keyframes thumb-pulse {
+  0%, 100% {
+    background-color: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+  }
+  50% {
+    background-color: var(--ion-color-step-200, rgba(120, 120, 128, 0.22));
+  }
 }
 .thumb img,
 .thumb video {
   width: 100%;
-  max-height: 360px;
+  height: 100%;
   object-fit: cover;
   display: block;
 }
-.thumb .voice {
+.voice {
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 14px;
   color: var(--ion-color-medium);
+  cursor: pointer;
 }
 .thumb .play {
   position: absolute;

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -4,10 +4,21 @@
       <ion-toolbar>
         <ion-title>Wall</ion-title>
         <ion-buttons slot="end">
+          <ion-button :aria-label="muted ? 'Wall notifications muted' : 'Mute Wall notifications'" @click="openMuteMenu">
+            <ion-icon slot="icon-only" :icon="muted ? notificationsOffOutline : notificationsOutline" />
+          </ion-button>
           <ion-button aria-label="New post" @click="compose">
             <ion-icon slot="icon-only" :icon="createOutline" />
           </ion-button>
         </ion-buttons>
+      </ion-toolbar>
+      <ion-toolbar>
+        <ion-searchbar
+          :value="search"
+          placeholder="Search posts, comments, people"
+          :debounce="150"
+          @ion-input="onSearch"
+        />
       </ion-toolbar>
     </ion-header>
 
@@ -18,13 +29,17 @@
         </ion-toolbar>
       </ion-header>
 
-      <div v-if="!wall.length" class="empty">
+      <div v-if="loaded && !wall.length" class="empty">
         <ion-icon :icon="sparklesOutline" />
         <p>No posts yet. Share a moment with your friends.</p>
         <ion-button fill="solid" @click="compose">New post</ion-button>
       </div>
 
-      <ion-card v-for="p in wall" :key="p.id" class="post">
+      <div v-if="loaded && wall.length && !filteredWall.length" class="empty">
+        <p>No posts match “{{ search }}”.</p>
+      </div>
+
+      <ion-card v-for="p in filteredWall" :key="p.id" class="post">
         <!-- Header: avatar + name + a subtle "disappears in …" countdown. -->
         <div class="phead">
           <ion-avatar class="avatar" @click="open(p.id)">
@@ -42,6 +57,9 @@
           <span v-if="left(p)" class="countdown" :title="'This post auto-deletes'">
             <ion-icon :icon="timeOutline" />{{ left(p) }}
           </span>
+          <button v-if="!p.isOwn" class="cardmenu" aria-label="Post options" @click.stop="openPostMenu(p)">
+            <ion-icon :icon="ellipsisVertical" />
+          </button>
         </div>
 
         <!-- Media + body (tap → full post). -->
@@ -103,24 +121,53 @@
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue';
+import { computed, reactive, ref, watch } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent,
-  IonCard, IonAvatar, IonIcon, IonInput, toastController,
+  IonCard, IonAvatar, IonIcon, IonInput, IonSearchbar, toastController, actionSheetController,
+  onIonViewWillEnter, onIonViewWillLeave,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
-import { createOutline, sparklesOutline, micOutline, playCircleOutline, happyOutline, timeOutline } from 'ionicons/icons';
+import {
+  createOutline, sparklesOutline, micOutline, playCircleOutline, happyOutline, timeOutline,
+  ellipsisVertical, notificationsOutline, notificationsOffOutline,
+} from 'ionicons/icons';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
 import { useWall, type WallPost } from '@/composables/useWall';
 import { useReactionPicker } from '@/composables/useReactionPicker';
-import { reactToPost, commentOnPost, MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS } from '@/db/queries';
+import {
+  reactToPost, commentOnPost, MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS,
+  markWallSeen, setWallMuteUntil, isWallTempMuted,
+  setWallUserMuted, setWallUserHidden, isWallUserMuted, isWallUserHidden,
+} from '@/db/queries';
 import { timeLeft, ago } from '@/utils/post-time';
 
 const router = useRouter();
-const { wall, now } = useWall();
+const { wall, now, loaded } = useWall();
 const { openQuick } = useReactionPicker();
 const draft = reactive<Record<string, string>>({});
+
+// Search across a post's body, its comments, and the author's name/username.
+const search = ref('');
+function onSearch(e: CustomEvent): void {
+  search.value = (e.detail as { value?: string | null }).value ?? '';
+}
+const filteredWall = computed(() => {
+  const q = search.value.trim().toLowerCase();
+  if (!q) return wall.value;
+  return wall.value.filter((p) => {
+    const hay = [
+      p.body ?? '',
+      p.authorName,
+      p.authorUsername ?? '',
+      ...p.comments.map((c) => `${c.text} ${c.authorName}`),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return hay.includes(q);
+  });
+});
 
 function compose(): void {
   void router.push('/wall/compose');
@@ -165,6 +212,72 @@ async function sendComment(post: WallPost): Promise<void> {
   if (!t) return;
   draft[post.id] = '';
   await commentOnPost(post.id, t);
+}
+
+// --- seen-tracking: clear the badge while the Wall is open (and as posts arrive) ---
+let active = false;
+const muted = ref(false);
+onIonViewWillEnter(async () => {
+  active = true;
+  await markWallSeen();
+  muted.value = await isWallTempMuted();
+});
+onIonViewWillLeave(() => {
+  active = false;
+});
+watch(
+  () => wall.value.length,
+  () => {
+    if (active) void markWallSeen();
+  },
+);
+
+// --- temporary mute of all Wall notifications ---
+function tomorrow9am(): number {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  d.setHours(9, 0, 0, 0);
+  return d.getTime();
+}
+async function openMuteMenu(): Promise<void> {
+  const buttons = [
+    { text: 'Mute for 1 hour', handler: () => void mute(Date.now() + 60 * 60_000) },
+    { text: 'Mute for 8 hours', handler: () => void mute(Date.now() + 8 * 60 * 60_000) },
+    { text: 'Mute until 9 AM tomorrow', handler: () => void mute(tomorrow9am()) },
+    { text: 'Mute until I turn it back on', handler: () => void mute(Number.MAX_SAFE_INTEGER) },
+  ];
+  if (muted.value) buttons.unshift({ text: 'Turn notifications back on', handler: () => void mute(0) });
+  const sheet = await actionSheetController.create({
+    header: 'Wall notifications',
+    buttons: [...buttons, { text: 'Cancel', role: 'cancel' }],
+  });
+  await sheet.present();
+}
+async function mute(until: number): Promise<void> {
+  await setWallMuteUntil(until);
+  muted.value = await isWallTempMuted();
+}
+
+// --- per-user mute / hide ---
+async function openPostMenu(post: WallPost): Promise<void> {
+  const [isMuted, isHidden] = [await isWallUserMuted(post.author), await isWallUserHidden(post.author)];
+  const name = post.authorName;
+  const sheet = await actionSheetController.create({
+    header: name,
+    buttons: [
+      {
+        text: isMuted ? `Unmute ${name}'s posts` : `Mute ${name}'s posts`,
+        handler: () => void setWallUserMuted(post.author, !isMuted),
+      },
+      {
+        text: isHidden ? `Unhide ${name}'s posts` : `Hide ${name}'s posts`,
+        role: isHidden ? undefined : 'destructive',
+        handler: () => void setWallUserHidden(post.author, !isHidden),
+      },
+      { text: 'Cancel', role: 'cancel' },
+    ],
+  });
+  await sheet.present();
 }
 </script>
 
@@ -234,6 +347,15 @@ async function sendComment(post: WallPost): Promise<void> {
   background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
   padding: 3px 8px;
   border-radius: 999px;
+}
+.cardmenu {
+  flex: none;
+  border: none;
+  background: none;
+  color: var(--ion-color-medium);
+  font-size: 20px;
+  padding: 2px 4px;
+  cursor: pointer;
 }
 .thumb {
   position: relative;

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -385,6 +385,18 @@ async function confirmDeletePost(post: WallPost): Promise<void> {
   background: var(--ion-card-background, var(--ion-item-background, #fff));
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
 }
+/* Swipe actions are shaped like the card they sit under: same 8px vertical inset and
+   16px corners, so as the card slides they're revealed from behind its edge as a
+   rounded pill rather than a full-height square button flush to the screen edge.
+   (The options are siblings of .postitem inside ion-item-sliding, not descendants.) */
+ion-item-sliding ion-item-option {
+  margin: 8px 6px;
+  border-radius: 16px;
+  --border-radius: 16px;
+  overflow: hidden;
+  font-weight: 600;
+  min-width: 76px;
+}
 .phead {
   display: flex;
   align-items: center;

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -39,83 +39,102 @@
         <p>No posts match “{{ search }}”.</p>
       </div>
 
-      <ion-card v-for="p in filteredWall" :key="p.id" class="post">
-        <!-- Header: avatar + name + a subtle "disappears in …" countdown. -->
-        <div class="phead">
-          <ion-avatar class="avatar" @click="open(p.id)">
-            <img v-if="p.authorAvatar" :src="p.authorAvatar" :alt="p.authorName" />
-            <div v-else class="ph">{{ initial(p.authorName) }}</div>
-          </ion-avatar>
-          <div class="who" @click="open(p.id)">
-            <div class="name">
-              {{ p.authorName }}<span v-if="p.authorUsername" class="user"> @{{ p.authorUsername }}</span>
+      <!-- Each post is a sliding item: swipe LEFT to delete your own post (or hide
+           someone else's), swipe RIGHT to mute/unmute their Wall notifications. -->
+      <ion-item-sliding v-for="p in filteredWall" :key="p.id">
+        <ion-item lines="none" class="postitem">
+          <div class="post">
+            <!-- Header: avatar + name + a subtle "disappears in …" countdown. -->
+            <div class="phead">
+              <ion-avatar class="avatar" @click="open(p.id)">
+                <img v-if="p.authorAvatar" :src="p.authorAvatar" :alt="p.authorName" />
+                <div v-else class="ph">{{ initial(p.authorName) }}</div>
+              </ion-avatar>
+              <div class="who" @click="open(p.id)">
+                <div class="name">
+                  {{ p.authorName }}<span v-if="p.authorUsername" class="user"> @{{ p.authorUsername }}</span>
+                </div>
+                <div class="sub">
+                  {{ ago(p.createdAt, now) }}<span v-if="p.audience === 'close'"> · Close friends</span><span v-if="p.muted"> · Muted</span>
+                </div>
+              </div>
+              <span v-if="left(p)" class="countdown" :title="'This post auto-deletes'">
+                <ion-icon :icon="timeOutline" />{{ left(p) }}
+              </span>
             </div>
-            <div class="sub">
-              {{ ago(p.createdAt, now) }}<span v-if="p.audience === 'close'"> · Close friends</span>
+
+            <!-- Media + body (tap → full post). -->
+            <div v-if="p.mediaUrl" class="thumb" @click="open(p.id)">
+              <img v-if="p.kind === 'image'" :src="p.mediaUrl" :alt="p.body || 'Photo'" />
+              <video v-else-if="p.kind === 'video'" :src="p.mediaUrl" muted playsinline preload="metadata" />
+              <div v-else class="voice"><ion-icon :icon="micOutline" /> Voice message</div>
+              <ion-icon v-if="p.kind === 'video'" class="play" :icon="playCircleOutline" />
+            </div>
+            <p v-if="p.body" class="body" @click="open(p.id)"><EmojiText :text="p.body" /></p>
+
+            <!-- Reactions: pills + a quick-react button opening the shared picker. -->
+            <div class="rrow">
+              <button
+                v-for="r in p.reactions"
+                :key="r.emoji"
+                class="rpill"
+                :class="{ mine: r.mine }"
+                @click="onReact(p, r.emoji)"
+              >
+                <Emoji :emoji="r.emoji" /><span class="rc">{{ r.count }}</span>
+              </button>
+              <button class="raddbtn" aria-label="React" @click="openPicker(p, $event)">
+                <ion-icon :icon="happyOutline" />
+              </button>
+            </div>
+
+            <!-- Comment preview: first comment → "view all" → last comment (with avatars). -->
+            <div v-if="p.commentCount" class="cpreview">
+              <div class="crow">
+                <ion-avatar class="cmini">
+                  <img v-if="p.comments[0].authorAvatar" :src="p.comments[0].authorAvatar" :alt="p.comments[0].authorName" />
+                  <div v-else class="ph">{{ initial(p.comments[0].authorName) }}</div>
+                </ion-avatar>
+                <span class="cname">{{ p.comments[0].authorName }}</span>
+                <EmojiText :text="p.comments[0].text" />
+              </div>
+              <a v-if="p.commentCount > 2" class="more" @click="open(p.id)">
+                View all {{ p.commentCount }} comments
+              </a>
+              <div v-if="p.commentCount > 1" class="crow">
+                <ion-avatar class="cmini">
+                  <img v-if="p.comments[p.commentCount - 1].authorAvatar" :src="p.comments[p.commentCount - 1].authorAvatar" :alt="p.comments[p.commentCount - 1].authorName" />
+                  <div v-else class="ph">{{ initial(p.comments[p.commentCount - 1].authorName) }}</div>
+                </ion-avatar>
+                <span class="cname">{{ p.comments[p.commentCount - 1].authorName }}</span>
+                <EmojiText :text="p.comments[p.commentCount - 1].text" />
+              </div>
+            </div>
+
+            <!-- Quick comment from the feed. -->
+            <div class="cinput">
+              <ion-input
+                class="cfield"
+                :value="draft[p.id] || ''"
+                placeholder="Add a comment…"
+                @ion-input="onDraft(p.id, $event)"
+                @keyup.enter="sendComment(p)"
+              />
+              <ion-button size="small" fill="clear" :disabled="!(draft[p.id] || '').trim()" @click="sendComment(p)">
+                Post
+              </ion-button>
             </div>
           </div>
-          <span v-if="left(p)" class="countdown" :title="'This post auto-deletes'">
-            <ion-icon :icon="timeOutline" />{{ left(p) }}
-          </span>
-          <button v-if="!p.isOwn" class="cardmenu" aria-label="Post options" @click.stop="openPostMenu(p)">
-            <ion-icon :icon="ellipsisVertical" />
-          </button>
-        </div>
+        </ion-item>
 
-        <!-- Media + body (tap → full post). -->
-        <div v-if="p.mediaUrl" class="thumb" @click="open(p.id)">
-          <img v-if="p.kind === 'image'" :src="p.mediaUrl" :alt="p.body || 'Photo'" />
-          <video v-else-if="p.kind === 'video'" :src="p.mediaUrl" muted playsinline preload="metadata" />
-          <div v-else class="voice"><ion-icon :icon="micOutline" /> Voice message</div>
-          <ion-icon v-if="p.kind === 'video'" class="play" :icon="playCircleOutline" />
-        </div>
-        <p v-if="p.body" class="body" @click="open(p.id)"><EmojiText :text="p.body" /></p>
-
-        <!-- Reactions: pills + a quick-react button opening the shared picker. -->
-        <div class="rrow">
-          <button
-            v-for="r in p.reactions"
-            :key="r.emoji"
-            class="rpill"
-            :class="{ mine: r.mine }"
-            @click="onReact(p, r.emoji)"
-          >
-            <Emoji :emoji="r.emoji" /><span class="rc">{{ r.count }}</span>
-          </button>
-          <button class="raddbtn" aria-label="React" @click="openPicker(p, $event)">
-            <ion-icon :icon="happyOutline" />
-          </button>
-        </div>
-
-        <!-- Comment preview: first comment → "view all" → last comment. -->
-        <div v-if="p.commentCount" class="cpreview">
-          <div class="crow">
-            <span class="cname">{{ p.comments[0].authorName }}</span>
-            <EmojiText :text="p.comments[0].text" />
-          </div>
-          <a v-if="p.commentCount > 2" class="more" @click="open(p.id)">
-            View all {{ p.commentCount }} comments
-          </a>
-          <div v-if="p.commentCount > 1" class="crow">
-            <span class="cname">{{ p.comments[p.commentCount - 1].authorName }}</span>
-            <EmojiText :text="p.comments[p.commentCount - 1].text" />
-          </div>
-        </div>
-
-        <!-- Quick comment from the feed. -->
-        <div class="cinput">
-          <ion-input
-            class="cfield"
-            :value="draft[p.id] || ''"
-            placeholder="Add a comment…"
-            @ion-input="onDraft(p.id, $event)"
-            @keyup.enter="sendComment(p)"
-          />
-          <ion-button size="small" fill="clear" :disabled="!(draft[p.id] || '').trim()" @click="sendComment(p)">
-            Post
-          </ion-button>
-        </div>
-      </ion-card>
+        <ion-item-options v-if="!p.isOwn" side="start">
+          <ion-item-option color="medium" @click="toggleMute(p)">{{ p.muted ? 'Unmute' : 'Mute' }}</ion-item-option>
+        </ion-item-options>
+        <ion-item-options side="end">
+          <ion-item-option v-if="p.isOwn" color="danger" @click="confirmDeletePost(p)">Delete</ion-item-option>
+          <ion-item-option v-else color="dark" @click="hideUser(p)">Hide</ion-item-option>
+        </ion-item-options>
+      </ion-item-sliding>
     </ion-content>
   </ion-page>
 </template>
@@ -124,22 +143,22 @@
 import { computed, reactive, ref, watch } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent,
-  IonCard, IonAvatar, IonIcon, IonInput, IonSearchbar, toastController, actionSheetController,
+  IonItem, IonItemSliding, IonItemOption, IonItemOptions, IonAvatar, IonIcon, IonInput, IonSearchbar,
+  toastController, actionSheetController, alertController,
   onIonViewWillEnter, onIonViewWillLeave,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
 import {
   createOutline, sparklesOutline, micOutline, playCircleOutline, happyOutline, timeOutline,
-  ellipsisVertical, notificationsOutline, notificationsOffOutline,
+  notificationsOutline, notificationsOffOutline,
 } from 'ionicons/icons';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
 import { useWall, type WallPost } from '@/composables/useWall';
 import { useReactionPicker } from '@/composables/useReactionPicker';
 import {
-  reactToPost, commentOnPost, MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS,
-  markWallSeen, setWallMuteUntil, isWallTempMuted,
-  setWallUserMuted, setWallUserHidden, isWallUserMuted, isWallUserHidden,
+  reactToPost, commentOnPost, deletePost, MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS,
+  markWallSeen, setWallMuteUntil, isWallTempMuted, setWallUserMuted, setWallUserHidden,
 } from '@/db/queries';
 import { timeLeft, ago } from '@/utils/post-time';
 
@@ -262,26 +281,39 @@ async function mute(until: number): Promise<void> {
   muted.value = await isWallTempMuted();
 }
 
-// --- per-user mute / hide ---
-async function openPostMenu(post: WallPost): Promise<void> {
-  const [isMuted, isHidden] = [await isWallUserMuted(post.author), await isWallUserHidden(post.author)];
-  const name = post.authorName;
-  const sheet = await actionSheetController.create({
-    header: name,
+// --- per-user mute / hide (swipe-right = mute, swipe-left = hide) ---
+async function toggleMute(post: WallPost): Promise<void> {
+  await setWallUserMuted(post.author, !post.muted);
+  const t = await toastController.create({
+    message: post.muted ? `Unmuted ${post.authorName}` : `Muted ${post.authorName}'s Wall notifications`,
+    duration: 1400,
+    position: 'top',
+  });
+  await t.present();
+}
+async function hideUser(post: WallPost): Promise<void> {
+  await setWallUserHidden(post.author, true);
+  const t = await toastController.create({
+    message: `Hid ${post.authorName}'s posts. Undo from the bell menu.`,
+    duration: 1800,
+    position: 'top',
+  });
+  await t.present();
+}
+
+// --- delete your own post (swipe-left, with confirmation) ---
+async function confirmDeletePost(post: WallPost): Promise<void> {
+  const a = await alertController.create({
+    header: 'Delete post',
+    message:
+      'This removes the post for you and signals your audience to remove their copies. ' +
+      'Copies already downloaded can’t be guaranteed to disappear.',
     buttons: [
-      {
-        text: isMuted ? `Unmute ${name}'s posts` : `Mute ${name}'s posts`,
-        handler: () => void setWallUserMuted(post.author, !isMuted),
-      },
-      {
-        text: isHidden ? `Unhide ${name}'s posts` : `Hide ${name}'s posts`,
-        role: isHidden ? undefined : 'destructive',
-        handler: () => void setWallUserHidden(post.author, !isHidden),
-      },
       { text: 'Cancel', role: 'cancel' },
+      { text: 'Delete', role: 'destructive', handler: () => void deletePost(post.id) },
     ],
   });
-  await sheet.present();
+  await a.present();
 }
 </script>
 
@@ -299,9 +331,21 @@ async function openPostMenu(post: WallPost): Promise<void> {
   font-size: 44px;
   color: var(--ion-color-primary);
 }
+/* The sliding wrapper hosts a card-styled div in a transparent, padding-free item. */
+.postitem {
+  --background: transparent;
+  --padding-start: 12px;
+  --inner-padding-end: 12px;
+  --border-width: 0;
+  --min-height: 0;
+}
 .post {
-  margin: 12px;
+  width: 100%;
+  margin: 8px 0;
   border-radius: 16px;
+  overflow: hidden;
+  background: var(--ion-card-background, var(--ion-item-background, #fff));
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
 }
 .phead {
   display: flex;
@@ -351,15 +395,6 @@ async function openPostMenu(post: WallPost): Promise<void> {
   background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
   padding: 3px 8px;
   border-radius: 999px;
-}
-.cardmenu {
-  flex: none;
-  border: none;
-  background: none;
-  color: var(--ion-color-medium);
-  font-size: 20px;
-  padding: 2px 4px;
-  cursor: pointer;
 }
 .thumb {
   position: relative;
@@ -434,12 +469,30 @@ async function openPostMenu(post: WallPost): Promise<void> {
   padding: 2px 14px 4px;
 }
 .cpreview .crow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-size: 14px;
-  padding: 1px 0;
+  padding: 2px 0;
+}
+.cpreview .cmini {
+  width: 20px;
+  height: 20px;
+  flex: none;
+}
+.cpreview .cmini .ph {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--ion-color-step-150, rgba(120, 120, 128, 0.2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 10px;
 }
 .cpreview .cname {
   font-weight: 600;
-  margin-right: 6px;
 }
 .cpreview .more {
   display: block;

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -135,12 +135,17 @@
 
             <!-- Quick comment from the feed. -->
             <div class="cinput">
-              <ion-input
+              <ion-textarea
+                v-enter-send="() => sendComment(p)"
                 class="cfield"
-                :value="draft[p.id] || ''"
+                :auto-grow="true"
+                :rows="1"
                 placeholder="Add a comment…"
+                autocapitalize="sentences"
+                :spellcheck="true"
+                dir="auto"
+                :value="draft[p.id] || ''"
                 @ion-input="onDraft(p.id, $event)"
-                @keyup.enter="sendComment(p)"
               />
               <ion-button size="small" fill="clear" :disabled="!(draft[p.id] || '').trim()" @click="sendComment(p)">
                 Post
@@ -165,7 +170,7 @@
 import { computed, reactive, ref, watch } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent,
-  IonItem, IonItemSliding, IonItemOption, IonItemOptions, IonAvatar, IonIcon, IonInput, IonSearchbar,
+  IonItem, IonItemSliding, IonItemOption, IonItemOptions, IonAvatar, IonIcon, IonTextarea, IonSearchbar,
   toastController, actionSheetController, alertController,
   onIonViewWillEnter, onIonViewWillLeave,
 } from '@ionic/vue';
@@ -176,6 +181,7 @@ import {
 } from 'ionicons/icons';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
+import { vEnterSend } from '@/directives/enter-send';
 import { useWall, type WallPost } from '@/composables/useWall';
 import { useReactionPicker } from '@/composables/useReactionPicker';
 import {


### PR DESCRIPTION
Implements **spec 0003 — zero-knowledge social Wall**, plus the follow-on polish and the version-announcement push requested on top of it. The whole feature keeps Ring's zero-knowledge boundary intact: the server only ever stores/relays opaque ciphertext + per-recipient wrapped-key envelopes + coarse routing metadata, never post/media/reaction/comment plaintext, the audience tier, or the close-friends subset.

## What's in it

**Wall core (US1–US7)**
- Friend-request handshake (request / accept / decline / cancel + block interplay); `listFriends` drives the "all friends" audience.
- Compose **text / image / video / voice** posts with a per-post audience (all friends / close friends) and 1h / 24h / 72h lifetime — hard-capped at 72h on both client and server.
- Per-post `K_post` content key, ECIES-wrapped per recipient over the existing session; media keys sealed inside the payload; SD/HD-only media.
- Wall feed (activity-sorted, countdowns, owner header), inline quick-react + quick-comment, reaction caps (3/user, 5 distinct), audience-visible reactions + comments with avatars, author-only view receipts (seen-receipts gated), keep-alive.
- Close-friends list (search + a distinguishable top section), per-user mute/hide + a "Hidden & muted" restore screen, temporary mute (1h/24h/9AM/manual), post search, Wall bottom tab + badges, configurable notifications.

**This session's additions**
- **Close-friend revocation**: removing someone from close friends revokes your close-only posts from them (server drops their envelope + records a revocation; their device prunes the local copy live or on next sync).
- **Voice posts** recordable from the composer (the 4th spec post type).
- **FR-007 / FR-008 anti-abuse limits**: declined-request cooldown; per-author post / per-user engagement / per-post comment rate caps (429), enforced on routing metadata only.
- **Swipe actions** restyled to match the card/row and occlude cleanly on slide-back.
- **Desktop Enter-to-send** in the chat composer (Shift+Enter = newline).
- **Human-friendly "What's new"**: the update toast/sheet now filter out dev-noise commits (ci/docs/test/chore/…) and strip trailing spec/PR refs.
- **Version-announcement push**: on a version change the server broadcasts a content-free `{"t":"version"}` tickle to every subscription; the SW renders a friendly "Ring X — what's new" from the public `/v1/config` (or nudges an open app to surface the in-app update toast). Deduped via a new `app_meta` table; the first deploy of this feature records a baseline **without** broadcasting (no blast on rollout); `dev` builds never announce.

## Zero-knowledge posture
Every push stays content-free `{"t":…}`; engagement is sealed under `K_post`; the close-friend flag and per-post audience never cross the wire; the version push reads only the public, non-secret `/v1/config`.

## Verification
- Server: `go build` / `go vet` / `go test ./...` green (incl. new revocation, rate-limit, and version-broadcast tests).
- Client: `vue-tsc` typecheck + `vite build` clean; vitest suite 242 green.
- Drive scenarios: close-friend revocation, voice-post create→render, swipe-action styling, desktop Enter-to-send.

## Known follow-ups (intentionally not in this PR)
- T015 — Playwright e2e for the friend-request accept/decline/block flow (behavior works; no e2e yet).
- A per-user opt-out for the version announcement (needs server-side state; the push is `userVisibleOnly`, so it can't be suppressed purely client-side).

Implements the spec 0003 task issues (#250–#312); the two items above remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)