### PR TITLE
fix(wall): notification behavior — in-app when open, reactions don't wake devices (+ flaky test, toast restyle)

### DIFF
--- a/e2e/tab-transitions.spec.ts
+++ b/e2e/tab-transitions.spec.ts
@@ -81,6 +81,15 @@ test.describe('tab transitions', () => {
     const a = await createAccount(ctx, 'TABTRAN4');
     await a.page.evaluate((av) => (window as any).__ringTest.setProfile('Speedy', av), AVATAR);
 
+    // Warm the account first: prove the identity renders on Settings from LOCAL data,
+    // so the rapid-switch assertion below isolates "does fast switching leave the tab
+    // fully rendered" rather than racing a cold first-paint against the account's
+    // initial sync. The profile is local, but on a loaded CI runner a thrashing event
+    // loop (parallel contexts retrying failed network calls) could otherwise delay that
+    // very first Settings paint past the assertion timeout — the source of the flake.
+    await a.page.goto('/tabs/settings');
+    await expect(a.page.getByText('Speedy')).toBeVisible({ timeout: 30_000 });
+
     await a.page.goto('/tabs/chats');
     await tabBtn(a.page, 'Calls').waitFor({ state: 'visible', timeout: 30_000 });
 
@@ -89,7 +98,8 @@ test.describe('tab transitions', () => {
       await tabBtn(a.page, t).click();
     }
     // After the burst, the last tab (Settings) must be fully rendered, not stuck
-    // in a placeholder/partial state.
+    // in a placeholder/partial state (the identity is already warm from above, so this
+    // is purely a rendering-under-fast-switching check).
     await a.page.waitForURL('**/tabs/settings');
     await expect(a.page.getByText('Speedy')).toBeVisible();
 

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -311,8 +311,13 @@ func (h *Handlers) submitEngagement(w http.ResponseWriter, r *http.Request) {
 					h.Hub.Send(u, b)
 				}
 			}
+			// Wall engagement is a WALL event, so wake offline devices with the POST
+			// tickle, NOT the message tickle: the service worker's post handler suppresses
+			// the system notification whenever a window client exists (so an in-app user
+			// only gets the live in-app update, never a web-push), and a closed device
+			// shows the Wall notification — not a mislabeled "New message".
 			if h.Notifier != nil {
-				h.Notifier.Notify(r.Context(), u)
+				h.Notifier.NotifyPost(r.Context(), u)
 			}
 		}
 	}

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -306,17 +306,22 @@ func (h *Handlers) submitEngagement(w http.ResponseWriter, r *http.Request) {
 			if u == uid {
 				continue
 			}
+			// The content-free WS nudge fires for ALL engagement (live reconciliation —
+			// a reaction appearing/disappearing must reach online viewers immediately).
 			if h.Hub != nil {
 				if b, e := json.Marshal(map[string]any{"t": "post-engagement", "post": postID}); e == nil {
 					h.Hub.Send(u, b)
 				}
 			}
-			// Wall engagement is a WALL event, so wake offline devices with the POST
-			// tickle, NOT the message tickle: the service worker's post handler suppresses
-			// the system notification whenever a window client exists (so an in-app user
-			// only gets the live in-app update, never a web-push), and a closed device
-			// shows the Wall notification — not a mislabeled "New message".
-			if h.Notifier != nil {
+			// A web push (which can WAKE an offline device) fires ONLY for a new comment.
+			// Reactions (add AND remove) and comment tombstones sync live but never wake a
+			// device — removing a reaction or deleting a comment isn't worth a notification,
+			// and the server can't tell an add from a remove anyway (the `remove` flag is
+			// sealed under K_post), so gating on the unsealed `kind` is the zero-knowledge-
+			// clean way to silence them. It's a WALL event, so use the POST tickle (the SW
+			// suppresses the system notification when a window client exists, and a closed
+			// device shows the Wall notification — not a mislabeled "New message").
+			if h.Notifier != nil && req.Kind == "comment" {
 				h.Notifier.NotifyPost(r.Context(), u)
 			}
 		}

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -5,11 +5,48 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 
 	"ring/server/internal/store"
 	"ring/server/internal/ws"
 )
+
+// recordingNotifier records who was woken via NotifyPost, so a test can assert which
+// engagement actually wakes a device (vs. only syncing live).
+type recordingNotifier struct {
+	mu    sync.Mutex
+	posts []string
+}
+
+func (n *recordingNotifier) Notify(context.Context, string)     {}
+func (n *recordingNotifier) NotifyCall(context.Context, string) {}
+func (n *recordingNotifier) NotifyConn(context.Context, string) {}
+func (n *recordingNotifier) NotifyPost(_ context.Context, userID string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.posts = append(n.posts, userID)
+}
+func (n *recordingNotifier) postPushCount() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.posts)
+}
+func (n *recordingNotifier) pushedTo(userID string) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for _, u := range n.posts {
+		if u == userID {
+			return true
+		}
+	}
+	return false
+}
+func (n *recordingNotifier) reset() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.posts = nil
+}
 
 // fakePostConn is a ConnectionStore whose Connected() answers from an explicit
 // friendship set, so post-audience authorization can be exercised.
@@ -194,10 +231,16 @@ func (f *fakePostStore) RecentCommentCount(_ context.Context, postID, actor stri
 }
 
 func newPostTestServer(conn ConnectionStore, posts PostStore) http.Handler {
+	return newPostTestServerN(conn, posts, nil)
+}
+
+// newPostTestServerN is newPostTestServer with an injectable Notifier, so a test can
+// assert which engagement wakes an offline device (NotifyPost).
+func newPostTestServerN(conn ConnectionStore, posts PostStore, notifier ws.Notifier) http.Handler {
 	as := newFakeStore()
 	return NewRouter(&Handlers{
 		Store: as, Directory: as, Contacts: as, Blocks: as, Relay: as,
-		Connections: conn, Posts: posts, Hub: ws.NewHub(),
+		Connections: conn, Posts: posts, Hub: ws.NewHub(), Notifier: notifier,
 		Keys: newFakeKeysStore(), Blobs: newFakeBlobStore(), Sync: newFakeSyncStore(),
 		Push: newFakePushStore(), Invites: as,
 		PublicURL: "https://ring.example", VapidPublicKey: "VAPID_PUB",
@@ -535,5 +578,48 @@ func TestCommentRateLimitedPerPost(t *testing.T) {
 	eng := `{"id":"` + pid(3, maxCommentsPerPostWindow) + `","kind":"comment","payload":"SEALED"}`
 	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, eng); rr.Code != http.StatusTooManyRequests {
 		t.Fatalf("over-cap comment status = %d, want 429; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestReactionDoesNotPushButCommentDoes: a reaction (add OR remove) syncs live but
+// never wakes a device; only a new comment fires a web push to the audience. The server
+// can't see add-vs-remove (sealed under K_post), so it gates on the unsealed kind.
+func TestReactionDoesNotPushButCommentDoes(t *testing.T) {
+	conn := newFakePostConn()
+	notif := &recordingNotifier{}
+	srv := newPostTestServerN(conn, newFakePostStore(), notif)
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	body := `{"id":"` + postID + `","blobId":"cap","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	// A brand-new post DOES push its audience; clear the recorder to isolate engagement.
+	if !notif.pushedTo(bobID) {
+		t.Fatalf("expected the new post to push the audience (bob)")
+	}
+	notif.reset()
+
+	// Bob reacts → the audience syncs live but NO device is woken.
+	react := `{"id":"22222222-2222-2222-2222-222222222222","kind":"reaction","payload":"SEALED"}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, react); rr.Code != http.StatusCreated {
+		t.Fatalf("react status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if n := notif.postPushCount(); n != 0 {
+		t.Errorf("reaction pushed %d device(s); want 0 (reactions never wake a device)", n)
+	}
+
+	// Bob comments → the post author (alice) IS pushed; the actor (bob) never is.
+	comment := `{"id":"33333333-3333-3333-3333-333333333333","kind":"comment","payload":"SEALED"}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, comment); rr.Code != http.StatusCreated {
+		t.Fatalf("comment status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if !notif.pushedTo(aliceID) {
+		t.Errorf("expected the comment to push the post author (alice)")
+	}
+	if notif.pushedTo(bobID) {
+		t.Errorf("a comment must not push its own author (bob)")
 	}
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -273,14 +273,25 @@ body.keyboard-open ion-footer {
   overflow: hidden;
 }
 
-/* The "update available" toast surfaces at the top with the rest of the app's
-   notifications (Ionic's top toasts already clear the safe-area inset). Styled
-   like the in-app notification banners: neutral dark, white text reads in both
-   themes. */
+/* The "update available" toast is styled to MATCH the in-app notification banners
+   (NotificationBanners.vue), so every in-app notification + toast shares one look:
+   the brand-green translucent card with blur, white text, 18px corners, sitting just
+   below the app header (same safe-area + 56px offset as the banner stack) rather than
+   pinned to the very top. */
 ion-toast.app-update-toast {
-  --background: #2c2c30;
+  --background: rgba(var(--ion-color-primary-rgb, 16, 185, 129), 0.9);
   --color: #fff;
-  --border-radius: 14px;
+  --border-radius: 18px;
+  --max-width: 560px;
+  --box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22);
+  --button-color: #fff;
+}
+/* Push the box below the header and give it the banner's frosted blur. (The visible
+   box is the `container` part; offsetting it lines the toast up with the banners.) */
+ion-toast.app-update-toast::part(container) {
+  margin-top: calc(env(safe-area-inset-top, 0px) + 56px);
+  backdrop-filter: blur(18px) saturate(160%);
+  -webkit-backdrop-filter: blur(18px) saturate(160%);
 }
 /* Defensive: never let a long unbreakable token (e.g. a version with a git sha)
    wrap one character per line and blow up the toast. */
@@ -289,5 +300,14 @@ ion-toast.app-update-toast::part(message) {
 }
 ion-toast.app-update-toast::part(button) {
   color: #fff;
+}
+ion-toast.app-update-toast::part(icon) {
+  color: #fff;
+}
+/* Match the banners' slightly stronger fill in dark mode. */
+@media (prefers-color-scheme: dark) {
+  ion-toast.app-update-toast {
+    --background: rgba(var(--ion-color-primary-rgb, 16, 185, 129), 0.95);
+  }
 }
 </style>

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -20,6 +20,7 @@
 import { watch } from 'vue';
 import { useRegisterSW } from 'virtual:pwa-register/vue';
 import { toastController, modalController } from '@ionic/vue';
+import { sparklesOutline } from 'ionicons/icons';
 import { fetchServerConfig } from '@/services/api';
 import { computeDelta, userFacing, displayVersion, type ReleaseNote } from '@/services/release-notes';
 import WhatsNewSheet from '@/components/WhatsNewSheet.vue';
@@ -131,6 +132,8 @@ export function useAppUpdate(): void {
     const toast = await toastController.create({
       header: 'Update available',
       message: label,
+      icon: sparklesOutline, // leading glyph, matching the in-app banners' icon/avatar
+
       // Top of the screen, where every other notification (banners, error
       // toasts) surfaces; see the .app-update-toast rules in App.vue.
       position: 'top',

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -191,12 +191,14 @@ async function showVersionNotification(): Promise<void> {
   });
 }
 
-/** Generic, identity-safe notification for a new Wall post (spec 0003). Shown only
- *  when the app is closed; a live page shows the rich "X shared a photo" banner via
- *  the post-new WS frame, so the SW stays silent there to avoid a duplicate. */
+/** Generic, identity-safe notification for Wall activity — a new post OR engagement
+ *  (reaction/comment), which share the one content-free post tickle. Shown only when the
+ *  app is closed; a live page shows the rich in-app banner / live update via the WS
+ *  frame, so the SW stays silent there to avoid a duplicate. "Activity" rather than
+ *  "post" so it reads honestly for a reaction/comment too. */
 async function showPostNotification(): Promise<void> {
   await self.registration.showNotification('Ring', {
-    body: 'New post on your Wall',
+    body: 'New activity on your Wall',
     icon: ICON,
     badge: ICON,
     tag: 'ring:post',


### PR DESCRIPTION
Follow-up fixes after the Wall (spec 0003) merge, all touching how Wall activity notifies.

## Changes
- **Engagement stays in-app when you're online.** Wall engagement was waking offline devices with the generic *message* tickle, so a reaction on a post you can see could surface a "New message" web-push even while you were in the app (the SW message path never gets claimed by a non-message page), and mislabeled it when closed. Route engagement through `NotifyPost` so the SW post handler suppresses the system notification whenever a window client exists (in-app users get only the live update) and a closed device shows the Wall notification.
- **Reactions never wake a device — push only for new comments.** Removing a reaction (or deleting a comment) shouldn't notify anyone, but the server pushed for *every* engagement, including reaction removals. The `remove` flag is sealed under `K_post`, so the server can't tell add from remove — it gates on the unsealed `kind` instead: a new **comment** wakes the audience; reactions (add **and** remove) and comment tombstones only fan out the live WS sync frame (so they appear/disappear for online viewers) and never wake a device. Zero-knowledge-clean, server-only.
- **Hardened the flaky `tab transitions › rapid tab switching` e2e** (the one that bit develop CI): it coupled the render check with a cold first-paint of Settings that raced the account's initial sync — on a loaded runner that first paint could lag past 20s. Warm Settings once (proving the identity loads from local data), then do the burst and assert it stays rendered. Verified locally under induced sync-fetch failures.
- **Restyled the update toast to match the in-app banners** (chosen direction): the "update available" / version toast now uses the same brand-green translucent card, blur, 18px corners, leading icon, and below-the-header position as the activity banners, so every in-app notification + toast shares one look.

## Verification
- `go build` / `go vet` / `go test ./...` green, incl. new `TestReactionDoesNotPushButCommentDoes` (reaction → 0 pushes; comment → audience pushed, never the actor).
- `vue-tsc` + `vite build` clean; the hardened `tab-transitions` spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)