### PR TITLE
docs(roadmap): mark spec 2008 in-review

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,5 +52,5 @@ Specs are grouped by category band; status moves
 | [2005](specs/2005-pause-resume-during/spec.md) | Video-message recording — stop & review before sending, clean start, right-sized, out of the gallery | 🟢 shipped |
 | [2006](specs/2006-install-page-guidance/spec.md) | Install-page guidance for a Play Protect "older Android" block | 🟢 shipped |
 | [2007](specs/2007-video-hd-sd/spec.md) | HD/SD video sends are transcoded for real on device | 🔵 in-review |
-| [2008](specs/2008-fast-first-call-connect/spec.md) | Make the first call connect as fast as a call-waiting second call | 🟡 in-progress |
+| [2008](specs/2008-fast-first-call-connect/spec.md) | Make the first call connect as fast as a call-waiting second call | 🔵 in-review |
 | [2009](specs/2009-single-call-waiting-slot/spec.md) | Only one caller may wait in call-waiting; further callers get busy | 🔵 in-review |

--- a/specs/2008-fast-first-call-connect/spec.md
+++ b/specs/2008-fast-first-call-connect/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-24
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Cosmetic roadmap tidy: spec 2008's status was left at `in-progress` after merge; bump it to `in-review` to match 2009 and 1017 (all three are merged to develop, awaiting the next production release). Docs/roadmap only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)