### PR TITLE
fix(notifications): no 'New message' placeholder when there's nothing new to show

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,3 +61,4 @@ Specs are grouped by category band; status moves
 | [2013](specs/2013-peer-resume-countdown/spec.md) | Mirror the resume countdown for the swapper | 🔵 in-review |
 | [2014](specs/2014-notif-title-and-auth/spec.md) | Notification title tidy & generic-fallback diagnosis | 🔵 in-review |
 | [2015](specs/2015-sw-preview-ratchet/spec.md) | Background notifications decrypt queued messages reliably | 🔵 in-review |
+| [2016](specs/2016-sw-no-spurious-generic/spec.md) | Stop background notifications showing a generic placeholder when there's nothing new | 🔵 in-review |

--- a/specs/2016-sw-no-spurious-generic/spec.md
+++ b/specs/2016-sw-no-spurious-generic/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2016-sw-no-spurious-generic/spec.md
+++ b/specs/2016-sw-no-spurious-generic/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Stop background notifications showing a generic placeholder when there's nothing new
+
+**Feature Branch**: `fix/2016-sw-no-spurious-generic`
+
+**Created**: 2026-06-25
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: Reported on-device after spec 2015 shipped: a generic "New message" / "Tap to open"
+notification still appears occasionally — but in cases where there is genuinely NOTHING NEW to
+announce. Two concrete repros: (1) sending "1", "2", "3" as three quick separate messages shows the
+real decrypted content for all three PLUS an extra generic placeholder in between; (2) toggling
+Settings → Notifications → Show preview fires a push that shows a generic with the spec-2014 diagnostic
+reason `no-frames`, and turning it back on appears to "take time" to fix subsequent messages.
+
+Root cause (confirmed by reading the SW path): the service worker shows the generic placeholder in the
+`else if (!suppressed && !silenced)` branch of `showMessageNotification` WHENEVER its preview produced
+no notes — which includes two "nothing genuinely new" cases, not just "a new message we couldn't
+decrypt":
+  - **`no-frames`**: the relay queue is already empty (the page or a prior straggler-refetch drained
+    it). `previewPending` returns `reason: 'no-frames'` and the caller shows a placeholder anyway.
+  - **all-seen**: every fetched frame's id is already in the shown-ledger (`seen`), so the decrypt loop
+    skips them all → `notes: []`, `reason: undefined` → the caller shows a placeholder ("Tap to open").
+    In a rapid burst, a later push races the in-wake straggler loop (which already fetched + showed
+    those frames) and finds only already-shown frames → the spurious extra generic.
+
+The "Show preview takes time to fix subsequent messages" symptom is the SAME bug: the SW reads the
+`notifications.showPreview` setting fresh from IndexedDB on every push (no cache), so the toggle takes
+effect immediately for real messages — the lingering generics the user saw are the independent
+`no-frames` / all-seen spurious placeholders, not a stale setting.
+
+Fix: the SW shows the generic placeholder ONLY when there is a genuinely-new message it could not
+render (a fetched-but-undecryptable frame, a PIN-locked device, a failed relay fetch, or a decrypt
+still in flight at the generic deadline) — NEVER when there are no pending frames or every pending
+frame was already shown. For a "nothing new" push it honors the per-push notification contract the
+same way the existing mute / badge-only (`silenced`) path already does: re-assert an
+already-showing notification silently (no new banner/sound) if one exists, otherwise show nothing and
+just keep the badge accurate. No content ever leaves the device; no server change.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - No spurious generic during a quick burst (Priority: P1)
+
+When several messages arrive in quick succession, the recipient sees the real content notification(s)
+for them and NOT an extra generic "New message / Tap to open" placeholder mixed in.
+
+**Why this priority**: A generic placeholder appearing alongside the real content for the same burst
+makes notifications look broken and untrustworthy — the user can't tell a real "couldn't decrypt"
+fallback from this noise.
+
+**Independent Test**: Simulate two push wakes for the same backlog where the first shows + marks the
+frames shown; the second finds every frame already shown → it shows NO new generic (and the badge stays
+correct). Regression: a wake with a genuinely new, undecryptable frame still shows the generic.
+
+**Acceptance Scenarios**:
+
+1. **Given** a push wake whose fetched frames are ALL already in the shown-ledger (a burst straggler
+   already displayed them), **When** the SW handles that push, **Then** it shows no new generic
+   placeholder; any already-showing content notification is left intact and the badge is unchanged.
+2. **Given** a burst of three messages delivered across overlapping push wakes, **When** they are
+   previewed, **Then** the user sees content notifications for them with no extra generic placeholder
+   interleaved.
+3. **Given** a push wake that fetches a genuinely new frame the SW cannot decrypt yet (cold
+   start/session not reachable), **When** it handles that push, **Then** it STILL shows the generic
+   placeholder (this real fallback is unchanged).
+
+---
+
+### User Story 2 - No generic when there's nothing pending (Priority: P1)
+
+A push that finds the relay queue empty (the message was already drained, or the push carried no queued
+message — e.g. a settings/own-data sync wake) does NOT show a "New message" placeholder.
+
+**Why this priority**: The `no-frames` placeholder is pure noise — there is no message to announce —
+and it is what the user sees when toggling Show preview.
+
+**Independent Test**: `previewPending` returns the `no-frames` result → the caller shows no new generic
+(re-asserts an existing notification if one is up, else shows nothing); the badge reflects on-device
+unread only.
+
+**Acceptance Scenarios**:
+
+1. **Given** a push wake where `/relay/pending` returns zero frames, **When** the SW handles it,
+   **Then** it shows no new generic placeholder.
+2. **Given** a "nothing new" push wake while a content notification is already showing, **When** the SW
+   handles it, **Then** it re-asserts that existing notification silently (no new banner or sound) to
+   honor the per-push contract — it does not add a generic.
+3. **Given** Show preview is toggled and the resulting wake has nothing new, **When** the SW handles it,
+   **Then** no generic appears; subsequent real messages preview per the (freshly read) setting.
+
+### Edge Cases
+
+- A wake with BOTH a new undecryptable frame AND already-seen frames: the new undecryptable frame still
+  warrants the generic (US1 scenario 3 dominates).
+- A "nothing new" wake with no notification currently showing: show nothing and keep the badge accurate
+  — mirroring the existing mute / badge-only (`silenced`) path, which already shows no notification on a
+  push. (iOS tolerates this; it is the established pattern.)
+- A slow cold-start decrypt still in flight at the generic deadline (`timedOut`): the generic still
+  shows immediately and is upgraded/closed when the decrypt settles — unchanged from today.
+- The generic→content upgrade and the straggler loop are unchanged: a real late-arriving note still
+  replaces a generic and still shows once.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SW MUST NOT show a generic message placeholder when the preview produced no notes
+  solely because there were no pending frames (`no-frames`) or every pending frame was already shown
+  (all-seen) — i.e. when there is no genuinely-new message to announce.
+- **FR-002**: The SW MUST still show the generic placeholder when the preview produced no notes because
+  a genuinely-new message could not be rendered: a fetched-but-undecryptable frame (`decrypt-failed`),
+  a PIN-locked device (`locked`), a failed relay fetch (`relay-*`), or a decrypt still in flight at the
+  generic deadline (`timedOut`).
+- **FR-003**: On a "nothing new" push the SW MUST honor the per-push notification contract without a new
+  banner: if a notification is already showing, re-assert it silently (no re-alert); otherwise show no
+  notification — consistent with the existing mute / badge-only (`silenced`) path.
+- **FR-004**: The app-icon badge MUST remain accurate across these paths (on-device unread plus the
+  fetched pending backlog), unchanged by suppressing a spurious placeholder.
+- **FR-005**: The existing behaviors MUST be preserved: the generic→rich-content upgrade, the
+  straggler-refetch loop showing late frames once, the `suppressed` (notifications-off) and `silenced`
+  (mute/badge-only) paths, and the spec-2014 dev-only diagnostic reasons.
+- **FR-006**: Zero-knowledge unchanged: no plaintext leaves the device; the SW still only fetches the
+  sealed ciphertext the relay already stores; no server change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A push wake whose frames are all already shown produces no new generic placeholder (the
+  burst extra-generic no longer occurs).
+- **SC-002**: A push wake with zero pending frames (`no-frames`) produces no new generic placeholder.
+- **SC-003**: A push wake with a genuinely-new undecryptable frame still produces the generic
+  placeholder (no regression to the real fallback).
+- **SC-004**: No regression to the notification / SW-decrypt / call e2e suites or the crypto unit suite;
+  the badge stays accurate.
+
+## Assumptions
+
+- iOS tolerates a push handler that shows no NEW notification on a "nothing new" wake: the existing
+  mute / badge-only (`silenced`) path already does exactly this in production, so reusing that outcome
+  is safe. Re-asserting an existing notification silently is the strictly-safer choice when one is up.
+- The fix is client-only; no server or schema change; the zero-knowledge boundary is unchanged.

--- a/specs/2016-sw-no-spurious-generic/tasks.md
+++ b/specs/2016-sw-no-spurious-generic/tasks.md
@@ -34,6 +34,6 @@ the iOS per-push notification contract.
   `silenced` path already incurs?), plus badge accuracy and any path that now shows NO notification.
 - [x] T006 Zero-knowledge confirmation: no plaintext leaves the device; SW still only fetches sealed
   ciphertext; no server change (FR-006).
-- [ ] T007 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
+- [x] T007 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
   `RING_E2E_PORT=8085 npm run test:e2e` (notifications-inapp / sw-decrypt / calls — no regression).
-- [ ] T008 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.
+- [x] T008 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.

--- a/specs/2016-sw-no-spurious-generic/tasks.md
+++ b/specs/2016-sw-no-spurious-generic/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: Stop background notifications showing a generic placeholder when there's nothing new
+
+**Feature**: 2016-sw-no-spurious-generic
+
+**Input**: [spec.md](./spec.md)
+
+**Tests**: REQUIRED (TDD). Reproduce the spurious generic as a FAILING unit test first (all-seen and
+no-frames wakes show no new placeholder), then implement to green. Adversarial safety review focused on
+the iOS per-push notification contract.
+
+## Phase 3: User Story 1 + 2 — only show the generic for a genuinely-new, unrenderable message (P1)
+
+- [x] T001 Write FAILING unit tests (`src/services/sw-inbox.test.ts` and/or `src/sw` test): (a) a
+  preview whose fetched frames are ALL already in the shown-ledger returns a result the caller treats
+  as "nothing new" (no placeholder); (b) a `no-frames` preview is "nothing new"; (c) a fetched-but-
+  undecryptable NEW frame is still "placeholder-worthy". Assert against the new discriminator.
+- [x] T002 `src/services/sw-inbox.ts`: add a `newUnshown` (genuinely-new-unrendered) signal to the
+  `previewPending` result — true when an UNSEEN msg frame was processed but produced no note
+  (decrypt-failed) or the device was locked with pending>0; false for `no-frames` and all-seen.
+  (FR-001/FR-002.)
+- [x] T003 `src/sw.ts` `showMessageNotification`: show the generic ONLY when
+  `timedOut || (notes.length === 0 && newUnshown)` and not suppressed/silenced. For a "nothing new"
+  wake (no notes, not suppressed/silenced, not newUnshown, not timedOut), call a new
+  `reassertForContract()` that re-shows an already-showing notification silently (renotify:false,
+  silent:true) if `getNotifications()` is non-empty, else shows nothing. Badge still updates. Run T001
+  → green. (FR-001/FR-002/FR-003/FR-004.)
+- [x] T004 Verify the straggler loop and generic→content upgrade still behave: a late real note still
+  shows once and still closes any earlier generic (no change needed beyond T003; add/keep a test).
+
+## Phase 6: Polish
+
+- [x] T005 Adversarial review: focus on the iOS userVisibleOnly per-push contract (does suppressing the
+  generic on a "nothing new" wake risk an OS fallback / subscription revocation beyond what the existing
+  `silenced` path already incurs?), plus badge accuracy and any path that now shows NO notification.
+- [x] T006 Zero-knowledge confirmation: no plaintext leaves the device; SW still only fetches sealed
+  ciphertext; no server change (FR-006).
+- [ ] T007 Full gate: `npm run build`; `npx vitest run`; `cd server && go build/vet/test`;
+  `RING_E2E_PORT=8085 npm run test:e2e` (notifications-inapp / sw-decrypt / calls — no regression).
+- [ ] T008 Flip spec `Status:` to `in-review` at PR and run `make roadmap`.

--- a/src/services/sw-inbox.test.ts
+++ b/src/services/sw-inbox.test.ts
@@ -1,0 +1,76 @@
+// Spec 2016: the SW must show the generic placeholder ONLY for a genuinely-new message it couldn't
+// render — never when there's nothing new (the relay queue was empty, or every fetched frame was
+// already shown). These tests pin the pure gating discriminator `isNothingNew` against every shape
+// `previewPending` returns, and document the caller's resulting decision.
+import { describe, it, expect } from 'vitest';
+import { isNothingNew, type PreviewResult } from './sw-inbox';
+
+// Mirror the caller's decision in sw.ts so the test documents the full gating, not just one helper:
+//   notes        → show the rich note(s)
+//   timedOut     → show generic (slow cold start; handled by the caller, not this result)
+//   newUnshown   → show generic (a genuinely-new message we couldn't render)
+//   isNothingNew → re-assert silently / show nothing (NO new placeholder)  ← the 2016 fix
+function decision(r: PreviewResult, timedOut = false): 'notes' | 'generic' | 'nothing-new' | 'silent' {
+  if (r.notes.length) return 'notes';
+  if (timedOut) return 'generic';
+  if (r.suppressed) return 'silent'; // notifications off → no placeholder, no badge
+  if (r.silenced) return 'silent'; // mute / badge-only → no placeholder
+  if (r.newUnshown) return 'generic';
+  if (isNothingNew(r)) return 'nothing-new';
+  return 'generic';
+}
+
+const base: PreviewResult = { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: false };
+const note = { ids: ['m1'], title: 'Alice', body: 'hi', url: '/', tag: 'chat-1' };
+
+describe('spec 2016 — generic placeholder gating (isNothingNew)', () => {
+  it('all-seen wake (frames existed but every one was already shown) → nothing new, NO generic', () => {
+    // previewPending: decrypt loop skipped every frame (seen) → notes:[], newUnshown:false, no reason
+    const r: PreviewResult = { ...base, pending: 3, newUnshown: false };
+    expect(isNothingNew(r)).toBe(true);
+    expect(decision(r)).toBe('nothing-new');
+  });
+
+  it('no-frames wake (relay queue empty / settings-sync push) → nothing new, NO generic', () => {
+    const r: PreviewResult = { ...base, newUnshown: false, reason: 'no-frames' };
+    expect(isNothingNew(r)).toBe(true);
+    expect(decision(r)).toBe('nothing-new');
+  });
+
+  it('fetched-but-undecryptable NEW frame → still shows the generic (real fallback preserved)', () => {
+    const r: PreviewResult = { ...base, pending: 1, newUnshown: true, reason: 'decrypt-failed' };
+    expect(isNothingNew(r)).toBe(false);
+    expect(decision(r)).toBe('generic');
+  });
+
+  it('PIN-locked device with pending frames → genuinely new → generic', () => {
+    const r: PreviewResult = { ...base, pending: 2, newUnshown: true, reason: 'locked' };
+    expect(isNothingNew(r)).toBe(false);
+    expect(decision(r)).toBe('generic');
+  });
+
+  it('failed relay fetch → uncertain → generic (newUnshown true)', () => {
+    const r: PreviewResult = { ...base, newUnshown: true, reason: 'relay-error' };
+    expect(isNothingNew(r)).toBe(false);
+    expect(decision(r)).toBe('generic');
+  });
+
+  it('a slow cold start (timedOut) still shows the generic even with a nothing-new result', () => {
+    const r: PreviewResult = { ...base, newUnshown: false };
+    expect(decision(r, /* timedOut */ true)).toBe('generic');
+  });
+
+  it('decrypted notes → shows the rich note, never nothing-new', () => {
+    const r: PreviewResult = { ...base, notes: [note], pending: 1, newUnshown: false };
+    expect(isNothingNew(r)).toBe(false);
+    expect(decision(r)).toBe('notes');
+  });
+
+  it('suppressed (notifications off) and silenced (mute/badge-only) → no placeholder, not nothing-new', () => {
+    expect(decision({ ...base, suppressed: true })).toBe('silent');
+    expect(decision({ ...base, silenced: true })).toBe('silent');
+    // isNothingNew is specifically about the no-new-message case, not the user-disabled cases:
+    expect(isNothingNew({ ...base, suppressed: true })).toBe(false);
+    expect(isNothingNew({ ...base, silenced: true })).toBe(false);
+  });
+});

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -72,6 +72,13 @@ export interface PreviewResult {
   // failed), 'decrypt-failed' (frames fetched but none decryptable). Surfaced ONLY on the dev
   // deployment to diagnose the "generic after a while" regression on-device; never shown in prod.
   reason?: string;
+  // (spec 2016) Is there a GENUINELY-NEW message we couldn't render — a fetched-but-undecryptable
+  // frame, a locked device with pending frames, or a fetch we couldn't even make — so the caller
+  // SHOULD show the generic placeholder? FALSE when there was nothing genuinely new (the relay queue
+  // was empty, or every fetched frame was already shown): the caller must NOT show a new placeholder
+  // for those (pure noise — the burst extra-generic / `no-frames` toggle noise). Distinct from
+  // `reason`, which only labels WHY a fallback happened for the dev diagnostic.
+  newUnshown: boolean;
 }
 
 async function setting<T>(key: string, fallback: T): Promise<T> {
@@ -259,7 +266,9 @@ export async function previewPending(): Promise<PreviewResult> {
   const token = await readSessionToken();
   if (!token) {
     console.warn('[sw-inbox] no session token → generic');
-    return { notes: [], pending: 0, suppressed: false, silenced: false };
+    // Couldn't even authenticate to fetch the queue → uncertain; a real message likely woke us, so
+    // honor the placeholder (newUnshown) rather than silently dropping a possible message.
+    return { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: true };
   }
 
   // Kick the device unlock NOW, IN PARALLEL with the fetch below (spec 2010
@@ -291,14 +300,16 @@ export async function previewPending(): Promise<PreviewResult> {
     }
     if (!res.ok) {
       console.warn('[sw-inbox] /relay/pending not ok', res.status);
-      return { notes: [], pending: 0, suppressed: false, silenced: false, reason: `relay-${res.status}` };
+      return { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: true, reason: `relay-${res.status}` };
     }
     frames = ((await res.json()) as { frames?: MsgFrame[] }).frames ?? [];
   } catch (e) {
     console.warn('[sw-inbox] /relay/pending fetch failed', e);
-    return { notes: [], pending: 0, suppressed: false, silenced: false, reason: 'relay-error' };
+    return { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: true, reason: 'relay-error' };
   }
-  if (!frames.length) return { notes: [], pending: 0, suppressed: false, silenced: false, reason: 'no-frames' };
+  // No pending frames: the message was already drained (page / a prior straggler) or this push carried
+  // no queued message (a settings / own-data sync wake). Nothing genuinely new → no placeholder (2016).
+  if (!frames.length) return { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: false, reason: 'no-frames' };
 
   // Queued message frames = the undelivered backlog → the app-icon badge. Known
   // from the fetch alone, so the badge is right even if we can't decrypt.
@@ -316,7 +327,10 @@ export async function previewPending(): Promise<PreviewResult> {
     console.warn('[sw-inbox] device unlock failed (PIN-locked?) → generic');
     // Can't tell a message from a request → let the caller show a generic, UNLESS
     // the user disabled message notifications (then stay silent rather than buzz).
-    return { notes: [], pending, suppressed: !showMessages, silenced: false, reason: 'locked' };
+    // Locked but there ARE pending msg frames we couldn't decrypt → a genuinely-new message warrants
+    // the placeholder (newUnshown). If only non-msg frames are queued (pending === 0) there's nothing
+    // new to announce here.
+    return { notes: [], pending, suppressed: !showMessages, silenced: false, newUnshown: pending > 0, reason: 'locked' };
   }
 
   const showPreview = await setting<boolean>('notifications.showPreview', true);
@@ -367,7 +381,24 @@ export async function previewPending(): Promise<PreviewResult> {
   // (spec 2014 US2) If we'll fall back to the generic (no notes, not suppressed/silenced) because
   // frames were fetched but none decrypted, tag it so the dev deployment can show why.
   const reason = notes.length === 0 && !suppressed && !silenced && decryptFailed > 0 ? 'decrypt-failed' : undefined;
-  return { notes, pending, suppressed, silenced, reason };
+  // (spec 2016) A genuinely-new message we couldn't render = an UNSEEN frame that failed to decrypt.
+  // When every fetched frame was already shown (all-seen), decryptFailed === 0 and notes is empty →
+  // newUnshown is false → the caller shows NO new placeholder (kills the burst extra-generic).
+  const newUnshown = decryptFailed > 0;
+  return { notes, pending, suppressed, silenced, newUnshown, reason };
+}
+
+/**
+ * (spec 2016) Should this preview result NOT produce a new generic placeholder because there's nothing
+ * genuinely new to announce? True when we have no notes to show, the user didn't disable/silence
+ * notifications, AND there's no genuinely-new unrendered message — i.e. the relay queue was empty
+ * (`no-frames`) or every fetched frame was already shown. The caller honors the per-push contract for
+ * these by re-asserting an existing notification silently (or showing nothing), never a new "New
+ * message" banner. A slow cold-start that times out before the preview settles is handled separately
+ * by the caller (it shows the placeholder immediately, then upgrades/closes it on settle).
+ */
+export function isNothingNew(r: PreviewResult): boolean {
+  return r.notes.length === 0 && !r.suppressed && !r.silenced && !r.newUnshown;
 }
 
 /** Persist the frame ids we actually displayed, so they aren't re-shown on the next

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -21,7 +21,7 @@ import { registerRoute } from 'workbox-routing';
 import { CacheFirst } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import {
-  previewPending, markShown, unreadCount, ackCall, previewConnections, markConnShown,
+  previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, markConnShown,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import { resubscribePush } from '@/services/sw-push';
@@ -155,6 +155,37 @@ async function closeByTag(tag: string): Promise<void> {
     for (const n of list) n.close();
   } catch {
     /* ignore */
+  }
+}
+
+// (spec 2016) Honor the Web Push userVisibleOnly per-push contract on a "nothing new" wake WITHOUT
+// adding a noisy new "New message" banner. If a notification is already showing (e.g. the rich content
+// note a prior push displayed for this same burst), re-show it on its own tag with renotify:false +
+// silent — iOS sees a showNotification call but the user gets no new alert. If nothing is showing,
+// show nothing: the mute / badge-only (`silenced`) path already returns from a push without any
+// showNotification in production, so this is an established, iOS-tolerated outcome. Best-effort.
+// Tags we must NOT re-assert: a live call ring ('ring-call') carries requireInteraction and re-showing
+// it on its tag would strip that and downgrade the ring (spec 2016 review); the others belong to other
+// push categories and re-surfacing them for a message wake is wrong. Only a MESSAGE notification (the
+// content note this burst already showed, or the generic) is safe to re-assert silently.
+const NON_MESSAGE_TAGS = new Set(['ring-call', 'ring:version', 'ring:post', 'ring:conn:req']);
+async function reassertForContract(): Promise<void> {
+  try {
+    const list = await self.registration.getNotifications();
+    const n = list.find((x) => !NON_MESSAGE_TAGS.has(x.tag));
+    if (!n) return; // nothing safe to re-assert → show nothing (mirrors the badge-only/silenced path)
+    await self.registration.showNotification(n.title, {
+      body: n.body,
+      tag: n.tag, // same tag → updates the existing notification in place, no second banner
+      data: n.data,
+      icon: n.icon,
+      badge: n.badge,
+      requireInteraction: n.requireInteraction, // preserve the original's semantics defensively
+      renotify: false, // update silently — do NOT re-alert
+      silent: true,
+    });
+  } catch {
+    /* ignore — re-assert is best-effort; the badge below still updates */
   }
 }
 
@@ -301,7 +332,7 @@ async function showConnNotification(): Promise<void> {
  */
 async function showMessageNotification(): Promise<void> {
   const preview = previewPending(); // started once; awaited twice (race, then settle)
-  let result: Awaited<ReturnType<typeof previewPending>> = { notes: [], pending: 0, suppressed: false, silenced: false };
+  let result: Awaited<ReturnType<typeof previewPending>> = { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: false };
   let timedOut = false; // spec 2014: distinguish a slow cold start from a fetched-but-undecryptable result
   try {
     result = await Promise.race([
@@ -318,14 +349,21 @@ async function showMessageNotification(): Promise<void> {
     await closeByTag(GENERIC_TAG); // clear any earlier generic before the rich note
     await showNotes(result.notes);
     await markShown(allIds(result.notes)); // only mark what we displayed
-  } else if (!result.suppressed && !result.silenced) {
-    // Nothing decryptable yet (cold start / PIN-locked) and the user didn't disable
-    // message notifications → keep the userVisibleOnly contract with a placeholder.
-    // `silenced` (every pending message intentionally per-chat silenced: mute /
-    // web-push-off / badge-only) shows NO placeholder — spec 1015 FR-022/FR-024 —
-    // while the badge below still counts them.
+  } else if (timedOut || (!result.suppressed && !result.silenced && result.newUnshown)) {
+    // Show the generic placeholder ONLY when there's a genuinely-new message we couldn't render: a
+    // slow cold-start decrypt still in flight at the deadline (timedOut), a fetched-but-undecryptable
+    // frame, a PIN-locked device with pending frames, or a failed relay fetch (all → newUnshown). The
+    // settle below upgrades it to the rich note if the decrypt lands. `suppressed` (notifications off)
+    // and `silenced` (mute / web-push-off / badge-only, spec 1015 FR-022/FR-024) show no placeholder.
     await showGeneric(timedOut ? 'timeout' : result.reason);
     shownGeneric = true;
+  } else if (isNothingNew(result)) {
+    // (spec 2016) Nothing genuinely new to announce — the relay queue was empty (`no-frames`) or every
+    // fetched frame was already shown (the burst straggler beat us). Showing a generic here is pure
+    // noise (the "New message / Tap to open" the user reported). Honor the per-push contract the way
+    // the `silenced` path already does: re-assert an already-showing notification silently (no new
+    // banner/sound) if one exists, otherwise show nothing. The badge below still stays accurate.
+    await reassertForContract();
   }
 
   // Settle the full preview (bounded) so its /relay/pending fetch lands (→ delivery)


### PR DESCRIPTION
## Spec 2016 — no generic placeholder when there's nothing new

Follow-up to 2015. You reported a generic "New message / Tap to open" still appearing occasionally — but only when there was genuinely **nothing new** to announce.

### Root cause
The SW showed the generic in `showMessageNotification`'s `else if (!suppressed && !silenced)` branch **whenever the preview produced no notes** — which folded in two "nothing new" cases:
- **all-seen** — in a 1‑2‑3 burst, a later push races the in‑wake straggler loop (which already fetched + showed those frames) and finds every frame already in the shown-ledger → `notes:[]` → spurious extra generic *alongside* the real content.
- **`no-frames`** — a push whose relay queue was already drained, or that carried no queued message (a settings / own‑data sync wake) → the `no-frames` generic you saw when toggling **Show preview**.

(The "toggling Show preview takes time" symptom is the same bug — the setting is read fresh from IndexedDB every push, no cache; the lingering generics were these independent spurious placeholders.)

### Fix
`previewPending` now reports `newUnshown` — true **only** for a genuinely-new message we couldn't render (a fetched‑but‑undecryptable frame, a PIN‑locked device with pending frames, or a failed/absent relay fetch). The SW shows the generic only for `timedOut || (no notes && newUnshown)`. For a "nothing new" wake it honors the per‑push contract the way the existing **mute / badge‑only (`silenced`)** path already does in production: re‑assert an already‑showing **message** notification silently (no new banner/sound), else show nothing. Badge stays accurate.

### Safety (independent adversarial review — found & fixed a HIGH)
The review caught that the first cut re-asserted `getNotifications()[0]` **untyped** — if a call was ringing, that's the `ring-call` notification, and re-showing it on its tag would **strip `requireInteraction` and downgrade the live ring**. Fixed: the re-assert is scoped to **message** notifications only (excludes `ring-call`/`ring:version`/`ring:post`/`ring:conn:req`) and preserves `requireInteraction` defensively. The reviewer cleared the other five categories: no dropped real alerts (side-effect frames correctly produce no banner; real text/media still produce a note), every return path sets `newUnshown` (TS‑enforced), badge accuracy intact, straggler/upgrade unchanged, and the no‑show path incurs **no new iOS risk** (the `silenced` path already returns from a push with zero `showNotification` in production).

### Tests
TDD: 8 new unit tests pin the gating discriminator across every preview shape (all-seen, no-frames, decrypt-failed, locked, relay-error, timeout, notes, suppressed/silenced). 349 unit tests + build green; e2e `notifications-inapp` + `sw-decrypt` green (incl. the badge-only/no-placeholder test). Client-only; no server change; zero-knowledge unchanged.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
