### PR TITLE
fix(notifications): fix the broken update prompt and make in-app alerts consistent

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,17 +1,22 @@
 <!--
 Sync Impact Report
-- Version: 1.0.0 → 1.1.0 (MINOR: new principle added)
-- Added: Principle XI — Ionic-First UI (stock Ionic components + existing theme
-  tokens; custom only when no Ionic primitive exists, composed from Ionic).
-- Modified: none (Principle X unchanged; XI complements it).
+- Version: 1.1.0 → 1.2.0 (MINOR: Principle VII expanded with a new normative rule)
+- Added: Principle VII now mandates that user-facing commit subjects (feat/fix/perf/
+  security) be plain-language, benefit-focused, reference-free release-note copy, since
+  they are shown verbatim to end users as the "What's new" line.
+- Modified: Principle VII — added the release-note-copy rule; corrected the update-flow
+  wording from "toast-and-accept" to "prompt-and-accept" (the prompt now renders through
+  the shared in-app notification surface, not a separate toast). No other principle changed.
 - Removed: none.
 - Templates / docs reviewed for sync:
   - .specify/templates/plan-template.md — ✅ no change needed (Constitution Check is
-    derived generically from this file; XI is picked up automatically).
+    derived generically from this file).
   - .specify/templates/spec-template.md — ✅ no change needed (no new mandatory section).
   - .specify/templates/tasks-template.md — ✅ no change needed.
-  - CLAUDE.md — ✅ already advises Ionic-native components + the settings schema;
-    consistent with XI, no edit required.
+  - CLAUDE.md — ✅ updated: "Commit messages" now carries matching release-note-subject
+    guidance with a good/bad example (spec 2004).
+- Prior amendment (1.1.0): Added Principle XI — Ionic-First UI (stock Ionic components +
+  existing theme tokens; custom only when no Ionic primitive exists, composed from Ionic).
 - Deferred TODOs: none.
 -->
 # Ring Constitution
@@ -116,8 +121,18 @@ The server holds no state outside Postgres, and the schema only moves forward.
   coverage floors pass; and e2e passes where behavior changed.
 - Commits follow Conventional Commits with a scope describing user-facing behavior
   (`feat(call):`, `fix(media):`, `test(e2e):`, `ci:`, `docs:`).
+- Release-note copy: for user-facing commit types (`feat`, `fix`, `perf`,
+  `security`) the subject AFTER the `type(scope):` prefix is shown verbatim to end
+  users as the "What's new" line, so it MUST read as plain-language, benefit-focused
+  release-note copy — no internal jargon, no implementation shorthand, and no
+  spec/issue/PR references (`(spec 1016)`, `(#248)`, `US2/US3`, `FR-014`). Write what
+  the user gains ("Update reminders now arrive in the morning, not overnight"), not how
+  it was built ("9 AM-local, behind-only version-announcement push (spec 1016)").
+  Non-user-facing types (`chore`, `ci`, `build`, `docs`, `refactor`, `style`, `test`,
+  `deps`) are exempt — they never reach "What's new".
 - The PWA stays `registerType: 'prompt'`: a deploy MUST NOT silently reload; the
-  toast-and-accept update flow is preserved.
+  prompt-and-accept update flow is preserved (the prompt itself renders through the
+  shared in-app notification surface, not a separate toast).
 
 ### VIII. Traceable, Auto-Closing Delivery
 
@@ -221,4 +236,4 @@ These are project-specific guardrails every relevant spec MUST respect.
 - Runtime engineering guidance that is not constitutional lives in `CLAUDE.md` and
   `CONTRIBUTING.md`; where they conflict with this document, this document wins.
 
-**Version**: 1.1.0 | **Ratified**: 2026-06-15 | **Last Amended**: 2026-06-16
+**Version**: 1.2.0 | **Ratified**: 2026-06-15 | **Last Amended**: 2026-06-22

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,20 @@ GitFlow. **`develop`** is the integration branch; **`main`** is production.
 `feat(call): ...`, `fix(media): ...`, `feat(server): ...`, `test(e2e): ...`,
 `ci: ...`, `docs: ...`. The subject describes user-facing behavior, not internals.
 
+**Release-note subjects for end users** (constitution Principle VII). For user-facing
+types (`feat`, `fix`, `perf`, `security`) the subject *after* the `type(scope):` prefix is
+shown verbatim to users as the "What's new" line on update. Write it as plain-language,
+benefit-focused release-note copy — no internal jargon, no implementation shorthand, and
+no spec/issue/PR references (`(spec 1016)`, `(#248)`, `US2/US3`, `FR-014`).
+
+- ✅ `feat(notifications): show update reminders in the morning, not overnight`
+- ❌ `feat(notifications): 9 AM-local, behind-only version-announcement push (spec 1016)`
+
+Non-user-facing types (`chore`, `ci`, `build`, `docs`, `refactor`, `style`, `test`,
+`deps`) never reach "What's new", so they keep developer phrasing. (The client also
+strips trailing spec/issue refs at display time as a safety net — `release-notes.ts` —
+but the subject is the real lever.)
+
 ### Working in this environment
 
 - Develop on the branch the task assigns; create it locally if missing. Commit
@@ -249,5 +263,5 @@ GitFlow. **`develop`** is the integration branch; **`main`** is production.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1016-9-am-local/plan.md`
+`specs/2004-unify-app-notifications/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,3 +45,4 @@ Specs are grouped by category band; status moves
 | [2001](specs/2001-stabilize-message-status/spec.md) | Stabilize message status reporting around downloaded-blob receipts | 🟢 shipped |
 | [2002](specs/2002-media-thumbnails-stay/spec.md) | Media Thumbnails Stay Thumbnails (no autoplay storm) | 🟢 shipped |
 | [2003](specs/2003-android-install-gate/spec.md) | Fix Android install-gate false "browser can't install" warning | 🔵 in-review |
+| [2004](specs/2004-unify-app-notifications/spec.md) | Unify in-app notifications/toasts + user-friendly "What's new" | 🟡 in-progress |

--- a/drive/scenarios/update-banner.mjs
+++ b/drive/scenarios/update-banner.mjs
@@ -1,0 +1,32 @@
+/**
+ * Spec 2004 visual check: the app-update prompt now renders through the shared in-app
+ * notification overlay (NotificationBanners.vue) as a persistent rounded "action" card
+ * below the header — never a top-pinned, sharp-cornered toast. Also shoots a functional
+ * appToast() for the consistent-toast check.
+ *
+ *   HEADED=1 node drive/scenarios/update-banner.mjs
+ *
+ * Screenshots → .tmp/drive/*.png (Read them back to inspect).
+ */
+import { createAccount, shot, sweep, done } from '../driver.mjs';
+
+const u = await createAccount({ name: 'Uma', mobile: true });
+
+// Drive the real showActionBanner() through the app's own notify instance (the dev test
+// hook re-exports it), so we render the actual production card, not a mock. (A raw
+// dynamic import in page.evaluate loads a SECOND module copy whose ref the mounted
+// component never sees — the hook shares the app's instance.)
+await u.page.evaluate(() => window.__ringTest.showUpdateBanner());
+await u.page.waitForTimeout(500);
+await shot(u, '2004-update-banner');
+
+// And a functional toast through the shared helper.
+await u.page.evaluate(async () => {
+  const { appToast } = await import('/src/services/toast.ts');
+  await appToast({ message: "Muted Ada's Wall notifications", duration: 4000 });
+});
+await u.page.waitForTimeout(400);
+await shot(u, '2004-app-toast');
+
+await sweep([u]);
+await done();

--- a/specs/2004-unify-app-notifications/checklists/requirements.md
+++ b/specs/2004-unify-app-notifications/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Unify in-app notifications/toasts + user-friendly "What's new"
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Zero-Knowledge Impact section states there is none (client UI + phrasing + governance);
+  the crypto/ZK checklist is not required.
+- All product decisions were locked in the feature input (shared component for
+  notification cards, shared helper for functional toasts, persistent/replace update card,
+  governance amendment), so no [NEEDS CLARIFICATION] markers were needed. `/speckit-clarify`
+  will re-confirm.
+- Implementation specifics (which component/helper, CSS) deliberately kept out of the spec;
+  they belong in plan.md.

--- a/specs/2004-unify-app-notifications/data-model.md
+++ b/specs/2004-unify-app-notifications/data-model.md
@@ -1,0 +1,11 @@
+# Data Model: Unify in-app notifications/toasts + user-friendly "What's new"
+
+**No data model.** This feature is entirely client-side presentation (how in-app
+notifications/toasts render), release-note phrasing, and governance docs. There are no new
+entities, no IndexedDB object stores, no DB migrations, and no client/server payload changes
+(confirmed by the spec's "Key Entities — none" and "Zero-Knowledge Impact — none").
+
+The only internal shape touched is the in-app banner descriptor `NotifyBanner` (in
+`src/services/notify.ts`), which gains an optional `actions?` array and a persistent flag to
+support the `'action'` kind — an in-memory UI type, not persisted data. Detailed in plan.md
+§Design Overview.

--- a/specs/2004-unify-app-notifications/plan.md
+++ b/specs/2004-unify-app-notifications/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Unify in-app notifications/toasts + user-friendly "What's new"
+
+**Branch**: `fix/2004-unify-app-notifications` | **Date**: 2026-06-22 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/2004-unify-app-notifications/spec.md`
+
+## Summary
+
+Render the app-update prompt through the existing shared in-app notification overlay
+(`NotificationBanners.vue` + `notify.ts`) as a new persistent **"action"** card instead of
+an Ionic toast — fixing the iOS top-pinned/sharp-corner breakage and unifying all
+notification-class surfaces in one component. Add a shared `appToast()` helper for the ~two
+dozen functional/error toasts (one place for position/rounding/duration). Harden the
+release-note `prettify` to strip internal references that carry extra detail, and amend the
+constitution + CLAUDE.md so user-facing commit subjects read as plain release-note copy.
+
+## Technical Context
+
+**Language/Version**: TypeScript / Vue 3 + Ionic (client PWA only). No server change.
+
+**Primary Dependencies**: existing Ionic `toastController`, the in-app banner overlay
+(`src/services/notify.ts` + `src/components/NotificationBanners.vue`), `useAppUpdate.ts`,
+`release-notes.ts`. No new dependencies.
+
+**Storage**: none (no IndexedDB store, no migration).
+
+**Testing**: `vitest` for the pure `prettify` change (failing-first); `vue-tsc` + `vite
+build`; drive screenshots for the banner/toast rendering (not unit-testable in the harness).
+
+**Target Platform**: installable PWA (bug reported on iOS; fix is cross-platform).
+
+**Project Type**: client UI fix + governance docs.
+
+**Constraints**: Ionic-First (Principle XI) — reuse stock Ionic components + the theme;
+no zero-knowledge impact; forward-only (governance amendment bumps the constitution version).
+
+**Scale/Scope**: ~6 client files changed + ~14 toast call-site migrations + 2 governance docs.
+
+## Constitution Check
+
+*GATE: re-checked after Phase 1 — passing.*
+
+- **I. Zero-Knowledge Boundary** — PASS (N/A). Purely client-side rendering + phrasing +
+  docs; no client/server contract, payload, or stored-data change. Spec's Zero-Knowledge
+  Impact says none; the crypto/ZK **checklist is not required**.
+- **II. Spec-Driven Development** — PASS. Full pipeline; branch/commits/PR trace to spec 2004.
+- **III. Test-Driven Development** — PASS with a noted limit. The one unit-testable change
+  (`prettify` ref-stripping) gets a FAILING test first. The banner/toast **rendering** isn't
+  unit-testable in the harness (no DOM-screenshot in vitest); verified via drive screenshots
+  — a justified, recorded deviation from "add an e2e spec." This is a bug fix (2001+); the
+  regression test reproduces the jargon-leak defect.
+- **IV. Crypto Discipline** — PASS (N/A). No crypto.
+- **V. Offline-First** — PASS (N/A). No object-store change.
+- **VI. Forward-Only Migrations** — PASS (N/A). No DB migration; the constitution amendment
+  bumps its own version metadata.
+- **VII. Quality Gates** — PASS. `vue-tsc` + `vite build` + `vitest`. (This spec also
+  *amends* VII — see below.)
+- **VIII. Traceable Delivery** — PASS. `taskstoissues` → `Closes #N`.
+- **IX. Privacy & Data Minimization** — PASS (N/A).
+- **X. Accessibility & i18n** — PASS. Banner action buttons use stock Ionic + existing
+  theme; text stays bidi-safe.
+- **XI. Ionic-First UI** — PASS. The action card reuses the existing banner overlay (stock
+  Ionic `ion-button`s + theme tokens); the `appToast` helper wraps stock `ion-toast`.
+
+**Amendment in scope:** this spec *changes* the governing docs (Principle VII +
+CLAUDE.md) to require user-facing release-note phrasing, and bumps the constitution version
+(1.1.0 → 1.2.0). That is an intentional governance change carried out as part of the fix.
+
+**Gate result: PASS.**
+
+## Design Overview
+
+### 1. Update prompt → shared "action" banner (fixes the bug)
+- `src/services/notify.ts`: add `'action'` to `IncomingKind`; extend `NotifyBanner` with
+  `actions?: { text: string; role?: 'cancel'; handler: () => void }[]` and a persistent
+  flag. Add `showActionBanner({ name, body, icon, actions })` using a fixed `url`
+  (`'app-update'`) so dedup-by-url replaces on re-prompt; pin it (exempt from `MAX_BANNERS`)
+  and skip the `BANNER_MS` auto-dismiss via the existing `pinnedUrls`/`holdBanner`
+  machinery; add `dismissActionBanner(url)` for the action handlers.
+- `src/components/NotificationBanners.vue`: when `kind === 'action'`, render the `actions`
+  as a stock `ion-button` row under the body (no avatar quick-reply). Same card chrome →
+  identical position/rounding to message/system cards.
+- `src/composables/useAppUpdate.ts`: replace `toastController.create({cssClass:'app-update-toast', …})`
+  with `showActionBanner({ name: 'Update available', body: label, icon: sparklesOutline,
+  actions: [ {text:`What's new (N)`, handler: → presentWhatsNew}, {text:'Update', handler: →
+  updateServiceWorker(true)}, {text:'Later', role:'cancel', handler: → dismiss} ] })`. Keep
+  the `WhatsNewSheet` modal + the foreground re-prompt; the `prompting` guard still applies.
+- `src/App.vue`: delete the `ion-toast.app-update-toast` CSS block (dead).
+
+### 2. Shared `appToast()` for functional/error toasts
+- `src/services/toast.ts` (new): `appToast({ message, duration?, color?, icon? })` → one
+  `toastController.create({ position: 'top', cssClass: 'app-toast', duration: duration ??
+  1800, color, icon, message }).present()`.
+- `src/App.vue`: add `ion-toast.app-toast` style — rounded corners + below-header offset
+  (consistent, tunable in one place).
+- Migrate the ~24 functional/error `toastController.create` sites (e.g. `WallPage.vue`,
+  `ChatDetailPage.vue`, `ContactsPage.vue`, `DirectoryPage.vue`, `ContactDetailPage.vue`,
+  `AddByIdPage.vue`, `ContactQrPage.vue`, `ScanPage.vue`, `SelfTestPage.vue`,
+  `ChatListItem.vue`, `useCall.ts`, `useConnect.ts`, `PostDetailPage.vue`, `NotificationBanners.vue`
+  error path) to `appToast(...)`. Document exceptions left as-is: App.vue's sticky
+  failed-sends toast (has its own buttons) and the now-banner update prompt.
+
+### 3. User-friendly release notes + governance
+- `src/services/release-notes.ts`: broaden `TRAILING_REF` from `\(spec\s*\d+\)` to also
+  strip refs with trailing detail — `\((?:spec\s*\d+[^)]*|#\d+|gh-\d+)\)\s*$` — plus a
+  trailing `\s*\(\+[^)]*\)\s*$` ("(+ flaky test, …)") note. Add `prettify` test cases.
+- `.specify/memory/constitution.md`: extend Principle VII so user-facing commit types
+  (feat/fix/perf/security) MUST have plain-language, benefit-focused, jargon-free,
+  reference-free subjects (they become "What's new"). Bump `1.1.0 → 1.2.0` (Sync Impact
+  header + footer).
+- `CLAUDE.md`: under "Commit messages", add "Release-note subjects for end users" with a
+  good/bad example.
+
+## Project Structure
+```text
+specs/2004-unify-app-notifications/
+├── plan.md  research.md  data-model.md  quickstart.md  contracts/  tasks.md
+```
+Source touched: `src/services/notify.ts`, `src/components/NotificationBanners.vue`,
+`src/composables/useAppUpdate.ts`, `src/services/toast.ts` (new), `src/App.vue`,
+`src/services/release-notes.ts` (+ test), ~14 toast call sites, `.specify/memory/constitution.md`, `CLAUDE.md`.
+
+## Phasing
+- **Phase 0 — research.md**: the few decisions (banner action-card vs new component; toast
+  default duration; ref-stripping regex; constitution version bump). Done.
+- **Phase 1 — data-model.md / contracts / quickstart**: no data model (state it); the
+  in-app "contract" is the `showActionBanner`/`appToast` surface; quickstart = verification
+  recipe. Done.
+- **Phase 2 — tasks.md**: `/speckit-tasks` (TDD: prettify test first).
+
+## Complexity Tracking
+Only the noted TDD/e2e limitation (banner/toast rendering verified via drive screenshots,
+not unit tests) — justified by the harness's lack of DOM-screenshot in vitest.

--- a/specs/2004-unify-app-notifications/quickstart.md
+++ b/specs/2004-unify-app-notifications/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: verifying spec 2004
+
+## Build / typecheck / unit tests (CI gates)
+```sh
+npm run build          # vue-tsc --noEmit (typecheck) THEN vite build — must be clean
+npx vitest run         # unit tests — incl. the new release-notes prettify strip cases
+```
+The server side is untouched (no Go change).
+
+## TDD (Principle III)
+1. Add failing `prettify` cases to `src/services/release-notes.test.ts` first:
+   - `"feat(chat): … (spec 1013 US2/US3)"` → no `(spec …)` in output.
+   - `"fix(media): … (+ flaky test fix)"` → no `(+ …)` in output.
+   - A subject with no reference → returned unchanged (cleanup never eats real content).
+2. Run `npx vitest run` and confirm they FAIL.
+3. Implement the `TRAILING_REF` broadening; re-run until green.
+
+## Visual verification (drive/ — the banner/toast rendering)
+Not unit-testable in the harness, so verify against the live dev stack:
+```sh
+make start                                   # dev stack (Vite :5173 → ringd :8080)
+HEADED=1 node drive/scenarios/<scenario>.mjs # or a console call to showActionBanner(...)
+```
+Confirm and screenshot (`.tmp/drive/*.png`):
+- The **update prompt** renders as a rounded card **below the header** (matching the
+  message/system cards) with **What's new / Update / Later** buttons — never pinned under
+  the status bar, never sharp corners (SC-001, US1).
+- Dismiss + foreground re-prompt shows a **single** card (replace, not stack) (FR-003).
+- An `appToast('…')` renders with the shared rounded styling/position (US3, SC-003).
+
+## Governance verification
+- `.specify/memory/constitution.md`: Principle VII states the user-facing release-note
+  phrasing rule; version metadata bumped `1.1.0 → 1.2.0` (header + footer) (SC-005).
+- `CLAUDE.md`: "Commit messages" carries the release-note-subject guidance + a good/bad
+  example.
+- `make roadmap` after the spec's `**Status**` changes (never hand-edit ROADMAP.md).

--- a/specs/2004-unify-app-notifications/research.md
+++ b/specs/2004-unify-app-notifications/research.md
@@ -1,0 +1,68 @@
+# Research: Unify in-app notifications/toasts + user-friendly "What's new"
+
+All decisions below were locked in the feature input; this records the rationale and the
+alternatives considered so the plan is self-contained.
+
+## R1 — Render the update prompt through the existing banner overlay (not a new component)
+
+- **Decision**: Add an `'action'` notification kind to the existing in-app overlay
+  (`notify.ts` + `NotificationBanners.vue`) and route the app-update prompt through it.
+- **Rationale**: The overlay already positions message/request/system cards correctly on iOS
+  (rounded, below the header). The bug is that the update prompt is the *one* surface still
+  on an Ionic toast whose `::part(container)` offset/`--border-radius` hack doesn't take on
+  iOS. Reusing the overlay fixes position+corners once and guarantees the four kinds stay
+  visually identical (FR-001, FR-004, SC-002).
+- **Alternatives**: (a) Keep the toast, try harder CSS — rejected: the iOS `::part`
+  behavior is exactly what's broken and brittle. (b) Build a third notification component —
+  rejected: defeats the "fix once" goal and re-introduces drift.
+
+## R2 — Persistent, replace-on-reprompt action card
+
+- **Decision**: The action card uses a fixed identity (`url: 'app-update'`) so a re-prompt
+  replaces rather than stacks, and is pinned (exempt from `MAX_BANNERS` and the `BANNER_MS`
+  auto-dismiss) so it stays until the user acts.
+- **Rationale**: FR-003 + the re-prompt edge case. The overlay already dedups by `url`
+  (`pinnedUrls`), so this is reuse, not new machinery.
+- **Alternatives**: A separate persistent-banner store — rejected as redundant.
+
+## R3 — One shared `appToast()` helper for functional/error toasts
+
+- **Decision**: New `src/services/toast.ts` exporting `appToast({message, duration?, color?,
+  icon?})`; one `cssClass: 'app-toast'` styled in `App.vue`. Migrate the ~24 confirmation/
+  error `toastController.create` call sites.
+- **Rationale**: FR-005/FR-006, SC-003 — consistent position/rounding/duration tuned in one
+  place; functional toasts stay simple transient toasts (not avatar cards).
+- **Alternatives**: Route confirmations through the banner overlay too — explicitly rejected
+  by the locked decisions (don't force confirmations into the avatar-card component).
+- **Documented exceptions**: App.vue's sticky failed-sends toast (own buttons/lifecycle) and
+  the update prompt (now a banner) stay special-cased — recorded so SC-003's "drops to zero"
+  is measured excluding them.
+
+## R4 — Harden `prettify` to strip references carrying extra detail
+
+- **Decision**: Broaden `TRAILING_REF` from `\(spec\s*\d+\)` to also match
+  `\(spec\s*\d+[^)]*\)` (e.g. `(spec 1013 US2/US3)`), keep `#\d+`/`gh-\d+`, and strip a
+  trailing `(+ …)` parenthetical. Add `prettify` unit tests (failing-first per Principle III).
+- **Rationale**: FR-007, SC-004 — the current regex misses refs with trailing detail, which
+  is the reported jargon leak. This is display-time cleanup of *already-shipped* subjects.
+- **Alternatives**: Rewrite history — impossible/undesirable. The cleanup + the governance
+  rule (R5) together cover historical and future notes.
+
+## R5 — Governance: user-facing release-note subjects (constitution + CLAUDE.md)
+
+- **Decision**: Amend constitution Principle VII (Quality Gates) to require that user-facing
+  commit types (`feat`/`fix`/`perf`/`security`) have plain-language, benefit-focused,
+  jargon-free, reference-free subjects (they become "What's new"); bump the constitution
+  `1.1.0 → 1.2.0` (Sync Impact header + footer). Add matching guidance + a good/bad example
+  to CLAUDE.md's "Commit messages" section.
+- **Rationale**: FR-008, SC-005 — the "What's new" line is *solely* the prettified subject,
+  so the durable fix is the subject phrasing; prettify (R4) is the safety net for history.
+- **Alternatives**: CLAUDE.md only — rejected: the constitution is the governing authority a
+  spec is checked against, so the rule belongs there with a version bump.
+
+## TDD / verification note
+
+- The one unit-testable change (R4 `prettify`) gets a FAILING test first.
+- The banner/toast **rendering** is not unit-testable in this harness (no DOM-screenshot in
+  vitest); verified via `drive/` screenshots against the live `make start` stack — a
+  recorded, justified deviation from adding an e2e spec. (See quickstart.md.)

--- a/specs/2004-unify-app-notifications/spec.md
+++ b/specs/2004-unify-app-notifications/spec.md
@@ -1,0 +1,240 @@
+# Feature Specification: Unify in-app notifications/toasts + user-friendly "What's new"
+
+**Feature Branch**: `fix/2004-unify-app-notifications`
+
+**Created**: 2026-06-22
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     Directory number sets the category (2001+ = hotfix/bug). -->
+
+**Input**: An installed iOS user reported the "Update available" prompt rendering broken
+(pinned under the status bar, sharp top corners) and the "What's new" text reading as
+developer jargon ("9 AM-local, behind-only version-announcement push (spec 1016)").
+
+## Overview
+
+Ring surfaces several kinds of in-app messages: notification-class cards (an incoming
+message, a friend request, a system notice, and the "update available" prompt) and small
+functional toasts (confirmations like "Muted", "Copied"; errors like "Microphone
+unavailable"). Today the update prompt is rendered differently from the other notification
+cards and renders **broken** on iOS (pinned to the very top, sharp corners), and the
+functional toasts are created ad-hoc with inconsistent timing/appearance. Separately, the
+"What's new" release notes shown to users are copied verbatim from developer commit
+subjects, so they read as jargon with internal references.
+
+This change makes every in-app **notification card** render through **one shared surface**
+(so they look and sit identically and a fix in one place applies to all), gives the
+**functional toasts** a single shared presentation (consistent and tunable in one place),
+makes the **"What's new"** text read as plain user-facing language, and adds **governance**
+so future release notes stay user-friendly by construction.
+
+## Bug & Root Cause
+
+- **Symptom 1**: the "update available" prompt appears pinned to the top of the screen
+  (overlapping the status bar) with sharp top corners, unlike the app's other in-app
+  notification cards, which appear as rounded cards below the header.
+- **Root cause 1**: it is the only notification rendered as a transient system-style toast;
+  the offset/rounding applied to it does not take effect on iOS, while the shared in-app
+  notification overlay (used by messages/requests/system notices) positions and rounds
+  correctly.
+- **Symptom 2**: the "What's new" entry shows the raw (developer) commit summary, including
+  an internal spec reference.
+- **Root cause 2**: the user-facing release-note line is derived solely from the commit
+  subject, with no rule that subjects be written as end-user copy, and the cleanup that
+  strips internal references doesn't catch references that carry extra detail.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The update prompt looks like every other notification (Priority: P1)
+
+A user offered an app update sees the prompt as a rounded card sitting below the header —
+the same shape and position as an incoming-message or friend-request card — never pinned
+under the status bar and never with sharp corners. Its actions (What's new / Update /
+Later) are present and work.
+
+**Why this priority**: This is the reported breakage; fixing it is the point.
+
+**Independent Test**: Trigger the update prompt and confirm it renders as a rounded card
+below the header (matching the message/system cards), with working actions.
+
+**Acceptance Scenarios**:
+
+1. **Given** an update is available, **When** the prompt appears, **Then** it is a rounded
+   card positioned below the app header (not under the status bar, no sharp corners),
+   visually consistent with the other in-app notification cards.
+2. **Given** the prompt is showing, **When** the user taps What's new / Update / Later,
+   **Then** each action behaves as before (open the details sheet / install / dismiss).
+3. **Given** the prompt is dismissed but the update is still pending, **When** the app
+   returns to the foreground, **Then** the prompt re-appears as a single card (it replaces,
+   never stacks).
+
+### User Story 2 - All notification cards share one surface (fix-once) (Priority: P1)
+
+All notification-class surfaces (message, request, system notice, update prompt) render
+through one shared component, so a change to their position/appearance in one place applies
+to all of them.
+
+**Why this priority**: This is what guarantees the bug can't recur per-surface and is the
+user's explicit ask ("reuse the same shared component … adjusting it in one place fixes it
+for all").
+
+**Independent Test**: Change the shared card's offset/corner styling in one place and
+confirm every notification kind (including the update prompt) reflects it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the four notification kinds, **When** they are displayed, **Then** they share
+   identical position, corner rounding, width, and base styling because they come from one
+   component.
+2. **Given** a single styling change to that component, **When** rebuilt, **Then** all four
+   kinds reflect it without per-surface edits.
+
+### User Story 3 - Functional toasts are mutually consistent (Priority: P2)
+
+Confirmation and error toasts (e.g. "Muted", "Copied", "Microphone unavailable") look and
+behave consistently — same position, rounded corners, and a sensible default duration —
+because they go through one shared helper, tunable in one place. (They remain simple
+transient toasts, not avatar cards.)
+
+**Why this priority**: Consistency polish across ~two dozen scattered call sites; valuable
+but secondary to the broken prompt.
+
+**Independent Test**: Trigger several confirmation/error toasts from different screens and
+confirm uniform position, rounding, and duration; change the shared helper once and confirm
+all reflect it.
+
+**Acceptance Scenarios**:
+
+1. **Given** any confirmation or error toast, **When** shown, **Then** it uses the shared
+   presentation (same position, rounded corners, default duration unless explicitly set).
+2. **Given** a change to the shared toast presentation, **When** rebuilt, **Then** all
+   functional toasts reflect it.
+
+### User Story 4 - "What's new" reads as plain language (Priority: P2)
+
+A user reading "What's new" sees plain, benefit-focused descriptions with no internal
+jargon and no spec/issue references.
+
+**Why this priority**: The reported jargon issue; user-facing quality.
+
+**Independent Test**: Render the "What's new" list for release notes whose underlying
+subjects contain references like "(spec 1013 US2/US3)" and confirm no such reference text
+is shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** a release note whose source subject ends with an internal reference (even one
+   carrying extra detail, e.g. "(spec 1013 US2/US3)"), **When** shown in "What's new",
+   **Then** the reference is not displayed.
+2. **Given** the "What's new" list, **When** read, **Then** entries are sentence-style
+   plain language without code/spec jargon.
+
+### User Story 5 - Governance keeps release notes user-friendly (Priority: P2)
+
+The project's governing documents require that user-facing commit types' subjects be
+written as plain end-user release-note copy, so future "What's new" entries are
+user-friendly by construction (not reliant on after-the-fact cleanup).
+
+**Why this priority**: Prevents regression of US4 at the source; the user explicitly asked
+for it.
+
+**Independent Test**: The constitution and contributor guide state the rule (with an
+example), and the constitution version is bumped to reflect the amendment.
+
+**Acceptance Scenarios**:
+
+1. **Given** the governing documents, **When** read, **Then** they require feat/fix/perf/
+   security commit subjects to be plain-language, benefit-focused, jargon-free, and free of
+   spec/issue references.
+2. **Given** the amendment, **When** the constitution is inspected, **Then** its version
+   metadata reflects the change.
+
+### Edge Cases
+
+- **Re-prompting**: dismissing the update prompt and returning to the foreground shows one
+  card, not a growing stack (it replaces by identity).
+- **Update prompt persistence**: the update card is not auto-dismissed on a timer; it stays
+  until the user acts or explicitly closes it (unlike transient confirmation toasts).
+- **Long version strings**: an unbreakable token (e.g. a version with a build hash) must
+  not blow up the card layout.
+- **A toast and a notification card at the same time**: both remain legible (the rare
+  overlap is acceptable; they share the top region).
+- **A release note with no internal reference**: shown unchanged (the cleanup only removes
+  reference text, never real content).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The app-update prompt MUST render through the same shared in-app notification
+  surface as message/request/system notifications (a rounded card positioned below the
+  header), not as a separate top-pinned toast.
+- **FR-002**: The update card MUST present its actions — open "What's new", Update now, and
+  Later/dismiss — and each MUST behave as before.
+- **FR-003**: The update card MUST be persistent (no auto-dismiss timer) and, when
+  re-shown, MUST replace the existing card rather than stack a duplicate.
+- **FR-004**: All notification-class surfaces (message, request, system, update) MUST share
+  one component such that a single change to position/corners/base style applies to all.
+- **FR-005**: Functional confirmation and error toasts MUST be presented via one shared
+  helper that sets a consistent position, rounded corners, and default duration in one
+  place; individual call sites only supply message text (and optionally an error/success
+  variant or an explicit duration).
+- **FR-006**: Functional toasts MUST remain simple transient toasts (not rendered as
+  avatar/notification cards).
+- **FR-007**: The "What's new" release-note text MUST be shown free of internal references
+  (spec/issue identifiers), including references that carry extra detail such as
+  "(spec 1013 US2/US3)".
+- **FR-008**: The governing documents (project constitution and the contributor guide) MUST
+  require that, for user-facing commit types (feat/fix/perf/security), the subject after the
+  type/scope prefix is plain-language, benefit-focused end-user release-note copy with no
+  internal jargon and no spec/issue references; the constitution's version metadata MUST be
+  updated to record the amendment.
+- **FR-009**: The separate full-screen "What's new" details view (opened from the update
+  card) MUST be retained and continue to function.
+
+### Key Entities
+
+- *(none — client-side presentation + release-note phrasing + governance docs; no data
+  model change.)*
+
+## Zero-Knowledge Impact
+
+*(Required by Constitution Principle I.)*
+
+- **What new data becomes visible to the server?** None. This change is entirely
+  client-side presentation (how in-app notifications/toasts render), release-note phrasing,
+  and governance documents. No client/server contract, request, payload, or stored data
+  changes. The crypto/ZK checklist is therefore **not required** for this spec.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The update prompt appears as a rounded card below the header in 100% of cases
+  (never pinned under the status bar, never with sharp corners) — verified visually on the
+  affected platform.
+- **SC-002**: All four notification kinds (message/request/system/update) share identical
+  position and corner styling, sourced from a single component (one styling change updates
+  all four).
+- **SC-003**: 100% of functional confirmation/error toasts route through the shared helper
+  (consistent position + rounded corners + default duration); the count of direct ad-hoc
+  toast-creation call sites for confirmations/errors drops to zero (excluding documented
+  special cases).
+- **SC-004**: 0% of "What's new" entries display an internal spec/issue reference, including
+  references with extra detail — verified by a test over representative subjects.
+- **SC-005**: The constitution and contributor guide both state the user-facing
+  release-note phrasing rule, and the constitution version is bumped.
+
+## Assumptions
+
+- The existing in-app notification overlay (used for message/request/system cards) is the
+  correct, well-positioned surface to also host the update prompt; it can carry a title +
+  body + action buttons.
+- A small number of pre-existing toast call sites with bespoke behavior (e.g. a sticky
+  prompt with its own buttons) may remain special-cased and are documented as exceptions to
+  the shared functional-toast helper.
+- Already-shipped commit subjects cannot be rewritten; the phrasing rule applies going
+  forward, while the prettifier cleanup covers historical references at display time.
+- Desktop and Android render the same shared surfaces; the fix is not iOS-specific even
+  though the breakage was reported on iOS.

--- a/specs/2004-unify-app-notifications/tasks.md
+++ b/specs/2004-unify-app-notifications/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Unify in-app notifications/toasts + user-friendly "What's new"
+
+**Branch**: `fix/2004-unify-app-notifications` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+**Input**: plan.md, research.md, data-model.md (no data model), quickstart.md. No contracts/
+(internal client UI; no external interface).
+
+**Tests**: TDD per Constitution Principle III. The one unit-testable change (`prettify`) is
+written failing-first. Banner/toast rendering is verified via `drive/` screenshots (a
+recorded harness limitation — no DOM-screenshot in vitest); see plan.md Constitution Check.
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 Confirm dev gates run clean on the branch baseline: `npm run build` (vue-tsc + vite) and `npx vitest run` both green before any change.
+
+## Phase 2: Foundational (shared surfaces — blocks the user-story phases)
+
+- [X] T002 Add the `'action'` notification kind to `src/services/notify.ts`: extend `IncomingKind` with `'action'`; extend `NotifyBanner` with `actions?: { text: string; role?: 'cancel'; handler: () => void }[]` and a persistent flag; add `showActionBanner({ name, body, icon, actions })` (fixed `url: 'app-update'` so re-prompts replace via the existing `pinnedUrls` dedup; pinned → exempt from `MAX_BANNERS` and the `BANNER_MS` auto-dismiss) and `dismissActionBanner(url)`.
+- [X] T003 Render the action kind in `src/components/NotificationBanners.vue`: when `kind === 'action'`, show an `ion-button` row (the `actions`) under the body, reusing the existing card chrome/positioning (no avatar quick-reply) so it is pixel-identical to message/system cards.
+- [X] T004 [P] Create `src/services/toast.ts` exporting `appToast({ message, duration?, color?, icon? })` → one `toastController.create({ position: 'top', cssClass: 'app-toast', duration: duration ?? 1800, color, icon, message }).present()`.
+
+## Phase 3: User Story 1 — update prompt looks like every other notification (P1)
+
+**Goal**: the update prompt is a rounded card below the header with working actions.
+**Independent test**: trigger the prompt (drive/console) → rounded card below header, What's new / Update / Later all work, re-prompt replaces (drive screenshots, quickstart.md).
+
+- [X] T005 [US1] In `src/composables/useAppUpdate.ts`, replace the `toastController.create({ cssClass:'app-update-toast', … })` update prompt with `showActionBanner({ name:'Update available', body: label, icon: sparklesOutline, actions:[ {text:\`What's new (N)\`, handler:→presentWhatsNew}, {text:'Update', handler:→updateServiceWorker(true)}, {text:'Later', role:'cancel', handler:→dismissActionBanner} ] })`. Keep the `WhatsNewSheet` modal + the foreground re-prompt + the `prompting` guard.
+- [X] T006 [US1] Remove the now-dead `ion-toast.app-update-toast` CSS block from `src/App.vue`.
+- [X] T007 [US1] Verify via `drive/` (live `make start`): update card renders rounded, below header, with the three actions; dismiss + foreground re-prompt shows a single card (no stack). Capture screenshots (quickstart.md). Covers SC-001.
+
+## Phase 4: User Story 2 — all notification cards share one surface (P1)
+
+**Goal/Independent test**: a single styling change to the shared card updates all four kinds.
+(Satisfied structurally by Phase 2/3 — the update prompt now flows through the same overlay.)
+
+- [X] T008 [US2] Confirm the four kinds (message/request/system/action) all render through `NotificationBanners.vue` with one shared style block (no per-surface position/corner CSS remains); note it in the PR. Covers SC-002.
+
+## Phase 5: User Story 3 — functional toasts are mutually consistent (P2)
+
+**Goal**: confirmation/error toasts share one helper (position, rounding, default duration).
+**Independent test**: trigger several toasts from different screens → uniform; one helper change updates all.
+
+- [X] T009 [US3] Add the `ion-toast.app-toast` style to `src/App.vue` (rounded corners + below-header offset) — the single tuning point for functional toasts.
+- [X] T010 [P] [US3] Migrate confirmation/error `toastController.create` call sites to `appToast(...)` in: `src/views/tabs/WallPage.vue`, `src/views/tabs/ContactsPage.vue`.
+- [X] T011 [P] [US3] Migrate in: `src/views/detail/ChatDetailPage.vue`, `src/views/detail/PostDetailPage.vue`, `src/views/detail/ContactDetailPage.vue`.
+- [X] T012 [P] [US3] Migrate in: `src/views/detail/AddByIdPage.vue`, `src/views/detail/ContactQrPage.vue`, `src/views/detail/ScanPage.vue`, `src/views/detail/DirectoryPage.vue`, `src/views/detail/SelfTestPage.vue`.
+- [X] T013 [P] [US3] Migrate in: `src/components/ChatListItem.vue`, `src/composables/useCall.ts`, `src/composables/useConnect.ts`, and the error-path toast in `src/components/NotificationBanners.vue`.
+- [X] T014 [US3] Confirm only the documented exceptions still call `toastController.create` directly (App.vue sticky failed-sends with its own buttons; the update prompt is now a banner). Covers SC-003.
+
+## Phase 6: User Story 4 — "What's new" reads as plain language (P2)
+
+**Goal**: no internal spec/issue reference text in "What's new".
+
+- [X] T015 [US4] Add FAILING `prettify` tests to `src/services/release-notes.test.ts`: `"(spec 1013 US2/US3)"` stripped; `"(+ flaky test fix)"` stripped; a no-reference subject returned unchanged. Run `npx vitest run` and confirm they fail.
+- [X] T016 [US4] In `src/services/release-notes.ts`, broaden `TRAILING_REF` to `\((?:spec\s*\d+[^)]*|#\d+|gh-\d+)\)\s*$` and add a trailing `\s*\(\+[^)]*\)\s*$` strip; re-run `npx vitest run` until green. Covers SC-004.
+
+## Phase 7: User Story 5 — governance keeps release notes user-friendly (P2)
+
+- [X] T017 [P] [US5] Amend `.specify/memory/constitution.md` Principle VII (Quality Gates): require user-facing commit types (feat/fix/perf/security) to have plain-language, benefit-focused, jargon-free, reference-free subjects (they become "What's new"). Bump version `1.1.0 → 1.2.0` (Sync Impact header + footer "Last Amended").
+- [X] T018 [P] [US5] Add a "Release-note subjects for end users" note (good/bad example) under "Commit messages" in `CLAUDE.md`. Covers SC-005.
+
+## Phase 8: Polish & cross-cutting
+
+- [X] T019 Run the full client gate: `npm run build` (vue-tsc + vite) and `npx vitest run` — both green.
+- [X] T020 Set spec `**Status**: in-progress` (→ shipped on merge) and run `make roadmap`; confirm `git diff` of ROADMAP.md is intended (never hand-edit).
+
+---
+
+## Dependencies
+- Phase 2 (T002–T004) blocks Phase 3/5.
+- T002 → T003 → T005/T006 (same overlay; sequential).
+- T004 → T009 → T010–T013 (helper + style before migrations).
+- T015 (failing test) → T016 (implementation).
+- Phase 7 (T017/T018) is independent (docs) — parallel-safe.
+
+## Parallel example
+- After T004+T009: T010, T011, T012, T013 touch disjoint files → run together.
+- T017 and T018 (docs) → run together.
+
+## MVP
+US1 (T002, T003, T005–T007) — fixes the reported broken update prompt.

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,7 @@ import { isUnlockedNow, isUnlocked } from '@/services/crypto/identity';
 import { warmAll, clearWarm } from '@/composables/warmStores';
 import { IonApp, IonRouterOutlet, toastController } from '@ionic/vue';
 import { inviteNeedsProfile } from '@/services/invites';
+import { appToast } from '@/services/toast';
 import { useViewportHeight } from '@/composables/useViewportHeight';
 import { useTheme } from '@/composables/useTheme';
 import { useAppBadge } from '@/composables/useAppBadge';
@@ -96,12 +97,7 @@ watch(inviteNeedsProfile, async (needs) => {
   // While still in the sign-in/onboarding flow (/auth), the mandatory profile step
   // there already collects name + photo; don't race it with a second prompt.
   if (router.currentRoute.value.path === '/auth') return;
-  const t = await toastController.create({
-    message: 'Add your name and photo so people know it’s you.',
-    duration: 2800,
-    position: 'top',
-  });
-  await t.present();
+  await appToast({ message: 'Add your name and photo so people know it’s you.', duration: 2800 });
   router.push('/settings/profile');
 });
 
@@ -273,41 +269,24 @@ body.keyboard-open ion-footer {
   overflow: hidden;
 }
 
-/* The "update available" toast is styled to MATCH the in-app notification banners
-   (NotificationBanners.vue), so every in-app notification + toast shares one look:
-   the brand-green translucent card with blur, white text, 18px corners, sitting just
-   below the app header (same safe-area + 56px offset as the banner stack) rather than
-   pinned to the very top. */
-ion-toast.app-update-toast {
-  --background: rgba(var(--ion-color-primary-rgb, 16, 185, 129), 0.9);
-  --color: #fff;
-  --border-radius: 18px;
+/* Functional toasts (confirmations like "Muted"/"Copied" and errors) all go through the
+   shared appToast() helper (src/services/toast.ts) with this one cssClass, so they share a
+   single look — rounded corners, sitting just below the app header (same safe-area + 56px
+   offset as the in-app banner stack) rather than pinned to the very top — tunable here in
+   one place. (The "update available" prompt is NOT a toast; it renders as a persistent
+   card through the in-app banner overlay, NotificationBanners.vue.) */
+ion-toast.app-toast {
+  --border-radius: 14px;
   --max-width: 560px;
-  --box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22);
-  --button-color: #fff;
+  --box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
 }
-/* Push the box below the header and give it the banner's frosted blur. (The visible
-   box is the `container` part; offsetting it lines the toast up with the banners.) */
-ion-toast.app-update-toast::part(container) {
+/* Offset the visible box (the `container` part) below the header so a functional toast
+   lines up with the in-app banners instead of overlapping the status bar / header. */
+ion-toast.app-toast::part(container) {
   margin-top: calc(env(safe-area-inset-top, 0px) + 56px);
-  backdrop-filter: blur(18px) saturate(160%);
-  -webkit-backdrop-filter: blur(18px) saturate(160%);
 }
-/* Defensive: never let a long unbreakable token (e.g. a version with a git sha)
-   wrap one character per line and blow up the toast. */
-ion-toast.app-update-toast::part(message) {
+/* Defensive: never let a long unbreakable token wrap one character per line. */
+ion-toast.app-toast::part(message) {
   overflow-wrap: anywhere;
-}
-ion-toast.app-update-toast::part(button) {
-  color: #fff;
-}
-ion-toast.app-update-toast::part(icon) {
-  color: #fff;
-}
-/* Match the banners' slightly stronger fill in dark mode. */
-@media (prefers-color-scheme: dark) {
-  ion-toast.app-update-toast {
-    --background: rgba(var(--ion-color-primary-rgb, 16, 185, 129), 0.95);
-  }
 }
 </style>

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -71,7 +71,7 @@
 import { computed, ref } from 'vue';
 import {
   IonItemSliding, IonItem, IonItemOptions, IonItemOption, IonAvatar, IonLabel, IonNote,
-  IonBadge, IonIcon, toastController,
+  IonBadge, IonIcon,
 } from '@ionic/vue';
 import {
   pinOutline, archiveOutline, ellipsisHorizontal, mailOpenOutline, mailUnreadOutline,
@@ -82,6 +82,7 @@ import {
 import {
   markChatRead, markChatUnread, setChatPinned, setChatArchived, MAX_PINNED_CHATS,
 } from '@/db/queries';
+import { appToast } from '@/services/toast';
 import { peerPresence } from '@/composables/usePresence';
 import { activityFor, activityKindLabel } from '@/composables/useTyping';
 import { formatTime } from '@/utils/time';
@@ -128,12 +129,10 @@ async function toggleRead(): Promise<void> {
 async function togglePin(): Promise<void> {
   const ok = await setChatPinned(props.chat.id, !props.chat.pinned);
   if (!ok) {
-    const t = await toastController.create({
+    await appToast({
       message: `You can only pin ${MAX_PINNED_CHATS} chats.`,
       duration: 2200,
-      position: 'top',
     });
-    await t.present();
   }
   closeSwipe();
 }

--- a/src/components/NotificationBanners.vue
+++ b/src/components/NotificationBanners.vue
@@ -16,15 +16,23 @@
       <button class="nb-close" aria-label="Dismiss notification" @click.stop="dismissBanner(b.id)" @pointerdown.stop>
         <ion-icon :icon="closeOutline" />
       </button>
-      <!-- Header: tap anywhere here to open the full chat. -->
-      <div class="nb-main" role="button" tabindex="0" @click="open(b)" @keydown.enter="open(b)">
-        <div class="nb-avatar" :class="{ 'nb-system': b.kind === 'system' && !b.avatar }">
+      <!-- Header: tap anywhere here to open the full chat. An 'action' card (the update
+           prompt) is not a link — it carries its own buttons — so it isn't clickable. -->
+      <div
+        class="nb-main"
+        :class="{ 'nb-main-static': b.kind === 'action' }"
+        :role="b.kind === 'action' ? undefined : 'button'"
+        :tabindex="b.kind === 'action' ? undefined : 0"
+        @click="b.kind === 'action' ? undefined : open(b)"
+        @keydown.enter="b.kind === 'action' ? undefined : open(b)"
+      >
+        <div class="nb-avatar" :class="{ 'nb-system': (b.kind === 'system' || b.kind === 'action') && !b.avatar }">
           <img v-if="b.avatar" :src="b.avatar" :alt="b.name" />
           <ion-icon v-else :icon="bannerIcon(b)" />
         </div>
         <div class="nb-text">
           <div class="nb-name">{{ b.name }}</div>
-          <div class="nb-body">{{ sentId === b.id ? 'Sent' : b.body }}</div>
+          <div class="nb-body" :class="{ 'nb-body-wrap': b.kind === 'action' }">{{ sentId === b.id ? 'Sent' : b.body }}</div>
         </div>
         <ion-icon v-if="sentId === b.id" :icon="checkmarkCircle" class="nb-sent" />
       </div>
@@ -72,6 +80,18 @@
           <span class="nb-handle" aria-hidden="true" />
         </div>
       </template>
+      <!-- Action card (update prompt): its buttons (What's new / Update / Later). -->
+      <div v-else-if="b.kind === 'action' && b.actions?.length" class="nb-actions">
+        <button
+          v-for="(a, i) in b.actions"
+          :key="i"
+          class="nb-action"
+          :class="{ cancel: a.role === 'cancel' }"
+          @click.stop="onAction(b, a)"
+        >
+          {{ a.text }}
+        </button>
+      </div>
       <span v-else class="nb-handle nb-handle-static" aria-hidden="true" />
     </div>
   </div>
@@ -79,23 +99,38 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { IonIcon, IonTextarea, toastController } from '@ionic/vue';
+import { IonIcon, IonTextarea } from '@ionic/vue';
 import {
   personAddOutline, chatbubbleEllipsesOutline, sendOutline, checkmarkCircle, closeOutline,
+  sparklesOutline,
 } from 'ionicons/icons';
 import router from '@/router';
 import {
-  notifyBanners, dismissBanner, holdBanner, pinBanner, unpinBanner, type NotifyBanner,
+  notifyBanners, dismissBanner, holdBanner, pinBanner, unpinBanner,
+  type NotifyBanner, type NotifyAction,
 } from '@/services/notify';
 import { sendMessage } from '@/db/queries';
+import { appToast } from '@/services/toast';
 import { normalizeOutgoing } from '@/utils/text';
 
 const banners = notifyBanners;
 
-// The glyph for a banner with no avatar: a system notice carries its own icon; a
-// request shows the add-person icon; a message falls back to the chat bubble.
+// The glyph for a banner with no avatar: a system / action notice carries its own icon;
+// a request shows the add-person icon; an action card falls back to sparkles; a message
+// falls back to the chat bubble.
 function bannerIcon(b: NotifyBanner): string {
-  return b.icon || (b.kind === 'request' ? personAddOutline : chatbubbleEllipsesOutline);
+  if (b.icon) return b.icon;
+  if (b.kind === 'request') return personAddOutline;
+  if (b.kind === 'action') return sparklesOutline;
+  return chatbubbleEllipsesOutline;
+}
+
+// An action card's button: run its handler, then dismiss the card. Mirrors the old
+// update toast where any button closed it; dismissing fires the banner's onDismiss, which
+// lets useAppUpdate re-surface the prompt next foreground if the user chose "Later".
+function onAction(b: NotifyBanner, a: NotifyAction): void {
+  a.handler();
+  dismissBanner(b.id);
 }
 
 // Reply state is keyed by the banner's URL (its dedup identity), so a follow-up
@@ -155,13 +190,7 @@ async function sendReply(b: NotifyBanner): Promise<void> {
     await sendMessage(b.chatId, text);
   } catch {
     // Keep the reply open with the draft intact so it can be retried or opened fully.
-    const t = await toastController.create({
-      message: "Couldn't send. Tap the banner to open the chat.",
-      duration: 2200,
-      position: 'top',
-      color: 'danger',
-    });
-    await t.present();
+    await appToast({ message: "Couldn't send. Tap the banner to open the chat.", duration: 2200, color: 'danger' });
     return;
   }
   draft.value = '';
@@ -337,6 +366,10 @@ watch(
   gap: 12px;
   cursor: pointer;
 }
+/* An action card's header is informational (the prompt's title + body), not a link. */
+.nb-main-static {
+  cursor: default;
+}
 .nb-avatar {
   flex: none;
   width: 40px;
@@ -383,6 +416,13 @@ watch(
   text-overflow: ellipsis;
   unicode-bidi: plaintext;
   text-align: start;
+}
+/* The update prompt's body is a full sentence (and a version string that must not blow up
+   the layout) — let it wrap and break an unbreakable token instead of truncating. */
+.nb-body-wrap {
+  white-space: normal;
+  overflow: visible;
+  overflow-wrap: anywhere;
 }
 .nb-sent {
   flex: none;
@@ -466,5 +506,35 @@ watch(
 }
 .nb-handle-static {
   margin-top: 4px;
+}
+/* Action-card button row (update prompt). Buttons read on the saturated green using the
+   same translucent-white treatment as the quick-reply send button, so the card stays one
+   coherent surface; the cancel ("Later") option is quieter. */
+.nb-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 2px;
+  padding-top: 2px;
+}
+.nb-action {
+  border: none;
+  border-radius: 14px;
+  padding: 7px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.18);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.nb-action:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+.nb-action.cancel {
+  background: transparent;
+  font-weight: 500;
+  opacity: 0.85;
 }
 </style>

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -3,9 +3,9 @@
  *
  * The PWA is built with registerType: 'prompt' (vite.config.ts), so a freshly
  * deployed build installs its service worker but WAITS rather than taking over.
- * When that happens we surface a toast that NAMES the new version (read from
- * /v1/config, since the SW update event itself carries no version string) and let
- * the user pull it immediately (skipWaiting + reload) or defer. Deferring keeps the
+ * When that happens we surface an in-app notification card that NAMES the new version
+ * (read from /v1/config, since the SW update event itself carries no version string) and
+ * let the user pull it immediately (skipWaiting + reload) or defer. Deferring keeps the
  * current version running; the prompt REAPPEARS every time the app returns to the
  * foreground (and on next launch) until accepted, so a user who taps "Later" and
  * never fully closes the app is reminded again instead of having to hunt for a
@@ -19,9 +19,10 @@
  */
 import { watch } from 'vue';
 import { useRegisterSW } from 'virtual:pwa-register/vue';
-import { toastController, modalController } from '@ionic/vue';
+import { modalController } from '@ionic/vue';
 import { sparklesOutline } from 'ionicons/icons';
 import { fetchServerConfig } from '@/services/api';
+import { showActionBanner, type NotifyAction } from '@/services/notify';
 import { computeDelta, userFacing, displayVersion, type ReleaseNote } from '@/services/release-notes';
 import WhatsNewSheet from '@/components/WhatsNewSheet.vue';
 
@@ -82,16 +83,18 @@ export function useAppUpdate(): void {
 
   let prompting = false;
 
-  // Build + present the update toast. Idempotent while one is already showing
-  // (prompting) and a no-op when nothing is waiting (needRefresh false). Driven by
-  // BOTH the needRefresh watch (a new worker just appeared) and every return to the
-  // foreground, so tapping "Later" doesn't bury the update forever for someone who
-  // never fully closes the app — it comes back next time they reopen it.
+  // Build + present the update prompt as a persistent in-app notification card (the SAME
+  // shared overlay as message/request/system banners — NotificationBanners.vue — so it
+  // renders identically: a rounded card below the header, never a top-pinned toast).
+  // Idempotent while one is already showing (prompting) and a no-op when nothing is waiting
+  // (needRefresh false). Driven by BOTH the needRefresh watch (a new worker just appeared)
+  // and every return to the foreground, so tapping "Later" doesn't bury the update forever
+  // for someone who never fully closes the app — it comes back next time they reopen it.
   async function maybePrompt(): Promise<void> {
     if (!needRefresh.value || prompting) return;
     prompting = true;
     // The waiting SW IS the new build; ask the (already-deployed) server which
-    // version that is AND its release notes, so the toast can name the version and
+    // version that is AND its release notes, so the card can name the version and
     // offer a per-user "What's new". A miss just drops both (generic message).
     let version = '';
     let incoming: ReleaseNote[] = [];
@@ -104,7 +107,7 @@ export function useAppUpdate(): void {
     }
     const running = __APP_VERSION__;
     // Display version strips the long +<sha> build metadata (it's an unbreakable
-    // token that otherwise wraps one char per line and wrecks the toast).
+    // token that otherwise wraps one char per line and wrecks the layout).
     const shown = displayVersion(version);
     const label = version && version !== running ? `Ring ${shown} is ready to install.` : 'A new version of Ring is ready.';
 
@@ -113,12 +116,13 @@ export function useAppUpdate(): void {
     // chores) so "What's new" reads as improvements rather than a developer changelog.
     const delta = userFacing(computeDelta(incoming, __RELEASE_NOTES__ ?? []));
 
-    const buttons: { text: string; role?: 'cancel'; handler?: () => boolean | void }[] = [];
+    const actions: NotifyAction[] = [];
     if (delta.length) {
-      buttons.push({
+      actions.push({
         text: `What's new (${delta.length})`,
-        // No `return false`: tapping this dismisses the toast and opens the sheet,
-        // which carries its own Update / Later actions.
+        // Opens the sheet, which carries its own Update / Later actions. The card is
+        // dismissed by NotificationBanners' onAction; if the user closes the sheet without
+        // updating, the prompt re-appears on the next foreground (prompting is reset below).
         handler: () => {
           void presentWhatsNew(shown, delta).then((wantsUpdate) => {
             if (wantsUpdate) void updateServiceWorker(true);
@@ -126,30 +130,22 @@ export function useAppUpdate(): void {
         },
       });
     }
-    buttons.push({ text: 'Update', handler: () => void updateServiceWorker(true) });
-    buttons.push({ text: 'Later', role: 'cancel' });
+    actions.push({ text: 'Update', handler: () => void updateServiceWorker(true) });
+    // "Later": the card dismisses (NotificationBanners' onAction), which fires onDismiss
+    // below and re-arms the prompt for the next foreground.
+    actions.push({ text: 'Later', role: 'cancel', handler: () => {} });
 
-    const toast = await toastController.create({
-      header: 'Update available',
-      message: label,
+    showActionBanner({
+      name: 'Update available',
+      body: label,
       icon: sparklesOutline, // leading glyph, matching the in-app banners' icon/avatar
-
-      // Top of the screen, where every other notification (banners, error
-      // toasts) surfaces; see the .app-update-toast rules in App.vue.
-      position: 'top',
-      cssClass: 'app-update-toast',
-      // Stack the buttons BELOW the message. The default 'baseline' layout puts
-      // the (three) buttons inline with the message and reserves their width, so
-      // on a phone the message gets squeezed into a sliver and wraps one word per
-      // line. Stacked gives the message the full toast width.
-      layout: 'stacked',
-      // No duration: stay until the user chooses.
-      buttons,
+      actions,
+      // Mirror of the old toast.onDidDismiss: re-allow a prompt once the card is gone, so a
+      // deferred update resurfaces next foreground (or when a still-newer build appears).
+      onDismiss: () => {
+        prompting = false;
+      },
     });
-    void toast.onDidDismiss().then(() => {
-      prompting = false; // allow a re-prompt on next foreground / a still-newer build
-    });
-    await toast.present();
   }
 
   // Fire when a new worker first appears; immediate covers an update that was

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -11,7 +11,7 @@
  * owns the 1:1 path and the shared reactive state/UI surface.
  */
 import { ref, computed, watch } from 'vue';
-import { toastController } from '@ionic/vue';
+import { appToast } from '@/services/toast';
 import router from '@/router';
 import { uid } from '@/utils/uid';
 import {
@@ -321,8 +321,7 @@ function setState(s: CallState): void {
 }
 
 async function toast(message: string): Promise<void> {
-  const t = await toastController.create({ message, duration: 1800, position: 'top' });
-  await t.present();
+  await appToast({ message, duration: 1800 });
 }
 
 function gumConstraints(kind: CallKind): MediaStreamConstraints {

--- a/src/composables/useConnect.ts
+++ b/src/composables/useConnect.ts
@@ -5,8 +5,9 @@
  * your QR / Add by Ring ID. All stock Ionic overlays (action sheet + alert).
  */
 import { useRouter } from 'vue-router';
-import { alertController, actionSheetController, toastController } from '@ionic/vue';
+import { alertController, actionSheetController } from '@ionic/vue';
 import { addPendingInvite } from '@/db/queries';
+import { appToast } from '@/services/toast';
 import { createInvitation } from '@/services/api';
 import { ensureProfile } from '@/composables/useProfileGate';
 
@@ -56,9 +57,7 @@ export function useConnect() {
               handler: (data: { label?: string }) => {
                 const label = (data?.label ?? '').toString().trim();
                 if (!label) {
-                  void toastController
-                    .create({ message: 'Please add a nickname for this invite.', duration: 1600, position: 'top' })
-                    .then((t) => t.present());
+                  void appToast({ message: 'Please add a nickname for this invite.', duration: 1600 });
                   return false; // keep the alert open until they enter one
                 }
                 resolve(label);
@@ -100,7 +99,7 @@ export function useConnect() {
 
     const copy = (text: string, note: string): boolean => {
       void navigator.clipboard?.writeText(text);
-      void toastController.create({ message: note, duration: 1200, position: 'top' }).then((t) => t.present());
+      void appToast({ message: note, duration: 1200 });
       return false; // keep the alert open so multiple copies are possible
     };
 

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -73,9 +73,11 @@ async function ensurePrefs(): Promise<NotifyPrefs> {
 }
 
 // 'message' and 'request' are person-to-person; 'system' is an app event (e.g. an
-// invitee joining) — it has no chat/avatar, so it shows an ICON instead. All three
-// flow through the SAME banner (NotificationBanners.vue); only the payload differs.
-export type IncomingKind = 'message' | 'request' | 'system';
+// invitee joining) — it has no chat/avatar, so it shows an ICON instead. 'action' is a
+// persistent card carrying its own buttons (the app-update prompt). All flow through the
+// SAME banner (NotificationBanners.vue); only the payload differs — so every in-app
+// notification, the update prompt included, sits and looks identical (one component).
+export type IncomingKind = 'message' | 'request' | 'system' | 'action';
 
 // Default glyph for a system notice that doesn't name its own icon, so every system
 // banner shows an icon (parity with the avatar/chat-icon on person notifications).
@@ -93,15 +95,26 @@ export interface IncomingNotice {
 
 /* ---- in-app notification banners (custom green overlay; see NotificationBanners.vue) ---- */
 
+// One action button on an 'action' banner (the app-update prompt). `role: 'cancel'`
+// marks the dismissive option (e.g. "Later") so the component can style it quietly.
+export interface NotifyAction {
+  text: string;
+  role?: 'cancel';
+  handler: () => void;
+}
+
 export interface NotifyBanner {
   id: string;
   kind: IncomingKind;
   name: string;
   body: string;
   avatar: string;
-  icon?: string; // system banners: shown in the avatar circle instead of an image
+  icon?: string; // system / action banners: shown in the avatar circle instead of an image
   url: string;
   chatId?: string; // message banners only: target for inline quick-reply
+  actions?: NotifyAction[]; // 'action' banners: buttons rendered under the body
+  persistent?: boolean; // no auto-dismiss timer + exempt from the cap; stays until acted on
+  onDismiss?: () => void; // fired when the banner is removed (mirror of toast.onDidDismiss)
 }
 // Live list the overlay renders. Capped + deduped by target so a chatty
 // conversation collapses to one banner instead of stacking.
@@ -118,18 +131,65 @@ const pinnedUrls = new Set<string>();
 
 function showBanner(b: Omit<NotifyBanner, 'id'>): void {
   const id = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  // A persistent banner (the update prompt) is pinned so the cap can never evict it, and
+  // gets no auto-dismiss timer below — it stays until the user acts or closes it.
+  if (b.persistent) pinnedUrls.add(b.url);
   // Replacing a same-target banner: clear its old timer so it can't dismiss the new one.
+  // (A re-prompt of the persistent update banner lands here and simply replaces by url,
+  // never stacking a duplicate.)
   for (const old of notifyBanners.value.filter((x) => x.url === b.url)) clearBannerTimer(old.id);
   const merged = [...notifyBanners.value.filter((x) => x.url !== b.url), { ...b, id }];
-  // Keep every pinned (open-reply) banner, then fill the remaining slots with the most
-  // recent others, instead of a blind tail-slice that could drop a pinned banner.
+  // Keep every pinned (open-reply / persistent) banner, then fill the remaining slots with
+  // the most recent others, instead of a blind tail-slice that could drop a pinned banner.
   const pinned = merged.filter((x) => pinnedUrls.has(x.url));
   const room = Math.max(0, MAX_BANNERS - pinned.length);
   const others = merged.filter((x) => !pinnedUrls.has(x.url)).slice(-room);
   const kept = new Set([...pinned, ...others].map((x) => x.id));
   for (const dropped of merged.filter((x) => !kept.has(x.id))) clearBannerTimer(dropped.id);
   notifyBanners.value = merged.filter((x) => kept.has(x.id)); // preserves arrival order
-  bannerTimers.set(id, setTimeout(() => dismissBanner(id), BANNER_MS));
+  if (!b.persistent) bannerTimers.set(id, setTimeout(() => dismissBanner(id), BANNER_MS));
+}
+
+// The fixed identity of the (single) app-update prompt: a constant `url` means a
+// re-prompt REPLACES the existing card via showBanner's dedup, never stacks a duplicate.
+const UPDATE_BANNER_URL = 'app-update';
+
+/**
+ * Surface the app-update prompt as a persistent in-app notification card carrying its
+ * own action buttons — the SAME overlay/component as message/request/system banners, so
+ * it renders identically (rounded card below the header) on every platform. Replaces any
+ * existing update card (idempotent) and never auto-dismisses.
+ */
+export function showActionBanner(opts: {
+  name: string;
+  body: string;
+  icon?: string;
+  actions: NotifyAction[];
+  onDismiss?: () => void;
+}): void {
+  showBanner({
+    kind: 'action',
+    name: opts.name,
+    body: opts.body,
+    avatar: '',
+    icon: opts.icon,
+    url: UPDATE_BANNER_URL,
+    actions: opts.actions,
+    persistent: true,
+    onDismiss: opts.onDismiss,
+  });
+}
+
+/** Whether the app-update card is currently on screen (so the driver can avoid a needless
+ *  re-fetch/re-show while it's already showing). */
+export function actionBannerShowing(url = UPDATE_BANNER_URL): boolean {
+  return notifyBanners.value.some((b) => b.url === url);
+}
+
+/** Dismiss the app-update card (e.g. its "Later" action). */
+export function dismissActionBanner(url = UPDATE_BANNER_URL): void {
+  const b = notifyBanners.value.find((x) => x.url === url);
+  if (b) dismissBanner(b.id);
 }
 
 function clearBannerTimer(id: string): void {
@@ -159,6 +219,9 @@ export function dismissBanner(id: string): void {
   const gone = notifyBanners.value.find((b) => b.id === id);
   if (gone) pinnedUrls.delete(gone.url);
   notifyBanners.value = notifyBanners.value.filter((b) => b.id !== id);
+  // Mirror of toast.onDidDismiss: let the opener react (the update prompt resets its
+  // re-prompt guard here so it surfaces again next foreground if the user chose "Later").
+  gone?.onDismiss?.();
 }
 
 /* ---- which chat is on screen (set by ChatDetailPage) ---- */

--- a/src/services/release-notes.test.ts
+++ b/src/services/release-notes.test.ts
@@ -98,6 +98,18 @@ describe('prettify', () => {
     expect(prettify('feat: add search (gh-12)')).toBe('Add search');
   });
 
+  it('strips a trailing reference that carries extra detail', () => {
+    // The reported jargon leak: a spec ref with user-story suffix slipped through.
+    expect(prettify('feat(chat): visibility-driven Seen + catch-up (spec 1013 US2/US3)')).toBe(
+      'Visibility-driven Seen + catch-up',
+    );
+    expect(prettify('feat(notifications): reliable push (spec 1015 FR-014)')).toBe('Reliable push');
+  });
+
+  it('strips a trailing developer "(+ …)" note', () => {
+    expect(prettify('feat(media): album-view overhaul (+ flaky test fix)')).toBe('Album-view overhaul');
+  });
+
   it('keeps a meaningful trailing parenthetical that is not a reference', () => {
     expect(prettify('feat: add dark mode (finally)')).toBe('Add dark mode (finally)');
   });

--- a/src/services/release-notes.ts
+++ b/src/services/release-notes.ts
@@ -62,15 +62,29 @@ export function displayVersion(v: string): string {
 // Conventional-Commit prefix: type, optional (scope), optional `!`, then `: `.
 const CC_PREFIX = /^[a-z]+(\([^)]*\))?!?:\s*/i;
 
-// A trailing developer reference users don't need: `(spec 1015)`, `(#248)`, or a bare
-// PR/issue number like `(#248)` at the end of the subject. Stripped for display.
-const TRAILING_REF = /\s*\((?:spec\s*\d+|#\d+|gh-\d+)\)\s*$/i;
+// A trailing developer reference users don't need, stripped for display. Covers
+// `(spec 1015)`, a spec ref that carries extra detail like `(spec 1013 US2/US3)` or
+// `(spec 1015 FR-014)`, a PR/issue number `(#248)`, and a `(gh-12)` reference. The
+// `spec\s*\d+[^)]*` form deliberately swallows any suffix after the number (US/FR/task
+// labels) — the leak the iOS user saw — while `(finally)` and other prose parentheticals
+// are left alone because they don't start with `spec`/`#`/`gh-`.
+const TRAILING_REF = /\s*\((?:spec\s*\d+[^)]*|#\d+|gh-\d+)\)\s*$/i;
+
+// A trailing `(+ …)` developer aside (e.g. `(+ flaky test fix)`) — a parenthetical the
+// author tacked on, not user-facing. Only strips parens that OPEN with `+`, so genuine
+// notes like `(finally)` survive.
+const TRAILING_ASIDE = /\s*\(\+[^)]*\)\s*$/;
 
 /** Turn a commit subject into clean user-facing text: drop the `type(scope):` prefix,
- *  strip a trailing spec/issue/PR reference, and upper-case the first letter. A
- *  non-conforming subject is passed through (just trimmed + capitalized), never dropped. */
+ *  strip a trailing spec/issue/PR reference and any `(+ …)` aside, and upper-case the
+ *  first letter. A non-conforming subject is passed through (just trimmed + capitalized),
+ *  never dropped. */
 export function prettify(subject: string): string {
-  const stripped = subject.replace(CC_PREFIX, '').replace(TRAILING_REF, '').trim();
+  const stripped = subject
+    .replace(CC_PREFIX, '')
+    .replace(TRAILING_ASIDE, '')
+    .replace(TRAILING_REF, '')
+    .trim();
   const text = stripped || subject.trim();
   return text.charAt(0).toUpperCase() + text.slice(1);
 }

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -114,7 +114,7 @@ import {
   listConnections as apiListConnections,
 } from '@/services/api';
 import { runInviteSync } from '@/services/invites';
-import { notifyBanners } from '@/services/notify';
+import { notifyBanners, showActionBanner } from '@/services/notify';
 import { syncContactEdges } from '@/services/directory';
 import {
   requestConnect as storeRequestConnect, acceptConnect as storeAcceptConnect,
@@ -231,6 +231,18 @@ export function installTestHook(): void {
     /** Current in-app notification banners (kind/name/body) for asserting alerting. */
     notices: (): { kind: string; name: string; body: string }[] =>
       notifyBanners.value.map((b) => ({ kind: b.kind, name: b.name, body: b.body })),
+    /** Surface a sample app-update "action" banner (spec 2004) for visual checks — the
+     *  same shared overlay the real update prompt uses, via the app's notify instance. */
+    showUpdateBanner: (body = 'Ring 0.3.0 is ready to install.', whatsNewCount = 3): void =>
+      showActionBanner({
+        name: 'Update available',
+        body,
+        actions: [
+          ...(whatsNewCount > 0 ? [{ text: `What's new (${whatsNewCount})`, handler: () => {} }] : []),
+          { text: 'Update', handler: () => {} },
+          { text: 'Later' as const, role: 'cancel' as const, handler: () => {} },
+        ],
+      }),
     /** Ids of current (non-pending) contacts. */
     contactIds: async (): Promise<string[]> => (await listContacts()).map((c) => c.id),
     /** Set a known contact's display name (the name you'd have saved locally). */

--- a/src/services/toast.ts
+++ b/src/services/toast.ts
@@ -1,0 +1,41 @@
+/**
+ * The one place functional toasts are created.
+ *
+ * "Functional" toasts are the small, transient confirmations ("Muted", "Copied") and
+ * errors ("Microphone unavailable") scattered across the app — as opposed to the
+ * notification-class cards (messages / requests / system notices / the update prompt),
+ * which all render through the shared in-app banner overlay (NotificationBanners.vue).
+ *
+ * Routing every functional toast through `appToast` gives them ONE consistent
+ * position, corner rounding (via the `app-toast` cssClass styled once in App.vue), and
+ * default duration — tunable in a single place — so individual call sites only supply
+ * the message text (and optionally a colour variant or an explicit duration). These stay
+ * simple Ionic toasts on purpose; they are NOT forced into the avatar-card component.
+ */
+import { toastController } from '@ionic/vue';
+
+export interface AppToastOptions {
+  message: string;
+  /** ms on screen; defaults to a sensible short duration. */
+  duration?: number;
+  /** Ionic colour variant, e.g. 'danger' for errors, 'success' for confirmations. */
+  color?: string;
+  /** Optional leading ionicon. */
+  icon?: string;
+}
+
+const DEFAULT_DURATION_MS = 1800;
+
+/** Present a functional toast with the app's shared styling. */
+export async function appToast(opts: AppToastOptions | string): Promise<void> {
+  const o = typeof opts === 'string' ? { message: opts } : opts;
+  const t = await toastController.create({
+    message: o.message,
+    duration: o.duration ?? DEFAULT_DURATION_MS,
+    color: o.color,
+    icon: o.icon,
+    position: 'top',
+    cssClass: 'app-toast',
+  });
+  await t.present();
+}

--- a/src/views/detail/AddByIdPage.vue
+++ b/src/views/detail/AddByIdPage.vue
@@ -47,8 +47,9 @@ import { useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
   IonContent, IonText, IonList, IonItem, IonInput, IonButton,
-  onIonViewDidEnter, toastController,
+  onIonViewDidEnter,
 } from '@ionic/vue';
+import { appToast } from '@/services/toast';
 import { requestFriend } from '@/db/queries';
 
 const UUID_RE = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
@@ -75,8 +76,7 @@ async function paste() {
 }
 
 async function toast(message: string, color?: string) {
-  const t = await toastController.create({ message, duration: 1500, position: 'top', color });
-  await t.present();
+  await appToast({ message, duration: 1500, color });
 }
 
 async function send() {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -905,7 +905,7 @@ import { useRoute, useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton,
   IonBackButton, IonIcon, IonSearchbar, IonContent, IonFooter, IonTextarea,
-  IonAvatar, IonNote, IonModal, IonSpinner, IonDatetime, actionSheetController, alertController, popoverController, toastController,
+  IonAvatar, IonNote, IonModal, IonSpinner, IonDatetime, actionSheetController, alertController, popoverController,
   IonInfiniteScroll, IonInfiniteScrollContent, IonFab, IonFabButton,
   onIonViewWillEnter, onIonViewDidEnter, onIonViewWillLeave,
 } from '@ionic/vue';
@@ -930,6 +930,7 @@ import {
   CAPTION_MAX, getSetting, listChatMediaAll, getMessage, listMessagesOlder,
   backfillThumbTiers,
 } from '@/db/queries';
+import { appToast } from '@/services/toast';
 import { groupProgress } from '@/services/message-status';
 import { getSelfUserId } from '@/services/auth';
 import MessageActions from '@/components/MessageActions.vue';
@@ -1057,8 +1058,7 @@ async function onUnblock() {
   try {
     await unblockContact(pid);
   } catch {
-    const t = await toastController.create({ message: 'Could not unblock. Try again.', duration: 1500, position: 'top', color: 'danger' });
-    await t.present();
+    await appToast({ message: 'Could not unblock. Try again.', duration: 1500, color: 'danger' });
   }
 }
 
@@ -1073,8 +1073,7 @@ async function onPickDate(ev: CustomEvent): Promise<void> {
   day.setHours(0, 0, 0, 0);
   const id = await firstMessageOnOrAfter(chatId, day.getTime());
   if (!id) {
-    const t = await toastController.create({ message: 'No messages on or after that date', duration: 1500, position: 'top' });
-    await t.present();
+    await appToast({ message: 'No messages on or after that date', duration: 1500 });
     return;
   }
   showSearch.value = false;
@@ -1195,15 +1194,13 @@ const myEmojisFor = (m: Message) =>
 async function onReact(messageId: string, emoji: string): Promise<void> {
   const result = await reactToMessage(messageId, emoji);
   if (result === 'limit' || result === 'limit-emojis') {
-    const t = await toastController.create({
+    await appToast({
       message:
         result === 'limit-emojis'
           ? `This message already has ${MAX_DISTINCT_REACTIONS} different reactions — tap one of those instead.`
           : `You can add up to ${MAX_REACTIONS_PER_USER} reactions.`,
       duration: 1600,
-      position: 'top',
     });
-    await t.present();
   }
 }
 
@@ -1339,13 +1336,11 @@ async function saveMediaForMessages(ids: string[]): Promise<void> {
   }
   const msg = result === 'downloaded' ? 'Saved to your device' : result === 'empty' ? 'Nothing to save' : '';
   if (!msg) return;
-  const t = await toastController.create({
+  await appToast({
     message: msg,
     duration: 1500,
-    position: 'top',
     color: result === 'empty' ? 'danger' : undefined,
   });
-  await t.present();
 }
 async function onViewerCaption(id: string): Promise<void> {
   const m = viewerMsg(id);
@@ -1579,8 +1574,7 @@ async function onForwardSend(chatIds: string[]): Promise<void> {
   }
   forwardIds.value = [];
   exitSelect();
-  const t = await toastController.create({ message: 'Forwarded', duration: 1200, position: 'top' });
-  await t.present();
+  await appToast({ message: 'Forwarded', duration: 1200 });
 }
 
 /* ---- multi-select (bulk forward / delete) ----
@@ -1751,9 +1745,7 @@ function notAvailableToast(): void {
   // The quoted message isn't on this device, e.g. a reply to a message sent before we
   // joined this group. The quote bubble still renders from its embedded snapshot; there's
   // just nothing to scroll to.
-  void toastController
-    .create({ message: 'Original message not available', duration: 1400, position: 'top' })
-    .then((t) => t.present());
+  void appToast({ message: 'Original message not available', duration: 1400 });
 }
 // Poll briefly for the target row to mount, then center it (it may need a tick after a
 // window change). Returns true once it scrolled to it.
@@ -3439,8 +3431,7 @@ async function startRecording() {
     startSampler();
     startActivity('recording-audio'); // tell the peer we're recording a voice message (spec 1009)
   } catch {
-    const t = await toastController.create({ message: 'Microphone unavailable', duration: 1500, position: 'top' });
-    await t.present();
+    await appToast({ message: 'Microphone unavailable', duration: 1500 });
   }
 }
 

--- a/src/views/detail/ContactDetailPage.vue
+++ b/src/views/detail/ContactDetailPage.vue
@@ -121,7 +121,7 @@ import { useRoute, useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
   IonContent, IonAvatar, IonButton, IonIcon, IonList, IonItem, IonLabel, IonNote, IonToggle,
-  toastController, alertController, actionSheetController,
+  alertController, actionSheetController,
 } from '@ionic/vue';
 import {
   chatbubbleOutline, searchOutline, banOutline, imagesOutline,
@@ -132,6 +132,7 @@ import {
   getContact, startDirectChat, blockContact, unblockContact, listChats, setChatMute, setChatTtl,
   getPresenceOverrides, setPresenceOverride, setChatNotifyPrefs, type ChatNotifyContent,
 } from '@/db/queries';
+import { appToast } from '@/services/toast';
 import { ensureProfile } from '@/composables/useProfileGate';
 import { forceReconnect } from '@/composables/useSync';
 import type { Contact, Chat } from '@/db/types';
@@ -310,9 +311,7 @@ async function block() {
             try {
               await blockContact(contactId);
             } catch {
-              void toastController
-                .create({ message: 'Could not block. Try again.', duration: 1500, position: 'top', color: 'danger' })
-                .then((t) => t.present());
+              void appToast({ message: 'Could not block. Try again.', duration: 1500, color: 'danger' });
             }
           })();
         },
@@ -338,9 +337,7 @@ async function unblock() {
               // blocked (the offline queue only flushes on connect).
               forceReconnect();
             } catch {
-              void toastController
-                .create({ message: 'Could not unblock. Try again.', duration: 1500, position: 'top', color: 'danger' })
-                .then((t) => t.present());
+              void appToast({ message: 'Could not unblock. Try again.', duration: 1500, color: 'danger' });
             }
           })();
         },
@@ -353,7 +350,7 @@ async function unblock() {
 function copyUsername() {
   if (!contact.value?.username) return;
   void navigator.clipboard?.writeText(`@${contact.value.username}`);
-  void toastController.create({ message: 'Username copied', duration: 1200, position: 'top' }).then((t) => t.present());
+  void appToast({ message: 'Username copied', duration: 1200 });
 }
 </script>
 

--- a/src/views/detail/ContactQrPage.vue
+++ b/src/views/detail/ContactQrPage.vue
@@ -54,8 +54,9 @@ import { onMounted, ref } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
   IonContent, IonAvatar, IonText, IonImg, IonSpinner, IonList, IonItem, IonLabel,
-  IonButton, toastController,
+  IonButton,
 } from '@ionic/vue';
+import { appToast } from '@/services/toast';
 import { getSecret } from '@/db/secrets';
 import { initialsAvatar } from '@/db/avatars';
 import { getSelfUserId, getSelfUsername } from '@/services/auth';
@@ -71,7 +72,7 @@ function copyHandle(): void {
   if (!username.value) return;
   void navigator.clipboard?.writeText(`@${username.value}`);
   copied.value = true;
-  void toastController.create({ message: 'Username copied', duration: 1200, position: 'top' }).then((t) => t.present());
+  void appToast({ message: 'Username copied', duration: 1200 });
 }
 
 onMounted(async () => {

--- a/src/views/detail/DirectoryPage.vue
+++ b/src/views/detail/DirectoryPage.vue
@@ -58,8 +58,9 @@ import { useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonContent,
   IonSearchbar, IonList, IonItem, IonAvatar, IonLabel, IonNote, IonSpinner,
-  actionSheetController, toastController,
+  actionSheetController,
 } from '@ionic/vue';
+import { appToast } from '@/services/toast';
 import { fetchDirectory, type DirectoryUser } from '@/services/api';
 import { requestConnect, incomingRequests, outgoingRequests, refreshConnections } from '@/services/connections';
 import { getContact, startDirectChat, listContacts } from '@/db/queries';
@@ -138,15 +139,12 @@ async function connect(u: DirectoryUser): Promise<void> {
       if (c) router.push(`/chat/${await startDirectChat(c)}`);
       return;
     }
-    const t = await toastController.create({
+    await appToast({
       message: state === 'rejected' ? 'Your request was declined.' : 'Connection request sent.',
       duration: 1800,
-      position: 'top',
     });
-    await t.present();
   } catch {
-    const t = await toastController.create({ message: 'Could not send request. Try again.', duration: 1500, position: 'top', color: 'danger' });
-    await t.present();
+    await appToast({ message: 'Could not send request. Try again.', duration: 1500, color: 'danger' });
   }
 }
 

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -125,7 +125,7 @@ import {
 import { useRoute, useRouter } from 'vue-router';
 import { trashOutline, happyOutline, timeOutline } from 'ionicons/icons';
 import { timeLeft, formatPostDateTime } from '@/utils/post-time';
-import { toastController } from '@ionic/vue';
+import { appToast } from '@/services/toast';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
 import { vEnterSend } from '@/directives/enter-send';
@@ -182,15 +182,13 @@ const grouped = computed(() => {
 async function react(emoji: string): Promise<void> {
   const res = await reactToPost(postId, emoji);
   if (res === 'limit' || res === 'limit-emojis') {
-    const t = await toastController.create({
+    await appToast({
       message:
         res === 'limit-emojis'
           ? `This post already has ${MAX_DISTINCT_REACTIONS} different reactions — tap one of those instead.`
           : `You can add up to ${MAX_REACTIONS_PER_USER} reactions.`,
       duration: 1600,
-      position: 'top',
     });
-    await t.present();
   }
 }
 function openPicker(ev: Event): void {

--- a/src/views/detail/ScanPage.vue
+++ b/src/views/detail/ScanPage.vue
@@ -26,10 +26,11 @@ import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
-  IonContent, IonText, onIonViewDidEnter, onIonViewWillLeave, toastController,
+  IonContent, IonText, onIonViewDidEnter, onIonViewWillLeave,
 } from '@ionic/vue';
 import { BrowserQRCodeReader, type IScannerControls } from '@zxing/browser';
 import { requestFriend } from '@/db/queries';
+import { appToast } from '@/services/toast';
 
 const router = useRouter();
 const videoEl = ref<HTMLVideoElement | null>(null);
@@ -55,7 +56,7 @@ async function onDecoded(text: string): Promise<void> {
   handled = true;
   stopCamera();
   await requestFriend(id);
-  void toastController.create({ message: 'Friend request sent', duration: 1400, position: 'top' }).then((t) => t.present());
+  void appToast({ message: 'Friend request sent', duration: 1400 });
   router.replace('/tabs/contacts');
 }
 

--- a/src/views/detail/SelfTestPage.vue
+++ b/src/views/detail/SelfTestPage.vue
@@ -43,9 +43,10 @@
 import { computed, ref } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
-  IonContent, IonButton, IonList, IonItem, IonLabel, IonIcon, toastController,
+  IonContent, IonButton, IonList, IonItem, IonLabel, IonIcon,
 } from '@ionic/vue';
 import { checkmarkCircle, closeCircle } from 'ionicons/icons';
+import { appToast } from '@/services/toast';
 import { runSelfTest, type CheckResult } from '@/services/crypto/selftest';
 
 const running = ref(false);
@@ -62,13 +63,11 @@ async function run(): Promise<void> {
     results.value = r;
     const pass = r.filter((x) => x.ok).length;
     summary.value = `${pass}/${r.length} checks passed`;
-    const t = await toastController.create({
+    await appToast({
       message: summary.value,
       duration: 2500,
-      position: 'top',
       color: pass === r.length ? 'success' : 'danger',
     });
-    await t.present();
   } catch (e) {
     summary.value = e instanceof Error ? e.message : String(e);
   } finally {

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -192,7 +192,7 @@ import {
   IonItemDivider, IonAvatar, IonLabel, IonNote,
   IonInfiniteScroll, IonInfiniteScrollContent,
   IonItemSliding, IonItemOptions, IonItemOption,
-  actionSheetController, alertController, toastController, onIonViewWillEnter,
+  actionSheetController, alertController, onIonViewWillEnter,
 } from '@ionic/vue';
 import type { InfiniteScrollCustomEvent } from '@ionic/vue';
 import { personAddOutline, trashOutline, ellipsisHorizontal, compassOutline, banOutline } from 'ionicons/icons';
@@ -200,6 +200,7 @@ import {
   incomingRequests, outgoingRequests, acceptConnect, rejectConnect, withdrawConnect, refreshConnections,
   type ConnItem,
 } from '@/services/connections';
+import { appToast } from '@/services/toast';
 import { formatStamp } from '@/utils/time';
 import {
   deleteContact, listContacts,
@@ -300,8 +301,7 @@ function inviteStatus(code: string): string {
 }
 
 async function toast(message: string): Promise<void> {
-  const t = await toastController.create({ message, duration: 1800, position: 'top' });
-  await t.present();
+  await appToast({ message, duration: 1800 });
 }
 
 async function inviteActions(inv: PendingInvite): Promise<void> {

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -171,7 +171,7 @@ import { computed, reactive, ref, watch } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent,
   IonItem, IonItemSliding, IonItemOption, IonItemOptions, IonAvatar, IonIcon, IonTextarea, IonSearchbar,
-  toastController, actionSheetController, alertController,
+  actionSheetController, alertController,
   onIonViewWillEnter, onIonViewWillLeave,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
@@ -179,6 +179,7 @@ import {
   createOutline, sparklesOutline, micOutline, playCircleOutline, happyOutline, timeOutline,
   notificationsOutline, notificationsOffOutline,
 } from 'ionicons/icons';
+import { appToast } from '@/services/toast';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
 import { vEnterSend } from '@/directives/enter-send';
@@ -240,15 +241,13 @@ const left = (p: WallPost): string => timeLeft(p.expiresAt, now.value);
 async function onReact(post: WallPost, emoji: string): Promise<void> {
   const res = await reactToPost(post.id, emoji);
   if (res === 'limit' || res === 'limit-emojis') {
-    const t = await toastController.create({
+    await appToast({
       message:
         res === 'limit-emojis'
           ? `This post already has ${MAX_DISTINCT_REACTIONS} different reactions — tap one of those instead.`
           : `You can add up to ${MAX_REACTIONS_PER_USER} reactions.`,
       duration: 1600,
-      position: 'top',
     });
-    await t.present();
   }
 }
 function openPicker(post: WallPost, ev: Event): void {
@@ -322,21 +321,17 @@ async function mute(until: number): Promise<void> {
 // --- per-user mute / hide (swipe-right = mute, swipe-left = hide) ---
 async function toggleMute(post: WallPost): Promise<void> {
   await setWallUserMuted(post.author, !post.muted);
-  const t = await toastController.create({
+  await appToast({
     message: post.muted ? `Unmuted ${post.authorName}` : `Muted ${post.authorName}'s Wall notifications`,
     duration: 1400,
-    position: 'top',
   });
-  await t.present();
 }
 async function hideUser(post: WallPost): Promise<void> {
   await setWallUserHidden(post.author, true);
-  const t = await toastController.create({
+  await appToast({
     message: `Hid ${post.authorName}'s posts. Undo from the bell menu.`,
     duration: 1800,
-    position: 'top',
   });
-  await t.present();
 }
 
 // --- delete your own post (swipe-left, with confirmation) ---


### PR DESCRIPTION
## Why

An installed iOS user reported the **"Update available"** prompt rendering broken — pinned under the status bar with sharp top corners — and the **"What's new"** text reading as developer jargon (`9 AM-local … (spec 1016)`). Spec **2004** (hotfix).

## What changed

- **Update prompt → shared in-app card (the bug).** It was the one notification rendered as a top-pinned Ionic toast; the offset/rounding hack doesn't take on iOS. It now renders through the same overlay (`NotificationBanners.vue` + `notify.ts`) as message/request/system cards, as a new persistent **`'action'`** kind — a rounded card below the header with **What's new / Update / Later**. One styling change now updates every notification kind.
- **Consistent functional toasts.** New shared `appToast()` helper (`src/services/toast.ts`); one position/rounding/duration tuned in one place. **26 call sites** migrated across 13 files. Only documented exceptions still create toasts directly (App.vue's sticky failed-sends toast with its own buttons; the helper itself).
- **Cleaner "What's new".** `prettify` now strips trailing refs that carry extra detail (`(spec 1013 US2/US3)`, `(+ …)`) — TDD, failing test first.
- **Governance.** Constitution Principle VII now requires user-facing commit subjects (`feat/fix/perf/security`) to be plain-language, benefit-focused, reference-free (they become "What's new"); bumped **1.1.0 → 1.2.0**. Matching good/bad-example guidance in CLAUDE.md.

## Verification

- `npm run build` (vue-tsc + vite) clean; `vitest` **251/251**.
- Drive screenshots confirm the update prompt renders as a rounded card below the header with the three actions, and a functional `appToast()` matches.
- Update prompt re-prompt replaces (doesn't stack); `WhatsNewSheet` retained.

## Notes

- **Zero-knowledge impact: none** — client-side presentation + release-note phrasing + governance docs only. No client/server contract, payload, or stored-data change; crypto/ZK checklist not required.
- Adds a dev-only `__ringTest.showUpdateBanner` hook (stripped from production builds) + a `drive/scenarios/update-banner.mjs` for the visual check.

Closes #339, #340, #341, #342, #343, #344, #345, #346, #347, #348, #349, #350, #351, #352, #353, #354, #355, #356, #357, #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
