### PR TITLE
fix(install): guide Android users past a Play Protect "older version" block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/2004-unify-app-notifications/plan.md`
+`specs/2006-install-page-guidance/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,3 +46,4 @@ Specs are grouped by category band; status moves
 | [2002](specs/2002-media-thumbnails-stay/spec.md) | Media Thumbnails Stay Thumbnails (no autoplay storm) | 🟢 shipped |
 | [2003](specs/2003-android-install-gate/spec.md) | Fix Android install-gate false "browser can't install" warning | 🟢 shipped |
 | [2004](specs/2004-unify-app-notifications/spec.md) | Unify in-app notifications/toasts + user-friendly "What's new" | 🟢 shipped |
+| [2006](specs/2006-install-page-guidance/spec.md) | Install-page guidance for a Play Protect "older Android" block | 🟡 in-progress |

--- a/specs/2006-install-page-guidance/checklists/requirements.md
+++ b/specs/2006-install-page-guidance/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Install-page guidance for a Play Protect "older Android" block
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Zero-Knowledge Impact: none (static install-page copy). Crypto/ZK checklist not required.
+- The decision to add the guidance (vs. leave it / dig deeper) was made with the user before
+  writing the spec, so no [NEEDS CLARIFICATION] markers were needed.
+- Root cause established by investigation: the WebAPK `targetSdkVersion` is set by Google's
+  minting server, not Ring; there is no Ring-side fix, so the spec is scoped to guidance.

--- a/specs/2006-install-page-guidance/plan.md
+++ b/specs/2006-install-page-guidance/plan.md
@@ -1,0 +1,52 @@
+# Implementation Plan: Install-page guidance for a Play Protect "older Android" block
+
+**Branch**: `fix/2006-install-page-guidance` | **Date**: 2026-06-22 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Add a calm, muted secondary help note to `InstallGuard.vue`, shown only on the **Android
+installable** install page, that explains the Play Protect "built for an older version of
+Android / unsafe app blocked" symptom is a Chrome/Play-Protect quirk (not a Ring problem) and
+how to get past it (update Chrome + Google Play services and retry, or "More details → Install
+anyway"). No WebAPK/manifest/build change — none is available to Ring (the WebAPK target SDK
+is Google's). Copy-only.
+
+## Technical Context
+
+**Language/Version**: TypeScript / Vue 3 + Ionic (client install gate only). No server change.
+**Storage**: none. **Testing**: `vue-tsc` + `vite build`; visual check via `drive/` against the
+install gate is not straightforward (the gate is bypassed in dev/test), so this is verified by
+typecheck + reading the rendered conditions; the change is static copy. **Project Type**: client
+UI copy. **Constraints**: Ionic-First; no zero-knowledge impact; no migration.
+
+## Constitution Check — PASS
+
+- **I. Zero-Knowledge** — PASS (N/A): static client copy; no contract/payload/stored-data change.
+  ZK checklist not required.
+- **II. Spec-Driven** — PASS: full lightweight pipeline; commits/PR trace to 2006.
+- **III. TDD** — PASS with limit: this is static copy with no logic seam and the install gate
+  isn't exercisable in the unit/drive harness (it's bypassed there); verified by typecheck +
+  the conditional render reasoning. Recorded deviation (copy-only, no behavior to unit-test).
+- **IV–IX** — PASS (N/A): no crypto/store/migration/privacy surface.
+- **X. Accessibility/i18n** — PASS: plain text in the existing muted-note pattern.
+- **XI. Ionic-First** — PASS: reuses the existing `InstallGuard` callout/markup + theme tokens.
+
+## Design Overview
+
+`src/components/InstallGuard.vue`:
+- Add a muted help block (NOT the warning-styled `.cant-install`) rendered when
+  `platform === 'android' && !installUnavailable` (a real Android browser that can install;
+  the WebView case already shows its own callout and shouldn't be duplicated). Place it near
+  the "How to install" steps / the "Already added it?" note.
+- Copy (calm, reassuring): names the symptom ("If Android blocks Ring as 'unsafe' or 'built
+  for an older version of Android'"), states it's a Chrome/Play-Protect quirk with installed
+  web apps (not a Ring problem), and gives the remedy (update Chrome + Google Play services
+  and try again, or tap "More details → Install anyway").
+- A `.install-help` muted style (neutral background, `ion-color-medium` text), distinct from
+  the warning `.cant-install`.
+
+No other files; no manifest/build/target-SDK change (FR-005).
+
+## Phasing
+- Phase 0/1: trivial (no research/data-model/contracts — static copy). This plan + spec suffice.
+- Phase 2: tasks.md (below).

--- a/specs/2006-install-page-guidance/spec.md
+++ b/specs/2006-install-page-guidance/spec.md
@@ -1,0 +1,138 @@
+# Feature Specification: Install-page guidance for a Play Protect "older Android" block
+
+**Feature Branch**: `fix/2006-install-page-guidance`
+
+**Created**: 2026-06-22
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     Directory number sets the category (2001+ = hotfix/bug). -->
+
+**Input**: A Galaxy S22+ user, installing the Ring PWA, hit Google Play Protect: "Unsafe app
+blocked — This app was built for an older version of Android and doesn't include the latest
+privacy protections." Investigation: this is a device/Chrome-side WebAPK issue — when Chrome
+installs a PWA it asks Google's WebAPK minting server to build the app shell, whose
+`targetSdkVersion` (set by Google, tied to the installed Chrome/WebView version) can lag the
+device's Android version and trip Play Protect. Ring's manifest is complete and correct; we
+cannot set the WebAPK's target SDK. The fix we CAN ship is on-page guidance so an affected
+user can self-resolve.
+
+## Overview
+
+Ring's install gate (`InstallGuard`) blocks a plain browser tab until Ring is added to the
+Home Screen, with platform-specific steps and a callout for in-app browsers (WebView) that
+can't install at all. It says nothing about the case where the browser CAN install but
+Android's Play Protect blocks the resulting app as "built for an older version of Android"
+/ "unsafe." This change adds a short, calm, secondary help note on the Android install page
+explaining that this is a Chrome/Play-Protect quirk (not a Ring problem) and what to do:
+update Chrome + Google Play services and retry, or proceed via "More details → Install
+anyway."
+
+## Bug & Root Cause
+
+- **Symptom**: on some Android devices (e.g. S22+ on Android 14/15), installing Ring triggers
+  Play Protect "Unsafe app blocked — built for an older version of Android."
+- **Root cause**: the WebAPK shell Chrome installs is built and signed by Google's WebAPK
+  minting server; its `targetSdkVersion` is controlled by Google (and follows the device's
+  Chrome / Android System WebView version), not by Ring. When that target lags the device's
+  Android API by more than two versions, Play Protect warns/blocks. Ring's web app manifest
+  is complete and correct, and there is no Ring-side setting for the WebAPK target SDK — so
+  the only Ring-side remedy is to guide the user.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - An Android user who hit the block can self-resolve (Priority: P1)
+
+An Android user on the install page who sees (or anticipates) Play Protect blocking Ring as
+"built for an older version of Android / unsafe" finds a short note explaining it's a
+browser/Play-Protect quirk and how to get past it.
+
+**Why this priority**: It's the reported blocker; without guidance the user is stuck at a
+system dialog that looks like Ring is malware.
+
+**Independent Test**: Open the Android install page and confirm a calm, secondary help note
+is present that names the Play-Protect symptom and gives the resolution steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Android install page (a browser that can install), **When** the user reads
+   it, **Then** a secondary note explains the "older version of Android / unsafe" block is a
+   Chrome/Play-Protect issue (not a Ring defect) and lists the remedy: update Chrome and
+   Google Play services and retry, or use "More details → Install anyway."
+2. **Given** the note, **When** the user reads it, **Then** it is visually secondary/calm
+   (not an alarming error), distinct from the existing WebView "can't install here" callout.
+
+### User Story 2 - The note is shown only where it's relevant (Priority: P2)
+
+The note appears only on Android where a real install (and thus a WebAPK / Play Protect) is
+possible — not on iOS/desktop, and not as a duplicate of the in-app-browser (WebView)
+callout, which already tells the user to open Ring in a real browser.
+
+**Why this priority**: Showing it on platforms where Play Protect can't occur would be
+confusing noise.
+
+**Independent Test**: Confirm the note shows on the Android installable page and not on iOS,
+desktop, or the WebView-unavailable state.
+
+**Acceptance Scenarios**:
+
+1. **Given** iOS or desktop, **When** the install page renders, **Then** the Play-Protect note
+   is not shown.
+2. **Given** an Android in-app browser (WebView, install unavailable), **When** the page
+   renders, **Then** the WebView callout is shown and the Play-Protect note is not duplicated.
+
+### Edge Cases
+
+- **Wording stays calm**: the note must not read as an error/alarm (the system dialog already
+  alarms); it reassures that Ring is fine and gives steps.
+- **No detection promised**: Ring cannot detect whether Play Protect will block (it's a
+  post-install system dialog), so the note is informational guidance, always available on the
+  relevant Android page rather than triggered by the block.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Android install page MUST include a secondary help note covering the Play
+  Protect "built for an older version of Android" / "unsafe app blocked" case, stating it is a
+  Chrome/Play-Protect quirk (not a Ring problem).
+- **FR-002**: The note MUST give the resolution: update Chrome and Google Play services and
+  try again, or proceed via the dialog's "More details → Install anyway."
+- **FR-003**: The note MUST be visually secondary/calm (muted), distinct from the existing
+  warning-styled WebView "can't install here" callout.
+- **FR-004**: The note MUST be shown only on Android where a real install is possible (not
+  iOS/desktop, and not duplicating the WebView-unavailable callout).
+- **FR-005**: No change to the WebAPK, the manifest, or any build/target-SDK setting (none is
+  available to Ring); this is install-page copy only.
+
+### Key Entities
+
+- *(none — static install-page UI copy; no data, no stored entity.)*
+
+## Zero-Knowledge Impact
+
+*(Required by Constitution Principle I.)*
+
+- **What new data becomes visible to the server?** None. This is static client-side copy on
+  the install gate; no client/server contract, payload, or stored data changes. The crypto/ZK
+  checklist is therefore **not required**.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The Android installable install page shows the Play-Protect help note (symptom +
+  remedy), styled as a calm/muted secondary note.
+- **SC-002**: The note does not appear on iOS, on desktop, or as a duplicate in the Android
+  WebView-unavailable state.
+- **SC-003**: No WebAPK/manifest/build change is made (verified by diff — install-page copy
+  only).
+
+## Assumptions
+
+- The browser that successfully reaches a WebAPK install is recent enough that "update Chrome
+  / Play services and retry" is the effective remedy; "Install anyway" covers the rest.
+- The existing `InstallGuard` platform detection (`platform`, `installUnavailable`) is the
+  correct gate for where to show the note.
+- Already-shipped device behavior (Play Protect) is outside Ring's control; this spec only
+  adds guidance.

--- a/specs/2006-install-page-guidance/tasks.md
+++ b/specs/2006-install-page-guidance/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Install-page guidance for a Play Protect "older Android" block
+
+**Branch**: `fix/2006-install-page-guidance` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+**Tests**: Copy-only change with no logic seam; the install gate isn't exercisable in the
+unit/drive harness (bypassed there). Verified by `vue-tsc` + `vite build` and the conditional
+render reasoning. (See plan.md Constitution Check — recorded TDD limitation.)
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 Confirm baseline gates: `npm run build` (vue-tsc + vite) green before the change.
+
+## Phase 2: Implementation
+
+- [X] T002 [US1] In `src/components/InstallGuard.vue`, add a muted help note rendered when `platform === 'android' && !installUnavailable`, near the "How to install" list / "Already added it?" note. Copy: name the Play Protect "unsafe / built for an older version of Android" symptom, state it's a Chrome/Play-Protect quirk with installed web apps (not a Ring problem), and give the remedy — update Chrome + Google Play services and retry, or "More details → Install anyway." (FR-001, FR-002, FR-004)
+- [X] T003 [US1] Add a `.install-help` muted style (neutral background + `ion-color-medium` text), distinct from the warning-styled `.cant-install`. (FR-003)
+
+## Phase 3: Verify
+
+- [X] T004 Confirm the note's render condition excludes iOS, desktop, and the Android WebView-unavailable state (no duplication of the WebView callout); confirm no manifest/build/WebAPK change in the diff. (SC-002, SC-003, FR-005)
+- [X] T005 Run `npm run build` (vue-tsc + vite) — green; set spec `**Status**` appropriately and run `make roadmap`.
+
+---
+
+## Dependencies
+- T002 → T003 (markup then style). T004/T005 after.
+
+## MVP
+T002 + T003 — the note itself.

--- a/src/components/InstallGuard.vue
+++ b/src/components/InstallGuard.vue
@@ -102,6 +102,23 @@
         </ion-item>
       </ion-list>
 
+      <!-- Some Android devices block the installed app via Play Protect ("unsafe" /
+           "built for an older version of Android"). That's a Chrome/Play-Protect quirk with
+           installed web apps — the WebAPK shell's target SDK is Google's, not Ring's — so we
+           can't fix it in the app; instead, guide the user. Shown only on a real Android
+           browser that can install (not iOS/desktop, not the in-app-browser callout above). -->
+      <div v-if="platform === 'android' && !installUnavailable" class="ion-padding">
+        <div class="install-help">
+          <ion-icon :icon="informationCircleOutline" />
+          <span>
+            If Android blocks Ring as “unsafe” or “built for an older version of Android,”
+            that’s a Google Play Protect quirk with installed web apps — not a problem with
+            Ring. Update Chrome and Google Play services, then try again. If it still shows,
+            tap “More details” → “Install anyway.”
+          </span>
+        </div>
+      </div>
+
       <div class="ion-padding ion-text-center">
         <ion-text color="medium">
           <p>Already added it? Open Ring from your Home Screen.</p>
@@ -118,7 +135,7 @@ import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonContent,
   IonText, IonButton, IonIcon, IonList, IonListHeader, IonItem, IonLabel, IonNote,
 } from '@ionic/vue';
-import { downloadOutline, shareOutline, warningOutline } from 'ionicons/icons';
+import { downloadOutline, shareOutline, warningOutline, informationCircleOutline } from 'ionicons/icons';
 import { useInstallGuard, promptInstall } from '@/composables/useInstallGuard';
 
 const { mustInstall, platform, canPrompt, installUnavailable } = useInstallGuard();
@@ -185,6 +202,24 @@ ion-page {
 .cant-install ion-icon {
   flex: none;
   font-size: 20px;
+  margin-top: 1px;
+}
+/* Calm, secondary help note (Play Protect "older Android" guidance). Deliberately muted —
+   NOT the warning colour of .cant-install — so it reassures rather than alarms. */
+.install-help {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--ion-color-medium) 12%, transparent);
+  color: var(--ion-color-medium-shade, #6b6f76);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.install-help ion-icon {
+  flex: none;
+  font-size: 18px;
   margin-top: 1px;
 }
 /* One identical 24×24 start-slot wrapper per step. Putting a uniform element in


### PR DESCRIPTION
## Why

A Galaxy S22+ user installing the Ring PWA hit **Google Play Protect**: "Unsafe app blocked — This app was built for an older version of Android and doesn't include the latest privacy protections." Spec **2006** (hotfix).

**Root cause (investigated):** when Chrome installs a PWA it has Google's **WebAPK minting server** build the app shell; that shell's `targetSdkVersion` is set by Google (and follows the device's Chrome / Android System WebView version), **not by Ring**. When it lags the device's Android API by >2 versions, Play Protect blocks it. Ring's web manifest is complete and correct, and **there is no Ring-side setting for the WebAPK target SDK** — so the only thing we can fix is guidance.

## What changed

`src/components/InstallGuard.vue`: a calm, **muted** secondary help note shown only on a **real Android browser that can install** (`platform === 'android' && !installUnavailable` — not iOS/desktop, and not duplicating the existing WebView "can't install here" callout). It explains the "unsafe / older version of Android" block is a Play Protect quirk with installed web apps, not a Ring problem, and gives the remedy: **update Chrome + Google Play services and retry, or "More details → Install anyway."** A new `.install-help` muted style keeps it distinct from the warning-coloured `.cant-install`.

**Copy-only — no WebAPK/manifest/build/target-SDK change** (none is available to us).

## Verification

- `npm run build` (vue-tsc + vite) clean.
- Render condition reasoned: shown on Android-installable only; hidden on iOS, desktop, and the Android WebView-unavailable state. (The install gate is bypassed in the dev/test harness, so this is verified by typecheck + the conditional — a recorded TDD limitation for copy-only install-gate UI; see plan.md.)

## Notes

- **Zero-knowledge impact: none** — static install-page copy. Crypto/ZK checklist not required.
- Sources behind the root-cause analysis: [Google Play Protect dev guidance](https://developers.google.com/android/play-protect/warning-dev-guidance), [Analyzing WebAPKs in Chrome for Android](https://blog.takemyhand.xyz/2023/10/analyzing-webapks-in-chrome-for-android).

Closes #380, #381, #382, #383, #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
