### PR TITLE
fix(install): don't falsely block capable Android Chrome at the install gate (spec 2003)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,3 +43,4 @@ Specs are grouped by category band; status moves
 |------|-------|--------|
 | [2001](specs/2001-stabilize-message-status/spec.md) | Stabilize message status reporting around downloaded-blob receipts | 🟢 shipped |
 | [2002](specs/2002-media-thumbnails-stay/spec.md) | Media Thumbnails Stay Thumbnails (no autoplay storm) | 🟢 shipped |
+| [2003](specs/2003-android-install-gate/spec.md) | Fix Android install-gate false "browser can't install" warning | 🔵 in-review |

--- a/specs/2003-android-install-gate/spec.md
+++ b/specs/2003-android-install-gate/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: Fix Android install-gate false "browser can't install" warning
+
+**Feature Branch**: `fix/2003-android-install-gate`
+
+**Created**: 2026-06-22
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     The directory number sets the category (2001+ = hotfix/bug). -->
+
+**Input**: Android user on current Chrome was blocked at the install gate by a warning
+saying their browser "can't install Ring as an app … Update Chrome … or open Ring in a
+newer browser," when their browser is in fact fully capable of installing the PWA.
+
+## Overview
+
+Ring gates un-installed visits behind an install guide (it only runs as an installed
+PWA). On Android, the guide currently decides a browser is *incapable of installing* — and
+shows an alarming "this browser can't install Ring, update Chrome / use a newer browser"
+warning — purely because the Chromium `beforeinstallprompt` event did not fire within
+**2.5 seconds** of load. That signal is unreliable: a perfectly capable, current Chrome can
+fire it later than 2.5s, or not auto-fire it at all (Chrome may suppress/delay it), so
+real users are wrongly told their browser is too old and are effectively blocked.
+
+The genuinely-incapable case on Android is an **embedded WebView** (an in-app browser with
+no menu to "Install app"), which is identifiable from the user agent. This bug fix makes
+the "can't install" determination accurate: warn only for a true WebView, and otherwise
+always show the normal install steps (and the one-tap install button if/when the prompt is
+available) without the false "update your browser" message.
+
+## Bug & Root Cause
+
+- **Symptom**: On Android Chrome, the install gate shows the warning *"This browser can't
+  install Ring as an app, it would only add a shortcut … Update Chrome … or open Ring in a
+  newer browser"* even though the browser can install Ring.
+- **Root cause**: the gate sets an "install unavailable" flag whenever
+  `beforeinstallprompt` has not fired ~2.5s after load. Absence of that event does not mean
+  the browser is incapable — it is commonly just delayed or suppressed on a fully capable
+  Chrome. The 2.5s timeout is therefore a false-negative source.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Capable Android browser is not falsely blocked (Priority: P1)
+
+A person opening Ring in a normal, current Android browser (Chrome, Samsung Internet,
+Edge, Firefox, etc.) must NOT be told their browser can't install Ring. They see the
+install steps (and a one-tap install button when the browser offers it) and can install.
+
+**Why this priority**: This is the bug — capable users are blocked/misinformed. Fixing it
+is the whole point.
+
+**Independent Test**: With a normal Android Chrome user agent and no `beforeinstallprompt`
+within several seconds, the gate does not show the "can't install / update your browser"
+warning and still presents the install steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** a normal Android browser user agent, **When** the install gate evaluates
+   capability and `beforeinstallprompt` has not (yet) fired, **Then** the "can't install"
+   warning is NOT shown and the manual install steps are shown.
+2. **Given** a normal Android browser where `beforeinstallprompt` later fires, **When** the
+   gate updates, **Then** the one-tap install button appears (existing behavior preserved).
+
+### User Story 2 - Genuinely-incapable surface gets accurate guidance (Priority: P2)
+
+A person who opened Ring inside an embedded in-app browser (Android WebView) — which truly
+cannot install a PWA — is told accurately to open Ring in their real browser app and
+install from there, rather than the misleading "update Chrome."
+
+**Why this priority**: Preserves a useful, *accurate* warning for the one case where it's
+true, without the false positives.
+
+**Independent Test**: With an Android WebView user agent, the gate shows the
+incapable-surface guidance directing the user to open Ring in a real browser.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Android WebView user agent, **When** the gate evaluates capability, **Then**
+   it shows guidance to open Ring in a real browser app (not "update Chrome").
+
+### Edge Cases
+
+- **`beforeinstallprompt` fires after several seconds**: the one-tap button still appears
+  when it arrives; the user is never shown the false warning in the interim.
+- **Non-Chromium Android browsers (Firefox, Samsung Internet)**: not treated as incapable —
+  they can install via their own menu, so the steps are shown without the warning.
+- **Desktop / iOS**: unaffected (this fix is scoped to the Android branch of the gate).
+- **PWA install criteria genuinely unmet (manifest/SW)**: out of scope — that is a separate
+  manifest issue, not a browser-capability one; the gate must not blame the browser for it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The install gate MUST NOT classify an Android browser as "unable to install"
+  based on the absence/delay of the `beforeinstallprompt` event.
+- **FR-002**: The install gate MUST classify an Android browser as "unable to install" ONLY
+  when the user agent identifies a genuinely-incapable surface — specifically an embedded
+  Android **WebView**.
+- **FR-003**: For any Android browser NOT identified as a WebView, the gate MUST show the
+  manual install steps and MUST NOT show the "can't install / update your browser" warning.
+- **FR-004**: When `beforeinstallprompt` is available, the gate MUST still offer the one-tap
+  install button (existing behavior preserved).
+- **FR-005**: The WebView warning copy MUST give accurate guidance — open Ring in a real
+  browser app and install from there — and MUST NOT instruct the user to "update Chrome" as
+  the remedy.
+- **FR-006**: WebView detection MUST be a pure function of the user-agent string so it is
+  unit-testable, and MUST correctly classify representative user agents: Android WebView →
+  incapable; Chrome / Samsung Internet / Firefox / Edge on Android → capable; non-Android →
+  not applicable.
+
+### Key Entities
+
+- *(none — this is a client-side detection fix; no data model change.)*
+
+## Zero-Knowledge Impact
+
+*(Required by Constitution Principle I.)*
+
+- **What new data becomes visible to the server?** None. This is a purely client-side UI/UX
+  fix to install-gate detection; no request, payload, or stored data changes.
+- **Boundary**: unchanged. No client/server contract is touched.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A normal current-Chrome Android user agent never triggers the "can't install"
+  warning, in 100% of evaluations, regardless of whether `beforeinstallprompt` has fired.
+- **SC-002**: An Android WebView user agent triggers the (accurate) incapable-surface
+  guidance in 100% of evaluations.
+- **SC-003**: The one-tap install button still appears whenever `beforeinstallprompt` is
+  offered (no regression).
+- **SC-004**: WebView-vs-capable classification is verified by a unit test over a
+  representative set of real user-agent strings.
+
+## Assumptions
+
+- On Android in the current browser landscape, the only common surface that genuinely
+  cannot install a PWA (no "Install app" path) is an embedded WebView; mainstream browsers
+  (Chrome, Samsung Internet, Edge, Firefox) can install via their menu.
+- Cases where the PWA fails install criteria for manifest/service-worker reasons are
+  separate and out of scope for this gate-capability fix.
+- Desktop and iOS gate behavior is correct and unchanged.

--- a/specs/2003-android-install-gate/tasks.md
+++ b/specs/2003-android-install-gate/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Fix Android install-gate false "browser can't install" warning
+
+**Feature**: spec 2003 (hotfix) | **Branch**: `fix/2003-android-install-gate`
+**Spec**: [spec.md](./spec.md)
+
+Per Constitution Principle III, a bug fix begins with a FAILING regression test that
+reproduces the defect. The fix is a small, client-side detection change with no
+server/ZK impact.
+
+## Tasks
+
+- [ ] T001 [P] Write FAILING unit test for a pure `isAndroidWebView(ua: string)` helper in `src/composables/useInstallGuard.test.ts`: an Android **WebView** UA (`; wv)` and/or `Version/x.x … Chrome/…`) → `true`; Chrome, Samsung Internet, Firefox, Edge on Android → `false`; desktop/iOS UAs → `false`. (FR-006, SC-004)
+- [ ] T002 Implement the pure `isAndroidWebView(ua)` in `src/composables/useInstallGuard.ts`, and base `installUnavailable` on it (Android && WebView) — **removing** the 2.5s `beforeinstallprompt`-timeout heuristic. Keep `canPrompt`/`beforeinstallprompt` wiring intact for the one-tap button. Makes T001 pass. (FR-001/002/003/004)
+- [ ] T003 Update the warning in `src/components/InstallGuard.vue` so the (now WebView-only) callout gives accurate guidance — "open Ring in your browser app (e.g. Chrome) and install from there" — and drop the "update Chrome / open in a newer browser" remedy. (FR-005)
+- [ ] T004 Gates: `npm run build` (vue-tsc + vite) and `npx vitest run src/composables/useInstallGuard.test.ts`. Confirm no regression: the one-tap button still shows when `beforeinstallprompt` fires; desktop/iOS branches unchanged. (SC-001/002/003)
+- [ ] T005 Bump spec `Status:` → in-review and run `make roadmap`.
+
+## Notes / right-sizing
+Small hotfix: a single tracking issue (not one-per-task) is created and the PR `Closes` it;
+no `clarify` (unambiguous) and no full per-task issue fan-out. ZK impact: none.

--- a/src/components/InstallGuard.vue
+++ b/src/components/InstallGuard.vue
@@ -49,16 +49,17 @@
         </ion-text>
       </div>
 
-      <!-- Old Android / WebView that can't do a real PWA install (no
-           beforeinstallprompt): explain why, rather than show steps whose
-           "Add to Home" only makes a shortcut. -->
+      <!-- Embedded in-app browser (Android WebView): it has no "Install app" path, so
+           give accurate guidance to open Ring in a real browser app rather than the
+           (wrong) "update Chrome" advice. Shown only for a true WebView, never merely
+           because beforeinstallprompt was slow on a capable browser (spec 2003). -->
       <div v-if="platform === 'android' && installUnavailable" class="ion-padding">
         <div class="cant-install">
           <ion-icon :icon="warningOutline" />
           <span>
-            This browser can’t install Ring as an app, it would only add a shortcut
-            (which can’t run in the background or receive notifications). Update Chrome
-            to the latest version, or open Ring in a newer browser, then install.
+            You’ve opened Ring inside another app’s browser, which can’t install apps.
+            Tap the ⋮ menu and choose “Open in Chrome” (or your browser app), then install
+            Ring from there.
           </span>
         </div>
       </div>

--- a/src/composables/useInstallGuard.test.ts
+++ b/src/composables/useInstallGuard.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { isAndroidWebView } from './useInstallGuard';
+
+// Regression for spec 2003: the install gate must call a browser "can't install" ONLY for a
+// genuinely-incapable surface (an embedded Android WebView), identified from the user agent —
+// NOT because beforeinstallprompt was slow to fire on a capable Chrome.
+
+describe('isAndroidWebView', () => {
+  it('detects an embedded Android WebView (the "; wv)" tag)', () => {
+    const ua =
+      'Mozilla/5.0 (Linux; Android 13; Pixel 7 Build/TQ3A.230805.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/119.0.6045.193 Mobile Safari/537.36';
+    expect(isAndroidWebView(ua)).toBe(true);
+  });
+
+  it('detects a legacy Android WebView (Version/x.x alongside Chrome/, no wv tag)', () => {
+    const ua =
+      'Mozilla/5.0 (Linux; Android 9; SM-G960F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36';
+    expect(isAndroidWebView(ua)).toBe(true);
+  });
+
+  it('does NOT flag normal Android Chrome (the bug being fixed)', () => {
+    const ua =
+      'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36';
+    expect(isAndroidWebView(ua)).toBe(false);
+  });
+
+  it('does NOT flag Samsung Internet (Chrome token but no Version/)', () => {
+    const ua =
+      'Mozilla/5.0 (Linux; Android 13; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36';
+    expect(isAndroidWebView(ua)).toBe(false);
+  });
+
+  it('does NOT flag Edge on Android', () => {
+    const ua =
+      'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36 EdgA/119.0.0.0';
+    expect(isAndroidWebView(ua)).toBe(false);
+  });
+
+  it('does NOT flag Firefox on Android (no Chrome token)', () => {
+    const ua = 'Mozilla/5.0 (Android 13; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0';
+    expect(isAndroidWebView(ua)).toBe(false);
+  });
+
+  it('is not applicable to desktop or iOS user agents', () => {
+    expect(
+      isAndroidWebView(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+      ),
+    ).toBe(false);
+    expect(
+      isAndroidWebView(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/composables/useInstallGuard.ts
+++ b/src/composables/useInstallGuard.ts
@@ -47,14 +47,36 @@ function detectPlatform(): InstallPlatform {
   return 'desktop';
 }
 
+/**
+ * Whether an Android user agent is an embedded WebView — the one common Android surface
+ * that genuinely CANNOT install a PWA (no "Install app" menu; "Add to Home" only makes a
+ * shortcut). Pure (UA-only) so it's unit-testable and deterministic.
+ *
+ * We deliberately do NOT infer incapability from a missing/slow `beforeinstallprompt`
+ * event: a fully capable, current Chrome can fire it late or not auto-fire it at all, so
+ * that signal produced false "your browser can't install / update Chrome" warnings for
+ * real users (spec 2003). Mainstream Android browsers (Chrome, Samsung Internet, Edge,
+ * Firefox) can all install via their own menu and are NOT WebViews.
+ *
+ * Detection: the modern WebView tags itself with "; wv)" in the platform section; the
+ * legacy signature is a "Version/x.x" token alongside "Chrome/" (real Chrome / Samsung /
+ * Edge on Android do not carry "Version/").
+ */
+export function isAndroidWebView(ua: string): boolean {
+  if (!/android/i.test(ua)) return false;
+  if (/;\s*wv[)]/i.test(ua)) return true;
+  return /\bVersion\/[\d.]+/i.test(ua) && /\bChrome\/[\d.]+/i.test(ua);
+}
+
 // Singleton state shared across the (single) guard component.
 const mustInstall = ref(false);
 const platform = ref<InstallPlatform>('desktop');
 const canPrompt = ref(false);
-// Android only: set true when we've waited for `beforeinstallprompt` and it never
-// fired, which means this browser (e.g. old Chrome / a WebView on Android 6) can't
-// install Ring as a real standalone PWA - "Add to Home" would only make a shortcut.
-// The guard uses it to explain that, instead of showing steps that won't work.
+// Android only: true ONLY for a genuinely-incapable surface — an embedded WebView, which
+// has no "Install app" path so "Add to Home" would just make a shortcut. Determined from
+// the user agent (isAndroidWebView), NOT from a missing/slow `beforeinstallprompt` event
+// (that was a false-negative source on capable Chrome — spec 2003). The guard uses it to
+// show accurate "open in your browser app" guidance instead of steps that won't work.
 const installUnavailable = ref(false);
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
 let started = false;
@@ -65,13 +87,10 @@ function start(): void {
   platform.value = detectPlatform();
   mustInstall.value = !isStandalone() && !isLocalhost();
 
-  // On Android a capable Chrome fires `beforeinstallprompt` within a moment of load;
-  // if it hasn't after a short wait (and we're still gated), this browser can't do a
-  // real install, so surface the clearer guidance.
+  // Only an embedded Android WebView genuinely can't install Ring; a normal Android
+  // browser can (via its menu), even if `beforeinstallprompt` is slow or never auto-fires.
   if (platform.value === 'android' && mustInstall.value) {
-    setTimeout(() => {
-      if (!canPrompt.value) installUnavailable.value = true;
-    }, 2500);
+    installUnavailable.value = isAndroidWebView(navigator.userAgent || '');
   }
 
   // If the page is ever (re)evaluated as standalone, drop the gate.


### PR DESCRIPTION
**Hotfix (spec 2003).** Reported by an Android user on current Chrome who was blocked at the install gate by *"This browser can't install Ring as an app… Update Chrome… or open Ring in a newer browser."*

## Root cause
`useInstallGuard.ts` flagged an Android browser as **incapable of installing** whenever the Chromium `beforeinstallprompt` event hadn't fired within **2.5s** of load. That's a false-negative: a capable, current Chrome can fire it late or not auto-fire it at all (Chrome may delay/suppress it), so real users get wrongly told their browser is too old and are effectively blocked.

## Fix
- Add a pure, unit-tested `isAndroidWebView(ua)` — the only common Android surface that genuinely can't install a PWA is an embedded **WebView** (no "Install app" path).
- Base `installUnavailable` on that UA check and **remove the 2.5s timeout heuristic**.
- WebView now gets accurate guidance ("open Ring in your browser app, then install") instead of "update Chrome." Mainstream Android browsers (Chrome, Samsung Internet, Edge, Firefox) get the normal install steps + the one-tap button when `beforeinstallprompt` fires.

## Verification
- New `src/composables/useInstallGuard.test.ts` (TDD, failing-first): WebView UAs → incapable; Chrome/Samsung/Edge/Firefox Android → capable; desktop/iOS → n/a.
- `vue-tsc` + `vite build` clean; full vitest **249 pass**. No server / zero-knowledge impact.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)