### PR TITLE
fix(call): a later caller can't bump someone already waiting to reach you (spec 2009)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,3 +52,4 @@ Specs are grouped by category band; status moves
 | [2006](specs/2006-install-page-guidance/spec.md) | Install-page guidance for a Play Protect "older Android" block | 🟢 shipped |
 | [2007](specs/2007-video-hd-sd/spec.md) | HD/SD video sends are transcoded for real on device | 🔵 in-review |
 | [2008](specs/2008-fast-first-call-connect/spec.md) | Make the first call connect as fast as a call-waiting second call | 🟡 in-progress |
+| [2009](specs/2009-single-call-waiting-slot/spec.md) | Only one caller may wait in call-waiting; further callers get busy | 🔵 in-review |

--- a/e2e/call-waiting-slot.spec.ts
+++ b/e2e/call-waiting-slot.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startCall, accept, hangup, waitCallState, callState,
+  acceptAndHold, hasSecondIncoming,
+} from './helpers';
+
+/**
+ * Spec 2009 — only ONE caller may occupy the call-waiting slot at a time. While a second call is
+ * already ringing/waiting (the Accept & hold prompt is shown, not yet accepted), a further caller
+ * must get busy immediately and must NOT steal the waiting caller's place.
+ */
+
+test('a further caller cannot steal the call-waiting slot from the one already waiting', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const ctxD = await browser.newContext();
+  const a = await createAccount(ctxA, 'CWSA');
+  const b = await createAccount(ctxB, 'CWSB');
+  const c = await createAccount(ctxC, 'CWSC');
+  const d = await createAccount(ctxD, 'CWSD');
+  await pair(a, b);
+  await pair(a, c);
+  await pair(a, d);
+
+  // A and B are on a call.
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+
+  // C calls A → A shows the Accept & hold (call-waiting) prompt; C is the waiting caller.
+  await startCall(c, a.id, 'audio');
+  await a.page.waitForFunction(() => (window as any).__ringTest.hasSecondIncoming() === true, null, { timeout: 15_000 });
+
+  // D calls A while C is still waiting → D MUST get busy and MUST NOT replace C in the prompt.
+  await startCall(d, a.id, 'audio');
+  await waitCallState(d, ['idle', 'ended'], 15_000); // D is told busy (pre-fix: D steals the slot)
+  expect(await hasSecondIncoming(a)).toBe(true); // A still has a pending second call (still C)
+  expect(await callState(a)).toBe('connected'); // A↔B undisturbed
+
+  // Accepting the waiting call connects A to C (the original waiter), proving D didn't steal it.
+  await acceptAndHold(a);
+  await waitCallState(c, ['connected']);
+  expect(await callState(c)).toBe('connected');
+
+  await hangup(a);
+  await hangup(c).catch(() => {});
+  await ctxA.close();
+  await ctxB.close();
+  await ctxC.close();
+  await ctxD.close();
+});

--- a/specs/2009-single-call-waiting-slot/spec.md
+++ b/specs/2009-single-call-waiting-slot/spec.md
@@ -1,0 +1,101 @@
+# Feature Specification: Only one caller may wait in call-waiting; further callers get busy
+
+**Feature Branch**: `fix/2009-single-call-waiting-slot`
+
+**Created**: 2026-06-24
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report: "If device 2 is in a call with device 1, and device 3 is waiting (call-waiting) to talk to device 1, then a 4th device calling device 1 STEALS the queue from device 3. We should never allow more than one device to be in call-waiting; the next caller should get 'busy in another call' right away."
+
+## Overview
+
+Call waiting (spec 0005) lets a busy user be offered an incoming call as a "second call" they can
+Accept & hold. The two-call cap is enforced once a call is actually **held** (`heldSlot` set). But
+between a second call **ringing** (the Accept & hold prompt is shown) and it being **accepted**,
+the cap is not enforced: a third caller's offer is allowed to replace the pending prompt, so a
+later caller silently **steals** the waiting slot from the one already there.
+
+This hotfix closes that window: at most **one** caller may occupy the call-waiting slot at a time.
+While a second call is already ringing-and-waiting, any further incoming call is answered **busy**
+immediately — exactly as a call that arrives when the two-call cap is already full.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A second waiting caller can't be displaced (Priority: P1)
+
+While A is in a call with B and C is already waiting in A's call-waiting prompt, D calls A. D is
+told A is busy right away, and C keeps its place — A's prompt still shows C, not D.
+
+**Why this priority**: It's the reported correctness bug; a caller losing their place to a later
+caller is confusing for both C (silently dropped from the queue) and A (the prompt identity
+changes underfoot).
+
+**Independent Test**: With A↔B connected and C ringing A (Accept & hold prompt shown), have D call
+A; confirm D receives busy/unavailable, A's pending second-incoming is still C, and accepting it
+connects A↔C.
+
+**Acceptance Scenarios**:
+
+1. **Given** A is in a call and C is waiting in A's call-waiting prompt, **When** D calls A,
+   **Then** D receives a busy result and A's prompt is unchanged (still C).
+2. **Given** D was told busy, **When** A accepts the waiting call, **Then** A connects to C (the
+   original waiting caller), not D.
+3. **Given** C cancels or times out (the prompt clears), **When** a later caller E calls A,
+   **Then** E may now occupy the freed waiting slot (the cap is one at a time, not one ever).
+
+### Edge Cases
+
+- **Simultaneous third + fourth**: if two further callers arrive while C waits, both get busy;
+  neither displaces C.
+- **C accepted just as D arrives**: once A accepts C (now held), D still gets busy (the existing
+  two-call cap already covers this — this fix only adds the not-yet-accepted window).
+- **Glare unaffected**: a caller the user is already dialing (outgoing glare) keeps its existing
+  resolution; this fix only changes the "someone else is already waiting" case.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow at most one incoming call to occupy the call-waiting slot at a
+  time — counting both an already-held second call AND a second call that is still ringing/waiting
+  (not yet accepted).
+- **FR-002**: When a second call is already ringing/waiting (the Accept & hold prompt is shown) or
+  a call is already held, any further incoming call MUST be answered busy immediately, with no
+  prompt shown for it and no change to the existing waiting call.
+- **FR-003**: The original waiting caller MUST retain its place until it is accepted, declined,
+  cancelled by the caller, or times out; only then may a later caller occupy the freed slot.
+- **FR-004**: This MUST hold for any combination of 1:1 and group incoming calls that would
+  otherwise raise the second-incoming prompt.
+
+### Zero-Knowledge Impact
+
+- **FR-005**: This is a client-side guard change only. The busy reply uses the existing
+  `call-busy` signalling; no new server message, metadata, or state. The zero-knowledge boundary
+  is unchanged.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With a waiting caller already present, a further caller is told busy 100% of the
+  time, and the waiting caller's place is never displaced.
+- **SC-002**: After the waiting caller is accepted, the connected party is always the original
+  waiting caller.
+- **SC-003**: Once the waiting slot is freed (cancel/decline/timeout/accept-resolved), a later
+  caller can occupy it — the limit is one-at-a-time, not one-ever.
+- **SC-004**: The existing call and call-waiting e2e suites remain green (no regression to the
+  Accept & hold / busy behavior).
+
+## Assumptions
+
+- Builds on spec 0005 (call waiting). The fix is to the shared gate that decides whether to raise
+  the Accept & hold prompt versus reply busy.
+- "Waiting" means a second incoming call is being shown/queued but not yet accepted; "held" means
+  it was accepted and the first call was parked. The cap of one covers both states together.
+- A bug fix (`2001+`): begins with a failing regression test reproducing the slot theft.

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -353,10 +353,20 @@ function beginResumeCountdown(target: RTCPeerConnection): void {
   }, 1000);
 }
 
-/** Whether a second incoming call can be taken with Accept & hold: we're in exactly one call
- *  (active, no held slot yet) so a slot is free (two-call cap, spec 0005). */
+/** Whether the active call can be put on hold to take another (we're in a call and nothing is
+ *  parked yet). NOTE: this is also `acceptAndHold`'s guard, so it MUST stay true while a second
+ *  call is *being accepted* (incomingSecond set) — the "only one waiter" cap (spec 2009) is
+ *  enforced at the prompt-raising site (`canRaiseSecondIncoming`), not here. */
 export function canHoldIncoming(): boolean {
   return callState.value !== 'idle' && callState.value !== 'ended' && heldSlot === null;
+}
+
+/** Whether a NEW incoming call may be raised as the call-waiting prompt: there's room to hold the
+ *  active call AND no other caller is already occupying the waiting slot. Once a second call is
+ *  ringing/waiting (prompt shown, not yet accepted), a further caller falls through to the busy
+ *  reply instead of stealing the pending prompt — at most one waiter at a time (spec 2009). */
+function canRaiseSecondIncoming(): boolean {
+  return canHoldIncoming() && incomingSecond.value === null;
 }
 
 /** Latest per-tile audio RMS for the active group call (tile key → level). Empty when
@@ -1467,8 +1477,10 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
       const self = getSelfUserId() ?? '';
       if (self < from) return; // we win, keep our outgoing offer, ignore theirs
       await teardown('answered-elsewhere', { silent: true }); // we yield, accept theirs
-    } else if (canHoldIncoming()) {
-      // Call waiting (spec 0005): a held slot is free → offer Accept & hold instead of busy.
+    } else if (canRaiseSecondIncoming()) {
+      // Call waiting (spec 0005): a held slot is free AND no one is already waiting → offer
+      // Accept & hold instead of busy. The waiting-slot check (spec 2009) stops a later caller
+      // from stealing the place of one already in the prompt.
       await presentSecondDirect(frame, from);
       return;
     } else {


### PR DESCRIPTION
## Spec 2009 — Only one caller may wait in call-waiting; further callers get busy

**Bug (reported):** while you're on a call and a second caller is already waiting (the Accept & hold prompt is showing), a third caller would *replace* them in the prompt — silently bumping the person who was waiting.

**Root cause:** `canHoldIncoming()` is used both to raise the prompt *and* as `acceptAndHold`'s guard; it only checked "room to hold" (no held slot), ignoring a pending waiter.

**Fix:** a dedicated `canRaiseSecondIncoming()` = room to hold **and** no one already waiting, gating only the prompt-raising site. A further caller now falls through to the existing `call-busy` reply, and the waiting caller keeps their place; the slot frees only when the waiter is accepted/declined/cancelled/times out.

**Verification (TDD):** failing-first regression `e2e/call-waiting-slot.spec.ts` (4th caller gets busy, doesn't steal the 3rd's slot, accept connects the original waiter) → fix → green; `call-waiting` + `call-busy` no-regression green. Rebased on the merged spec 2008.

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
