### PR TITLE
fix(push): one push subscription per account (stop duplicate notifications)

### DIFF
--- a/server/internal/api/push_handlers_test.go
+++ b/server/internal/api/push_handlers_test.go
@@ -27,32 +27,24 @@ func newFakePushStore() *fakePushStore {
 	return &fakePushStore{recs: map[string][]*fakePushRecord{}}
 }
 
-// SaveSubscription upserts by (userID, endpoint): keys are always refreshed; version/tz are
-// updated ONLY when provided (non-nil), mimicking the real COALESCE so a version-less
+// SaveSubscription stores ONE subscription per user, overwriting any previous one (mirrors
+// the real ON CONFLICT (user_id) upsert — migration 0026). Keys are always refreshed;
+// version/tz are updated ONLY when provided (non-nil), mimicking COALESCE, so a version-less
 // re-subscribe preserves the stored values. last_announced_version is never written here.
 func (f *fakePushStore) SaveSubscription(_ context.Context, userID string, sub store.PushSubscription, installedVersion *string, tzOffsetMinutes *int) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	for _, r := range f.recs[userID] {
-		if r.endpoint == sub.Endpoint {
-			r.p256dh, r.auth = sub.P256dh, sub.Auth
-			if installedVersion != nil {
-				r.version = *installedVersion
-			}
-			if tzOffsetMinutes != nil {
-				r.tz = tzOffsetMinutes
-			}
-			return nil
-		}
-	}
 	r := &fakePushRecord{endpoint: sub.Endpoint, p256dh: sub.P256dh, auth: sub.Auth}
+	if existing := f.recs[userID]; len(existing) > 0 {
+		r.version, r.tz = existing[0].version, existing[0].tz // COALESCE: preserve unless provided below
+	}
 	if installedVersion != nil {
 		r.version = *installedVersion
 	}
 	if tzOffsetMinutes != nil {
 		r.tz = tzOffsetMinutes
 	}
-	f.recs[userID] = append(f.recs[userID], r)
+	f.recs[userID] = []*fakePushRecord{r} // exactly one per user
 	return nil
 }
 
@@ -144,6 +136,30 @@ func TestPushSubscribeStoresVersionAndTz(t *testing.T) {
 	}
 	if r.p256dh != "PUB2" || r.auth != "AUTH2" {
 		t.Errorf("keys not refreshed on re-subscribe: %s/%s", r.p256dh, r.auth)
+	}
+}
+
+// TestPushOneSubscriptionPerAccount: a new subscription (e.g. a rotated endpoint, or a login
+// from another device) REPLACES the account's previous one — so a single message is delivered
+// once, not fanned out to every endpoint the account ever registered (migration 0026).
+func TestPushOneSubscriptionPerAccount(t *testing.T) {
+	p := newFakePushStore()
+	srv := newTestServerWithPush(p)
+	token, _ := registerUser(t, srv)
+	subscribe := func(ep string) {
+		body := `{"endpoint":"` + ep + `","keys":{"p256dh":"PUB","auth":"AUTH"}}`
+		if rr := do(t, srv, http.MethodPost, "/v1/push/subscribe", token, body); rr.Code != http.StatusOK {
+			t.Fatalf("subscribe %s status = %d", ep, rr.Code)
+		}
+	}
+	subscribe("https://push.example/old")
+	subscribe("https://push.example/new")
+
+	if p.get("https://push.example/old") != nil {
+		t.Error("old subscription was not replaced — account would receive duplicate pushes")
+	}
+	if p.get("https://push.example/new") == nil {
+		t.Error("the current subscription is missing")
 	}
 }
 

--- a/server/internal/db/migrations/0026_push_one_per_user.sql
+++ b/server/internal/db/migrations/0026_push_one_per_user.sql
@@ -1,0 +1,19 @@
+-- One push subscription per account (single active device by design).
+--
+-- The table was keyed on (user_id, endpoint), so every web-push endpoint a device ever minted
+-- accumulated as its own row — Apple rotates endpoints, and a reinstall / notification-
+-- permission re-grant makes a new one — and a single message then fanned out to all of them
+-- (observed: 7 pushes for one account). Collapse to the newest subscription per user and key
+-- the table on user_id alone, so a new subscription (including a login from another device)
+-- OVERWRITES the previous one, revoking the old endpoint. No data is lost that matters: a
+-- subscription is just a delivery handle, refreshed by the client whenever it loads.
+
+-- Keep only the most-recently-created subscription per user (endpoint breaks created_at ties).
+DELETE FROM push_subscriptions a
+  USING push_subscriptions b
+ WHERE a.user_id = b.user_id
+   AND (b.created_at, b.endpoint) > (a.created_at, a.endpoint);
+
+DROP INDEX IF EXISTS push_subscriptions_user_idx; -- redundant once user_id is the primary key
+ALTER TABLE push_subscriptions DROP CONSTRAINT push_subscriptions_pkey;
+ALTER TABLE push_subscriptions ADD PRIMARY KEY (user_id);

--- a/server/internal/store/push.go
+++ b/server/internal/store/push.go
@@ -14,17 +14,21 @@ type PushSubscription struct {
 	TZOffsetMinutes  int
 }
 
-// SaveSubscription upserts a push subscription for a user (idempotent on the endpoint,
-// refreshing its keys). installedVersion / tzOffsetMinutes are the client's reported app
-// version + local UTC offset (minutes); each is updated ONLY when provided (non-nil), so a
-// version-less re-subscribe (e.g. the service-worker resubscribe path) preserves the
-// values the page reported (COALESCE). last_announced_version is never written here — only
+// SaveSubscription stores the user's ONE push subscription, overwriting any previous one
+// (single active device by design — see migration 0026). The table is keyed on user_id, so a
+// new or rotated endpoint replaces the old row rather than adding another, which is also how a
+// login from a second device revokes the first's push: registering the new subscription drops
+// the old endpoint. The keys are always refreshed; installedVersion / tzOffsetMinutes (the
+// client's reported app version + coarse local UTC offset) are updated ONLY when provided
+// (non-nil), so a version-less re-subscribe (the service-worker resubscribe path) preserves
+// the values the page reported (COALESCE). last_announced_version is never written here — only
 // the version scheduler sets it.
 func (s *Store) SaveSubscription(ctx context.Context, userID string, sub PushSubscription, installedVersion *string, tzOffsetMinutes *int) error {
 	_, err := s.pool.Exec(ctx,
 		`INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth, installed_version, tz_offset_minutes)
 		 VALUES ($1, $2, $3, $4, $5, $6)
-		 ON CONFLICT (user_id, endpoint) DO UPDATE SET
+		 ON CONFLICT (user_id) DO UPDATE SET
+		     endpoint = EXCLUDED.endpoint,
 		     p256dh = EXCLUDED.p256dh,
 		     auth = EXCLUDED.auth,
 		     installed_version = COALESCE(EXCLUDED.installed_version, push_subscriptions.installed_version),


### PR DESCRIPTION
## Problem
A single message fired **multiple push notifications** to the same account (observed: 7 deliveries to `web.push.apple.com` for one message). The `push_subscriptions` table was keyed on `(user_id, endpoint)`, so every web-push endpoint a device ever minted accumulated as its own row — Apple rotates endpoints, and a reinstall / notification-permission re-grant mints a new one — and one message fanned out to all of them.

## Fix
Key the table on `user_id` alone:
- Migration 0026 collapses existing rows to the newest subscription per user, then makes `user_id` the primary key.
- `SaveSubscription` upserts `ON CONFLICT (user_id)`, so a new/rotated subscription **overwrites** the previous one.

This also makes a login from a second device revoke the first's push (registering the new subscription drops the old endpoint) — matching the single-active-device design.

## Verified
On the dev DB the migration applied cleanly and every account collapsed to exactly **1** subscription (including the one that had 7). New regression test `TestPushOneSubscriptionPerAccount` asserts a second endpoint replaces the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)