### PR TITLE
docs(roadmap): mark specs 2005 and 2006 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,5 +46,5 @@ Specs are grouped by category band; status moves
 | [2002](specs/2002-media-thumbnails-stay/spec.md) | Media Thumbnails Stay Thumbnails (no autoplay storm) | 🟢 shipped |
 | [2003](specs/2003-android-install-gate/spec.md) | Fix Android install-gate false "browser can't install" warning | 🟢 shipped |
 | [2004](specs/2004-unify-app-notifications/spec.md) | Unify in-app notifications/toasts + user-friendly "What's new" | 🟢 shipped |
-| [2005](specs/2005-pause-resume-during/spec.md) | Video-message recording — stop & review before sending, clean start, right-sized, out of the gallery | 🟡 in-progress |
-| [2006](specs/2006-install-page-guidance/spec.md) | Install-page guidance for a Play Protect "older Android" block | 🟡 in-progress |
+| [2005](specs/2005-pause-resume-during/spec.md) | Video-message recording — stop & review before sending, clean start, right-sized, out of the gallery | 🟢 shipped |
+| [2006](specs/2006-install-page-guidance/spec.md) | Install-page guidance for a Play Protect "older Android" block | 🟢 shipped |

--- a/specs/2005-pause-resume-during/spec.md
+++ b/specs/2005-pause-resume-during/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-22
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      Directory number sets the category (2001+ = hotfix/bug). -->
 

--- a/specs/2006-install-page-guidance/spec.md
+++ b/specs/2006-install-page-guidance/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-22
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      Directory number sets the category (2001+ = hotfix/bug). -->
 


### PR DESCRIPTION
Specs **2005** (#379) and **2006** (#385) merged to develop but their `spec.md` Status was still `in-progress`, so the generated `ROADMAP.md` showed them unshipped. Bump both to `shipped` and regenerate `ROADMAP.md` (never hand-edited).

Docs/specs only — the develop merge skips the heavy build/test/e2e suite and the develop image rebuild (per #360).

🤖 Generated with [Claude Code](https://claude.com/claude-code)