### PR TITLE
fix(app): no more blank-screen on back-swipe, and reliable message notifications

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,4 +55,4 @@ Specs are grouped by category band; status moves
 | [2007](specs/2007-video-hd-sd/spec.md) | HD/SD video sends are transcoded for real on device | 🔵 in-review |
 | [2008](specs/2008-fast-first-call-connect/spec.md) | Make the first call connect as fast as a call-waiting second call | 🔵 in-review |
 | [2009](specs/2009-single-call-waiting-slot/spec.md) | Only one caller may wait in call-waiting; further callers get busy | 🔵 in-review |
-| [2010](specs/2010-nav-notification-robustness/spec.md) | Navigation & notification robustness | ⚪ planned |
+| [2010](specs/2010-nav-notification-robustness/spec.md) | Navigation & notification robustness | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,3 +55,4 @@ Specs are grouped by category band; status moves
 | [2007](specs/2007-video-hd-sd/spec.md) | HD/SD video sends are transcoded for real on device | 🔵 in-review |
 | [2008](specs/2008-fast-first-call-connect/spec.md) | Make the first call connect as fast as a call-waiting second call | 🔵 in-review |
 | [2009](specs/2009-single-call-waiting-slot/spec.md) | Only one caller may wait in call-waiting; further callers get busy | 🔵 in-review |
+| [2010](specs/2010-nav-notification-robustness/spec.md) | Navigation & notification robustness | ⚪ planned |

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -94,3 +94,35 @@ test('switching tabs transitions the page after a drill-down + back', async ({ b
 
   await ctx.close();
 });
+
+/**
+ * Spec 2010 — navigation robustness. The installed iOS PWA's OS edge-swipe can't be disabled and, at
+ * history depth 1, underflows past start_url into a blank browser view. Two guarantees: (1) any path
+ * that doesn't match a real screen redirects to the main list (catch-all) — never a blank view; and
+ * (2) a back navigation at a tab root keeps the user on an in-app screen (the app stays mounted),
+ * thanks to the catch-all + the base-entry seed.
+ */
+test('unknown paths redirect into the app; back at a tab root stays in-app', async ({ browser }) => {
+  const ctx = await browser.newContext();
+  const a = await createAccount(ctx, 'NAVROBUST');
+  const AVATAR = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>';
+  await a.page.evaluate((av) => (window as any).__ringTest.setProfile('Nav', av), AVATAR);
+
+  // (1) Catch-all: an unknown path resolves to the main list, not a blank document.
+  await a.page.goto('/this/path/does/not/exist');
+  await a.page.waitForURL('**/tabs/chats');
+  expect(await a.page.evaluate(() => !!document.querySelector('ion-router-outlet'))).toBe(true);
+
+  // (2) From a tab root, a back navigation must stay in-app (an in-app route + the app still mounted),
+  // never about:blank / browser chrome.
+  await a.page.goto('/tabs/chats');
+  await a.page.waitForURL('**/tabs/chats');
+  expect(await a.page.evaluate(() => history.length)).toBeGreaterThanOrEqual(2);
+  await a.page.goBack();
+  await a.page.waitForTimeout(300);
+  expect(a.page.url()).not.toContain('about:blank');
+  expect(await a.page.evaluate(() => location.pathname)).not.toBe('');
+  expect(await a.page.evaluate(() => !!document.querySelector('ion-app, ion-router-outlet'))).toBe(true);
+
+  await ctx.close();
+});

--- a/specs/2010-nav-notification-robustness/checklists/requirements.md
+++ b/specs/2010-nav-notification-robustness/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Navigation & notification robustness
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec carries the technical root causes only as context in the **Input** line and Assumptions;
+  the body stays behavior-focused (WHAT/WHY). The HOW (catch-all route, deterministic page↔SW
+  handoff, SW timeout ordering) belongs in plan.md.
+- Two P1 user stories (navigation, notification consistency) + one P2 (single-notification / badge
+  accuracy). All independently testable via the e2e harness.
+- Validated in one pass: no [NEEDS CLARIFICATION] markers — all decisions (keep-user-in-app on
+  tab-root back-swipe; deterministic foreground/background notification ownership; no new settings)
+  were supplied in the description.

--- a/specs/2010-nav-notification-robustness/plan.md
+++ b/specs/2010-nav-notification-robustness/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Navigation & notification robustness
+
+**Spec**: [spec.md](./spec.md) · **Branch**: `fix/2010-nav-notification-robustness` · **Date**: 2026-06-25
+
+## Summary
+
+Two independent robustness fixes in the client only (no server change, zero-knowledge boundary
+intact):
+
+1. **Navigation** — stop the iOS-PWA edge back-swipe from underflowing past the app's single history
+   entry into a blank browser view. Keep a shell entry beneath the tab roots and add a catch-all
+   route, using stock vue-router/Ionic routing (no popstate hacks).
+2. **Notifications** — make the foreground-page ↔ service-worker hand-off deterministic so the same
+   chat reliably shows content (per `notifyContent`) when unlocked, with exactly one notification per
+   message, and fix the SW generic-vs-content timeout ordering + cold-start latency.
+
+## Technical Context
+
+- **Client**: Vue 3 + Ionic + vue-router (`createWebHistory`), custom service worker (`src/sw.ts`),
+  Web Push (content-free tickle → SW fetches `/relay/pending` + decrypts + shows). Per-chat
+  notification prefs already exist (`Chat.notifyContent | notifyWebPush | notifyInApp | mutedUntil`).
+- **Server**: unchanged.
+- **Testing**: Playwright e2e (`e2e/`), incl. `navigation.spec.ts` and notification specs; the SW
+  notification logic is exercised via the page↔SW message protocol and the dev `__ringTest` hooks.
+- **Constraints**: zero-knowledge (no content in push payload; decrypt on-device over the sealed
+  relay); iOS/Safari installed PWA must keep showing a notification per push.
+
+## Root causes (from investigation)
+
+### Navigation (US1)
+- The app runs at browser-history **depth 1** at the tab roots: `/` → redirect to `/tabs/chats`
+  (`router/index.ts:17`), tab switches use Ionic `navigate(path,'root','replace')`
+  (`TabsPage.vue:92-95`), `swipeBackEnabled:false` (`main.ts`), and the OS edge-swipe **cannot** be
+  disabled. With one entry, the OS swipe pops past `start_url` → the pre-PWA blank document inside the
+  app shell. There is also **no catch-all route**, so any unmatched path renders nothing. (The old
+  `fix(nav)` flattening commits `b16b095`/`3dc18e1` are intact — this is an always-present gap, not a
+  regression.)
+
+### Notifications (US2/US3)
+- **(a) Ambiguous hand-off (primary):** the page posts `ring:handled` to the SW the instant it sees
+  it's unlocked (`App.vue:173-183`), *not* when it actually shows something. The SW then stays silent
+  (`sw.ts:459-462`) while the page legitimately drops the alert via the 2.5s post-unlock settle window
+  (`notify.ts:318`, `useSync.ts:496`), a `document.visibilityState` race in `notifyLocal`
+  (`push.ts:106-109`), or an idle/connected transport where `nudgeReconnect` is a no-op
+  (`useSync.ts:210-214`) so the message isn't drained in the push window. Result: content (page) vs
+  nothing vs SW-generic, at random.
+- **(b) SW timeout ordering:** `GENERIC_AFTER_MS=6000` shows generic if fetch+decrypt is slow, but the
+  upgrade window `SETTLE_MAX_MS=9000` is too tight vs `PENDING_FETCH_TIMEOUT_MS=8000`
+  (`sw.ts:82-83`, `sw-inbox.ts:99`), so a slow fetch shows generic and never upgrades.
+- **(c) SW cold start:** the SW re-derives the unlocked key bundle on every fresh wake (separate
+  in-memory state from the page, `identity.ts:445-460`), and does so *after* the fetch
+  (`sw-inbox.ts:298`), so the first push after eviction pays libsodium-init + unwrap latency and
+  misses the 6s timeout → generic.
+
+## Design
+
+### US1 — Navigation (stock routing, no hacks)
+1. **Catch-all route** at the end of the route table (`router/index.ts`):
+   `{ path: '/:pathMatch(.*)*', redirect: '/tabs/chats' }` → no path ever renders blank (FR-002).
+2. **Anchor a shell entry beneath the tab roots** so history depth ≥ 2 at a tab root. Keep `/` as a
+   real entry rather than collapsing onto it: on first landing (the `/`→tabs redirect and the auth
+   entry in `AuthPage.vue`), ensure a base `/` entry remains, so the OS back-swipe from a tab root
+   pops to `/`, whose redirect immediately bounces back into `/tabs/chats` — the user stays in the app
+   (FR-001). The terminal-tab `switchTab` flattening (`TabsPage.vue`) and `swipeBackEnabled:false`
+   stay exactly as they are; detail-page back is unchanged (FR-003/FR-004).
+3. Decision: a tab-root back-swipe is a **benign no-op / re-anchor** (stay in app), not an attempted
+   app exit (which the platform can't do cleanly and is what surfaces the blank view).
+
+### US2/US3 — Deterministic notification hand-off + SW timing
+1. **Single source of truth for who alerts (FR-006/FR-007):**
+   - The **page acks `ring:handled` only when it actually presents a visible in-app banner** (app
+     visible + not suppressed). When the page is hidden, or would suppress (settle window / muted /
+     active chat / content=none), it does **not** ack → the SW deterministically owns the OS
+     notification. Remove the page's "ack-on-unlocked" behavior and the page-side `notifyLocal`
+     OS-notification path from the hand-off (the SW owns OS notifications).
+   - Exclude push-woken items from the `settledUntil` suppression so a freshly-woken message is never
+     swallowed-and-acked.
+2. **SW timeout ordering (FR-008):** widen `SETTLE_MAX_MS` above `PENDING_FETCH_TIMEOUT_MS` (e.g.
+   8000 fetch → 12000 settle) so a decrypt that lands within the fetch budget always upgrades the
+   generic; keep the per-chat tag replace (`closeByTag(GENERIC_TAG)` → show content).
+3. **Cold-start (edge case):** kick libsodium `ready()` + `attemptDeviceUnlock()` **in parallel** with
+   the `/relay/pending` fetch (instead of after it) so cold-wake decrypt latency overlaps the fetch.
+4. **iOS-safe (FR-013):** the SW still calls `showNotification()` for every push (generic placeholder
+   first if needed, upgraded after); badge-only (`notifyContent='none'`) updates the badge — verify on
+   iOS the push handler still presents *something* per push or the badge-only path is acceptable to
+   the platform (document the on-device check).
+5. **No new settings (FR-010):** all per-chat prefs unchanged; this only makes them deterministic.
+
+## Constitution / zero-knowledge check
+
+- **Principle I (Zero-Knowledge):** unchanged — no content in the push payload; the SW still fetches
+  the sealed message over the existing relay and decrypts on-device. No new server route/metadata.
+- **No server change** (FR-012). **TDD:** notification hand-off decision logic is factored into a
+  pure/testable predicate where feasible (who-owns-the-alert given app-state/lock/visibility/prefs)
+  with unit tests; the e2e harness covers the cross-context behavior; navigation gets an e2e for the
+  history-depth invariant.
+
+## Files (anticipated)
+
+- Navigation: `src/router/index.ts` (catch-all + entry anchoring), possibly `src/views/tabs/AuthPage.vue`
+  / `src/main.ts` (entry), `e2e/navigation.spec.ts` (depth ≥ 2 + back-at-root stays in-app).
+- Notifications: `src/App.vue` (ack-only-when-shown), `src/services/notify.ts` (return whether it
+  presented; exclude push items from settle suppression), `src/sw.ts` (hand-off + timeouts),
+  `src/services/sw-inbox.ts` (parallel unlock + timeouts), small pure helper + unit test for the
+  ownership predicate, plus an e2e for consistent-content / single-notification.
+
+## Phasing
+
+US1 (navigation) is independent and the smallest, shippable on its own. US2 then US3 (same hand-off
+mechanism). Polish: full gate (build, unit, server, e2e) + on-device iOS notification check + roadmap.

--- a/specs/2010-nav-notification-robustness/spec.md
+++ b/specs/2010-nav-notification-robustness/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2010-nav-notification-robustness/spec.md
+++ b/specs/2010-nav-notification-robustness/spec.md
@@ -1,0 +1,207 @@
+# Feature Specification: Navigation & notification robustness
+
+**Feature Branch**: `fix/2010-nav-notification-robustness`
+
+**Created**: 2026-06-25
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: Two recurring robustness defects in the installed PWA: (1) a back-swipe from a main
+screen sometimes drops the user into a blank browser view inside the app window; (2) message
+notifications randomly show a generic "New message" placeholder instead of the real content even
+when the device is unlocked. Fix both so navigation never escapes the app and notifications are
+consistent.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A back-swipe never drops me out of the app (Priority: P1)
+
+A person using the installed app swipes right (the phone's edge back-gesture) to return toward the
+main list. Today, from a top-level screen this sometimes lands them on a blank page showing the
+browser's own back/forward/reload buttons inside the app window — they appear to have fallen out of
+the app and have to relaunch it. After this change, a back-swipe from a main screen keeps them in the
+app: it harmlessly returns them to (or holds them on) the main list, and no blank/browser view is
+ever shown.
+
+**Why this priority**: Falling out of the app into a dead blank view is a trust-breaking, "the app is
+broken" moment that forces a relaunch. It can happen from the most-used screens (the tab roots) with
+an ordinary, frequent gesture.
+
+**Independent Test**: From a fresh launch, navigate to each main tab and repeatedly trigger a back
+navigation at the tab root; confirm the app stays on an in-app screen every time and the browser
+chrome / a blank document never appears. Also confirm drilling into a detail screen and swiping back
+still returns to its parent as before.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is freshly launched at a main tab list, **When** the user triggers a back
+   navigation from that tab root, **Then** the app remains on an in-app screen (the main list) and no
+   blank page or browser chrome is shown.
+2. **Given** the user is several screens deep (e.g. a chat opened from a list), **When** they swipe
+   back repeatedly, **Then** each step returns to the expected parent screen and the final back at the
+   tab root still keeps them in the app.
+3. **Given** any URL/path that does not correspond to a real screen is reached, **When** it loads,
+   **Then** the app shows the main list instead of a blank/empty view.
+
+---
+
+### User Story 2 - Notifications consistently show the real message (Priority: P1)
+
+A person has a chat set to show message content in notifications, and their device is unlocked (the
+normal state). When a message arrives while the app is backgrounded or closed, they expect the
+notification to show the actual decrypted message — every time. Today it flip-flops: the same chat
+sometimes shows the real content and sometimes a generic "New message", seemingly at random. After
+this change, in the unlocked state the notification reliably reflects the chat's chosen content level
+(full content, no-preview/generic, or badge-only), consistently across messages.
+
+**Why this priority**: Inconsistent previews make notifications untrustworthy — the user can't tell at
+a glance whether a generic alert means "preview is off" or "the app failed to decrypt this one". It's
+the headline complaint and affects every incoming message.
+
+**Independent Test**: With a chat set to full content and the device unlocked, deliver several messages
+in succession with the app backgrounded; confirm each notification shows the decrypted content (no
+random generic). Repeat with the chat set to no-preview and to badge-only and confirm each behaves
+per its setting consistently.
+
+**Acceptance Scenarios**:
+
+1. **Given** a chat set to show full content and an unlocked device, **When** multiple messages arrive
+   while the app is backgrounded, **Then** every resulting notification shows the decrypted content
+   (none fall back to generic).
+2. **Given** decryption of a just-arrived message takes a moment, **When** a placeholder notification
+   is shown first, **Then** it is replaced by the real content once decryption completes (within the
+   wake window), rather than leaving a stale generic.
+3. **Given** a chat set to no-preview (generic) or badge-only, **When** messages arrive, **Then** the
+   notification consistently honors that setting (generic text, or badge update with no banner).
+
+---
+
+### User Story 3 - Exactly one notification per message (Priority: P2)
+
+When a message arrives, the user gets a single notification for it — never two for the same message
+(one from the running app and one from the background handler), and never zero when they should have
+been alerted. The unread badge count stays accurate regardless of the per-chat content setting.
+
+**Why this priority**: Duplicate notifications are noisy and erode trust; a silently-missing alert is
+worse. Both stem from the same ambiguous hand-off between the foreground app and the background
+handler that drives the US2 flip-flop, so fixing it cleanly resolves duplicates/misses too.
+
+**Independent Test**: Deliver a message in each app state (visible, backgrounded, closed) and confirm
+exactly one user-facing alert results, and that the badge reflects the true unread count.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is open and visible, **When** a message arrives, **Then** the user sees exactly
+   one alert (an in-app banner) and not also a system notification for the same message.
+2. **Given** the app is backgrounded or closed, **When** a message arrives, **Then** the user sees
+   exactly one system notification for it.
+3. **Given** any per-chat content setting (full / generic / badge-only / muted), **When** messages
+   arrive, **Then** the app's unread badge reflects the true unread count.
+
+---
+
+### Edge Cases
+
+- **Back-swipe at the very first screen after launch**: the gesture must not exit to a blank/browser
+  view; it harmlessly keeps the user on the main list.
+- **Locked device (PIN/passkey, no auto-unlock)**: the background handler cannot decrypt, so a generic
+  placeholder is the correct, expected result — consistency means "always generic while locked", not a
+  flip-flop. This is in scope only insofar as the behavior must be deterministic per lock state.
+- **Slow network / slow decryption on wake**: a placeholder may appear first but must be upgraded to
+  real content once decryption finishes within the wake window; it must not strand a generic.
+- **Cold background handler (first message after the app/handler was evicted)**: the first
+  notification after a cold wake must still reach the right content level, not reliably degrade to
+  generic due to start-up latency.
+- **Rapid burst of messages**: each message resolves to a single, correctly-leveled notification;
+  placeholders are replaced, not stacked alongside their upgrades.
+- **iOS platform constraint**: the background handler must present a notification for every push so the
+  platform does not substitute its own fallback notification or revoke the push subscription; the
+  badge-only path must satisfy this constraint.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Navigation**
+
+- **FR-001**: A back navigation from a main tab list MUST keep the user within the app — it MUST NOT
+  expose the browser's chrome (back/forward/reload) or a blank/empty document inside the app window.
+- **FR-002**: Reaching any path that does not correspond to a real screen MUST resolve to the main
+  list (never a blank view).
+- **FR-003**: Existing back behavior MUST be preserved: from a drilled-in detail screen, back returns
+  to its parent screen, step by step, as it does today.
+- **FR-004**: The fix MUST use the app's standard routing/navigation behavior (no fragile
+  platform-gesture interception) and MUST NOT regress tab switching or the existing navigation suite.
+
+**Notifications**
+
+- **FR-005**: When the device is unlocked, a message notification MUST consistently reflect the
+  chat's content setting (full content / generic / badge-only) — the same chat MUST NOT alternate
+  between real content and generic across messages under unchanged conditions.
+- **FR-006**: Each incoming message MUST produce exactly one user-facing alert — never a duplicate
+  from both the foreground app and the background handler, and never a missing alert when one is due.
+- **FR-007**: Responsibility for alerting MUST be unambiguous: the foreground app owns the alert only
+  when it actually presents an in-app banner; otherwise the background handler owns the notification.
+  An item the foreground app does not actually present MUST NOT be suppressed by it.
+- **FR-008**: A placeholder notification shown while a message is still being decrypted MUST be
+  replaced by the real content once decryption completes within the wake window (no stranded generic
+  when content was available).
+- **FR-009**: The unread badge MUST stay accurate regardless of the per-chat content setting,
+  including badge-only and muted chats.
+- **FR-010**: Existing per-chat notification settings (full / generic / badge-only, web-push on/off,
+  in-app banner on/off, mute) MUST be honored unchanged; this work makes the existing settings behave
+  consistently and MUST NOT add new settings.
+
+**Constraints (cross-cutting)**
+
+- **FR-011**: The zero-knowledge boundary MUST be preserved: message content MUST NOT appear in the
+  push payload; the background handler MUST obtain content only by fetching the sealed message over
+  the existing relay and decrypting it on-device.
+- **FR-012**: The change MUST require no server modifications.
+- **FR-013**: On iOS/Safari installed PWAs, the background handler MUST present a notification for
+  every push (so the platform does not show its own fallback or revoke the subscription); the
+  badge-only path MUST satisfy this constraint while showing no message banner.
+
+### Key Entities *(include if feature involves data)*
+
+- **Per-chat notification preference**: the existing per-conversation choice of content level (full
+  content / generic / badge-only), plus web-push, in-app-banner, and mute toggles. Not changed by this
+  work; honored consistently.
+- **Notification hand-off signal**: the existing coordination between the foreground app and the
+  background handler that decides which one alerts the user for a given message. Made deterministic by
+  this work.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With a chat set to full content and the device unlocked, every notification over a run of
+  consecutive backgrounded messages shows the decrypted content — zero random generic fallbacks (where
+  decryption was possible).
+- **SC-002**: Each delivered message results in exactly one user-facing alert (no duplicates, no
+  misses) across the app states visible / backgrounded / closed.
+- **SC-003**: Repeatedly triggering a back navigation from any main tab root never exposes browser
+  chrome or a blank document; the app stays on an in-app screen every time.
+- **SC-004**: Any non-existent path resolves to the main list rather than a blank view.
+- **SC-005**: The unread badge matches the true unread count for chats across all content settings
+  (full / generic / badge-only / muted).
+- **SC-006**: No regression to the existing navigation, notification, and call test suites.
+
+## Assumptions
+
+- The reported notification flip-flop occurs in the normal unlocked (auto-unlock) state; a PIN/passkey
+  lock legitimately forces generic placeholders (the background handler cannot decrypt without the
+  unlock), and "consistency" there means deterministically-generic, not content.
+- The existing per-chat notification settings and the existing background fetch-and-decrypt pipeline
+  are kept; this is a robustness/correctness fix, not a new feature surface.
+- "Keep the user in the app" on a tab-root back-swipe is the desired behavior (a benign no-op /
+  re-anchor to the main list), in preference to attempting a clean app exit — which the platform does
+  not reliably support and which currently manifests as the blank browser view.
+- Behavior is validated with the existing automated end-to-end harness plus the background handler's
+  own code paths; on-device iOS confirmation covers the platform-specific notification constraint.
+- No server changes are required or made; the zero-knowledge boundary is unchanged.

--- a/specs/2010-nav-notification-robustness/tasks.md
+++ b/specs/2010-nav-notification-robustness/tasks.md
@@ -1,0 +1,112 @@
+---
+description: "Task list for spec 2010 — navigation & notification robustness"
+---
+
+# Tasks: Navigation & notification robustness
+
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md)
+
+**Tests**: REQUIRED. The notification ownership decision is factored into a pure predicate with unit
+tests (TDD); navigation + cross-context notification behavior are covered by Playwright e2e.
+
+**Organization**: by user story. US1 (navigation) is independent and smallest; US2 (consistent
+content) + US3 (single notification / badge) share one deterministic page↔SW hand-off.
+
+## Format: `[ID] [P?] [Story] Description with file path`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm the e2e harness can (a) read `window.history.length` / current route in a tab root,
+  and (b) drive a backgrounded message + observe the resulting notification path via the existing
+  `__ringTest` / SW message hooks; note any hook gap to add.
+
+## Phase 2: Foundational
+
+- [ ] T002 Add a pure, unit-testable predicate `notificationOwner(state)` (new
+  `src/services/notify-policy.ts`): given app-visibility, lock state, per-chat prefs
+  (content/in-app/web-push/mute), active-chat, and whether the item was push-woken, return who alerts
+  — `page-banner` | `sw-notification` | `suppress` — so the page and SW agree deterministically (no
+  ack-on-unlocked). Pure; no DOM/IDB.
+
+## Phase 3: User Story 1 — Back-swipe never escapes the app (Priority: P1)
+
+**Goal**: A back navigation from a tab root keeps the user in-app; no blank/browser view; no path
+renders blank.
+
+- [ ] T003 [US1] Add a catch-all route `{ path: '/:pathMatch(.*)*', redirect: '/tabs/chats' }` at the
+  end of the route table in `src/router/index.ts` (FR-002).
+- [ ] T004 [US1] Anchor a shell history entry beneath the tab roots so depth ≥ 2 at a fresh tab root,
+  using stock routing (keep `/` as a real entry; the OS back-swipe pops to `/` → redirect bounces back
+  into `/tabs/chats`). Touch `src/router/index.ts` and the app entry (`src/views/tabs/AuthPage.vue` /
+  `src/main.ts`) only as needed; do NOT change `swipeBackEnabled` or `switchTab` flattening (FR-001/
+  FR-003/FR-004).
+- [ ] T005 [US1] e2e in `e2e/navigation.spec.ts`: at a fresh tab root assert `history.length >= 2`;
+  simulate a back at the tab root and assert the app stays on an in-app route (not a blank document);
+  assert an unknown path resolves to `/tabs/chats`. Confirm detail-page back still returns to parent.
+
+**Checkpoint**: back-swipe at a tab root keeps the app mounted; no blank/browser view; unknown paths
+redirect.
+
+## Phase 4: User Story 2 — Notifications consistently show the real message (Priority: P1)
+
+**Goal**: In the unlocked state, the same chat reliably shows content per `notifyContent` — no random
+generic.
+
+- [ ] T006 [US2] Write FAILING unit tests for `notificationOwner` (`notify-policy.test.ts`): unlocked
+  + visible + full-content + not-active → `page-banner`; unlocked + hidden → `sw-notification`;
+  active-chat / content=none / muted → `suppress`/badge per pref; push-woken item must NOT be
+  suppressed by the settle window.
+- [ ] T007 [US2] Make the page ack deterministic in `src/App.vue`: ack `ring:handled` ONLY when the
+  page actually presents an in-app banner (owner === `page-banner` AND it rendered); otherwise do not
+  ack → the SW owns the OS notification. Remove the ack-on-`isUnlockedNow()` behavior (FR-007).
+- [ ] T008 [US2] In `src/services/notify.ts`: have `notifyIncoming` use `notificationOwner` and return
+  whether it presented a banner; exclude push-woken items from the `settledUntil` suppression so a
+  woken message is never swallowed-then-acked; the page no longer shows OS notifications via
+  `notifyLocal` for the hand-off (the SW owns OS notifications) (FR-005/FR-006/FR-007).
+- [ ] T009 [US2] Fix SW timing in `src/sw.ts` + `src/services/sw-inbox.ts`: widen `SETTLE_MAX_MS`
+  above `PENDING_FETCH_TIMEOUT_MS` so a decrypt within the fetch budget always upgrades the generic;
+  start libsodium `ready()` + `attemptDeviceUnlock()` in PARALLEL with the `/relay/pending` fetch to
+  cut cold-start latency (FR-008, cold-start edge case). Run T006 to GREEN.
+- [ ] T010 [US2] e2e: with a chat at full content + unlocked + backgrounded, deliver several messages
+  and assert every resulting notification carries the decrypted content (no generic) and content/
+  generic/badge-only each behave per setting (SC-001).
+
+**Checkpoint**: unlocked notifications consistently honor the content setting; no random generic.
+
+## Phase 5: User Story 3 — Exactly one notification per message; accurate badge (Priority: P2)
+
+**Goal**: One alert per message across app states; badge accurate for every content setting.
+
+- [ ] T011 [US3] Verify/:ensure the deterministic owner yields exactly one alert: visible →
+  page-banner only (SW suppressed via ack); hidden/closed → SW only (no page duplicate). Adjust
+  `App.vue`/`sw.ts` hand-off if any double/zero remains (FR-006).
+- [ ] T012 [US3] Confirm badge accuracy across content settings (incl. badge-only/muted) in
+  `src/sw.ts` / `useBadges.ts`; the badge reflects true unread even when no banner shows (FR-009).
+- [ ] T013 [US3] e2e: deliver a message in visible / backgrounded states and assert exactly one
+  user-facing alert each, and the badge matches unread (SC-002/SC-005).
+
+**Checkpoint**: single notification per message; badge accurate.
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T014 Zero-knowledge confirmation (Principle I): no content in the push payload; SW fetch+decrypt
+  over the existing sealed relay only; no server/DB/migration change (FR-011/FR-012).
+- [ ] T015 iOS-safe check (FR-013): the SW presents a notification per push; the badge-only path is
+  iOS-acceptable. On-device confirmation via the dev deployment (a backgrounded message shows content
+  consistently; a back-swipe at a tab root never shows browser chrome).
+- [ ] T016 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
+  `RING_E2E_PORT=8085 npm run test:e2e` (navigation + notification + no regression to call suites).
+- [ ] T017 Flip spec `Status:` to `in-progress` (then `in-review` at PR) and run `make roadmap`.
+
+## Dependencies
+
+- **Foundational (T002)** before the notification stories. **US1 (T003–T005)** is fully independent
+  and can land first. **US2 (T006–T010)** establishes the deterministic hand-off that **US3
+  (T011–T013)** verifies. Polish last.
+
+## Tracking Issues
+
+One issue per phase/story group (the feature→develop PR must `Closes` each) — created by
+`taskstoissues`.

--- a/specs/2010-nav-notification-robustness/tasks.md
+++ b/specs/2010-nav-notification-robustness/tasks.md
@@ -18,13 +18,13 @@ content) + US3 (single notification / badge) share one deterministic page↔SW h
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm the e2e harness can (a) read `window.history.length` / current route in a tab root,
+- [x] T001 Confirm the e2e harness can (a) read `window.history.length` / current route in a tab root,
   and (b) drive a backgrounded message + observe the resulting notification path via the existing
   `__ringTest` / SW message hooks; note any hook gap to add.
 
 ## Phase 2: Foundational
 
-- [ ] T002 Add a pure, unit-testable predicate `notificationOwner(state)` (new
+- [x] T002 Add a pure, unit-testable predicate `notificationOwner(state)` (new
   `src/services/notify-policy.ts`): given app-visibility, lock state, per-chat prefs
   (content/in-app/web-push/mute), active-chat, and whether the item was push-woken, return who alerts
   — `page-banner` | `sw-notification` | `suppress` — so the page and SW agree deterministically (no
@@ -35,14 +35,14 @@ content) + US3 (single notification / badge) share one deterministic page↔SW h
 **Goal**: A back navigation from a tab root keeps the user in-app; no blank/browser view; no path
 renders blank.
 
-- [ ] T003 [US1] Add a catch-all route `{ path: '/:pathMatch(.*)*', redirect: '/tabs/chats' }` at the
+- [x] T003 [US1] Add a catch-all route `{ path: '/:pathMatch(.*)*', redirect: '/tabs/chats' }` at the
   end of the route table in `src/router/index.ts` (FR-002).
-- [ ] T004 [US1] Anchor a shell history entry beneath the tab roots so depth ≥ 2 at a fresh tab root,
+- [x] T004 [US1] Anchor a shell history entry beneath the tab roots so depth ≥ 2 at a fresh tab root,
   using stock routing (keep `/` as a real entry; the OS back-swipe pops to `/` → redirect bounces back
   into `/tabs/chats`). Touch `src/router/index.ts` and the app entry (`src/views/tabs/AuthPage.vue` /
   `src/main.ts`) only as needed; do NOT change `swipeBackEnabled` or `switchTab` flattening (FR-001/
   FR-003/FR-004).
-- [ ] T005 [US1] e2e in `e2e/navigation.spec.ts`: at a fresh tab root assert `history.length >= 2`;
+- [x] T005 [US1] e2e in `e2e/navigation.spec.ts`: at a fresh tab root assert `history.length >= 2`;
   simulate a back at the tab root and assert the app stays on an in-app route (not a blank document);
   assert an unknown path resolves to `/tabs/chats`. Confirm detail-page back still returns to parent.
 
@@ -54,22 +54,22 @@ redirect.
 **Goal**: In the unlocked state, the same chat reliably shows content per `notifyContent` — no random
 generic.
 
-- [ ] T006 [US2] Write FAILING unit tests for `notificationOwner` (`notify-policy.test.ts`): unlocked
+- [x] T006 [US2] Write FAILING unit tests for `notificationOwner` (`notify-policy.test.ts`): unlocked
   + visible + full-content + not-active → `page-banner`; unlocked + hidden → `sw-notification`;
   active-chat / content=none / muted → `suppress`/badge per pref; push-woken item must NOT be
   suppressed by the settle window.
-- [ ] T007 [US2] Make the page ack deterministic in `src/App.vue`: ack `ring:handled` ONLY when the
+- [x] T007 [US2] Make the page ack deterministic in `src/App.vue`: ack `ring:handled` ONLY when the
   page actually presents an in-app banner (owner === `page-banner` AND it rendered); otherwise do not
   ack → the SW owns the OS notification. Remove the ack-on-`isUnlockedNow()` behavior (FR-007).
-- [ ] T008 [US2] In `src/services/notify.ts`: have `notifyIncoming` use `notificationOwner` and return
+- [x] T008 [US2] In `src/services/notify.ts`: have `notifyIncoming` use `notificationOwner` and return
   whether it presented a banner; exclude push-woken items from the `settledUntil` suppression so a
   woken message is never swallowed-then-acked; the page no longer shows OS notifications via
   `notifyLocal` for the hand-off (the SW owns OS notifications) (FR-005/FR-006/FR-007).
-- [ ] T009 [US2] Fix SW timing in `src/sw.ts` + `src/services/sw-inbox.ts`: widen `SETTLE_MAX_MS`
+- [x] T009 [US2] Fix SW timing in `src/sw.ts` + `src/services/sw-inbox.ts`: widen `SETTLE_MAX_MS`
   above `PENDING_FETCH_TIMEOUT_MS` so a decrypt within the fetch budget always upgrades the generic;
   start libsodium `ready()` + `attemptDeviceUnlock()` in PARALLEL with the `/relay/pending` fetch to
   cut cold-start latency (FR-008, cold-start edge case). Run T006 to GREEN.
-- [ ] T010 [US2] e2e: with a chat at full content + unlocked + backgrounded, deliver several messages
+- [x] T010 [US2] e2e: with a chat at full content + unlocked + backgrounded, deliver several messages
   and assert every resulting notification carries the decrypted content (no generic) and content/
   generic/badge-only each behave per setting (SC-001).
 
@@ -79,26 +79,26 @@ generic.
 
 **Goal**: One alert per message across app states; badge accurate for every content setting.
 
-- [ ] T011 [US3] Verify/:ensure the deterministic owner yields exactly one alert: visible →
+- [x] T011 [US3] Verify/:ensure the deterministic owner yields exactly one alert: visible →
   page-banner only (SW suppressed via ack); hidden/closed → SW only (no page duplicate). Adjust
   `App.vue`/`sw.ts` hand-off if any double/zero remains (FR-006).
-- [ ] T012 [US3] Confirm badge accuracy across content settings (incl. badge-only/muted) in
+- [x] T012 [US3] Confirm badge accuracy across content settings (incl. badge-only/muted) in
   `src/sw.ts` / `useBadges.ts`; the badge reflects true unread even when no banner shows (FR-009).
-- [ ] T013 [US3] e2e: deliver a message in visible / backgrounded states and assert exactly one
+- [x] T013 [US3] e2e: deliver a message in visible / backgrounded states and assert exactly one
   user-facing alert each, and the badge matches unread (SC-002/SC-005).
 
 **Checkpoint**: single notification per message; badge accurate.
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T014 Zero-knowledge confirmation (Principle I): no content in the push payload; SW fetch+decrypt
+- [x] T014 Zero-knowledge confirmation (Principle I): no content in the push payload; SW fetch+decrypt
   over the existing sealed relay only; no server/DB/migration change (FR-011/FR-012).
-- [ ] T015 iOS-safe check (FR-013): the SW presents a notification per push; the badge-only path is
+- [~] T015 iOS-safe check (FR-013): the SW presents a notification per push; the badge-only path is
   iOS-acceptable. On-device confirmation via the dev deployment (a backgrounded message shows content
   consistently; a back-swipe at a tab root never shows browser chrome).
-- [ ] T016 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
+- [x] T016 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
   `RING_E2E_PORT=8085 npm run test:e2e` (navigation + notification + no regression to call suites).
-- [ ] T017 Flip spec `Status:` to `in-progress` (then `in-review` at PR) and run `make roadmap`.
+- [x] T017 Flip spec `Status:` to `in-progress` (then `in-review` at PR) and run `make roadmap`.
 
 ## Dependencies
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,13 +28,13 @@
 import { onMounted, onUnmounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { isAuthenticated } from '@/services/auth';
-import { isUnlockedNow, isUnlocked } from '@/services/crypto/identity';
+import { isUnlocked } from '@/services/crypto/identity';
 import { warmAll, clearWarm } from '@/composables/warmStores';
 import { IonApp, IonRouterOutlet } from '@ionic/vue';
 import { alertCircleOutline } from 'ionicons/icons';
 import { inviteNeedsProfile } from '@/services/invites';
 import { appToast } from '@/services/toast';
-import { showActionBanner, dismissActionBanner } from '@/services/notify';
+import { showActionBanner, dismissActionBanner, markPushWake, onBannerPresented } from '@/services/notify';
 import { useViewportHeight } from '@/composables/useViewportHeight';
 import { useTheme } from '@/composables/useTheme';
 import { useAppBadge } from '@/composables/useAppBadge';
@@ -161,6 +161,24 @@ async function routeRelevant(url?: string): Promise<void> {
   router.push(unread ? `/chat/${unread.id}` : '/tabs/chats');
 }
 
+// How long to wait for a drained message's in-app banner to render before giving
+// up and letting the SW own the OS notification. Slightly above the SW's own
+// pageWillNotify wait (sw.ts) so a page that WILL show a banner reliably claims it
+// (a fast already-connected drain renders well within this), while a page that
+// won't (hidden / suppressed / locked) simply never acks → the SW shows it.
+const DRAIN_ACK_WINDOW_MS = 2000;
+function waitForBannerThenAck(reqId: string): void {
+  let unsub = (): void => {};
+  const timer = setTimeout(() => unsub(), DRAIN_ACK_WINDOW_MS);
+  unsub = onBannerPresented(() => {
+    clearTimeout(timer);
+    unsub();
+    // The page presented an in-app banner for this drain → claim it so the SW
+    // suppresses its own OS notification (no duplicate).
+    navigator.serviceWorker.controller?.postMessage({ type: 'ring:handled', reqId });
+  });
+}
+
 function onServiceWorkerMessage(ev: MessageEvent): void {
   const data = ev.data as { type?: string; url?: string; reqId?: string } | undefined;
   if (!data) return;
@@ -171,15 +189,16 @@ function onServiceWorkerMessage(ev: MessageEvent): void {
   } else if (data.type === 'ring:checkupdate') {
     checkForUpdate(true); // a version-announcement push woke us → check now (surfaces the update toast)
   } else if (data.type === 'ring:drain') {
+    markPushWake(); // a push woke us → arriving messages bypass the settle window
     nudgeReconnect(); // pull queued messages now
-    // We're a live page: if we're UNLOCKED we'll surface the message in-app
-    // (notifyIncoming → banner when visible / notifyLocal when hidden), so claim it
-    // back to the service worker so it suppresses its own OS notification (no
-    // duplicate). A locked page can't show decrypted content, so it stays silent and
-    // the SW shows the notification itself.
-    if (data.reqId && isUnlockedNow()) {
-      navigator.serviceWorker.controller?.postMessage({ type: 'ring:handled', reqId: data.reqId });
-    }
+    // Hand-off (spec 2010): ack `ring:handled` ONLY when the page actually presents
+    // an in-app banner for the drained message — not merely because we're unlocked.
+    // The old "unlocked → ack" was ambiguous: it claimed the alert, then the settle
+    // window / visibility race often dropped the banner, so neither the page nor the
+    // SW alerted. Now we register a one-shot listener for this drain: if a banner
+    // renders within the window, ack (the page owns it); otherwise stay silent so the
+    // SW deterministically owns the OS notification (hidden / suppressed / locked).
+    if (data.reqId) waitForBannerThenAck(data.reqId);
   }
 }
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -19,7 +19,7 @@ import { b64urlToBytes } from '@/services/crypto/envelope';
 import { getSecret, setSecret } from '@/db/secrets';
 import { isUnlockedNow, getIdentityKeys } from '@/services/crypto/identity';
 import { getSelfUserId, getSelfUsername } from '@/services/auth';
-import { notifyIncoming, isChatActive } from '@/services/notify';
+import { notifyIncoming, isChatActive, pushWakeActive } from '@/services/notify';
 import { compressImage, compressVideo, achievedQuality } from '@/services/media-encode';
 import { setCompressProgress, setUploadProgress, resetJobProgress, clearJobProgress } from '@/services/media-jobs';
 import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deriveTiers, blobToDataUrl } from '@/utils/media-meta';
@@ -4067,6 +4067,10 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     // The notification spells out shared location / contact / poll (no icon to lean
     // on), unlike the terser `preview` used for the chats list above.
     body: isGroupMsg ? `${contact.name}: ${notifyPreview(payload)}` : notifyPreview(payload) || 'New message',
+    // A ring:drain push woke us to fetch this → bypass the post-unlock settle window
+    // and let the SW (which already fired for that push) own the OS notification, so
+    // a woken message is never swallowed AND never double-announced (spec 2010).
+    pushWoken: pushWakeActive(),
   }).catch(() => {});
 
   // Durably stored now → record so a duplicate re-send/redelivery is skipped. Marked

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,6 +109,15 @@ seedIfEmpty().finally(() => {
     // After mount, the Ionic web components are defined, so the clones upgrade
     // and hydrate before the first page transition.
     ensureClonedTransitionElements();
+    // Spec 2010: an installed iOS PWA gets its OWN OS edge-swipe back gesture that no web API can
+    // disable, and we deliberately land directly on a tab root at browser-history DEPTH 1 (the `/`
+    // redirect + 'replace' tab flattening). At depth 1 that swipe underflows PAST start_url into a
+    // blank browser view inside the app shell. Seed ONE base history entry at the same URL so the
+    // first OS-back pops to an in-app screen and the user stays in the app. This is a one-time base
+    // seed, NOT a gesture interceptor; the catch-all route bounces any popped-to path back in-app.
+    if (window.history.length <= 1) {
+      window.history.pushState(window.history.state, '', window.location.href);
+    }
   });
 });
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -163,6 +163,13 @@ const routes: RouteRecordRaw[] = [
     path: '/settings/:section',
     component: () => import('@/views/detail/SettingDetailPage.vue'),
   },
+  // Catch-all (spec 2010): any path that doesn't match a real screen redirects to the main list
+  // instead of rendering a blank view — so a stale/unknown URL (or a history entry the OS back-swipe
+  // pops to) always resolves to something in-app, never an empty document.
+  {
+    path: '/:pathMatch(.*)*',
+    redirect: '/tabs/chats',
+  },
 ];
 
 const router = createRouter({

--- a/src/services/notify-policy.test.ts
+++ b/src/services/notify-policy.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { notificationOwner, type NotifyInput } from './notify-policy';
+
+// A sensible default: unlocked, visible, off the active chat, not push-woken, no
+// settle window, full content, everything allowed. Each test overrides only the
+// fields it cares about so the intent of each case is obvious.
+type Override = Partial<Omit<NotifyInput, 'pref'>> & { pref?: Partial<NotifyInput['pref']> };
+function input(over: Override = {}): NotifyInput {
+  const { pref: prefOver, ...rest } = over;
+  return {
+    appVisible: true,
+    unlocked: true,
+    isActiveChat: false,
+    pushWoken: false,
+    inSettleWindow: false,
+    ...rest,
+    // Merge pref separately so a test can override one pref field without restating all.
+    pref: { webPush: true, inApp: true, content: 'full', muted: false, ...(prefOver ?? {}) },
+  };
+}
+
+describe('notificationOwner', () => {
+  it('unlocked + visible + full + not active → page shows the banner', () => {
+    expect(notificationOwner(input())).toBe('page-banner');
+  });
+
+  it('unlocked + app hidden → the SW owns the OS notification', () => {
+    expect(notificationOwner(input({ appVisible: false }))).toBe('sw-notification');
+  });
+
+  it('viewing the active chat (visible) → suppress (just a sound)', () => {
+    expect(notificationOwner(input({ isActiveChat: true }))).toBe('suppress');
+  });
+
+  it('muted chat → suppress regardless of visibility', () => {
+    expect(notificationOwner(input({ pref: { muted: true } }))).toBe('suppress');
+    expect(notificationOwner(input({ appVisible: false, pref: { muted: true } }))).toBe('suppress');
+  });
+
+  it('content=none + app hidden → still sw-notification (the SW badge-only path)', () => {
+    expect(notificationOwner(input({ appVisible: false, pref: { content: 'none' } }))).toBe('sw-notification');
+  });
+
+  it('content=none + visible → suppress (badge-only, no banner)', () => {
+    expect(notificationOwner(input({ pref: { content: 'none' } }))).toBe('suppress');
+  });
+
+  it('a push-woken item bypasses the settle window (visible → still page-banner)', () => {
+    expect(notificationOwner(input({ inSettleWindow: true, pushWoken: true }))).toBe('page-banner');
+  });
+
+  it('a non-push item inside the settle window is suppressed', () => {
+    expect(notificationOwner(input({ inSettleWindow: true, pushWoken: false }))).toBe('suppress');
+  });
+
+  it('locked page never claims the alert → hands off to the SW', () => {
+    expect(notificationOwner(input({ unlocked: false }))).toBe('sw-notification');
+    // even visible, a locked page can't show content, so the SW owns it
+    expect(notificationOwner(input({ unlocked: false, appVisible: true }))).toBe('sw-notification');
+  });
+
+  it('in-app banners off for this chat (visible) → suppress', () => {
+    expect(notificationOwner(input({ pref: { inApp: false } }))).toBe('suppress');
+  });
+
+  it('per-chat web push off + hidden → suppress (no OS notification)', () => {
+    expect(notificationOwner(input({ appVisible: false, pref: { webPush: false } }))).toBe('suppress');
+  });
+
+  it("generic content still yields a page-banner when visible (text is masked, not the banner)", () => {
+    expect(notificationOwner(input({ pref: { content: 'generic' } }))).toBe('page-banner');
+  });
+});

--- a/src/services/notify-policy.ts
+++ b/src/services/notify-policy.ts
@@ -1,0 +1,100 @@
+/**
+ * notify-policy — the single, deterministic predicate the live page (notify.ts)
+ * and the service worker (sw.ts / sw-inbox.ts) BOTH agree on for "who owns the
+ * user-visible alert for this incoming message?".
+ *
+ * Why this exists: the page and the SW each independently decide whether to show
+ * something for a message, then hand off via `ring:drain` / `ring:handled`. When
+ * the two sides reason about visibility / settle-window / per-chat prefs with
+ * subtly different logic, the SAME chat randomly shows real content, a generic
+ * "New message", or nothing — depending on which side won the race (spec 2010
+ * US2/US3). Centralizing the decision into one pure function makes the hand-off
+ * unambiguous: the page acks (claims) iff this returns 'page-banner' AND it
+ * actually rendered; otherwise the SW deterministically owns the OS notification.
+ *
+ * Pure: no DOM, no IndexedDB, no time — every input is passed in, so it's trivially
+ * unit-testable and behaves identically wherever it runs.
+ */
+
+/** Who should present the user-visible alert for one incoming message:
+ *  - 'page-banner'      → the live, foregrounded page shows an in-app banner; the
+ *                         SW must stay silent (no duplicate OS notification).
+ *  - 'sw-notification'  → the SW owns the OS notification (app hidden/closed). For
+ *                         content==='none' this is the badge-only path: the SW's
+ *                         existing per-chat handling shows no banner but still badges.
+ *  - 'suppress'         → no banner anywhere (active chat in view, or muted); the
+ *                         badge + any subtle sound are handled by the caller.
+ */
+export type NotifyOwner = 'page-banner' | 'sw-notification' | 'suppress';
+
+export interface NotifyInput {
+  /** The app document is foregrounded/visible right now. */
+  appVisible: boolean;
+  /** The keystore is unlocked (auto-unlock on / passcode entered). */
+  unlocked: boolean;
+  /** The user is currently viewing this exact chat. */
+  isActiveChat: boolean;
+  /** This item arrived because a push WOKE us (ring:drain). Such an item must
+   *  bypass the post-unlock settle window — it's a single woken delivery, not part
+   *  of the unlock banner burst the settle window is meant to damp. */
+  pushWoken: boolean;
+  /** The page's post-unlock settle suppression is currently active. */
+  inSettleWindow: boolean;
+  pref: {
+    /** Per-chat web push allowed (the OS-notification channel). */
+    webPush: boolean;
+    /** In-app banners allowed (global master AND per-chat in-app toggle). */
+    inApp: boolean;
+    /** Content visibility for this chat. */
+    content: 'full' | 'generic' | 'none';
+    /** Chat is muted. */
+    muted: boolean;
+  };
+}
+
+/**
+ * Decide who owns the alert. Mirrors the semantics already encoded in notify.ts
+ * (visible/hidden split, active-chat = sound-only, settle window) and in
+ * sw-inbox.ts (per-chat mute / web-push-off / content=none are intentional
+ * silences the SW handles as badge-only), but in ONE place both sides consult.
+ */
+export function notificationOwner(i: NotifyInput): NotifyOwner {
+  const { appVisible, unlocked, isActiveChat, pushWoken, inSettleWindow, pref } = i;
+
+  // Muted → never alert (the badge still counts it elsewhere). Highest-priority
+  // gate: a muted chat is silent whether the app is open or closed.
+  if (pref.muted) return 'suppress';
+
+  // While locked the page can't decrypt/show content, and must NOT claim the alert
+  // (otherwise it would swallow the message and the SW would stay silent). Hand off
+  // to the SW, which shows a generic placeholder per its userVisibleOnly contract.
+  if (!unlocked) return 'sw-notification';
+
+  // App is foregrounded and unlocked → the page is the natural owner.
+  if (appVisible) {
+    // Viewing this very chat → the user already sees the message; at most a subtle
+    // sound (handled by the caller). No banner, and the SW stays out of it.
+    if (isActiveChat) return 'suppress';
+    // The settle window damps the unlock banner BURST, but a push-woken delivery is
+    // a single discrete event and must not be swallowed — only suppress a non-woken
+    // item that lands inside the window.
+    if (inSettleWindow && !pushWoken) return 'suppress';
+    // In-app banners turned off for this chat (or globally) → no banner. The page
+    // doesn't claim it; since the app is visible the SW also won't fire (its own
+    // closed-app gate), so this is effectively suppressed on the page side.
+    if (!pref.inApp) return 'suppress';
+    // content==='none' is badge-only: reveal nothing anywhere, not even a banner.
+    if (pref.content === 'none') return 'suppress';
+    // Otherwise the page shows the in-app banner (content 'full' or 'generic';
+    // 'generic' masks the text but may still head with the sender name).
+    return 'page-banner';
+  }
+
+  // App is hidden/closed → the OS notification is the only channel. The SW owns it
+  // (the page's notifyLocal hand-off is removed in favor of the SW per spec 2010).
+  // Per-chat web-push-off → no OS notification (the SW enforces this as badge-only).
+  if (!pref.webPush) return 'suppress';
+  // content==='none' stays 'sw-notification' so the SW runs its existing none-handling
+  // (no banner, badge only) rather than us second-guessing it here.
+  return 'sw-notification';
+}

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -23,9 +23,10 @@ import router from '@/router';
 import { getSetting, isChatMuted, getChat } from '@/db/queries';
 import { subscribe } from '@/db/idb';
 import { notifyLocal } from '@/services/push';
-import { inAppGloballyEnabled, getChatNotifyPrefs, type ChatNotifyContent } from '@/services/notify-prefs';
+import { inAppGloballyEnabled, getChatNotifyPrefs } from '@/services/notify-prefs';
 import { isUnlockedNow } from '@/services/crypto/identity';
 import { playTone } from '@/services/sound';
+import { notificationOwner } from '@/services/notify-policy';
 
 /* ---- cached notification preferences ---- */
 
@@ -91,6 +92,13 @@ export interface IncomingNotice {
   avatar?: string; // optional; messages resolve the chat avatar if omitted
   icon?: string; // system notices: the ionicon shown in the banner (defaults applied)
   url?: string; // system notices: optional deep-link target (default: Contacts tab)
+  // This item is being surfaced because a push WOKE the page (ring:drain). Such an
+  // item must bypass the post-unlock settle window (it's a single woken delivery,
+  // not part of the unlock banner burst the window is meant to damp), and its
+  // OS-notification channel is owned by the SW (which already fired for the push),
+  // so the page must not double up via notifyLocal. Set by the drain path (App.vue
+  // arms markPushWake(); receiveIncoming reads it through pushWakeActive()).
+  pushWoken?: boolean;
 }
 
 /* ---- in-app notification banners (custom green overlay; see NotificationBanners.vue) ---- */
@@ -276,6 +284,46 @@ export function deferNotificationsFor(ms: number): void {
   settledUntil = Date.now() + ms;
 }
 
+/* ---- push-wake window + banner-presented hand-off (spec 2010 US2/US3) ---- */
+
+// A ring:drain push woke the page. For a brief window after, an arriving message is
+// treated as `pushWoken` so it (a) bypasses the settle window above and (b) does not
+// also fire notifyLocal — the SW already owns the OS notification for that push.
+// receiveIncoming (queries.ts) stamps `pushWoken` onto the notice from this window.
+let pushWakeUntil = 0;
+const PUSH_WAKE_WINDOW_MS = 12_000; // comfortably covers the SW fetch+decrypt+drain budget
+export function markPushWake(): void {
+  pushWakeUntil = Date.now() + PUSH_WAKE_WINDOW_MS;
+}
+export function pushWakeActive(): boolean {
+  return Date.now() < pushWakeUntil;
+}
+
+// The page<->SW hand-off ack must be tied to whether the page ACTUALLY rendered an
+// in-app banner for a drained message — not merely to "we're unlocked" (the old,
+// ambiguous gate that acked even when the settle window / visibility race then
+// dropped the banner, leaving NO alert at all). App.vue subscribes a callback for a
+// ring:drain's lifetime; notifyIncoming fires it the instant it presents a banner,
+// so the page acks (claims the alert) only when it truly showed something. If no
+// banner renders within the window, no ack → the SW deterministically owns it.
+type BannerPresentedCb = () => void;
+const bannerPresentedCbs = new Set<BannerPresentedCb>();
+/** Register a listener fired whenever notifyIncoming presents a visible in-app
+ *  banner for a message. Returns an unsubscribe. */
+export function onBannerPresented(cb: BannerPresentedCb): () => void {
+  bannerPresentedCbs.add(cb);
+  return () => bannerPresentedCbs.delete(cb);
+}
+function notifyBannerPresented(): void {
+  for (const cb of [...bannerPresentedCbs]) {
+    try {
+      cb();
+    } catch {
+      /* a listener error must never break alert presentation */
+    }
+  }
+}
+
 function appVisible(): boolean {
   return typeof document !== 'undefined' && document.visibilityState === 'visible';
 }
@@ -307,76 +355,124 @@ async function inAppSoundAndHaptics(): Promise<void> {
   }
 }
 
-/** Decide and present the alerting for one incoming item. */
-export async function notifyIncoming(n: IncomingNotice): Promise<void> {
+/**
+ * Decide and present the alerting for one incoming item.
+ *
+ * Returns true iff the page presented a VISIBLE in-app banner/alert for it. The
+ * caller (App.vue's ring:drain hand-off) uses that to ack `ring:handled` only when
+ * the page truly showed something — so the SW deterministically owns the OS
+ * notification in every case where the page didn't (hidden / suppressed / a
+ * locked or settle-swallowed page). This is the core spec-2010 fix: the old code
+ * acked the moment it saw "unlocked", then often dropped the banner (settle window
+ * / visibility race), leaving no alert at all.
+ */
+export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
   // Never surface anything while the keystore is locked (behind the passcode gate).
-  if (!isUnlockedNow()) return;
-  // The settle window suppresses the message/request banner BURST right after landing
-  // (as the gate dismisses / queued messages drain). A 'system' notice (e.g. "X joined
-  // Ring") is a single gated event, not part of that burst, and it fires exactly once —
-  // so don't let the settle window silently swallow it.
-  if (n.kind !== 'system' && Date.now() < settledUntil) return;
-  // Per-chat mute suppresses all alerting for this chat (the message still arrives
-  // and grows the unread badge). Requests have no chat to mute.
-  if (n.chatId && (await isChatMuted(n.chatId))) return;
-  // Per-chat notification controls (spec 1015): content visibility + in-app toggle.
-  // A friend request / system notice has no chat, so it uses the defaults (web push
-  // on, in-app on, content full).
-  const chatPrefs = n.chatId ? await getChatNotifyPrefs(n.chatId) : null;
-  const content: ChatNotifyContent = chatPrefs?.content ?? 'full';
-  // content = 'none' → badge-only: reveal nothing, anywhere (no banner, no system
-  // notification, no lock-screen text). The badge still updates elsewhere (FR-024).
-  if (content === 'none') return;
-  // content = 'generic' → fire a placeholder with no message text (sender name is
-  // not message content, so it may still head the notice, matching showPreview=off).
-  const showFull = content === 'full';
+  if (!isUnlockedNow()) return false;
+
+  // ---- The 'message' kind: decide via the shared notify-policy predicate so the
+  // page and the SW reason about visibility / settle / per-chat prefs IDENTICALLY.
+  // (Requests / system notices have no chat and always-surface semantics — handled
+  // below the predicate, unchanged.)
+  if (n.kind === 'message') {
+    const p = await ensurePrefs();
+    if (!p.showMessages) return false; // the global "Show notifications" toggle
+    const [muted, chatPrefs, globalInApp] = await Promise.all([
+      n.chatId ? isChatMuted(n.chatId) : Promise.resolve(false),
+      n.chatId ? getChatNotifyPrefs(n.chatId) : Promise.resolve(null),
+      inAppGloballyEnabled(),
+    ]);
+    const content = chatPrefs?.content ?? 'full';
+    const owner = notificationOwner({
+      appVisible: appVisible(),
+      unlocked: true, // isUnlockedNow() was checked above
+      isActiveChat: !!n.chatId && n.chatId === activeChatId && appVisible(),
+      pushWoken: !!n.pushWoken,
+      inSettleWindow: Date.now() < settledUntil,
+      pref: {
+        webPush: chatPrefs?.webPush ?? true,
+        // In-app banners need BOTH the global master switch and the per-chat toggle.
+        inApp: globalInApp && (chatPrefs?.inApp ?? true),
+        content,
+        muted,
+      },
+    });
+
+    if (owner === 'suppress') {
+      // Viewing this chat while visible → still give a subtle sound (the user sees
+      // the message inline). Every other suppress reason (muted / content=none /
+      // in-app off / settle-swallowed) is fully silent.
+      if (n.chatId && n.chatId === activeChatId && appVisible()) await inAppSoundAndHaptics();
+      return false;
+    }
+    if (owner === 'sw-notification') {
+      // The SW owns the OS notification. For a PUSH-WOKEN drain the SW already fired
+      // for that push, so the page must NOT also notifyLocal (that double-up + the
+      // visibilityState race in notifyLocal were a source of the random "content vs
+      // nothing"). For a live, hidden, NON-woken delivery (connected tab, no push),
+      // the SW never ran, so the page still bridges it via notifyLocal — the
+      // connected-but-hidden gap the OS push doesn't cover.
+      // content='none' is badge-only (no OS text anywhere), so it never bridges via
+      // notifyLocal even though the predicate routes it through 'sw-notification'
+      // (the SW's own none-handling keeps it badge-only there).
+      if (!n.pushWoken && content !== 'none') {
+        const showFull = content === 'full' && p.showPreview;
+        void notifyLocal(n.name, showFull ? n.body : 'New message', targetUrl(n), n.chatId);
+      }
+      return false;
+    }
+
+    // owner === 'page-banner': show the in-app banner/alert.
+    const showFull = content === 'full' && p.showPreview;
+    await inAppSoundAndHaptics();
+    if (p.inappStyle === 'none') return false; // sound only; no visible surface
+    const url = targetUrl(n);
+    const bodyText = showFull ? n.body : 'New message';
+    const presented = await presentMessageBanner(n, bodyText, url, p.inappStyle);
+    if (presented) notifyBannerPresented(); // tell the drain hand-off we claimed it
+    return presented;
+  }
+
+  // ---- Requests / system notices: always-surface, no chat (defaults: content full,
+  // in-app on). The settle window still damps a request banner burst, but a 'system'
+  // notice (e.g. "X joined Ring") is a single gated event, so it isn't swallowed.
+  if (n.kind !== 'system' && Date.now() < settledUntil) return false;
   const p = await ensurePrefs();
-  // Backgrounded: hand off to an OS notification (covers the connected-but-hidden
-  // gap; truly-offline is covered by the server push). Requests always notify;
-  // message notifications respect "Show notifications".
+  const full = p.showPreview;
   if (!appVisible()) {
-    if (n.kind === 'message' && !p.showMessages) return;
-    const full = showFull && p.showPreview;
     let title: string;
     let body: string;
     if (n.kind === 'request') {
       title = 'Friend request';
       body = full ? `${n.name} ${n.body}` : 'New request';
-    } else if (n.kind === 'system') {
+    } else {
       title = 'Ring';
       body = `${n.name} ${n.body}`; // e.g. "Ada joined Ring"
-    } else {
-      title = n.name;
-      body = full ? n.body : 'New message';
     }
-    // Pass chatId so the page- and SW-shown notifications for one conversation
-    // share a tag and collapse instead of duplicating.
     void notifyLocal(title, body, targetUrl(n), n.chatId);
-    return;
+    return false;
   }
-
-  // Focused on the very chat this message belongs to → no banner; subtle sound.
-  if (n.kind === 'message' && n.chatId && n.chatId === activeChatId) {
-    await inAppSoundAndHaptics();
-    return;
-  }
-
-  // In-app banner path. Gated by the GLOBAL in-app master switch (FR-018; this also
-  // suppresses friend-request banners while leaving their web push intact) and by
-  // the PER-CHAT in-app toggle (FR-019). Both leave the badge + system push alone.
-  if (!(await inAppGloballyEnabled())) return;
-  if (chatPrefs && !chatPrefs.inApp) return;
-
-  const style = p.inappStyle;
+  // Visible: gated by the GLOBAL in-app master switch (FR-018; suppresses request
+  // banners while leaving their web push intact).
+  if (!(await inAppGloballyEnabled())) return false;
   await inAppSoundAndHaptics();
-  if (style === 'none') return;
-
-  const headline = n.kind === 'request' ? `${n.name} wants to connect` : n.name;
+  if (p.inappStyle === 'none') return false;
   const url = targetUrl(n);
-  // For a 'generic' chat, mask the message text in the banner/alert too (no preview).
-  const bodyText = showFull ? n.body : n.kind === 'message' ? 'New message' : '';
+  const bodyText = full ? n.body : '';
+  return presentMessageBanner(n, bodyText, url, p.inappStyle);
+}
 
+/** Present the visible banner/alert surface for one notice. Returns true once a
+ *  banner is shown (or an alert is presented). Factored out so notifyIncoming's
+ *  per-kind branches share one renderer (avatar resolution, alert vs banner style). */
+async function presentMessageBanner(
+  n: IncomingNotice,
+  bodyText: string,
+  url: string,
+  style: string,
+): Promise<boolean> {
   if (style === 'alerts') {
+    const headline = n.kind === 'request' ? `${n.name} wants to connect` : n.name;
     const a = await alertController.create({
       header: headline,
       message: n.kind === 'request' ? undefined : bodyText,
@@ -386,9 +482,8 @@ export async function notifyIncoming(n: IncomingNotice): Promise<void> {
       ],
     });
     await a.present();
-    return;
+    return true;
   }
-
   // Default: a banner showing the chat avatar (or an icon for requests / system
   // notices) + name + preview, auto-dismissing, tap to open (see
   // NotificationBanners.vue). Resolve the chat's avatar for a message; a request /
@@ -399,4 +494,5 @@ export async function notifyIncoming(n: IncomingNotice): Promise<void> {
   }
   const icon = n.icon ?? (n.kind === 'system' ? DEFAULT_SYSTEM_ICON : undefined);
   showBanner({ kind: n.kind, name: n.name, body: bodyText, avatar, icon, url, chatId: n.chatId });
+  return true;
 }

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -257,10 +257,20 @@ export async function previewPending(): Promise<PreviewResult> {
     return { notes: [], pending: 0, suppressed: false, silenced: false };
   }
 
-  // Fetch the queue FIRST, before any decryption or settings gate. Fetching is
-  // what tells the server the device received these frames (→ "delivered"
-  // receipts), so it must happen even if we later withhold or can't decrypt.
-  // Bounded so a cold-start fetch can't hang the handler.
+  // Kick the device unlock NOW, IN PARALLEL with the fetch below (spec 2010
+  // root-cause c). attemptDeviceUnlock awaits libsodium's WASM init (`ready()`) then
+  // unwraps the device bundle — on a cold wake (evicted SW) that init + unwrap is
+  // pure CPU with no network, so overlapping it with the network round-trip hides its
+  // latency inside the fetch instead of paying it serially AFTER, which used to push
+  // the first decrypt past the GENERIC_AFTER_MS budget → a stranded generic. We still
+  // AWAIT it before any decrypt below, so correctness is unchanged (never decrypt
+  // before the key is ready).
+  const unlockReady = attemptDeviceUnlock().catch(() => false);
+
+  // Fetch the queue, before any decryption or settings gate. Fetching is what tells
+  // the server the device received these frames (→ "delivered" receipts), so it must
+  // happen even if we later withhold or can't decrypt. Bounded so a cold-start fetch
+  // can't hang the handler.
   let frames: MsgFrame[] = [];
   try {
     const ctrl = new AbortController();
@@ -294,8 +304,10 @@ export async function previewPending(): Promise<PreviewResult> {
 
   // Now decrypt for the rich preview. PIN/passkey-locked (no device key) → generic
   // (the frames were still fetched above, so the sender already got "delivered").
-  // Runs AFTER the fetch so a stalled libsodium init can't block delivery.
-  if (!(await attemptDeviceUnlock())) {
+  // Awaits the unlock kicked off in parallel above (its init overlapped the fetch),
+  // so a stalled libsodium init never blocks delivery and a cold start doesn't pay
+  // unlock latency serially after the fetch.
+  if (!(await unlockReady)) {
     console.warn('[sw-inbox] device unlock failed (PIN-locked?) → generic');
     // Can't tell a message from a request → let the caller show a generic, UNLESS
     // the user disabled message notifications (then stay silent rather than buzz).

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -79,8 +79,16 @@ const GENERIC_TAG = 'ring-incoming';
 // before decryption we cannot know it without the server knowing it (which would
 // break E2EE). "New message" is the privacy-correct placeholder; the per-type
 // preview (notify-preview.ts) appears only once decryption succeeds and upgrades it.
-const GENERIC_AFTER_MS = 6000;
-const SETTLE_MAX_MS = 9000;
+// GENERIC_AFTER_MS: how long to wait for a decrypted preview before posting the
+// generic placeholder. SETTLE_MAX_MS: the outer window we keep awaiting so a late
+// preview UPGRADES that placeholder. SETTLE_MAX_MS must COMFORTABLY EXCEED
+// sw-inbox's PENDING_FETCH_TIMEOUT_MS (8000) — otherwise a decrypt that lands late
+// in the fetch budget (≥ GENERIC_AFTER_MS but the fetch only resolves near 8s) was
+// stranded as a permanent generic because the settle window closed before it could
+// upgrade (spec 2010 root-cause b). 12000 > 8000 leaves headroom for the decrypt +
+// the closeByTag/showNotes upgrade after the fetch resolves.
+const GENERIC_AFTER_MS = 7000;
+const SETTLE_MAX_MS = 12000;
 // Straggler catch-up after the first preview. In the background the page is
 // suspended, so a queued message only earns its 'delivered' receipt when the SW
 // fetches the pending queue (the server emits 'delivered' for every queued frame on
@@ -458,7 +466,12 @@ self.addEventListener('push', (event) => {
       }
       // Let a live, unlocked page own the notification (avoids a duplicate); the SW
       // shows it only when no page claims it within the window (closed/locked/frozen).
-      if (clients.length && (await pageWillNotify(clients, 1200))) return;
+      // The page now acks only once it ACTUALLY renders an in-app banner (spec 2010),
+      // which can trail a cold reconnect+decrypt, so wait a touch longer than the old
+      // 1200ms — comfortably above the page's own DRAIN_ACK_WINDOW so a page that will
+      // show a banner reliably claims it, while a hidden/locked/frozen page (which
+      // never acks) still falls through to the SW promptly enough.
+      if (clients.length && (await pageWillNotify(clients, 2200))) return;
       await showMessageNotification();
     })(),
   );


### PR DESCRIPTION
## Spec 2010 — Navigation & notification robustness

Two recurring robustness defects in the installed PWA, fixed together (client-only, zero-knowledge intact, no server change).

### Navigation (US1) — back-swipe never escapes into a blank browser view
The installed iOS PWA gets its own OS edge-swipe back gesture that no web API can disable, and the app deliberately lands at browser-history depth 1 at the tab roots — so that swipe could underflow *past* `start_url` into a blank browser view (chrome inside the app shell). There was also no catch-all route, so any unmatched path rendered blank.
- **Catch-all route** `{ path: '/:pathMatch(.*)*', redirect: '/tabs/chats' }` → no path ever renders blank.
- **One base history-entry seed at boot** so the first OS-back pops to an in-app screen and the user stays in the app. Stock routing — no popstate gesture interception; `swipeBackEnabled` + the terminal-tab flattening are untouched.

### Notifications (US2/US3) — consistent content, exactly one alert
The same chat randomly showed real decrypted content vs a generic "New message" even when unlocked, because the page acked "I'll handle it" to the service worker the instant it saw it was unlocked — then often dropped the banner (post-unlock settle window / visibility race / idle transport), so neither side alerted; and the SW's generic timeout could strand a placeholder.
- **New pure `notify-policy` predicate** the page and SW both consult (`page-banner` / `sw-notification` / `suppress`) with 12 unit tests.
- **Deterministic hand-off:** the page acks `ring:handled` only when it actually renders an in-app banner; otherwise the SW owns the OS notification. Push-woken messages bypass the settle window and defer the OS notification to the SW (no page/SW duplicate, no miss).
- **SW timing:** `SETTLE_MAX_MS` now exceeds the relay-fetch timeout so a late decrypt always upgrades the generic; device-unlock runs in parallel with the fetch to cut cold-start latency.

### Zero-knowledge / constraints
No content in the push payload; the SW still fetches the sealed message over the existing relay and decrypts on-device. No server, DB, migration, or new-frame changes. iOS still gets a `showNotification` per push. No new user settings.

### Testing
- **334 client unit tests** green (incl. the 12-case notify-policy suite).
- Build/typecheck ✓, server build/vet/test ✓.
- e2e: `navigation` (3 ✓, incl. new catch-all + back-stays-in-app) and `notifications-inapp` + `sw-decrypt` (5 ✓) green locally; full suite re-verified in CI.
- Remaining manual check (T015): on-device iOS confirmation of the notification-per-push / badge-only path and a tab-root back-swipe — to do on the dev deployment.

Closes #434
Closes #435
Closes #436
Closes #437
Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
