### PR TITLE
fix(notifications): background notifications decrypt queued messages after the ratchet advanced

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,4 +60,4 @@ Specs are grouped by category band; status moves
 | [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | 🔵 in-review |
 | [2013](specs/2013-peer-resume-countdown/spec.md) | Mirror the resume countdown for the swapper | 🔵 in-review |
 | [2014](specs/2014-notif-title-and-auth/spec.md) | Notification title tidy & generic-fallback diagnosis | 🔵 in-review |
-| [2015](specs/2015-sw-preview-ratchet/spec.md) | Background notifications decrypt queued messages reliably | ⚪ planned |
+| [2015](specs/2015-sw-preview-ratchet/spec.md) | Background notifications decrypt queued messages reliably | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,3 +60,4 @@ Specs are grouped by category band; status moves
 | [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | 🔵 in-review |
 | [2013](specs/2013-peer-resume-countdown/spec.md) | Mirror the resume countdown for the swapper | 🔵 in-review |
 | [2014](specs/2014-notif-title-and-auth/spec.md) | Notification title tidy & generic-fallback diagnosis | 🔵 in-review |
+| [2015](specs/2015-sw-preview-ratchet/spec.md) | Background notifications decrypt queued messages reliably | ⚪ planned |

--- a/specs/2015-sw-preview-ratchet/spec.md
+++ b/specs/2015-sw-preview-ratchet/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2015-sw-preview-ratchet/spec.md
+++ b/specs/2015-sw-preview-ratchet/spec.md
@@ -1,0 +1,131 @@
+# Feature Specification: Background notifications decrypt queued messages reliably
+
+**Feature Branch**: `fix/2015-sw-preview-ratchet`
+
+**Created**: 2026-06-25
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: Confirmed on-device (via the spec-2014 diagnostic, reason = `decrypt-failed`): after the
+app has been idle a while, background push notifications show the generic "New message" instead of the
+content because the service worker's READ-ONLY message preview can't decrypt the queued message. Root
+cause: 1:1 call signalling (offer/ICE and spec-0007's frequent `qos` health reports) rides the SAME
+pairwise Double Ratchet as chat, but is sent LIVE over the WebSocket and never queued in the relay.
+While the app is open those live signals advance AND persist the ratchet, moving the persisted state
+PAST a chat message still sitting in the relay queue. The SW's read-only preview then decrypts that
+queued message from an over-advanced ratchet base → wrong key → "ciphertext cannot be decrypted" →
+generic. Fix: let the preview persist the receiving-ratchet advance + skipped message keys (so the
+session moves forward and stays able to decrypt), while keeping prekey/X3DH and the send-preamble
+strictly the page's job. No content ever leaves the device.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Background notifications show the message even after a gap (Priority: P1)
+
+When a message arrives while the app is backgrounded/closed — even after the app has been idle a long
+time and there's been call activity in between — the notification shows the real (decrypted) message
+content (for a chat set to show content), not a generic placeholder, just as it does right after the
+app was last open.
+
+**Why this priority**: Notifications silently degrading to "New message" makes them untrustworthy;
+the user can't tell "preview off" from "the app failed to decrypt this".
+
+**Independent Test**: Establish a 1:1 session; advance + persist the ratchet via live signalling (a
+call's signals / `qos`) so the persisted state is ahead of a queued chat message; then have the
+service worker preview that queued message → it decrypts and shows the content (no `decrypt-failed`
+fallback). Regression: a normal fresh message still previews.
+
+**Acceptance Scenarios**:
+
+1. **Given** a 1:1 chat (content shown) and a persisted ratchet that live signalling has advanced past
+   a queued chat message, **When** the service worker previews that queued message in the background,
+   **Then** it decrypts and the notification shows the content (not generic).
+2. **Given** a backlog of several queued messages, **When** the SW previews them, **Then** each
+   decrypts (in order) and the per-conversation notification shows the latest content.
+3. **Given** the page later opens for real (authoritative receive), **When** it processes those same
+   messages, **Then** it still decrypts them correctly and the session is not corrupted (no lost or
+   undecryptable messages).
+
+---
+
+### User Story 2 - The authoritative receive and X3DH stay intact (Priority: P1)
+
+The change must not corrupt the end-to-end-encrypted session: the page's authoritative message
+receive continues to work, one-time prekeys are still consumed only by the page, and the initiator's
+send-preamble is still cleared only by the page. The preview only ever moves the receiving ratchet
+forward and caches skipped keys — both idempotent with the page's later open.
+
+**Why this priority**: A wrong move here could drop messages or break the session — worse than the
+original bug.
+
+**Independent Test**: After the SW preview persists an advanced ratchet, the page's authoritative
+open of the same and subsequent messages still succeeds; a first-contact prekey message is still
+established/consumed by the page, not the preview.
+
+**Acceptance Scenarios**:
+
+1. **Given** the SW preview advanced + persisted the receiving ratchet, **When** the page later opens
+   the same messages, **Then** they decrypt (via the cached skipped keys) and later messages continue
+   to decrypt.
+2. **Given** a first-contact prekey (X3DH) message, **When** the SW previews it, **Then** it does NOT
+   consume the one-time prekey or persist a new responder session (the page remains authoritative for
+   X3DH); the preview still shows the content in-memory.
+3. **Given** an initiator awaiting confirmation, **When** the SW previews an inbound message, **Then**
+   the send-preamble is NOT cleared by the preview (only the page clears it).
+
+### Edge Cases
+
+- Out-of-order / re-delivered frames: decrypt via the persisted skipped-key cache (Double Ratchet's
+  normal mechanism), bounded by the existing max-skip.
+- A large backlog (more than the relay returns at once): previewing from the persisted base skips and
+  caches forward as needed, within the existing max-skip bound.
+- Concurrent SW push handlers: the preview's session writes are serialized (per-chat) so two pushes
+  can't interleave a load→advance→save.
+- The page and SW are different execution contexts: their session writes converge via last-write-wins
+  + the skipped-key cache (the same idempotency the protocol already relies on for out-of-order).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The service-worker message preview MUST be able to decrypt a queued message whose
+  position is behind a persisted ratchet that live signalling (call/`qos`) advanced past — by
+  persisting the receiving-ratchet advance and the skipped message keys it generates.
+- **FR-002**: Previewing a backlog MUST decrypt the queued messages in order (advancing one session),
+  not fail on messages after the first.
+- **FR-003**: The preview MUST NOT consume one-time prekeys or persist a newly-established responder
+  (X3DH) session — first-contact prekey handling remains the page's job (decrypt in-memory only).
+- **FR-004**: The preview MUST NOT clear the initiator send-preamble (only the page's authoritative
+  receive clears it).
+- **FR-005**: After the preview persists an advanced ratchet, the page's authoritative receive of the
+  same or later messages MUST still decrypt correctly (no corruption, no lost messages) — relying on
+  the skipped-key cache for idempotency.
+- **FR-006**: The preview's per-chat session writes MUST be serialized so concurrent background push
+  handlers can't interleave a load→advance→save on the same session.
+- **FR-007**: Zero-knowledge unchanged: no plaintext leaves the device; the SW still only fetches the
+  sealed ciphertext the relay already stores; no server change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With the persisted ratchet advanced past a queued message (via simulated live
+  signalling), the SW preview decrypts it and the notification shows content — the `decrypt-failed`
+  fallback no longer occurs for this case.
+- **SC-002**: A queued backlog previews fully (each message decrypts in order).
+- **SC-003**: The authoritative page receive still decrypts the same + subsequent messages after a
+  preview advanced the session; first-contact prekey + preamble remain page-only.
+- **SC-004**: No regression to the crypto unit suite or the notification/SW-decrypt e2e.
+
+## Assumptions
+
+- The Double Ratchet's skipped-key cache makes a forward-advanced session idempotent for the page's
+  later open (the protocol's intended out-of-order path), so persisting the preview's advance is safe.
+- The dominant trigger is live call/`qos` signalling advancing the shared ratchet (confirmed
+  mechanism); making the preview persist-forward fixes it regardless of which signal advanced it.
+- The fix is client-only; no server or schema change; the zero-knowledge boundary is unchanged.

--- a/specs/2015-sw-preview-ratchet/tasks.md
+++ b/specs/2015-sw-preview-ratchet/tasks.md
@@ -1,0 +1,39 @@
+---
+description: "Task list for spec 2015 — SW preview decrypts queued messages after the ratchet advanced"
+---
+
+# Tasks: Background notifications decrypt queued messages reliably
+
+**Input**: [spec.md](./spec.md)
+
+**Tests**: REQUIRED (TDD). Reproduce the decrypt failure as a FAILING crypto/messaging unit test
+first, then implement the fix to green. Touches the E2EE ratchet → adversarial safety review required.
+
+## Phase 3: User Story 1 + 2 — reliable preview without corrupting the session (P1)
+
+- [ ] T001 Write a FAILING unit test reproducing the bug: establish a 1:1 session; ADVANCE + PERSIST
+  the receiving ratchet (simulating live call/`qos` signals received + saved) so the persisted base is
+  past a still-queued earlier message; then `previewPacket` that queued message → currently throws
+  ("ciphertext cannot be decrypted"). (`src/services/messaging.test.ts` or `crypto/*.test.ts`.)
+- [ ] T002 Fix `previewPacket` (`src/services/messaging.ts`): run inside `sessionMutex` (FR-006);
+  when an ESTABLISHED (persisted) session decrypts a NORMAL message, `saveSession` the advanced
+  receiving ratchet + skipped keys (FR-001/FR-002); for a prekey / no-session / re-init path, decrypt
+  IN-MEMORY only — do NOT consume the one-time prekey or persist a new responder session (FR-003); do
+  NOT touch the send-preamble (FR-004). Run T001 → green.
+- [ ] T003 Test idempotency/no-corruption (FR-005): after `previewPacket` advanced+persisted, the
+  authoritative `openPacket` of the same and subsequent messages still decrypts (via the skipped-key
+  cache); a first-contact prekey is still established/consumed only by `openPacket`, and the preamble
+  is cleared only by `openPacket`.
+- [ ] T004 (Optional, robustness) In `src/services/sw-inbox.ts` `previewPending`, decrypt a backlog as
+  one in-order advancing pass (per session) rather than reloading per frame — only if it doesn't
+  complicate the mutex/persist model.
+
+## Phase 6: Polish
+
+- [ ] T005 Adversarial review: a fresh pass specifically hunting session-corruption / message-loss /
+  prekey-consumption / SW↔page race regressions in the fix.
+- [ ] T006 Zero-knowledge confirmation: no plaintext leaves the device; SW still only fetches the
+  sealed ciphertext; no server change (FR-007).
+- [ ] T007 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
+  `RING_E2E_PORT=8085 npm run test:e2e` (notifications-inapp / sw-decrypt / calls — no regression).
+- [ ] T008 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.

--- a/specs/2015-sw-preview-ratchet/tasks.md
+++ b/specs/2015-sw-preview-ratchet/tasks.md
@@ -11,29 +11,29 @@ first, then implement the fix to green. Touches the E2EE ratchet → adversarial
 
 ## Phase 3: User Story 1 + 2 — reliable preview without corrupting the session (P1)
 
-- [ ] T001 Write a FAILING unit test reproducing the bug: establish a 1:1 session; ADVANCE + PERSIST
+- [x] T001 Write a FAILING unit test reproducing the bug: establish a 1:1 session; ADVANCE + PERSIST
   the receiving ratchet (simulating live call/`qos` signals received + saved) so the persisted base is
   past a still-queued earlier message; then `previewPacket` that queued message → currently throws
   ("ciphertext cannot be decrypted"). (`src/services/messaging.test.ts` or `crypto/*.test.ts`.)
-- [ ] T002 Fix `previewPacket` (`src/services/messaging.ts`): run inside `sessionMutex` (FR-006);
+- [x] T002 Fix `previewPacket` (`src/services/messaging.ts`): run inside `sessionMutex` (FR-006);
   when an ESTABLISHED (persisted) session decrypts a NORMAL message, `saveSession` the advanced
   receiving ratchet + skipped keys (FR-001/FR-002); for a prekey / no-session / re-init path, decrypt
   IN-MEMORY only — do NOT consume the one-time prekey or persist a new responder session (FR-003); do
   NOT touch the send-preamble (FR-004). Run T001 → green.
-- [ ] T003 Test idempotency/no-corruption (FR-005): after `previewPacket` advanced+persisted, the
+- [x] T003 Test idempotency/no-corruption (FR-005): after `previewPacket` advanced+persisted, the
   authoritative `openPacket` of the same and subsequent messages still decrypts (via the skipped-key
   cache); a first-contact prekey is still established/consumed only by `openPacket`, and the preamble
   is cleared only by `openPacket`.
-- [ ] T004 (Optional, robustness) In `src/services/sw-inbox.ts` `previewPending`, decrypt a backlog as
+- [~] T004 (Optional, robustness) In `src/services/sw-inbox.ts` `previewPending`, decrypt a backlog as
   one in-order advancing pass (per session) rather than reloading per frame — only if it doesn't
   complicate the mutex/persist model.
 
 ## Phase 6: Polish
 
-- [ ] T005 Adversarial review: a fresh pass specifically hunting session-corruption / message-loss /
+- [x] T005 Adversarial review: a fresh pass specifically hunting session-corruption / message-loss /
   prekey-consumption / SW↔page race regressions in the fix.
-- [ ] T006 Zero-knowledge confirmation: no plaintext leaves the device; SW still only fetches the
+- [x] T006 Zero-knowledge confirmation: no plaintext leaves the device; SW still only fetches the
   sealed ciphertext; no server change (FR-007).
-- [ ] T007 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
+- [x] T007 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
   `RING_E2E_PORT=8085 npm run test:e2e` (notifications-inapp / sw-decrypt / calls — no regression).
-- [ ] T008 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.
+- [x] T008 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.

--- a/src/services/crypto/message.ts
+++ b/src/services/crypto/message.ts
@@ -5,7 +5,13 @@
  * transport. The media blob itself is handled separately (media-transfer.ts);
  * only the small reference (id + wrapped file key) rides inside the payload.
  */
-import { ratchetEncrypt, ratchetDecrypt, type RatchetState, type Header } from './ratchet';
+import {
+  ratchetEncrypt,
+  ratchetDecrypt,
+  ratchetDecryptPreview,
+  type RatchetState,
+  type Header,
+} from './ratchet';
 import { utf8ToBytes, bytesToUtf8, type Envelope } from './envelope';
 import type { ReplyRef, GeoLocation, Poll, SharedContact, AudioMeta } from '@/db/types';
 
@@ -260,4 +266,19 @@ export function openMessage(
 ): MessagePayload {
   const pt = ratchetDecrypt(state, wire.header, wire.env, ad);
   return JSON.parse(bytesToUtf8(pt)) as MessagePayload;
+}
+
+/**
+ * Decrypt a wire message for the service-worker PREVIEW path (spec 2015): advances
+ * `state` the same way but leaves the read message's own key in the skipped-key
+ * cache, so persisting this advance can't make the message undecryptable for the
+ * page's later authoritative openMessage. Throws if it doesn't authenticate.
+ */
+export function openMessagePreview(
+  state: RatchetState,
+  wire: WireMessage,
+  ad: Uint8Array = new Uint8Array(0),
+): { payload: MessagePayload; advancedDh: boolean } {
+  const { plaintext, advancedDh } = ratchetDecryptPreview(state, wire.header, wire.env, ad);
+  return { payload: JSON.parse(bytesToUtf8(plaintext)) as MessagePayload, advancedDh };
 }

--- a/src/services/crypto/ratchet.test.ts
+++ b/src/services/crypto/ratchet.test.ts
@@ -9,6 +9,7 @@ import {
   x3dhResponder,
   ratchetInitAlice,
   ratchetInitBob,
+  ratchetDecryptPreview,
   type RatchetState,
 } from './ratchet';
 import { sealMessage, openMessage } from './message';
@@ -63,6 +64,28 @@ describe('Double Ratchet', () => {
     // Bob replies -> triggers a DH ratchet on Alice's side.
     expect(openMessage(alice, sealMessage(bob, msg('hey alice'), ad), ad).body).toBe('hey alice');
     expect(openMessage(bob, sealMessage(alice, msg('after ratchet'), ad), ad).body).toBe('after ratchet');
+  });
+
+  it('preview reports advancedDh: false within a chain, true across a DH ratchet (spec 2015 safety gate)', () => {
+    // The service-worker preview persists ONLY same-chain advances. A frame that triggers a DH
+    // ratchet (which would mint a fresh sending keypair) MUST be reported so previewPacket does NOT
+    // persist it — otherwise the SW could clobber the page's authoritative send-state. This asserts
+    // the flag that gate relies on.
+    const { alice, bob, ad } = setupPair();
+    // Establish Bob's receiving chain (Alice's FIRST message triggers Bob's initial DH ratchet, so
+    // it can't be the "same-chain" case). Open it authoritatively.
+    openMessage(bob, sealMessage(alice, msg('m0'), ad), ad);
+    // Alice's NEXT message is within the same sending chain → preview takes NO DH step.
+    const same = sealMessage(alice, msg('m1'), ad);
+    const r0 = ratchetDecryptPreview(bob, same.header, same.env, ad);
+    expect(JSON.parse(new TextDecoder().decode(r0.plaintext)).body).toBe('m1');
+    expect(r0.advancedDh).toBe(false);
+    // Make Alice ratchet: she receives a reply from Bob → her next message is a NEW chain.
+    openMessage(alice, sealMessage(bob, msg('reply'), ad), ad);
+    const dhStep = sealMessage(alice, msg('m2 new chain'), ad);
+    const r1 = ratchetDecryptPreview(bob, dhStep.header, dhStep.env, ad);
+    expect(JSON.parse(new TextDecoder().decode(r1.plaintext)).body).toBe('m2 new chain');
+    expect(r1.advancedDh).toBe(true);
   });
 
   it('handles out-of-order delivery (skipped message keys)', () => {

--- a/src/services/crypto/ratchet.ts
+++ b/src/services/crypto/ratchet.ts
@@ -193,6 +193,57 @@ export function ratchetDecrypt(
   return open(msgKey(mk), env, concat(ad, headerBytes(header)));
 }
 
+/**
+ * Decrypt exactly like ratchetDecrypt, but leave the decrypted message's own key
+ * RETRIEVABLE from the skipped-key cache afterwards instead of consuming it.
+ *
+ * This is the service-worker PREVIEW variant (spec 2015). The preview advances and
+ * PERSISTS the receiving ratchet so it can move past a base that live call/`qos`
+ * signalling already advanced, and so a queued backlog previews in order. But a
+ * plain ratchetDecrypt of the current message consumes its message key (advances
+ * the chain, leaves nothing in `skipped`) — so the page's later AUTHORITATIVE open
+ * of that very message would re-derive the wrong key and the message would be lost.
+ * To stay idempotent with the page, we keep this message's key in `skipped` (the
+ * Double Ratchet's normal out-of-order mechanism), so openPacket re-finds it there.
+ * Net effect: forward progress is persisted, but nothing this preview reads becomes
+ * undecryptable for the authoritative receiver — it only ever ADDS to the cache.
+ */
+export function ratchetDecryptPreview(
+  state: RatchetState,
+  header: Header,
+  env: Envelope,
+  ad: Uint8Array,
+): { plaintext: Uint8Array; advancedDh: boolean } {
+  const skKey = `${header.dh}:${header.n}`;
+  // Already in the cache (skipped over earlier): decrypt WITHOUT deleting, so the
+  // key stays available for the page's authoritative open. No DH step taken.
+  const cached = state.skipped.get(skKey);
+  if (cached) return { plaintext: open(msgKey(cached), env, concat(ad, headerBytes(header))), advancedDh: false };
+  // Otherwise advance the receiving chain up to AND INCLUDING this message, caching
+  // every key (including this one) via skipMessageKeys. We deliberately reuse the
+  // skip path for header.n+1 so the current message's key lands in `skipped` rather
+  // than being consumed, then read it back from there.
+  //
+  // `advancedDh` reports whether we had to take a DH-ratchet step. A DH ratchet mints
+  // a FRESH sending keypair (DHs); the caller (previewPacket) must NOT persist that
+  // from the service worker, or the SW becomes a competing writer of the SENDING key
+  // and the page↔SW last-write-wins race can clobber the page's authoritative
+  // send-state (permanent outbound divergence — adversarial review). So the caller
+  // persists ONLY same-chain advances (advancedDh === false): those are deterministic
+  // and purely ADDITIVE to the skipped-key cache, hence safe to converge via LWW.
+  const headerDh = b64urlToBytes(header.dh);
+  let advancedDh = false;
+  if (!state.DHr || !equalBytes(headerDh, state.DHr)) {
+    skipMessageKeys(state, header.pn);
+    dhRatchet(state, headerDh);
+    advancedDh = true;
+  }
+  skipMessageKeys(state, header.n + 1); // caches keys Nr..n (incl. this message)
+  const mk = state.skipped.get(skKey);
+  if (!mk) throw new Error('preview: message key not derivable'); // unreachable in practice
+  return { plaintext: open(msgKey(mk), env, concat(ad, headerBytes(header))), advancedDh };
+}
+
 function skipMessageKeys(state: RatchetState, until: number): void {
   if (state.CKr === null) return;
   if (state.Nr + MAX_SKIP < until) throw new Error('ratchet: too many skipped messages');

--- a/src/services/messaging-preview.test.ts
+++ b/src/services/messaging-preview.test.ts
@@ -1,0 +1,255 @@
+// Spec 2015 — the service-worker READ-ONLY message preview (`previewPacket`) must
+// reliably decrypt queued chat messages even after the authoritative receive path
+// (`openPacket`, driven by live 1:1 call signalling — offer/ICE + spec-0007 `qos`)
+// has advanced AND persisted the shared pairwise Double Ratchet PAST those messages
+// while the app was open.
+//
+// The bug lives in the load→advance→(save?) persistence dance, not the pure ratchet,
+// so these tests exercise the messaging-layer functions (openPacket / previewPacket).
+// We mock the three boundaries messaging.ts depends on:
+//   - @/db/idb  → an in-memory record store (sessions + settings); structuredClone on
+//                 write so the persisted copy can't share mutable refs with the
+//                 in-memory one (otherwise read-only-vs-persisted bugs would be masked).
+//   - identity  → Bob's responder key material (so establishResponderSession works).
+//   - api       → never hit the network.
+// The ratchet/X3DH crypto itself runs for real.
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+const stores: Record<string, Map<string, unknown>> = {};
+function storeOf(name: string): Map<string, unknown> {
+  return (stores[name] ??= new Map());
+}
+vi.mock('@/db/idb', () => ({
+  get: vi.fn(async (store: string, key: string) => storeOf(store).get(key)),
+  put: vi.fn(async (store: string, value: { id?: string; key?: string }) => {
+    const k = (value.id ?? value.key) as string;
+    storeOf(store).set(k, structuredClone(value));
+  }),
+  remove: vi.fn(async (store: string, key: string) => {
+    storeOf(store).delete(key);
+  }),
+}));
+vi.mock('./api', () => ({
+  publishPreKeys: vi.fn(),
+  preKeyCount: vi.fn(),
+  addOneTimeKeys: vi.fn(),
+  fetchPeerBundle: vi.fn(),
+}));
+
+import { ready } from './crypto/primitives';
+import { bytesToB64url } from './crypto/envelope';
+import {
+  x3dhInitiator,
+  x3dhResponder,
+  ratchetInitAlice,
+  ratchetInitBob,
+  saveSession,
+  loadSession,
+  type RatchetState,
+} from './crypto/ratchet';
+import { sealMessage } from './crypto/message';
+import { generateIdentityMaterial, type SecretBundle } from './crypto/identity';
+import * as identity from './crypto/identity';
+import type { WirePacket } from './messaging';
+
+let bob: SecretBundle;
+let alice: RatchetState; // the sender's ratchet, driven in-memory by the test
+
+vi.spyOn(identity, 'getIdentityKeys').mockImplementation(() => ({ ed: bob.ed, x: bob.x }));
+vi.spyOn(identity, 'getSignedPreKey').mockImplementation(() => ({
+  id: bob.signedPreKey.id,
+  keypair: bob.signedPreKey.keypair,
+}));
+vi.spyOn(identity, 'getOneTimePreKeyById').mockImplementation(
+  (id: string) => bob.oneTimePreKeys.find((p) => p.id === id)?.keypair ?? null,
+);
+
+import { openPacket, previewPacket } from './messaging';
+
+beforeAll(async () => {
+  await ready();
+});
+
+const CHAT = 'chat-with-alice';
+const body = (s: string) => ({ body: s, kind: 'text', timestamp: 1 });
+
+// Build a live Alice↔Bob pair via real X3DH. `alice` (the sender) is driven in
+// memory; Bob's session is persisted into the mock idb under CHAT — the on-device
+// state messaging.ts loads. Returns the prekey preamble for the first packet.
+async function setupPersistedPair(): Promise<{
+  preamble: Omit<Extract<WirePacket, { type: 'prekey' }>, 'v' | 'type' | 'msg'>;
+}> {
+  bob = generateIdentityMaterial(2);
+  const a: SecretBundle = generateIdentityMaterial(2);
+  const otk = bob.oneTimePreKeys[0];
+  const init = x3dhInitiator(a.x.privateKey, {
+    identityX: bob.x.publicKey,
+    signedPreKey: bob.signedPreKey.keypair.publicKey,
+    oneTimePreKey: otk.keypair.publicKey,
+  });
+  const bobSK = x3dhResponder({
+    identityXPriv: bob.x.privateKey,
+    signedPreKeyPriv: bob.signedPreKey.keypair.privateKey,
+    oneTimePreKeyPriv: otk.keypair.privateKey,
+    initiatorIdentityX: a.x.publicKey,
+    initiatorEphemeral: init.ephemeral.publicKey,
+  });
+  alice = ratchetInitAlice(init.sk, bob.signedPreKey.keypair.publicKey);
+  await saveSession(CHAT, ratchetInitBob(bobSK, bob.signedPreKey.keypair));
+  return {
+    preamble: {
+      idEd: bytesToB64url(a.ed.publicKey),
+      idX: bytesToB64url(a.x.publicKey),
+      eph: bytesToB64url(init.ephemeral.publicKey),
+      spkId: bob.signedPreKey.id,
+      otkId: otk.id,
+    },
+  };
+}
+
+const N = (b: string): WirePacket => ({ v: 1, type: 'normal', msg: sealMessage(alice, body(b)) });
+const PREKEY = (
+  preamble: Awaited<ReturnType<typeof setupPersistedPair>>['preamble'],
+  b: string,
+): WirePacket => ({ v: 1, type: 'prekey', ...preamble, msg: sealMessage(alice, body(b)) });
+
+beforeEach(() => {
+  for (const m of Object.values(stores)) m.clear();
+});
+
+describe('spec 2015: SW preview decrypts a backlog the persisted base advanced past', () => {
+  // The defining repro. A purely read-only preview reloads the SAME persisted base for
+  // EVERY frame, so it can only reach a frame within MAX_SKIP (1000) of that base. When
+  // the relay returns a backlog longer than MAX_SKIP — exactly what builds up after the
+  // app is idle a while, with live call/`qos` signalling having pushed the base forward —
+  // the read-only preview hits the skip wall and fails ("ciphertext cannot be decrypted")
+  // for everything past it, degrading those notifications to generic. By persisting the
+  // advance, each frame is previewed from a base that has moved forward, so an arbitrarily
+  // long backlog previews in order (FR-001/FR-002, edge case "a large backlog").
+  it('REPRO: a backlog longer than MAX_SKIP previews in order (read-only would wall at 1000)', { timeout: 30_000 }, async () => {
+    const { preamble } = await setupPersistedPair();
+    await openPacket(CHAT, PREKEY(preamble, 'hi')); // establish; Nr→1
+
+    const BACKLOG = 1050; // > MAX_SKIP (1000): enough to cross the read-only skip wall
+    const frames: WirePacket[] = [];
+    for (let i = 0; i < BACKLOG; i++) frames.push(N(`m${i}`));
+
+    // Previewing past index ~1000 is the regression line: with the OLD read-only preview
+    // this rejects with "ciphertext cannot be decrypted using that key"; the fix advances
+    // the persisted base so it keeps going.
+    for (let i = 0; i < BACKLOG; i++) {
+      expect((await previewPacket(CHAT, frames[i])).body).toBe(`m${i}`);
+    }
+  });
+
+  // Control: confirm the mechanism is the over-advanced base / skip wall, not the harness.
+  it('control: a fresh in-order queued message still previews', async () => {
+    const { preamble } = await setupPersistedPair();
+    await openPacket(CHAT, PREKEY(preamble, 'hi'));
+    expect((await previewPacket(CHAT, N('hello'))).body).toBe('hello');
+  });
+
+  // The dominant real-world trigger: live call/`qos` signalling opened authoritatively
+  // (openPacket) advances + persists the base PAST a chat message still queued in the
+  // relay. The preview must still decrypt that queued message.
+  it('decrypts a queued message after live signalling advanced+persisted the base past it', async () => {
+    const { preamble } = await setupPersistedPair();
+    await openPacket(CHAT, PREKEY(preamble, 'hi')); // n=0, Nr→1
+
+    const queued = N('queued chat message'); // n=1 — stays in the relay queue
+    const sig1 = N('call offer'); // n=2  — live signals over the WS
+    const sig2 = N('ice candidate'); // n=3
+    const sig3 = N('qos report'); // n=4
+
+    // App open: only the live signals are received authoritatively (queued never is),
+    // advancing + persisting Bob's base to Nr=5.
+    await openPacket(CHAT, sig1);
+    await openPacket(CHAT, sig2);
+    await openPacket(CHAT, sig3);
+
+    // SW previews the still-queued frame from the over-advanced base → must decrypt.
+    expect((await previewPacket(CHAT, queued)).body).toBe('queued chat message');
+  });
+});
+
+describe('spec 2015: idempotency / no corruption (FR-005)', () => {
+  // After the SW preview advanced + PERSISTED the receiving ratchet, the page's
+  // authoritative open of the SAME and SUBSEQUENT messages must still decrypt — the
+  // preview must never make a message undecryptable for the authoritative receiver.
+  it('authoritative openPacket still decrypts the same + later messages after a preview', async () => {
+    const { preamble } = await setupPersistedPair();
+    await openPacket(CHAT, PREKEY(preamble, 'hi'));
+
+    const m1 = N('one');
+    const m2 = N('two');
+    const m3 = N('three');
+
+    // SW previews a backlog (advances + persists).
+    expect((await previewPacket(CHAT, m1)).body).toBe('one');
+    expect((await previewPacket(CHAT, m2)).body).toBe('two');
+    expect((await previewPacket(CHAT, m3)).body).toBe('three');
+
+    // Page later opens them authoritatively — must all still decrypt (via the
+    // persisted skipped-key cache the preview left behind), in any order.
+    expect((await openPacket(CHAT, m2)).body).toBe('two');
+    expect((await openPacket(CHAT, m1)).body).toBe('one');
+    expect((await openPacket(CHAT, m3)).body).toBe('three');
+
+    // And a brand-new message after all that still works both ways.
+    const m4 = N('four');
+    expect((await previewPacket(CHAT, m4)).body).toBe('four');
+    expect((await openPacket(CHAT, m4)).body).toBe('four');
+  });
+
+  // A first-contact prekey (X3DH) message previewed by the SW must NOT consume the
+  // one-time prekey or persist a responder session — the page stays authoritative for
+  // X3DH, so its later open of that same prekey message must still succeed.
+  it('a previewed first-contact prekey is NOT consumed: the page can still open it', async () => {
+    const { preamble } = await setupPersistedPair();
+    // No session persisted for a *different* chat: simulate first contact by clearing
+    // the persisted session so previewPacket takes the establish-responder path.
+    await import('@/db/idb').then((idb) => idb.remove('sessions', CHAT));
+
+    const first = PREKEY(preamble, 'first hello');
+
+    // Preview decrypts in-memory (shows content) ...
+    expect((await previewPacket(CHAT, first)).body).toBe('first hello');
+    // ... but must NOT have persisted a responder session.
+    expect(await loadSession(CHAT)).toBeNull();
+    // ... so the page's authoritative open still establishes + decrypts it.
+    expect((await openPacket(CHAT, first)).body).toBe('first hello');
+    expect(await loadSession(CHAT)).not.toBeNull();
+  });
+
+  // The initiator send-preamble is cleared only by the page's authoritative openPacket,
+  // never by a preview (FR-004). We assert via the session-meta the preview leaves alone.
+  it('the send-preamble is cleared only by openPacket, never by previewPacket', async () => {
+    const { preamble } = await setupPersistedPair();
+    await openPacket(CHAT, PREKEY(preamble, 'hi'));
+
+    // Make THIS device an initiator awaiting confirmation: write a session-meta with
+    // sendPreamble=true (the shape sealForChat writes; we set it directly to avoid the
+    // network bootstrap).
+    const idb = await import('@/db/idb');
+    await idb.put('settings', {
+      key: `smeta:${CHAT}`,
+      value: { peerUserId: 'alice', sendPreamble: true, preamble: { idEd: 'x', idX: 'x', eph: 'x', spkId: 'x' } },
+    });
+
+    // A preview of an inbound message must NOT clear the preamble.
+    await previewPacket(CHAT, N('inbound'));
+    const afterPreview = await idb.get<{ key: string; value: { sendPreamble: boolean } }>(
+      'settings',
+      `smeta:${CHAT}`,
+    );
+    expect(afterPreview?.value.sendPreamble).toBe(true);
+
+    // The page's authoritative open DOES clear it.
+    await openPacket(CHAT, N('inbound 2'));
+    const afterOpen = await idb.get<{ key: string; value: { sendPreamble: boolean } }>(
+      'settings',
+      `smeta:${CHAT}`,
+    );
+    expect(afterOpen?.value.sendPreamble).toBe(false);
+  });
+});

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -28,7 +28,7 @@ import {
   type RatchetState,
   type PreKeyBundlePub,
 } from './crypto/ratchet';
-import { sealMessage, openMessage, type MessagePayload, type WireMessage } from './crypto/message';
+import { sealMessage, openMessage, openMessagePreview, type MessagePayload, type WireMessage } from './crypto/message';
 import { KeyedMutex } from './keyed-mutex';
 import {
   getIdentityKeys,
@@ -238,10 +238,32 @@ export async function openPacket(chatId: string, raw: unknown): Promise<MessageP
 
 /**
  * Decrypt an incoming packet for PREVIEW ONLY (service-worker notifications).
- * Unlike openPacket it does NOT persist the advanced ratchet, consume prekeys, or
- * clear the send-preamble, so it never disturbs the session state the page will
- * advance for real when it next drains the relay. Safe to run in the service
- * worker: the ratchet advance happens on an in-memory copy that's discarded.
+ *
+ * Unlike openPacket this never consumes one-time prekeys, never persists a newly
+ * ESTABLISHED responder (X3DH) session, and never clears the initiator send-
+ * preamble — first-contact/X3DH and the preamble stay strictly the page's job.
+ *
+ * It DOES, however, persist the RECEIVING-ratchet advance (incl. the skipped
+ * message keys it generates) when an ALREADY-ESTABLISHED session decrypts a
+ * NORMAL packet. This is required, not cosmetic: 1:1 call signalling (offer/ICE
+ * and spec-0007 `qos`) rides the SAME pairwise ratchet as chat but is sent LIVE
+ * over the WebSocket and never queued in the relay. While the app is open those
+ * live signals are opened by openPacket, which advances + persists the receiving
+ * ratchet — moving the persisted base PAST a chat message still sitting in the
+ * relay queue. A purely read-only preview would reload that over-advanced base
+ * and re-derive the wrong key for the queued message ("ciphertext cannot be
+ * decrypted") → the notification degrades to generic. Persisting the advance lets
+ * the preview move forward and caches the skipped keys, so a queued message behind
+ * the base stays reachable and a backlog previews in order (FR-001/FR-002).
+ *
+ * Persisting from the SW is safe because the advance is idempotent with the page's
+ * later authoritative open: the Double Ratchet's skipped-key cache (the protocol's
+ * own out-of-order mechanism) means openPacket re-finds each key it needs in the
+ * persisted cache. Page and SW are different contexts; their writes converge via
+ * last-write-wins + that cache — exactly the idempotency the protocol already
+ * relies on. The per-chat sessionMutex serializes the load→advance→save so two
+ * concurrent background push handlers can't interleave (FR-006).
+ *
  * Throws if it can't decrypt/authenticate.
  */
 export async function previewPacket(chatId: string, raw: unknown): Promise<MessagePayload> {
@@ -249,21 +271,48 @@ export async function previewPacket(chatId: string, raw: unknown): Promise<Messa
   if (!packet || (packet.type !== 'prekey' && packet.type !== 'normal')) {
     throw new Error('malformed wire packet');
   }
+  // Serialize with the matching seals/opens AND with other background previews —
+  // now that this path persists, two concurrent SW push handlers must not interleave
+  // a load→advance→save on the same session. See sessionMutex.
+  return sessionMutex.run(chatId, async () => {
   let session = await loadSession(chatId);
   const hadExistingSession = !!session;
   if (!session) {
+    // No session yet → this must be a first-contact prekey packet. Establish a
+    // responder session IN MEMORY ONLY to decrypt the preview: do NOT consume the
+    // one-time prekey and do NOT persist the session. X3DH stays the page's
+    // authoritative job (FR-003), so the page's later openPacket still runs it.
     if (packet.type !== 'prekey') throw new Error('no session for incoming message and no prekey preamble');
-    session = establishResponderSession(packet);
+    return openMessage(establishResponderSession(packet), packet.msg);
   }
   try {
-    return openMessage(session, packet.msg);
+    // openMessagePreview advances the receiving ratchet but keeps THIS message's key
+    // in the skipped-key cache, so persisting the advance never makes the message
+    // undecryptable for the page's later authoritative open (it re-finds the key in
+    // the cache). A prekey re-init (the catch below) deliberately does NOT reach here.
+    const { payload, advancedDh } = openMessagePreview(session, packet.msg);
+    // Persist ONLY a same-receiving-chain advance (the base moves forward so a backlog previews in
+    // order and can pass a point live call/`qos` signalling already advanced). If this frame
+    // triggered a DH-ratchet step, do NOT persist: a DH ratchet mints a fresh SENDING keypair (DHs),
+    // and the SW persisting it would make the worker a competing writer of the send-state — the
+    // page↔SW last-write-wins race could then clobber the page's authoritative DHs and permanently
+    // break outbound to the peer (adversarial review). The DH-step frame still decrypted in-memory
+    // for this preview; the page authoritatively performs (and persists) that ratchet when it drains.
+    if (!advancedDh) await saveSession(chatId, session);
+    return payload;
   } catch (e) {
+    // The established session couldn't open this. If it's a prekey packet the peer
+    // likely RE-INITIATED a fresh session (e.g. they deleted the chat). Decrypt with
+    // a fresh responder session IN MEMORY ONLY — do NOT persist it or consume the
+    // prekey; replacing the live ratchet is the page's authoritative call (FR-003).
     if (hadExistingSession && packet.type === 'prekey') {
       return openMessage(establishResponderSession(packet), packet.msg);
     }
     throw e;
   }
-  // Deliberately NO saveSession / session-meta writes (read-only preview).
+  // Deliberately NO session-meta writes: the send-preamble is cleared only by
+  // openPacket (FR-004), never by a preview.
+  });
 }
 
 /* ---- own prekey publication ---- */


### PR DESCRIPTION
## Spec 2015 — Background notifications decrypt queued messages reliably

Fixes the confirmed `decrypt-failed` cause behind "notifications show 'New message' after the app's been idle a while."

### Root cause
1:1 call signalling (offer/ICE + spec-0007 `qos`) rides the **same pairwise Double Ratchet** as chat but is sent **live** over the WebSocket and **never queued** in the relay. While the app is open, those live signals **advance + persist** the ratchet past chat messages still sitting in the relay queue. The service worker's **read-only** preview then decrypts a queued message from an over-advanced base → wrong key → "ciphertext cannot be decrypted" → generic.

### Fix
`previewPacket` now **persists the receiving-ratchet advance + skipped keys** so the SW preview can move forward and decrypt the backlog — via a new **additive** `ratchetDecryptPreview` that keeps each read message's key in the skipped-key cache, so the page's authoritative open stays idempotent (it re-finds the key there). Serialized under `sessionMutex`. Prekey/X3DH and the send-preamble stay **page-authoritative** (decrypt in-memory only).

### Safety (independent adversarial review — found & closed a blocker)
A DH-ratchet step mints a fresh **sending** keypair; persisting that from the SW could clobber the page's authoritative send-state under the page↔SW last-write-wins race → **permanent outbound divergence**. So the preview persists **only same-chain advances** (deterministic + purely additive); **DH-ratchet frames decrypt in-memory and are NOT persisted** (the page performs that ratchet authoritatively). The other five attack classes (key consumption/loss, prekey consumption, skipped-map growth/MAX_SKIP, forward secrecy, DH-divergence-in-isolation) were cleared.

### Tests
TDD: a `>MAX_SKIP` backlog repro (failing before the fix), idempotent page-open after preview, prekey-not-consumed, preamble page-only, and the `advancedDh` safety-gate. 341 unit tests + build green; notification e2e (`notifications-inapp`, `sw-decrypt`) green. Client-only; no server change; zero-knowledge unchanged.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
