### PR TITLE
test(e2e): end-to-end coverage for the Wall (spec 0003)

### DIFF
--- a/e2e/wall.spec.ts
+++ b/e2e/wall.spec.ts
@@ -1,0 +1,207 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair, type RingClient } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Zero-Knowledge Social Wall (spec 0003) end-to-end. Drives real accounts through the
+ * ACTUAL encrypt → upload → fan-out → receive/open path (via __ringTest, which calls the
+ * same queries.ts orchestration the UI does), so these exercise behavior, not shortcuts.
+ *
+ * Coverage (closes the spec's e2e tasks): audience delivery + isolation (US2/US3),
+ * audience-visible reactions with reactor identity (US4), comments + moderation (US6),
+ * the close-friends audience + un-close-friend revocation (US5), and author-only view
+ * receipts with seen-receipts reciprocity (US7).
+ */
+
+const post = (c: RingClient, opts: { body?: string; audience?: 'friends' | 'close'; lifetime?: '1h' | '24h' | '72h' }): Promise<string> =>
+  c.page.evaluate((o) => (window as any).__ringTest.post(o), opts);
+const syncPosts = (c: RingClient): Promise<void> => c.page.evaluate(() => (window as any).__ringTest.syncPosts());
+const wallIds = (c: RingClient): Promise<string[]> => c.page.evaluate(() => (window as any).__ringTest.wallPostIds());
+const getPost = (c: RingClient, id: string): Promise<any> => c.page.evaluate((i) => (window as any).__ringTest.getPost(i), id);
+const react = (c: RingClient, id: string, emoji: string): Promise<string> =>
+  c.page.evaluate(([i, e]) => (window as any).__ringTest.reactToPost(i, e), [id, emoji]);
+const syncEng = (c: RingClient, id: string): Promise<void> => c.page.evaluate((i) => (window as any).__ringTest.syncEngagement(i), id);
+const reactions = (c: RingClient, id: string): Promise<{ actor: string; emoji: string }[]> =>
+  c.page.evaluate((i) => (window as any).__ringTest.postReactions(i), id);
+const comment = (c: RingClient, id: string, text: string): Promise<void> =>
+  c.page.evaluate(([i, t]) => (window as any).__ringTest.commentOnPost(i, t), [id, text]);
+const comments = (c: RingClient, id: string): Promise<{ id: string; actor: string; text: string; deleted: boolean }[]> =>
+  c.page.evaluate((i) => (window as any).__ringTest.postComments(i), id);
+const delComment = (c: RingClient, id: string, cid: string): Promise<void> =>
+  c.page.evaluate(([i, x]) => (window as any).__ringTest.deletePostComment(i, x), [id, cid]);
+const recordView = (c: RingClient, id: string): Promise<void> => c.page.evaluate((i) => (window as any).__ringTest.recordPostView(i), id);
+const views = (c: RingClient, id: string): Promise<string[]> => c.page.evaluate((i) => (window as any).__ringTest.postViews(i), id);
+const setClose = (c: RingClient, id: string, v: boolean): Promise<void> =>
+  c.page.evaluate(([i, val]) => (window as any).__ringTest.setCloseFriend(i, val), [id, v as any]);
+const closeIds = (c: RingClient): Promise<string[]> => c.page.evaluate(() => (window as any).__ringTest.closeFriendIds());
+const setSetting = (c: RingClient, key: string, val: unknown): Promise<void> =>
+  c.page.evaluate(([k, v]) => (window as any).__ringTest.setSetting(k, v), [key, val as any]);
+
+// Pull + return the observer's feed; used inside expect.poll so propagation is retried.
+const pulledWall = async (c: RingClient): Promise<string[]> => {
+  await syncPosts(c);
+  return wallIds(c);
+};
+const pulledReactions = async (c: RingClient, id: string): Promise<string[]> => {
+  await syncEng(c, id);
+  return (await reactions(c, id)).map((r) => `${r.actor}:${r.emoji}`);
+};
+const pulledComments = async (c: RingClient, id: string): Promise<{ id: string; actor: string; text: string; deleted: boolean }[]> => {
+  await syncEng(c, id);
+  return comments(c, id);
+};
+
+test('wall: a post reaches its friend audience and no one else; author identity travels', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const ctxD = await browser.newContext();
+  const a = await createAccount(ctxA, 'WALL01');
+  const b = await createAccount(ctxB, 'WALL02');
+  const c = await createAccount(ctxC, 'WALL03');
+  const d = await createAccount(ctxD, 'WALL04');
+  await pair(a, b);
+  await pair(a, c);
+  // d is intentionally NOT a friend of a.
+
+  const id = await post(a, { body: 'hello friends 👋', audience: 'friends' });
+
+  // B and C (the friend audience) receive it, with A as the incoming author.
+  for (const f of [b, c]) {
+    await expect.poll(() => pulledWall(f)).toContain(id);
+    expect(await getPost(f, id)).toMatchObject({ id, body: 'hello friends 👋', author: a.id, outgoing: false });
+  }
+  // A's own copy is outgoing.
+  expect(await getPost(a, id)).toMatchObject({ author: a.id, outgoing: true });
+
+  // D (not in the audience) never receives it — the server has no envelope for them.
+  await syncPosts(d);
+  expect(await wallIds(d)).not.toContain(id);
+
+  for (const ctx of [ctxA, ctxB, ctxC, ctxD]) await ctx.close();
+});
+
+test('wall: reactions are audience-visible with the reactor identity, and toggling removes them', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'WALL11');
+  const b = await createAccount(ctxB, 'WALL12');
+  const c = await createAccount(ctxC, 'WALL13');
+  await pair(a, b);
+  await pair(a, c);
+
+  const id = await post(a, { body: 'rate this 🎬', audience: 'friends' });
+  await expect.poll(() => pulledWall(b)).toContain(id);
+  await expect.poll(() => pulledWall(c)).toContain(id);
+
+  // B reacts. The author (A) AND another audience member (C) both see it, attributed to B.
+  expect(await react(b, id, '❤️')).toBe('added');
+  for (const obs of [a, c]) {
+    await expect.poll(() => pulledReactions(obs, id)).toContain(`${b.id}:❤️`);
+  }
+
+  // B toggles the same emoji off → it's removed for the whole audience.
+  expect(await react(b, id, '❤️')).toBe('removed');
+  for (const obs of [a, c]) {
+    await expect.poll(() => pulledReactions(obs, id)).toHaveLength(0);
+  }
+
+  for (const ctx of [ctxA, ctxB, ctxC]) await ctx.close();
+});
+
+test('wall: comments are audience-visible and removable by the commenter or the post author', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'WALL21');
+  const b = await createAccount(ctxB, 'WALL22');
+  const c = await createAccount(ctxC, 'WALL23');
+  await pair(a, b);
+  await pair(a, c);
+
+  const id = await post(a, { body: 'thread starter', audience: 'friends' });
+  await expect.poll(() => pulledWall(b)).toContain(id);
+  await expect.poll(() => pulledWall(c)).toContain(id);
+
+  // B comments → the author sees it attributed to B.
+  await comment(b, id, 'first!');
+  await expect.poll(async () => (await pulledComments(a, id)).filter((x) => !x.deleted).map((x) => `${x.actor}:${x.text}`)).toContain(`${b.id}:first!`);
+
+  // The COMMENTER removes their own comment → the tombstone propagates and it vanishes
+  // from the author's thread (a deleted comment is filtered out, not shown crossed-out).
+  const bComment = (await comments(b, id)).find((x) => x.actor === b.id && x.text === 'first!')!;
+  await delComment(b, id, bComment.id);
+  await expect.poll(async () => (await pulledComments(a, id)).some((x) => x.id === bComment.id)).toBe(false);
+
+  // C comments → the POST AUTHOR (A) can moderate it away (present, then removed).
+  await comment(c, id, 'mine too');
+  await expect.poll(async () => (await pulledComments(a, id)).some((x) => x.actor === c.id && x.text === 'mine too')).toBe(true);
+  const cComment = (await comments(a, id)).find((x) => x.actor === c.id && x.text === 'mine too')!;
+  await delComment(a, id, cComment.id); // A authored the post → allowed to remove others' comments
+  await expect.poll(async () => (await comments(a, id)).some((x) => x.id === cComment.id)).toBe(false);
+
+  for (const ctx of [ctxA, ctxB, ctxC]) await ctx.close();
+});
+
+test('wall: close-friends audience excludes other friends, and un-close-friending revokes the post', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'WALL31');
+  const b = await createAccount(ctxB, 'WALL32');
+  const c = await createAccount(ctxC, 'WALL33');
+  await pair(a, b);
+  await pair(a, c);
+
+  // A curates B as a close friend (C stays a regular friend).
+  await setClose(a, b.id, true);
+  expect(await closeIds(a)).toContain(b.id);
+  expect(await closeIds(a)).not.toContain(c.id);
+
+  // A close-only post reaches B but NOT C (a regular friend).
+  const id = await post(a, { body: 'close circle only 🤫', audience: 'close' });
+  await expect.poll(() => pulledWall(b)).toContain(id);
+  await syncPosts(c);
+  expect(await wallIds(c)).not.toContain(id);
+
+  // Demote B from close friends → A's close-only post is revoked from B's device.
+  await setClose(a, b.id, false);
+  await expect.poll(() => pulledWall(b)).not.toContain(id);
+
+  for (const ctx of [ctxA, ctxB, ctxC]) await ctx.close();
+});
+
+test('wall: view receipts are author-only and honor seen-receipts reciprocity', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'WALL41');
+  const b = await createAccount(ctxB, 'WALL42');
+  const c = await createAccount(ctxC, 'WALL43');
+  await pair(a, b);
+  await pair(a, c);
+
+  const id = await post(a, { body: 'who saw this?', audience: 'friends' });
+  await expect.poll(() => pulledWall(b)).toContain(id);
+  await expect.poll(() => pulledWall(c)).toContain(id);
+
+  // B (seen-receipts on by default) views it → the author A sees B in the view list.
+  await recordView(b, id);
+  await expect.poll(() => views(a, id)).toContain(b.id);
+
+  // C turns seen-receipts OFF, then views → C's receipt is NOT sent (reciprocity), so A
+  // never sees C even though C opened the post.
+  await setSetting(c, 'privacy.seenReceipts', false);
+  await recordView(c, id);
+  await expect.poll(() => views(a, id)).not.toContain(c.id);
+  expect(await views(a, id)).toContain(b.id); // B is still there
+
+  // Author-side reciprocity: if A turns its OWN seen-receipts off, A forfeits the view
+  // list entirely (it returns empty), even though receipts exist on the server.
+  await setSetting(a, 'privacy.seenReceipts', false);
+  expect(await views(a, id)).toHaveLength(0);
+
+  for (const ctx of [ctxA, ctxB, ctxC]) await ctx.close();
+});

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -88,6 +88,21 @@ import {
   listLockedChats,
   getSetting,
   downloadMessageMedia as dbDownloadMessageMedia,
+  createPost as dbCreatePost,
+  syncPosts as dbSyncPosts,
+  getPost as dbGetPost,
+  listWallPosts as dbListWallPosts,
+  reactToPost as dbReactToPost,
+  syncEngagement as dbSyncEngagement,
+  listPostReactions as dbListPostReactions,
+  listPostComments as dbListPostComments,
+  commentOnPost as dbCommentOnPost,
+  deleteComment as dbDeleteComment,
+  recordPostView as dbRecordPostView,
+  listPostViews as dbListPostViews,
+  setCloseFriend as dbSetCloseFriend,
+  listCloseFriends as dbListCloseFriends,
+  listFriends as dbListFriends,
 } from '@/db/queries';
 import { downloadBlob } from '@/services/media-transfer';
 import {
@@ -699,6 +714,48 @@ export function installTestHook(): void {
     incomingRequestIds: (): string[] => storeIncomingRequests.value.map((r) => r.userId),
     searchDirectory: async (q: string) =>
       (await searchDirectory(q)).map((u) => ({ id: u.id, username: u.username, displayName: u.displayName })),
+
+    /* ---- Wall (spec 0003): drive the real queries.ts orchestration so e2e exercises
+       the actual encrypt → upload → fan-out → receive/open path, not a shortcut. ---- */
+    /** Compose + share a post. Returns the new post id. */
+    post: async (opts: { body?: string; audience?: 'friends' | 'close'; lifetime?: '1h' | '24h' | '72h' }): Promise<string> => {
+      const p = await dbCreatePost({ body: opts.body, audience: opts.audience ?? 'friends', lifetime: opts.lifetime ?? '24h' });
+      return p.id;
+    },
+    /** Pull posts addressed to us (and apply revocations). */
+    syncPosts: () => dbSyncPosts(),
+    /** Ids of the non-expired, non-hidden posts on this device (feed order). */
+    wallPostIds: async (): Promise<string[]> => (await dbListWallPosts()).map((p) => p.id),
+    /** A single post as a lean view, or null if we don't have it. */
+    getPost: async (id: string) => {
+      const p = await dbGetPost(id);
+      return p ? { id: p.id, kind: p.kind, body: p.body, author: p.author, audience: p.audience, outgoing: p.outgoing } : null;
+    },
+    /** React to a post; returns the action ('added' | 'removed' | 'limit' | ...). */
+    reactToPost: (postId: string, emoji: string) => dbReactToPost(postId, emoji),
+    /** Pull a post's engagement (reactions/comments/views) from the server. */
+    syncEngagement: (postId: string) => dbSyncEngagement(postId),
+    /** A post's reactions as { actor, emoji } pairs. */
+    postReactions: async (postId: string): Promise<{ actor: string; emoji: string }[]> =>
+      (await dbListPostReactions(postId)).map((r) => ({ actor: r.actor, emoji: r.emoji ?? '' })),
+    /** Add a comment to a post. */
+    commentOnPost: (postId: string, text: string) => dbCommentOnPost(postId, text),
+    /** A post's comments as { id, actor, text, deleted } (excludes nothing, so a
+     *  tombstoned comment shows deleted=true). */
+    postComments: async (postId: string): Promise<{ id: string; actor: string; text: string; deleted: boolean }[]> =>
+      (await dbListPostComments(postId)).map((c) => ({ id: c.id, actor: c.actor, text: c.text ?? '', deleted: !!c.deleted })),
+    /** Delete one of our own comments (or any comment if we authored the post). */
+    deletePostComment: (postId: string, commentId: string) => dbDeleteComment(postId, commentId),
+    /** Record that we viewed a post (gated by the seen-receipts setting). */
+    recordPostView: (postId: string) => dbRecordPostView(postId),
+    /** A post's viewer ids (author-only server-side). */
+    postViews: (postId: string): Promise<string[]> => dbListPostViews(postId),
+    /** Toggle a contact's close-friend flag (demoting revokes close-only posts). */
+    setCloseFriend: (id: string, value: boolean) => dbSetCloseFriend(id, value),
+    /** Ids of the current close friends. */
+    closeFriendIds: async (): Promise<string[]> => (await dbListCloseFriends()).map((c) => c.id),
+    /** Ids of all accepted friends (the "all friends" audience source). */
+    friendIds: async (): Promise<string[]> => (await dbListFriends()).map((c) => c.id),
 
     /** Place a 1:1 call. */
     startCall: (peerId: string, kind: 'audio' | 'video') => startDirectCall(peerId, kind),


### PR DESCRIPTION
The Wall (spec 0003) shipped with unit + drive coverage but no Playwright e2e. This adds a real multi-account suite driving the actual encrypt → upload → fan-out → receive/open path via `__ringTest` (which calls the same `queries.ts` orchestration the UI does).

## Coverage (5 specs, all green locally — 32.8s)
- **Audience delivery + isolation** — a post reaches only its friend audience; a non-friend never gets an envelope; the author identity travels with it.
- **Reactions** — audience-visible and attributed to the reactor; toggling the same emoji removes it for the whole audience.
- **Comments + moderation** — audience-visible; removable by the commenter **and** the post author (the tombstone propagates and the comment vanishes from the thread).
- **Close friends** — a close-only post excludes regular friends; un-close-friending a recipient **revokes** the post from their device.
- **View receipts** — author-only; honors seen-receipts reciprocity both ways (a viewer with receipts off is never reported; an author with receipts off forfeits the list).

Closes the spec's open e2e task issues (T032/T038/T045/T050/T054).

## Notes
- Extends the dev-only test hook (`src/services/testhook.ts`) with the Wall surface (`post`/`syncPosts`/`wallPostIds`/`getPost`/`reactToPost`/`syncEngagement`/`postReactions`/`comment`/`postComments`/`deletePostComment`/`recordPostView`/`postViews`/`setCloseFriend`/close+friend ids) — purely additive, tree-shaken from production. `vue-tsc` clean.
- One thing the suite confirmed as correct (not a bug): a deleted comment is filtered out of the thread entirely rather than shown crossed-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)