### PR TITLE
feat(push): 9 AM-local, behind-only version-announcement push (spec 1016)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,5 +249,5 @@ GitFlow. **`develop`** is the integration branch; **`main`** is production.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/0003-zero-knowledge-social/plan.md`
+`specs/1016-9-am-local/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,6 +36,7 @@ Specs are grouped by category band; status moves
 | [1013](specs/1013-jump-pill-seen-receipts/spec.md) | Expanding "Jump to Latest" Pill + Visibility-Driven Seen Receipts | 🟢 shipped |
 | [1014](specs/1014-image-thumbnails-album/spec.md) | Multi-Size Image Thumbnails + Album-View Overhaul | 🟢 shipped |
 | [1015](specs/1015-reliable-push-notifications/spec.md) | Reliable Push & Redesigned In-App Notifications | 🟢 shipped |
+| [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Specs are grouped by category band; status moves
 | [1013](specs/1013-jump-pill-seen-receipts/spec.md) | Expanding "Jump to Latest" Pill + Visibility-Driven Seen Receipts | 🟢 shipped |
 | [1014](specs/1014-image-thumbnails-album/spec.md) | Multi-Size Image Thumbnails + Album-View Overhaul | 🟢 shipped |
 | [1015](specs/1015-reliable-push-notifications/spec.md) | Reliable Push & Redesigned In-App Notifications | 🟢 shipped |
-| [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | ⚪ planned |
+| [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/server/cmd/ringd/main.go
+++ b/server/cmd/ringd/main.go
@@ -99,41 +99,34 @@ func devProxy(cfg config.Config) string {
 	return ""
 }
 
-// lastAnnouncedVersionKey is the app_meta key holding the version we last broadcast a
-// "what's new" push for.
-const lastAnnouncedVersionKey = "last_announced_version"
+// versionSweepInterval is how often the scheduler checks for behind devices whose local
+// time is the 09:00 hour (spec 1016). 15 min lands the push near 09:00 while staying cheap;
+// once-per-release dedup keeps repeated ticks within the hour idempotent.
+const versionSweepInterval = 15 * time.Minute
 
-// announceVersionIfChanged broadcasts a version-announcement push when the running
-// build's version differs from the one we last announced, then records the new version.
-// It is deliberately conservative about WHEN it actually pushes:
-//   - skip the local `dev` build (no real release to announce);
-//   - skip when there is no previously recorded version (fresh DB / first run after this
-//     feature ships) — record a baseline instead, so we never blast on a rollout deploy;
-//   - skip an unchanged version (a plain restart);
-// otherwise record the new version and fan the tickle out in the background (never
-// blocking boot). Best-effort: a metadata error just logs and skips the broadcast.
-func announceVersionIfChanged(ctx context.Context, st *store.Store, notifier *push.Notifier, version string) {
-	if version == "" || version == "dev" || notifier == nil {
+// startVersionAnnouncer runs the 9-AM-local version-announcement scheduler: every
+// versionSweepInterval it sends the content-free version push to each device that is behind
+// the running version and whose local time is the 09:00 hour, once per release. Replaces
+// the old immediate on-boot broadcast. No-op (the sweep self-skips) for the local `dev`
+// build or when push is disabled. Stops cleanly on ctx cancel.
+func startVersionAnnouncer(ctx context.Context, st *store.Store, notifier *push.Notifier, version string) {
+	if notifier == nil {
 		return
 	}
-	prev, err := st.GetAppMeta(ctx, lastAnnouncedVersionKey)
-	if err != nil {
-		slog.Warn("version announce: read last-announced failed", "err", err)
-		return
-	}
-	if prev == version {
-		return // same version (restart) → nothing to announce
-	}
-	if err := st.SetAppMeta(ctx, lastAnnouncedVersionKey, version); err != nil {
-		slog.Warn("version announce: record version failed", "err", err)
-		return
-	}
-	if prev == "" {
-		slog.Info("version announce: recording baseline (no broadcast on first run)", "version", version)
-		return
-	}
-	slog.Info("version announce: new version deployed, broadcasting", "from", prev, "to", version)
-	go notifier.BroadcastVersion(context.Background())
+	go func() {
+		ticker := time.NewTicker(versionSweepInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				sctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+				push.SweepVersionAnnouncements(sctx, st, notifier, version, time.Now().UTC())
+				cancel()
+			}
+		}
+	}()
 }
 
 // ensureBootstrapInvite guarantees an empty system can onboard its first user.
@@ -317,14 +310,12 @@ func run() error {
 		st,
 	)
 
-	// Version-announcement push: when a freshly-deployed binary boots with a version
-	// different from the one we last announced, fan a content-free "new version" tickle
-	// out to every subscription. The SW turns it into a user-friendly "what's new" from
-	// the public /v1/config. Deduped via app_meta so a plain restart (same version)
-	// stays silent; skipped on the very first run after this feature ships (no recorded
-	// previous version → we can't claim a "change", and don't want to blast on the
-	// rollout deploy itself) and for local `dev` builds.
-	announceVersionIfChanged(ctx, st, notifier, version)
+	// Version-announcement push (spec 1016): a periodic scheduler sends a content-free
+	// "new version" tickle to each device that is behind the running version, at 09:00 in
+	// that device's local time, once per release. The SW turns it into a user-friendly
+	// "what's new" from the public /v1/config. (Replaces the old immediate on-boot
+	// broadcast so a late-night deploy never wakes anyone overnight.)
+	startVersionAnnouncer(ctx, st, notifier, version)
 
 	// Embedded TURN/STUN relay for WebRTC calls. Media is relayed opaquely (the
 	// server never sees DTLS keys). In dev it runs plaintext on TurnListen; in

--- a/server/internal/api/push_handlers.go
+++ b/server/internal/api/push_handlers.go
@@ -15,6 +15,10 @@ type pushSubscriptionDTO struct {
 		P256dh string `json:"p256dh"`
 		Auth   string `json:"auth"`
 	} `json:"keys"`
+	// Optional per-device metadata for the 9-AM-local version announcement (spec 1016).
+	// Pointers so an omitted field (e.g. the SW resubscribe path) preserves the stored value.
+	InstalledVersion *string `json:"installedVersion"`
+	TzOffsetMinutes  *int    `json:"tzOffsetMinutes"`
 }
 
 // subscribePush (POST /v1/push/subscribe) registers a browser push subscription.
@@ -31,7 +35,7 @@ func (h *Handlers) subscribePush(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.Push.SaveSubscription(r.Context(), uid, store.PushSubscription{
 		Endpoint: req.Endpoint, P256dh: req.Keys.P256dh, Auth: req.Keys.Auth,
-	}); err != nil {
+	}, req.InstalledVersion, req.TzOffsetMinutes); err != nil {
 		httpx.Error(w, http.StatusInternalServerError, "could not save subscription")
 		return
 	}

--- a/server/internal/api/push_handlers_test.go
+++ b/server/internal/api/push_handlers_test.go
@@ -2,40 +2,94 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
 
 	"ring/server/internal/store"
+	"ring/server/internal/ws"
 )
+
+// fakePushRecord mirrors one push_subscriptions row for assertions. version=="" / tz==nil
+// model NULL (not-yet-reported).
+type fakePushRecord struct {
+	endpoint, p256dh, auth, version string
+	tz                              *int
+}
 
 type fakePushStore struct {
 	mu   sync.Mutex
-	subs map[string][]store.PushSubscription
+	recs map[string][]*fakePushRecord // userID -> records
 }
 
 func newFakePushStore() *fakePushStore {
-	return &fakePushStore{subs: map[string][]store.PushSubscription{}}
+	return &fakePushStore{recs: map[string][]*fakePushRecord{}}
 }
 
-func (f *fakePushStore) SaveSubscription(_ context.Context, userID string, sub store.PushSubscription) error {
+// SaveSubscription upserts by (userID, endpoint): keys are always refreshed; version/tz are
+// updated ONLY when provided (non-nil), mimicking the real COALESCE so a version-less
+// re-subscribe preserves the stored values. last_announced_version is never written here.
+func (f *fakePushStore) SaveSubscription(_ context.Context, userID string, sub store.PushSubscription, installedVersion *string, tzOffsetMinutes *int) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.subs[userID] = append(f.subs[userID], sub)
+	for _, r := range f.recs[userID] {
+		if r.endpoint == sub.Endpoint {
+			r.p256dh, r.auth = sub.P256dh, sub.Auth
+			if installedVersion != nil {
+				r.version = *installedVersion
+			}
+			if tzOffsetMinutes != nil {
+				r.tz = tzOffsetMinutes
+			}
+			return nil
+		}
+	}
+	r := &fakePushRecord{endpoint: sub.Endpoint, p256dh: sub.P256dh, auth: sub.Auth}
+	if installedVersion != nil {
+		r.version = *installedVersion
+	}
+	if tzOffsetMinutes != nil {
+		r.tz = tzOffsetMinutes
+	}
+	f.recs[userID] = append(f.recs[userID], r)
 	return nil
 }
 
 func (f *fakePushStore) DeleteSubscription(_ context.Context, userID, endpoint string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	kept := f.subs[userID][:0]
-	for _, s := range f.subs[userID] {
-		if s.Endpoint != endpoint {
-			kept = append(kept, s)
+	kept := f.recs[userID][:0]
+	for _, r := range f.recs[userID] {
+		if r.endpoint != endpoint {
+			kept = append(kept, r)
 		}
 	}
-	f.subs[userID] = kept
+	f.recs[userID] = kept
 	return nil
+}
+
+func (f *fakePushStore) get(endpoint string) *fakePushRecord {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, recs := range f.recs {
+		for _, r := range recs {
+			if r.endpoint == endpoint {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func newTestServerWithPush(p *fakePushStore) http.Handler {
+	as := newFakeStore()
+	return NewRouter(&Handlers{
+		Store: as, Directory: as, Contacts: as, Blocks: as, Relay: as,
+		Hub: ws.NewHub(), Keys: newFakeKeysStore(), Blobs: newFakeBlobStore(),
+		Sync: newFakeSyncStore(), Push: p, Invites: as,
+		PublicURL: "https://ring.example", VapidPublicKey: "VAPID_PUB",
+	}, []string{"http://localhost:5173"})
 }
 
 func TestPushSubscribe(t *testing.T) {
@@ -59,4 +113,47 @@ func TestPushSubscribe(t *testing.T) {
 	if rr := do(t, srv, http.MethodPost, "/v1/push/unsubscribe", token, `{"endpoint":"https://push.example/abc"}`); rr.Code != http.StatusOK {
 		t.Fatalf("unsubscribe status = %d", rr.Code)
 	}
+}
+
+// TestPushSubscribeStoresVersionAndTz: subscribing with installedVersion + tzOffsetMinutes
+// persists them; a re-subscribe that OMITS them preserves the stored values (COALESCE) while
+// still refreshing the keys (spec 1016 FR-013/FR-014).
+func TestPushSubscribeStoresVersionAndTz(t *testing.T) {
+	p := newFakePushStore()
+	srv := newTestServerWithPush(p)
+	token, _ := registerUser(t, srv)
+
+	const ep = "https://push.example/v"
+	body := `{"endpoint":"` + ep + `","keys":{"p256dh":"PUB","auth":"AUTH"},"installedVersion":"1.2.3+sha","tzOffsetMinutes":-120}`
+	if rr := do(t, srv, http.MethodPost, "/v1/push/subscribe", token, body); rr.Code != http.StatusOK {
+		t.Fatalf("subscribe status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	r := p.get(ep)
+	if r == nil || r.version != "1.2.3+sha" || r.tz == nil || *r.tz != -120 {
+		t.Fatalf("after subscribe: %s, want version=1.2.3+sha tz=-120", desc(r))
+	}
+
+	// Re-subscribe WITHOUT version/tz (the SW resubscribe path) → previous values preserved.
+	if rr := do(t, srv, http.MethodPost, "/v1/push/subscribe", token,
+		`{"endpoint":"`+ep+`","keys":{"p256dh":"PUB2","auth":"AUTH2"}}`); rr.Code != http.StatusOK {
+		t.Fatalf("re-subscribe status = %d", rr.Code)
+	}
+	r = p.get(ep)
+	if r.version != "1.2.3+sha" || r.tz == nil || *r.tz != -120 {
+		t.Errorf("version-less re-subscribe clobbered metadata: %s, want preserved", desc(r))
+	}
+	if r.p256dh != "PUB2" || r.auth != "AUTH2" {
+		t.Errorf("keys not refreshed on re-subscribe: %s/%s", r.p256dh, r.auth)
+	}
+}
+
+func desc(r *fakePushRecord) string {
+	if r == nil {
+		return "<no record>"
+	}
+	tz := "nil"
+	if r.tz != nil {
+		tz = fmt.Sprintf("%d", *r.tz)
+	}
+	return fmt.Sprintf("version=%q tz=%s keys=%s/%s", r.version, tz, r.p256dh, r.auth)
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -89,7 +89,7 @@ type SyncStore interface {
 
 // PushStore is the Web Push subscription persistence.
 type PushStore interface {
-	SaveSubscription(ctx context.Context, userID string, sub store.PushSubscription) error
+	SaveSubscription(ctx context.Context, userID string, sub store.PushSubscription, installedVersion *string, tzOffsetMinutes *int) error
 	DeleteSubscription(ctx context.Context, userID, endpoint string) error
 }
 

--- a/server/internal/db/migrations/0025_push_version.sql
+++ b/server/internal/db/migrations/0025_push_version.sql
@@ -1,0 +1,11 @@
+-- Per-device version + timezone for the 9-AM-local version-announcement push (spec 1016).
+-- Each push subscription reports the client version it's running and the device's coarse
+-- local UTC offset (minutes), so the server can deliver "a new version is available" at
+-- 09:00 local time only to devices that are behind. `last_announced_version` dedups to
+-- once-per-release. All three are coarse, non-secret metadata (the version is already
+-- public; the offset is minutes, never a zone name or location) — see spec Zero-Knowledge
+-- Impact / NFR-ZK-002. Additive; forward-only.
+ALTER TABLE push_subscriptions
+    ADD COLUMN installed_version      text,
+    ADD COLUMN tz_offset_minutes      int,
+    ADD COLUMN last_announced_version text;

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -83,16 +83,18 @@ const (
 	postTTL   = 7 * 24 * 60 * 60 // 604800s
 	postTopic = "ring-post"
 
-	// versionTTL / versionTopic: a "new version" announcement is worth holding a few
-	// days so a device offline over a weekend still learns of it, but a weeks-stale
-	// announcement is noise (the SW reads the CURRENT version from /v1/config on wake).
+	// versionTTL / versionTopic: a "new version" announcement is sent at ~09:00 in the
+	// device's local time (spec 1016), so it must EXPIRE by roughly local midday rather
+	// than be held for late delivery — otherwise a device that was offline at 9 AM would
+	// get woken that evening/night, the exact disturbance the 9-AM schedule exists to
+	// avoid. A short TTL (a few hours) means a missed-morning push is dropped, not held.
 	// Collapsed per subscription so multiple deploys while offline yield ONE wake.
-	versionTTL   = 3 * 24 * 60 * 60 // 259200s
+	versionTTL   = 3 * 60 * 60 // 10800s (~3h: expires by roughly local midday)
 	versionTopic = "ring-version"
 
-	// broadcastConcurrency bounds in-flight deliveries during an all-users broadcast,
-	// so a fan-out to the whole subscription base can't open thousands of sockets at once.
-	broadcastConcurrency = 16
+	// versionSweepConcurrency bounds in-flight deliveries during a version-announcement
+	// sweep, so a fan-out across the due subscriptions can't open thousands of sockets.
+	versionSweepConcurrency = 16
 
 	// sendBudget bounds one subscription's whole delivery attempt (incl. retries),
 	// so one slow/hung endpoint can't starve a user's other devices.
@@ -132,7 +134,6 @@ var (
 // SubStore is the subscription persistence the notifier needs.
 type SubStore interface {
 	SubscriptionsFor(ctx context.Context, userID string) ([]store.PushSubscription, error)
-	AllSubscriptions(ctx context.Context) ([]store.PushSubscription, error)
 	DeleteSubscriptionByEndpoint(ctx context.Context, endpoint string) error
 }
 
@@ -214,39 +215,16 @@ func (n *Notifier) NotifyPost(ctx context.Context, userID string) {
 	n.notify(ctx, userID, postParams())
 }
 
-// BroadcastVersion sends a content-free version-announcement tickle to EVERY push
-// subscription (a new app version was deployed). The SW renders the user-friendly
-// "what's new" from the public /v1/config. Deliveries are bounded by
-// broadcastConcurrency; dead endpoints are pruned and failures logged. Safe to call in
-// a goroutine — a panic is recovered, so a bad broadcast can never crash the server.
-func (n *Notifier) BroadcastVersion(ctx context.Context) {
-	defer recoverLog("push: broadcast")
-	subs, err := n.store.AllSubscriptions(ctx)
-	if err != nil {
-		slog.Error("push: load all subscriptions for broadcast", "err", err)
-		return
-	}
-	if len(subs) == 0 {
-		return
-	}
-	slog.Info("push: broadcasting version announcement", "subscriptions", len(subs))
-	p := versionParams()
-	sem := make(chan struct{}, broadcastConcurrency)
-	var wg sync.WaitGroup
-	for _, sub := range subs {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(sub store.PushSubscription) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			defer recoverLog("push: broadcast deliver")
-			sctx, cancel := context.WithTimeout(ctx, sendBudget)
-			defer cancel()
-			n.deliver(sctx, sub, p)
-		}(sub)
-	}
-	wg.Wait()
-	slog.Info("push: version broadcast complete", "subscriptions", len(subs))
+// SendVersion delivers the content-free version-announcement tickle to ONE subscription
+// (a device that is behind, at its local 09:00 — spec 1016). The SW renders the
+// user-friendly "what's new" from the public /v1/config; only the {"t":"version"} marker
+// crosses the push service. A dead endpoint is pruned; a panic is recovered so a bad send
+// can't crash the sweep. Satisfies the push.VersionSender used by SweepVersionAnnouncements.
+func (n *Notifier) SendVersion(ctx context.Context, sub store.PushSubscription) {
+	defer recoverLog("push: send version")
+	sctx, cancel := context.WithTimeout(ctx, sendBudget)
+	defer cancel()
+	n.deliver(sctx, sub, versionParams())
 }
 
 func (n *Notifier) notify(ctx context.Context, userID string, p pushParams) {

--- a/server/internal/push/push_test.go
+++ b/server/internal/push/push_test.go
@@ -296,9 +296,10 @@ func TestNotifyRecoversPanicInFanout(t *testing.T) {
 	n.Notify(context.Background(), "u1") // returns only if the fan-out recover holds
 }
 
-// TestBroadcastVersionHeaders verifies the version-announcement push is a content-free
-// tickle that is low-urgency, a few days long, and collapsible under its own topic.
-func TestBroadcastVersionHeaders(t *testing.T) {
+// TestSendVersionHeaders verifies the version-announcement push to ONE device is a
+// content-free tickle: low-urgency, SHORT-lived (expires by ~local midday, not days), and
+// collapsible under its own topic (spec 1016 FR-015).
+func TestSendVersionHeaders(t *testing.T) {
 	cap := &capturedReq{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cap.record(r)
@@ -307,14 +308,11 @@ func TestBroadcastVersionHeaders(t *testing.T) {
 	defer srv.Close()
 
 	p256dh, auth := newSubKeys(t)
-	st := &memSubStore{subs: map[string][]store.PushSubscription{
-		"u1": {{Endpoint: srv.URL, P256dh: p256dh, Auth: auth}},
-	}}
-	n := newNotifier(t, st)
+	n := newNotifier(t, &memSubStore{subs: map[string][]store.PushSubscription{}})
 
-	n.BroadcastVersion(context.Background())
-	if cap.ttl != "259200" {
-		t.Errorf("version TTL = %q, want 259200 (3d)", cap.ttl)
+	n.SendVersion(context.Background(), store.PushSubscription{Endpoint: srv.URL, P256dh: p256dh, Auth: auth})
+	if cap.ttl != "10800" {
+		t.Errorf("version TTL = %q, want 10800 (~3h, expires by local midday)", cap.ttl)
 	}
 	if cap.urgency != "low" {
 		t.Errorf("version Urgency = %q, want low", cap.urgency)
@@ -324,36 +322,18 @@ func TestBroadcastVersionHeaders(t *testing.T) {
 	}
 }
 
-// TestBroadcastVersionReachesEveryDevice verifies the broadcast fans out to EVERY
-// subscription across ALL users (not just one user's devices).
-func TestBroadcastVersionReachesEveryDevice(t *testing.T) {
-	cap := &capturedReq{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cap.record(r)
-		w.WriteHeader(http.StatusCreated)
-	}))
-	defer srv.Close()
-
-	mk := func() store.PushSubscription {
-		p256dh, auth := newSubKeys(t)
-		return store.PushSubscription{Endpoint: srv.URL, P256dh: p256dh, Auth: auth}
-	}
-	st := &memSubStore{subs: map[string][]store.PushSubscription{
-		"u1": {mk(), mk()}, // two devices
-		"u2": {mk()},
-		"u3": {mk()},
-	}}
-	n := newNotifier(t, st)
-
-	n.BroadcastVersion(context.Background())
-	if got := atomic.LoadInt32(&cap.hits); got != 4 {
-		t.Errorf("broadcast reached %d subscriptions, want 4 (all devices of all users)", got)
+// TestVersionPayloadContentFree asserts the version tickle carries ONLY the type marker —
+// no version string, notes, or any content (NFR-ZK-001). The device fetches the public
+// "what's new" itself; nothing about the release rides through the push service.
+func TestVersionPayloadContentFree(t *testing.T) {
+	if got := string(versionParams().payload); got != `{"t":"version"}` {
+		t.Errorf("version payload = %q, want exactly the content-free marker {\"t\":\"version\"}", got)
 	}
 }
 
-// TestBroadcastVersionRecoversPanic asserts a panic while loading subscriptions can't
-// escape the broadcast (it runs in a goroutine off boot).
-func TestBroadcastVersionRecoversPanic(t *testing.T) {
-	n := NewNotifier(nil, panicSubStore{})
-	n.BroadcastVersion(context.Background()) // AllSubscriptions panics; recover must contain it
+// TestSendVersionRecoversPanic asserts a panic during a single version send can't escape
+// (the sweep runs it in a goroutine).
+func TestSendVersionRecoversPanic(t *testing.T) {
+	n := NewNotifier(nil, panicSubStore{}) // nil sender → deliver panics on s.subject deref
+	n.SendVersion(context.Background(), store.PushSubscription{Endpoint: "https://x/y", P256dh: "x", Auth: "y"})
 }

--- a/server/internal/push/schedule.go
+++ b/server/internal/push/schedule.go
@@ -1,0 +1,82 @@
+package push
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"ring/server/internal/store"
+)
+
+// 9-AM-local version-announcement scheduler (spec 1016). The on-boot all-device broadcast
+// is gone; instead a periodic sweep sends the content-free version push to each device that
+// is BEHIND the current version, at 09:00 in that device's local time, once per release.
+
+// dueAtNine returns the subscriptions whose LOCAL time falls in the 09:00 hour, given the
+// current UTC time. JavaScript getTimezoneOffset() = UTC − local, so local = UTC − offset.
+// Pure + clock-injected, so the timezone math is unit-testable without a DB or real time.
+func dueAtNine(subs []store.PushSubscription, nowUTC time.Time) []store.PushSubscription {
+	out := make([]store.PushSubscription, 0, len(subs))
+	for _, s := range subs {
+		local := nowUTC.Add(-time.Duration(s.TZOffsetMinutes) * time.Minute)
+		if local.Hour() == 9 {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// VersionSchedStore is the persistence the version sweep needs (satisfied by *store.Store).
+type VersionSchedStore interface {
+	SubscriptionsBehind(ctx context.Context, currentVersion string) ([]store.PushSubscription, error)
+	MarkAnnounced(ctx context.Context, endpoint, version string) error
+}
+
+// VersionSender delivers a version tickle to one subscription (satisfied by *Notifier).
+type VersionSender interface {
+	SendVersion(ctx context.Context, sub store.PushSubscription)
+}
+
+// SweepVersionAnnouncements is one tick of the scheduler: for every device that is BEHIND
+// the current version (SubscriptionsBehind already excludes up-to-date / already-announced
+// ones) AND whose LOCAL time is the 09:00 hour, send the version push and mark it announced
+// (dedup-on-send → once per release; the short TTL means a missed-morning push expires
+// rather than arriving at night). No-op on a dev/empty version. Bounded concurrency;
+// panic-safe so a bad tick can never crash the server.
+func SweepVersionAnnouncements(ctx context.Context, st VersionSchedStore, sender VersionSender, currentVersion string, nowUTC time.Time) {
+	defer recoverLog("push: version sweep")
+	if currentVersion == "" || currentVersion == "dev" {
+		return
+	}
+	behind, err := st.SubscriptionsBehind(ctx, currentVersion)
+	if err != nil {
+		slog.Error("push: version sweep load behind", "err", err)
+		return
+	}
+	due := dueAtNine(behind, nowUTC)
+	if len(due) == 0 {
+		return
+	}
+	sem := make(chan struct{}, versionSweepConcurrency)
+	var wg sync.WaitGroup
+	for _, sub := range due {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(sub store.PushSubscription) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer recoverLog("push: version sweep deliver")
+			sender.SendVersion(ctx, sub)
+			// Dedup-on-send: mark regardless of delivery outcome (Web Push gives no
+			// receipt; once-per-release is keyed on send, never on confirmed delivery).
+			if err := st.MarkAnnounced(ctx, sub.Endpoint, currentVersion); err != nil {
+				slog.Warn("push: version sweep mark announced", "err", err)
+			}
+		}(sub)
+	}
+	wg.Wait()
+	// NFR-ZK-004: coarse count only — never a device's local time-of-day, endpoint, or
+	// per-device send history.
+	slog.Info("push: version announcement sweep", "sent", len(due))
+}

--- a/server/internal/push/schedule_test.go
+++ b/server/internal/push/schedule_test.go
@@ -1,0 +1,138 @@
+package push
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"ring/server/internal/store"
+)
+
+// fakeSchedStore is an in-memory VersionSchedStore: `behind` are the already-behind
+// candidates (the real SQL applies the behind/non-null pre-filter); SubscriptionsBehind
+// additionally drops any endpoint already announced for the queried version (mimicking the
+// last_announced_version dedup clause).
+type fakeSchedStore struct {
+	mu        sync.Mutex
+	behind    []store.PushSubscription
+	announced map[string]string // endpoint -> version
+}
+
+func (f *fakeSchedStore) SubscriptionsBehind(_ context.Context, current string) ([]store.PushSubscription, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []store.PushSubscription
+	for _, s := range f.behind {
+		if f.announced[s.Endpoint] != current {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeSchedStore) MarkAnnounced(_ context.Context, endpoint, version string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.announced == nil {
+		f.announced = map[string]string{}
+	}
+	f.announced[endpoint] = version
+	return nil
+}
+
+type recordingSender struct {
+	mu   sync.Mutex
+	sent []string
+}
+
+func (r *recordingSender) SendVersion(_ context.Context, sub store.PushSubscription) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sent = append(r.sent, sub.Endpoint)
+}
+func (r *recordingSender) sentEndpoints() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.sent...)
+}
+
+func schedSub(ep string, tzOffsetMinutes int) store.PushSubscription {
+	return store.PushSubscription{Endpoint: ep, P256dh: "x", Auth: "y", TZOffsetMinutes: tzOffsetMinutes}
+}
+func utc(h, m int) time.Time { return time.Date(2026, 6, 22, h, m, 0, 0, time.UTC) }
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDueAtNine: a subscription is selected iff its LOCAL hour (UTC − tz offset) is 09.
+func TestDueAtNine(t *testing.T) {
+	cases := []struct {
+		name       string
+		tz         int
+		nowH, nowM int
+		want       bool
+	}{
+		{"UTC 09:30 → local 09:30", 0, 9, 30, true},
+		{"EST(+300) 14:15 → local 09:15", 300, 14, 15, true},
+		{"CEST(-120) 07:00 → local 09:00", -120, 7, 0, true},
+		{"IST(-330 half-hour, UTC+5:30) 03:30 → local 09:00", -330, 3, 30, true},
+		{"UTC 08:30 → local 08:30", 0, 8, 30, false},
+		{"UTC 10:00 → local 10:00", 0, 10, 0, false},
+		{"EST(+300) 13:30 → local 08:30", 300, 13, 30, false},
+	}
+	for _, c := range cases {
+		got := dueAtNine([]store.PushSubscription{schedSub("e", c.tz)}, utc(c.nowH, c.nowM))
+		if sel := len(got) == 1; sel != c.want {
+			t.Errorf("%s: selected=%v, want %v", c.name, sel, c.want)
+		}
+	}
+}
+
+// TestSweepSelectsDueOnly: among behind candidates, only those at local 09:00 are sent; a
+// dev/empty version sends nothing.
+func TestSweepSelectsDueOnly(t *testing.T) {
+	st := &fakeSchedStore{behind: []store.PushSubscription{
+		schedSub("at9", 0),   // local 09:30 at 09:30 UTC → due
+		schedSub("not9", 60), // local 08:30 at 09:30 UTC → not due
+	}}
+	sender := &recordingSender{}
+	SweepVersionAnnouncements(context.Background(), st, sender, "v2", utc(9, 30))
+	got := sender.sentEndpoints()
+	if len(got) != 1 || !contains(got, "at9") || contains(got, "not9") {
+		t.Errorf("sent=%v; want only [at9]", got)
+	}
+
+	// A local `dev`/empty version is a no-op.
+	dev := &recordingSender{}
+	SweepVersionAnnouncements(context.Background(), st, dev, "dev", utc(9, 30))
+	SweepVersionAnnouncements(context.Background(), st, dev, "", utc(9, 30))
+	if n := len(dev.sentEndpoints()); n != 0 {
+		t.Errorf("dev/empty version sent %d, want 0", n)
+	}
+}
+
+// TestSweepDedupOncePerRelease: a device is sent once for a version; a second sweep at its
+// 09:00 does not re-send; a NEWER version makes it eligible again exactly once.
+func TestSweepDedupOncePerRelease(t *testing.T) {
+	st := &fakeSchedStore{behind: []store.PushSubscription{schedSub("d", 0)}}
+	sender := &recordingSender{}
+
+	SweepVersionAnnouncements(context.Background(), st, sender, "v2", utc(9, 30))
+	if n := len(sender.sentEndpoints()); n != 1 {
+		t.Fatalf("first sweep sent %d, want 1", n)
+	}
+	SweepVersionAnnouncements(context.Background(), st, sender, "v2", utc(9, 30))
+	if n := len(sender.sentEndpoints()); n != 1 {
+		t.Errorf("second sweep (same version) total sent %d, want 1 (deduped)", n)
+	}
+	SweepVersionAnnouncements(context.Background(), st, sender, "v3", utc(9, 30))
+	if n := len(sender.sentEndpoints()); n != 2 {
+		t.Errorf("after newer version, total sent %d, want 2 (one more)", n)
+	}
+}

--- a/server/internal/store/push.go
+++ b/server/internal/store/push.go
@@ -1,27 +1,35 @@
 package store
 
-import (
-	"context"
-	"errors"
+import "context"
 
-	"github.com/jackc/pgx/v5"
-)
-
-// PushSubscription is a browser Web Push subscription.
+// PushSubscription is a browser Web Push subscription. InstalledVersion + TZOffsetMinutes
+// are the per-device metadata for the 9-AM-local version announcement (spec 1016); they
+// are zero/empty on subscriptions that haven't reported them and on read paths that don't
+// select them.
 type PushSubscription struct {
-	Endpoint string
-	P256dh   string
-	Auth     string
+	Endpoint         string
+	P256dh           string
+	Auth             string
+	InstalledVersion string
+	TZOffsetMinutes  int
 }
 
-// SaveSubscription upserts a push subscription for a user (idempotent on the
-// endpoint, refreshing its keys).
-func (s *Store) SaveSubscription(ctx context.Context, userID string, sub PushSubscription) error {
+// SaveSubscription upserts a push subscription for a user (idempotent on the endpoint,
+// refreshing its keys). installedVersion / tzOffsetMinutes are the client's reported app
+// version + local UTC offset (minutes); each is updated ONLY when provided (non-nil), so a
+// version-less re-subscribe (e.g. the service-worker resubscribe path) preserves the
+// values the page reported (COALESCE). last_announced_version is never written here — only
+// the version scheduler sets it.
+func (s *Store) SaveSubscription(ctx context.Context, userID string, sub PushSubscription, installedVersion *string, tzOffsetMinutes *int) error {
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth)
-		 VALUES ($1, $2, $3, $4)
-		 ON CONFLICT (user_id, endpoint) DO UPDATE SET p256dh = EXCLUDED.p256dh, auth = EXCLUDED.auth`,
-		userID, sub.Endpoint, sub.P256dh, sub.Auth)
+		`INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth, installed_version, tz_offset_minutes)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (user_id, endpoint) DO UPDATE SET
+		     p256dh = EXCLUDED.p256dh,
+		     auth = EXCLUDED.auth,
+		     installed_version = COALESCE(EXCLUDED.installed_version, push_subscriptions.installed_version),
+		     tz_offset_minutes = COALESCE(EXCLUDED.tz_offset_minutes, push_subscriptions.tz_offset_minutes)`,
+		userID, sub.Endpoint, sub.P256dh, sub.Auth, installedVersion, tzOffsetMinutes)
 	return err
 }
 
@@ -32,8 +40,8 @@ func (s *Store) DeleteSubscription(ctx context.Context, userID, endpoint string)
 	return err
 }
 
-// DeleteSubscriptionByEndpoint removes a dead subscription (push service
-// returned 404/410), regardless of owner.
+// DeleteSubscriptionByEndpoint removes a dead subscription (push service returned
+// 404/410), regardless of owner.
 func (s *Store) DeleteSubscriptionByEndpoint(ctx context.Context, endpoint string) error {
 	_, err := s.pool.Exec(ctx, `DELETE FROM push_subscriptions WHERE endpoint = $1`, endpoint)
 	return err
@@ -41,18 +49,8 @@ func (s *Store) DeleteSubscriptionByEndpoint(ctx context.Context, endpoint strin
 
 // SubscriptionsFor returns all of a user's push subscriptions.
 func (s *Store) SubscriptionsFor(ctx context.Context, userID string) ([]PushSubscription, error) {
-	return s.querySubscriptions(ctx,
+	rows, err := s.pool.Query(ctx,
 		`SELECT endpoint, p256dh, auth FROM push_subscriptions WHERE user_id = $1`, userID)
-}
-
-// AllSubscriptions returns every push subscription across all users — used for the
-// version-announcement broadcast (the only fan-out that isn't addressed to one user).
-func (s *Store) AllSubscriptions(ctx context.Context) ([]PushSubscription, error) {
-	return s.querySubscriptions(ctx, `SELECT endpoint, p256dh, auth FROM push_subscriptions`)
-}
-
-func (s *Store) querySubscriptions(ctx context.Context, q string, args ...any) ([]PushSubscription, error) {
-	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -68,24 +66,39 @@ func (s *Store) querySubscriptions(ctx context.Context, q string, args ...any) (
 	return out, rows.Err()
 }
 
-// GetAppMeta reads a server-side metadata value (empty string if the key is absent).
-func (s *Store) GetAppMeta(ctx context.Context, key string) (string, error) {
-	var v string
-	err := s.pool.QueryRow(ctx, `SELECT value FROM app_meta WHERE key = $1`, key).Scan(&v)
+// SubscriptionsBehind returns the candidate subscriptions for a version announcement: those
+// that have reported a version AND a timezone offset, whose installed version differs from
+// currentVersion (behind), and that have not already been announced for currentVersion
+// (once-per-release dedup). The local-09:00 filter is applied in Go (dueAtNine) so it stays
+// unit-testable; this is the cheap SQL pre-filter. Each row carries its TZOffsetMinutes.
+func (s *Store) SubscriptionsBehind(ctx context.Context, currentVersion string) ([]PushSubscription, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT endpoint, p256dh, auth, COALESCE(tz_offset_minutes, 0)
+		   FROM push_subscriptions
+		  WHERE installed_version IS NOT NULL
+		    AND tz_offset_minutes IS NOT NULL
+		    AND installed_version <> $1
+		    AND (last_announced_version IS NULL OR last_announced_version <> $1)`, currentVersion)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return "", nil
-		}
-		return "", err
+		return nil, err
 	}
-	return v, nil
+	defer rows.Close()
+	var out []PushSubscription
+	for rows.Next() {
+		var sub PushSubscription
+		if err := rows.Scan(&sub.Endpoint, &sub.P256dh, &sub.Auth, &sub.TZOffsetMinutes); err != nil {
+			return nil, err
+		}
+		out = append(out, sub)
+	}
+	return out, rows.Err()
 }
 
-// SetAppMeta upserts a server-side metadata value.
-func (s *Store) SetAppMeta(ctx context.Context, key, value string) error {
+// MarkAnnounced records that this subscription was sent the announcement for `version`,
+// so it isn't notified again for the same release (dedup-on-send).
+func (s *Store) MarkAnnounced(ctx context.Context, endpoint, version string) error {
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO app_meta (key, value) VALUES ($1, $2)
-		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
-		key, value)
+		`UPDATE push_subscriptions SET last_announced_version = $2 WHERE endpoint = $1`,
+		endpoint, version)
 	return err
 }

--- a/specs/1016-9-am-local/checklists/crypto-zk.md
+++ b/specs/1016-9-am-local/checklists/crypto-zk.md
@@ -1,0 +1,95 @@
+# Checklist: Crypto / Zero-Knowledge — 9-AM-Local Version-Announcement Push
+
+**Purpose**: Validate that the REQUIREMENTS (spec.md + plan.md + NFR-ZK + Zero-Knowledge
+Impact) are complete, unambiguous, and tight on the zero-knowledge boundary and metadata
+minimization. Required by Constitution Principle I (Zero-Knowledge) + Principle IX (Data
+Minimization). This feature adds NO new cryptography, so items target the metadata surface,
+not cipher/forgery/replay mechanics.
+
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content-Free Push (no content crosses the push service)
+
+- [x] CHK001 - Do the requirements state explicitly that the push payload carries no release
+  notes, version text, location, or user data — only a type marker? [Clarity, Spec §NFR-ZK-001]
+- [x] CHK002 - Is it specified that the human-readable "what's new" / version name is fetched
+  by the device from the already-public configuration at delivery time, not carried in the
+  push? [Completeness, Spec §FR-010]
+- [x] CHK003 - Are the requirements consistent that time-shifting WHEN the push is sent does
+  not change WHAT it contains (still content-free)? [Consistency, Spec §FR-010/§NFR-ZK-001]
+
+## Metadata Minimization (exactly what the server stores)
+
+- [x] CHK004 - Do the requirements enumerate the EXACT new per-device fields (installed
+  version, coarse UTC-offset-minutes, last-announced-version) and nothing more? [Completeness,
+  Spec §NFR-ZK-002 / Data Model]
+- [x] CHK005 - Is "timezone" pinned to a COARSE UTC offset in whole minutes (not an IANA zone
+  name, not coordinates), with only the local HOUR ever used? [Clarity, Spec §NFR-ZK-002,
+  Research R2]
+- [x] CHK006 - Do the requirements explicitly EXCLUDE IANA zone name, precise location, and
+  per-user behavioral/engagement history from what is stored? [Completeness, Spec §NFR-ZK-002]
+- [x] CHK007 - Is the installed-version field characterized as already-public information
+  (not newly-sensitive), so its storage doesn't widen the trust model? [Clarity, Spec §ZK
+  Impact]
+- [x] CHK008 - Is it stated that the offset is reported/refreshed via the EXISTING
+  subscribe exchange (no new always-on reporting channel that could carry more)? [Coverage,
+  Spec §FR-013, Research R1]
+
+## Single-Purpose / No Repurposing
+
+- [x] CHK009 - Do the requirements limit the new metadata's use to exactly two decisions —
+  "is this device behind?" and "is it ~9 AM there?" — and nothing else? [Clarity,
+  Spec §NFR-ZK-003]
+- [x] CHK010 - Is there an explicit prohibition on repurposing the metadata for analytics,
+  profiling, or other tracking? [Completeness, Spec §NFR-ZK-003]
+- [x] CHK011 - Are the requirements internally consistent that no NEW endpoint or query
+  exposes the per-device version/offset back to clients or third parties? [Consistency,
+  Spec §Contracts / §FR-013]
+
+## Boundary Unchanged Elsewhere
+
+- [x] CHK012 - Do the requirements affirm that messages, posts, profiles, and media remain
+  opaque ciphertext and this feature adds nothing to what the server can read about them?
+  [Completeness, Spec §ZK Impact, Boundary]
+- [x] CHK013 - Is it clear that removing the old immediate broadcast (Research R7) does not
+  itself relax any zero-knowledge guarantee? [Consistency, Research R7]
+
+## Logging & Observability (no profile-building leak)
+
+- [x] CHK014 - Do the requirements/plan state that the new metadata and the scheduler MUST
+  NOT be logged in a way that builds a per-user timezone or behavioral profile beyond the
+  coarse stored fields? [Gap, Spec §NFR-ZK-003]
+- [x] CHK015 - Is it specified that scheduler/delivery logs avoid recording per-device local
+  times or send-history in a form that reconstructs user routines? [Coverage, Gap]
+
+## Dedup-on-Send / No Delivery Tracking
+
+- [x] CHK016 - Is once-per-release dedup specified as keyed on SEND (last-announced-version),
+  explicitly NOT requiring delivery/open receipts? [Clarity, Spec §FR-006/§FR-015, Research R5]
+- [x] CHK017 - Do the requirements confirm that NO delivery-confirmation or open-tracking
+  metadata is collected (which would be extra surveillance surface)? [Completeness, Gap,
+  Spec §NFR-ZK-002]
+- [x] CHK018 - Is the short-TTL / expire-by-midday behavior tied to the no-overnight goal
+  WITHOUT introducing any new per-device delivery state beyond last-announced-version?
+  [Consistency, Spec §FR-015, Research R5]
+
+## Coverage, Edge Cases & Measurability
+
+- [x] CHK019 - Are the "no new data beyond X" guarantees expressed as a verifiable success
+  criterion (inspectable), not just prose? [Measurability, Spec §SC-006]
+- [x] CHK020 - Is the "no timezone reported" case covered such that absence of data simply
+  excludes the device (no fallback that infers location)? [Edge Case, Spec §FR-012]
+- [x] CHK021 - Are requirements consistent that a user with multiple devices yields only
+  per-device coarse data, never a merged cross-device profile? [Consistency, Spec §FR-008]
+- [x] CHK022 - Does the spec's Zero-Knowledge Impact section answer all constitution-required
+  prompts (what new data is visible, why each is unavoidable, what is NOT collected, boundary
+  unchanged)? [Completeness, Constitution Principle I]
+
+## Notes
+
+- All product/crypto-relevant decisions are settled (content-free payload reused from #313;
+  offset-not-zone per R2; dedup-on-send + short TTL per R5; broadcast removed per R7).
+- This checklist validates requirement QUALITY; the implementation-level zero-knowledge
+  behavior is additionally guarded by unit tests (no content in payload, only the listed
+  columns) per plan.md Verification.

--- a/specs/1016-9-am-local/checklists/requirements.md
+++ b/specs/1016-9-am-local/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: 9-AM-Local Version-Announcement Push
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Zero-knowledge is captured as explicit NFR-ZK requirements + US4; the crypto/ZK
+  checklist is required at the `/speckit-checklist` step (new per-device metadata surface).
+- All product choices are locked in the feature input (fixed 09:00, once-per-release,
+  per-device, UTC-offset-minutes via re-registration); remaining defaults are recorded in
+  Assumptions, so no [NEEDS CLARIFICATION] markers were needed. `/speckit-clarify` will
+  re-confirm.
+- "Implementation details" were deliberately kept out of the spec (no columns, endpoints,
+  schedulers); those belong in plan.md.

--- a/specs/1016-9-am-local/contracts/push-subscribe.md
+++ b/specs/1016-9-am-local/contracts/push-subscribe.md
@@ -1,0 +1,41 @@
+# Contract delta — `POST /v1/push/subscribe`
+
+The only wire-contract change. The endpoint, auth (Bearer), and existing fields are
+unchanged; **two optional fields are added** to the request body. No response change.
+
+## Request body (additions in **bold**)
+
+```jsonc
+{
+  "endpoint": "https://push.example/...",   // existing, required
+  "keys": {
+    "p256dh": "<base64url>",                // existing, required
+    "auth":   "<base64url>"                 // existing, required
+  },
+  "installedVersion": "0.1.0-dev.131+abc1234",  // NEW, optional — the client's __APP_VERSION__
+  "tzOffsetMinutes": -120                        // NEW, optional — new Date().getTimezoneOffset()
+}
+```
+
+### Field rules
+- `installedVersion` (optional, string): the running client build. Sent by the page on
+  subscribe/foreground. Omitted by the service-worker resubscribe path.
+- `tzOffsetMinutes` (optional, integer): JS `getTimezoneOffset()` (minutes; `UTC − local`,
+  e.g. EST → `300`, CEST → `-120`). Omitted by the SW resubscribe path.
+- **Omission semantics**: when a field is absent, the server preserves the previously stored
+  value for that subscription (COALESCE upsert). Sending both keeps them current; the SW's
+  version-less resubscribe never clears them.
+- These fields are **not** secret, but they are metadata — the server stores only these two
+  coarse values (plus a server-written `last_announced_version`) and nothing more
+  (NFR-ZK-002).
+
+## Response
+Unchanged (e.g. `204 No Content` / existing success). No new response fields.
+
+## Behavioral contract (server-internal, no external endpoint)
+- A periodic job sends the existing content-free `{"t":"version"}` Web Push **only** to
+  subscriptions that are behind the current server version, **at the device's local 09:00**,
+  with a **short TTL** (expires by ~local midday), **once per current version**
+  (`last_announced_version`).
+- There is **no** immediate broadcast on deploy and **no** new client-facing endpoint for
+  scheduling — it is entirely server-side off the stored subscription metadata.

--- a/specs/1016-9-am-local/data-model.md
+++ b/specs/1016-9-am-local/data-model.md
@@ -1,0 +1,44 @@
+# Phase 1 — Data Model
+
+Only the existing `push_subscriptions` table changes (additive). No client IndexedDB
+change, no new tables.
+
+## `push_subscriptions` (existing — migration 0006) + this feature's additions
+
+| Column | Type | Origin | Purpose |
+|---|---|---|---|
+| `user_id` | uuid | existing | owner (PK part) |
+| `endpoint` | text | existing | unique device push endpoint (PK part) |
+| `p256dh` | text | existing | Web Push key |
+| `auth` | text | existing | Web Push key |
+| `created_at` | timestamptz | existing | — |
+| **`installed_version`** | **text NULL** | **new** | the client version this device currently runs (reported on subscribe). NULL = not yet reported → device is not a 9-AM candidate (FR-012). |
+| **`tz_offset_minutes`** | **int NULL** | **new** | device local UTC offset in minutes (`getTimezoneOffset()`; `local = UTC − offset`). NULL = not yet reported → not a candidate. |
+| **`last_announced_version`** | **text NULL** | **new** | the latest version this device was last *sent* an announcement for. Drives once-per-release dedup. Written only by the scheduler. |
+
+### Validation / rules
+- `installed_version`, `tz_offset_minutes` are written via `SaveSubscription` only when the
+  request provides them; a request that omits them preserves prior values
+  (`COALESCE(EXCLUDED.x, push_subscriptions.x)`).
+- `last_announced_version` is written only by `MarkAnnounced` (the scheduler), never by
+  subscribe.
+- A device is a **9-AM candidate** iff `installed_version IS NOT NULL AND tz_offset_minutes
+  IS NOT NULL`.
+- A candidate is **behind** iff `installed_version <> <server current version>`.
+- A behind candidate is **due** iff `(last_announced_version IS NULL OR <> current)` AND its
+  local hour (`UTC − tz_offset_minutes`) == 9.
+
+### State transitions (per subscription, w.r.t. announcements)
+```
+        subscribe(version V, tz)                scheduler @ local 9AM, behind, not-announced
+[no version] ───────────────► [reporting V, tz] ───────────────────────────────────────► [announced=current]
+        ▲                              │                                                          │
+        │ resubscribe (omit version)   │ user updates → subscribe(version=current)                │ newer release deploys
+        └──────────────────────────────┘ ───────────────► [reporting=current → not behind]        └──► [behind again → eligible once for the new version]
+```
+
+## Derived / in-memory (not stored)
+- **Latest deployed version**: the running server's `version` (ldflags-stamped
+  `main.version` → `Handlers.Version`); the comparison reference, not persisted per device.
+- **`dueAtNine` result**: the per-tick set of subscriptions whose local hour == 9 — computed,
+  not stored.

--- a/specs/1016-9-am-local/plan.md
+++ b/specs/1016-9-am-local/plan.md
@@ -1,0 +1,166 @@
+# Implementation Plan: 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only)
+
+**Branch**: `feat/1016-9-am-local` | **Date**: 2026-06-22 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1016-9-am-local/spec.md`
+
+## Summary
+
+Replace the immediate, all-device version-announcement broadcast (shipped in #313) with a
+**scheduled, per-device, behind-only** delivery: the content-free `{"t":"version"}` push
+is sent at **09:00 in each device's local time**, only to devices whose installed client
+version differs from the server's current version, **once per release**, and with a
+**short lifetime** so a missed-morning push expires by ~local midday instead of arriving
+at night. The client reports its installed version + local UTC-offset-minutes by
+piggybacking on the existing push-subscribe call; a periodic server job evaluates which
+devices are due and sends to each.
+
+## Technical Context
+
+**Language/Version**: Go 1.26 (server `ringd`); TypeScript / Vue 3 + Ionic (client PWA).
+
+**Primary Dependencies**: stdlib `net/http`, `pgx` v5, embedded SQL migrations,
+`SherClockHolmes/webpush-go` (existing); client `fetch` + existing push/SW stack. No new
+dependencies.
+
+**Storage**: PostgreSQL — extend the existing `push_subscriptions` table (forward-only
+migration). No client IndexedDB change.
+
+**Testing**: `go test ./...` (in-memory fake store) for store/handler/scheduler-selector;
+a pure unit test for the local-9AM selector; client `vue-tsc` + `vite build`; drive/console
+spot-check that the subscribe request carries the new fields.
+
+**Target Platform**: Linux server + installable PWA (existing).
+
+**Project Type**: web-service + PWA (existing Ring monorepo).
+
+**Performance Goals**: the periodic scheduler runs every ~15 min and queries a
+pre-filtered (behind, not-yet-announced) subset; bounded delivery concurrency (reuse the
+existing broadcast cap). No user-facing latency path.
+
+**Constraints**: zero-knowledge boundary (Principle I); forward-only migrations
+(Principle VI); content-free push payload; coarse metadata only.
+
+**Scale/Scope**: Ring's small private network — at most a few thousand subscriptions;
+every-15-min full evaluation is comfortably within budget.
+
+## Constitution Check
+
+*GATE: re-checked after Phase 1 design — still passing.*
+
+- **I. Zero-Knowledge Boundary (NON-NEGOTIABLE)** — PASS. Push payload stays content-free;
+  the only new server-readable data is the installed version (already public) + a coarse
+  UTC-offset-in-minutes + a last-notified-version dedup marker. Captured in the spec's
+  **Zero-Knowledge Impact** section + NFR-ZK-001..003. The crypto/ZK **checklist is
+  REQUIRED** (next step) because this adds a metadata surface.
+- **II. Spec-Driven Development** — PASS. Running the full pipeline; branch/commits/issues
+  trace to spec 1016.
+- **III. Test-Driven Development** — PASS with a noted limitation. `tasks.md` orders
+  failing tests first: a pure `dueAtNine` selector unit test, store query/dedup tests, and
+  subscribe-handler persistence tests (fake store). **e2e limitation**: the actual
+  9-AM-local push *delivery* is not e2e-testable in the harness (no push service + no
+  wall-clock/timezone control), so behavioral coverage is unit-level for the timing/targeting
+  logic; client-side reporting is verified via typecheck + a drive spot-check. Justified
+  deviation from "add an e2e spec," recorded here.
+- **IV. Crypto Discipline** — PASS (N/A). No crypto added or changed.
+- **V. Offline-First Data Integrity** — PASS (N/A). No IndexedDB object store change; the
+  client only adds two fields to an existing outbound request.
+- **VI. Stateless Server & Forward-Only Migrations** — PASS. New `NNNN_*.sql` migration
+  (ALTER push_subscriptions, additive); no shipped migration edited; `SECRETS_KEY`
+  untouched.
+- **VII. Quality Gates** — PASS. `go build/vet/test`, `vue-tsc`, `vite build` are the DoD.
+- **VIII. Traceable, Auto-Closing Delivery** — PASS. `taskstoissues` → `Closes #N` in the
+  PR.
+- **IX. Privacy & Data Minimization** — PASS. Two coarse fields, minimal, single-purpose,
+  not repurposed (NFR-ZK-003).
+- **X. Accessibility & i18n** — PASS (N/A). No new text surface (the notification copy is
+  unchanged and already rendered from public config).
+- **XI. Ionic-First UI** — PASS (N/A). No UI change.
+
+**Gate result: PASS** — proceed; the crypto/ZK checklist is the one required follow-up
+artifact before tasks.
+
+## Design Overview
+
+### Client (report version + tz on the existing subscribe)
+- The client already re-POSTs the push subscription on app start and on each foreground
+  (`src/services/push.ts` `ensurePushSubscription` / `revalidatePushSubscription`, ~5-min
+  throttle). Add two fields to that request body: `installedVersion` (the compile-time
+  `__APP_VERSION__`, already used in `src/composables/useAppUpdate.ts`) and
+  `tzOffsetMinutes` (`new Date().getTimezoneOffset()`).
+- `src/services/api.ts` `subscribePush` gains the two optional fields.
+- The service-worker resubscribe path (`src/services/sw-push.ts`) keeps sending without
+  these fields (no `__APP_VERSION__` in the SW build); the server preserves existing values
+  when they're absent (COALESCE), so the SW path never clobbers them.
+
+### Server (store the fields, schedule the 9-AM delivery)
+- **Migration** (next `NNNN`): `ALTER TABLE push_subscriptions ADD COLUMN installed_version
+  text, ADD COLUMN tz_offset_minutes int, ADD COLUMN last_announced_version text;`
+- **`SaveSubscription`** (`store/push.go`): accept optional `installedVersion *string` +
+  `tzOffsetMinutes *int`; upsert refreshes p256dh/auth always and version/tz only when
+  provided (`COALESCE(EXCLUDED.x, push_subscriptions.x)`). `last_announced_version` is never
+  written here.
+- **`SubscriptionsBehind(ctx, currentVersion)`** (`store/push.go`): SQL pre-filter —
+  `installed_version IS NOT NULL AND tz_offset_minutes IS NOT NULL AND installed_version <>
+  $1 AND (last_announced_version IS NULL OR last_announced_version <> $1)`; returns endpoint
+  + keys + tz_offset (new `TZOffsetMinutes` field on the `PushSubscription` struct).
+- **Pure selector** `dueAtNine(subs, nowUTC) []PushSubscription` (new
+  `internal/push/schedule.go`): keep subs whose **local** hour == 9, where `local = nowUTC -
+  tz_offset_minutes` (JS `getTimezoneOffset()` = UTC−local). Unit-testable with an injected
+  `now`.
+- **`SendVersion(ctx, sub)`** (`internal/push/push.go`): deliver the existing
+  `versionParams()` tickle to ONE subscription — with a **short TTL** for the
+  expire-by-midday requirement (FR-015). Reuse `deliver`; set `versionTTL` to a few hours so
+  a missed morning push never arrives at night. (The collapsible `ring-version` topic stays.)
+- **`MarkAnnounced(ctx, endpoint, version)`** (`store/push.go`): set `last_announced_version
+  = version WHERE endpoint = $1` — dedup-on-send (FR-006/FR-015).
+- **Scheduler goroutine** in `cmd/ringd/main.go run()`, modeled on the existing relay-sweep
+  ticker (`time.NewTicker`, `defer ticker.Stop()`, `select { <-ctx.Done() | <-ticker.C }`):
+  every ~15 min, skip if `version == "dev"`/`""` or `notifier == nil`; else `subs :=
+  SubscriptionsBehind(version)`; for each `dueAtNine(subs, time.Now().UTC())` →
+  `SendVersion` + `MarkAnnounced` (bounded concurrency like the old broadcast).
+- **Remove** the on-boot broadcast: `announceVersionIfChanged` (main.go) +
+  `Notifier.BroadcastVersion` + `Store.AllSubscriptions` (+ `GetAppMeta`/`SetAppMeta` /
+  `lastAnnouncedVersionKey` if unused). The `app_meta` table (migration 0024) stays
+  (append-only) but is no longer used by this feature.
+
+### Unchanged
+- The service-worker `{"t":"version"}` handler + `showVersionNotification` (fetches
+  `/v1/config` at delivery, content-free) and the in-app `useAppUpdate` toast are untouched
+  — the SW path is delivery-time-agnostic, so time-shifting the push needs no SW change.
+
+## Project Structure
+
+### Documentation (this feature)
+```text
+specs/1016-9-am-local/
+├── plan.md          # this file
+├── research.md      # Phase 0
+├── data-model.md    # Phase 1
+├── quickstart.md    # Phase 1
+├── contracts/       # Phase 1 (subscribe request contract delta)
+└── tasks.md         # /speckit-tasks (next)
+```
+
+### Source (touched)
+```text
+server/internal/db/migrations/NNNN_push_version.sql   # new (additive ALTER)
+server/internal/store/push.go                          # fields + SaveSubscription + SubscriptionsBehind + MarkAnnounced; remove AllSubscriptions
+server/internal/push/push.go                           # SendVersion + short version TTL; remove BroadcastVersion
+server/internal/push/schedule.go                       # new: pure dueAtNine + tests
+server/internal/api/push_handlers.go                   # subscribe DTO gains installedVersion/tzOffsetMinutes
+server/cmd/ringd/main.go                               # remove announceVersionIfChanged; add the 15-min scheduler
+src/services/api.ts, src/services/push.ts              # send installedVersion + tzOffsetMinutes on subscribe
+```
+
+## Phasing
+- **Phase 0 — research.md**: design parameters (scheduler cadence, short TTL value, offset
+  sign, dedup-on-send, COALESCE upsert). Done.
+- **Phase 1 — data-model.md / contracts / quickstart**: the `push_subscriptions` delta, the
+  `/v1/push/subscribe` request contract delta, the verification recipe. Done.
+- **Phase 2 — tasks.md**: produced by `/speckit-tasks` (TDD order).
+
+## Complexity Tracking
+No constitution deviations requiring justification beyond the noted TDD/e2e limitation
+(push-timing not e2e-testable in the harness; covered by unit tests + typecheck + drive
+spot-check).

--- a/specs/1016-9-am-local/quickstart.md
+++ b/specs/1016-9-am-local/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart — verifying 9-AM-local version-announcement push
+
+## Build / gates
+```sh
+cd server && go build ./... && go vet ./... && go test ./...   # store + handler + scheduler-selector
+npm run build                                                   # client typecheck + build
+```
+
+## What to verify
+
+### 1. Client reports version + tz (unit/spot-check)
+- After `npm run build`, the `POST /v1/push/subscribe` body includes `installedVersion`
+  (= `__APP_VERSION__`) and `tzOffsetMinutes` (= `getTimezoneOffset()`).
+- Spot-check against the live dev stack (`make start`): in the app, enable notifications and
+  watch the network/console — the subscribe request carries the two new fields.
+
+### 2. Server persists + preserves (Go tests, in-memory fake store)
+- Subscribe with `installedVersion`/`tzOffsetMinutes` → both persisted.
+- Resubscribe **without** them (the SW path) → previously stored values **unchanged**
+  (COALESCE).
+- `MarkAnnounced(endpoint, V)` → `last_announced_version == V`.
+
+### 3. `dueAtNine` selector (pure unit test — the core timing logic)
+With an injected `nowUTC`, assert a subscription is selected **iff** its local hour
+(`UTC − tz_offset_minutes`) == 9:
+- UTC `09:30`, `tzOffsetMinutes = 0` (UTC) → **selected** (local 09:30).
+- UTC `14:15`, `tzOffsetMinutes = 300` (EST, UTC−5) → **selected** (local 09:15).
+- UTC `07:00`, `tzOffsetMinutes = -120` (CEST, UTC+2) → **selected** (local 09:00).
+- UTC `03:30`, `tzOffsetMinutes = -330` (IST, UTC+5:30) → **selected** (local 09:00) — half-hour zone.
+- Same subs one hour earlier/later → **not** selected.
+
+### 4. `SubscriptionsBehind` filtering (Go test)
+- A device on the current version → excluded.
+- A device already announced for the current version → excluded.
+- A device with NULL version or NULL tz → excluded (not a candidate).
+- A behind, not-yet-announced device with version+tz → included.
+
+### 5. Scheduler wiring (reasoning / log check)
+- On a `dev`/empty version or nil notifier, the scheduler does nothing.
+- On a real version, each ~15-min tick: `SubscriptionsBehind(current)` → `dueAtNine(now)` →
+  `SendVersion` + `MarkAnnounced` per device. Confirm via `slog` on the dev stack that a
+  tick runs and is a no-op when no device is due.
+
+## Out of scope for automated verification
+The end-to-end **push delivery at 09:00 local** can't run in the e2e harness (no push
+service, no wall-clock/timezone control). The timing/targeting logic is covered by the pure
+`dueAtNine` + store tests above; the rest is the existing, already-shipped SW
+`{"t":"version"}` path (unchanged).

--- a/specs/1016-9-am-local/research.md
+++ b/specs/1016-9-am-local/research.md
@@ -1,0 +1,77 @@
+# Phase 0 — Research: 9-AM-Local Version-Announcement Push
+
+All "NEEDS CLARIFICATION" items from Technical Context are resolved below.
+
+## R1 — Where the client reports installed version + timezone
+**Decision**: Piggyback on the existing `POST /v1/push/subscribe` call.
+**Rationale**: The client already re-sends the subscription on app start and on every
+foreground (`src/services/push.ts` `ensurePushSubscription`/`revalidatePushSubscription`,
+~5-min throttle), so version + offset stay fresh (DST/travel/updates picked up on the next
+foreground) with no new endpoint or always-on channel — matches the locked decision.
+**Alternatives considered**: a dedicated `device-report` WS frame on connect (more code,
+new surface); a separate REST endpoint (extra surface). Rejected for minimalism.
+
+## R2 — Timezone representation + sign convention
+**Decision**: Store a coarse **UTC offset in whole minutes** = JavaScript
+`new Date().getTimezoneOffset()`. Local time = `UTC − offset` (getTimezoneOffset returns
+`UTC − local`, e.g. New York EST → +300, Berlin CEST → −120).
+**Rationale**: Minutes cover half/45-min zones; far less identifying than an IANA name or
+coordinates (Principle IX). Refreshed each foreground, so DST is handled without storing a
+zone. The only use is `EXTRACT hour(local) == 9`.
+**Alternatives considered**: IANA zone name (more identifying, more storage, needs a tz
+database server-side). Rejected.
+
+## R3 — "Behind" comparison
+**Decision**: `installed_version <> current_server_version` (string inequality).
+**Rationale**: Ring is single-deployment (one current version at a time); dev builds carry
+`-dev.N+sha`, so any difference is a real "not the current build." No semver parsing
+needed.
+**Alternatives considered**: semver "<" comparison — unnecessary and fragile against the
+`+sha` build metadata; could mis-handle pre-release ordering. Rejected.
+
+## R4 — When is it "9 AM there"? (scheduler cadence + window)
+**Decision**: A periodic job every **15 minutes** selects devices whose **local hour == 9**
+(a pure `dueAtNine(subs, nowUTC)` function), then sends + marks-announced. Delivery lands
+within the local 09:00–09:59 window, deduped to once.
+**Rationale**: 15 min is frequent enough to land near 09:00 and cheap at Ring's scale; the
+hour-equality + once-per-release dedup keeps it simple and idempotent across ticks within
+the hour. Pure function = unit-testable with an injected clock (no DB, no real time).
+**Alternatives considered**: per-device timers (state explosion); exact 09:00 cron per zone
+(complex, marginal benefit); doing the hour math in SQL (harder to unit-test). Rejected.
+
+## R5 — Offline-at-9 AM behavior + dedup point (from the clarification)
+**Decision**: Send the version push with a **short TTL (~a few hours, expiring by local
+midday)** and mark the device announced-for-this-version **on send** (not on confirmed
+delivery — Web Push gives no delivery receipt).
+**Rationale**: A short TTL guarantees a missed-morning push is dropped by the push service
+rather than delivered that night (satisfies SC-001 / FR-015). Dedup-on-send keeps
+"once per release" simple; a device that misses the window relies on the in-app prompt and
+becomes eligible again only when a newer version ships. Matches the user's clarification.
+**Alternatives considered**: long hold (re-introduces night delivery — rejected); retry
+next morning until delivered (needs delivery tracking Web Push can't provide, and blurs
+once-per-release — rejected).
+
+## R6 — Upsert that doesn't clobber version/tz from the SW resubscribe
+**Decision**: `SaveSubscription` upserts p256dh/auth always, and version/tz via
+`COALESCE(EXCLUDED.x, push_subscriptions.x)` so a request that omits them (the SW
+`resubscribePush`, which has no `__APP_VERSION__`) preserves the page-reported values.
+`last_announced_version` is only ever written by the scheduler.
+**Rationale**: Keeps the existing single subscribe endpoint authoritative while tolerating
+the version-less SW path. **Alternatives**: a separate metadata endpoint (extra surface).
+Rejected.
+
+## R7 — Replace, not augment, the on-boot broadcast
+**Decision**: Remove `announceVersionIfChanged` (boot broadcast) + `BroadcastVersion` +
+`AllSubscriptions`; the scheduler is the sole delivery path. Keep `versionParams`/
+`tickleVersion`/`ring-version` topic; reduce `versionTTL` to the short value (R5).
+**Rationale**: The user wants no immediate blast. The `app_meta` table (migration 0024)
+becomes unused for this feature but stays (migrations are forward-only); drop the now-dead
+`GetAppMeta`/`SetAppMeta`/`lastAnnouncedVersionKey` only if no other caller.
+
+## R8 — Background-job pattern + graceful shutdown
+**Decision**: Reuse the existing relay-sweep ticker pattern in `cmd/ringd/main.go run()`:
+`go func(){ t := time.NewTicker(15*time.Minute); defer t.Stop(); for { select { case
+<-ctx.Done(): return; case <-t.C: /* evaluate + send */ } } }()`, with a bounded work
+timeout per tick and `slog` logging.
+**Rationale**: Proven pattern in the codebase; honors `ctx` from `signal.NotifyContext` for
+clean shutdown; has direct access to `st` (store) + `notifier`.

--- a/specs/1016-9-am-local/spec.md
+++ b/specs/1016-9-am-local/spec.md
@@ -1,0 +1,294 @@
+# Feature Specification: 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only)
+
+**Feature Branch**: `feat/1016-9-am-local`
+
+**Created**: 2026-06-22
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "9 AM local version-announcement push (per-device, behind-only)"
+
+## Overview
+
+Ring tells people when a newer version of the app is available with a "what's new"
+notification. Today that notification is sent to **every** device **the moment** a new
+release is deployed — which can wake people in the middle of the night during a
+late-night release, and pesters people who have already updated.
+
+This feature changes **when** and **to whom** the update notification is delivered (it
+does not change the notification's content or the separate in-app "what's new" prompt).
+The notification is delivered at **09:00 in each device's own local time**, and **only**
+to devices that are **behind** the latest release. A device already on the latest version
+is never disturbed, and a device that ignores a nudge is not re-nagged for the same
+version.
+
+## Clarifications
+
+### Session 2026-06-22
+
+- Q: If a behind device is offline at its local 09:00, how should the update push behave (a held push could otherwise be delivered at night)? → A: The 09:00 push carries a short lifetime and expires by roughly local midday if undelivered, so it is **never** delivered outside the morning window; a device that misses it relies on the in-app prompt, and a future newer release re-triggers a fresh morning nudge. The device is counted as notified-for-this-version when the push is sent (not on confirmed delivery).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Out-of-date user is told at a humane local hour, not overnight (Priority: P1)
+
+Someone whose installed app is older than the latest release should learn about the
+update at a reasonable morning hour in their own timezone — never at 3 AM because a
+release happened to ship overnight.
+
+**Why this priority**: This is the core problem being solved — avoiding off-hours
+disturbance. Without it, the feature delivers nothing.
+
+**Independent Test**: Put a device on an older version in a known timezone; advance to
+09:00 local and confirm the update notification arrives; confirm that at any other local
+hour (e.g., 03:00 local) it does not.
+
+**Acceptance Scenarios**:
+
+1. **Given** a device is behind the latest version and its local time reaches 09:00,
+   **When** the system evaluates pending announcements, **Then** that device receives the
+   "a new version is available" notification.
+2. **Given** a device is behind the latest version and its local time is outside the
+   09:00 hour (e.g., 02:00 or 14:00 local), **When** the system evaluates pending
+   announcements, **Then** that device receives no announcement at that time.
+3. **Given** a release is deployed at 01:00 in a device's local time, **When** that night
+   passes, **Then** the device is not notified until 09:00 local that morning.
+
+---
+
+### User Story 2 - Already-updated users are never pinged (Priority: P1)
+
+Someone who has already updated to the latest version should never receive an "update
+available" notification — it would be wrong and annoying.
+
+**Why this priority**: Equally core; notifying up-to-date users is both incorrect and a
+disturbance. P1 alongside US1 — together they form the MVP.
+
+**Independent Test**: Put a device on the latest version; advance through 09:00 local and
+confirm it receives no update notification.
+
+**Acceptance Scenarios**:
+
+1. **Given** a device's installed version equals the latest deployed version, **When**
+   09:00 local arrives, **Then** the device receives no update notification.
+2. **Given** a user has two devices — one updated, one behind — **When** both reach 09:00
+   local, **Then** only the behind device is notified.
+
+---
+
+### User Story 3 - A user who ignores the nudge isn't re-nagged for the same version (Priority: P2)
+
+Someone who is behind and chooses not to update right away should be told **once** per
+release, not nagged every morning.
+
+**Why this priority**: A refinement that prevents the feature from becoming an annoyance;
+not required for the basic timing/targeting to work, so P2.
+
+**Independent Test**: Keep a device behind across several days; confirm it receives the
+announcement once for the current latest version, then nothing further for that same
+version; after a newer version ships, confirm it receives exactly one announcement for
+the newer version.
+
+**Acceptance Scenarios**:
+
+1. **Given** a behind device was already notified about the current latest version,
+   **When** subsequent 09:00-local windows pass without a new release, **Then** the device
+   receives no further announcements.
+2. **Given** a behind device that was previously notified about version A, **When** a
+   newer version B becomes the latest and the device is still behind, **Then** at the next
+   09:00 local the device receives exactly one announcement (for B).
+
+---
+
+### User Story 4 - The operator/server learns only coarse, minimal metadata (Priority: P2)
+
+To schedule per-device, behind-only delivery, the server must know each device's
+installed version and roughly what time it is there. This must be the **minimum** needed,
+consistent with Ring's zero-knowledge posture — no notification content, no precise
+location, no behavioral profiling.
+
+**Why this priority**: Ring's defining constraint is zero-knowledge; this story makes the
+privacy envelope explicit and testable. P2 because the headline behavior (US1/US2) can be
+demonstrated first, but this MUST hold before shipping.
+
+**Independent Test**: Inspect everything stored/logged for the feature and confirm it is
+limited to (a) an installed version string and (b) a coarse local UTC offset in minutes
+per device — and that the notification itself carries no content.
+
+**Acceptance Scenarios**:
+
+1. **Given** the feature is active, **When** the data retained per device is inspected,
+   **Then** it contains only the installed version, a coarse local UTC offset in whole
+   minutes, and a record of the last version that device was notified about — and nothing
+   else new.
+2. **Given** an update notification is delivered, **When** its payload is inspected,
+   **Then** it contains no release notes, version text, location, or user data — only a
+   marker that prompts the device to fetch the already-public "what's new" information
+   itself.
+
+---
+
+### Edge Cases
+
+- **Multiple releases overnight**: if two releases ship before a device's 09:00, the
+  device is notified once at 09:00 for whatever is the **current** latest version then —
+  not once per intervening release.
+- **Timezone change / DST / travel**: the device's local offset is refreshed when the app
+  is next opened, so the next 09:00-local evaluation uses the updated offset.
+- **Half-hour / 45-minute timezones** (e.g., UTC+5:30, UTC+5:45): 09:00 local is still
+  well-defined from the minute offset.
+- **Device offline at its 09:00**: the notification has a short lifetime and expires by
+  roughly local midday — it is **never** held and delivered that evening/night. A device
+  offline through the morning simply misses that version's push (it still sees the in-app
+  prompt on next open, and a future newer release re-triggers a fresh morning nudge).
+- **Device never reopens the app after a release**: it never reports a newer installed
+  version, so if it was already behind and reachable it still receives one 09:00 nudge for
+  the current latest version.
+- **No timezone reported yet**: a device that has never reported a local offset is not
+  scheduled for 09:00-local delivery; it learns of updates via the in-app prompt instead.
+- **Notifications disabled / no registration**: a device with no notification
+  registration receives no announcement (inherent).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST record, per device notification registration, the app
+  version that device currently has installed.
+- **FR-002**: The system MUST record, per device notification registration, the device's
+  local time as a coarse UTC offset in whole minutes, and MUST refresh it whenever the
+  device re-registers for notifications, so timezone and daylight-saving changes are
+  reflected.
+- **FR-003**: The system MUST treat a device as "behind" when its recorded installed
+  version differs from the latest deployed version.
+- **FR-004**: The system MUST deliver the "a new version is available" notification to a
+  behind device during the **09:00 hour in that device's local time**.
+- **FR-005**: The system MUST NOT deliver the update notification to a device whose
+  recorded installed version equals the latest deployed version.
+- **FR-006**: For a given latest version, the system MUST deliver the update notification
+  to a behind device **at most once** (no repeat for the same target version).
+- **FR-007**: If a device remains behind and a **newer** version later becomes the latest,
+  the system MUST deliver exactly one notification for that newer version at the device's
+  next 09:00 local.
+- **FR-008**: The system MUST evaluate "behind" and the local 09:00 window **per device**,
+  so different devices belonging to the same user are notified independently based on each
+  device's own installed version and local offset.
+- **FR-009**: The system MUST NOT perform an immediate, all-device broadcast when a new
+  version is deployed; this scheduled, behind-only delivery replaces that behavior.
+- **FR-010**: The device MUST obtain the notification's human-readable content (the
+  version name and "what's new") at delivery time from the already-public app
+  configuration; this content MUST NOT be carried in the notification payload.
+- **FR-011**: The separate in-app "what's new" prompt shown when a user opens the app MUST
+  be unaffected by this feature.
+- **FR-012**: A device that has not reported a local UTC offset MUST NOT be scheduled for
+  09:00-local delivery.
+- **FR-013**: The device MUST report its installed version and local offset by reusing the
+  existing notification-registration exchange (no separate always-on reporting channel is
+  introduced).
+- **FR-014**: Re-reporting an installed version or offset MUST NOT disturb an existing
+  registration's other data, and a re-registration that omits version/offset MUST leave
+  the previously recorded values intact.
+- **FR-015**: The update notification MUST carry a short lifetime so it is **never**
+  delivered outside the morning window: if a device is offline at its 09:00 and does not
+  come online by roughly local midday, the notification MUST expire undelivered rather
+  than arrive later that evening or night. A device for which the notification was sent
+  MUST be treated as notified for that version (once-per-release dedup is on send, not on
+  confirmed delivery), so it relies on the in-app prompt for that release and is eligible
+  again only when a newer version becomes the latest.
+
+### Non-Functional Requirements — Zero-Knowledge (NFR-ZK)
+
+- **NFR-ZK-001**: The update notification payload MUST remain content-free — it MUST carry
+  no release notes, no version text, and no user data; it carries only a marker that
+  causes the device to fetch the public "what's new" information itself.
+- **NFR-ZK-002**: The only new per-device metadata stored for this feature MUST be (a) the
+  installed app version string (already public information), (b) a coarse local UTC offset
+  in whole minutes, and (c) the last app version that device was notified about (for
+  once-per-release dedup). No IANA timezone name, no precise location, no per-user
+  behavioral history, and no notification content may be stored or logged.
+- **NFR-ZK-003**: The added metadata MUST be used solely to decide "is this device behind?"
+  and "is it the 09:00 hour there?"; it MUST NOT be repurposed for other tracking or
+  analytics.
+- **NFR-ZK-004**: Logs and other observability output MUST NOT record the new metadata (or
+  scheduler activity) in a way that reconstructs a per-user timezone or behavioral profile —
+  e.g., no logging of a device's local time of day, send history, or delivery/open events
+  beyond the coarse fields needed to operate and debug the scheduler. No delivery- or
+  open-confirmation metadata is collected at all (the once-per-release dedup is keyed on
+  send, not on delivery).
+
+### Key Entities *(include if feature involves data)*
+
+- **Device notification registration**: one device's registration to receive
+  notifications. For this feature it additionally carries the device's installed app
+  version, its coarse local UTC offset (minutes), and the last app version it was notified
+  about.
+- **Latest deployed version**: the app version the running service currently reports as
+  current; the reference point for deciding whether a device is "behind."
+
+## Zero-Knowledge Impact
+
+*(Required by Constitution Principle I.)*
+
+- **What new data, if any, becomes visible to the server?** Per device notification
+  registration, two new values plus one dedup marker: (a) the installed app version
+  string — already public (the running server publishes its own version, and the client
+  version is shown in-app); (b) a coarse local UTC offset in **whole minutes**; and (c) the
+  last app version that device was notified about. Nothing else.
+- **Why is each unavoidable for the feature?** The version is required to decide "is this
+  device behind the latest?"; the UTC-offset-minutes is the minimum needed to know when it
+  is 09:00 in the device's local time; the last-notified version is required for
+  once-per-release dedup. None can be omitted without losing a core requirement.
+- **What is explicitly NOT collected?** No notification content (the push stays
+  content-free; the device fetches the public "what's new" itself), no IANA timezone name,
+  no precise location or coordinates, no per-user behavioral/engagement history, no
+  delivery/open tracking. The offset is coarse (minutes, and only the local *hour* is ever
+  used), which is far less identifying than a named zone or a location.
+- **Boundary:** This feature does not change what the server can read about messages,
+  posts, profiles, or media — all of which remain opaque ciphertext. It only adds the two
+  coarse routing fields above to the existing notification-registration metadata, used
+  solely to time and target the update nudge, never repurposed (NFR-ZK-003).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 0% of update notifications are delivered to a device between 22:00 and 08:59
+  in that device's local time (no overnight disturbances).
+- **SC-002**: 100% of update notifications delivered to reachable, behind devices land
+  during the 09:00 hour in the device's local time.
+- **SC-003**: A device whose installed version equals the latest receives 0 update
+  notifications.
+- **SC-004**: A behind device receives at most 1 update notification per distinct newer
+  version (no duplicate nags for the same version).
+- **SC-005**: For a user with two devices — one updated, one behind — the update
+  notification appears on exactly 1 of the 2 devices (the behind one).
+- **SC-006**: The per-device data introduced by this feature is limited to the installed
+  version, a UTC-offset-in-minutes, and the last-notified version — verifiable by
+  inspection — and the notification payload contains no release content.
+
+## Assumptions
+
+- Delivery occurs **during** the device's local 09:00 hour, as close to 09:00 as the
+  system's notification-evaluation cadence allows; exact-to-the-second delivery is not
+  promised.
+- Only devices running the updated client (which reports installed version + local offset)
+  are candidates. On the deploy that **introduces** this feature, devices report the
+  now-current version and are therefore not "behind," so the **first real announcement
+  occurs on the next version change after this ships**. This is expected, not a defect.
+- A device that has not reported a local offset is not scheduled for 09:00-local delivery
+  and relies on the in-app prompt; this is acceptable.
+- The existing notification (push) delivery mechanism and the existing public app-config
+  source for version + "what's new" are reused; "latest version" is the version the
+  running service reports as current.
+- A device offline across its 09:00 does not receive that version's notification (it
+  expires by roughly local midday rather than being held for late delivery); guaranteeing
+  every offline device eventually gets a push per release is out of scope — the in-app
+  prompt covers that case.
+- "Behind" is decided by simple inequality between the device's installed version and the
+  latest deployed version, which is correct for Ring's single-deployment model (one
+  current version at a time) and for development build identifiers.

--- a/specs/1016-9-am-local/spec.md
+++ b/specs/1016-9-am-local/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-22
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1016-9-am-local/tasks.md
+++ b/specs/1016-9-am-local/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only)
+
+**Feature**: spec 1016 | **Branch**: `feat/1016-9-am-local`
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Data model**: [data-model.md](./data-model.md) | **Contract**: [contracts/push-subscribe.md](./contracts/push-subscribe.md)
+
+TDD is mandated (Constitution Principle III): each user story lists its **failing tests
+first**, then the implementation that makes them pass. `[P]` = parallelizable (distinct
+files, no incomplete-task dependency).
+
+## Phase 1: Setup
+
+- [ ] T001 Add forward-only migration `server/internal/db/migrations/0025_push_version.sql`: `ALTER TABLE push_subscriptions ADD COLUMN installed_version text, ADD COLUMN tz_offset_minutes int, ADD COLUMN last_announced_version text;` (additive; no shipped migration edited — Principle VI).
+
+## Phase 2: Foundational — per-device metadata capture + storage (BLOCKS all user stories; realizes US4's storage shape)
+
+- [ ] T002 [P] Add `TZOffsetMinutes int` (plus the new fields as needed for reads/writes) to the `PushSubscription` struct in `server/internal/store/push.go`.
+- [ ] T003 [P] Write FAILING handler tests in `server/internal/api/push_handlers_test.go`: subscribing with `installedVersion`+`tzOffsetMinutes` persists both; a re-subscribe that OMITS them preserves the previously stored values (COALESCE semantics); `last_announced_version` is never written by subscribe.
+- [ ] T004 Extend the subscribe DTO in `server/internal/api/push_handlers.go` with optional `installedVersion *string` + `tzOffsetMinutes *int` and pass them to `SaveSubscription`.
+- [ ] T005 Update `SaveSubscription` in `server/internal/store/push.go` to upsert p256dh/auth always and version/tz only when provided (`COALESCE(EXCLUDED.x, push_subscriptions.x)`); update the in-memory fake store in `push_handlers_test.go` to mimic COALESCE. Makes T003 pass.
+- [ ] T006 [P] Client: add `installedVersion` (the `__APP_VERSION__` constant) + `tzOffsetMinutes` (`new Date().getTimezoneOffset()`) to `subscribePush` in `src/services/api.ts` and its caller in `src/services/push.ts` (the SW resubscribe path in `src/services/sw-push.ts` intentionally omits them).
+
+## Phase 3: User Story 1 — Out-of-date user told at 09:00 local, not overnight (P1)
+
+**Goal**: deliver the update push during the device's local 09:00 hour (never at night).
+**Independent test**: `dueAtNine` selects a behind device at local 09:00 and not at other hours; `SendVersion` uses the short, expire-by-midday TTL.
+
+- [ ] T007 [P] [US1] Write FAILING unit tests for `dueAtNine(subs, nowUTC)` in `server/internal/push/schedule_test.go`: selected iff local hour (`UTC − tz_offset_minutes`) == 9 — cover UTC(0), EST(+300), CEST(−120), IST(+330 half-hour); and the same subs one hour off → not selected.
+- [ ] T008 [US1] Implement the pure `dueAtNine` in `server/internal/push/schedule.go`. Makes T007 pass.
+- [ ] T009 [P] [US1] Write FAILING test in `server/internal/push/push_test.go`: `SendVersion(sub)` delivers the content-free `{"t":"version"}` tickle to ONE subscription with the SHORT TTL (a few hours, not the old 3 days) and the `ring-version` topic / low urgency.
+- [ ] T010 [US1] Implement `SendVersion(ctx, sub)` in `server/internal/push/push.go` and set `versionTTL` to the short value (FR-015 expire-by-midday). Makes T009 pass.
+
+## Phase 4: User Story 2 — Already-updated users never pinged (P1)
+
+**Goal**: only devices whose installed version differs from current are eligible.
+**Independent test**: the sweep includes a behind+9 AM device and excludes up-to-date / NULL-metadata devices.
+
+- [ ] T011 [P] [US2] Write FAILING tests in `server/internal/push/schedule_test.go` for the per-tick sweep selection (over a fake `VersionSchedStore`): a behind device at local 09:00 is chosen; an up-to-date device, and a device with NULL version or NULL offset, are excluded.
+- [ ] T012 [US2] Implement `SubscriptionsBehind(ctx, currentVersion)` in `server/internal/store/push.go` (SQL pre-filter: non-null version+tz, `installed_version <> $1`) and `SweepVersionAnnouncements(ctx, store, notifier, currentVersion, nowUTC)` in `server/internal/push/schedule.go` (calls `SubscriptionsBehind` → `dueAtNine` → `SendVersion`) over a small `VersionSchedStore` interface. Makes T011 pass.
+
+## Phase 5: User Story 3 — Not re-nagged for the same version (P2)
+
+**Goal**: once-per-release dedup keyed on send.
+**Independent test**: a device already announced for the current version is skipped; after a newer version it becomes eligible once.
+
+- [ ] T013 [P] [US3] Write FAILING tests in `server/internal/push/schedule_test.go`: a device with `last_announced_version == current` is excluded; after the sweep sends + marks, a second sweep does not re-select it; when `current` changes to a newer value, it is selected exactly once.
+- [ ] T014 [US3] Implement `MarkAnnounced(ctx, endpoint, version)` in `server/internal/store/push.go`, add the `(last_announced_version IS NULL OR <> $1)` dedup clause to `SubscriptionsBehind`, and call `MarkAnnounced` after `SendVersion` in the sweep (dedup-on-send). Makes T013 pass.
+
+## Phase 6: User Story 4 — Minimal metadata / ZK + remove the old broadcast (P2)
+
+**Goal**: content-free payload, only the three coarse fields, no profile-building logs; the immediate broadcast is gone.
+**Independent test**: payload bytes are exactly `{"t":"version"}`; no delivery/open tracking exists; the boot broadcast path is removed.
+
+- [ ] T015 [P] [US4] Write/extend a FAILING assertion test in `server/internal/push/push_test.go` that the version push payload is content-free (carries only the `{"t":"version"}` marker, no version/notes) and that no delivery- or open-confirmation is recorded anywhere (dedup is send-keyed only).
+- [ ] T016 [US4] Remove the immediate broadcast: delete `announceVersionIfChanged` and its boot call in `server/cmd/ringd/main.go`; remove `Notifier.BroadcastVersion` (`server/internal/push/push.go`) and `Store.AllSubscriptions` (`server/internal/store/push.go`) — plus `GetAppMeta`/`SetAppMeta`/`lastAnnouncedVersionKey` if they have no other caller. Wire the 15-min scheduler goroutine in `main.go run()` (relay-sweep ticker pattern: `time.NewTicker`, `defer Stop`, `select{<-ctx.Done()|<-t.C}`; skip when `version`==`dev`/`""` or `notifier==nil`) calling `SweepVersionAnnouncements(ctx, st, notifier, version, time.Now().UTC())`.
+- [ ] T017 [US4] Ensure NFR-ZK-004: review `SweepVersionAnnouncements`/`SendVersion`/scheduler `slog` calls so they record only coarse operational counts (e.g., "due=N sent=N") — never a device's local time-of-day, per-device send history, or delivery/open events.
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T018 [P] Run gates: `cd server && go build ./... && go vet ./... && go test ./...` and `npm run build` (vue-tsc + vite). Fix any failure. Confirm the in-app update toast path (`useAppUpdate` / SW `{"t":"version"}` handler) is untouched (FR-011) and that no new endpoint/query exposes the per-device version/offset (NFR-ZK-003).
+- [ ] T019 [P] Drive/console spot-check against the live `make start` stack that `POST /v1/push/subscribe` now carries `installedVersion` + `tzOffsetMinutes` (quickstart §1).
+- [ ] T020 Bump spec `Status:` (planned → in-progress, later in-review) and run `make roadmap`.
+
+## Dependencies & Order
+
+- **Phase 1 → Phase 2** block everything (migration + metadata capture/storage).
+- **US1 (T007–T010)** provides `dueAtNine` + `SendVersion`, consumed by **US2 (T011–T012)**'s sweep; **US3 (T013–T014)** adds dedup to that sweep; **US4 (T015–T017)** wires the scheduler + removes the old path.
+- **Phase 7** runs last.
+- Within a story, the `[P]` test task precedes its implementation task (TDD).
+
+## Parallel Example
+After Phase 2, the test-authoring tasks T007, T009, T011, T013, T015 touch the same two test files (`schedule_test.go`, `push_test.go`) so are only partly parallel; T006 (client) is fully parallel with all server tasks; T002 is parallel with T003.
+
+## MVP
+**US1 + US2** (deliver the update push at the device's local 09:00, only to behind devices) is the minimum that solves the stated problem. US3 (no re-nag) and US4 (ZK/cleanup) are required before shipping but layer on top.
+
+## Implementation Strategy
+Build Phase 2 once (capture/store), then add the pure `dueAtNine` and `SendVersion` (US1),
+the `SubscriptionsBehind` filter + sweep (US2), the dedup (US3), and finally wire the
+scheduler + delete the old broadcast (US4). Keep each story's tests green before moving on.

--- a/specs/1016-9-am-local/tasks.md
+++ b/specs/1016-9-am-local/tasks.md
@@ -9,56 +9,56 @@ files, no incomplete-task dependency).
 
 ## Phase 1: Setup
 
-- [ ] T001 Add forward-only migration `server/internal/db/migrations/0025_push_version.sql`: `ALTER TABLE push_subscriptions ADD COLUMN installed_version text, ADD COLUMN tz_offset_minutes int, ADD COLUMN last_announced_version text;` (additive; no shipped migration edited — Principle VI).
+- [ ] T001 Add forward-only migration `server/internal/db/migrations/0025_push_version.sql`: `ALTER TABLE push_subscriptions ADD COLUMN installed_version text, ADD COLUMN tz_offset_minutes int, ADD COLUMN last_announced_version text;` (additive; no shipped migration edited — Principle VI). (#316)
 
 ## Phase 2: Foundational — per-device metadata capture + storage (BLOCKS all user stories; realizes US4's storage shape)
 
-- [ ] T002 [P] Add `TZOffsetMinutes int` (plus the new fields as needed for reads/writes) to the `PushSubscription` struct in `server/internal/store/push.go`.
-- [ ] T003 [P] Write FAILING handler tests in `server/internal/api/push_handlers_test.go`: subscribing with `installedVersion`+`tzOffsetMinutes` persists both; a re-subscribe that OMITS them preserves the previously stored values (COALESCE semantics); `last_announced_version` is never written by subscribe.
-- [ ] T004 Extend the subscribe DTO in `server/internal/api/push_handlers.go` with optional `installedVersion *string` + `tzOffsetMinutes *int` and pass them to `SaveSubscription`.
-- [ ] T005 Update `SaveSubscription` in `server/internal/store/push.go` to upsert p256dh/auth always and version/tz only when provided (`COALESCE(EXCLUDED.x, push_subscriptions.x)`); update the in-memory fake store in `push_handlers_test.go` to mimic COALESCE. Makes T003 pass.
-- [ ] T006 [P] Client: add `installedVersion` (the `__APP_VERSION__` constant) + `tzOffsetMinutes` (`new Date().getTimezoneOffset()`) to `subscribePush` in `src/services/api.ts` and its caller in `src/services/push.ts` (the SW resubscribe path in `src/services/sw-push.ts` intentionally omits them).
+- [ ] T002 [P] Add `TZOffsetMinutes int` (plus the new fields as needed for reads/writes) to the `PushSubscription` struct in `server/internal/store/push.go`. (#317)
+- [ ] T003 [P] Write FAILING handler tests in `server/internal/api/push_handlers_test.go`: subscribing with `installedVersion`+`tzOffsetMinutes` persists both; a re-subscribe that OMITS them preserves the previously stored values (COALESCE semantics); `last_announced_version` is never written by subscribe. (#318)
+- [ ] T004 Extend the subscribe DTO in `server/internal/api/push_handlers.go` with optional `installedVersion *string` + `tzOffsetMinutes *int` and pass them to `SaveSubscription`. (#319)
+- [ ] T005 Update `SaveSubscription` in `server/internal/store/push.go` to upsert p256dh/auth always and version/tz only when provided (`COALESCE(EXCLUDED.x, push_subscriptions.x)`); update the in-memory fake store in `push_handlers_test.go` to mimic COALESCE. Makes T003 pass. (#320)
+- [ ] T006 [P] Client: add `installedVersion` (the `__APP_VERSION__` constant) + `tzOffsetMinutes` (`new Date().getTimezoneOffset()`) to `subscribePush` in `src/services/api.ts` and its caller in `src/services/push.ts` (the SW resubscribe path in `src/services/sw-push.ts` intentionally omits them). (#321)
 
 ## Phase 3: User Story 1 — Out-of-date user told at 09:00 local, not overnight (P1)
 
 **Goal**: deliver the update push during the device's local 09:00 hour (never at night).
 **Independent test**: `dueAtNine` selects a behind device at local 09:00 and not at other hours; `SendVersion` uses the short, expire-by-midday TTL.
 
-- [ ] T007 [P] [US1] Write FAILING unit tests for `dueAtNine(subs, nowUTC)` in `server/internal/push/schedule_test.go`: selected iff local hour (`UTC − tz_offset_minutes`) == 9 — cover UTC(0), EST(+300), CEST(−120), IST(+330 half-hour); and the same subs one hour off → not selected.
-- [ ] T008 [US1] Implement the pure `dueAtNine` in `server/internal/push/schedule.go`. Makes T007 pass.
-- [ ] T009 [P] [US1] Write FAILING test in `server/internal/push/push_test.go`: `SendVersion(sub)` delivers the content-free `{"t":"version"}` tickle to ONE subscription with the SHORT TTL (a few hours, not the old 3 days) and the `ring-version` topic / low urgency.
-- [ ] T010 [US1] Implement `SendVersion(ctx, sub)` in `server/internal/push/push.go` and set `versionTTL` to the short value (FR-015 expire-by-midday). Makes T009 pass.
+- [ ] T007 [P] [US1] Write FAILING unit tests for `dueAtNine(subs, nowUTC)` in `server/internal/push/schedule_test.go`: selected iff local hour (`UTC − tz_offset_minutes`) == 9 — cover UTC(0), EST(+300), CEST(−120), IST(+330 half-hour); and the same subs one hour off → not selected. (#322)
+- [ ] T008 [US1] Implement the pure `dueAtNine` in `server/internal/push/schedule.go`. Makes T007 pass. (#323)
+- [ ] T009 [P] [US1] Write FAILING test in `server/internal/push/push_test.go`: `SendVersion(sub)` delivers the content-free `{"t":"version"}` tickle to ONE subscription with the SHORT TTL (a few hours, not the old 3 days) and the `ring-version` topic / low urgency. (#324)
+- [ ] T010 [US1] Implement `SendVersion(ctx, sub)` in `server/internal/push/push.go` and set `versionTTL` to the short value (FR-015 expire-by-midday). Makes T009 pass. (#325)
 
 ## Phase 4: User Story 2 — Already-updated users never pinged (P1)
 
 **Goal**: only devices whose installed version differs from current are eligible.
 **Independent test**: the sweep includes a behind+9 AM device and excludes up-to-date / NULL-metadata devices.
 
-- [ ] T011 [P] [US2] Write FAILING tests in `server/internal/push/schedule_test.go` for the per-tick sweep selection (over a fake `VersionSchedStore`): a behind device at local 09:00 is chosen; an up-to-date device, and a device with NULL version or NULL offset, are excluded.
-- [ ] T012 [US2] Implement `SubscriptionsBehind(ctx, currentVersion)` in `server/internal/store/push.go` (SQL pre-filter: non-null version+tz, `installed_version <> $1`) and `SweepVersionAnnouncements(ctx, store, notifier, currentVersion, nowUTC)` in `server/internal/push/schedule.go` (calls `SubscriptionsBehind` → `dueAtNine` → `SendVersion`) over a small `VersionSchedStore` interface. Makes T011 pass.
+- [ ] T011 [P] [US2] Write FAILING tests in `server/internal/push/schedule_test.go` for the per-tick sweep selection (over a fake `VersionSchedStore`): a behind device at local 09:00 is chosen; an up-to-date device, and a device with NULL version or NULL offset, are excluded. (#326)
+- [ ] T012 [US2] Implement `SubscriptionsBehind(ctx, currentVersion)` in `server/internal/store/push.go` (SQL pre-filter: non-null version+tz, `installed_version <> $1`) and `SweepVersionAnnouncements(ctx, store, notifier, currentVersion, nowUTC)` in `server/internal/push/schedule.go` (calls `SubscriptionsBehind` → `dueAtNine` → `SendVersion`) over a small `VersionSchedStore` interface. Makes T011 pass. (#327)
 
 ## Phase 5: User Story 3 — Not re-nagged for the same version (P2)
 
 **Goal**: once-per-release dedup keyed on send.
 **Independent test**: a device already announced for the current version is skipped; after a newer version it becomes eligible once.
 
-- [ ] T013 [P] [US3] Write FAILING tests in `server/internal/push/schedule_test.go`: a device with `last_announced_version == current` is excluded; after the sweep sends + marks, a second sweep does not re-select it; when `current` changes to a newer value, it is selected exactly once.
-- [ ] T014 [US3] Implement `MarkAnnounced(ctx, endpoint, version)` in `server/internal/store/push.go`, add the `(last_announced_version IS NULL OR <> $1)` dedup clause to `SubscriptionsBehind`, and call `MarkAnnounced` after `SendVersion` in the sweep (dedup-on-send). Makes T013 pass.
+- [ ] T013 [P] [US3] Write FAILING tests in `server/internal/push/schedule_test.go`: a device with `last_announced_version == current` is excluded; after the sweep sends + marks, a second sweep does not re-select it; when `current` changes to a newer value, it is selected exactly once. (#328)
+- [ ] T014 [US3] Implement `MarkAnnounced(ctx, endpoint, version)` in `server/internal/store/push.go`, add the `(last_announced_version IS NULL OR <> $1)` dedup clause to `SubscriptionsBehind`, and call `MarkAnnounced` after `SendVersion` in the sweep (dedup-on-send). Makes T013 pass. (#329)
 
 ## Phase 6: User Story 4 — Minimal metadata / ZK + remove the old broadcast (P2)
 
 **Goal**: content-free payload, only the three coarse fields, no profile-building logs; the immediate broadcast is gone.
 **Independent test**: payload bytes are exactly `{"t":"version"}`; no delivery/open tracking exists; the boot broadcast path is removed.
 
-- [ ] T015 [P] [US4] Write/extend a FAILING assertion test in `server/internal/push/push_test.go` that the version push payload is content-free (carries only the `{"t":"version"}` marker, no version/notes) and that no delivery- or open-confirmation is recorded anywhere (dedup is send-keyed only).
-- [ ] T016 [US4] Remove the immediate broadcast: delete `announceVersionIfChanged` and its boot call in `server/cmd/ringd/main.go`; remove `Notifier.BroadcastVersion` (`server/internal/push/push.go`) and `Store.AllSubscriptions` (`server/internal/store/push.go`) — plus `GetAppMeta`/`SetAppMeta`/`lastAnnouncedVersionKey` if they have no other caller. Wire the 15-min scheduler goroutine in `main.go run()` (relay-sweep ticker pattern: `time.NewTicker`, `defer Stop`, `select{<-ctx.Done()|<-t.C}`; skip when `version`==`dev`/`""` or `notifier==nil`) calling `SweepVersionAnnouncements(ctx, st, notifier, version, time.Now().UTC())`.
-- [ ] T017 [US4] Ensure NFR-ZK-004: review `SweepVersionAnnouncements`/`SendVersion`/scheduler `slog` calls so they record only coarse operational counts (e.g., "due=N sent=N") — never a device's local time-of-day, per-device send history, or delivery/open events.
+- [ ] T015 [P] [US4] Write/extend a FAILING assertion test in `server/internal/push/push_test.go` that the version push payload is content-free (carries only the `{"t":"version"}` marker, no version/notes) and that no delivery- or open-confirmation is recorded anywhere (dedup is send-keyed only). (#330)
+- [ ] T016 [US4] Remove the immediate broadcast: delete `announceVersionIfChanged` and its boot call in `server/cmd/ringd/main.go`; remove `Notifier.BroadcastVersion` (`server/internal/push/push.go`) and `Store.AllSubscriptions` (`server/internal/store/push.go`) — plus `GetAppMeta`/`SetAppMeta`/`lastAnnouncedVersionKey` if they have no other caller. Wire the 15-min scheduler goroutine in `main.go run()` (relay-sweep ticker pattern: `time.NewTicker`, `defer Stop`, `select{<-ctx.Done()|<-t.C}`; skip when `version`==`dev`/`""` or `notifier==nil`) calling `SweepVersionAnnouncements(ctx, st, notifier, version, time.Now().UTC())`. (#331)
+- [ ] T017 [US4] Ensure NFR-ZK-004: review `SweepVersionAnnouncements`/`SendVersion`/scheduler `slog` calls so they record only coarse operational counts (e.g., "due=N sent=N") — never a device's local time-of-day, per-device send history, or delivery/open events. (#332)
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T018 [P] Run gates: `cd server && go build ./... && go vet ./... && go test ./...` and `npm run build` (vue-tsc + vite). Fix any failure. Confirm the in-app update toast path (`useAppUpdate` / SW `{"t":"version"}` handler) is untouched (FR-011) and that no new endpoint/query exposes the per-device version/offset (NFR-ZK-003).
-- [ ] T019 [P] Drive/console spot-check against the live `make start` stack that `POST /v1/push/subscribe` now carries `installedVersion` + `tzOffsetMinutes` (quickstart §1).
-- [ ] T020 Bump spec `Status:` (planned → in-progress, later in-review) and run `make roadmap`.
+- [ ] T018 [P] Run gates: `cd server && go build ./... && go vet ./... && go test ./...` and `npm run build` (vue-tsc + vite). Fix any failure. Confirm the in-app update toast path (`useAppUpdate` / SW `{"t":"version"}` handler) is untouched (FR-011) and that no new endpoint/query exposes the per-device version/offset (NFR-ZK-003). (#333)
+- [ ] T019 [P] Drive/console spot-check against the live `make start` stack that `POST /v1/push/subscribe` now carries `installedVersion` + `tzOffsetMinutes` (quickstart §1). (#334)
+- [ ] T020 Bump spec `Status:` (planned → in-progress, later in-review) and run `make roadmap`. (#335)
 
 ## Dependencies & Order
 

--- a/specs/1016-9-am-local/tasks.md
+++ b/specs/1016-9-am-local/tasks.md
@@ -9,56 +9,56 @@ files, no incomplete-task dependency).
 
 ## Phase 1: Setup
 
-- [ ] T001 Add forward-only migration `server/internal/db/migrations/0025_push_version.sql`: `ALTER TABLE push_subscriptions ADD COLUMN installed_version text, ADD COLUMN tz_offset_minutes int, ADD COLUMN last_announced_version text;` (additive; no shipped migration edited — Principle VI). (#316)
+- [x] T001 Add forward-only migration `server/internal/db/migrations/0025_push_version.sql`: `ALTER TABLE push_subscriptions ADD COLUMN installed_version text, ADD COLUMN tz_offset_minutes int, ADD COLUMN last_announced_version text;` (additive; no shipped migration edited — Principle VI). (#316)
 
 ## Phase 2: Foundational — per-device metadata capture + storage (BLOCKS all user stories; realizes US4's storage shape)
 
-- [ ] T002 [P] Add `TZOffsetMinutes int` (plus the new fields as needed for reads/writes) to the `PushSubscription` struct in `server/internal/store/push.go`. (#317)
-- [ ] T003 [P] Write FAILING handler tests in `server/internal/api/push_handlers_test.go`: subscribing with `installedVersion`+`tzOffsetMinutes` persists both; a re-subscribe that OMITS them preserves the previously stored values (COALESCE semantics); `last_announced_version` is never written by subscribe. (#318)
-- [ ] T004 Extend the subscribe DTO in `server/internal/api/push_handlers.go` with optional `installedVersion *string` + `tzOffsetMinutes *int` and pass them to `SaveSubscription`. (#319)
-- [ ] T005 Update `SaveSubscription` in `server/internal/store/push.go` to upsert p256dh/auth always and version/tz only when provided (`COALESCE(EXCLUDED.x, push_subscriptions.x)`); update the in-memory fake store in `push_handlers_test.go` to mimic COALESCE. Makes T003 pass. (#320)
-- [ ] T006 [P] Client: add `installedVersion` (the `__APP_VERSION__` constant) + `tzOffsetMinutes` (`new Date().getTimezoneOffset()`) to `subscribePush` in `src/services/api.ts` and its caller in `src/services/push.ts` (the SW resubscribe path in `src/services/sw-push.ts` intentionally omits them). (#321)
+- [x] T002 [P] Add `TZOffsetMinutes int` (plus the new fields as needed for reads/writes) to the `PushSubscription` struct in `server/internal/store/push.go`. (#317)
+- [x] T003 [P] Write FAILING handler tests in `server/internal/api/push_handlers_test.go`: subscribing with `installedVersion`+`tzOffsetMinutes` persists both; a re-subscribe that OMITS them preserves the previously stored values (COALESCE semantics); `last_announced_version` is never written by subscribe. (#318)
+- [x] T004 Extend the subscribe DTO in `server/internal/api/push_handlers.go` with optional `installedVersion *string` + `tzOffsetMinutes *int` and pass them to `SaveSubscription`. (#319)
+- [x] T005 Update `SaveSubscription` in `server/internal/store/push.go` to upsert p256dh/auth always and version/tz only when provided (`COALESCE(EXCLUDED.x, push_subscriptions.x)`); update the in-memory fake store in `push_handlers_test.go` to mimic COALESCE. Makes T003 pass. (#320)
+- [x] T006 [P] Client: add `installedVersion` (the `__APP_VERSION__` constant) + `tzOffsetMinutes` (`new Date().getTimezoneOffset()`) to `subscribePush` in `src/services/api.ts` and its caller in `src/services/push.ts` (the SW resubscribe path in `src/services/sw-push.ts` intentionally omits them). (#321)
 
 ## Phase 3: User Story 1 — Out-of-date user told at 09:00 local, not overnight (P1)
 
 **Goal**: deliver the update push during the device's local 09:00 hour (never at night).
 **Independent test**: `dueAtNine` selects a behind device at local 09:00 and not at other hours; `SendVersion` uses the short, expire-by-midday TTL.
 
-- [ ] T007 [P] [US1] Write FAILING unit tests for `dueAtNine(subs, nowUTC)` in `server/internal/push/schedule_test.go`: selected iff local hour (`UTC − tz_offset_minutes`) == 9 — cover UTC(0), EST(+300), CEST(−120), IST(+330 half-hour); and the same subs one hour off → not selected. (#322)
-- [ ] T008 [US1] Implement the pure `dueAtNine` in `server/internal/push/schedule.go`. Makes T007 pass. (#323)
-- [ ] T009 [P] [US1] Write FAILING test in `server/internal/push/push_test.go`: `SendVersion(sub)` delivers the content-free `{"t":"version"}` tickle to ONE subscription with the SHORT TTL (a few hours, not the old 3 days) and the `ring-version` topic / low urgency. (#324)
-- [ ] T010 [US1] Implement `SendVersion(ctx, sub)` in `server/internal/push/push.go` and set `versionTTL` to the short value (FR-015 expire-by-midday). Makes T009 pass. (#325)
+- [x] T007 [P] [US1] Write FAILING unit tests for `dueAtNine(subs, nowUTC)` in `server/internal/push/schedule_test.go`: selected iff local hour (`UTC − tz_offset_minutes`) == 9 — cover UTC(0), EST(+300), CEST(−120), IST(+330 half-hour); and the same subs one hour off → not selected. (#322)
+- [x] T008 [US1] Implement the pure `dueAtNine` in `server/internal/push/schedule.go`. Makes T007 pass. (#323)
+- [x] T009 [P] [US1] Write FAILING test in `server/internal/push/push_test.go`: `SendVersion(sub)` delivers the content-free `{"t":"version"}` tickle to ONE subscription with the SHORT TTL (a few hours, not the old 3 days) and the `ring-version` topic / low urgency. (#324)
+- [x] T010 [US1] Implement `SendVersion(ctx, sub)` in `server/internal/push/push.go` and set `versionTTL` to the short value (FR-015 expire-by-midday). Makes T009 pass. (#325)
 
 ## Phase 4: User Story 2 — Already-updated users never pinged (P1)
 
 **Goal**: only devices whose installed version differs from current are eligible.
 **Independent test**: the sweep includes a behind+9 AM device and excludes up-to-date / NULL-metadata devices.
 
-- [ ] T011 [P] [US2] Write FAILING tests in `server/internal/push/schedule_test.go` for the per-tick sweep selection (over a fake `VersionSchedStore`): a behind device at local 09:00 is chosen; an up-to-date device, and a device with NULL version or NULL offset, are excluded. (#326)
-- [ ] T012 [US2] Implement `SubscriptionsBehind(ctx, currentVersion)` in `server/internal/store/push.go` (SQL pre-filter: non-null version+tz, `installed_version <> $1`) and `SweepVersionAnnouncements(ctx, store, notifier, currentVersion, nowUTC)` in `server/internal/push/schedule.go` (calls `SubscriptionsBehind` → `dueAtNine` → `SendVersion`) over a small `VersionSchedStore` interface. Makes T011 pass. (#327)
+- [x] T011 [P] [US2] Write FAILING tests in `server/internal/push/schedule_test.go` for the per-tick sweep selection (over a fake `VersionSchedStore`): a behind device at local 09:00 is chosen; an up-to-date device, and a device with NULL version or NULL offset, are excluded. (#326)
+- [x] T012 [US2] Implement `SubscriptionsBehind(ctx, currentVersion)` in `server/internal/store/push.go` (SQL pre-filter: non-null version+tz, `installed_version <> $1`) and `SweepVersionAnnouncements(ctx, store, notifier, currentVersion, nowUTC)` in `server/internal/push/schedule.go` (calls `SubscriptionsBehind` → `dueAtNine` → `SendVersion`) over a small `VersionSchedStore` interface. Makes T011 pass. (#327)
 
 ## Phase 5: User Story 3 — Not re-nagged for the same version (P2)
 
 **Goal**: once-per-release dedup keyed on send.
 **Independent test**: a device already announced for the current version is skipped; after a newer version it becomes eligible once.
 
-- [ ] T013 [P] [US3] Write FAILING tests in `server/internal/push/schedule_test.go`: a device with `last_announced_version == current` is excluded; after the sweep sends + marks, a second sweep does not re-select it; when `current` changes to a newer value, it is selected exactly once. (#328)
-- [ ] T014 [US3] Implement `MarkAnnounced(ctx, endpoint, version)` in `server/internal/store/push.go`, add the `(last_announced_version IS NULL OR <> $1)` dedup clause to `SubscriptionsBehind`, and call `MarkAnnounced` after `SendVersion` in the sweep (dedup-on-send). Makes T013 pass. (#329)
+- [x] T013 [P] [US3] Write FAILING tests in `server/internal/push/schedule_test.go`: a device with `last_announced_version == current` is excluded; after the sweep sends + marks, a second sweep does not re-select it; when `current` changes to a newer value, it is selected exactly once. (#328)
+- [x] T014 [US3] Implement `MarkAnnounced(ctx, endpoint, version)` in `server/internal/store/push.go`, add the `(last_announced_version IS NULL OR <> $1)` dedup clause to `SubscriptionsBehind`, and call `MarkAnnounced` after `SendVersion` in the sweep (dedup-on-send). Makes T013 pass. (#329)
 
 ## Phase 6: User Story 4 — Minimal metadata / ZK + remove the old broadcast (P2)
 
 **Goal**: content-free payload, only the three coarse fields, no profile-building logs; the immediate broadcast is gone.
 **Independent test**: payload bytes are exactly `{"t":"version"}`; no delivery/open tracking exists; the boot broadcast path is removed.
 
-- [ ] T015 [P] [US4] Write/extend a FAILING assertion test in `server/internal/push/push_test.go` that the version push payload is content-free (carries only the `{"t":"version"}` marker, no version/notes) and that no delivery- or open-confirmation is recorded anywhere (dedup is send-keyed only). (#330)
-- [ ] T016 [US4] Remove the immediate broadcast: delete `announceVersionIfChanged` and its boot call in `server/cmd/ringd/main.go`; remove `Notifier.BroadcastVersion` (`server/internal/push/push.go`) and `Store.AllSubscriptions` (`server/internal/store/push.go`) — plus `GetAppMeta`/`SetAppMeta`/`lastAnnouncedVersionKey` if they have no other caller. Wire the 15-min scheduler goroutine in `main.go run()` (relay-sweep ticker pattern: `time.NewTicker`, `defer Stop`, `select{<-ctx.Done()|<-t.C}`; skip when `version`==`dev`/`""` or `notifier==nil`) calling `SweepVersionAnnouncements(ctx, st, notifier, version, time.Now().UTC())`. (#331)
-- [ ] T017 [US4] Ensure NFR-ZK-004: review `SweepVersionAnnouncements`/`SendVersion`/scheduler `slog` calls so they record only coarse operational counts (e.g., "due=N sent=N") — never a device's local time-of-day, per-device send history, or delivery/open events. (#332)
+- [x] T015 [P] [US4] Write/extend a FAILING assertion test in `server/internal/push/push_test.go` that the version push payload is content-free (carries only the `{"t":"version"}` marker, no version/notes) and that no delivery- or open-confirmation is recorded anywhere (dedup is send-keyed only). (#330)
+- [x] T016 [US4] Remove the immediate broadcast: delete `announceVersionIfChanged` and its boot call in `server/cmd/ringd/main.go`; remove `Notifier.BroadcastVersion` (`server/internal/push/push.go`) and `Store.AllSubscriptions` (`server/internal/store/push.go`) — plus `GetAppMeta`/`SetAppMeta`/`lastAnnouncedVersionKey` if they have no other caller. Wire the 15-min scheduler goroutine in `main.go run()` (relay-sweep ticker pattern: `time.NewTicker`, `defer Stop`, `select{<-ctx.Done()|<-t.C}`; skip when `version`==`dev`/`""` or `notifier==nil`) calling `SweepVersionAnnouncements(ctx, st, notifier, version, time.Now().UTC())`. (#331)
+- [x] T017 [US4] Ensure NFR-ZK-004: review `SweepVersionAnnouncements`/`SendVersion`/scheduler `slog` calls so they record only coarse operational counts (e.g., "due=N sent=N") — never a device's local time-of-day, per-device send history, or delivery/open events. (#332)
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T018 [P] Run gates: `cd server && go build ./... && go vet ./... && go test ./...` and `npm run build` (vue-tsc + vite). Fix any failure. Confirm the in-app update toast path (`useAppUpdate` / SW `{"t":"version"}` handler) is untouched (FR-011) and that no new endpoint/query exposes the per-device version/offset (NFR-ZK-003). (#333)
-- [ ] T019 [P] Drive/console spot-check against the live `make start` stack that `POST /v1/push/subscribe` now carries `installedVersion` + `tzOffsetMinutes` (quickstart §1). (#334)
-- [ ] T020 Bump spec `Status:` (planned → in-progress, later in-review) and run `make roadmap`. (#335)
+- [x] T018 [P] Run gates: `cd server && go build ./... && go vet ./... && go test ./...` and `npm run build` (vue-tsc + vite). Fix any failure. Confirm the in-app update toast path (`useAppUpdate` / SW `{"t":"version"}` handler) is untouched (FR-011) and that no new endpoint/query exposes the per-device version/offset (NFR-ZK-003). (#333)
+- [x] T019 [P] Drive/console spot-check against the live `make start` stack that `POST /v1/push/subscribe` now carries `installedVersion` + `tzOffsetMinutes` (quickstart §1). (#334)
+- [x] T020 Bump spec `Status:` (planned → in-progress, later in-review) and run `make roadmap`. (#335)
 
 ## Dependencies & Order
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -553,7 +553,15 @@ export async function listConnections(): Promise<{ incoming: ConnReq[]; outgoing
 }
 
 /** Register a browser push subscription with the backend. */
-export async function subscribePush(sub: { endpoint: string; keys: { p256dh: string; auth: string } }): Promise<void> {
+export async function subscribePush(sub: {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+  // Optional per-device metadata for the 9-AM-local version announcement (spec 1016):
+  // the running client version and the device's local UTC offset in minutes. The server
+  // preserves prior values when these are omitted (e.g. the SW resubscribe path).
+  installedVersion?: string;
+  tzOffsetMinutes?: number;
+}): Promise<void> {
   const res = await fetch(`${apiBaseUrl()}/v1/push/subscribe`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders() },

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -78,7 +78,15 @@ export async function ensurePushSubscription(): Promise<boolean> {
     const p256dh = json.keys?.p256dh;
     const auth = json.keys?.auth;
     if (json.endpoint && p256dh && auth) {
-      await subscribePush({ endpoint: json.endpoint, keys: { p256dh, auth } });
+      // Report this device's running version + local UTC offset (spec 1016), refreshed on
+      // each (re)subscribe — app start + every foreground — so the 9-AM-local version
+      // announcement targets only devices that are behind, at their local morning.
+      await subscribePush({
+        endpoint: json.endpoint,
+        keys: { p256dh, auth },
+        installedVersion: __APP_VERSION__,
+        tzOffsetMinutes: new Date().getTimezoneOffset(),
+      });
       return true;
     }
     return false;


### PR DESCRIPTION
Implements **spec 1016** (ad-hoc), built spec-first through the full pipeline (specify → clarify → plan → checklist → tasks → analyze → implement).

Replaces the immediate, all-device version-announcement broadcast (shipped in #313) with a **per-device, 9-AM-local, behind-only, once-per-release** delivery — so a late-night release never wakes anyone overnight, and people who already updated are never pinged.

## What changed
- **Per-device metadata (minimal):** clients report `installedVersion` (`__APP_VERSION__`) + `tzOffsetMinutes` (`getTimezoneOffset()`) by piggybacking the existing `/v1/push/subscribe` call. Migration `0025` adds `installed_version`, `tz_offset_minutes`, `last_announced_version` to `push_subscriptions`; `SaveSubscription` COALESCE-upserts so a version-less SW resubscribe never clobbers them.
- **Scheduler:** a 15-min goroutine (relay-sweep pattern, ctx-cancel clean) runs `SweepVersionAnnouncements` → `SubscriptionsBehind` (behind + not-yet-announced) → pure **`dueAtNine`** (local hour == 9) → `SendVersion` + `MarkAnnounced` (dedup-on-send). `SendVersion` uses a **short TTL (~3h)** so a missed-morning push expires by local midday instead of arriving at night (clarified FR-015).
- **Removed** the old immediate path: `announceVersionIfChanged`, `Notifier.BroadcastVersion`, `Store.AllSubscriptions`/`GetAppMeta`/`SetAppMeta`.

## Zero-knowledge
Push payload stays content-free `{"t":"version"}`; the SW fetches the public `/v1/config` for "what's new" (the SW + in-app toast paths are untouched — delivery-time-agnostic). The only new server-stored metadata is the version (already public) + a coarse UTC-offset-in-minutes + a last-announced marker (NFR-ZK-002/004). Crypto/ZK checklist in `specs/1016-9-am-local/checklists/crypto-zk.md`.

## Verification (TDD)
Pure `dueAtNine` tests (UTC/EST/CEST/IST half-hour), sweep selection + once-per-release dedup, `SendVersion` short-TTL + content-free-payload tests, subscribe persistence/COALESCE test. `go build/vet/test`, `vue-tsc`, `vite build`, full `vitest` all green.

## Rollout note
This deploy *arms* the feature; the **next** version change after it ships is the first real 9-AM announcement (a freshly-updated device reports the current version → not behind → silent).

Closes #316, #317, #318, #319, #320, #321, #322, #323, #324, #325, #326, #327, #328, #329, #330, #331, #332, #333, #334, #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)