### PR TITLE
ci: skip the heavy suite and develop image for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
-# CI: runs the full build + test suite on every develop push and on every PR
-# (including PRs into main, so the merge that cuts a release is already proven
-# green). On a develop push it also publishes the rolling develop image.
+# CI: runs the full build + test suite on every develop push and PR that touches
+# code (path-filtered — doc/spec/tooling-only changes skip it), including PRs into
+# main so the merge that cuts a release is already proven green. A develop push that
+# changed code also publishes the rolling develop image; a docs-only develop push
+# skips both the suite and the image rebuild (the app is byte-identical).
 name: CI
 
 on:
@@ -58,13 +60,17 @@ jobs:
               - '.dockerignore'
               - '.github/workflows/**'
 
-  # The full build + test suite. Path-filtering only optimizes PR CI: a doc/spec-only
-  # PR skips this (the CI gate still reports a single required status). A push to
-  # develop or a manual workflow_dispatch ALWAYS runs it, so the develop image is
-  # rebuilt for every develop commit and `workflow_dispatch` reliably republishes.
+  # The full build + test suite. Path-filtering gates it on BOTH PRs and develop
+  # pushes: a doc/spec/tooling-only change (markdown, specs/, .specify/, ROADMAP.md,
+  # scripts/) skips the heavy suite — and, because the develop image job chains off
+  # `verify`, also skips the image rebuild — since the built app is byte-identical to
+  # the previous commit. The always-on roadmap guard is the real gate for those.
+  # Anything in app/server/e2e/deps/configs/Dockerfile/workflows still runs the full
+  # suite. `workflow_dispatch` ALWAYS runs it, so a manual run reliably republishes
+  # the develop image even when nothing code-relevant changed.
   verify:
     needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true' }}
     uses: ./.github/workflows/build-test.yml
 
   # Gate the one merge that actually ships: a PR into main must carry a version


### PR DESCRIPTION
## Why

A push to `develop` ran the full build/test/**e2e** suite and rebuilt + republished the `:develop` Docker image **unconditionally** — even for doc/spec/ROADMAP-only commits, whose built app is byte-identical to the previous one. That's a wasted ~12-minute build + multi-arch image push per docs change. (PR CI was already path-filtered; only the develop **push** path wasn't.)

## What changed

One line in `ci.yml`: `verify`'s `if` now gates on the existing `changes` path-filter for **both** PRs and develop pushes:

```diff
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true' }}
```

- A docs/spec/`.specify/`/ROADMAP/`scripts/`-only push to develop now **skips** `verify`; since `develop-image` chains off `needs: verify`, it skips too — no rebuild, no republish.
- Anything under `src/`, `server/`, `e2e/`, `public/`, deps, `tsconfig*`, `vite/vitest/playwright` configs, `Dockerfile`, or `.github/workflows/**` still **always** runs the full suite and publishes on a develop push.
- `workflow_dispatch` remains an unconditional **force-republish** escape hatch.
- `ci-gate` (required check, `if: always()`) treats a skipped `verify` as pass, so branch protection is unaffected.

## Verification

This PR touches `.github/workflows/**`, so the `changes` filter marks it `code=true` and the **full suite runs on this PR** (proving the gate still fires for workflow changes). After it lands, the follow-up ROADMAP status-bump push will be the first to exercise the docs-only skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
