### PR TITLE
fix(call): a call survives the callee reloading mid-ring, and ringing tells the truth

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,4 +57,4 @@ Specs are grouped by category band; status moves
 | [2009](specs/2009-single-call-waiting-slot/spec.md) | Only one caller may wait in call-waiting; further callers get busy | 🔵 in-review |
 | [2010](specs/2010-nav-notification-robustness/spec.md) | Navigation & notification robustness | 🔵 in-review |
 | [2011](specs/2011-hold-ui-and-1to1-diag/spec.md) | Call on-hold visualization & 1:1 diagnostics | 🔵 in-review |
-| [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | ⚪ planned |
+| [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,3 +57,4 @@ Specs are grouped by category band; status moves
 | [2009](specs/2009-single-call-waiting-slot/spec.md) | Only one caller may wait in call-waiting; further callers get busy | 🔵 in-review |
 | [2010](specs/2010-nav-notification-robustness/spec.md) | Navigation & notification robustness | 🔵 in-review |
 | [2011](specs/2011-hold-ui-and-1to1-diag/spec.md) | Call on-hold visualization & 1:1 diagnostics | 🔵 in-review |
+| [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | ⚪ planned |

--- a/e2e/call-waiting.spec.ts
+++ b/e2e/call-waiting.spec.ts
@@ -9,7 +9,7 @@ import {
 
 /** Set up the common state: A↔B connected (1:1), then C calls A and A accepts-and-holds, so
  *  A↔C is ACTIVE and A↔B is HELD (B sees on hold). Returns the clients + a cleanup. */
-async function twoCalls(browser: Browser, tag: string): Promise<{ a: RingClient; b: RingClient; c: RingClient; close: () => Promise<void> }> {
+async function twoCalls(browser: Browser, tag: string, kind: 'audio' | 'video' = 'audio'): Promise<{ a: RingClient; b: RingClient; c: RingClient; close: () => Promise<void> }> {
   const ctxA = await browser.newContext();
   const ctxB = await browser.newContext();
   const ctxC = await browser.newContext();
@@ -18,11 +18,11 @@ async function twoCalls(browser: Browser, tag: string): Promise<{ a: RingClient;
   const c = await createAccount(ctxC, `${tag}C`);
   await pair(a, b);
   await pair(a, c);
-  await startCall(a, b.id, 'audio');
+  await startCall(a, b.id, kind);
   await waitCallState(b, ['incoming']);
   await accept(b);
   await waitCallState(a, ['connected']);
-  await startCall(c, a.id, 'audio');
+  await startCall(c, a.id, kind);
   await a.page.waitForFunction(() => (window as any).__ringTest.hasSecondIncoming() === true, null, { timeout: 15_000 });
   await acceptAndHold(a);
   await waitCallState(a, ['connected']);
@@ -349,10 +349,10 @@ test('FR-010: a held-then-resumed call logs as ONE history entry (hold/swap/resu
   await ctxC.close();
 });
 
-test('the party coming off hold gets a resume countdown before going live again', async ({ browser }) => {
-  // A↔B connected; A takes a 2nd call from C (B held); A drops C → returns to B, which RESUMES B.
-  // B (the held party) should see a countdown before its camera/mic go live, then it clears.
-  const { a, b, c, close } = await twoCalls(browser, 'CWRC');
+test('a VIDEO call coming off hold gets a resume countdown before the camera goes live', async ({ browser }) => {
+  // A↔B VIDEO; A takes a 2nd call from C (B held); A drops C → returns to B, which RESUMES B.
+  // B (the held party) should see a countdown before its camera goes live again, then it clears.
+  const { a, b, c, close } = await twoCalls(browser, 'CWRC', 'video');
   // While A is on C, B is held: B's outgoing is paused and B is not yet counting down.
   expect(await resumeCountdown(b)).toBeNull();
   expect(await isRemoteHeld(b)).toBe(true);
@@ -370,6 +370,27 @@ test('the party coming off hold gets a resume countdown before going live again'
 
   // After the countdown elapses it clears and the call carries on connected.
   await b.page.waitForFunction(() => (window as any).__ringTest.resumeCountdown() === null, null, { timeout: 10_000 });
+  expect(await callState(b)).toBe('connected');
+  expect(await callState(a)).toBe('connected');
+
+  await hangup(a);
+  await close();
+});
+
+test('an AUDIO call coming off hold resumes immediately with no "on camera" countdown (spec 2012)', async ({ browser }) => {
+  // The resume countdown is a heads-up before the CAMERA goes live; an audio call has no camera, so
+  // it must resume immediately with no countdown.
+  const { a, b, c, close } = await twoCalls(browser, 'CWRA', 'audio');
+  expect(await resumeCountdown(b)).toBeNull();
+  expect(await isRemoteHeld(b)).toBe(true);
+
+  await hangup(a); // drop C → A returns to the held call (B), resuming it
+  await waitCallState(c, ['idle', 'ended']);
+
+  // B resumes: the held/blur state clears, and because it's AUDIO there is NO countdown — it stays
+  // connected. (Poll remoteHeld to know the resume landed, then assert the countdown never armed.)
+  await b.page.waitForFunction(() => (window as any).__ringTest.isRemoteHeld() === false, null, { timeout: 10_000 });
+  expect(await resumeCountdown(b)).toBeNull();
   expect(await callState(b)).toBe('connected');
   expect(await callState(a)).toBe('connected');
 

--- a/server/internal/ws/call_test.go
+++ b/server/internal/ws/call_test.go
@@ -274,5 +274,169 @@ func TestGroupCallSecondJoinDoesNotRering(t *testing.T) {
 	}
 }
 
+// spec 2012 US1: a 1:1 offer delivered LIVE to an online callee is ALSO retained, so a callee
+// that reloads mid-ring (its in-memory call state and the offer lost) re-rings on reconnect via
+// flushBufferedCalls() and can still answer.
+func TestCallOfferReDeliveredToReloadedCallee(t *testing.T) {
+	srv, _ := newRelayServer()
+	defer srv.Close()
+
+	a := dial(t, srv, "tokA")
+	defer a.Close()
+	b := dial(t, srv, "tokB")
+	time.Sleep(50 * time.Millisecond)
+
+	// A calls B (online) → B gets it live, A flips to ringing.
+	if err := a.WriteJSON(map[string]any{
+		"t": "call-offer", "to": "user-b", "callId": "c-reload", "kind": "video", "ciphertext": "SDP_A",
+	}); err != nil {
+		t.Fatalf("A call-offer: %v", err)
+	}
+	if got := readFrame(t, b); got["t"] != "call-offer" || got["callId"] != "c-reload" {
+		t.Fatalf("B expected live call-offer, got: %v", got)
+	}
+	if got := readFrame(t, a); got["t"] != "call-ringing" {
+		t.Fatalf("A expected call-ringing, got: %v", got)
+	}
+
+	// B reloads: drop its socket and reconnect (call still active).
+	b.Close()
+	time.Sleep(50 * time.Millisecond)
+	b2 := dial(t, srv, "tokB")
+	defer b2.Close()
+
+	// The retained offer is re-delivered → B's incoming-call screen comes back.
+	got := readFrame(t, b2)
+	if got["t"] != "call-offer" || got["callId"] != "c-reload" || got["from"] != "user-a" {
+		t.Fatalf("reloaded B expected the recovered call-offer, got: %v", got)
+	}
+	if got["ciphertext"] != "SDP_A" {
+		t.Fatalf("recovered offer must carry the same opaque ciphertext, got: %v", got["ciphertext"])
+	}
+}
+
+// spec 2012 US1 FR-003: once a 1:1 call RESOLVES (here, B answers), its retained invite is
+// cleared, so a later B reconnect does NOT re-ring a call that's already over (no ghost ring).
+func TestResolvedCallNotReDeliveredOnReconnect(t *testing.T) {
+	srv, _ := newRelayServer()
+	defer srv.Close()
+
+	a := dial(t, srv, "tokA")
+	defer a.Close()
+	b := dial(t, srv, "tokB")
+	time.Sleep(50 * time.Millisecond)
+
+	if err := a.WriteJSON(map[string]any{
+		"t": "call-offer", "to": "user-b", "callId": "c-done", "kind": "audio", "ciphertext": "SDP_A",
+	}); err != nil {
+		t.Fatalf("A call-offer: %v", err)
+	}
+	if got := readFrame(t, b); got["t"] != "call-offer" {
+		t.Fatalf("B expected live call-offer, got: %v", got)
+	}
+	if got := readFrame(t, a); got["t"] != "call-ringing" {
+		t.Fatalf("A expected call-ringing, got: %v", got)
+	}
+
+	// B answers → the call is settled; the retained invite must be cleared.
+	if err := b.WriteJSON(map[string]any{"t": "call-answer", "to": "user-a", "callId": "c-done", "ciphertext": "SDP_B"}); err != nil {
+		t.Fatalf("B call-answer: %v", err)
+	}
+	if got := readFrame(t, a); got["t"] != "call-answer" {
+		t.Fatalf("A expected call-answer, got: %v", got)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// B reconnects later → NO ghost incoming call for the settled c-done.
+	b.Close()
+	time.Sleep(50 * time.Millisecond)
+	b2 := dial(t, srv, "tokB")
+	defer b2.Close()
+	_ = b2.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+	if _, _, err := b2.ReadMessage(); err == nil {
+		t.Fatal("reconnecting B must NOT re-ring a call that was already answered")
+	}
+}
+
+// spec 2012 US2 FR-005: when the callee's socket drops mid-ring and they do NOT re-ack within
+// the grace, the caller is told the callee is unreachable (call-end{reason:"unreachable"}) so it
+// ends promptly instead of ringing out the full no-answer window.
+func TestCallerNotifiedWhenCalleeVanishes(t *testing.T) {
+	defer ws.SetRingDropGraceForTest(150 * time.Millisecond)()
+	srv, _ := newRelayServer()
+	defer srv.Close()
+
+	a := dial(t, srv, "tokA")
+	defer a.Close()
+	b := dial(t, srv, "tokB")
+	time.Sleep(50 * time.Millisecond)
+
+	if err := a.WriteJSON(map[string]any{
+		"t": "call-offer", "to": "user-b", "callId": "c-gone", "kind": "video", "ciphertext": "SDP_A",
+	}); err != nil {
+		t.Fatalf("A call-offer: %v", err)
+	}
+	if got := readFrame(t, b); got["t"] != "call-offer" {
+		t.Fatalf("B expected live call-offer, got: %v", got)
+	}
+	if got := readFrame(t, a); got["t"] != "call-ringing" {
+		t.Fatalf("A expected call-ringing, got: %v", got)
+	}
+
+	// B vanishes (closes and does NOT come back) → after the grace, A is told it's unreachable.
+	b.Close()
+	got := readFrame(t, a) // readFrame allows up to 2s; the 150ms grace fires well within it
+	if got["t"] != "call-end" || got["reason"] != "unreachable" || got["callId"] != "c-gone" {
+		t.Fatalf("A expected call-end{reason:unreachable} for c-gone, got: %v", got)
+	}
+}
+
+// spec 2012 US2 scenario 2 / FR-006: a callee that drops but reconnects, recovers the offer, and
+// re-acks ringing WITHIN the grace must NOT cause the caller's call to falsely end.
+func TestCallerNotEndedWhenCalleeReAcksWithinGrace(t *testing.T) {
+	defer ws.SetRingDropGraceForTest(700 * time.Millisecond)()
+	srv, _ := newRelayServer()
+	defer srv.Close()
+
+	a := dial(t, srv, "tokA")
+	defer a.Close()
+	b := dial(t, srv, "tokB")
+	time.Sleep(50 * time.Millisecond)
+
+	if err := a.WriteJSON(map[string]any{
+		"t": "call-offer", "to": "user-b", "callId": "c-flap", "kind": "video", "ciphertext": "SDP_A",
+	}); err != nil {
+		t.Fatalf("A call-offer: %v", err)
+	}
+	if got := readFrame(t, b); got["t"] != "call-offer" {
+		t.Fatalf("B expected live call-offer, got: %v", got)
+	}
+	if got := readFrame(t, a); got["t"] != "call-ringing" {
+		t.Fatalf("A expected the initial call-ringing, got: %v", got)
+	}
+
+	// B reloads: drop, reconnect, receive the recovered offer, and re-ack by echoing call-ringing
+	// (the foregrounded in-app re-ack path) — all within the grace.
+	b.Close()
+	time.Sleep(50 * time.Millisecond)
+	b2 := dial(t, srv, "tokB")
+	defer b2.Close()
+	if got := readFrame(t, b2); got["t"] != "call-offer" || got["callId"] != "c-flap" {
+		t.Fatalf("reloaded B expected the recovered offer, got: %v", got)
+	}
+	if err := b2.WriteJSON(map[string]any{"t": "call-ringing", "to": "user-a", "callId": "c-flap"}); err != nil {
+		t.Fatalf("B re-ack call-ringing: %v", err)
+	}
+	// A receives the re-acked call-ringing (still reachable) ...
+	if got := readFrame(t, a); got["t"] != "call-ringing" || got["callId"] != "c-flap" {
+		t.Fatalf("A expected the re-acked call-ringing, got: %v", got)
+	}
+	// ... and must NOT subsequently receive a terminal unreachable frame (grace was cancelled).
+	_ = a.SetReadDeadline(time.Now().Add(900 * time.Millisecond))
+	if _, data, err := a.ReadMessage(); err == nil {
+		t.Fatalf("A must NOT receive a terminal frame after a within-grace re-ack, got: %s", data)
+	}
+}
+
 // NOTE: the SFU-era call-key-request / call-streamid relays were removed with the SFU
 // (spec 0004 US6) — the mesh distributes nothing of the sort, so those tests are gone.

--- a/server/internal/ws/hub.go
+++ b/server/internal/ws/hub.go
@@ -159,6 +159,30 @@ type Hub struct {
 	// removed and the roster re-broadcast (call dropped, no auto-recall). Keyed "room\x00user".
 	evictMu     sync.Mutex
 	evictTimers map[string]*time.Timer
+	// Active 1:1 rings + the "callee went unreachable" grace timers behind US2 (honest
+	// ringing). activeRings tracks every in-flight 1:1 offer (caller↔callee↔callId) — unlike
+	// callRings (which only exists when the callee is push-rung) it's recorded for ALL offers,
+	// including an online/foregrounded callee, so a mid-ring reload of exactly that callee is
+	// covered. When a callee's LAST socket drops we start a short grace timer per active ring;
+	// if they reconnect and re-ack ringing within it (recovered offer re-flushes → re-ring →
+	// AckCallReachable) we cancel it, otherwise we tell the caller the callee is unreachable so
+	// it ends promptly instead of ringing into the void for the full no-answer window.
+	ringMu2     sync.Mutex
+	activeRings map[string]activeRing // callId → caller/callee
+	dropTimers  map[string]*time.Timer
+}
+
+// ringDropGrace is how long the caller keeps "ringing" after the callee's last socket drops,
+// before being told the callee is unreachable. Long enough for a fast reload to reconnect,
+// re-flush the recovered offer, re-ring, and re-ack (US2 scenario 2); short enough that a
+// genuinely-gone callee ends the caller's call in a few seconds, not the ~60s no-answer
+// backstop. var (not const) so tests can shrink it; production value is unchanged.
+var ringDropGrace = 8 * time.Second
+
+// activeRing is one in-flight 1:1 ring tracked for the US2 unreachable-callee teardown.
+type activeRing struct {
+	caller string
+	callee string
 }
 
 // callRecoveryGrace is how long a disconnected participant is held in a call room before
@@ -201,9 +225,12 @@ const (
 )
 
 // bufferedCall is a call offer held for a few seconds so a push-woken device
-// that reconnects still receives it (background ringing).
+// that reconnects still receives it (background ringing). callID (when known) lets
+// the buffer be cleared per-call once that call resolves, so a settled/declined
+// invite can't re-ring on a later reconnect (spec 2012 US1); empty for group invites.
 type bufferedCall struct {
 	payload []byte
+	callID  string
 	exp     time.Time
 }
 
@@ -228,6 +255,8 @@ func NewHub() *Hub {
 		callRings:   make(map[string]*callRing),
 		groupRings:  make(map[string]map[string]context.CancelFunc),
 		evictTimers: make(map[string]*time.Timer),
+		activeRings: make(map[string]activeRing),
+		dropTimers:  make(map[string]*time.Timer),
 	}
 }
 
@@ -363,6 +392,116 @@ func (h *Hub) AckCallReachable(callee string) {
 			h.Send(t.caller, payload)
 		}
 	}
+	// A fresh ring-ack from this callee means they're reachable again → cancel any pending
+	// "callee unreachable" grace for their rings, so a quick reload that re-rings within the
+	// grace doesn't falsely end the caller's call (spec 2012 US2 scenario 2).
+	h.cancelRingDropTimersForCallee(callee)
+}
+
+// trackRing records an in-flight 1:1 ring so the US2 drop-detection (cleanup) can find rings
+// where a vanished user is the callee. Recorded for EVERY 1:1 offer, including a live-delivered
+// one. Replaces any prior entry for the callId (idempotent re-offer).
+func (h *Hub) trackRing(caller, callee, callID string) {
+	if callID == "" || callee == "" {
+		return
+	}
+	h.ringMu2.Lock()
+	h.activeRings[callID] = activeRing{caller: caller, callee: callee}
+	h.ringMu2.Unlock()
+}
+
+// startRingDropTimer arms (or replaces) the grace timer for one ring after the callee's last
+// socket drops. On expiry — if nothing cancelled it (no re-ack within the grace) — it tells the
+// CALLER the callee is unreachable via a call-end{reason:"unreachable"} (a frame the caller
+// already tears down on while ringing), then forgets the ring. The lock is NOT held across the
+// timer callback; the callback re-locks only briefly to remove itself.
+func (h *Hub) startRingDropTimer(callID, caller string) {
+	if callID == "" {
+		return
+	}
+	h.ringMu2.Lock()
+	if old := h.dropTimers[callID]; old != nil {
+		old.Stop()
+	}
+	h.dropTimers[callID] = time.AfterFunc(ringDropGrace, func() {
+		h.ringMu2.Lock()
+		// Already cancelled/superseded? Then this fire is stale — do nothing.
+		if t := h.dropTimers[callID]; t == nil {
+			h.ringMu2.Unlock()
+			return
+		}
+		delete(h.dropTimers, callID)
+		delete(h.activeRings, callID)
+		h.ringMu2.Unlock()
+		// Grace elapsed without the callee re-acking → end the caller's call promptly with a
+		// clear outcome instead of the ~60s no-answer wait. Also stop the push ring loop so a
+		// backgrounded callee that returns later isn't buzzed for a call the caller has ended.
+		h.stopCallRing(callID)
+		if payload, err := json.Marshal(frame{T: "call-end", CallID: callID, Reason: "unreachable"}); err == nil {
+			h.Send(caller, payload)
+		}
+	})
+	h.ringMu2.Unlock()
+}
+
+// stopRingDropTimer cancels and forgets the grace timer + tracked ring for a callId (the call
+// resolved, or the callee re-acked). Safe if none exists.
+func (h *Hub) stopRingDropTimer(callID string) {
+	if callID == "" {
+		return
+	}
+	h.ringMu2.Lock()
+	if t := h.dropTimers[callID]; t != nil {
+		t.Stop()
+		delete(h.dropTimers, callID)
+	}
+	delete(h.activeRings, callID)
+	h.ringMu2.Unlock()
+}
+
+// cancelRingDropTimersForCallee cancels any pending grace timers whose callee just became
+// reachable again (re-acked ringing). Leaves the ring tracked (the call is still in-flight).
+func (h *Hub) cancelRingDropTimersForCallee(callee string) {
+	h.ringMu2.Lock()
+	for callID, r := range h.activeRings {
+		if r.callee != callee {
+			continue
+		}
+		if t := h.dropTimers[callID]; t != nil {
+			t.Stop()
+			delete(h.dropTimers, callID)
+		}
+	}
+	h.ringMu2.Unlock()
+}
+
+// ringDropOnCalleeGone is called from cleanup when a user's LAST socket drops: for every active
+// ring where they're the callee, start the grace timer. A still-connected callee (another
+// device) is unaffected. Snapshots under the lock, then arms timers (startRingDropTimer re-locks).
+func (h *Hub) ringDropOnCalleeGone(callee string) {
+	type pend struct{ callID, caller string }
+	var pending []pend
+	h.ringMu2.Lock()
+	for callID, r := range h.activeRings {
+		if r.callee == callee {
+			pending = append(pending, pend{callID, r.caller})
+		}
+	}
+	h.ringMu2.Unlock()
+	for _, p := range pending {
+		h.startRingDropTimer(p.callID, p.caller)
+	}
+}
+
+// stopAllRingDropTimers cancels every grace timer (hub shutdown / test cleanup) so no timer
+// goroutine leaks past the hub's life.
+func (h *Hub) stopAllRingDropTimers() {
+	h.ringMu2.Lock()
+	for callID, t := range h.dropTimers {
+		t.Stop()
+		delete(h.dropTimers, callID)
+	}
+	h.ringMu2.Unlock()
 }
 
 // ringMember rings ONE group-call invitee: the initial invite (live + buffered for a
@@ -376,7 +515,7 @@ func (c *Client) ringMember(roomID, member string, invite []byte) {
 		c.notifyAsync(member, true)
 	}
 	if !delivered {
-		c.hub.bufferCall(member, invite) // a push-woken reconnect still finds the invite
+		c.hub.bufferCall(member, "", invite) // a push-woken reconnect still finds the invite (group: cleared per-user)
 	}
 	c.hub.startGroupMemberRing(c.notifier, roomID, member, invite)
 }
@@ -497,8 +636,10 @@ func (h *Hub) forgetRingIfGone(userID string) {
 	h.ringMu.Unlock()
 }
 
-// bufferCall holds a call offer for `to` for a short TTL (expiring older ones).
-func (h *Hub) bufferCall(to string, payload []byte) {
+// bufferCall holds a call offer/ICE for `to` for a short TTL (expiring older ones).
+// callID tags the frame so the hold can later be cleared per-call when that call
+// resolves (empty for group invites, which are cleared per-user on join/leave/evict).
+func (h *Hub) bufferCall(to, callID string, payload []byte) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	now := time.Now()
@@ -508,7 +649,7 @@ func (h *Hub) bufferCall(to string, payload []byte) {
 			kept = append(kept, b)
 		}
 	}
-	buf := append(kept, bufferedCall{payload: payload, exp: now.Add(callBufferTTL)})
+	buf := append(kept, bufferedCall{payload: payload, callID: callID, exp: now.Add(callBufferTTL)})
 	// Bound the hold (offer + trickled ICE) so a chatty/abusive caller can't grow it without
 	// limit; a normal call setup is well under this. Dropping the oldest first is acceptable.
 	if len(buf) > maxBufferedCallFrames {
@@ -540,6 +681,35 @@ func (h *Hub) clearBufferedCalls(userID string) {
 	h.mu.Lock()
 	delete(h.callBuf, userID)
 	h.mu.Unlock()
+}
+
+// clearBufferedCallID drops only the held frames (offer + trickled ICE) for ONE 1:1 callId,
+// leaving any unrelated held offer intact. Called when a 1:1 call resolves
+// (answered/declined/cancelled/ended) so its now-retained invite can't re-ring the callee on a
+// later reconnect (spec 2012 US1 FR-003). callId-scoped because a 1:1 offer is now buffered
+// even when delivered live; we must forget it precisely when the call settles, not the user's
+// whole buffer.
+func (h *Hub) clearBufferedCallID(userID, callID string) {
+	if callID == "" {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	bufs := h.callBuf[userID]
+	if len(bufs) == 0 {
+		return
+	}
+	kept := bufs[:0]
+	for _, b := range bufs {
+		if b.callID != callID {
+			kept = append(kept, b)
+		}
+	}
+	if len(kept) == 0 {
+		delete(h.callBuf, userID)
+	} else {
+		h.callBuf[userID] = kept
+	}
 }
 
 // SharesCallRoom reports whether a and b are currently in a common call room. Used by the
@@ -868,6 +1038,14 @@ func (c *Client) cleanup() {
 		for _, roomID := range c.hub.rooms.RoomsForUser(c.userID) {
 			c.hub.scheduleEviction(roomID, c.userID)
 		}
+	}
+	// Honest ringing (spec 2012 US2): if this was the user's LAST socket and they're the callee
+	// of an in-flight 1:1 ring, start the grace timer. A fast reload that reconnects, re-flushes
+	// the recovered offer, re-rings and re-acks within the grace cancels it; otherwise the caller
+	// is told the callee is unreachable so it ends promptly. A user with another live device is
+	// still reachable, so no timer is armed.
+	if !c.hub.hasAnyConn(c.userID) {
+		c.hub.ringDropOnCalleeGone(c.userID)
 	}
 	_ = c.conn.Close()
 	// Only a genuine online→offline transition is a presence change. A
@@ -1241,6 +1419,11 @@ func (c *Client) handleFrame(data []byte) {
 		if payload == nil {
 			return
 		}
+		// Track this ring (caller↔callee↔callId) for the US2 honest-ringing drop detection —
+		// recorded for ALL offers, including a live-delivered one, so a mid-ring reload of an
+		// online callee is covered (the common case the bug report hit). Cleared when the call
+		// resolves or the unreachable grace fires.
+		c.hub.trackRing(c.userID, f.To, f.CallID)
 		delivered := c.hub.Send(f.To, payload)
 		if delivered {
 			// The callee has a live socket and just received the offer → it's reachable.
@@ -1262,28 +1445,32 @@ func (c *Client) handleFrame(data []byte) {
 			// which flips the caller's UI to "Ringing". Cancelled on answer/decline/end.
 			c.hub.startCallRing(c.notifier, c.userID, f.To, f.CallID)
 		}
-		// No live socket at all → hold the offer briefly so a push-woken device
-		// that reconnects still rings. The caller keeps ringing; its own dial
-		// timeout ends the call if nobody answers.
-		if !delivered {
-			c.hub.bufferCall(f.To, payload)
-		}
+		// Retain the offer briefly so a CALLEE THAT RECONNECTS still rings — whether it was
+		// offline (push-woken cold start) OR online but reloaded mid-ring (e.g. tapped an app
+		// update from the incoming-call screen), which destroys its in-memory call state and the
+		// offer client-side (spec 2012 US1). We buffer regardless of `delivered`: a live delivery
+		// already rang it once, but flushBufferedCalls() on its next connect re-delivers this so a
+		// reloaded callee re-rings and can still answer. The hold is callId-tagged and cleared when
+		// the call resolves (clearBufferedCallID), so a settled/declined call never re-rings. The
+		// caller keeps ringing; its own dial timeout (or US2 unreachable drop) ends the call.
+		c.hub.bufferCall(f.To, f.CallID, payload)
 
 	case "call-ringing", "call-answer", "call-ice", "call-accept",
 		"call-reject", "call-cancel", "call-busy", "call-end",
 		"call-upgrade-request", "call-upgrade-accept", "call-upgrade-reject":
 		// Pure live relay of the remaining 1:1 signalling (incl. the consent-gated
 		// audio<->video upgrade). The sender is authoritative; SDP/ICE stay E2EE'd.
-		delivered := c.relayCall(f)
-		// A 1:1 caller trickles its ICE candidates right after the offer. If the callee is
-		// briefly offline (backgrounded long enough — ~30s — that iOS suspended its socket),
-		// those candidates would be lost while only the offer is buffered, so an answered
-		// call could never connect. Buffer undelivered 1:1 ICE too, flushed (after the offer,
-		// in arrival order) when the device reconnects. Mesh ICE (roomId) is group signalling
-		// between already-present peers and stays live-only.
-		if !delivered && f.T == "call-ice" && f.RoomID == "" && f.To != "" {
+		c.relayCall(f)
+		// A 1:1 caller trickles its ICE candidates right after the offer. Retain 1:1 ICE
+		// alongside the offer so a callee that reconnects — whether it was offline (iOS
+		// suspended its socket) or reloaded mid-ring (spec 2012 US1) — receives the candidates
+		// too (flushed after the offer, in arrival order), otherwise an answered call could never
+		// connect. Buffered regardless of `delivered` and callId-tagged, mirroring the offer, so
+		// the whole hold is cleared together when the call resolves. Mesh ICE (roomId) is group
+		// signalling between already-present peers and stays live-only.
+		if f.T == "call-ice" && f.RoomID == "" && f.To != "" {
 			if rp := c.forwardedCallPayload(f); rp != nil {
-				c.hub.bufferCall(f.To, rp)
+				c.hub.bufferCall(f.To, f.CallID, rp)
 			}
 		}
 		// Once the callee engages (ringing/answered) or the call resolves, stop the
@@ -1291,6 +1478,29 @@ func (c *Client) handleFrame(data []byte) {
 		switch f.T {
 		case "call-ringing", "call-answer", "call-accept", "call-reject", "call-cancel", "call-busy", "call-end":
 			c.hub.stopCallRing(f.CallID)
+		}
+		// A callee echoing call-ringing (in-app, the foregrounded-reload re-ack path) means it's
+		// reachable again → cancel any pending US2 unreachable grace for its rings, so a quick
+		// reload that re-rings within the grace doesn't falsely end the caller's call (US2
+		// scenario 2). The HTTP /v1/call/ack push path already does this via AckCallReachable.
+		if f.T == "call-ringing" && f.RoomID == "" {
+			c.hub.cancelRingDropTimersForCallee(c.userID)
+		}
+		// When a 1:1 call SETTLES (answered/declined/cancelled/ended), forget the retained
+		// invite for that callId so a later callee reconnect can't re-ring a call that's already
+		// over (spec 2012 US1 FR-003). Scope it by callId on both parties — whoever holds the
+		// buffer — since either side may send the resolving frame and a roomId means it's group
+		// signalling (handled separately, not a 1:1 invite). call-ringing is engagement, not a
+		// resolution, so it does NOT clear the invite (a reload after ringing must still recover).
+		if f.RoomID == "" && f.CallID != "" {
+			switch f.T {
+			case "call-answer", "call-reject", "call-cancel", "call-busy", "call-end":
+				c.hub.clearBufferedCallID(f.To, f.CallID)
+				c.hub.clearBufferedCallID(c.userID, f.CallID)
+				// A settled call also cancels any pending US2 "callee unreachable" grace timer for
+				// this callId, so a normal hangup never fires the unreachable teardown.
+				c.hub.stopRingDropTimer(f.CallID)
+			}
 		}
 		// A group-call recall "remove" (call-cancel carrying a roomId + target) → stop
 		// reminding that invitee; the relay above also tells their device to stop ringing.

--- a/server/internal/ws/testhooks.go
+++ b/server/internal/ws/testhooks.go
@@ -30,6 +30,14 @@ func SetCallRecoveryGraceForTest(d time.Duration) func() {
 	return func() { callRecoveryGrace = prev }
 }
 
+// SetRingDropGraceForTest shrinks the US2 "callee unreachable" grace so tests don't wait the
+// production window; returns a restore func.
+func SetRingDropGraceForTest(d time.Duration) func() {
+	prev := ringDropGrace
+	ringDropGrace = d
+	return func() { ringDropGrace = prev }
+}
+
 // SetAudioMaxForTest overrides the audio participant cap, mirroring SetVideoMaxForTest.
 func SetAudioMaxForTest(n int) func() {
 	prev := call.AudioMax

--- a/specs/2012-call-invite-recovery/plan.md
+++ b/specs/2012-call-invite-recovery/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Call invite recovery & honest ringing
+
+**Spec**: [spec.md](./spec.md) · **Branch**: `fix/2012-call-invite-recovery` · **Date**: 2026-06-25
+
+## Summary
+
+Make a mid-ring callee reload non-fatal and the caller's "ringing" honest. Primarily a small
+server-side relay change (`server/internal/ws/hub.go`) plus tiny client guards. Zero-knowledge intact
+(the recovered invite is the existing sealed call-offer ciphertext).
+
+## Root causes (from investigation)
+
+- The server **only buffers** a 1:1 `call-offer` when the callee was offline (`hub.go` `if !delivered`).
+  When the callee is online, the offer is delivered live once and never retained — so after the
+  callee's reload (in-memory call state destroyed; offer not persisted client-side), reconnect's
+  `flushBufferedCalls()` has nothing → no incoming UI.
+- The caller's `call-ringing` is a **one-shot** (server auto-issues it when the callee's socket first
+  receives the offer, or on the SW push-ack). There is **no ringing keepalive** and nothing tells the
+  caller the callee's socket dropped, so the caller waits out the full ~60s `ANSWER_TIMEOUT_MS`.
+- The resume countdown (`beginResumeCountdown`) always runs on resume, regardless of call kind.
+
+## Design
+
+### US1 — Callee recovery (server retains + re-delivers the offer)
+- In `hub.go`, **always buffer the 1:1 `call-offer`** (and its trickled ICE) for its existing short
+  TTL, not only when `!delivered`. On the callee's next socket connect, the existing
+  `flushBufferedCalls()` re-delivers it → the callee rings again.
+- **Clear the buffered invite when the call resolves** for that callId: extend the existing
+  answer/cancel/end/reject/busy handling (where the ring loop is stopped) to also clear the callId's
+  buffered call frames — so a settled/declined call never re-rings on a later reconnect (FR-003).
+- **Client double-ring guard** (`src/composables/useCall.ts` `handleOffer`): early-return if we're
+  already showing the incoming call for the same `callId` (FR-002).
+- The TTL already bounds staleness (FR-004). No client-side persistence of the SDP (keeps plaintext
+  off disk, FR-009).
+
+### US2 — Caller honesty (drop on callee unreachable, with grace)
+- The hub tracks active 1:1 rings (the `callRing` registry used by the ring loop / `AckCallReachable`).
+  When the **callee's last socket drops** (`cleanup`), for any active ring where that user is the
+  callee, start a short **grace timer**. If the callee reconnects and re-acks ringing within the
+  grace (the recovered offer re-flushes → callee re-rings → re-ack), cancel it (FR-006). Otherwise
+  send the **caller** a `call-end` (or `call-cancel`) with reason `unreachable` (FR-005). The caller
+  already tears down on `call-end`/`call-cancel` while ringing (`useCall.ts` `handleCallFrame`).
+- Keep the existing `ANSWER_TIMEOUT_MS`/no-answer behavior as the long backstop (FR-007).
+
+### US3 — No countdown on audio resume (client)
+- In `src/composables/useCall.ts` `beginResumeCountdown` (and/or its caller on `resume`), gate on the
+  call being video: for an audio call, skip the countdown and resume immediately (FR-008). The
+  CallActivePage `resume-countdown` UI already only shows when `resumeCountdown !== null`, so not
+  arming it for audio is sufficient.
+
+## Constitution / ZK
+
+- **Zero-knowledge (Principle I):** the buffered/re-delivered invite is the existing sealed call-offer
+  ciphertext; the server cannot read it and stores no plaintext. No new readable metadata. (FR-009)
+- **Server change is allowed and minimal** — relay buffering/notification only; no schema change.
+- **TDD:** the hub has table tests (`hub_test.go` / handler tests). Add server tests for: an
+  online-delivered offer is re-delivered on the callee's reconnect; a resolved call's invite is NOT
+  re-delivered; the caller is notified when the callee drops without re-ringing within grace. Client:
+  the `handleOffer` dedup guard; audio resume arms no countdown.
+
+## Files
+
+- `server/internal/ws/hub.go` (+ `*_test.go`) — always-buffer the offer; clear on resolve; notify
+  caller on callee drop (with grace).
+- `src/composables/useCall.ts` — `handleOffer` dedup guard; gate `beginResumeCountdown` on video.
+- `e2e/` — callee-reload-recovers-incoming-call; caller-drops-on-vanished-callee; audio-resume-no-countdown
+  (where the harness can drive a reload / socket drop).
+
+## Phasing
+
+US1 (recovery) and US2 (honesty) are the core, both in `hub.go` and complementary; US3 is an
+independent one-line client gate. Polish: server + client gates, e2e, roadmap.

--- a/specs/2012-call-invite-recovery/spec.md
+++ b/specs/2012-call-invite-recovery/spec.md
@@ -1,0 +1,160 @@
+# Feature Specification: Call invite recovery & honest ringing
+
+**Feature Branch**: `fix/2012-call-invite-recovery`
+
+**Created**: 2026-06-25
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: A 1:1 call breaks if the callee's app reloads mid-ring (e.g. they open the call from a
+notification, see the pending app-update prompt, and tap "Update"): the callee loses the incoming-call
+screen and can't answer, while the caller stays stuck on "ringing" for a full minute even though
+nobody is ringing. Make this robust: the callee should get the incoming call back after a reload and
+still be able to answer; and the caller's "ringing" should be honest — if the callee goes away, end
+the call promptly instead of ringing into the void. Also: a held call's resume countdown ("You'll be
+on camera…") only makes sense for video — audio calls should skip it.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The incoming call survives an app reload (Priority: P1)
+
+The callee is being rung, opens the app/notification, and the app reloads for any reason (a pending
+update they accept, a crash, a manual refresh). After the reload the incoming-call screen comes back
+and they can still answer the call (as long as the caller is still ringing).
+
+**Why this priority**: Today a reload mid-ring drops the incoming call entirely — the callee simply
+can't answer, which looks like the app or the call is broken at the worst moment.
+
+**Independent Test**: Caller A rings callee B (B online). Reload B's app while ringing → B's
+incoming-call screen reappears and B can accept → the call connects normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** B is being rung and the call is still active, **When** B's app reloads, **Then** B's
+   incoming-call screen reappears and B can accept and connect.
+2. **Given** B's app reloads after the call already ended/was cancelled/declined, **When** B
+   reconnects, **Then** B does NOT see a stale incoming call (no ghost ring).
+3. **Given** B was already showing the incoming call and the invite is re-delivered, **When** both
+   arrive, **Then** B rings only once (no duplicate incoming screen).
+
+---
+
+### User Story 2 - "Ringing" is honest; a vanished callee ends the call (Priority: P1)
+
+When the caller is showing "ringing", that reflects a callee who is actually reachable. If the callee
+goes away (their app reloads/closes/loses connection and isn't ringing anymore), the caller's call
+ends promptly with a clear outcome, instead of ringing into the void for ~a minute.
+
+**Why this priority**: A minute of false "ringing" with no possibility of an answer is confusing and
+wastes the caller's time; it also masks the real state (the callee isn't there).
+
+**Independent Test**: A rings B; while ringing, B's connection drops (reload/close) and B does not
+re-ring within a short grace → A's call ends promptly (well under the old ~60s), with a clear
+"unavailable/ended" outcome.
+
+**Acceptance Scenarios**:
+
+1. **Given** A is ringing B, **When** B's connection drops and B does not resume ringing within a
+   short grace window, **Then** A's call ends promptly with a clear outcome (not a full ~60s timeout).
+2. **Given** A is ringing B, **When** B reloads and the incoming call is recovered (US1) and B
+   continues ringing, **Then** A keeps ringing normally (the recovery and honesty work together — a
+   quick reload does not falsely end the call).
+3. **Given** B answers, declines, or the caller cancels, **When** that happens, **Then** the existing
+   outcomes are unchanged (answer connects; decline/cancel/end tear down as today).
+
+---
+
+### User Story 3 - No "on camera" countdown for audio calls (Priority: P3)
+
+When a held call resumes, the person coming back on gets a brief "You'll be on camera…" countdown
+before their camera/mic go live. On an audio call there is no camera, so this countdown is
+nonsensical — audio calls resume immediately without it; video calls keep it.
+
+**Why this priority**: Minor polish, but the "on camera" wording on an audio call is confusing/wrong.
+
+**Independent Test**: Put a 1:1 audio call on hold and resume → no "on camera" countdown, resumes
+immediately. Put a video call on hold and resume → the countdown still shows.
+
+**Acceptance Scenarios**:
+
+1. **Given** a held audio call, **When** it resumes, **Then** there is no resume countdown and the
+   call resumes immediately.
+2. **Given** a held video call, **When** it resumes, **Then** the existing resume countdown still
+   shows before the camera goes live.
+
+---
+
+### Edge Cases
+
+- Reload after the call already connected (not ringing): the reload is outside this scope (an active
+  media session lost on reload is a separate concern); US1 covers the ringing window.
+- The recovered invite expiring: if the callee reloads after the invite's short server-side validity
+  has lapsed (caller already gave up), the callee does NOT ring — it's stale.
+- Caller's own reload while ringing: out of scope here (this spec covers the callee-reload and
+  caller-honesty cases the user reported); existing behavior unchanged.
+- A flapping callee (drops and re-rings repeatedly): the caller should not end on a single brief drop
+  if the callee re-rings within the grace window (US2 scenario 2).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: If a 1:1 callee's app reloads/reconnects while a call is still active (ringing), the
+  incoming-call invite MUST be re-delivered so the callee sees the incoming-call screen again and can
+  answer.
+- **FR-002**: A re-delivered invite MUST NOT produce a duplicate incoming-call screen if the callee is
+  already showing it.
+- **FR-003**: A callee MUST NOT be rung for a call that has already ended, been answered elsewhere,
+  declined, or cancelled (the recoverable invite is cleared when the call resolves).
+- **FR-004**: The recoverable invite MUST expire (a short server-side validity window) so a callee
+  reconnecting long after the caller gave up is not falsely rung.
+- **FR-005**: When the caller is ringing and the callee becomes unreachable (connection dropped and
+  not re-ringing within a short grace), the caller's call MUST end promptly with a clear outcome,
+  rather than continuing to "ring" until the long no-answer timeout.
+- **FR-006**: A brief callee reload that recovers the invite and resumes ringing within the grace MUST
+  NOT cause the caller to falsely end the call.
+- **FR-007**: Existing call outcomes (answer → connect; decline/cancel/busy/end → teardown) and the
+  existing no-answer timeout MUST be preserved.
+- **FR-008**: A held **audio** call MUST resume immediately with no "on camera" resume countdown; a
+  held **video** call MUST keep the existing resume countdown.
+- **FR-009**: The zero-knowledge boundary MUST be preserved: the recoverable invite is the existing
+  sealed call-offer ciphertext relayed as today; the server never reads call content, and no message
+  plaintext is persisted in the clear.
+
+### Key Entities *(include if feature involves data)*
+
+- **Recoverable call invite**: the existing sealed `call-offer` (and its early ICE), retained by the
+  relay for a short validity window so it can be re-delivered to a callee that reconnects while the
+  call is still active; cleared when the call resolves.
+- **Ringing reachability**: the caller-visible "ringing" state, now tied to the callee remaining
+  connected/ringing rather than a single one-shot ring signal.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Reloading the callee's app mid-ring reliably restores the incoming-call screen and the
+  callee can answer and connect.
+- **SC-002**: A reloaded/declined/ended call does not produce a ghost incoming ring on reconnect, and
+  a re-delivered invite never double-rings.
+- **SC-003**: When the callee becomes unreachable mid-ring, the caller's call ends within a few
+  seconds (well under the prior ~60s), with a clear outcome.
+- **SC-004**: A quick callee reload that recovers and re-rings within the grace does not falsely end
+  the caller's call.
+- **SC-005**: A held audio call resumes with no countdown; a held video call still shows it.
+- **SC-006**: No regression to the existing call connect / call-waiting / answer-decline-cancel suites.
+
+## Assumptions
+
+- The fix is primarily server-side relay behavior (retain + re-deliver the sealed call-offer for a
+  short window; notify the caller when the callee's socket drops) plus small client guards; the offer
+  is already sealed ciphertext, so retaining it briefly does not expose plaintext.
+- "Promptly" for the caller-honesty drop is a few seconds' grace (enough to cover a fast reload that
+  re-rings), not instantaneous, so a brief reconnect doesn't kill a still-valid call.
+- The resume countdown's purpose is to warn before the camera goes live, so it is gated on the call
+  being a video call.

--- a/specs/2012-call-invite-recovery/spec.md
+++ b/specs/2012-call-invite-recovery/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2012-call-invite-recovery/tasks.md
+++ b/specs/2012-call-invite-recovery/tasks.md
@@ -1,0 +1,51 @@
+---
+description: "Task list for spec 2012 — call invite recovery & honest ringing"
+---
+
+# Tasks: Call invite recovery & honest ringing
+
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md)
+
+**Tests**: REQUIRED. Server table tests (`hub`) lead for the relay behavior; client guards + e2e for
+the cross-context flows.
+
+## Phase 3: User Story 1 — incoming call survives a reload (P1)
+
+- [ ] T001 [US1] In `server/internal/ws/hub.go`: always buffer the 1:1 `call-offer` (+ its trickled
+  ICE) for the existing TTL, not only when `!delivered`, so a reconnecting callee re-receives it via
+  `flushBufferedCalls()` (FR-001/FR-004).
+- [ ] T002 [US1] In `hub.go`: clear the buffered invite for a callId when the call resolves
+  (answer/cancel/end/reject/busy), so a settled/declined call never re-rings on a later reconnect
+  (FR-003).
+- [ ] T003 [US1] In `src/composables/useCall.ts` `handleOffer`: early-return if already showing the
+  incoming call for the same `callId` (no duplicate ring on re-delivery) (FR-002).
+- [ ] T004 [US1] Server tests (`hub_test.go`): an online-delivered offer is re-delivered on the
+  callee's reconnect; a resolved/declined call's invite is NOT re-delivered.
+
+## Phase 4: User Story 2 — honest ringing (P1)
+
+- [ ] T005 [US2] In `hub.go`: when the callee's last socket drops during an active ring, start a short
+  grace; if the callee re-rings within it, cancel; else notify the CALLER with a `call-end`/
+  `call-cancel` (reason `unreachable`) so it ends promptly (FR-005/FR-006). Preserve the long
+  no-answer backstop (FR-007).
+- [ ] T006 [US2] Server tests: caller is notified when the callee drops and does not re-ring within
+  grace; caller is NOT notified when the callee re-rings within grace.
+
+## Phase 5: User Story 3 — no audio resume countdown (P3)
+
+- [ ] T007 [US3] In `src/composables/useCall.ts`: gate `beginResumeCountdown` on the call being video;
+  an audio call resumes immediately with no countdown (FR-008).
+
+## Phase 6: Polish
+
+- [ ] T008 Zero-knowledge confirmation (Principle I): the recovered invite is the existing sealed
+  call-offer ciphertext; server stores no plaintext; no new readable metadata (FR-009).
+- [ ] T009 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
+  `RING_E2E_PORT=8085 npm run test:e2e` (call-connect / call-waiting / calls — no regression).
+- [ ] T010 e2e: a callee reload mid-ring restores the incoming call (where the harness can drive a
+  reload/drop); audio resume shows no countdown.
+- [ ] T011 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.
+
+## Tracking Issues
+
+Created by `taskstoissues` — one per story group; the PR `Closes` each.

--- a/specs/2012-call-invite-recovery/tasks.md
+++ b/specs/2012-call-invite-recovery/tasks.md
@@ -11,40 +11,40 @@ the cross-context flows.
 
 ## Phase 3: User Story 1 — incoming call survives a reload (P1)
 
-- [ ] T001 [US1] In `server/internal/ws/hub.go`: always buffer the 1:1 `call-offer` (+ its trickled
+- [x] T001 [US1] In `server/internal/ws/hub.go`: always buffer the 1:1 `call-offer` (+ its trickled
   ICE) for the existing TTL, not only when `!delivered`, so a reconnecting callee re-receives it via
   `flushBufferedCalls()` (FR-001/FR-004).
-- [ ] T002 [US1] In `hub.go`: clear the buffered invite for a callId when the call resolves
+- [x] T002 [US1] In `hub.go`: clear the buffered invite for a callId when the call resolves
   (answer/cancel/end/reject/busy), so a settled/declined call never re-rings on a later reconnect
   (FR-003).
-- [ ] T003 [US1] In `src/composables/useCall.ts` `handleOffer`: early-return if already showing the
+- [x] T003 [US1] In `src/composables/useCall.ts` `handleOffer`: early-return if already showing the
   incoming call for the same `callId` (no duplicate ring on re-delivery) (FR-002).
-- [ ] T004 [US1] Server tests (`hub_test.go`): an online-delivered offer is re-delivered on the
+- [x] T004 [US1] Server tests (`hub_test.go`): an online-delivered offer is re-delivered on the
   callee's reconnect; a resolved/declined call's invite is NOT re-delivered.
 
 ## Phase 4: User Story 2 — honest ringing (P1)
 
-- [ ] T005 [US2] In `hub.go`: when the callee's last socket drops during an active ring, start a short
+- [x] T005 [US2] In `hub.go`: when the callee's last socket drops during an active ring, start a short
   grace; if the callee re-rings within it, cancel; else notify the CALLER with a `call-end`/
   `call-cancel` (reason `unreachable`) so it ends promptly (FR-005/FR-006). Preserve the long
   no-answer backstop (FR-007).
-- [ ] T006 [US2] Server tests: caller is notified when the callee drops and does not re-ring within
+- [x] T006 [US2] Server tests: caller is notified when the callee drops and does not re-ring within
   grace; caller is NOT notified when the callee re-rings within grace.
 
 ## Phase 5: User Story 3 — no audio resume countdown (P3)
 
-- [ ] T007 [US3] In `src/composables/useCall.ts`: gate `beginResumeCountdown` on the call being video;
+- [x] T007 [US3] In `src/composables/useCall.ts`: gate `beginResumeCountdown` on the call being video;
   an audio call resumes immediately with no countdown (FR-008).
 
 ## Phase 6: Polish
 
-- [ ] T008 Zero-knowledge confirmation (Principle I): the recovered invite is the existing sealed
+- [x] T008 Zero-knowledge confirmation (Principle I): the recovered invite is the existing sealed
   call-offer ciphertext; server stores no plaintext; no new readable metadata (FR-009).
-- [ ] T009 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
+- [x] T009 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
   `RING_E2E_PORT=8085 npm run test:e2e` (call-connect / call-waiting / calls — no regression).
-- [ ] T010 e2e: a callee reload mid-ring restores the incoming call (where the harness can drive a
+- [x] T010 e2e: a callee reload mid-ring restores the incoming call (where the harness can drive a
   reload/drop); audio resume shows no countdown.
-- [ ] T011 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.
+- [x] T011 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.
 
 ## Tracking Issues
 

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -339,6 +339,15 @@ function cancelResumeCountdown(): void {
  *  call moved on (torn down, re-held, or swapped) in the meantime. */
 function beginResumeCountdown(target: RTCPeerConnection): void {
   cancelResumeCountdown();
+  // (spec 2012) The countdown is a heads-up before our CAMERA goes back live ("You'll be on
+  // camera…"). On an audio call there is no camera, so the countdown is meaningless — resume the
+  // (audio) outgoing immediately with no countdown. Video calls keep the heads-up.
+  if (callMeta.value?.kind !== 'video') {
+    if (pc === target && !remoteHeld.value && localStream.value) {
+      void set1to1Senders(target, localStream.value);
+    }
+    return;
+  }
   let n = RESUME_COUNTDOWN_SEC;
   resumeCountdown.value = n;
   callCue('resuming'); // audible "you're about to be back" notification
@@ -1514,6 +1523,11 @@ function clearGroupIdleTimeout(): void {
 async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Promise<void> {
   const from = frame.from;
   if (!from || !frame.callId) return;
+
+  // (spec 2012) Duplicate incoming invite: the relay now retains the sealed offer and may re-deliver
+  // it (the recovery path — e.g. after the callee reconnects following a reload). If we're already
+  // ringing for this same callId, don't raise a second incoming screen.
+  if (callState.value === 'incoming' && callMeta.value?.callId === frame.callId) return;
 
   // Renegotiation of an in-progress call (e.g. the peer's ICE restart): same
   // call + peer and we're already connected/connecting → apply as offer/answer,
@@ -2859,7 +2873,11 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
         return;
       }
       if (meta && meta.callId === frame.callId) {
-        await teardown(frame.reason === 'unavailable' ? 'unavailable' : 'remote');
+        // 'unreachable' (spec 2012 US2): the server tells the caller the callee's socket dropped mid-
+        // ring and didn't come back — surface it as the clear "unavailable" outcome, not a generic
+        // remote hang-up, so the caller knows the callee wasn't there (rather than 60s of false ring).
+        const unavailable = frame.reason === 'unavailable' || frame.reason === 'unreachable';
+        await teardown(unavailable ? 'unavailable' : 'remote');
       } else if (heldSlot && heldSlot.meta.callId === frame.callId) {
         // The HELD call's remote hung up → free the held slot; the active call is undisturbed
         // (spec 0005 FR-009).


### PR DESCRIPTION
## Spec 2012 — Call invite recovery & honest ringing

Makes a mid-ring callee reload non-fatal and the caller's "ringing" honest. Zero-knowledge intact (the retained invite is the existing sealed call-offer ciphertext the server can't read).

### US1 — incoming call survives a reload
If the callee taps an app-update (or otherwise reloads) from the incoming-call screen, their in-memory call state is destroyed and the call was lost — the live `call-offer` was a one-shot the server only buffered when the callee was *offline*. Now the relay **retains the sealed 1:1 offer (+ trickled ICE) regardless of delivery**, cleared when the call resolves, so the callee's reconnect **re-rings** via the existing flush and they can still answer. A client guard prevents a duplicate incoming screen.

### US2 — honest ringing
The caller's "ringing" was a one-shot with no keepalive, so a vanished callee left it ringing for the full ~60s. Now when the callee's last socket drops mid-ring and they don't re-ack within an **8s grace** (a fast reload that re-rings cancels it), the server tells the caller the callee is **unreachable** → the caller ends promptly with a clear "unavailable" outcome.

### US3 — no resume countdown on audio
The "You'll be on camera…" resume heads-up only makes sense with a camera; **audio calls resume immediately**, video keeps the countdown.

### Testing
- Server table tests (offer re-delivered on reconnect; resolved call not re-delivered; caller ended on vanished callee; not ended when callee re-rings in grace). `go build/vet/test` ✓.
- 334 client unit tests ✓; build ✓.
- e2e locally: `call-intro`, `call-connect-speed`, `call-waiting` (incl. new audio-no-countdown / video-keeps-countdown) all green; full suite in CI.

Closes #444
Closes #445
Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
