### PR TITLE
fix(notifications): no more double app name; pinpoint why content falls back to generic

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,4 +59,4 @@ Specs are grouped by category band; status moves
 | [2011](specs/2011-hold-ui-and-1to1-diag/spec.md) | Call on-hold visualization & 1:1 diagnostics | 🔵 in-review |
 | [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | 🔵 in-review |
 | [2013](specs/2013-peer-resume-countdown/spec.md) | Mirror the resume countdown for the swapper | 🔵 in-review |
-| [2014](specs/2014-notif-title-and-auth/spec.md) | Notification title tidy & generic-fallback diagnosis | ⚪ planned |
+| [2014](specs/2014-notif-title-and-auth/spec.md) | Notification title tidy & generic-fallback diagnosis | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,3 +59,4 @@ Specs are grouped by category band; status moves
 | [2011](specs/2011-hold-ui-and-1to1-diag/spec.md) | Call on-hold visualization & 1:1 diagnostics | 🔵 in-review |
 | [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | 🔵 in-review |
 | [2013](specs/2013-peer-resume-countdown/spec.md) | Mirror the resume countdown for the swapper | 🔵 in-review |
+| [2014](specs/2014-notif-title-and-auth/spec.md) | Notification title tidy & generic-fallback diagnosis | ⚪ planned |

--- a/specs/2014-notif-title-and-auth/spec.md
+++ b/specs/2014-notif-title-and-auth/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2014-notif-title-and-auth/spec.md
+++ b/specs/2014-notif-title-and-auth/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Notification title tidy & generic-fallback diagnosis
+
+**Feature Branch**: `fix/2014-notif-title-and-auth`
+
+**Created**: 2026-06-25
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: Two notification fixes. (1) The generic/placeholder push notification sets its OWN title to
+"Ring", which duplicates the app-name header iOS already shows — so the user sees "Ring" twice
+("Ring › Ring › New message"). Tidy it so the title doesn't repeat the OS app name. (2) After the app
+has been idle/closed a while (~an hour), background notifications stop showing the decrypted message
+and fall back to the generic "New message". The initial hypothesis (expired access token) was
+INVESTIGATED AND RULED OUT — Ring's bearer token is a permanent device credential with no TTL and no
+refresh, and the relay fetch doesn't 401 for a logged-in device. The real cause is undetermined (most
+likely the service worker being evicted after inactivity → a cold start whose decrypt misses the
+window, or the device-unlock / read-only ratchet preview failing). So this spec (a) does NOT add token
+refresh (it would fix nothing) and (b) surfaces the EXACT generic-fallback reason on the dev deployment
+so the real cause can be confirmed on-device, ahead of the targeted content-fix.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The app name isn't shown twice on placeholder notifications (Priority: P1)
+
+When a content-free placeholder notification is shown (locked, no-preview, or before decryption), the
+notification reads cleanly — the OS shows the app name once (its forced attribution), and the
+notification's own title is the message status, not a second "Ring".
+
+**Why this priority**: "Ring › Ring › New message" looks broken/unpolished; it's the most-seen
+placeholder.
+
+**Independent Test**: Trigger a generic placeholder notification → its title is the status ("New
+message"), not "Ring"; the OS still attributes it to Ring once. Rich (decrypted) notifications already
+use the sender name as title — unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a generic placeholder message notification, **When** it shows, **Then** its title is not
+   the literal app name "Ring" (so the app name isn't shown twice with the OS attribution).
+2. **Given** a decrypted (rich) message notification, **When** it shows, **Then** its title is still
+   the sender/group name (unchanged).
+
+---
+
+### User Story 2 - We can identify why a notification fell back to generic (Priority: P1)
+
+When a background notification falls back to the generic placeholder, the **dev deployment** surfaces
+the precise reason (couldn't reach the relay, device locked, decrypt failed, or cold-start timeout) so
+the actual cause of the "generic after a while" regression can be confirmed on a real device — instead
+of guessing (the token-expiry guess was already disproven). Production notifications are unchanged (no
+debug text leaks to end users).
+
+**Why this priority**: The root cause is undetermined and time-correlated; we must confirm it on-device
+before shipping a content-fix, having already ruled out the token hypothesis.
+
+**Independent Test**: On the dev host, force a fallback (e.g., locked device) → the generic
+notification's body includes the reason tag; on a production host, the body shows no reason tag.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app runs on the dev deployment, **When** a notification falls back to generic,
+   **Then** the generic notification conveys the reason (relay-unreachable / locked / decrypt-failed /
+   timeout) for diagnosis.
+2. **Given** the app runs on the production host, **When** a notification falls back to generic,
+   **Then** no internal reason text is shown to the user.
+
+### Edge Cases
+
+- The reason diagnostic is gated to the dev host (`ring-dev` / localhost), so it never reaches a
+  production release even though both run the same build.
+- Multiple fallback causes in one wake: report the first/most-specific reason.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The generic/placeholder message notification MUST NOT use the literal app name as its
+  title (so iOS doesn't show the app name twice); rich notifications keep the sender/group name title.
+- **FR-002**: When a background notification falls back to the generic placeholder, the service worker
+  MUST determine the reason (relay non-OK / relay fetch error / device locked / decrypt failed /
+  cold-start timeout).
+- **FR-003**: On the dev deployment only, the generic notification MUST convey that reason (for
+  on-device diagnosis); on a production host it MUST NOT show any internal reason text.
+- **FR-004**: This spec MUST NOT add access-token refresh machinery — the token is a permanent device
+  credential with no expiry, so token refresh would fix nothing (documented non-goal).
+- **FR-005**: No server change; the zero-knowledge boundary is unchanged; the badge/iOS-notification-
+  per-push behavior is preserved.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A generic placeholder notification's title is not "Ring"; the app name appears once (the
+  OS attribution), not twice.
+- **SC-002**: On the dev host, a forced fallback shows its reason; on production, it does not.
+- **SC-003**: No regression to the existing notification/SW-decrypt suites; rich notifications still
+  show the sender name + content.
+
+## Assumptions
+
+- iOS forces the app-name attribution header from the manifest `name`; it cannot be removed per
+  notification — only the notification's own title/body are controllable, so US1 fixes the title.
+- The "generic after a while" root cause is undetermined; this spec instruments it (US2) rather than
+  applying an unproven fix. The targeted content-fix follows once the dev-deployment reason confirms
+  the cause.

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -67,6 +67,11 @@ export interface PreviewResult {
   // so the badge keeps updating, and from a cold-start undecryptable frame (which
   // still gets a generic placeholder to honor the Web Push userVisibleOnly contract).
   silenced: boolean;
+  // (spec 2014 US2) When we end up with NO decrypted notes and fall back to the generic placeholder,
+  // why? — 'relay-<status>' / 'relay-error' (couldn't fetch the queue), 'locked' (device unlock
+  // failed), 'decrypt-failed' (frames fetched but none decryptable). Surfaced ONLY on the dev
+  // deployment to diagnose the "generic after a while" regression on-device; never shown in prod.
+  reason?: string;
 }
 
 async function setting<T>(key: string, fallback: T): Promise<T> {
@@ -286,14 +291,14 @@ export async function previewPending(): Promise<PreviewResult> {
     }
     if (!res.ok) {
       console.warn('[sw-inbox] /relay/pending not ok', res.status);
-      return { notes: [], pending: 0, suppressed: false, silenced: false };
+      return { notes: [], pending: 0, suppressed: false, silenced: false, reason: `relay-${res.status}` };
     }
     frames = ((await res.json()) as { frames?: MsgFrame[] }).frames ?? [];
   } catch (e) {
     console.warn('[sw-inbox] /relay/pending fetch failed', e);
-    return { notes: [], pending: 0, suppressed: false, silenced: false };
+    return { notes: [], pending: 0, suppressed: false, silenced: false, reason: 'relay-error' };
   }
-  if (!frames.length) return { notes: [], pending: 0, suppressed: false, silenced: false };
+  if (!frames.length) return { notes: [], pending: 0, suppressed: false, silenced: false, reason: 'no-frames' };
 
   // Queued message frames = the undelivered backlog → the app-icon badge. Known
   // from the fetch alone, so the badge is right even if we can't decrypt.
@@ -311,7 +316,7 @@ export async function previewPending(): Promise<PreviewResult> {
     console.warn('[sw-inbox] device unlock failed (PIN-locked?) → generic');
     // Can't tell a message from a request → let the caller show a generic, UNLESS
     // the user disabled message notifications (then stay silent rather than buzz).
-    return { notes: [], pending, suppressed: !showMessages, silenced: false };
+    return { notes: [], pending, suppressed: !showMessages, silenced: false, reason: 'locked' };
   }
 
   const showPreview = await setting<boolean>('notifications.showPreview', true);
@@ -359,7 +364,10 @@ export async function previewPending(): Promise<PreviewResult> {
   // decrypted (decryptFailed > 0) we can't know its chat, so we fall back to the
   // generic placeholder (userVisibleOnly) rather than silently dropping it.
   const silenced = notes.length === 0 && !suppressed && silencedMessage && decryptFailed === 0;
-  return { notes, pending, suppressed, silenced };
+  // (spec 2014 US2) If we'll fall back to the generic (no notes, not suppressed/silenced) because
+  // frames were fetched but none decrypted, tag it so the dev deployment can show why.
+  const reason = notes.length === 0 && !suppressed && !silenced && decryptFailed > 0 ? 'decrypt-failed' : undefined;
+  return { notes, pending, suppressed, silenced, reason };
 }
 
 /** Persist the frame ids we actually displayed, so they aren't re-shown on the next

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -99,9 +99,17 @@ const SETTLE_MAX_MS = 12000;
 const STRAGGLER_WINDOW_MS = 9000;
 const STRAGGLER_INTERVAL_MS = 4500;
 
-async function showGeneric(): Promise<void> {
-  await self.registration.showNotification('Ring', {
-    body: 'New message',
+// (spec 2014) The dev deployment (ring-dev / localhost) surfaces the generic-fallback REASON in the
+// notification for on-device diagnosis; production (same build) never shows internal reason text.
+const DEV_HOST = /(^|\.)ring-dev\./.test(self.location.hostname) || self.location.hostname === 'localhost' || self.location.hostname === '127.0.0.1';
+
+async function showGeneric(reason?: string): Promise<void> {
+  // (spec 2014 US1) Title is the STATUS, not the literal app name: iOS already shows "Ring" as its
+  // forced app-name header, so titling this "Ring" too rendered the app name twice
+  // ("Ring › Ring › New message"). (US2) On the dev host only, the body carries why we fell back to
+  // generic so the "generic after a while" cause can be confirmed on a real device.
+  await self.registration.showNotification('New message', {
+    body: DEV_HOST && reason ? reason : 'Tap to open',
     icon: ICON,
     badge: ICON,
     tag: GENERIC_TAG,
@@ -294,12 +302,14 @@ async function showConnNotification(): Promise<void> {
 async function showMessageNotification(): Promise<void> {
   const preview = previewPending(); // started once; awaited twice (race, then settle)
   let result: Awaited<ReturnType<typeof previewPending>> = { notes: [], pending: 0, suppressed: false, silenced: false };
+  let timedOut = false; // spec 2014: distinguish a slow cold start from a fetched-but-undecryptable result
   try {
     result = await Promise.race([
       preview,
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('preview-timeout')), GENERIC_AFTER_MS)),
     ]);
   } catch {
+    timedOut = true;
     console.warn('[sw] preview slow/failed → generic fallback');
   }
 
@@ -314,7 +324,7 @@ async function showMessageNotification(): Promise<void> {
     // `silenced` (every pending message intentionally per-chat silenced: mute /
     // web-push-off / badge-only) shows NO placeholder — spec 1015 FR-022/FR-024 —
     // while the badge below still counts them.
-    await showGeneric();
+    await showGeneric(timedOut ? 'timeout' : result.reason);
     shownGeneric = true;
   }
 


### PR DESCRIPTION
## Spec 2014 — Notification title tidy & generic-fallback diagnosis

### US1 — stop showing the app name twice
The generic/placeholder push notification titled itself **"Ring"**, which duplicates the app-name header iOS already shows — so users saw **"Ring › Ring › New message"**. Now the placeholder's title is the status (**"New message"**); rich (decrypted) notifications keep the sender/group name. (iOS forces the app-name attribution from the manifest — it can't be removed, only not repeated.)

### US2 — diagnose "generic after a while" (token theory ruled out)
The reported regression — after the app's been idle ~an hour, notifications stop showing content and fall back to "New message" — was hypothesized to be an **expired access token**. **Investigated and disproven:** Ring's bearer token is a **permanent device credential with no TTL and no refresh**, and the relay fetch doesn't 401 for a logged-in device. So this PR deliberately **does not add token refresh** (it would fix nothing). Instead it surfaces the **exact fallback reason** (`relay-*` / `locked` / `decrypt-failed` / `no-frames` / `timeout`) in the generic notification — **gated to the dev host only** (production shows none) — so the real cause (most likely SW eviction → cold-start timeout, or device-unlock / decrypt failure) can be confirmed on-device before the targeted content-fix.

### Testing / constraints
334 unit tests ✓, build ✓, notification e2e (`notifications-inapp`, `sw-decrypt`) green. No server change; ZK unchanged; iOS notification-per-push + badge behavior preserved.

Closes #450
Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
