### PR TITLE
feat(emoji): animated emoji load instantly after the first time instead of re-downloading (spec 1017)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,7 @@ Specs are grouped by category band; status moves
 | [1014](specs/1014-image-thumbnails-album/spec.md) | Multi-Size Image Thumbnails + Album-View Overhaul | 🟢 shipped |
 | [1015](specs/1015-reliable-push-notifications/spec.md) | Reliable Push & Redesigned In-App Notifications | 🟢 shipped |
 | [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | 🟢 shipped |
+| [1017](specs/1017-cache-reusable-assets/spec.md) | Cache reusable assets (animated emoji + avatars) so they aren't refetched | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1017-cache-reusable-assets/spec.md
+++ b/specs/1017-cache-reusable-assets/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Cache reusable assets (animated emoji + avatars) so they aren't refetched
+
+**Feature Branch**: `feat/1017-cache-reusable-assets`
+
+**Created**: 2026-06-24
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User request: "Make sure the reusable assets are properly cached in the app so we don't refetch them every time, like animation emojis and user's avatars as long as they aren't changed."
+
+## Overview
+
+Some reusable assets are re-fetched or re-materialized more than they need to be:
+
+- **Animated emoji**: each `AnimatedEmoji` `fetch`es its Noto Lottie JSON from the self-hosted
+  proxy (`/v1/emoji/{codepoints}/lottie.json`) on first visibility. There is **no runtime cache**
+  (the service worker only precaches the app shell) and **no in-memory cache**, so the same emoji
+  is fetched again every time it scrolls into view, every chat, every app open — even though a
+  given codepoint's animation never changes.
+- **Avatars**: avatars are already `data:` URLs (generated initials SVGs, or decrypted profile
+  images held in IndexedDB) bound directly to `<img>` — so they do **not** hit the network. The
+  goal here is only to confirm they are materialized once and reused while unchanged (keyed by the
+  profile's last-updated marker), not redundantly re-read/re-decoded, and that any caching we add
+  is correctly **invalidated when the avatar changes**.
+
+The per-codepoint Lottie is immutable, so it can be cached aggressively and effectively forever;
+avatars must refresh when the underlying profile changes. Everything stays self-hosted and
+zero-knowledge: emoji come from our own proxy (never a third-party CDN), and avatars never leave
+the device.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Animated emoji load instantly after the first time (Priority: P1)
+
+A user who has already seen a given animated emoji sees it again (same chat, another chat, or a
+later session) without it re-downloading — it appears immediately from cache.
+
+**Why this priority**: This is the concrete, repeated network refetch the user reported; caching it
+removes redundant requests and makes emoji feel instant.
+
+**Independent Test**: Render an animated emoji, then render the same emoji again; confirm the Lottie
+data is served from cache (no second network fetch) within a session, and persists across reloads.
+
+**Acceptance Scenarios**:
+
+1. **Given** an animated emoji has been loaded once, **When** the same emoji is shown again in the
+   same session, **Then** its Lottie data is reused from an in-memory cache with no new request.
+2. **Given** an animated emoji was loaded in a previous session, **When** it is shown after an app
+   reload, **Then** its Lottie data is served from the persistent (service-worker) cache, not the
+   network.
+3. **Given** an emoji has no Lottie / the fetch fails, **When** it is shown, **Then** it falls back
+   to the native glyph exactly as today (caching must not change the fallback behavior).
+
+### User Story 2 - Avatars are reused while unchanged, refreshed when changed (Priority: P2)
+
+Navigating between screens that show the same person's avatar doesn't re-materialize it each time;
+when a profile's avatar actually changes, the new one shows.
+
+**Why this priority**: Avatars are already local `data:` URLs, so the win is smaller (avoid
+redundant work, not network), but correctness of change-invalidation matters.
+
+**Independent Test**: Show the same contact's avatar on multiple screens; confirm it isn't
+redundantly re-derived; then change the profile's avatar and confirm the new image appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contact's avatar is shown on one screen, **When** the same avatar is shown on
+   another, **Then** it is reused (no redundant re-read/re-decode) while the profile is unchanged.
+2. **Given** a profile's avatar changes, **When** any screen shows that avatar next, **Then** the
+   updated avatar is shown (the cache is keyed by a change marker, not stale forever).
+
+### Edge Cases
+
+- **Cache growth**: the emoji cache must be bounded (size/age) so it can't grow without limit.
+- **Emoji proxy update**: if the server ever changes a codepoint's Lottie, the immutable cache
+  would keep the old one — acceptable for Noto (stable), but the cache strategy must be documented
+  and bust-able (e.g. via the existing app-version/precache lifecycle).
+- **Offline**: a cached emoji should still animate offline; an uncached one falls back to the glyph.
+- **Avatar removed**: clearing/resetting an avatar must invalidate its cached entry.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST serve a given animated emoji's Lottie data from cache after its first
+  load — both within a session (in-memory) and across sessions/reloads (persistent), without a new
+  network request for an already-cached codepoint.
+- **FR-002**: The animated-emoji cache MUST be bounded (by count and/or age) so it cannot grow
+  unbounded, and MUST be invalidatable through the app's existing update/precache lifecycle.
+- **FR-003**: Caching MUST NOT change the existing fallback: a missing Lottie or a failed fetch
+  still shows the native glyph, and animation still respects the user's reduce-motion / animation
+  setting.
+- **FR-004**: Avatars MUST be reused while their source profile is unchanged and MUST refresh when
+  the avatar changes (any cache is keyed by a change marker such as the profile's updatedAt).
+- **FR-005**: All cached assets MUST remain self-hosted/local — emoji from the first-party proxy,
+  avatars never leaving the device — with no third-party CDN or new external fetch introduced.
+
+### Zero-Knowledge Impact
+
+- **FR-006**: Caching introduces no new server endpoint, request shape, or metadata. The emoji
+  proxy request is unchanged (only its result is cached); avatars stay device-local `data:` URLs.
+  The cache stores only non-sensitive, public emoji animations and the device's own avatar data —
+  nothing is sent anywhere new, and the server learns nothing it didn't already.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Showing an already-seen animated emoji a second time issues **zero** additional
+  network requests for its Lottie within a session.
+- **SC-002**: After an app reload, a previously-seen animated emoji loads from the persistent cache
+  with no network request (verifiable offline).
+- **SC-003**: The emoji cache stays within its configured bound (count/age) regardless of how many
+  distinct emoji are viewed.
+- **SC-004**: A changed avatar is reflected on next render (no stale avatar), and an unchanged
+  avatar is not redundantly re-materialized across screens.
+- **SC-005**: Existing behavior is unregressed: emoji fallback to glyph, reduce-motion handling,
+  and avatar rendering all unchanged; the build/test suites stay green.
+
+## Assumptions
+
+- Animated emoji come from the first-party proxy `/v1/emoji/{codepoints}/lottie.json`; a given
+  codepoint's Lottie is immutable, so it is safe to cache aggressively.
+- Avatars are already `data:` URLs (generated SVG initials or decrypted profile images from
+  IndexedDB) bound directly to `<img>`; they do not hit the network, so their "caching" is about
+  avoiding redundant re-materialization and correct change-invalidation, not network avoidance.
+- The service worker (`src/sw.ts`, Workbox) is the right layer for the persistent emoji cache
+  (a runtime route), alongside a small in-memory cache in the emoji component for same-session hits.
+- This is an ad-hoc enhancement (no new user-facing UI); success is measured by request counts and
+  unregressed rendering.

--- a/src/components/AnimatedEmoji.vue
+++ b/src/components/AnimatedEmoji.vue
@@ -7,6 +7,7 @@
 
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { loadEmojiLottie } from '@/services/emoji-cache';
 
 /**
  * An emoji that plays its Noto Lottie animation in a continuous loop WHILE it is
@@ -44,10 +45,10 @@ async function ensureLoaded(): Promise<void> {
   if (anim || loading || !props.animate || !anchor.value) return;
   loading = true;
   try {
-    // Self-hosted: proxied + cached by our own server (never a third-party CDN).
-    const res = await fetch(`/v1/emoji/${codepoints()}/lottie.json`);
-    if (!res.ok) return; // no Noto animation → keep the native glyph
-    const data = await res.json();
+    // Self-hosted proxy, cached in-memory per session (spec 1017) + persistently by the service
+    // worker — so a repeat view of the same emoji never refetches. null = no Noto animation.
+    const data = await loadEmojiLottie(codepoints());
+    if (!data) return; // no Noto animation (or fetch failed) → keep the native glyph
     // lottie_light has no expression engine (no eval, smaller), fine for Noto.
     const lottie = (await import('lottie-web/build/player/lottie_light')).default;
     anim = lottie.loadAnimation({

--- a/src/services/emoji-cache.test.ts
+++ b/src/services/emoji-cache.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { loadEmojiLottie, clearEmojiCache, emojiCacheSize } from './emoji-cache';
+
+describe('emoji lottie cache (spec 1017)', () => {
+  beforeEach(() => {
+    clearEmojiCache();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => clearEmojiCache());
+
+  it('fetches once, then serves repeat views from cache (no second request)', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ v: 1 }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const a = await loadEmojiLottie('1f600');
+    const b = await loadEmojiLottie('1f600');
+    expect(a).toEqual({ v: 1 });
+    expect(b).toEqual({ v: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // SC-001: cached, no refetch
+  });
+
+  it('de-dupes concurrent loads of the same emoji into one request', async () => {
+    let resolve!: (r: Response) => void;
+    const fetchMock = vi.fn(() => new Promise<Response>((res) => (resolve = res)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const p1 = loadEmojiLottie('1f9e1');
+    const p2 = loadEmojiLottie('1f9e1');
+    resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual({ ok: true });
+    expect(r2).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('negative-caches a 404 (no animation) so it is not refetched', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await loadEmojiLottie('2705')).toBeNull();
+    expect(await loadEmojiLottie('2705')).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // known-missing cached
+  });
+
+  it('does NOT cache a transient network error — a later view retries', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ v: 2 }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await loadEmojiLottie('1f680')).toBeNull(); // failed, not cached
+    expect(await loadEmojiLottie('1f680')).toEqual({ v: 2 }); // retried successfully
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds the cache so it cannot grow without limit (SC-003)', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ v: 1 }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    for (let i = 0; i < 400; i++) await loadEmojiLottie(`cp_${i}`);
+    expect(emojiCacheSize()).toBeLessThanOrEqual(256);
+  });
+});

--- a/src/services/emoji-cache.ts
+++ b/src/services/emoji-cache.ts
@@ -1,0 +1,70 @@
+/**
+ * In-memory cache of fetched Noto Lottie animation data, keyed by emoji codepoints (spec 1017).
+ *
+ * A given codepoint's animation is immutable and served from our own first-party proxy
+ * (`/v1/emoji/{codepoints}/lottie.json`), so once fetched it is reused for the rest of the session
+ * — no repeat network request as the emoji scrolls in/out of view or shows up in another chat.
+ * Concurrent requests for the same codepoints are de-duped. A bounded LRU cap keeps memory in
+ * check. Cross-SESSION persistence is handled separately by the service worker's runtime cache for
+ * `/v1/emoji/*`; this layer is the fast same-session path.
+ *
+ * Pure-ish and unit-testable: it only depends on `fetch`, which tests can stub.
+ */
+
+const MAX_ENTRIES = 256;
+
+// Value is the parsed Lottie object, or `null` to NEGATIVE-cache "this emoji has no animation"
+// (a 404) so we don't refetch a known-missing glyph every time. A transient network error is NOT
+// cached, so it can be retried later.
+const cache = new Map<string, unknown | null>();
+const inflight = new Map<string, Promise<unknown | null>>();
+
+function remember(key: string, value: unknown | null): void {
+  cache.delete(key); // re-insert so it becomes most-recently-used
+  cache.set(key, value);
+  if (cache.size > MAX_ENTRIES) {
+    const oldest = cache.keys().next().value; // Map preserves insertion order → oldest first
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+}
+
+/**
+ * Fetch (or return the cached) Lottie animation data for an emoji's codepoints. Resolves to the
+ * parsed animation object, or `null` when there is no animation (404) or the fetch failed — the
+ * caller falls back to the native glyph. De-dupes concurrent loads of the same codepoints.
+ */
+export async function loadEmojiLottie(codepoints: string): Promise<unknown | null> {
+  if (cache.has(codepoints)) return cache.get(codepoints) ?? null;
+  const pending = inflight.get(codepoints);
+  if (pending) return pending;
+
+  const p = (async (): Promise<unknown | null> => {
+    try {
+      const res = await fetch(`/v1/emoji/${codepoints}/lottie.json`);
+      if (!res.ok) {
+        remember(codepoints, null); // known-missing → negative cache (don't refetch the 404)
+        return null;
+      }
+      const data = await res.json();
+      remember(codepoints, data);
+      return data;
+    } catch {
+      return null; // transient error: do NOT cache, so a later view can retry
+    } finally {
+      inflight.delete(codepoints);
+    }
+  })();
+  inflight.set(codepoints, p);
+  return p;
+}
+
+/** Test/maintenance helper: drop the in-memory cache (does not touch the service-worker cache). */
+export function clearEmojiCache(): void {
+  cache.clear();
+  inflight.clear();
+}
+
+/** Test introspection: number of cached codepoints (including negative entries). */
+export function emojiCacheSize(): number {
+  return cache.size;
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -17,6 +17,9 @@
  * per-chat tags collapse the page- and SW-shown notes so there's never a duplicate.
  */
 import { precacheAndRoute } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { CacheFirst } from 'workbox-strategies';
+import { ExpirationPlugin } from 'workbox-expiration';
 import {
   previewPending, markShown, unreadCount, ackCall, previewConnections, markConnShown,
   type SwNote, type ConnNote,
@@ -30,6 +33,26 @@ declare const self: ServiceWorkerGlobalScope & {
 
 // App-shell precache (manifest injected at build time).
 precacheAndRoute(self.__WB_MANIFEST);
+
+// Reusable-asset runtime cache (spec 1017): a given animated emoji's Noto Lottie is immutable and
+// served from our own first-party proxy, so cache-first it persistently across sessions — a repeat
+// view never hits the network (and it animates offline). Bounded by count + age so it can't grow
+// without limit; purged on quota pressure. (Same-session hits are served even faster by the
+// in-memory cache in emoji-cache.ts.) Avatars are device-local `data:` URLs, so they need no
+// runtime route here.
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/v1/emoji/'),
+  new CacheFirst({
+    cacheName: 'emoji-lottie-v1',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 512,
+        maxAgeSeconds: 60 * 60 * 24 * 60, // 60 days
+        purgeOnQuotaError: true,
+      }),
+    ],
+  }),
+);
 
 // Update model (pairs with registerType: 'prompt'): a freshly-installed worker
 // WAITS instead of taking over, so the page keeps running the version the user is


### PR DESCRIPTION
## Spec 1017 — Cache reusable assets (animated emoji) so they aren't refetched

Animated emoji re-downloaded their Noto Lottie animation on **every** view (no runtime or in-memory cache; the service worker only precached the app shell), so the same emoji refetched as it scrolled in/out of view, in every chat, every session.

**Fix:**
- **In-memory cache** (`src/services/emoji-cache.ts`): fetch a codepoint's Lottie once, reuse for the session; de-dupes concurrent loads; negative-caches 404s (no animation) but retries transient errors; bounded LRU.
- **Service-worker runtime cache** (`sw.ts`, Workbox `CacheFirst` for `/v1/emoji/*`, bounded by count/age): persistent across reloads, animates offline.
- Falls back to the native glyph exactly as before.
- **Avatars need no change** — already device-local `data:` URLs in reactive stores (no network; refreshed on profile change).

**Zero-knowledge:** no new endpoint/request/metadata; emoji stay first-party, avatars stay on-device.

**Verification:** 5 unit tests (`emoji-cache.test.ts` — cache hit, de-dupe, negative-cache, transient-retry, LRU bound); full build incl. the SW bundle; 313 unit total green. Rebased on merged specs 2008 + 2009.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
