### PR TITLE
docs(roadmap): mark specs 0003, 1016, 2003, 2004 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Specs are grouped by category band; status moves
 |------|-------|--------|
 | [0001](specs/0001-show-what-changed/spec.md) | Show what changed in the update toast (release-note delta) | 🟢 shipped |
 | [0002](specs/0002-connections-and-friendship/spec.md) | Connections & Friendship | 🟢 shipped |
-| [0003](specs/0003-zero-knowledge-social/spec.md) | Zero-Knowledge Social Wall | ⚪ planned |
+| [0003](specs/0003-zero-knowledge-social/spec.md) | Zero-Knowledge Social Wall | 🟢 shipped |
 
 ## ⚡ Ad-hoc (1001–1999)
 
@@ -36,7 +36,7 @@ Specs are grouped by category band; status moves
 | [1013](specs/1013-jump-pill-seen-receipts/spec.md) | Expanding "Jump to Latest" Pill + Visibility-Driven Seen Receipts | 🟢 shipped |
 | [1014](specs/1014-image-thumbnails-album/spec.md) | Multi-Size Image Thumbnails + Album-View Overhaul | 🟢 shipped |
 | [1015](specs/1015-reliable-push-notifications/spec.md) | Reliable Push & Redesigned In-App Notifications | 🟢 shipped |
-| [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | 🔵 in-review |
+| [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -44,5 +44,5 @@ Specs are grouped by category band; status moves
 |------|-------|--------|
 | [2001](specs/2001-stabilize-message-status/spec.md) | Stabilize message status reporting around downloaded-blob receipts | 🟢 shipped |
 | [2002](specs/2002-media-thumbnails-stay/spec.md) | Media Thumbnails Stay Thumbnails (no autoplay storm) | 🟢 shipped |
-| [2003](specs/2003-android-install-gate/spec.md) | Fix Android install-gate false "browser can't install" warning | 🔵 in-review |
-| [2004](specs/2004-unify-app-notifications/spec.md) | Unify in-app notifications/toasts + user-friendly "What's new" | 🟡 in-progress |
+| [2003](specs/2003-android-install-gate/spec.md) | Fix Android install-gate false "browser can't install" warning | 🟢 shipped |
+| [2004](specs/2004-unify-app-notifications/spec.md) | Unify in-app notifications/toasts + user-friendly "What's new" | 🟢 shipped |

--- a/specs/0003-zero-knowledge-social/spec.md
+++ b/specs/0003-zero-knowledge-social/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-20
 
-**Status**: planned
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1016-9-am-local/spec.md
+++ b/specs/1016-9-am-local/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-22
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2003-android-install-gate/spec.md
+++ b/specs/2003-android-install-gate/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-22
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      The directory number sets the category (2001+ = hotfix/bug). -->
 

--- a/specs/2004-unify-app-notifications/spec.md
+++ b/specs/2004-unify-app-notifications/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-22
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      Directory number sets the category (2001+ = hotfix/bug). -->
 


### PR DESCRIPTION
## Why

Specs **0003** (PRs #313/#314/#315), **1016** (#338), **2003** (#337), and **2004** (#359) all merged to `develop`, but their `spec.md` **Status** lines were never bumped from `planned`/`in-review`/`in-progress`. Since `ROADMAP.md` is generated from those Status lines, the roadmap showed them as unshipped.

## What changed

- Each of the four `spec.md` Status lines → `shipped`.
- `ROADMAP.md` regenerated via `make roadmap` (never hand-edited).

Docs/specs only — no code change.

## Note: validates PR #360

This is the **first docs-only `develop` change** since #360 landed the path-filter on develop pushes. On merge, the heavy build/test/**e2e** suite and the develop **image rebuild** should be **skipped** (only the always-on roadmap/release guards + CI gate run). The PR itself already skips `verify` — visible in its checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
