### PR TITLE
feat(privacy): hide chats behind a PIN, revealed only from the search bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1018-media-sharing-and/plan.md`
+`specs/1019-hidden-chats-pin/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,7 @@ Specs are grouped by category band; status moves
 | [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | 🟢 shipped |
 | [1017](specs/1017-cache-reusable-assets/spec.md) | Cache reusable assets (animated emoji + avatars) so they aren't refetched | 🔵 in-review |
 | [1018](specs/1018-media-sharing-and/spec.md) | Media Sharing & Viewer Improvements | 🔵 in-review |
+| [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@ Specs are grouped by category band; status moves
 | [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | 🟢 shipped |
 | [1017](specs/1017-cache-reusable-assets/spec.md) | Cache reusable assets (animated emoji + avatars) so they aren't refetched | 🔵 in-review |
 | [1018](specs/1018-media-sharing-and/spec.md) | Media Sharing & Viewer Improvements | 🔵 in-review |
-| [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | ⚪ planned |
+| [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/hidden-chats-1019.mjs
+++ b/drive/scenarios/hidden-chats-1019.mjs
@@ -1,0 +1,45 @@
+/**
+ * Visual walkthrough of Hidden Chats (spec 1019) on the live dev stack.
+ *
+ *   node drive/scenarios/hidden-chats-1019.mjs        (headless)
+ *   HEADED=1 node drive/scenarios/hidden-chats-1019.mjs   (watch it)
+ *
+ * Captures, on Alice's mobile Chats tab: the chat visible, then hidden (gone),
+ * then revealed by typing the PIN into the search bar. Screenshots → .tmp/drive/.
+ */
+import {
+  createAccount, pair, chatWith, say, waitForMessage, shot, sweep, done, poll,
+} from '../driver.mjs';
+
+const ev = (c, fn, ...args) => c.page.evaluate(fn, ...args);
+const visibleIds = (c) => c.page.evaluate(() => window.__ringTest.visibleChatIds());
+
+const alice = await createAccount({ name: 'Alice', mobile: true });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+// A real conversation so the chat row is populated.
+await say(bob, alice.id, 'meet me at the usual spot 🤫');
+await waitForMessage(alice, bob.id, 'usual spot');
+const chat = await chatWith(alice, bob.id);
+
+// Enable the feature + set a PIN, then screenshot the chat VISIBLE.
+await ev(alice, () => window.__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+await ev(alice, (pin) => window.__ringTest.hiddenSetPin(pin), '2468');
+await shot(alice, 'hidden-1-visible', { route: '/tabs/chats' });
+
+// Hide it → the row disappears from the Chats tab.
+await ev(alice, (id) => window.__ringTest.hiddenAdd(id), chat);
+await poll(() => visibleIds(alice), (ids) => !ids.includes(chat), { label: 'chat hidden' });
+await shot(alice, 'hidden-2-hidden', { route: '/tabs/chats' });
+
+// Reveal via the search-bar PIN gesture → it returns.
+await alice.page.locator('ion-searchbar input').first().fill('2468');
+await poll(() => visibleIds(alice), (ids) => ids.includes(chat), { label: 'chat revealed' });
+await shot(alice, 'hidden-3-revealed');
+
+// The Settings → Privacy → Hidden chats screen.
+await shot(alice, 'hidden-4-settings', { route: '/settings/privacy-hidden-chats' });
+
+await sweep([alice, bob]);
+await done();

--- a/e2e/hidden-chats.spec.ts
+++ b/e2e/hidden-chats.spec.ts
@@ -89,3 +89,24 @@ test('search-bar PIN reveals hidden chats in the UI (US3 reveal gesture)', async
   await search.fill('4321');
   await expect.poll(() => visibleIds(a), { timeout: 15_000 }).toContain(chat);
 });
+
+test('PIN reset wipes hidden chats and blocks re-sync (US7)', async ({ browser }) => {
+  test.setTimeout(90_000);
+  const a = await createAccount(await browser.newContext(), 'HIDDEN05');
+  const b = await createAccount(await browser.newContext(), 'HIDDEN06');
+  await pair(a, b);
+
+  await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  const chat = await chatWith(a, b.id);
+  await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '1357');
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), chat);
+  expect(await hiddenIds(a)).toContain(chat);
+
+  // Reset → the hidden set is empty, the conversation is gone, and the old PIN no
+  // longer reveals anything.
+  const res = await ev(a, () => (window as any).__ringTest.hiddenReset());
+  expect(res.wiped).toContain(chat);
+  expect(await hiddenIds(a)).toEqual([]);
+  await expect.poll(() => visibleIds(a)).not.toContain(chat); // wiped, not merely hidden
+  expect(await ev(a, (p: string) => (window as any).__ringTest.hiddenReveal(p), '1357')).toBe(false);
+});

--- a/e2e/hidden-chats.spec.ts
+++ b/e2e/hidden-chats.spec.ts
@@ -71,9 +71,11 @@ test('search-bar PIN reveals hidden chats in the UI (US3 reveal gesture)', async
   const b = await createAccount(await browser.newContext(), 'HIDDEN04');
   await pair(a, b);
 
-  // Create the 1:1, set a PIN, and hide it.
+  // Create the 1:1, enable the feature (so the reveal gesture is armed — FR-013a),
+  // set a PIN, and hide it.
   await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
   const chat = await chatWith(a, b.id);
+  await ev(a, () => (window as any).__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
   await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '4321');
   await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), chat);
 

--- a/e2e/hidden-chats.spec.ts
+++ b/e2e/hidden-chats.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1019 — Hidden Chats. Hiding is a local, zero-knowledge privacy layer: a
+// hidden conversation is removed from every visible surface and only revealed by
+// the dedicated PIN. Driven through the dev test hook (the same service the UI
+// calls) plus a real UI check of the search-bar reveal gesture.
+
+const ev = (p: any, fn: (...a: any[]) => any, ...args: any[]): Promise<any> =>
+  p.page.evaluate(fn, ...args);
+const visibleIds = (p: any): Promise<string[]> =>
+  p.page.evaluate(() => (window as any).__ringTest.visibleChatIds());
+const hiddenIds = (p: any): Promise<string[]> =>
+  p.page.evaluate(() => (window as any).__ringTest.hiddenIds());
+const chatWith = (p: any, peerId: string): Promise<string> =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
+
+test('hide → reveal → unhide, coexistence, and re-locks across a restart (US1/US2/US3)', async ({ browser }) => {
+  test.setTimeout(90_000);
+  const a = await createAccount(await browser.newContext(), 'HIDDEN01');
+  const b = await createAccount(await browser.newContext(), 'HIDDEN02');
+  await pair(a, b);
+
+  // A has a normal, visible 1:1 chat with B.
+  await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  const oneToOne = await chatWith(a, b.id);
+  expect(oneToOne).not.toBe('');
+  expect(await visibleIds(a)).toContain(oneToOne);
+
+  // US1: set the dedicated PIN and hide the chat → it leaves every visible surface.
+  await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '1234');
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), oneToOne);
+  expect(await hiddenIds(a)).toContain(oneToOne);
+  await expect.poll(() => visibleIds(a)).not.toContain(oneToOne);
+
+  // US3: a wrong PIN reveals nothing; the correct PIN reveals the hidden chat.
+  expect(await ev(a, (p: string) => (window as any).__ringTest.hiddenReveal(p), '0000')).toBe(false);
+  await expect.poll(() => visibleIds(a)).not.toContain(oneToOne);
+  expect(await ev(a, (p: string) => (window as any).__ringTest.hiddenReveal(p), '1234')).toBe(true);
+  await expect.poll(() => visibleIds(a)).toContain(oneToOne);
+
+  // FR-005: re-lock → hidden again.
+  await ev(a, () => (window as any).__ringTest.hiddenRelock());
+  await expect.poll(() => visibleIds(a)).not.toContain(oneToOne);
+
+  // FR-005 / SC-009: a full restart (reload) re-locks — the hidden chat stays
+  // hidden with no reveal session carried over.
+  await a.page.reload();
+  await a.page.waitForFunction(() => (window as any).__ringTest?.isUnlocked() === true, null, { timeout: 30_000 });
+  await expect.poll(() => visibleIds(a), { timeout: 15_000 }).not.toContain(oneToOne);
+  expect(await hiddenIds(a)).toContain(oneToOne); // set survived the restart
+
+  // US2: a NEW hidden chat with the SAME contact is a DISTINCT conversation; the
+  // normal 1:1 is untouched.
+  const hiddenChat = await ev(a, (id: string) => (window as any).__ringTest.hiddenStartChat(id), b.id);
+  expect(hiddenChat).not.toBe(oneToOne);
+  expect(await hiddenIds(a)).toEqual(expect.arrayContaining([oneToOne, hiddenChat]));
+
+  // US3 unhide (FR-006): the 1:1 returns permanently, even after a re-lock; the
+  // distinct hidden chat stays hidden.
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenRemove(id), oneToOne);
+  await ev(a, () => (window as any).__ringTest.hiddenRelock());
+  await expect.poll(() => visibleIds(a)).toContain(oneToOne);
+  await expect.poll(() => visibleIds(a)).not.toContain(hiddenChat);
+});
+
+test('search-bar PIN reveals hidden chats in the UI (US3 reveal gesture)', async ({ browser }) => {
+  test.setTimeout(90_000);
+  const a = await createAccount(await browser.newContext(), 'HIDDEN03');
+  const b = await createAccount(await browser.newContext(), 'HIDDEN04');
+  await pair(a, b);
+
+  // Create the 1:1, set a PIN, and hide it.
+  await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  const chat = await chatWith(a, b.id);
+  await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '4321');
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), chat);
+
+  // Land on the Chats tab; the hidden chat is excluded from the list.
+  await a.page.goto('/tabs/chats');
+  await a.page.waitForFunction(() => (window as any).__ringTest?.isUnlocked() === true, null, { timeout: 30_000 });
+  const search = a.page.locator('ion-searchbar input').first();
+  await expect(search).toBeVisible({ timeout: 15_000 });
+  await expect.poll(() => visibleIds(a), { timeout: 15_000 }).not.toContain(chat);
+
+  // Typing the dedicated PIN into the real search bar input triggers the reveal
+  // gesture (the only entry point, US3) — the hidden chat returns to the list.
+  await search.fill('4321');
+  await expect.poll(() => visibleIds(a), { timeout: 15_000 }).toContain(chat);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/1019-hidden-chats-pin/checklists/requirements.md
+++ b/specs/1019-hidden-chats-pin/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Hidden Chats Locked Behind a PIN
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Ring-Specific
+
+- [x] Zero-Knowledge Impact section present and answers what crosses the wire,
+      what is encrypted, what metadata is visible, and why it is safe (Principle I)
+
+## Notes
+
+- All clarifications resolved in the 2026-06-26 session (recorded in spec
+  Clarifications): FR-015 separate dedicated PIN; FR-016 reset = wipe + block
+  re-sync; FR-017/FR-018 distinct coexisting conversation with local-only hiding;
+  FR-019 no call-history trail; FR-005/FR-020 sticky reveal grace window.
+- Spec is ready for `/speckit-plan` (the `/speckit-clarify` step has effectively
+  been satisfied interactively; re-run it if further ambiguities surface).

--- a/specs/1019-hidden-chats-pin/checklists/security.md
+++ b/specs/1019-hidden-chats-pin/checklists/security.md
@@ -1,0 +1,103 @@
+# Security & Zero-Knowledge Checklist: Hidden Chats Locked Behind a PIN
+
+**Purpose**: Validate that the crypto / zero-knowledge **requirements** for this
+feature are complete, clear, consistent, and measurable — *before* implementation.
+This is a requirements-quality gate (per Constitution Principles I & IV, which
+mandate a checklist for crypto / zero-knowledge specs), not a test plan.
+**Created**: 2026-06-26
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [research.md](../research.md)
+
+**How to use**: Each item asks whether the requirements are *written well enough*
+to implement and security-review safely. A failing item means a spec/plan edit is
+needed, not a code fix.
+
+## Zero-Knowledge Boundary (nothing new on the wire)
+
+- [ ] CHK001 Is "nothing new crosses the wire" stated as a verifiable requirement rather than an aspiration (i.e., a concrete equivalence a reviewer can check)? [Measurability, Spec §Zero-Knowledge Impact, §SC-004]
+- [ ] CHK002 Are the requirements explicit that the synced `chats` row is byte-identical whether or not a conversation is hidden? [Clarity, Spec §FR-014, §SC-004]
+- [ ] CHK003 Is it specified that the hidden set, PIN material, grace/biometric prefs, and do-not-resync block are NEVER included in any sync payload? [Completeness, Spec §FR-009; Research §R1]
+- [ ] CHK004 Are the metadata items the server *unavoidably* still sees enumerated, and confirmed unchanged from today (no new signal that a chat is hidden / the feature is enabled / a PIN exists)? [Completeness, Spec §Zero-Knowledge Impact]
+- [ ] CHK005 Do the requirements address whether creating the distinct 2-person hidden group leaks a *correlatable* signal to the server (e.g., a new group sharing participants with an existing 1:1), and assert why it does not? [Coverage, Spec §Zero-Knowledge Impact; Research §R2]
+- [ ] CHK006 Is it required that no log line, metric, error payload, or debug aid emit the hidden state or hidden-set contents (client or server)? [Gap, Constitution §I]
+- [ ] CHK007 Are call signalling / SFU paths for a hidden chat's calls required to be indistinguishable from non-hidden calls on the wire? [Coverage, Spec §FR-019; Research §R7]
+
+## At-Rest Protection — Hidden Set
+
+- [ ] CHK008 Is "protected at rest so it cannot be read off the device without the PIN (or biometric)" quantified to a specific protection (which key wraps the set)? [Clarity, Spec §FR-010; Research §R1]
+- [ ] CHK009 Is the distinction between *knowing membership* (to hide by default) and *authorizing reveal* (the PIN) stated unambiguously, so the wrapping-key choice is justified? [Clarity, Spec §FR-002 vs §FR-004; Research §R1/§R3]
+- [ ] CHK010 Is the residual at-rest exposure of hidden *message bodies* (plaintext in the on-device `messages` store) explicitly acknowledged and scoped, with the threat model it is/ isn't meant to defend? [Ambiguity, Spec §FR-010, §Assumptions; Research §R1]
+- [ ] CHK011 Is the threat model the at-rest protection targets ("briefly handed the unlocked phone") documented and distinguished from forensic disk extraction? [Assumption, Spec §Overview; Research §R1]
+- [x] CHK012 Are requirements defined for what happens to the wrapped set if it fails to decrypt / is corrupt (fail-closed vs fail-open)? [Edge Case, Gap]
+
+## At-Rest Protection — Separate Dedicated PIN
+
+- [ ] CHK013 Is it required that the hidden-chats PIN is fully independent of the app-unlock PIN (separate salt/key), and that app unlock does not reveal hidden chats? [Consistency, Spec §FR-015; Research §R3]
+- [ ] CHK014 Is "the PIN is never stored in recoverable plaintext" stated as a requirement, with verification defined as decryption success (AEAD), not a stored comparison? [Clarity, Spec §FR-010; Research §R3]
+- [ ] CHK015 Are requirements for PIN format (numeric, length, min/max) specified or explicitly deferred with a named default, so auto-verify-at-length is unambiguous? [Completeness, Spec §Assumptions (PIN format); Research §R5]
+- [ ] CHK016 Are wrong-PIN requirements explicit that no oracle is leaked — no error or UI state that differs from the all-visible case, and no app-wide lockout? [Clarity, Spec §FR-004, §SC-006, §Edge Cases]
+- [x] CHK017 Are rate-limiting / brute-force-resistance expectations for the reveal PIN specified or explicitly out of scope (and is Argon2id cost the stated mitigation)? [Gap, Non-Functional]
+- [ ] CHK018 Are change-PIN requirements defined (old-PIN proof required, set re-wrapped, no window where the set is unprotected)? [Completeness, Research §R3; Spec §FR-012]
+- [ ] CHK019 Is the relationship/precedence between the master-key-wrapped set and the PIN-wrapped capability specified clearly enough to avoid a second plaintext copy of the set? [Ambiguity, Research §R3]
+
+## Reveal-Session Lifecycle (cold-start re-lock)
+
+- [ ] CHK020 Is "full app close always re-locks" stated as an invariant with a measurable check (next launch begins locked, indistinguishable from never-revealed)? [Measurability, Spec §FR-005, §SC-009, §US3 AC6]
+- [ ] CHK021 Is it explicitly required that NO state which would auto-reveal survives a cold start (nothing persisted that resumes a reveal session)? [Clarity, Spec §FR-005; Research §R4]
+- [ ] CHK022 Are the exact reveal-ending triggers enumerated and consistent across spec and plan (grace elapse while backgrounded, explicit re-hide, full close)? [Consistency, Spec §FR-005/§FR-020 vs Research §R4]
+- [ ] CHK023 Is the grace-window default and option set specified unambiguously, and is the "immediately" option's behavior defined? [Clarity, Spec §FR-020; Research §R4; Data-Model §6]
+- [ ] CHK024 Is the boundary between "brief backgrounding" (kept) and "grace elapsed" (re-locked) defined by a precise elapsed-time rule rather than a vague notion of focus? [Ambiguity, Spec §US3; Research §R4]
+- [x] CHK025 Are requirements defined for an in-progress reveal interacting with a separate app-lock (auto-lock) event — which takes precedence? [Coverage, Gap; Research §R10]
+- [ ] CHK026 Is behavior specified for a hidden chat that is open/visible at the moment the grace window expires (does the open view also re-hide)? [Edge Case, Spec §Edge Cases]
+- [x] CHK027 Are device-clock-change / suspended-timer cases for the grace window addressed (so a manipulated clock can't extend reveal)? [Edge Case, Gap]
+
+## Notification Leak Prevention
+
+- [ ] CHK028 Is "no sender name, avatar, or content" specified as an exhaustive list of fields that MUST be absent for hidden-chat notifications? [Completeness, Spec §FR-007]
+- [x] CHK029 Is the fail-safe requirement explicit — if the service worker cannot determine hidden status (e.g., cannot unlock), it MUST default to a content-free notification? [Clarity, Spec §FR-007; Research §R6]
+- [ ] CHK030 Is the tap-routing requirement unambiguous (a hidden-chat notification lands on the Chats tab and never deep-links into / reveals the hidden chat)? [Clarity, Spec §FR-008; Research §R6]
+- [ ] CHK031 Are requirements consistent that existing burst-coalescing / dedup behavior must not cause a hidden chat's identity to surface in an aggregated notification? [Consistency, Spec §US3 AC3/AC4; Research §R6]
+- [ ] CHK032 Is the offline-queued / reconnect case required to honor the no-preview rule (no preview leaks when a backlog is delivered)? [Coverage, Spec §US3 AC4]
+- [ ] CHK033 Is the interaction with the existing per-chat `notifyContent` (full/generic/none) and global preview toggle specified, so hidden status overrides them deterministically? [Conflict, Research §R6]
+
+## Call-History Leak Prevention
+
+- [ ] CHK034 Is it required that placed, received, AND missed calls for a hidden chat are absent from the Calls tab / call history (all three explicitly)? [Completeness, Spec §FR-019, §US5]
+- [ ] CHK035 Is the missed-call badge/count requirement explicit that a hidden chat contributes no attributable badge? [Clarity, Spec §FR-019, §US5 AC2]
+- [ ] CHK036 Is the pre-answer caller-identity suppression requirement defined for both first incoming and call-waiting/second-incoming surfaces? [Coverage, Research §R7; Spec §US5 AC3]
+- [ ] CHK037 Is it specified that a previously hidden call remains absent after the chat is unhidden (was never logged) — i.e., the rule is "not logged," not "filtered on display"? [Clarity, Spec §US5 AC4]
+- [ ] CHK038 Is the in-conversation call-log line (inside the hidden chat) confirmed to carry no identity beyond what the conversation already shows? [Coverage, Research §R7]
+
+## Reset Wipe + Local-Only Do-Not-Resync Block
+
+- [ ] CHK039 Is the reset scope specified exhaustively (which local data is deleted: messages, sessions, sender keys, chat row, hidden set, PIN material)? [Completeness, Spec §FR-016; Research §R8; Data-Model §State transitions]
+- [ ] CHK040 Is "block re-sync on this device" required to be LOCAL-ONLY — explicitly NOT uploaded and NOT propagated to the user's other devices or the server? [Clarity, Spec §FR-016; Research §R8]
+- [ ] CHK041 Is the distinction between the existing (uploaded) tombstone and the new local-only block stated clearly enough to prevent accidental propagation? [Ambiguity, Research §R8]
+- [ ] CHK042 Is the destructive warning's required content specified (states permanent deletion of hidden conversations before confirmation)? [Completeness, Spec §FR-012, §US7 AC1]
+- [x] CHK043 Are requirements defined for the wipe being atomic / resilient to interruption (no partial state that re-exposes a half-wiped hidden chat)? [Edge Case, Gap; Recovery]
+- [ ] CHK044 Is the post-reset state specified (old PIN invalid, a fresh PIN can be created, no orphaned wrapped set referencing wiped ids)? [Completeness, Spec §US7 AC2; Data-Model]
+- [ ] CHK045 Is it defined whether the counterpart's copy / the server ciphertext is intentionally untouched by reset, and that this is acceptable? [Assumption, Spec §FR-018; Research §R8]
+
+## Crypto Discipline & Review Readiness
+
+- [ ] CHK046 Do the requirements mandate reuse of the existing libsodium primitives and the wrapSecret/verifyPin pattern, with "no new key-exchange/ratchet/primitive" stated? [Consistency, Constitution §IV; Plan §Constitution Check; Research §R2/§R3]
+- [ ] CHK047 Is the 2-person-group reuse (sender keys) identified as the mechanism, with no minimum-size assumption relied upon that the code doesn't guarantee? [Assumption, Research §R2]
+- [ ] CHK048 Is a security review explicitly required as a gate before implement, with its scope (at-rest wrapping, separate-PIN handling, reveal lifecycle, local-only block) named? [Traceability, Plan §Constitution Check; Research §Summary]
+- [ ] CHK049 Are the open composition details flagged in research (exact PIN↔set binding; local-only-tombstone representation) marked as review/implementation items that do NOT block tasks? [Clarity, Research §Summary]
+- [ ] CHK050 Is each security-relevant requirement traceable to an FR/SC and an acceptance scenario, so the reviewer can map requirement → oracle? [Traceability, Spec §Requirements/§Success Criteria; Contracts §Behavioral contracts]
+
+## Consistency, Ambiguities & Assumptions (cross-cutting)
+
+- [ ] CHK051 Are "hidden," "revealed," "locked," and "wiped+blocked" used consistently across spec, plan, data-model, and contracts (no overloaded terms with the existing "Locked chats" feature)? [Consistency, Research §R10; Data-Model]
+- [ ] CHK052 Is the per-device-divergence assumption (same conversation hidden on one device, visible on another) documented and reconciled with sync requirements (no sync error)? [Assumption, Spec §Edge Cases, §FR-018]
+- [ ] CHK053 Are the success criteria (SC-001…SC-009) each objectively measurable and individually traceable to a requirement? [Measurability, Spec §Success Criteria]
+- [ ] CHK054 Is the boundary with explicitly out-of-scope hardening (encrypting hidden message bodies at rest; cross-device hidden-state sync) stated so reviewers don't assume coverage? [Coverage, Spec §Out of Scope; Research §R1]
+
+## Notes
+
+- Items are requirement-quality questions. A `[ ]` that can't be answered "yes"
+  signals a spec/plan/research edit — resolve before `/speckit-implement`.
+- `[Gap]` items most likely need a new line in spec or plan. Highest-risk gaps to
+  watch: CHK012/CHK017 (fail-closed + brute-force), CHK027 (clock/timer), CHK043
+  (atomic wipe).
+- This checklist is itself a Constitution §I/§IV gate artifact; the named security
+  review (CHK048) is a separate, required human step.

--- a/specs/1019-hidden-chats-pin/contracts/internal-api.md
+++ b/specs/1019-hidden-chats-pin/contracts/internal-api.md
@@ -1,0 +1,97 @@
+# Phase 1 Contracts: Hidden Chats Locked Behind a PIN
+
+This is a **client-only** feature. **There is no external/wire contract** — no new
+HTTP endpoint, request, response field, header, or push payload. The server is
+untouched and remains unable to distinguish a hidden conversation from a visible
+one (Zero-Knowledge Impact, spec).
+
+> **Wire contract**: *none.* Confirmed against the zero-knowledge boundary
+> (Principle I). The only thing that crosses the wire is the hidden conversation's
+> normal sealed group traffic, identical to any other group.
+
+What follows is the **client-internal API surface** the implementation introduces
+and the call sites it edits — the "contract" other modules and the e2e tests rely
+on. Signatures are indicative (TypeScript), to be finalized in implementation.
+
+## New module: `src/services/hidden-chats.ts`
+
+```ts
+// ── Membership (master-key-wrapped set; requires unlocked app) ──
+export async function getHiddenSet(): Promise<Set<string>>;        // ids hidden on this device
+export async function isHidden(chatId: string): Promise<boolean>;
+export async function addHidden(chatId: string): Promise<void>;    // hide existing conversation
+export async function removeHidden(chatId: string): Promise<void>; // unhide
+
+// ── Separate dedicated PIN (mirrors identity.ts wrapSecret/verifyPin) ──
+export async function hasHiddenPin(): Promise<boolean>;
+export async function enableHiddenPin(pin: string): Promise<void>;
+export async function changeHiddenPin(oldPin: string, newPin: string): Promise<void>;
+export async function verifyHiddenPin(pin: string): Promise<boolean>; // = decryption success
+export async function hiddenPinLength(): Promise<number | null>;       // for auto-verify-at-length
+
+// ── Destructive reset: wipe local history + block re-sync (this device only) ──
+export async function resetHiddenChats(): Promise<{ wiped: string[] }>;
+
+// ── Start a NEW distinct hidden conversation (US2 coexistence) ──
+export async function startHiddenChat(contactId: string): Promise<string>; // returns groupId, added to set
+```
+
+**Guarantees**:
+- `getHiddenSet`/`isHidden` resolve from the master-key-wrapped blob; callable by
+  the page **and** the service worker (post device-unlock). If the app/SW cannot
+  unlock, callers treat *everything* as "preview-suppressed" (fail-safe).
+- `verifyHiddenPin` never reveals whether any chats are hidden on failure.
+- `resetHiddenChats` deletes messages/sessions/sender-keys/chat-rows for every
+  hidden id, records a **local-only** do-not-resync block per id, clears the set
+  and PIN material, and returns the wiped ids (for UI confirmation/logging — never
+  sent anywhere).
+
+## New composable: `src/composables/useHiddenChats.ts`
+
+```ts
+export function useHiddenChats(): {
+  revealed: Ref<boolean>;                 // in-memory reveal session state
+  reveal(pin: string): Promise<boolean>;  // verify → start session (+ grace timer)
+  revealWithBiometric(): Promise<boolean>;// if enabled+available; falls back to PIN
+  relock(): void;                         // explicit re-hide
+  // internally: visibilitychange + grace-window timer (mirrors useAutoLock);
+  // ALWAYS starts locked on cold load; full close re-locks.
+};
+```
+
+## Edited choke points (existing code)
+
+| Module | Change | Anchor |
+|---|---|---|
+| `src/db/queries.ts` `listChats()` | Exclude ids in the hidden set unless a reveal session is active | `:54` |
+| `src/db/queries.ts` `listCallGroups()` | Filter calls whose `contactId` ∈ hidden set; exclude from missed-call badge | `:1878`, `:1953` |
+| `src/services/chat-filters.ts` | Inherits exclusion via `listChats` (no per-chip change needed) | `chatMatchesFilter` |
+| `src/services/sw-inbox.ts` `noteForPayload()` | If chat ∈ hidden set → generic note (no sender/avatar/body) + `url:'/tabs/chats'` | `:138-224`, `:219` |
+| `src/services/ownsync.ts` `pullOwnData()` | Skip ingest for ids in the local-only do-not-resync block | `:172` |
+| `src/db/tombstones.ts` | Add local-only ("do not upload") tombstone variant | — |
+| `src/composables/useCall.ts` | Generic caller identity in `callMeta` when originating chat ∈ hidden set (incoming + call-waiting) | `:1663-1673` |
+| `src/components/ChatActionsSheet.vue` | "Hide chat" / "Unhide" action | action list |
+| `src/views/tabs/ChatsPage.vue` | PIN-in-searchbar reveal gesture; show hidden chats while revealed | `:13-17` |
+| `src/settings/schema.ts` | `privacy-hidden-chats` screen (enable, set/change PIN, reset PIN [danger+confirm], biometric, grace choice) | `privacy` node |
+
+## Behavioral contracts (testable assertions)
+
+These map directly to spec FR/SC and become the test oracles:
+
+1. **Exclusion is total**: a hidden id never appears from `listChats()`,
+   `listCallGroups()`, chat search, any picker, or a notification preview.
+   *(FR-002/007/019, SC-001/002)*
+2. **Wire-identical**: the synced `chats` row for a conversation is byte-identical
+   before and after hiding it. *(FR-009/014, SC-004/005)*
+3. **Reveal requires the dedicated PIN**: `listChats()` includes hidden ids only
+   while `revealed === true`; a wrong PIN yields no reveal and no signal.
+   *(FR-004, SC-006)*
+4. **Cold start re-locks**: after `reveal()` then a simulated full close,
+   `revealed` is `false` on next load and hidden chats are absent. *(FR-005, SC-009)*
+5. **Coexistence**: `startHiddenChat(c)` leaves the existing 1:1 with `c` intact
+   and listed; the two threads never merge. *(FR-017, SC-008)*
+6. **Reset is permanent**: after `resetHiddenChats()`, the wiped conversations'
+   local data is gone and a subsequent `pullOwnData()` does not re-add them.
+   *(FR-016, SC-007)*
+7. **Notifications fail safe**: if the SW cannot unlock, hidden (and all) previews
+   are generic — never a leak. *(FR-007)*

--- a/specs/1019-hidden-chats-pin/data-model.md
+++ b/specs/1019-hidden-chats-pin/data-model.md
@@ -1,0 +1,114 @@
+# Phase 1 Data Model: Hidden Chats Locked Behind a PIN
+
+**No new IndexedDB object store. No `DB_VERSION` bump** (stays 9). All state rides
+existing stores. Nothing here is added to the synced `chats` row.
+
+## Entities
+
+### 1. Hidden set (the membership)
+
+The set of conversation ids the user has hidden **on this device**.
+
+- **Storage**: one record in the existing `settings` store, key
+  `privacy.hiddenChats`. Value is an **AEAD `Envelope`** (via `sealJson`) wrapping
+  `string[]` (conversation ids), sealed under the **master key**.
+- **Why master-key-wrapped (not the hidden PIN)**: must be readable while the app
+  is unlocked so hidden chats can be *excluded by default*, before any reveal.
+  Protected at rest because the master key is itself PIN-wrapped (FR-010).
+- **Never synced**: not in `ownsync.SYNCED`; lives only in `settings`, which is
+  excluded from the profile/prefs sync bundle.
+- **Lifecycle**: created lazily on first hide; mutated on hide/unhide; cleared on
+  PIN reset.
+
+### 2. Hidden-chats PIN material (the lock)
+
+The separate, dedicated PIN gating *reveal*.
+
+- **Storage**: in `settings`/`keystore` (kept out of sync):
+  - `hiddenPinSalt` — b64url Argon2id salt, stored in the clear.
+  - `hiddenPinWrapped` — `Envelope` whose successful decryption proves the PIN
+    (and yields the capability to unlock the reveal session). No plaintext PIN.
+  - `hiddenPinLength` — digit count, for auto-verify at length (mirrors app PIN).
+- **Verification**: decryption success (AEAD tag) — `verifyHiddenPin(pin)`,
+  modeled on `identity.verifyPin`.
+- **Lifecycle**: set on enable / change PIN; rotated on change; destroyed on reset.
+
+### 3. Reveal session (ephemeral)
+
+Whether hidden chats are currently unlocked for viewing.
+
+- **Storage**: **in-memory only** (a composable ref in `useHiddenChats.ts`) plus a
+  background-entered timestamp used to compute grace expiry. **Never persisted in
+  a way that survives a cold start.**
+- **States**: `locked` (default) → `revealed` (after correct PIN/biometric) →
+  back to `locked` on grace-expiry, explicit re-hide, or full app close.
+- **Grace**: `immediately` / `1m` / `5m`; full close always re-locks.
+
+### 4. Do-not-resync block (reset permanence)
+
+Marks conversations wiped by a PIN reset so they don't re-download — **this
+device only**.
+
+- **Storage**: a **local-only** tombstone variant — either `tombstones` records
+  with `localOnly: true`, or a dedicated `settings` block-set
+  (`privacy.hiddenResyncBlock`). Consulted at sync-pull ingest; **never uploaded**
+  (so other devices and the server are unaffected).
+- **Lifecycle**: appended on PIN reset (one entry per wiped conversation);
+  effectively permanent on this device.
+
+### 5. Hidden conversation (reuses existing entities)
+
+A hidden chat is an ordinary conversation; only its *membership in the hidden set*
+is special.
+
+- **Storage**: existing `chats` (the 2-person group), `messages`, `sessions`,
+  `senderkeys` — unchanged shapes. The group is created by
+  `createGroup('', [contactId])` and immediately added to the hidden set.
+- **On the wire**: identical to any group → opaque to the server (ZK preserved).
+- **Other devices**: the group syncs as a normal conversation (visible there
+  unless independently hidden) — the accepted per-device-divergence behavior.
+
+### 6. Settings values (device-local prefs)
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `privacy.hiddenChatsEnabled` | toggle | `false` | Feature on/off for this device |
+| `privacy.hiddenChatsGrace` | choice | `1m` | Grace window: `immediately`/`1m`/`5m` |
+| `privacy.hiddenChatsBiometric` | toggle | `false` | Offer biometric unlock at reveal |
+
+(The wrapped set, PIN material, and block list above are *not* user-facing
+settings rows; they are internal records under the `settings`/`keystore` stores.)
+
+## Relationships & invariants
+
+- A conversation id is in **at most one** state relevant here: visible (not in
+  set), hidden (in set), or wiped+blocked (in the do-not-resync block, removed
+  from the set).
+- The **hidden set** excludes a conversation from: `listChats()` (and therefore
+  every chat-filter chip), chat search, chat pickers, `listCallGroups()` + missed-
+  call badges, and notification previews — a single source of truth consulted at
+  each surface.
+- **Membership knowledge ≠ reveal authorization**: the app can read the set
+  (master key) to *hide*; only the hidden **PIN** (or enabled biometric) flips the
+  **reveal session** to *show* them.
+- **Reveal session never persists** across a full app close (invariant behind
+  SC-009 / FR-005).
+- The **synced `chats` row is byte-identical** whether or not the conversation is
+  hidden (invariant behind SC-004 / FR-014).
+
+## State transitions
+
+```text
+Conversation visibility (this device):
+
+  VISIBLE ──hide()──────────────▶ HIDDEN ──unhide()──────────▶ VISIBLE
+                                    │
+                                    └─PIN reset wipe()─▶ WIPED+BLOCKED (terminal,
+                                                          local-only; no re-sync)
+
+Reveal session:
+
+  LOCKED ──correct PIN / biometric──▶ REVEALED
+  REVEALED ──grace elapsed (bg) / explicit re-hide / FULL CLOSE──▶ LOCKED
+  (cold start always begins LOCKED)
+```

--- a/specs/1019-hidden-chats-pin/plan.md
+++ b/specs/1019-hidden-chats-pin/plan.md
@@ -1,0 +1,169 @@
+# Implementation Plan: Hidden Chats Locked Behind a PIN
+
+**Branch**: `feat/1019-hidden-chats-pin` | **Date**: 2026-06-26 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/1019-hidden-chats-pin/spec.md`
+
+## Summary
+
+Add a client-only privacy layer that lets a user take specific conversations out
+of every visible surface (Chats tab, search, pickers, Calls tab / call history,
+notification previews) and reveal them only by entering a **separate dedicated
+PIN** in the chat-list search field, with optional biometric unlock. A hidden
+chat is a **distinct conversation** — modeled on the existing group mechanism (a
+2-person "group" reusing sender-key crypto) so it can coexist with the normal 1:1
+with the same person. Revealing is "sticky" within a short, configurable grace
+window across brief backgrounding but **always re-locks on a full app close**.
+Resetting the PIN permanently wipes the hidden conversations on this device and
+blocks them from re-syncing from the server.
+
+**Technical approach (grounded in the codebase):**
+
+- **Membership, not a column.** The set of hidden conversation ids is held as a
+  *separate, local-only, master-key-wrapped* blob in the `settings` store — never
+  a field on the synced `chats` row (rows are sealed and synced whole via
+  `ownsync.ts`, so a `hidden` column would propagate to other devices and violate
+  "hiding is local per device"). The single choke point `listChats()`
+  (`src/db/queries.ts`) and the `calls`/notification paths consult this set to
+  exclude hidden conversations everywhere.
+- **Separate PIN** mirrors the existing app-PIN pattern (`identity.ts`
+  `wrapSecret`/`verifyPin`): an Argon2id-derived key over a random salt, stored as
+  a wrapped verifier; "verify" is decryption success (AEAD tag), no plaintext PIN
+  at rest. Entering it starts an in-memory **reveal session**.
+- **Reveal session + grace window** reuse the `useAutoLock.ts` pattern
+  (`visibilitychange` + elapsed-time check). The revealed state lives only in
+  memory and is never persisted in a form that survives a cold start, so a full
+  close always re-locks.
+- **Distinct conversation** uses `createGroup('', [contactId])` (no minimum size
+  enforced) to mint a coexisting hidden thread; the counterpart sees a normal
+  separate conversation (confirmed acceptable).
+- **Reset wipe + block re-sync** reuses the **tombstone** mechanism, but with a
+  new *local-only* variant that blocks ingest in `pullOwnData()` without uploading
+  a deletion frame (so other devices keep their copy).
+- **No server changes, no new IndexedDB store, no DB_VERSION bump.** Everything
+  rides existing stores (`settings`, `keystore`, `chats`, `messages`, `sessions`,
+  `senderkeys`, `calls`) and existing client paths.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES modules, `@/`→`src/`), Vue 3 `<script setup>`
++ Ionic; Go 1.26 server (untouched by this feature).
+
+**Primary Dependencies**: Ionic Vue, libsodium-wrappers-sumo (existing crypto
+core: X3DH, Double Ratchet, sender keys), IndexedDB via `src/db/idb.ts`.
+
+**Storage**: IndexedDB (offline-first source of truth). Reused stores: `settings`
+(wrapped hidden-set, hidden-PIN verifier, local-only block list, grace/biometric
+prefs), `keystore` (PIN-derived wrapping), `chats`/`messages`/`sessions`/
+`senderkeys` (the distinct hidden conversation), `calls` (history filtering),
+`tombstones` (extended with a local-only flavor). **No new store; no DB_VERSION
+bump** (current `DB_VERSION` = 9, unchanged).
+
+**Testing**: `npm run build` (vue-tsc typecheck) + vitest unit tests for the pure
+pieces (set wrap/unwrap, PIN verify, filter exclusion, reset wipe/block logic);
+Playwright e2e under `e2e/` for hide → reveal → coexist → notification → call-log
+suppression; `drive/` for manual multi-user inspection.
+
+**Target Platform**: Installable PWA (mobile-first, iPhone-under-chromium parity);
+custom service worker (`src/sw.ts`) for Web Push.
+
+**Project Type**: Client-only feature within the Vue PWA (no `server/` changes).
+
+**Performance Goals**: No perceptible regression to chat-list/search render; the
+hidden-set lookup is an in-memory Set membership check. Reveal/lock transitions
+feel instant (<100ms perceived).
+
+**Constraints**: Zero-knowledge boundary intact (no new wire data); offline-first;
+"no observable signal when unused" (FR-014/SC-005); must not regress the existing
+notification burst-coalescing (spec 2017) or the Locked-chats feature.
+
+**Scale/Scope**: Per-device set of hidden conversations (tens, realistically);
+touches ~6 client subsystems (data layer, crypto, chat-list/search UI, settings,
+notifications/SW, calls, sync). ~7 user stories, P1→P3 sliceable.
+
+## Constitution Check
+
+*GATE: re-checked after Phase 1 design — still PASS.*
+
+| Principle | Assessment |
+|---|---|
+| **I. Zero-Knowledge (NON-NEGOTIABLE)** | PASS. No new request/field/log crosses the wire. The hidden conversation is just another opaque group to the server (membership already encrypted). The hidden-set, PIN verifier and block-list never leave the device. Spec carries the mandatory **Zero-Knowledge Impact** section. |
+| **II. Spec-Driven** | PASS. Spec written, clarified (2026-06-26 session, 0 open markers), now planning. Branch/commits traceable to `1019`. |
+| **III. TDD** | PASS (enforced in tasks). `tasks.md` will order failing unit tests (set wrap/unwrap, separate-PIN verify, `listChats` exclusion, calls exclusion, reset wipe+block, generic-notification builder) and an e2e spec before implementation. |
+| **IV. Crypto Discipline** | PASS. Reuses libsodium primitives (`seal/open/sealJson/openJson`, `argon2id`) and the `wrapSecret`/`verifyPin` pattern; reuses sender keys for the 2-person group. **No new primitives or schemes.** Requires a **security review** and a **`/speckit-checklist`** (crypto/ZK spec) before implement. |
+| **V. Offline-First** | PASS. IndexedDB stays source of truth; reactivity via the existing change-bus + `useLiveQuery`. **No new object store / no `onupgradeneeded` change** — all state in existing stores. |
+| **VI. Stateless Server & Migrations** | PASS (trivially). No server code, no SQL migration, no `SECRETS_KEY` impact. |
+| **VII. Quality Gates** | PASS at done: `npm run build`, server build/vet/test (unaffected), vitest + e2e green. Release-note subject will be plain-language. |
+| **VIII. Traceable Delivery** | PASS. `taskstoissues` → one issue per task; feature→`develop` PR lists `Closes #N`. |
+| **IX. Privacy & Data Minimization** | PASS (the feature *strengthens* privacy; collects nothing new). |
+| **X. Accessibility & i18n** | PASS. Settings via the declarative schema; reveal/PIN UI from Ionic primitives; bidi-correct. |
+| **XI. Ionic-First UI** | PASS. Reuses `ion-searchbar` (reveal), `ChatActionsSheet`/`ChatListItem` (Hide action), `SettingDetailPage` schema (controls), Ionic alerts for the destructive reset warning. No bespoke widgets. |
+
+**Result: PASS — no violations. Complexity Tracking left empty.**
+
+Two mandated follow-ups before `/speckit-implement` (per Principles III/IV):
+1. Run **`/speckit-checklist`** (crypto / zero-knowledge spec).
+2. Plan for a **security review** of the at-rest wrapping, the separate-PIN
+   handling, and the reveal-session lifecycle.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1019-hidden-chats-pin/
+├── spec.md              # Feature spec (done)
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions & rationale
+├── data-model.md        # Phase 1 — entities, stores, fields, lifecycle
+├── quickstart.md        # Phase 1 — how to build/verify the slices
+├── contracts/
+│   └── internal-api.md   # Phase 1 — client-internal API surface (no wire changes)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (done) + crypto checklist (TODO via /speckit-checklist)
+└── tasks.md             # Phase 2 — created by /speckit-tasks (NOT here)
+```
+
+### Source Code (repository root) — client only
+
+```text
+src/
+├── db/
+│   ├── queries.ts            # + hidden-set get/add/remove; listChats() exclusion;
+│   │                         #   listCallGroups() exclusion; reset wipe+block;
+│   │                         #   startHiddenChat() (createGroup wrapper)
+│   ├── tombstones.ts         # + local-only "do-not-resync" block variant
+│   └── types.ts              # (no synced Chat field; types for hidden-set/prefs)
+├── services/
+│   ├── hidden-chats.ts       # NEW — hidden-set wrap/unwrap, separate-PIN
+│   │                         #   verify/enable/change/reset, block-list mgmt
+│   ├── ownsync.ts            # + consult local-only block list on pull ingest
+│   ├── sw-inbox.ts           # + generic notification + /tabs/chats url for hidden
+│   └── crypto/               # (reused as-is: envelope, identity, senderkeys)
+├── composables/
+│   ├── useHiddenChats.ts     # NEW — reveal session + grace window (mirrors useAutoLock)
+│   └── useCall.ts            # + generic caller identity when chat is hidden
+├── components/
+│   ├── ChatActionsSheet.vue  # + "Hide chat" / "Unhide" action
+│   └── (reveal handling in ChatsPage)
+├── views/
+│   ├── tabs/ChatsPage.vue     # + PIN-in-searchbar reveal gesture; revealed list state
+│   ├── tabs/CallsPage.vue     # (auto via listCallGroups exclusion)
+│   └── detail/SettingDetail…  # (schema-driven; no per-screen code)
+├── settings/schema.ts        # + privacy-hidden-chats screen (enable, PIN, reset, biometric, grace)
+└── sw.ts                     # (uses sw-inbox changes; notificationclick already routes by url)
+
+e2e/
+└── hidden-chats.spec.ts      # NEW — hide/reveal/coexist/notif/call-log/reset
+```
+
+**Structure Decision**: Single-project client feature. New code is concentrated
+in one new service (`src/services/hidden-chats.ts`) and one new composable
+(`src/composables/useHiddenChats.ts`), with surgical edits to the existing choke
+points identified in research (`listChats`, `listCallGroups`, `sw-inbox`,
+`ownsync`/`tombstones`, `useCall`, `ChatActionsSheet`, `ChatsPage`, `schema.ts`).
+No server, no new IndexedDB store.
+
+## Complexity Tracking
+
+> No Constitution violations — section intentionally empty.

--- a/specs/1019-hidden-chats-pin/quickstart.md
+++ b/specs/1019-hidden-chats-pin/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: Building & Verifying Hidden Chats
+
+A practical guide to implementing and checking the feature slice-by-slice. Each
+user story is an independently shippable increment.
+
+## Prerequisites
+
+```sh
+make start        # Postgres + ringd (air) + Vite at http://localhost:5173
+```
+
+Client changes need a rebuild to show on installed/phone PWA; in-browser dev sees
+them via Vite HMR. Typecheck/build gate:
+
+```sh
+npm run build     # vue-tsc --noEmit (typecheck) THEN vite build — run after TS/Vue edits
+```
+
+This is a **client-only** feature — no `server/` changes, no SQL migration, no
+`DB_VERSION` bump.
+
+## Suggested build order (by user story / priority)
+
+### Slice 1 — Hide + reveal MVP (US1 + US3, P1)
+1. `src/services/hidden-chats.ts`: master-key-wrapped hidden set
+   (`getHiddenSet/isHidden/addHidden/removeHidden`) + separate-PIN
+   (`enable/verify/changeHiddenPin`, modeled on `identity.ts`).
+2. Exclude the set in `src/db/queries.ts` `listChats()` (single choke point).
+3. `src/composables/useHiddenChats.ts`: in-memory reveal session + grace window
+   (mirror `useAutoLock.ts`); always start locked on cold load.
+4. `ChatActionsSheet.vue`: "Hide chat" action (prompts to create the PIN the
+   first time). Reveal: PIN typed into the `ChatsPage.vue` searchbar.
+- **Verify**: hide a chat → gone from Chats tab + search; type PIN in searchbar →
+  it reappears; background briefly → still revealed; fully close → re-locked.
+
+### Slice 2 — Coexisting distinct conversation (US2, P1)
+5. `startHiddenChat(contactId)` → `createGroup('', [contactId])` + add to set.
+6. Entry point to start a hidden chat with a contact.
+- **Verify** with `drive/`: a normal 1:1 with a friend stays listed while a
+  separate hidden chat with the same friend exists and only shows on reveal; the
+  two histories never merge; the friend's device shows a normal separate group.
+
+### Slice 3 — Private notifications (US4, P2)
+7. `src/services/sw-inbox.ts` `noteForPayload()`: generic note + `/tabs/chats`
+   url for hidden chats; keep burst-coalescing intact.
+- **Verify**: from another account, message a hidden chat → notification shows no
+  sender/avatar/body; tapping lands on Chats tab, chat still hidden.
+
+### Slice 4 — No call-history trail (US5, P2)
+8. Filter `listCallGroups()` (and missed-call badge) by the hidden set.
+9. `useCall.ts`: generic caller identity for incoming calls from a hidden chat.
+- **Verify**: place/miss calls in a hidden chat → absent from Calls tab; incoming
+  call shows a generic caller pre-answer.
+
+### Slice 5 — Biometric unlock (US6, P3)
+10. `revealWithBiometric()` + `privacy.hiddenChatsBiometric` toggle; PIN fallback
+    always works.
+
+### Slice 6 — Reset PIN: wipe + block re-sync (US7, P3)
+11. Local-only do-not-resync tombstone variant + `pullOwnData()` ingest skip.
+12. `resetHiddenChats()` (delete local data, add blocks, clear set + PIN) behind a
+    danger action with explicit destructive confirm in settings.
+- **Verify**: with hidden chats present, reset → warned → confirmed → local
+  history gone and does NOT re-appear after a sync pull.
+
+### Settings (supporting, any time)
+13. `src/settings/schema.ts`: `privacy-hidden-chats` screen (enable, set/change
+    PIN, reset PIN [danger+confirm], biometric, grace choice
+    `immediately`/`1m`/`5m`, default `1m`).
+
+## Tests (TDD — write first, per Constitution III)
+
+- **Unit (vitest)**: hidden-set wrap/unwrap; `verifyHiddenPin` (right/wrong, no
+  leak); `listChats()` excludes hidden / includes when revealed; `listCallGroups()`
+  exclusion + missed badge; `noteForPayload()` generic rendering + url; reset
+  wipe + do-not-resync block prevents `pullOwnData` re-add; reveal session
+  re-locks on simulated cold start.
+- **e2e (`e2e/hidden-chats.spec.ts`)**: hide → reveal → unhide; coexisting hidden
+  chat with same contact; hidden-chat notification has no preview; hidden call
+  absent from Calls tab; reset wipes and does not resurrect. Keep to 2-account
+  flows (3-person mesh is too flaky for headless CI — see project memory).
+- **Manual (`drive/`)**: multi-user coexistence + screenshots for the reveal UX.
+
+## Done = green gates (Constitution VII)
+
+```sh
+npm run build                 # client typecheck + build
+cd server && go build ./... && go vet ./... && go test ./...   # unaffected, must stay green
+npm run test:e2e              # needs `make db-up`
+```
+
+## Before `/speckit-implement` (mandated)
+
+- Run **`/speckit-checklist`** — required for crypto / zero-knowledge specs.
+- Line up a **security review** of: the master-key-wrapped set, the separate-PIN
+  wrap/verify, the reveal-session lifecycle, and the local-only do-not-resync
+  block. (Confirm none of them ever touch the wire.)

--- a/specs/1019-hidden-chats-pin/research.md
+++ b/specs/1019-hidden-chats-pin/research.md
@@ -1,0 +1,256 @@
+# Phase 0 Research: Hidden Chats Locked Behind a PIN
+
+All spec clarifications were resolved in the 2026-06-26 session. This document
+records the *technical* decisions reached by mapping the existing codebase, with
+rationale and rejected alternatives. File:line anchors are the integration points
+the implementation will touch.
+
+## R1. Where the "hidden" designation lives
+
+**Decision**: Store the set of hidden conversation ids as a **separate,
+local-only, master-key-wrapped blob in the `settings` store** (e.g. key
+`privacy.hiddenChats`). Do **not** add a `hidden` field to the `Chat` record.
+
+**Rationale**:
+- `ownsync.ts` seals and uploads **whole `chats` rows** under the master key
+  (`SYNCED = ['contacts','chats','chatlists']`, `sealJson(mk, row, 'sync')`). A
+  `hidden` field on the row would therefore sync to the server (as ciphertext)
+  **and propagate to the user's other devices**, violating FR-018 / FR-009
+  ("hiding is local to this device").
+- A separate set keeps the synced `chats` row byte-identical to a non-hidden
+  chat → satisfies FR-014 / SC-005 ("no observable signal when the feature is in
+  use") and SC-004 ("hidden vs visible indistinguishable on the wire").
+- Wrapping the set under the **master key** (available whenever the app/SW is
+  unlocked) meets FR-010 ("protected at rest, not readable without unlock") while
+  still letting the app/SW *exclude* hidden chats by default (before the hidden
+  PIN is entered). The hidden **PIN** gates *revealing*, not *knowing membership*.
+
+**Alternatives rejected**:
+- *Plaintext `hidden:boolean` on the Chat row* (like the existing `locked`
+  flag): simplest, but it syncs and is readable at rest — fails FR-009/010/018.
+- *Wrap the set under the hidden PIN itself*: then the app couldn't exclude
+  hidden chats until the PIN was entered — backwards (they'd be visible by
+  default). Membership must be knowable while unlocked; **revealing** is what the
+  PIN authorizes.
+
+**Integration points**: `src/db/queries.ts:54` `listChats()` (single choke point —
+all filter chips compose over it via `src/services/chat-filters.ts`
+`chatMatchesFilter`); `src/services/ownsync.ts:27` `SYNCED` (leave `chats` as-is,
+keep the set out).
+
+**Residual at-rest note (for security review)**: chat *message bodies* already
+live in the `messages` store in the clear on-device (offline-first; the
+zero-knowledge boundary is about the **server**, not local forensics). Hidden
+chats inherit that same posture — wrapping the *membership set* hides *which*
+chats are hidden, not the message bytes of a fully-forensic device image.
+Deeper at-rest encryption of hidden message bodies is **out of scope** (a future
+hardening) and is called out for the security review. This matches the threat
+model in the spec: "someone briefly handed the unlocked phone," not disk forensics.
+
+## R2. The distinct, coexisting hidden conversation
+
+**Decision**: A hidden chat is realized as a **2-person group** via
+`createGroup('', [contactId])`. Two flows:
+- **Hide existing** (US1): add an existing conversation's id to the hidden set.
+- **New hidden chat** (US2): create a fresh 2-person group, add it to the hidden
+  set immediately → coexists with the normal 1:1.
+
+**Rationale**:
+- `createGroup(name, memberIds)` (`src/db/queries.ts:1091`) enforces **no minimum
+  size**; a 2-person group is valid and yields a distinct `groupId`, its own
+  sender-key state, and its own history — exactly the "coexists with the 1:1"
+  requirement (FR-017). Reusing the group primitive honors Crypto Discipline
+  (Principle IV): **no new key-exchange/ratchet**.
+- `startDirectChat()` (`:3518`) dedupes 1:1s by contact, so you cannot get a
+  second 1:1 with the same person — confirming the group route is the way to a
+  coexisting distinct thread.
+
+**Accepted consequence (confirmed with user)**: the counterpart sees a normal
+separate 2-person group conversation on their device (FR-018). "Hidden" is local.
+
+**Alternatives rejected**:
+- *Second 1:1 thread*: impossible — 1:1 is identity-pair keyed and deduped.
+- *Pure-local "shadow" conversation with no real session*: messages need a real
+  crypto session to flow; would mean hand-rolling — rejected by Principle IV.
+
+**Integration points**: `src/db/queries.ts:1091` `createGroup`, `:419`
+`sealAndEnqueueGroup`, `src/services/crypto/senderkeys.ts`.
+
+## R3. Separate dedicated PIN (verify, enable, change, reset)
+
+**Decision**: Mirror the app-PIN pattern for an independent secret. Store, in the
+`settings`/`keystore` area (kept out of sync), `hiddenPinSalt` (b64url, clear),
+`hiddenPinWrapped` (an `Envelope` sealing a known marker / the hidden-set key),
+and `hiddenPinLength`. **Verification = decryption success** (AEAD tag), exactly
+like `verifyPin()` — no plaintext PIN, no separate stored verifier.
+
+**Rationale**: `src/services/crypto/identity.ts:217` `wrapSecret` /`:226`
+`unwrapSecret` /`:410` `verifyPin` /`:477` `enableLock` already implement this
+pattern with `argon2id` (`primitives.ts:138`) and the `envelope.ts` `seal/open`
+primitives. Reuse → Principle IV, and the separate salt/key keeps it fully
+independent of the app-unlock PIN (FR-015).
+
+**Detail**: the hidden-set blob (R1) is wrapped under the **master key** for
+default exclusion; the **hidden PIN** unlocks a *reveal session*. To bind reveal
+to the PIN without a second copy of the data, the hidden PIN wraps a small
+capability (e.g. the marker proving PIN-correctness); on success the app flips the
+reveal session on. (Exact composition — PIN wraps marker vs. PIN wraps the set's
+read — finalized in implementation; both reuse `sealJson/openJson`.)
+
+**Integration points**: `src/services/crypto/identity.ts:217/226/410/477`,
+`src/services/crypto/envelope.ts:54-85`, `primitives.ts:138`.
+
+## R4. Reveal session + sticky grace window + re-lock on full close
+
+**Decision**: Model on `useAutoLock.ts`. The revealed state is an **in-memory**
+ref plus a grace timer driven by `visibilitychange`. On background, record a
+timestamp; on return within the configured grace window, stay revealed; on
+elapse, explicit re-hide, or **cold start**, re-lock. **Nothing that auto-reveals
+is persisted across a full close** → an immediate relaunch shows no hidden chats
+(FR-005, FR-020, US3 AC5/AC6, SC-009).
+
+**Rationale**: `useAutoLock.ts:23-49` already does "stored timestamp + elapsed
+check" for app-lock, and `:52-58` wires `visibilitychange`; `useSync.ts:481`
+shows `pagehide` handling. Reusing this pattern avoids a parallel lifecycle
+implementation and inherits its tested edge handling.
+
+**Grace options**: `immediately` / `1m` / `5m`, default **1 minute** (privacy-
+leaning but enough for copy-paste). A full close always wins regardless.
+
+**Integration points**: new `src/composables/useHiddenChats.ts` (mirrors
+`useAutoLock.ts`); `src/views/tabs/ChatsPage.vue` consumes the revealed state.
+
+## R5. Reveal gesture in the search bar
+
+**Decision**: Reuse the existing `ion-searchbar` on `ChatsPage.vue:13-17`. When
+the typed query verifies as the hidden PIN, start the reveal session and surface
+hidden chats; otherwise it behaves as normal search (FR-004, SC-005/SC-006 — an
+incorrect/normal query is indistinguishable from the pre-feature behavior).
+
+**Rationale**: no discoverable entry point (the whole point), and it reuses an
+Ionic primitive already in the header (Principle XI). Mirrors Viber.
+
+**Detail**: attempt verification when the query is all-digits and matches
+`hiddenPinLength` (auto-verify at length, as the app PIN does). Non-matching input
+never errors or hints.
+
+**Integration points**: `src/views/tabs/ChatsPage.vue` search handler; gate the
+revealed list through `listChats()`/`useChatFilters` with a "include hidden when
+revealed" flag.
+
+## R6. Notifications — generic, no preview, no deep-link
+
+**Decision**: In `noteForPayload()` (`src/services/sw-inbox.ts:138-224`), if the
+target chat id ∈ hidden set, render a generic content-free note (no sender, no
+avatar, neutral body) and set `url` to `/tabs/chats` (not `/chat/{id}`), so a tap
+lands on the Chats tab without opening/revealing the chat (FR-007, FR-008).
+
+**Rationale**: the SW already imports `@/db/idb` and reads `chats`/`contacts`/
+settings (`sw-inbox.ts:23,395`), already supports `notifyContent: generic/none`,
+and already builds the `url`. The SW reads the master-key-wrapped hidden set
+**after** `attemptDeviceUnlock()`; if device-unlock fails it already shows a
+generic notification — so the no-preview guarantee holds **fail-safe**. Existing
+burst-coalescing (spec 2017, `coalesceForShow`/`serializeNotify`) is untouched.
+
+**Integration points**: `src/services/sw-inbox.ts:138-224` (build), `:219-220`
+(url), `src/sw.ts:582-600` (`notificationclick` already routes by `data.url`).
+
+## R7. Call history & pre-answer caller suppression
+
+**Decision**: (a) Exclude hidden conversations from the Calls tab by filtering in
+`listCallGroups()` (`src/db/queries.ts:1878`) before grouping; (b) suppress missed-
+call badges for hidden chats; (c) in `useCall.ts` incoming-offer handling
+(`:1663-1673`, and the call-waiting second-incoming branch), substitute a generic
+caller identity when the originating conversation is hidden, so
+`IncomingCallOverlay.vue` shows nothing identifying (FR-019).
+
+**Rationale**: the `calls` store records `contactId = roomId` for group calls
+(`types.ts:302`, `recordGroupCall`/`createCall` `:4225+`). Since hidden chats are
+2-person **groups**, their calls carry `contactId = hidden groupId`, which is a
+direct membership check against the hidden set — clean, no schema change. The
+pre-answer UI resolves name/avatar in `useCall.ts`, the single place to branch.
+
+**Edge**: the in-chat call-log line (`logCallToChat`/`calllog.ts`) is already
+generic and stays inside the (hidden) conversation — safe.
+
+**Integration points**: `src/db/queries.ts:1878` `listCallGroups`, `:1953`
+`markCallsSeen`; `src/composables/useCall.ts:1663-1673` (+ call-waiting branch);
+`src/components/IncomingCallOverlay.vue` (auto via `callMeta`).
+
+## R8. PIN reset: wipe local history + block re-sync (this device only)
+
+**Decision**: On reset, for each hidden conversation: delete its messages,
+sessions, sender keys, and chat row locally, **and** record a **local-only
+"do-not-resync" block** so `pullOwnData()` ingest skips it — **without** uploading
+a deletion tombstone (other devices keep their copy). Then clear the hidden set
+and the hidden-PIN material; the user can set a fresh PIN.
+
+**Rationale**: the existing tombstone mechanism (`src/db/tombstones.ts`
+`recordTombstone`/`isTombstoned`, checked in `sync.ts`/`ownsync.ts`
+`pullOwnData` ingest) already does "prevent resurrection from server pull" — but
+`listTombstones()` **uploads** tombstones, which would delete the conversation on
+other devices and is observable. So we add a **local-only variant** (e.g. a
+`localOnly: true` flag on the tombstone, or a separate `settings` block-set) that
+is consulted at ingest but never enqueued/uploaded. This satisfies FR-016 ("wipe
++ block re-sync on this device") and the user's "Wipe + block re-sync" choice
+while keeping it device-local.
+
+**Alternatives rejected**:
+- *Normal tombstone*: propagates the delete to other devices and to the server
+  cursor — wrong scope, and observable.
+- *Just delete locally, no block*: the conversation re-downloads on next
+  `pullOwnData()` — fails FR-016.
+
+**Integration points**: `src/db/tombstones.ts` (+ local-only flavor),
+`src/services/ownsync.ts:172` `pullOwnData` (ingest skip), the deletion helpers in
+`src/db/queries.ts` (`deleteChat` and message/session/senderkey removal).
+
+## R9. Settings surface
+
+**Decision**: Add a `privacy-hidden-chats` screen under the existing
+`privacy` hub in `src/settings/schema.ts` (declarative, rendered by
+`SettingDetailPage.vue`): enable toggle, set/change PIN (action), reset PIN
+(danger action with explicit confirm), biometric toggle, and a grace-window
+`choice` (`immediately`/`1m`/`5m`). Values read via `getSetting`/`setSetting`.
+
+**Rationale**: Principles X/XI — a settings screen is a data edit here, not a new
+component. App-lock/device-local settings are already **excluded from sync**
+(`ownsync.ts` comment), so the hidden-chats prefs stay per-device automatically.
+
+**Integration points**: `src/settings/schema.ts` (`privacy` node ~`:240`,
+sibling to `privacy-app-lock`/`privacy-chat-lock`); `SettingDetailPage.vue`
+(`str/bool` readers, `setSetting` writers).
+
+## R10. Relationship to the existing "Locked chats" feature
+
+**Decision**: Build Hidden Chats as a **distinct** feature, reusing building
+blocks but not the `locked` flag.
+
+**Rationale**: Locked chats (`chat.locked`, `listLockedChats`, `privacy-chat-lock`,
+gated by app auth, shown in a discoverable "Locked chats" view, and **synced**)
+differ from Hidden Chats on every defining requirement: separate dedicated PIN,
+**no** discoverable entry point, notification/call-history suppression, distinct-
+conversation coexistence, local-only + reset wipe/block. Overloading `locked`
+would entangle two different threat models and break "no observable signal."
+Reused *patterns*: the per-flag exclusion at `listChats`, the `useAutoLock` grace
+lifecycle, the wrap/verify primitives, the settings schema, `ChatActionsSheet`.
+
+## Summary of decisions
+
+| # | Decision | Key reuse |
+|---|---|---|
+| R1 | Hidden-set = local-only, master-key-wrapped blob in `settings` (no Chat field) | `ownsync` SYNCED set, `sealJson` |
+| R2 | Hidden chat = 2-person group (coexists with 1:1) | `createGroup`, sender keys |
+| R3 | Separate PIN via wrap/verify (decryption = verification) | `identity.ts` wrapSecret/verifyPin |
+| R4 | Reveal session + grace window; cold start always re-locks | `useAutoLock` pattern |
+| R5 | Reveal = PIN typed into the chat-list searchbar | `ion-searchbar` on ChatsPage |
+| R6 | Generic notification + `/tabs/chats` url for hidden | `sw-inbox.noteForPayload` |
+| R7 | Exclude from Calls tab + generic pre-answer caller | `listCallGroups`, `useCall` |
+| R8 | Reset = wipe local + **local-only** do-not-resync block | tombstones + `pullOwnData` |
+| R9 | Declarative `privacy-hidden-chats` settings screen | `settings/schema.ts` |
+| R10 | Distinct from Locked-chats; reuse blocks, not the `locked` flag | — |
+
+**Open for `/speckit-checklist` + security review**: exact PIN↔set composition
+(R3), the precise local-only-tombstone representation (R8), and the at-rest
+residual on message bodies (R1). None block tasks; all are implementation/review
+details.

--- a/specs/1019-hidden-chats-pin/spec.md
+++ b/specs/1019-hidden-chats-pin/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-26
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1019-hidden-chats-pin/spec.md
+++ b/specs/1019-hidden-chats-pin/spec.md
@@ -1,0 +1,558 @@
+# Feature Specification: Hidden Chats Locked Behind a PIN
+
+**Feature Branch**: `feat/1019-hidden-chats-pin`
+
+**Created**: 2026-06-26
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Hidden chats locked behind a PIN — let users hide specific 1:1 and group conversations so they don't appear in the main chat list and are only revealed by entering a PIN (with optional biometric unlock). Notifications for hidden chats arrive but show no sender/content preview. Hiding is local to the device and never visible to the server (zero-knowledge). Resetting the PIN wipes hidden-chat local state. Inspired by Viber's hidden chats."
+
+## Overview
+
+Some conversations are private even from someone who is briefly handed the
+phone. **Hidden Chats** lets a user take a specific 1:1 or group conversation
+out of the visible chat list and tuck it behind a PIN (with optional biometric
+unlock). The hidden conversation does not appear in the Chats tab, its incoming
+notifications reveal no sender or content, and it is only brought back into view
+by entering the PIN. Hiding is a purely local, on-device privacy layer on top of
+Ring's existing end-to-end encryption — the server is never told that a chat is
+hidden and learns nothing new.
+
+This is plausible-deniability UX, not a second cryptographic scheme: every chat
+is already E2E-encrypted, so Hidden Chats governs *visibility on this device*,
+backed by an at-rest lock so the hidden designation can't be read off the device
+either.
+
+A hidden chat is a **distinct conversation**, not a hidden flag toggled on an
+existing one. Modeling it on Ring's existing group-conversation mechanism (a
+conversation with its own identity, reusing the established sender-key crypto)
+lets a normal, fully visible chat with a friend and a *separate* hidden chat with
+that same friend coexist in parallel — the visible one is never removed or
+altered when the hidden one exists. Revealing is also "sticky" within a short
+grace window so brief app-switching stays fluid, while a full app close always
+re-locks and leaves no trace — including in call history.
+
+## Clarifications
+
+### Session 2026-06-26
+
+- **PIN model (FR-015)**: RESOLVED → a **separate, dedicated** Hidden Chats PIN,
+  distinct from the app-unlock PIN (defense-in-depth; unlocking the app does not
+  reveal hidden chats).
+- **Distinct-conversation model (FR-017)**: ADOPTED → a hidden chat is a separate
+  conversation (modeled on the group mechanism) that coexists with the normal 1:1;
+  hiding never consumes or alters the visible conversation. *Open consequence to
+  confirm:* the other participant(s) see this separate conversation as a normal
+  chat on their device (hidden-ness is strictly local). See open question below.
+- **Reveal grace window (FR-005)**: ADOPTED → revealed hidden chats stay revealed
+  across brief backgrounding for a short, configurable timeout (assumed default 1
+  minute, options up to 5 minutes) and ALWAYS re-lock on full app termination.
+- **Call-history trail (FR-019)**: ADOPTED → calls and missed calls in hidden
+  chats are never logged in the Calls tab / call history.
+- **Counterpart visibility (FR-018)**: RESOLVED → acceptable that the other
+  participant sees the hidden chat as a normal separate conversation; hidden-ness is
+  strictly local to the hiding device.
+- **PIN-reset wipe scope (FR-016)**: RESOLVED → reset permanently deletes the local
+  history of hidden conversations AND blocks them from re-syncing from the server on
+  this device (strongest/Viber-style permanence).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Hide a conversation behind a PIN (Priority: P1)
+
+A user wants a specific conversation to stop showing up in their chat list. From
+that chat (or via a long-press on the chat row), they choose **Hide Chat**. The
+first time, they are asked to create a Hidden Chats PIN. After confirming, the
+conversation disappears from the Chats tab. Handing the phone to someone else,
+the conversation is nowhere to be found in the normal UI.
+
+**Why this priority**: This is the core of the feature and the minimum viable
+slice — the ability to remove a conversation from view and gate it behind a
+secret. Without it nothing else matters.
+
+**Independent Test**: Hide a 1:1 chat, confirm it vanishes from the Chats tab and
+from search-by-name, and confirm a PIN was required to create the hidden state.
+Delivers the headline privacy value on its own.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visible 1:1 chat and no Hidden Chats PIN yet, **When** the user
+   chooses Hide Chat, **Then** they are prompted to create and confirm a PIN, and
+   on success the chat leaves the Chats tab.
+2. **Given** a Hidden Chats PIN already exists, **When** the user hides another
+   chat, **Then** the chat is hidden immediately without re-entering the PIN
+   creation flow.
+3. **Given** a hidden chat, **When** the user browses the Chats tab and the
+   normal in-app search, **Then** the hidden chat does not appear in either.
+4. **Given** a group chat, **When** the user chooses Hide Chat, **Then** it is
+   hidden using the same flow as a 1:1 chat.
+
+---
+
+### User Story 2 - A hidden chat coexists with the normal chat (Priority: P1)
+
+A user wants a private side-conversation with a friend they *also* have a normal,
+fully visible chat with. The hidden chat is a **separate conversation** with its
+own history — the everyday chat keeps working and stays visible and tracked,
+while the hidden one only appears after the PIN is entered. Both can be active at
+the same time without one masking or overwriting the other.
+
+**Why this priority**: This is the structural decision that makes the feature
+coherent. If "hidden" were just a flag on the single canonical 1:1, a user could
+never have both a visible chat and a hidden chat with the same person — they'd
+collide. Treating the hidden chat as a distinct conversation (modeled on the
+group mechanism, reusing existing crypto) is what makes coexistence possible, so
+it ships with the MVP.
+
+**Independent Test**: With a friend you have a normal visible 1:1 with, create
+and use a hidden chat with that same friend; confirm the visible 1:1 is unchanged
+and still listed, and that the hidden conversation is a separate thread that only
+appears after entering the PIN.
+
+**Acceptance Scenarios**:
+
+1. **Given** a normal visible 1:1 with a contact, **When** the user has a hidden
+   chat with that same contact, **Then** both conversations exist independently —
+   the visible one stays in the Chats tab with its own history, the hidden one
+   only appears on reveal.
+2. **Given** messages sent in the hidden chat, **When** the user views the visible
+   1:1, **Then** those messages do not appear in the visible conversation (and
+   vice versa) — the two threads never merge.
+3. **Given** the hidden chat is a distinct conversation, **When** it is created,
+   **Then** it reuses the existing conversation/crypto machinery rather than a new
+   bespoke scheme (no new key-exchange or ratchet design).
+4. **Given** the other participant's device, **When** they receive the hidden
+   chat's messages, **Then** they see it as a normal separate conversation on
+   their side (hidden-ness is local to the hiding user) unless they also hide it.
+
+---
+
+### User Story 3 - Reveal and unhide a conversation with the PIN (Priority: P1)
+
+The user needs to get back into a hidden conversation. They perform the reveal
+gesture — entering their PIN in the chat-list search field — and the hidden
+conversations matching that PIN appear, openable for the session. From a revealed
+chat they can also permanently **Unhide** it so it returns to the normal list.
+
+To keep the experience fluid, revealing is "sticky" for a short, configurable
+grace window: stepping out of the app to copy-paste or check something else does
+**not** immediately re-lock. The reveal persists across brief backgrounding until
+the grace window elapses — and, regardless of the timer, a **full app close
+always re-locks**. After a full close, even reopening immediately shows no hidden
+chats. Privacy is therefore never more than one full app-close away.
+
+**Why this priority**: A hide feature with no reliable way back in is unusable.
+Reveal + unhide is the other half of the MVP and must ship with US1.
+
+**Independent Test**: With a chat already hidden, enter the PIN via the reveal
+gesture, confirm the hidden chat becomes openable, read it, switch apps briefly
+and return to confirm it is still revealed within the grace window, then unhide
+it and confirm it returns to the normal Chats tab.
+
+**Acceptance Scenarios**:
+
+1. **Given** one or more hidden chats, **When** the user enters the correct PIN in
+   the reveal gesture, **Then** the matching hidden chats become visible and
+   openable.
+2. **Given** the reveal gesture, **When** the user enters an incorrect PIN, **Then**
+   no hidden chats are revealed and no hint is given that hidden chats exist.
+3. **Given** a revealed hidden chat, **When** the user chooses Unhide, **Then** the
+   chat returns permanently to the Chats tab and no longer requires the PIN.
+4. **Given** hidden chats are currently revealed, **When** the user briefly
+   switches to another app and returns within the grace window, **Then** the
+   hidden chats are still revealed without re-entering the PIN.
+5. **Given** hidden chats are currently revealed, **When** the grace window
+   elapses while backgrounded **or** the app is fully closed (whichever happens
+   first), **Then** the chats return to hidden and the PIN is required again.
+6. **Given** the app was fully closed while hidden chats were revealed, **When**
+   the user reopens it immediately, **Then** no hidden chats appear and there is
+   no trace that any were revealed.
+
+---
+
+### User Story 4 - Private notifications for hidden chats (Priority: P2)
+
+The user keeps receiving messages in a hidden conversation. A notification still
+arrives so they aren't cut off, but it shows no sender name, avatar, or message
+content — only a neutral, generic prompt. Tapping it does not open the hidden
+chat or reveal that it exists; it lands on the normal Chats tab, where the hidden
+chat is still absent until the PIN is entered.
+
+**Why this priority**: A real privacy feature must not leak through the lock
+screen. It builds on US1/US2 but is a distinct, independently testable slice.
+
+**Independent Test**: Hide a chat, send it a message from another account, and
+confirm the resulting notification carries no sender/content preview and that
+tapping it does not reveal or open the hidden chat.
+
+**Acceptance Scenarios**:
+
+1. **Given** a hidden chat, **When** it receives a new message, **Then** the
+   notification shows a generic, content-free message with no sender name, avatar,
+   or body text.
+2. **Given** a hidden-chat notification, **When** the user taps it, **Then** they
+   land on the Chats tab without the hidden chat being opened or revealed.
+3. **Given** a mix of hidden and visible chats receiving messages, **When**
+   notifications are shown, **Then** only the visible chats' notifications carry
+   sender/content previews; hidden chats stay generic.
+4. **Given** a hidden chat, **When** the device is offline and later reconnects,
+   **Then** any queued notification for that chat still respects the no-preview
+   rule.
+
+---
+
+### User Story 5 - Hidden chats leave no trace in call history (Priority: P2)
+
+The user makes and receives calls in a hidden conversation. Those calls — placed,
+received, and **missed** — never appear in the Calls tab or call history. Like
+messages, an incoming call from a hidden chat is delivered with no identifying
+preview on the pre-answer surface, and nothing about it is logged where someone
+browsing the phone could see it.
+
+**Why this priority**: Call history is a second, easy-to-forget leak path. A
+privacy feature that hides the chat but lists the calls right next to it would
+defeat itself. Independently testable and important enough to ship with the core.
+
+**Independent Test**: Place and miss calls in a hidden chat, then browse the Calls
+tab and confirm none of them are listed, while calls in visible chats still are.
+
+**Acceptance Scenarios**:
+
+1. **Given** a hidden chat, **When** a call is placed or completed in it, **Then**
+   it does not appear in the Calls tab / call history.
+2. **Given** a hidden chat, **When** a call from it is missed, **Then** no missed-
+   call entry appears in call history and no missed-call badge attributes to it.
+3. **Given** a hidden chat, **When** an incoming call arrives, **Then** the
+   pre-answer surface follows the no-preview rule (no hidden contact/group
+   identity shown).
+4. **Given** a chat that is later unhidden, **When** the user views call history,
+   **Then** the previously hidden calls remain absent (they were never logged),
+   consistent with the documented behavior.
+
+---
+
+### User Story 6 - Optional biometric unlock (Priority: P3)
+
+A user who finds typing a PIN repeatedly tedious enables biometric unlock (e.g.
+device fingerprint/face) for the reveal gesture. When enabled, the reveal step
+offers biometrics and falls back to the PIN if biometrics fail or are
+unavailable. Biometrics never replace the PIN as the recovery secret — the PIN
+always works.
+
+**Why this priority**: A convenience layer on top of the PIN. Valuable but
+strictly optional, and the feature is complete without it.
+
+**Independent Test**: With biometrics enabled on a device that supports them,
+trigger reveal, authenticate biometrically, and confirm hidden chats appear
+without typing the PIN; then disable biometrics and confirm PIN entry is required
+again.
+
+**Acceptance Scenarios**:
+
+1. **Given** biometric unlock is available and enabled, **When** the user triggers
+   reveal, **Then** they may authenticate biometrically instead of typing the PIN.
+2. **Given** biometric authentication fails or is cancelled, **When** the user
+   triggers reveal, **Then** they can still enter the PIN to reveal hidden chats.
+3. **Given** a device with no biometric support, **When** the user opens Hidden
+   Chats settings, **Then** the biometric option is unavailable/disabled and the
+   PIN flow is unaffected.
+
+---
+
+### User Story 7 - Reset the Hidden Chats PIN (Priority: P3)
+
+A user who has forgotten their PIN needs a way out. From Settings they can reset
+the Hidden Chats PIN. Because the PIN is the only key to the hidden state and is
+never recoverable from the server, resetting it is **destructive**: it permanently
+deletes the local history of every hidden conversation on this device and blocks
+those conversations from re-downloading from the server, so a forced reset can
+never expose their contents. The user is clearly warned about exactly what is lost
+before they confirm.
+
+**Why this priority**: A necessary escape hatch, but an edge path most users
+never hit. Ships after the core flows.
+
+**Independent Test**: With hidden chats present and the PIN forgotten, perform a
+PIN reset, confirm the explicit destructive warning is shown, confirm the hidden
+conversations' local history is gone afterward, and confirm they do not reappear
+via sync.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Hidden Chats PIN is set, **When** the user chooses Reset PIN,
+   **Then** they are shown an explicit, specific warning that hidden conversations
+   will be permanently deleted, and must confirm before anything is cleared.
+2. **Given** the user confirms the reset, **When** it completes, **Then** the old
+   PIN no longer works, a new PIN can be created from scratch, and the previously
+   hidden conversations' local history is permanently gone.
+3. **Given** the reset deleted hidden conversations, **When** the device continues
+   syncing, **Then** those conversations do NOT re-download/reappear on this device.
+4. **Given** the user cancels the reset, **When** they return, **Then** their PIN
+   and hidden chats are unchanged.
+
+---
+
+### Edge Cases
+
+- **Last chat unhidden / all chats unhidden**: when no chats remain hidden, the
+  reveal gesture must behave exactly as it did before the feature existed (e.g. a
+  PIN-shaped search query just returns normal search results), giving no signal
+  that the feature is even in use.
+- **New message into a hidden chat while it is currently revealed**: it appears in
+  the open conversation like any message; when the reveal session ends it is
+  hidden again.
+- **Hiding a chat that is currently open**: hiding navigates the user out and
+  requires the PIN to return.
+- **Grace window vs. full close**: a revealed session survives brief backgrounding
+  up to the grace window, but a full app termination re-locks immediately and
+  unconditionally — even an instant relaunch shows no hidden chats and no "recently
+  revealed" trace.
+- **Incorrect PIN attempts**: repeated wrong PINs must not lock the user out of the
+  rest of the app, and must not confirm or deny that any hidden chats exist.
+- **Hidden chat with the same person as a visible 1:1**: the hidden conversation
+  and the visible 1:1 stay fully independent — separate histories, separate unread
+  state — and neither leaks into the other.
+- **Unread badges / counts**: aggregate unread indicators must not let a hidden
+  chat's unread count visibly attribute to that chat or reveal its existence.
+- **Per-device divergence**: because hiding is local, the same conversation can be
+  hidden on one of the user's devices and visible on another; this is expected and
+  must not cause sync errors.
+- **App reinstall / data wipe**: losing local data clears hidden state along with
+  everything else; chats re-sync as normal *visible* chats (no hidden flag is
+  restored from the server, because the server never had it).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Users MUST be able to mark any 1:1 or group conversation as hidden
+  from within that chat and/or from a long-press action on its chat-list row.
+- **FR-002**: A hidden chat MUST NOT appear in the Chats tab, in name/keyword
+  search, in recent-chats surfaces, in any chat picker, or in the Calls tab / call
+  history, while it is hidden.
+- **FR-003**: The first time a user hides a chat, the system MUST require them to
+  create and confirm a Hidden Chats PIN before the chat is hidden.
+- **FR-004**: Users MUST be able to reveal hidden chats by entering the correct
+  PIN via the reveal gesture (entering the PIN in the chat-list search field); an
+  incorrect PIN MUST reveal nothing and MUST NOT disclose whether any hidden chats
+  exist.
+- **FR-005**: Revealed hidden chats MUST stay revealed across brief app
+  backgrounding for a configurable grace window, and MUST return to the hidden
+  state when (a) the grace window elapses, (b) the app is fully closed/terminated,
+  or (c) the user explicitly re-hides — whichever happens first. After a full
+  close, an immediate relaunch MUST show no hidden chats and no trace that any were
+  revealed.
+- **FR-006**: Users MUST be able to permanently unhide a revealed chat so it
+  returns to the normal Chats tab and no longer requires the PIN.
+- **FR-007**: Notifications for messages in a hidden chat MUST be delivered without
+  any sender name, avatar, or message content — only a neutral, generic message.
+- **FR-008**: Tapping a hidden-chat notification MUST NOT open or reveal the hidden
+  chat; it MUST land on the normal Chats tab with the hidden chat still hidden.
+- **FR-009**: The hidden designation and the PIN MUST be stored only on the local
+  device and MUST NEVER be transmitted to or stored on the server in any form
+  (including logs, metrics, or sync payloads).
+- **FR-010**: The PIN MUST be verified without storing it in recoverable plaintext,
+  and the local record of which chats are hidden MUST be protected at rest so it
+  cannot be read off the device without the PIN (or enabled biometric).
+- **FR-011**: Users MUST be able to optionally enable biometric unlock for the
+  reveal gesture; biometrics MUST be a convenience over the PIN, never a
+  replacement — the PIN MUST always work.
+- **FR-012**: Users MUST be able to reset the Hidden Chats PIN; the system MUST
+  show an explicit, specific destructive-consequences warning and require
+  confirmation before clearing anything.
+- **FR-013**: The Hidden Chats controls (enable, change PIN, reset PIN, biometric
+  toggle, grace-window duration) MUST live in the app's Settings (Privacy) area.
+- **FR-013a**: Disabling the Hidden Chats feature MUST NEVER expose existing hidden
+  conversations: it only removes the entry points (Hide action, reveal gesture).
+  Already-hidden conversations remain hidden and protected; revealing them still
+  requires the PIN (or, where supported, re-enabling and unlocking). Disabling MUST
+  NOT, by itself, unhide, wipe, or surface any hidden conversation.
+- **FR-014**: When no chats are hidden, every surface MUST behave exactly as before
+  the feature existed, giving no observable signal that the feature is in use.
+- **FR-015**: The Hidden Chats PIN MUST be a separate, dedicated PIN distinct from
+  the app-unlock PIN; unlocking the app MUST NOT reveal hidden chats. (Resolved
+  2026-06-26.)
+- **FR-016**: Resetting the Hidden Chats PIN MUST permanently delete the local
+  history of all hidden conversations on this device AND mark those conversations so
+  they do **not** re-sync/re-download from the server on this device — so a forced
+  reset can never expose hidden contents, even later. The destructive warning
+  (FR-012) MUST state this clearly before the user confirms. (Resolved 2026-06-26.)
+- **FR-017**: A hidden chat MUST be a distinct conversation that can coexist with a
+  normal, visible conversation involving the same participants; creating or
+  maintaining a hidden chat MUST NOT remove, alter, or merge into the user's
+  existing visible conversation. The distinct conversation MUST reuse Ring's
+  existing conversation/crypto machinery (the group mechanism), not a new
+  hand-rolled scheme (Constitution Principle IV).
+- **FR-018**: "Hidden" MUST be a strictly local-to-the-device property: the other
+  participant(s) of a hidden conversation see it as a normal separate conversation
+  on their own device unless they independently hide it. The system MUST NOT
+  attempt to hide the conversation on anyone else's device.
+- **FR-019**: Calls in a hidden chat — placed, received, and missed — MUST NOT be
+  logged in the Calls tab / call history, and MUST NOT raise a missed-call badge
+  attributable to the hidden chat. An incoming call from a hidden chat MUST follow
+  the no-preview rule on its pre-answer surface.
+- **FR-020**: The grace-window duration MUST be user-configurable (options:
+  immediately / 1 minute / 5 minutes) and MUST default to **1 minute**. A full app
+  termination MUST always re-lock regardless of the configured duration.
+- **FR-021**: The feature MUST fail closed: if the protected hidden state cannot
+  be read or decrypted (locked, corrupt, or unavailable), the system MUST treat
+  affected conversations as hidden and notifications as content-free, never
+  defaulting to exposing them.
+- **FR-022**: An incorrect reveal-PIN attempt MUST NOT lock the user out of the
+  rest of the app, MUST NOT reveal whether any hidden chats exist, and the PIN
+  check MUST rely on a deliberately slow key derivation (the existing Argon2id
+  cost) as its brute-force mitigation; no faster comparison path may exist.
+- **FR-023**: The reveal grace window MUST be measured by actual elapsed
+  background time such that manipulating the device clock cannot extend a reveal
+  session beyond the configured duration.
+- **FR-024**: A PIN reset's wipe MUST be atomic with respect to exposure: it MUST
+  NOT leave a partially-wiped state in which a hidden conversation becomes visible
+  or readable. If interrupted, the conversation MUST remain hidden/locked until
+  the wipe completes.
+- **FR-025**: When the app's existing auto-lock and an active reveal session
+  coincide, the more restrictive state MUST win — an app lock MUST also end any
+  reveal session (hidden chats never remain revealed behind a locked app).
+
+### Key Entities *(include if feature involves data)*
+
+- **Hidden Chats lock**: the per-device secret state that gates hidden chats — a
+  verifier for the PIN and the key material protecting the hidden set at rest.
+  Holds no server-visible data; recoverable only with the PIN (or enabled
+  biometric).
+- **Hidden conversation**: a distinct conversation (modeled on the group
+  mechanism) that may coexist with a normal visible conversation between the same
+  people. It is an ordinary conversation on the wire; only its *hidden designation*
+  is special, and only locally.
+- **Hidden designation**: a per-device, per-conversation marker that a given
+  conversation is hidden. Exists only locally, protected at rest, never synced.
+- **Reveal session**: ephemeral state indicating hidden chats are currently
+  unlocked for viewing; persists across brief backgrounding until the grace window
+  elapses and is cleared on grace expiry, full app termination, or explicit
+  re-hide.
+- **Auto-lock timeout preference**: a local setting for the grace-window duration
+  (e.g. immediately / 1 min / 5 min) governing how long a reveal survives
+  backgrounding.
+- **Biometric preference**: a local on/off setting recording whether biometric
+  unlock is enabled for the reveal gesture on this device.
+
+## Zero-Knowledge Impact *(mandatory — Constitution Principle I)*
+
+- **What crosses the wire**: Nothing new. Hidden Chats adds no new client→server
+  request, field, or payload. Messages for hidden chats continue to flow as the
+  same sealed envelopes as any other chat; the server cannot distinguish a hidden
+  chat from a visible one.
+- **What is encrypted / protected**: The PIN is never stored in recoverable form;
+  the set of hidden-chat ids and the lock state are protected at rest on the device
+  (consistent with Ring's existing PIN-derived at-rest wrapping for secrets), so
+  the hidden designation cannot be read off the device without the PIN/biometric.
+- **What metadata is unavoidably visible to the server**: Unchanged from today. The
+  server still relays ciphertext envelopes and sees the same relay-required
+  metadata it already sees for every chat. It gains **no** new signal that a chat is
+  hidden, that the feature is enabled, or that a PIN exists.
+- **Distinct conversation (group model)**: A hidden chat realized as a separate
+  conversation is, to the server, just another opaque conversation/group — the same
+  thing it already relays. Group membership is already encrypted and invisible to
+  the server, so it cannot tell that a hidden conversation shares participants with
+  a visible 1:1, nor that it is "hidden." Calls in a hidden chat ride the existing
+  call signalling/relay unchanged; hiding them is purely a local call-history
+  concern.
+- **Notifications**: The push path already carries no plaintext to the server; the
+  no-preview rule is enforced entirely on the client when rendering the
+  notification, so the privacy guarantee does not depend on the server.
+- **Why this is safe**: Hidden Chats is a client-only visibility layer over content
+  that is already end-to-end encrypted. It cannot weaken the zero-knowledge
+  boundary because it never introduces a new thing for the server to know.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A hidden chat appears in **zero** user-facing surfaces (Chats tab,
+  search, pickers, recents, Calls tab / call history) while hidden, verified across
+  all such surfaces — including missed calls.
+- **SC-002**: 100% of notifications for hidden chats render with no sender name,
+  avatar, or content — only the generic message — including offline-queued and
+  burst cases.
+- **SC-003**: A user can hide a chat and later reveal it with the PIN in under 15
+  seconds each way, on first attempt, without external help.
+- **SC-004**: The server receives **no** new field, request, or log entry as a
+  result of a chat being hidden — confirmed by inspecting the client/server wire
+  for a hidden vs. visible chat and seeing them indistinguishable.
+- **SC-005**: With no chats hidden, the app is behaviorally identical to before the
+  feature (the reveal gesture produces normal search results), so the feature's
+  presence is unobservable.
+- **SC-006**: An incorrect PIN at the reveal gesture never reveals a hidden chat and
+  never produces UI that confirms hidden chats exist (no error that differs from the
+  all-chats-visible case).
+- **SC-007**: Losing/forgetting the PIN has a defined, warned recovery path; after a
+  PIN reset the hidden conversations' local history is gone and does not reappear via
+  sync, so no recovery path exposes hidden content without the PIN or enabled
+  biometric.
+- **SC-008**: A normal visible conversation and a hidden conversation with the same
+  participant(s) coexist with fully independent histories — confirmed by exchanging
+  messages in each and seeing no cross-contamination.
+- **SC-009**: After a full app close, hidden chats are re-locked 100% of the time,
+  with no observable difference between "just revealed then closed" and "never
+  revealed" on the next launch.
+
+## Assumptions
+
+- **Local-only by design (v1)**: Per the feature description, hiding is per-device
+  and is *not* synced across the user's own linked devices in v1. A future spec
+  could E2E-sync the hidden designation between a user's own devices; out of scope
+  here.
+- **Reveal gesture**: The reveal mechanism is entering the PIN in the chat-list
+  search field (mirroring Viber), chosen because it adds no discoverable entry
+  point. The exact gesture can be refined in plan/UX without changing scope.
+- **At-rest protection reuses existing machinery**: Protecting the hidden set and
+  verifying the PIN build on Ring's existing PIN-derived, Argon2id-wrapped at-rest
+  secret handling rather than inventing new crypto (Constitution Principle IV).
+- **Distinct conversation via the group mechanism**: The hidden conversation reuses
+  Ring's existing group/sender-key conversation primitive to obtain a distinct
+  identity that coexists with the canonical 1:1. This is an implementation reuse
+  direction (Principle IV) to be confirmed in the plan; the spec-level requirement
+  is only that the hidden chat be a distinct, coexisting conversation.
+- **Counterpart visibility**: Confirmed acceptable — because hiding is local, the
+  other side sees the hidden conversation as a normal separate chat unless they also
+  hide it (FR-018). This matches "hiding a chat on your phone does not hide it on
+  anyone else's."
+- **Grace-window default**: Assumed default of ~1 minute, user-configurable up to a
+  few minutes, with an "immediately" option; a full app close always re-locks. Exact
+  values are a plan/UX detail.
+- **Settings placement**: Controls live under Settings → Privacy via the
+  declarative settings schema (Constitution Principles X/XI), not a bespoke screen,
+  wherever the stock components allow it.
+- **PIN format**: A numeric PIN (Viber uses 4 digits); exact length/format is a
+  plan-level UX detail, assumed to align with Ring's existing app-PIN conventions.
+- **Group hiding hides the conversation, not membership**: hiding a group chat
+  removes it from view locally; it does not leave the group or change anything other
+  members or the server can observe.
+
+## Out of Scope
+
+- Syncing the hidden state across a user's own devices.
+- Hiding a contact from the Contacts tab (the conversation and its calls are hidden;
+  the contact entry itself is a potential follow-up).
+- A separate "vault" for hidden *media/files* distinct from the chats themselves.
+- Server-side enforcement of any kind (the feature is intentionally client-only).
+- Disappearing-messages / auto-delete behavior for hidden chats (separate concern).
+
+## Dependencies
+
+- Ring's existing PIN / at-rest secret-wrapping machinery (Argon2id-derived key).
+- The existing group/conversation primitive (sender keys) reused to mint the
+  distinct, coexisting hidden conversation.
+- The existing notification rendering path (client-side), where the no-preview rule
+  is enforced.
+- The existing chat-list, search, chat-picker, and Calls tab / call-history
+  surfaces that must learn to exclude hidden chats (including missed calls).
+- The app lifecycle / foreground-background signals used to drive the reveal grace
+  window and re-lock on full close.
+- The own-data sync path, which must support marking specific conversations as
+  "do not re-sync to this device" so a PIN reset's wipe is permanent (FR-016).

--- a/specs/1019-hidden-chats-pin/tasks.md
+++ b/specs/1019-hidden-chats-pin/tasks.md
@@ -1,0 +1,233 @@
+---
+description: "Task list for Hidden Chats Locked Behind a PIN"
+---
+
+# Tasks: Hidden Chats Locked Behind a PIN
+
+**Input**: Design documents from `specs/1019-hidden-chats-pin/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/internal-api.md
+
+**Tests**: INCLUDED — Constitution Principle III (TDD) is a mandate. Failing unit
+tests precede implementation; new user-facing behavior gets an e2e spec.
+
+**Organization**: Grouped by user story (spec priorities). US1+US3 together are
+the MVP. This is a **client-only** feature — no `server/` tasks, no SQL migration,
+no `DB_VERSION` bump.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete work)
+- **[Story]**: US1–US7 (maps to spec user stories); Setup/Foundational/Polish have none
+- Exact file paths included. FR/SC refs point back to spec.md.
+
+## Path Conventions
+
+Single-project Vue PWA: client under `src/`, e2e under `e2e/`, unit tests as
+`*.test.ts` siblings (vitest). Spec docs under `specs/1019-hidden-chats-pin/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Scaffolding the new modules and test surfaces this feature adds.
+
+- [ ] T001 Create the new service stub `src/services/hidden-chats.ts` exporting the signatures in [contracts/internal-api.md](./contracts/internal-api.md) (membership, PIN, reset, startHiddenChat) as typed no-op/throw stubs so dependents typecheck.
+- [ ] T002 [P] Create the new composable stub `src/composables/useHiddenChats.ts` exporting `{ revealed, reveal, revealWithBiometric, relock }` per the contract.
+- [ ] T003 [P] Create the e2e spec skeleton `e2e/hidden-chats.spec.ts` (2-account flow scaffold via `window.__ringTest`; describe blocks per user story, all `test.fixme` initially).
+- [ ] T004 [P] Add the `privacy-hidden-chats` settings screen scaffold under the `privacy` hub in `src/settings/schema.ts` (enable toggle `privacy.hiddenChatsEnabled` default false; placeholders for PIN/reset/biometric/grace, filled in per story).
+
+**Checkpoint**: New files exist and `npm run build` typechecks with stubs.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The membership store, the separate PIN, and the single chat-list
+choke-point exclusion. **No user story can be implemented until this is done.**
+
+**⚠️ Implements the core security requirements (FR-009/010/014/015/021/022).**
+
+- [ ] T005 [P] Unit test `src/services/hidden-chats.test.ts`: the hidden set is a master-key-wrapped (`sealJson`) blob in `settings` key `privacy.hiddenChats`; round-trips through `getHiddenSet/addHidden/removeHidden`; is NEVER added to the synced `chats` row (FR-009, Research §R1).
+- [ ] T006 [P] Unit test (same file): `verifyHiddenPin` succeeds only on the correct PIN via decryption (AEAD), uses a separate salt/key from the app PIN (FR-015), and fails closed on corrupt/absent state (FR-021); a wrong PIN reveals no "exists" signal (FR-004/SC-006).
+- [ ] T007 [P] Unit test `src/db/queries.test.ts`: `listChats()` excludes ids in the hidden set by default and includes them only when a reveal flag is passed/active (FR-002/FR-004); a hidden chat's synced row is byte-identical to a non-hidden one (FR-014/SC-004).
+- [ ] T008 Implement the hidden-set storage + accessors in `src/services/hidden-chats.ts` (`getHiddenSet/isHidden/addHidden/removeHidden`) using `crypto/envelope.ts` `sealJson/openJson` under the master key; lazily create the record on first hide (data-model §1). Makes T005 pass.
+- [ ] T009 Implement the separate-PIN material + `enableHiddenPin/verifyHiddenPin/changeHiddenPin/hasHiddenPin/hiddenPinLength` mirroring `src/services/crypto/identity.ts` `wrapSecret/verifyPin`, with independent `hiddenPinSalt/hiddenPinWrapped/hiddenPinLength` kept out of sync; Argon2id cost is the brute-force mitigation (FR-022). Makes T006 pass.
+- [ ] T010 Wire the exclusion into the single choke point `src/db/queries.ts` `listChats()` (consult `getHiddenSet()`; add an "include hidden" parameter for the revealed path) so every filter chip in `src/services/chat-filters.ts` inherits it. Makes T007 pass.
+- [ ] T011 Confirm `src/services/ownsync.ts` `SYNCED` and the profile/prefs bundle still exclude all hidden-chats keys (`privacy.hiddenChats*`, PIN material, prefs); add a guard/assertion test in `src/services/ownsync.test.ts` that none of these appear in a push payload (FR-009, SC-004).
+
+**Checkpoint**: Hidden set + PIN + global exclusion exist and are unit-tested.
+Hidden chats can be hidden/excluded programmatically; UI stories can begin.
+
+---
+
+## Phase 3: User Story 1 — Hide a conversation behind a PIN (Priority: P1) 🎯 MVP
+
+**Goal**: From a conversation, hide it behind the dedicated PIN; it leaves the
+Chats tab and search.
+
+**Independent test**: Hide a 1:1 → it vanishes from Chats tab + search; first hide
+prompts PIN creation.
+
+- [ ] T012 [P] [US1] e2e in `e2e/hidden-chats.spec.ts`: first "Hide chat" prompts PIN creation; after confirm, the chat is absent from the Chats tab and from search-by-name (spec US1 AC1–AC3).
+- [ ] T013 [US1] Add a "Hide chat" action to `src/components/ChatActionsSheet.vue` (and ensure it's reachable from `ChatListItem.vue` "More"); on first use, route through a PIN-creation flow that requires **entering and confirming** the PIN (double-entry; reject mismatch) before calling `enableHiddenPin` then `addHidden` (FR-003).
+- [ ] T014 [US1] Add the "Set / change PIN" action rows to the `privacy-hidden-chats` screen in `src/settings/schema.ts`, wired to `enableHiddenPin/changeHiddenPin` (FR-013); change-PIN re-wraps the set with no unprotected window (security CHK018).
+- [ ] T015 [US1] Verify `useChatFilters`/`listChats` reactivity: hiding a chat fires the change-bus so the list updates live (no manual refresh); extend `src/db/queries.test.ts` if a gap is found.
+
+**Checkpoint**: A conversation can be hidden and disappears everywhere in the chat list.
+
+---
+
+## Phase 4: User Story 2 — A hidden chat coexists with the normal chat (Priority: P1)
+
+**Goal**: A hidden chat is a distinct conversation (2-person group) that coexists
+with the normal 1:1 with the same person.
+
+**Independent test**: Start a hidden chat with a contact you already have a 1:1
+with; both exist independently; histories never merge.
+
+- [ ] T016 [P] [US2] Unit test `src/services/hidden-chats.test.ts`: `startHiddenChat(contactId)` creates a distinct group (own id) via `createGroup('', [contactId])`, adds it to the hidden set, and leaves any existing 1:1 with that contact untouched (FR-017, SC-008).
+- [ ] T017 [P] [US2] e2e in `e2e/hidden-chats.spec.ts`: with a visible 1:1 present, a hidden chat with the same contact coexists; messages in one never appear in the other; the counterpart sees a normal separate conversation (FR-018, US2 AC1–AC4).
+- [ ] T018 [US2] Implement `startHiddenChat(contactId)` in `src/services/hidden-chats.ts` wrapping `createGroup` (queries.ts:1091) + `addHidden`. Makes T016 pass.
+- [ ] T019 [US2] Add a "New hidden chat" entry point (e.g., from the contact detail / new-chat surface) that calls `startHiddenChat` and lands the user in the revealed conversation; reuse existing Ionic navigation. Keep it non-discoverable when the feature is disabled.
+
+**Checkpoint**: Coexisting hidden + visible conversations with the same person work.
+
+---
+
+## Phase 5: User Story 3 — Reveal & unhide with the PIN + grace window (Priority: P1) 🎯 MVP
+
+**Goal**: Reveal hidden chats by typing the PIN in the search bar; sticky grace
+window across brief backgrounding; full close always re-locks; unhide is permanent.
+
+**Independent test**: Type PIN in searchbar → hidden chats appear; background
+briefly → still revealed; full close → re-locked even on instant reopen; unhide →
+returns to normal list.
+
+- [ ] T020 [P] [US3] Unit test `src/composables/useHiddenChats.test.ts`: reveal session starts locked on cold load; correct PIN → revealed; grace window keeps revealed across simulated background within the window and re-locks after elapsed time measured by actual elapsed time, not wall-clock the user can manipulate (FR-005/FR-023); explicit relock works; an app auto-lock event ends the reveal session (FR-025).
+- [ ] T021 [P] [US3] e2e in `e2e/hidden-chats.spec.ts`: PIN-in-searchbar reveals hidden chats; a wrong/normal query just returns normal search results with no signal (FR-004/SC-005/SC-006); simulated full close re-locks (FR-005/SC-009); unhide returns the chat to the Chats tab (US3 AC1–AC6).
+- [ ] T022 [US3] Implement `useHiddenChats.ts`: in-memory `revealed` ref + grace timer mirroring `src/composables/useAutoLock.ts` (`visibilitychange`, elapsed-time check); never persist anything that auto-reveals on cold start; subscribe to the app-lock event to force relock (FR-005/FR-020/FR-023/FR-025). **Verify first** that `useAutoLock` exposes a consumable lock event/state; if it does not, add the minimal lock signal it needs and note the added wiring (resolves analyze finding U2). Makes T020 pass.
+- [ ] T023 [US3] Wire the reveal gesture in `src/views/tabs/ChatsPage.vue`: when the searchbar query is all-digits matching `hiddenPinLength`, attempt `reveal(pin)`; on success show hidden chats merged into the list (pass the "include hidden" flag to `listChats`); non-matching input behaves as normal search (FR-004).
+- [ ] T024 [US3] Add the grace-window `choice` row (`privacy.hiddenChatsGrace`: `immediately`/`1m`/`5m`, default `1m`) to `src/settings/schema.ts` and read it in `useHiddenChats.ts` (FR-020).
+- [ ] T025 [US3] Add an "Unhide" action to the revealed-chat surface (`ChatActionsSheet.vue`) calling `removeHidden` (FR-006); confirm it survives a re-lock (chat stays visible).
+
+**Checkpoint**: MVP complete — hide (US1), coexist (US2), reveal/unhide + grace (US3).
+
+---
+
+## Phase 6: User Story 4 — Private notifications for hidden chats (Priority: P2)
+
+**Goal**: Hidden-chat notifications carry no sender/avatar/content and never
+deep-link into the hidden chat; fail-safe to generic when status is unknown.
+
+**Independent test**: Message a hidden chat from another account → notification is
+content-free; tapping lands on Chats tab without revealing the chat.
+
+- [ ] T026 [P] [US4] Unit test `src/services/sw-inbox.test.ts`: `noteForPayload()` for a chat in the hidden set yields a generic title/body (no sender/avatar/preview) and `url: '/tabs/chats'` (FR-007/FR-008); when hidden status can't be determined (no unlock), it defaults to generic (FR-021/CHK029); burst-coalescing still aggregates without surfacing identity (US3/US4 AC3–AC4).
+- [ ] T027 [P] [US4] e2e in `e2e/hidden-chats.spec.ts`: a message into a hidden chat produces a notification with no preview and a tap that does not open/reveal it (US4 AC1–AC2). (Headless-CI-safe; skip if push can't be driven, leave a `log()` note.)
+- [ ] T028 [US4] Implement the hidden branch in `src/services/sw-inbox.ts` `noteForPayload()` (consult the hidden set via `getHiddenSet` post device-unlock): generic note + `/tabs/chats` url; ensure `src/sw.ts` `notificationclick` routing needs no change (it routes by `data.url`). Makes T026 pass.
+- [ ] T029 [US4] Verify interaction with per-chat `notifyContent` and the global preview toggle: hidden status overrides both deterministically (CHK033); add an assertion to T026 if needed.
+
+**Checkpoint**: Hidden chats never leak through notifications.
+
+---
+
+## Phase 7: User Story 5 — Hidden chats leave no trace in call history (Priority: P2)
+
+**Goal**: Placed/received/missed calls in hidden chats are absent from the Calls
+tab and missed-call badge; incoming calls show a generic pre-answer caller.
+
+**Independent test**: Place & miss calls in a hidden chat → none appear in Calls
+tab; incoming call shows a generic caller.
+
+- [ ] T030 [P] [US5] Unit test `src/db/queries.test.ts`: `listCallGroups()` excludes calls whose `contactId` ∈ hidden set (group calls carry `contactId = hidden groupId`), and `markCallsSeen`/missed-badge computation ignores them (FR-019, US5 AC1–AC2/AC4).
+- [ ] T031 [P] [US5] e2e in `e2e/hidden-chats.spec.ts`: a call in a hidden chat does not appear in the Calls tab; a visible chat's call still does (US5 AC1).
+- [ ] T032 [US5] Implement the Calls-tab exclusion in `src/db/queries.ts` `listCallGroups()` (filter by `getHiddenSet()` before grouping) and exclude hidden chats from the missed-call badge/count. Makes T030 pass.
+- [ ] T033 [US5] Branch `src/composables/useCall.ts` incoming-offer handling (and the call-waiting/second-incoming branch) to substitute a generic `callMeta` identity (no name/avatar) when the originating conversation ∈ hidden set, so `IncomingCallOverlay.vue` shows nothing identifying (FR-019, US5 AC3).
+
+**Checkpoint**: No call-history or pre-answer leak for hidden chats.
+
+---
+
+## Phase 8: User Story 6 — Optional biometric unlock (Priority: P3)
+
+**Goal**: Biometric unlock for the reveal gesture, with PIN always as fallback.
+
+**Independent test**: Enable biometrics → reveal without typing the PIN; on
+failure/unsupported, PIN still works.
+
+- [ ] T034 [P] [US6] Unit test `src/composables/useHiddenChats.test.ts`: `revealWithBiometric()` reveals when enabled+available, falls back to PIN on failure/cancel, and the option is inert when unsupported (US6 AC1–AC3); biometrics never replace the PIN (FR-011).
+- [ ] T035 [US6] **Spike first** (resolves analyze finding U1): determine whether the app already has a device-auth/biometric primitive (e.g., used by app-lock / `useAutoLock`). Then implement `revealWithBiometric()` in `src/composables/useHiddenChats.ts` reusing it if present, else the platform credential prompt (WebAuthn), gated by `privacy.hiddenChatsBiometric`; PIN fallback always works (FR-011). Makes T034 pass.
+- [ ] T036 [US6] Add the biometric toggle row (`privacy.hiddenChatsBiometric`, default false) to `src/settings/schema.ts`, disabled/hidden when the device lacks support (FR-011/FR-013).
+
+**Checkpoint**: Biometric convenience layer works; PIN remains authoritative.
+
+---
+
+## Phase 9: User Story 7 — Reset the PIN: wipe + block re-sync (Priority: P3)
+
+**Goal**: Reset permanently wipes hidden conversations locally and blocks them
+from re-syncing on this device, behind an explicit destructive warning.
+
+**Independent test**: With hidden chats present, reset → warned → confirmed →
+local history gone and does NOT reappear after a sync pull.
+
+- [ ] T037 [P] [US7] Unit test `src/db/tombstones.test.ts`: a local-only "do-not-resync" block is recorded per wiped id, is consulted at ingest, and is NEVER returned by `listTombstones()` / never uploaded (FR-016, Research §R8).
+- [ ] T038 [P] [US7] Unit test `src/services/hidden-chats.test.ts`: `resetHiddenChats()` deletes messages/sessions/sender-keys/chat-rows for every hidden id, records the local-only block per id, clears the set + PIN material, and a subsequent `pullOwnData()` does not re-add them (FR-016/SC-007); the wipe leaves no partially-visible state (FR-024).
+- [ ] T039 [US7] Add a local-only tombstone variant in `src/db/tombstones.ts` (e.g. `localOnly: true`) recorded by a new helper and excluded from `listTombstones()`. Makes T037 pass.
+- [ ] T040 [US7] Consult the local-only block in `src/services/ownsync.ts` `pullOwnData()` ingest so blocked ids are skipped (alongside the existing `isTombstoned` check). 
+- [ ] T041 [US7] Implement `resetHiddenChats()` in `src/services/hidden-chats.ts` (atomic wipe order: block → delete data → clear set/PIN, so an interruption keeps chats hidden, FR-024). Makes T038 pass.
+- [ ] T042 [US7] Add the "Reset PIN" danger action with an explicit destructive `confirm` to the `privacy-hidden-chats` screen in `src/settings/schema.ts`; the warning states permanent deletion of hidden conversations before confirmation (FR-012, US7 AC1).
+- [ ] T043 [P] [US7] e2e in `e2e/hidden-chats.spec.ts`: reset shows the destructive warning, wipes the hidden conversation, and it does not reappear after a sync round-trip (US7 AC1–AC3).
+
+**Checkpoint**: Reset is permanent and device-local; other devices/server untouched.
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+**Purpose**: Whole-feature guarantees, a11y, gates, and the mandated review.
+
+- [ ] T044 [P] Add a zero-knowledge boundary test (`src/services/ownsync.test.ts` or a dedicated `src/services/hidden-chats.zk.test.ts`): the push payload for a conversation is identical before and after hiding it, and no hidden-chats key is ever uploaded (SC-004, security CHK001–CHK003).
+- [ ] T045 [P] Audit for leak surfaces missed: chat pickers, recents, share/forward targets, quoted-reply pickers, and global search all exclude hidden chats (FR-002); add tests where a surface bypasses `listChats`.
+- [ ] T046 [P] Grep for and remove any log line / debug aid that could emit hidden state or set contents in client code (Constitution §I, security CHK006).
+- [ ] T047 [P] Accessibility & bidi for the reveal/PIN UI and the settings screen: labels, focus, contrast via `--ring-*` tokens; RTL-correct (Constitution §X/§XI).
+- [ ] T048 Update `e2e/hidden-chats.spec.ts`: remove all `test.fixme`, keep flows to 2 accounts (3-person mesh too flaky for headless CI — project memory), ensure it boots within the isolated e2e stack.
+- [ ] T049 Run full gates: `npm run build` (typecheck + build), `cd server && go build ./... && go vet ./... && go test ./...` (must stay green/untouched), `npm run test:e2e` (needs `make db-up`).
+- [ ] T050 Re-check the `security.md` checklist items against the finished spec/code paths; complete the **mandated human security review** of at-rest wrapping, separate-PIN handling, reveal lifecycle, and the local-only block (Constitution §IV; checklist CHK048).
+- [ ] T051 Flip spec `Status` to `in-progress` (now) / `in-review` (at PR) and run `make roadmap`; ensure the eventual commit subject is plain-language release-note copy (Constitution §VII).
+- [ ] T052 [P] Implement + unit-test the disable-safety behavior (FR-013a): toggling `privacy.hiddenChatsEnabled` off removes the entry points only — it hides the "Hide chat" action and makes the searchbar reveal gesture inert (T019/T023), while already-hidden conversations stay hidden, protected, and unrevealed (no unhide/wipe/surface). Add a test in `src/services/hidden-chats.test.ts` asserting disable does not mutate the hidden set or reveal state.
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (Phase 1)** → **Foundational (Phase 2)** blocks everything below.
+- **MVP = US1 + US3** (and US2 for the coexistence promise). All three are P1.
+  - US1 (Phase 3) needs Foundational.
+  - US2 (Phase 4) needs Foundational (set) + `createGroup`.
+  - US3 (Phase 5) needs Foundational (PIN verify) + US1's hide path to test against.
+- **US4 (P2)**, **US5 (P2)** each need only Foundational (the hidden set via
+  `isHidden`/`getHiddenSet`) → can be built in parallel after Phase 2.
+- **US6 (P3)** needs US3 (the reveal composable).
+- **US7 (P3)** needs Foundational + the deletion helpers; independent of US4–US6.
+- **Polish (Phase 10)** last.
+
+### Parallel opportunities
+
+- Phase 2: T005, T006, T007 (tests) in parallel; then T008/T009 in parallel, T010
+  after T007/T008, T011 independent.
+- After Phase 2: US4 (Phase 6) and US5 (Phase 7) can proceed concurrently with
+  US2/US3 work since they touch different files (`sw-inbox.ts`, `useCall.ts`,
+  `listCallGroups`).
+- Within each story, `[P]` test tasks precede their implementation task.
+
+## Implementation Strategy
+
+1. **Land the MVP first**: Phase 1 → 2 → US1 → US3 (+ US2). This delivers the
+   headline value (hide, reveal, coexist) and is independently shippable.
+2. **Then privacy hardening**: US4 (notifications) and US5 (call history) close the
+   leak paths — ship together as the "no trace" increment.
+3. **Then convenience + safety**: US6 (biometric), US7 (reset) as P3 increments.
+4. **Gate every increment** on `npm run build` + relevant unit/e2e (Constitution
+   §VII). Do not start `/speckit-implement` until `/speckit-analyze` is clean and
+   the security review (T050) is scheduled.

--- a/src/components/ChatActionsSheet.vue
+++ b/src/components/ChatActionsSheet.vue
@@ -30,6 +30,10 @@
           <ion-icon slot="start" :icon="chat.locked ? lockOpenOutline : lockClosedOutline" />
           <ion-label>{{ chat.locked ? 'Unlock chat' : 'Lock chat' }}</ion-label>
         </ion-item>
+        <ion-item v-if="hiddenEnabled || hidden" button :detail="false" @click="toggleHidden">
+          <ion-icon slot="start" :icon="hidden ? eyeOutline : eyeOffOutline" />
+          <ion-label>{{ hidden ? 'Unhide chat' : 'Hide chat' }}</ion-label>
+        </ion-item>
         <ion-item button :detail="false" @click="toggleFavorite">
           <ion-icon slot="start" :icon="chat.favorite ? heart : heartOutline" />
           <ion-label>{{ chat.favorite ? 'Remove from Favorites' : 'Add to Favorites' }}</ion-label>
@@ -62,14 +66,18 @@ import {
 import {
   closeOutline, notificationsOffOutline, notificationsOutline, informationCircleOutline,
   heart, heartOutline, listOutline, closeCircleOutline, exitOutline, trashOutline,
-  lockClosedOutline, lockOpenOutline,
+  lockClosedOutline, lockOpenOutline, eyeOffOutline, eyeOutline,
 } from 'ionicons/icons';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   setChatMute, toggleChatFavorite, clearChat, deleteChat, leaveGroup, setChatLocked,
+  getSetting,
 } from '@/db/queries';
 import { lockConfigured } from '@/services/chat-lock';
+import { addHidden, removeHidden } from '@/services/hidden-chats';
+import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
+import { isHiddenId } from '@/services/hidden-state';
 import type { Chat } from '@/db/types';
 
 const props = defineProps<{ chat: Chat | null; isOpen: boolean }>();
@@ -78,6 +86,34 @@ const emit = defineEmits<{ (e: 'dismiss'): void; (e: 'addToList', chat: Chat): v
 const router = useRouter();
 const HOUR = 60 * 60 * 1000;
 const muted = computed(() => !!props.chat?.mutedUntil && props.chat.mutedUntil > Date.now());
+
+// Hidden Chats (spec 1019). The "Hide chat" entry point only shows when the
+// feature is enabled (FR-013a); "Unhide" always shows for an already-hidden chat
+// (reachable while revealed). `hidden` reflects the local hidden set.
+const hidden = computed(() => (props.chat ? isHiddenId(props.chat.id) : false));
+const hiddenEnabled = ref(false);
+watch(
+  () => props.isOpen,
+  async (open) => {
+    if (open) hiddenEnabled.value = await getSetting<boolean>('privacy.hiddenChatsEnabled', false);
+  },
+);
+
+async function toggleHidden(): Promise<void> {
+  const c = props.chat;
+  if (!c) return;
+  if (isHiddenId(c.id)) {
+    await removeHidden(c.id); // permanent unhide → returns to the normal list
+    emit('dismiss');
+    return;
+  }
+  if (!(await ensureHiddenPin())) {
+    emit('dismiss'); // user cancelled PIN creation
+    return;
+  }
+  await addHidden(c.id);
+  emit('dismiss');
+}
 
 async function openMute(): Promise<void> {
   const id = props.chat?.id;

--- a/src/composables/hiddenPinPrompt.ts
+++ b/src/composables/hiddenPinPrompt.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared UI helper for creating the Hidden Chats PIN (spec 1019). Used by both the
+ * "Hide chat" action and the "New hidden chat" flow so the first-time create flow
+ * (double-entry with confirmation, FR-003) lives in exactly one place.
+ *
+ * Kept out of `useHiddenChats.ts` so that composable stays free of `@ionic/vue`
+ * (and unit-testable in the node env without pulling Ionic in).
+ */
+import { alertController } from '@ionic/vue';
+import { hasHiddenPin, enableHiddenPin } from '@/services/hidden-chats';
+
+/** Prompt for a new PIN with confirmation; resolves the PIN, or null on cancel. */
+export async function promptCreateHiddenPin(): Promise<string | null> {
+  return new Promise((resolve) => {
+    void alertController
+      .create({
+        header: 'Create a Hidden Chats PIN',
+        message:
+          'Enter this PIN in the chat search bar to reveal hidden chats. Keep it safe — it is the only key.',
+        inputs: [
+          { name: 'pin', type: 'password', attributes: { inputmode: 'numeric' }, placeholder: 'PIN (4+ digits)' },
+          { name: 'confirm', type: 'password', attributes: { inputmode: 'numeric' }, placeholder: 'Confirm PIN' },
+        ],
+        buttons: [
+          { text: 'Cancel', role: 'cancel', handler: () => resolve(null) },
+          {
+            text: 'Create',
+            handler: (data: { pin?: string; confirm?: string }) => {
+              const pin = (data.pin ?? '').trim();
+              const confirm = (data.confirm ?? '').trim();
+              // Keep the alert open on an invalid or mismatched entry.
+              if (!/^\d{4,}$/.test(pin) || pin !== confirm) return false;
+              resolve(pin);
+              return true;
+            },
+          },
+        ],
+      })
+      .then((a) => a.present());
+  });
+}
+
+/** Ensure a Hidden Chats PIN exists, prompting to create one if not. */
+export async function ensureHiddenPin(): Promise<boolean> {
+  if (await hasHiddenPin()) return true;
+  const pin = await promptCreateHiddenPin();
+  if (!pin) return false;
+  await enableHiddenPin(pin);
+  return true;
+}

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -27,7 +27,13 @@ import {
   sendMessage,
   getSetting,
 } from '@/db/queries';
-import { groupAvatar } from '@/db/avatars';
+import { groupAvatar, initialsAvatar } from '@/db/avatars';
+import { isHidden } from '@/services/hidden-chats';
+
+// Pre-answer identity for a call whose conversation is hidden (spec 1019, FR-019):
+// the incoming surface must reveal nothing identifying. A neutral name + avatar.
+const HIDDEN_CALL_NAME = 'Private caller';
+const hiddenCallAvatar = (): string => initialsAvatar('•');
 import { capitalizeFirst } from '@/utils/text';
 import { getSelfUserId } from '@/services/auth';
 import { isUnlockedNow, isUnlocked } from '@/services/crypto/identity';
@@ -1461,6 +1467,7 @@ async function handleGroupInvite(frame: Extract<CallFrame, { t: 'call-group-invi
   // A real group chat lends its name/avatar; an ad-hoc room has none, so derive a title
   // from the people involved (server stays blind to it).
   const chat = await getChat(roomId);
+  const hiddenRoom = await isHidden(roomId); // FR-019: hidden group → generic pre-answer identity
   callMeta.value = {
     callId: roomId,
     isGroup: true,
@@ -1471,8 +1478,8 @@ async function handleGroupInvite(frame: Extract<CallFrame, { t: 'call-group-invi
     // roster once we join.
     roster: [...new Set([frame.from, ...(frame.members ?? [])])],
     invited: participants,
-    name: chat?.name || (await deriveGroupCallTitle(participants)),
-    avatar: chat?.avatar || groupAvatar(roomId),
+    name: hiddenRoom ? HIDDEN_CALL_NAME : chat?.name || (await deriveGroupCallTitle(participants)),
+    avatar: hiddenRoom ? hiddenCallAvatar() : chat?.avatar || groupAvatar(roomId),
   };
   setState('incoming');
   presentIncoming(); // full-screen if the app is being opened for this call; else the banner
@@ -1660,6 +1667,7 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
   }
 
   const kind: CallKind = signal.kind ?? 'audio';
+  const hiddenCall = await isHidden(chatId); // FR-019: no identity on the pre-answer surface
   callMeta.value = {
     callId: frame.callId,
     isGroup: false,
@@ -1668,8 +1676,8 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
     peerUserId: from,
     chatId,
     roster: [from],
-    name: contact.name,
-    avatar: contact.avatar,
+    name: hiddenCall ? HIDDEN_CALL_NAME : contact.name,
+    avatar: hiddenCall ? hiddenCallAvatar() : contact.avatar,
   };
   pendingOffer = { sdp: signal.sdp, sdpType: signal.sdpType ?? 'offer' };
   await createCall({ callId: frame.callId, contactId: from, direction: 'incoming', video: kind === 'video' });

--- a/src/composables/useHiddenChats.test.ts
+++ b/src/composables/useHiddenChats.test.ts
@@ -1,0 +1,57 @@
+// Unit tests for the reveal-session composable (spec 1019, US3). The PIN verifier
+// and the leaf reveal flag are mocked; we test the pure session logic: cold-start
+// locked, PIN-gated reveal, relock, and the grace-window mapping.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ revealed: { v: false }, validPin: '1234' }));
+
+vi.mock('@/services/hidden-chats', () => ({
+  verifyHiddenPin: async (pin: string) => pin === h.validPin,
+}));
+vi.mock('@/services/hidden-state', () => ({
+  setRevealed: (v: boolean) => {
+    h.revealed.v = v;
+  },
+  isRevealed: () => h.revealed.v,
+  clearHiddenState: () => {
+    h.revealed.v = false;
+  },
+}));
+vi.mock('@/db/queries', () => ({ getSetting: async (_k: string, fb: unknown) => fb }));
+vi.mock('@/services/crypto/identity', () => ({ isUnlocked: { value: true } }));
+
+import { revealWithPin, relockHidden, graceLimitMs, GRACE_MS } from './useHiddenChats';
+import { isRevealed } from '@/services/hidden-state';
+
+beforeEach(() => {
+  h.revealed.v = false;
+});
+
+describe('reveal session', () => {
+  it('starts locked (cold start)', () => {
+    expect(isRevealed()).toBe(false);
+  });
+
+  it('reveals only on the correct PIN, with no oracle on failure', async () => {
+    expect(await revealWithPin('0000')).toBe(false);
+    expect(isRevealed()).toBe(false);
+    expect(await revealWithPin('1234')).toBe(true);
+    expect(isRevealed()).toBe(true);
+  });
+
+  it('relock ends the session', async () => {
+    await revealWithPin('1234');
+    expect(isRevealed()).toBe(true);
+    relockHidden();
+    expect(isRevealed()).toBe(false);
+  });
+});
+
+describe('grace window', () => {
+  it('maps the options and defaults unknown to 1 minute', () => {
+    expect(graceLimitMs('immediately')).toBe(0);
+    expect(graceLimitMs('1m')).toBe(60_000);
+    expect(graceLimitMs('5m')).toBe(300_000);
+    expect(graceLimitMs('garbage')).toBe(GRACE_MS['1m']);
+  });
+});

--- a/src/composables/useHiddenChats.ts
+++ b/src/composables/useHiddenChats.ts
@@ -1,0 +1,90 @@
+/**
+ * Hidden Chats reveal session (spec 1019, US3).
+ *
+ * The "revealed" state is deliberately in-memory only — a full app close drops it
+ * so hidden chats always re-lock on cold start (FR-005 / SC-009). Revealing is
+ * sticky across brief backgrounding for a configurable grace window so switching
+ * apps to copy-paste doesn't re-lock every time; the window is measured with
+ * `performance.now()` (monotonic) so changing the device clock can't extend a
+ * reveal (FR-023). An app auto-lock also ends the session (FR-025).
+ *
+ * Mirrors `useAutoLock.ts`'s visibilitychange + elapsed-time pattern.
+ */
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+import { getSetting } from '@/db/queries';
+import { isUnlocked } from '@/services/crypto/identity';
+import { verifyHiddenPin } from '@/services/hidden-chats';
+import { setRevealed, isRevealed, clearHiddenState } from '@/services/hidden-state';
+
+/** Grace option → milliseconds. */
+export const GRACE_MS: Record<string, number> = {
+  immediately: 0,
+  '1m': 60_000,
+  '5m': 300_000,
+};
+
+export function graceLimitMs(pref: string): number {
+  return GRACE_MS[pref] ?? GRACE_MS['1m'];
+}
+
+// Single shared reveal-session state for all consumers. Starts locked; never
+// persisted, so a cold start is always locked.
+const revealed = ref(false);
+let hiddenAt: number | null = null;
+
+/** Verify the dedicated PIN and, on success, start the reveal session. */
+export async function revealWithPin(pin: string): Promise<boolean> {
+  const ok = await verifyHiddenPin(pin);
+  if (ok) {
+    setRevealed(true);
+    revealed.value = true;
+  }
+  return ok;
+}
+
+/** End the reveal session — hidden chats hide again immediately. */
+export function relockHidden(): void {
+  setRevealed(false);
+  revealed.value = false;
+  hiddenAt = null;
+}
+
+async function onForeground(): Promise<void> {
+  if (hiddenAt === null) return;
+  const away = performance.now() - hiddenAt;
+  hiddenAt = null;
+  if (!isRevealed()) return;
+  const pref = await getSetting<string>('privacy.hiddenChatsGrace', '1m');
+  if (away >= graceLimitMs(pref)) relockHidden();
+}
+
+function onVisibility(): void {
+  if (document.visibilityState === 'hidden') hiddenAt = performance.now();
+  else void onForeground();
+}
+
+export function useHiddenChats(): {
+  revealed: typeof revealed;
+  reveal: (pin: string) => Promise<boolean>;
+  relock: () => void;
+} {
+  let stopWatch: (() => void) | null = null;
+  onMounted(() => {
+    revealed.value = isRevealed();
+    document.addEventListener('visibilitychange', onVisibility);
+    // FR-025: an app auto-lock (keystore re-locks) must also end any reveal
+    // session and drop the cached set — hidden chats never sit revealed behind a
+    // locked app.
+    stopWatch = watch(isUnlocked, (v) => {
+      if (!v) {
+        relockHidden();
+        clearHiddenState();
+      }
+    });
+  });
+  onUnmounted(() => {
+    document.removeEventListener('visibilitychange', onVisibility);
+    stopWatch?.();
+  });
+  return { revealed, reveal: revealWithPin, relock: relockHidden };
+}

--- a/src/db/hidden-calls.test.ts
+++ b/src/db/hidden-calls.test.ts
@@ -1,0 +1,37 @@
+// Spec 1019 (US5/FR-019): hidden-chat call exclusion keys. A hidden 1:1 must drop
+// calls keyed on the PEER id; a hidden group must drop calls keyed on the GROUP id.
+import { describe, it, expect } from 'vitest';
+import { hiddenCallKeys } from './hidden-calls';
+import type { Chat } from './types';
+
+const chat = (over: Partial<Chat>): Chat => ({
+  id: 'x', name: '', avatar: '', isGroup: false, participantIds: [],
+  lastMessage: '', lastMessageTime: 0, unread: 0, updatedAt: 0, ...over,
+}) as Chat;
+
+describe('hiddenCallKeys', () => {
+  it('keys a hidden 1:1 on the peer id (and the chat id)', () => {
+    const chats = [chat({ id: 'c1', isGroup: false, participantIds: ['peerA'] })];
+    const keys = hiddenCallKeys(chats, new Set(['c1']));
+    expect(keys.has('peerA')).toBe(true); // 1:1 calls store contactId = peer id
+    expect(keys.has('c1')).toBe(true);
+  });
+
+  it('keys a hidden group on the group/chat id', () => {
+    const chats = [chat({ id: 'g1', isGroup: true, participantIds: ['m1', 'm2'] })];
+    const keys = hiddenCallKeys(chats, new Set(['g1']));
+    expect(keys.has('g1')).toBe(true); // group calls store contactId = room/group id
+    expect(keys.has('m1')).toBe(false); // members are not call keys
+  });
+
+  it('ignores non-hidden chats entirely', () => {
+    const chats = [
+      chat({ id: 'c1', participantIds: ['peerA'] }),
+      chat({ id: 'c2', participantIds: ['peerB'] }),
+    ];
+    const keys = hiddenCallKeys(chats, new Set(['c2']));
+    expect(keys.has('peerB')).toBe(true);
+    expect(keys.has('peerA')).toBe(false);
+    expect([...keys].sort()).toEqual(['c2', 'peerB']);
+  });
+});

--- a/src/db/hidden-calls.ts
+++ b/src/db/hidden-calls.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure helper (spec 1019, FR-019): map the hidden-chat set to the call
+ * `contactId`s that must be excluded from the Calls tab and the missed badge.
+ *
+ * A `Call` stores `contactId = peer userId` for a 1:1 and `= room/group id` for a
+ * group, while the hidden set holds chat ids — so a hidden group's calls key on
+ * its group/chat id, and a hidden 1:1's calls key on the peer id.
+ *
+ * Extracted from `queries.ts` so it can be unit-tested without importing the
+ * (heavy, DOM-dependent) data layer.
+ */
+import type { Chat } from './types';
+
+export function hiddenCallKeys(chats: Chat[], hidden: Set<string>): Set<string> {
+  const out = new Set<string>();
+  for (const c of chats) {
+    if (!hidden.has(c.id)) continue;
+    out.add(c.id); // group calls key on the group/chat id
+    if (!c.isGroup && c.participantIds[0]) out.add(c.participantIds[0]); // 1:1 calls key on the peer id
+  }
+  return out;
+}

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -364,6 +364,16 @@ function notify(name: StoreName): void {
   listeners.get(name)?.forEach((cb) => cb());
 }
 
+/**
+ * Manually fire the change bus for a store without writing to it. Used when a
+ * derived, in-memory view that `useLiveQuery` depends on changes (e.g. the
+ * hidden-chats reveal toggle flips which chats `listChats` returns) so the UI
+ * re-queries even though no stored row actually changed.
+ */
+export function touch(name: StoreName): void {
+  notify(name);
+}
+
 /** Subscribe to changes on any of the given stores. Returns an unsubscribe fn. */
 export function subscribe(names: StoreName[], cb: () => void): () => void {
   for (const n of names) {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -26,6 +26,7 @@ import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deri
 import { THUMB_TIERS } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview } from '@/services/link-preview';
+import { ensureHiddenLoaded, isRevealed } from '@/services/hidden-state';
 import type {
   MessagePayload, ContactCard, GroupCard, GroupMember, ReactionSignal, PollVoteSignal, MediaRef,
   EditSignal, EraseSignal, LinkPreviewSignal,
@@ -53,9 +54,14 @@ function chatOrder(a: Chat, b: Chat): number {
 
 export async function listChats(q = ''): Promise<Chat[]> {
   // The main list hides pending requests, archived chats, and locked chats (the
-  // last two have their own views). Pinned-first, then most-recent.
+  // last two have their own views). Hidden chats (spec 1019) are also excluded
+  // unless a reveal session is active — this is the single choke point every
+  // filter chip composes over, so excluding here covers them all. Pinned-first,
+  // then most-recent.
+  const hidden = await ensureHiddenLoaded();
+  const showHidden = isRevealed();
   const chats = (await getAll<Chat>('chats')).filter(
-    (c) => !c.pending && !c.archived && !c.locked,
+    (c) => !c.pending && !c.archived && !c.locked && (showHidden || !hidden.has(c.id)),
   );
   const filtered = q
     ? chats.filter((c) => matches(c.name, q) || matches(c.lastMessage, q))

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -27,6 +27,7 @@ import { THUMB_TIERS } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview } from '@/services/link-preview';
 import { ensureHiddenLoaded, isRevealed } from '@/services/hidden-state';
+import { hiddenCallKeys } from '@/db/hidden-calls';
 import type {
   MessagePayload, ContactCard, GroupCard, GroupMember, ReactionSignal, PollVoteSignal, MediaRef,
   EditSignal, EraseSignal, LinkPreviewSignal,
@@ -1881,8 +1882,17 @@ export interface CallGroup extends Call {
 }
 
 /** Collapse consecutive same-contact calls (WhatsApp-style "(2)" grouping). */
+// Hidden calls (spec 1019, FR-019) are excluded from the Calls tab and the missed
+// badge ALWAYS (even while revealed): the reveal session surfaces hidden chats to
+// read, but the call history stays clean of any trace. `hiddenCallKeys` maps the
+// hidden chat set to the call `contactId`s to drop (see src/db/hidden-calls.ts).
 export async function listCallGroups(q = ''): Promise<CallGroup[]> {
-  const calls = await listCalls(q); // newest first
+  let calls = await listCalls(q); // newest first
+  const hidden = await ensureHiddenLoaded();
+  if (hidden.size > 0) {
+    const exclude = hiddenCallKeys(await getAll<Chat>('chats'), hidden);
+    calls = calls.filter((c) => !exclude.has(c.contactId));
+  }
   const groups: CallGroup[] = [];
   for (const call of calls) {
     const prev = groups[groups.length - 1];
@@ -3287,13 +3297,19 @@ export async function resolveAlert(id: string): Promise<void> {
 /* ---- badge counts ---- */
 
 export async function countUnread(): Promise<number> {
+  // Hidden chats (spec 1019) never contribute to the badge — always, even while
+  // revealed — so the count can't reveal or attribute a hidden chat's existence.
+  const hidden = await ensureHiddenLoaded();
   const chats = await getAll<Chat>('chats');
-  return chats.reduce((n, c) => n + (c.unread || 0), 0);
+  return chats.reduce((n, c) => n + (hidden.has(c.id) ? 0 : c.unread || 0), 0);
 }
 
 export async function countMissedUnseen(): Promise<number> {
   const calls = await getAll<Call>('calls');
-  return calls.filter((c) => c.missed && !c.seen).length;
+  const hidden = await ensureHiddenLoaded();
+  if (hidden.size === 0) return calls.filter((c) => c.missed && !c.seen).length;
+  const exclude = hiddenCallKeys(await getAll<Chat>('chats'), hidden);
+  return calls.filter((c) => c.missed && !c.seen && !exclude.has(c.contactId)).length;
 }
 
 export async function countPendingRequests(): Promise<number> {

--- a/src/db/tombstones.test.ts
+++ b/src/db/tombstones.test.ts
@@ -1,0 +1,33 @@
+// Spec 1019 (US7/FR-016): a local-only tombstone must block re-sync ingest yet
+// never be uploaded (so a Hidden Chats reset doesn't propagate to other devices).
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const store = vi.hoisted(() => ({ m: new Map<string, any>() }));
+vi.mock('./idb', () => ({
+  get: async (_s: string, key: string) => store.m.get(key),
+  getAll: async () => [...store.m.values()],
+  put: async (_s: string, row: any) => {
+    store.m.set(row.id, row);
+  },
+}));
+
+import { recordTombstone, isTombstoned, listTombstones } from './tombstones';
+
+beforeEach(() => store.m.clear());
+
+describe('tombstones', () => {
+  it('a normal tombstone is uploadable and blocks ingest', async () => {
+    await recordTombstone('chats', 'c1', 1000);
+    expect(await isTombstoned('chats', 'c1', 500)).toBe(true); // covers older record
+    expect(await isTombstoned('chats', 'c1', 2000)).toBe(false); // newer record wins
+    expect((await listTombstones()).map((t) => t.recordId)).toContain('c1');
+  });
+
+  it('a localOnly tombstone blocks ingest but is NEVER uploaded (FR-016)', async () => {
+    await recordTombstone('chats', 'hidden1', Number.MAX_SAFE_INTEGER, true);
+    // Honored by the ingest block, even against a future updatedAt (permanent block).
+    expect(await isTombstoned('chats', 'hidden1', Date.now())).toBe(true);
+    // Excluded from the uploadable set → never propagates to the server/other devices.
+    expect((await listTombstones()).map((t) => t.recordId)).not.toContain('hidden1');
+  });
+});

--- a/src/db/tombstones.ts
+++ b/src/db/tombstones.ts
@@ -3,6 +3,12 @@
  * would happily resurrect. A tombstone records "(store, recordId) was deleted
  * at deletedAt"; the sync merge drops any incoming record that a newer-or-equal
  * tombstone covers. Tombstones themselves sync (so other devices honor them).
+ *
+ * EXCEPTION — `localOnly` tombstones (spec 1019): a Hidden Chats PIN reset wipes
+ * hidden conversations on THIS device and must block them from re-downloading,
+ * WITHOUT telling the server or the user's other devices (where the conversation
+ * may still be wanted). A `localOnly` tombstone is honored by the ingest check
+ * but excluded from `listTombstones()` so it is never uploaded.
  */
 import { get, getAll, put, type StoreName } from './idb';
 
@@ -11,6 +17,7 @@ export interface Tombstone {
   store: string;
   recordId: string;
   deletedAt: number;
+  localOnly?: boolean; // never uploaded (device-local re-sync block)
 }
 
 function key(store: string, recordId: string): string {
@@ -22,11 +29,15 @@ export async function recordTombstone(
   store: StoreName,
   recordId: string,
   deletedAt = Date.now(),
+  localOnly = false,
 ): Promise<void> {
-  await put<Tombstone>('tombstones', { id: key(store, recordId), store, recordId, deletedAt });
+  const t: Tombstone = { id: key(store, recordId), store, recordId, deletedAt };
+  if (localOnly) t.localOnly = true;
+  await put<Tombstone>('tombstones', t);
 }
 
-/** True if a tombstone covers this record at or after `updatedAt`. */
+/** True if a tombstone covers this record at or after `updatedAt`. Honors both
+ *  synced and localOnly tombstones (the ingest block applies to both). */
 export async function isTombstoned(
   store: string,
   recordId: string,
@@ -36,6 +47,8 @@ export async function isTombstoned(
   return !!t && t.deletedAt >= updatedAt;
 }
 
-export function listTombstones(): Promise<Tombstone[]> {
-  return getAll<Tombstone>('tombstones');
+/** All UPLOADABLE tombstones — excludes localOnly (device-local) markers so a
+ *  Hidden Chats reset never propagates its wipe to the server or other devices. */
+export async function listTombstones(): Promise<Tombstone[]> {
+  return (await getAll<Tombstone>('tombstones')).filter((t) => !t.localOnly);
 }

--- a/src/services/hidden-chats-reset.test.ts
+++ b/src/services/hidden-chats-reset.test.ts
@@ -1,0 +1,87 @@
+// Spec 1019 (US7/FR-016/FR-024): resetHiddenChats wipes hidden conversations'
+// local data, records a permanent local-only re-sync block per id (recorded
+// BEFORE the data wipe so an interruption never exposes a half-wiped chat), and
+// clears the set + PIN.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  hidden: new Set<string>(['chatHid', 'grpHid']),
+  removed: [] as Array<[string, string]>,
+  tombstones: [] as Array<{ store: string; recordId: string; deletedAt: number; localOnly: boolean }>,
+  cleared: false,
+  stateCleared: false,
+}));
+
+vi.mock('@/db/idb', () => ({
+  getByIndex: async (_store: string, _idx: string, chatId: string) =>
+    chatId === 'chatHid' ? [{ id: 'm1' }, { id: 'm2' }] : [],
+  remove: async (store: string, id: string) => {
+    h.removed.push([store, id]);
+  },
+}));
+vi.mock('@/db/tombstones', () => ({
+  recordTombstone: async (store: string, recordId: string, deletedAt: number, localOnly = false) => {
+    h.tombstones.push({ store, recordId, deletedAt, localOnly });
+  },
+}));
+vi.mock('@/services/hidden-chats', () => ({
+  getHiddenSet: async () => h.hidden,
+  clearHiddenStorage: async () => {
+    h.cleared = true;
+  },
+}));
+vi.mock('@/services/hidden-state', () => ({
+  clearHiddenState: () => {
+    h.stateCleared = true;
+  },
+}));
+
+import { resetHiddenChats } from './hidden-chats-reset';
+
+beforeEach(() => {
+  h.removed.length = 0;
+  h.tombstones.length = 0;
+  h.cleared = false;
+  h.stateCleared = false;
+  h.hidden = new Set(['chatHid', 'grpHid']);
+});
+
+describe('resetHiddenChats', () => {
+  it('blocks re-sync, wipes local data, and clears the set + PIN', async () => {
+    const { wiped } = await resetHiddenChats();
+    expect(wiped.sort()).toEqual(['chatHid', 'grpHid']);
+
+    // A permanent local-only block per hidden id (never uploaded).
+    expect(h.tombstones).toHaveLength(2);
+    for (const t of h.tombstones) {
+      expect(t.localOnly).toBe(true);
+      expect(t.deletedAt).toBe(Number.MAX_SAFE_INTEGER);
+      expect(t.store).toBe('chats');
+    }
+
+    // Local data removed: messages of chatHid, plus sessions/senderkeys/chats rows.
+    expect(h.removed).toContainEqual(['messages', 'm1']);
+    expect(h.removed).toContainEqual(['messages', 'm2']);
+    expect(h.removed).toContainEqual(['chats', 'chatHid']);
+    expect(h.removed).toContainEqual(['chats', 'grpHid']);
+
+    // Set + PIN + in-memory state cleared last.
+    expect(h.cleared).toBe(true);
+    expect(h.stateCleared).toBe(true);
+  });
+
+  it('records the re-sync block BEFORE removing the chat row (atomic wrt exposure, FR-024)', async () => {
+    const order: string[] = [];
+    // Re-mock to capture ordering across the two mocked modules via the arrays:
+    await resetHiddenChats();
+    // Tombstones are recorded in the first loop; chat removal in the second — so for
+    // each id the tombstone exists by the time we delete. Assert both happened and
+    // that no chat row removal lacks a matching block.
+    for (const [store, id] of h.removed) {
+      if (store === 'chats') order.push(id);
+    }
+    for (const id of order) {
+      expect(h.tombstones.find((t) => t.recordId === id)).toBeTruthy();
+    }
+  });
+});

--- a/src/services/hidden-chats-reset.ts
+++ b/src/services/hidden-chats-reset.ts
@@ -1,0 +1,43 @@
+/**
+ * Hidden Chats PIN reset (spec 1019, US7 / FR-016 / FR-024).
+ *
+ * Destructive: permanently deletes every hidden conversation's local data on THIS
+ * device AND records a device-local "do-not-resync" block so the server can never
+ * re-download them, without propagating the deletion to the user's other devices.
+ *
+ * Ordering matters for atomicity-with-respect-to-exposure (FR-024): the re-sync
+ * BLOCK is recorded before the data is deleted, and the hidden set is cleared
+ * LAST. So if the wipe is interrupted, the conversations are still hidden (in the
+ * set) and still blocked from re-sync — they can never flip to visible mid-reset.
+ */
+import { getByIndex, remove } from '@/db/idb';
+import { recordTombstone } from '@/db/tombstones';
+import { getHiddenSet, clearHiddenStorage } from '@/services/hidden-chats';
+import { clearHiddenState } from '@/services/hidden-state';
+import type { Message } from '@/db/types';
+
+// A far-future cover so the block is permanent on this device — even if the
+// server later holds a newer `updatedAt` for the conversation, the ingest check
+// (deletedAt >= updatedAt) still drops it.
+const PERMANENT = Number.MAX_SAFE_INTEGER;
+
+export async function resetHiddenChats(): Promise<{ wiped: string[] }> {
+  const ids = [...(await getHiddenSet())];
+
+  // 1) Block re-sync FIRST (local-only tombstone, never uploaded).
+  for (const id of ids) {
+    await recordTombstone('chats', id, PERMANENT, true);
+  }
+  // 2) Delete local data for each hidden conversation.
+  for (const id of ids) {
+    const msgs = await getByIndex<Message>('messages', 'chatId', id);
+    for (const m of msgs) await remove('messages', m.id);
+    await remove('sessions', id); // 1:1 ratchet session (no-op for a group)
+    await remove('senderkeys', id); // group sender-key state (no-op for a 1:1)
+    await remove('chats', id);
+  }
+  // 3) Clear the set + PIN material + in-memory state LAST.
+  await clearHiddenStorage();
+  clearHiddenState();
+  return { wiped: ids };
+}

--- a/src/services/hidden-chats-start.test.ts
+++ b/src/services/hidden-chats-start.test.ts
@@ -1,0 +1,27 @@
+// Unit test for startHiddenChat (spec 1019, US2): a hidden chat is a distinct
+// group conversation, added to the hidden set, leaving any existing 1:1 untouched.
+import { describe, it, expect, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ groups: [] as Array<{ name: string; members: string[] }>, hidden: [] as string[] }));
+
+vi.mock('@/db/queries', () => ({
+  createGroup: async (name: string, members: string[]) => {
+    h.groups.push({ name, members });
+    return `grp-${members.join('-')}-${h.groups.length}`;
+  },
+}));
+vi.mock('@/services/hidden-chats', () => ({
+  addHidden: async (id: string) => {
+    h.hidden.push(id);
+  },
+}));
+
+import { startHiddenChat } from './hidden-chats-start';
+
+describe('startHiddenChat', () => {
+  it('creates a distinct 2-person group and adds it to the hidden set (FR-017)', async () => {
+    const id = await startHiddenChat('contact-1');
+    expect(h.groups).toEqual([{ name: '', members: ['contact-1'] }]);
+    expect(h.hidden).toContain(id);
+  });
+});

--- a/src/services/hidden-chats-start.ts
+++ b/src/services/hidden-chats-start.ts
@@ -1,0 +1,21 @@
+/**
+ * Starting a distinct, coexisting hidden conversation (spec 1019, US2).
+ *
+ * Split out from `hidden-chats.ts` because it depends on `queries.ts`
+ * (`createGroup`), which the service worker must not pull in. UI/test callers
+ * import from here; the SW imports only the queries-free `hidden-chats.ts`.
+ */
+import { createGroup } from '@/db/queries';
+import { addHidden } from '@/services/hidden-chats';
+
+/**
+ * Start a NEW hidden conversation with a contact, modeled on the group mechanism
+ * so it coexists with any normal 1:1 with the same person (a distinct id, its own
+ * history). Reuses the existing sender-key crypto — no new scheme. Returns the new
+ * conversation id, already added to the hidden set.
+ */
+export async function startHiddenChat(contactId: string): Promise<string> {
+  const groupId = await createGroup('', [contactId]);
+  await addHidden(groupId);
+  return groupId;
+}

--- a/src/services/hidden-chats.test.ts
+++ b/src/services/hidden-chats.test.ts
@@ -1,0 +1,156 @@
+// Unit tests for the Hidden Chats service (spec 1019). The idb-backed settings
+// layer and the master-key accessor are mocked so we exercise the REAL crypto
+// (Argon2id PIN verifier + master-key-sealed hidden set) without a DOM/IndexedDB.
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { ready, randomBytes } from './crypto/primitives';
+
+// In-memory settings + a swappable master key, hoisted so the vi.mock factories
+// (which are hoisted above imports) can close over them.
+const h = vi.hoisted(() => ({
+  settings: new Map<string, unknown>(),
+  mk: { key: null as Uint8Array | null },
+  groups: [] as Array<{ name: string; members: string[] }>,
+}));
+
+vi.mock('@/db/queries', () => ({
+  getSetting: async (k: string, fb: unknown) => (h.settings.has(k) ? h.settings.get(k) : fb),
+  setSetting: async (k: string, v: unknown) => {
+    h.settings.set(k, v);
+  },
+  createGroup: async (name: string, members: string[]) => {
+    h.groups.push({ name, members });
+    return `grp-${members.join('-')}-${h.groups.length}`;
+  },
+}));
+
+vi.mock('@/services/crypto/identity', () => ({
+  getMasterKey: () => {
+    if (!h.mk.key) throw new Error('locked');
+    return h.mk.key;
+  },
+}));
+
+// Keep the real hidden-state leaf, but stub idb.touch (no DOM bus in node).
+vi.mock('@/db/idb', () => ({ touch: () => {} }));
+
+import {
+  getHiddenSet,
+  isHidden,
+  addHidden,
+  removeHidden,
+  hasHiddenPin,
+  enableHiddenPin,
+  verifyHiddenPin,
+  changeHiddenPin,
+  hiddenPinLength,
+  startHiddenChat,
+} from './hidden-chats';
+import { clearHiddenState, isRevealed } from './hidden-state';
+
+beforeAll(async () => {
+  await ready();
+  h.mk.key = randomBytes(32);
+});
+
+beforeEach(() => {
+  h.settings.clear();
+  h.groups.length = 0;
+  clearHiddenState();
+});
+
+describe('hidden set (membership)', () => {
+  it('starts empty and round-trips hides/unhides', async () => {
+    expect([...(await getHiddenSet())]).toEqual([]);
+    await addHidden('chat-A');
+    await addHidden('chat-B');
+    expect(await isHidden('chat-A')).toBe(true);
+    expect(await isHidden('chat-Z')).toBe(false);
+    await removeHidden('chat-A');
+    expect(await isHidden('chat-A')).toBe(false);
+    expect(await isHidden('chat-B')).toBe(true);
+  });
+
+  it('add/remove are idempotent', async () => {
+    await addHidden('chat-A');
+    await addHidden('chat-A');
+    expect([...(await getHiddenSet())]).toEqual(['chat-A']);
+    await removeHidden('nope'); // no-op
+    expect([...(await getHiddenSet())]).toEqual(['chat-A']);
+  });
+
+  it('persists the set AEAD-sealed at rest, never as plaintext ids (FR-010)', async () => {
+    await addHidden('secret-chat');
+    const stored = h.settings.get('privacy.hiddenChats') as { __enc?: number; env?: unknown };
+    expect(stored.__enc).toBe(1);
+    expect(stored.env).toBeDefined();
+    // The raw stored blob must not contain the plaintext id.
+    expect(JSON.stringify(stored)).not.toContain('secret-chat');
+  });
+
+  it('fails closed (empty) when the keystore is locked', async () => {
+    await addHidden('chat-A');
+    clearHiddenState();
+    const saved = h.mk.key;
+    h.mk.key = null; // simulate locked
+    expect([...(await getHiddenSet())]).toEqual([]); // no leak, no throw
+    h.mk.key = saved;
+  });
+});
+
+// Argon2id is deliberately slow (brute-force mitigation, FR-022); under the full
+// parallel suite these PIN tests need a generous timeout vs. the 5s default.
+const PIN_TIMEOUT = 30_000;
+
+describe('separate dedicated PIN', () => {
+  it('reports no PIN until enabled, then verifies only the correct PIN', async () => {
+    expect(await hasHiddenPin()).toBe(false);
+    expect(await verifyHiddenPin('1234')).toBe(false); // no PIN → no oracle
+    await enableHiddenPin('1234');
+    expect(await hasHiddenPin()).toBe(true);
+    expect(await verifyHiddenPin('1234')).toBe(true);
+    expect(await verifyHiddenPin('9999')).toBe(false);
+  }, PIN_TIMEOUT);
+
+  it('never stores the PIN in recoverable form', async () => {
+    await enableHiddenPin('4321');
+    expect(JSON.stringify(h.settings.get('privacy.hiddenPin'))).not.toContain('4321');
+  }, PIN_TIMEOUT);
+
+  it('exposes the PIN length for auto-verify-at-length', async () => {
+    expect(await hiddenPinLength()).toBeNull();
+    await enableHiddenPin('123456');
+    expect(await hiddenPinLength()).toBe(6);
+  }, PIN_TIMEOUT);
+
+  it('change requires the old PIN and rotates the verifier', async () => {
+    await enableHiddenPin('1111');
+    await expect(changeHiddenPin('0000', '2222')).rejects.toThrow();
+    await changeHiddenPin('1111', '2222');
+    expect(await verifyHiddenPin('1111')).toBe(false);
+    expect(await verifyHiddenPin('2222')).toBe(true);
+  }, PIN_TIMEOUT);
+
+  it('uses a salt independent of any app PIN (distinct salts per enable)', async () => {
+    await enableHiddenPin('1234');
+    const a = (h.settings.get('privacy.hiddenPin') as { salt: string }).salt;
+    await enableHiddenPin('1234');
+    const b = (h.settings.get('privacy.hiddenPin') as { salt: string }).salt;
+    expect(a).not.toEqual(b); // fresh random salt each time
+  }, PIN_TIMEOUT);
+});
+
+describe('startHiddenChat (coexisting distinct conversation)', () => {
+  it('creates a distinct group and hides it, leaving any 1:1 untouched (FR-017)', async () => {
+    const id = await startHiddenChat('contact-1');
+    expect(h.groups).toHaveLength(1);
+    expect(h.groups[0].members).toEqual(['contact-1']); // 2-person group
+    expect(await isHidden(id)).toBe(true);
+    // We never created or touched a 1:1 chat record here.
+  });
+});
+
+describe('reveal flag isolation', () => {
+  it('the reveal session starts locked', () => {
+    expect(isRevealed()).toBe(false);
+  });
+});

--- a/src/services/hidden-chats.test.ts
+++ b/src/services/hidden-chats.test.ts
@@ -9,18 +9,16 @@ import { ready, randomBytes } from './crypto/primitives';
 const h = vi.hoisted(() => ({
   settings: new Map<string, unknown>(),
   mk: { key: null as Uint8Array | null },
-  groups: [] as Array<{ name: string; members: string[] }>,
 }));
 
-vi.mock('@/db/queries', () => ({
-  getSetting: async (k: string, fb: unknown) => (h.settings.has(k) ? h.settings.get(k) : fb),
-  setSetting: async (k: string, v: unknown) => {
-    h.settings.set(k, v);
+// hidden-chats.ts persists via idb get/put on the 'settings' store directly; back
+// it with an in-memory map. `touch` is a no-op (no DOM bus in node).
+vi.mock('@/db/idb', () => ({
+  get: async (_store: string, key: string) => (h.settings.has(key) ? { key, value: h.settings.get(key) } : undefined),
+  put: async (_store: string, row: { key: string; value: unknown }) => {
+    h.settings.set(row.key, row.value);
   },
-  createGroup: async (name: string, members: string[]) => {
-    h.groups.push({ name, members });
-    return `grp-${members.join('-')}-${h.groups.length}`;
-  },
+  touch: () => {},
 }));
 
 vi.mock('@/services/crypto/identity', () => ({
@@ -29,9 +27,6 @@ vi.mock('@/services/crypto/identity', () => ({
     return h.mk.key;
   },
 }));
-
-// Keep the real hidden-state leaf, but stub idb.touch (no DOM bus in node).
-vi.mock('@/db/idb', () => ({ touch: () => {} }));
 
 import {
   getHiddenSet,
@@ -43,7 +38,6 @@ import {
   verifyHiddenPin,
   changeHiddenPin,
   hiddenPinLength,
-  startHiddenChat,
 } from './hidden-chats';
 import { clearHiddenState, isRevealed } from './hidden-state';
 
@@ -54,7 +48,6 @@ beforeAll(async () => {
 
 beforeEach(() => {
   h.settings.clear();
-  h.groups.length = 0;
   clearHiddenState();
 });
 
@@ -137,16 +130,6 @@ describe('separate dedicated PIN', () => {
     const b = (h.settings.get('privacy.hiddenPin') as { salt: string }).salt;
     expect(a).not.toEqual(b); // fresh random salt each time
   }, PIN_TIMEOUT);
-});
-
-describe('startHiddenChat (coexisting distinct conversation)', () => {
-  it('creates a distinct group and hides it, leaving any 1:1 untouched (FR-017)', async () => {
-    const id = await startHiddenChat('contact-1');
-    expect(h.groups).toHaveLength(1);
-    expect(h.groups[0].members).toEqual(['contact-1']); // 2-person group
-    expect(await isHidden(id)).toBe(true);
-    // We never created or touched a 1:1 chat record here.
-  });
 });
 
 describe('reveal flag isolation', () => {

--- a/src/services/hidden-chats.ts
+++ b/src/services/hidden-chats.ts
@@ -1,0 +1,156 @@
+/**
+ * Hidden Chats — the local, zero-knowledge privacy layer (spec 1019).
+ *
+ * A hidden chat is an ordinary conversation whose id is recorded in a per-device
+ * "hidden set". That set, and a separate dedicated reveal PIN, live ONLY on this
+ * device and never cross the wire (the server already can't read conversation
+ * content; hiding adds no new signal — see spec §Zero-Knowledge Impact).
+ *
+ * Storage (both device-local `settings` keys, deliberately excluded from
+ * own-data sync so hiding stays per-device):
+ *   - `privacy.hiddenChats`: the set of hidden conversation ids, AEAD-sealed under
+ *     the master key (so it can't be read off the device without unlocking, yet is
+ *     readable while the app is unlocked to exclude hidden chats *by default*).
+ *   - `privacy.hiddenPin`: a separate PIN verifier — a marker sealed under an
+ *     Argon2id key derived from the dedicated PIN. "Verify" is decryption success;
+ *     the PIN is never stored in recoverable form (FR-010/FR-015). Argon2id's cost
+ *     is the brute-force mitigation (FR-022).
+ *
+ * Knowing membership (to hide by default) is separate from authorizing a reveal:
+ * the master-key-sealed set answers "is this hidden?"; the dedicated PIN authorizes
+ * flipping the in-memory reveal session (held in `hidden-state.ts`).
+ */
+import { getSetting, setSetting, createGroup } from '@/db/queries';
+import { getMasterKey } from '@/services/crypto/identity';
+import {
+  sealJson,
+  openJson,
+  utf8ToBytes,
+  bytesToB64url,
+  b64urlToBytes,
+  type Envelope,
+} from '@/services/crypto/envelope';
+import { argon2id, randomBytes, ARGON_SALT_BYTES } from '@/services/crypto/primitives';
+import {
+  registerHiddenLoader,
+  ensureHiddenLoaded,
+  setHiddenIdsCache,
+} from '@/services/hidden-state';
+
+const SET_KEY = 'privacy.hiddenChats';
+const PIN_KEY = 'privacy.hiddenPin';
+// Versioned marker: decrypting it back proves the PIN. Opaque; carries no secret.
+const PIN_MARKER = 'ring-hidden-v1';
+
+/** Encrypted-at-rest wrapper, mirroring `src/db/secrets.ts`'s shape. */
+interface EncWrapper {
+  __enc: 1;
+  env: Envelope;
+}
+interface HiddenPinRec {
+  salt: string; // b64url Argon2id salt (clear)
+  env: Envelope; // PIN_MARKER sealed under the PIN-derived key
+  length: number; // digit count, for auto-verify-at-length
+}
+
+/* ---- hidden set: master-key-sealed, device-local ---- */
+
+function sealSet(ids: string[]): EncWrapper {
+  return { __enc: 1, env: sealJson(getMasterKey(), ids, 'master', utf8ToBytes(SET_KEY)) };
+}
+
+function openSet(w: EncWrapper): string[] {
+  return openJson<string[]>(getMasterKey(), w.env, utf8ToBytes(SET_KEY));
+}
+
+/** Decrypt the stored set. Throws if locked (caller fails closed). */
+async function loadSet(): Promise<Set<string>> {
+  const raw = await getSetting<EncWrapper | undefined>(SET_KEY, undefined);
+  if (!raw) return new Set();
+  return new Set(openSet(raw));
+}
+
+// Inject the decryptor into the leaf so `listChats`/`listCallGroups` can lazily
+// populate the cache without importing this (queries-dependent) module.
+registerHiddenLoader(loadSet);
+
+async function persist(ids: Set<string>): Promise<void> {
+  await setSetting<EncWrapper>(SET_KEY, sealSet([...ids]));
+  setHiddenIdsCache(ids);
+}
+
+/** The set of conversation ids hidden on this device (cached after first load). */
+export async function getHiddenSet(): Promise<Set<string>> {
+  return ensureHiddenLoaded();
+}
+
+export async function isHidden(chatId: string): Promise<boolean> {
+  return (await getHiddenSet()).has(chatId);
+}
+
+/** Hide an existing conversation. */
+export async function addHidden(chatId: string): Promise<void> {
+  const ids = new Set(await getHiddenSet());
+  if (ids.has(chatId)) return;
+  ids.add(chatId);
+  await persist(ids);
+}
+
+/** Permanently unhide a conversation (it returns to the normal list). */
+export async function removeHidden(chatId: string): Promise<void> {
+  const ids = new Set(await getHiddenSet());
+  if (!ids.delete(chatId)) return;
+  await persist(ids);
+}
+
+/* ---- separate dedicated PIN ---- */
+
+export async function hasHiddenPin(): Promise<boolean> {
+  return (await getSetting<HiddenPinRec | undefined>(PIN_KEY, undefined)) != null;
+}
+
+/** Set (or replace) the dedicated reveal PIN. */
+export async function enableHiddenPin(pin: string): Promise<void> {
+  const salt = randomBytes(ARGON_SALT_BYTES);
+  const key = argon2id(pin, salt);
+  const env = sealJson(key, PIN_MARKER, 'pin');
+  await setSetting<HiddenPinRec>(PIN_KEY, { salt: bytesToB64url(salt), env, length: pin.length });
+}
+
+/** Verify a reveal-PIN attempt. Returns false (no oracle) on any failure. */
+export async function verifyHiddenPin(pin: string): Promise<boolean> {
+  const rec = await getSetting<HiddenPinRec | undefined>(PIN_KEY, undefined);
+  if (!rec) return false;
+  try {
+    const key = argon2id(pin, b64urlToBytes(rec.salt));
+    return openJson<string>(key, rec.env) === PIN_MARKER;
+  } catch {
+    return false;
+  }
+}
+
+/** Change the PIN (requires the old one). Re-wraps the verifier; the set is
+ *  independent of the PIN, so there is no window where it is unprotected. */
+export async function changeHiddenPin(oldPin: string, newPin: string): Promise<void> {
+  if (!(await verifyHiddenPin(oldPin))) throw new Error('incorrect PIN');
+  await enableHiddenPin(newPin);
+}
+
+export async function hiddenPinLength(): Promise<number | null> {
+  const rec = await getSetting<HiddenPinRec | undefined>(PIN_KEY, undefined);
+  return rec ? rec.length : null;
+}
+
+/* ---- starting a distinct, coexisting hidden conversation (US2) ---- */
+
+/**
+ * Start a NEW hidden conversation with a contact, modeled on the group mechanism
+ * so it coexists with any normal 1:1 with the same person (a distinct id, its own
+ * history). Reuses the existing sender-key crypto — no new scheme. Returns the
+ * new conversation id, already added to the hidden set.
+ */
+export async function startHiddenChat(contactId: string): Promise<string> {
+  const groupId = await createGroup('', [contactId]);
+  await addHidden(groupId);
+  return groupId;
+}

--- a/src/services/hidden-chats.ts
+++ b/src/services/hidden-chats.ts
@@ -20,7 +20,11 @@
  * the master-key-sealed set answers "is this hidden?"; the dedicated PIN authorizes
  * flipping the in-memory reveal session (held in `hidden-state.ts`).
  */
-import { getSetting, setSetting, createGroup } from '@/db/queries';
+// Deliberately depends ONLY on idb + crypto (no `queries.ts`): this module is
+// pulled into the service-worker bundle via `readHiddenSet`, and `queries.ts`
+// drags in DOM-heavy media code the SW can't (and shouldn't) load. The one
+// queries-dependent action, `startHiddenChat`, lives in `hidden-chats-start.ts`.
+import { get, put } from '@/db/idb';
 import { getMasterKey } from '@/services/crypto/identity';
 import {
   sealJson,
@@ -36,6 +40,16 @@ import {
   ensureHiddenLoaded,
   setHiddenIdsCache,
 } from '@/services/hidden-state';
+
+// Local settings get/put (same shape as queries.getSetting/setSetting) so this
+// module needs no `queries.ts` import.
+async function readSetting<T>(key: string, fallback: T): Promise<T> {
+  const s = await get<{ key: string; value: T }>('settings', key);
+  return s ? s.value : fallback;
+}
+function writeSetting<T>(key: string, value: T): Promise<void> {
+  return put('settings', { key, value });
+}
 
 const SET_KEY = 'privacy.hiddenChats';
 const PIN_KEY = 'privacy.hiddenPin';
@@ -65,7 +79,7 @@ function openSet(w: EncWrapper): string[] {
 
 /** Decrypt the stored set. Throws if locked (caller fails closed). */
 async function loadSet(): Promise<Set<string>> {
-  const raw = await getSetting<EncWrapper | undefined>(SET_KEY, undefined);
+  const raw = await readSetting<EncWrapper | undefined>(SET_KEY, undefined);
   if (!raw) return new Set();
   return new Set(openSet(raw));
 }
@@ -75,13 +89,27 @@ async function loadSet(): Promise<Set<string>> {
 registerHiddenLoader(loadSet);
 
 async function persist(ids: Set<string>): Promise<void> {
-  await setSetting<EncWrapper>(SET_KEY, sealSet([...ids]));
+  await writeSetting<EncWrapper>(SET_KEY, sealSet([...ids]));
   setHiddenIdsCache(ids);
 }
 
 /** The set of conversation ids hidden on this device (cached after first load). */
 export async function getHiddenSet(): Promise<Set<string>> {
   return ensureHiddenLoaded();
+}
+
+/**
+ * Direct (uncached, no side effects) read of the hidden set — for the service
+ * worker's notification path. Fails CLOSED to an empty set when locked; that's
+ * safe because a locked keystore also can't decrypt the message, so the SW
+ * already shows a generic, content-free notification in that case.
+ */
+export async function readHiddenSet(): Promise<Set<string>> {
+  try {
+    return await loadSet();
+  } catch {
+    return new Set();
+  }
 }
 
 export async function isHidden(chatId: string): Promise<boolean> {
@@ -106,7 +134,7 @@ export async function removeHidden(chatId: string): Promise<void> {
 /* ---- separate dedicated PIN ---- */
 
 export async function hasHiddenPin(): Promise<boolean> {
-  return (await getSetting<HiddenPinRec | undefined>(PIN_KEY, undefined)) != null;
+  return (await readSetting<HiddenPinRec | undefined>(PIN_KEY, undefined)) != null;
 }
 
 /** Set (or replace) the dedicated reveal PIN. */
@@ -114,12 +142,12 @@ export async function enableHiddenPin(pin: string): Promise<void> {
   const salt = randomBytes(ARGON_SALT_BYTES);
   const key = argon2id(pin, salt);
   const env = sealJson(key, PIN_MARKER, 'pin');
-  await setSetting<HiddenPinRec>(PIN_KEY, { salt: bytesToB64url(salt), env, length: pin.length });
+  await writeSetting<HiddenPinRec>(PIN_KEY, { salt: bytesToB64url(salt), env, length: pin.length });
 }
 
 /** Verify a reveal-PIN attempt. Returns false (no oracle) on any failure. */
 export async function verifyHiddenPin(pin: string): Promise<boolean> {
-  const rec = await getSetting<HiddenPinRec | undefined>(PIN_KEY, undefined);
+  const rec = await readSetting<HiddenPinRec | undefined>(PIN_KEY, undefined);
   if (!rec) return false;
   try {
     const key = argon2id(pin, b64urlToBytes(rec.salt));
@@ -137,20 +165,6 @@ export async function changeHiddenPin(oldPin: string, newPin: string): Promise<v
 }
 
 export async function hiddenPinLength(): Promise<number | null> {
-  const rec = await getSetting<HiddenPinRec | undefined>(PIN_KEY, undefined);
+  const rec = await readSetting<HiddenPinRec | undefined>(PIN_KEY, undefined);
   return rec ? rec.length : null;
-}
-
-/* ---- starting a distinct, coexisting hidden conversation (US2) ---- */
-
-/**
- * Start a NEW hidden conversation with a contact, modeled on the group mechanism
- * so it coexists with any normal 1:1 with the same person (a distinct id, its own
- * history). Reuses the existing sender-key crypto — no new scheme. Returns the
- * new conversation id, already added to the hidden set.
- */
-export async function startHiddenChat(contactId: string): Promise<string> {
-  const groupId = await createGroup('', [contactId]);
-  await addHidden(groupId);
-  return groupId;
 }

--- a/src/services/hidden-chats.ts
+++ b/src/services/hidden-chats.ts
@@ -24,7 +24,7 @@
 // pulled into the service-worker bundle via `readHiddenSet`, and `queries.ts`
 // drags in DOM-heavy media code the SW can't (and shouldn't) load. The one
 // queries-dependent action, `startHiddenChat`, lives in `hidden-chats-start.ts`.
-import { get, put } from '@/db/idb';
+import { get, put, remove } from '@/db/idb';
 import { getMasterKey } from '@/services/crypto/identity';
 import {
   sealJson,
@@ -167,4 +167,13 @@ export async function changeHiddenPin(oldPin: string, newPin: string): Promise<v
 export async function hiddenPinLength(): Promise<number | null> {
   const rec = await readSetting<HiddenPinRec | undefined>(PIN_KEY, undefined);
   return rec ? rec.length : null;
+}
+
+/** Erase the hidden set + PIN material from storage and the in-memory cache.
+ *  Used by the destructive PIN reset (the conversation wipe lives in
+ *  `hidden-chats-reset.ts`). */
+export async function clearHiddenStorage(): Promise<void> {
+  await remove('settings', SET_KEY);
+  await remove('settings', PIN_KEY);
+  setHiddenIdsCache(new Set());
 }

--- a/src/services/hidden-chats.zk.test.ts
+++ b/src/services/hidden-chats.zk.test.ts
@@ -1,0 +1,35 @@
+// Spec 1019 zero-knowledge guard (T044 / SC-004 / FR-009): the hidden set, the
+// PIN material, and the hidden-chats prefs MUST NEVER be uploaded. Own-data sync
+// uploads only the explicit `SYNCED_PREF_KEYS` allowlist (settings are NOT synced
+// wholesale) and excludes localOnly tombstones. This test pins those invariants
+// against the source so a future edit can't silently start syncing hidden state.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const ownsync = readFileSync(resolve(root, 'src/services/ownsync.ts'), 'utf8');
+
+// The hidden-chats storage keys (mirrors hidden-chats.ts SET_KEY/PIN_KEY + prefs).
+const HIDDEN_KEYS = ['privacy.hiddenChats', 'privacy.hiddenPin', 'privacy.hiddenChatsEnabled', 'privacy.hiddenChatsGrace', 'privacy.hiddenChatsBiometric'];
+
+describe('zero-knowledge: hidden state never syncs', () => {
+  it('no hidden-chats key appears in the synced-pref allowlist', () => {
+    const block = ownsync.match(/SYNCED_PREF_KEYS[^\]]*\]/s)?.[0] ?? '';
+    expect(block).not.toEqual('');
+    for (const k of HIDDEN_KEYS) expect(block).not.toContain(k);
+  });
+
+  it('own-data sync only covers contacts/chats/chatlists stores (not settings wholesale)', () => {
+    const block = ownsync.match(/const SYNCED:\s*StoreName\[\]\s*=\s*\[[^\]]*\]/s)?.[0] ?? '';
+    expect(block).toContain("'chats'");
+    expect(block).not.toContain("'settings'"); // settings only sync via the explicit allowlist
+  });
+
+  it('localOnly tombstones are excluded from the uploadable set', () => {
+    const tombstones = readFileSync(resolve(root, 'src/db/tombstones.ts'), 'utf8');
+    // listTombstones must filter out localOnly markers before uploading.
+    expect(tombstones).toMatch(/listTombstones[\s\S]*filter[\s\S]*!t\.localOnly/);
+  });
+});

--- a/src/services/hidden-state.ts
+++ b/src/services/hidden-state.ts
@@ -1,0 +1,102 @@
+/**
+ * Hidden-chats in-memory state (the leaf module).
+ *
+ * Why this exists separately from `hidden-chats.ts`: the data layer
+ * (`queries.ts` → `listChats`, `listCallGroups`) needs to know, synchronously
+ * and on every query, which conversation ids are hidden and whether a reveal
+ * session is currently active. The full `hidden-chats` service depends on
+ * `queries.ts` (for settings/group/delete helpers), so if `queries.ts` imported
+ * it back we'd have a cycle. This leaf holds only the in-memory cache + the
+ * reveal flag, imports nothing heavy, and gets its decryptor injected by
+ * `hidden-chats.ts` at load via `registerHiddenLoader`. The data layer imports
+ * only this leaf.
+ *
+ * Nothing here is persisted — the cache mirrors the at-rest (master-key-wrapped)
+ * hidden set, and the reveal flag is deliberately memory-only so a full app
+ * close always re-locks (spec FR-005 / SC-009).
+ */
+import { touch } from '@/db/idb';
+
+let ids = new Set<string>();
+let loaded = false;
+let revealed = false;
+let loader: (() => Promise<Set<string>>) | null = null;
+
+/** Re-run any `useLiveQuery` watching the chat/call lists (no row changed). */
+function refreshLists(): void {
+  touch('chats');
+  touch('calls');
+}
+
+/**
+ * Injected by `hidden-chats.ts` so this leaf can lazily load the decrypted set
+ * without importing the heavy service (avoids a `queries.ts` import cycle).
+ */
+export function registerHiddenLoader(fn: () => Promise<Set<string>>): void {
+  loader = fn;
+}
+
+/** Ensure the cache is populated from at-rest storage (once). Safe when locked. */
+export async function ensureHiddenLoaded(): Promise<Set<string>> {
+  if (loaded) return ids;
+  // The decryptor lives in `hidden-chats.ts` (which depends on `queries.ts`). If
+  // nothing has imported it yet — e.g. the warm-store path queries chats before
+  // any hidden-chats UI mounts — pull it in lazily so the loader is always
+  // registered before the first read. A dynamic import keeps the static
+  // dependency graph acyclic (data layer → this leaf only).
+  if (!loader) {
+    try {
+      await import('@/services/hidden-chats');
+    } catch {
+      /* best-effort registration */
+    }
+  }
+  if (!loader) return ids; // still none → stay unloaded, retry on next call
+  try {
+    ids = await loader();
+    loaded = true; // cache only on a successful decrypt — see below
+  } catch {
+    // Locked / corrupt: do NOT mark loaded (so we retry once unlocked) and keep
+    // the last-known set rather than an empty one. This fails closed — a
+    // transient decrypt failure never reveals a previously-hidden chat.
+  }
+  return ids;
+}
+
+/** Synchronous read of the current cached hidden-id set. */
+export function hiddenIdsSync(): Set<string> {
+  return ids;
+}
+
+/** True if `id` is currently hidden (per the cache). */
+export function isHiddenId(id: string): boolean {
+  return ids.has(id);
+}
+
+/** Replace the cache (called by the service after a mutation/load). */
+export function setHiddenIdsCache(next: Iterable<string>): void {
+  ids = new Set(next);
+  loaded = true;
+  refreshLists();
+}
+
+/** Is a reveal session currently active? */
+export function isRevealed(): boolean {
+  return revealed;
+}
+
+/** Flip the reveal session. Refreshes the lists when it actually changes. */
+export function setRevealed(v: boolean): void {
+  if (revealed !== v) {
+    revealed = v;
+    refreshLists();
+  }
+}
+
+/** Drop all in-memory state (on lock / wipe / reset). */
+export function clearHiddenState(): void {
+  ids = new Set();
+  loaded = false;
+  revealed = false;
+  refreshLists();
+}

--- a/src/services/hidden-state.ts
+++ b/src/services/hidden-state.ts
@@ -55,6 +55,12 @@ export async function ensureHiddenLoaded(): Promise<Set<string>> {
   try {
     ids = await loader();
     loaded = true; // cache only on a successful decrypt — see below
+    // On a reload the warm chat list can paint before the keystore unlocks, so
+    // the first load attempt fails closed (unloaded). Once it finally succeeds,
+    // nudge the lists to re-query with the now-known set so any chat that was
+    // briefly shown gets excluded. Deferred to a microtask to avoid re-entering
+    // the in-flight query.
+    queueMicrotask(refreshLists);
   } catch {
     // Locked / corrupt: do NOT mark loaded (so we retry once unlocked) and keep
     // the last-known set rather than an empty one. This fails closed — a

--- a/src/services/sw-inbox.hidden.test.ts
+++ b/src/services/sw-inbox.hidden.test.ts
@@ -1,0 +1,41 @@
+// Spec 1019 (US4): a message into a HIDDEN chat must produce a generic,
+// content-free notification (no sender, avatar, or body) whose tap lands on the
+// Chats tab — never the hidden chat. A non-hidden chat is unaffected.
+import { describe, it, expect } from 'vitest';
+import { noteForPayload } from './sw-inbox';
+import type { Chat } from '@/db/types';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const frame = { id: 'm1', from: 'peer-1', t: 'msg', ciphertext: '' } as any;
+const payload = { text: 'secret plans' } as any;
+
+const oneToOne = (id: string): Chat =>
+  ({ id, name: 'Peer', isGroup: false, participantIds: ['peer-1'] }) as unknown as Chat;
+const contacts = [{ id: 'peer-1', name: 'Peer One' }] as any;
+
+describe('noteForPayload — hidden chats', () => {
+  it('renders a generic, content-free note for a hidden chat (FR-007/FR-008)', () => {
+    const chat = oneToOne('chat-1');
+    const { note } = noteForPayload(frame, payload, [chat], contacts, true, true, new Set(['chat-1']));
+    expect(note).toBeTruthy();
+    expect(note!.title).toBe('Ring'); // no sender name
+    expect(note!.body).toBe('New message'); // no message content
+    expect(note!.url).toBe('/tabs/chats'); // tap never opens the hidden chat
+    // No plaintext leaks into the note at all.
+    expect(JSON.stringify(note)).not.toContain('secret plans');
+    expect(JSON.stringify(note)).not.toContain('Peer One');
+  });
+
+  it('a non-hidden chat still shows the sender and a real preview', () => {
+    const chat = oneToOne('chat-2');
+    const { note } = noteForPayload(frame, payload, [chat], contacts, true, true, new Set(['chat-1']));
+    expect(note!.title).toBe('Peer One'); // sender shown
+    expect(note!.url).toBe('/chat/chat-2'); // deep-links into the chat
+  });
+
+  it('fails safe: with no hidden set provided, behaves normally (default empty)', () => {
+    const chat = oneToOne('chat-3');
+    const { note } = noteForPayload(frame, payload, [chat], contacts, true, true);
+    expect(note!.title).toBe('Peer One');
+  });
+});

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -19,6 +19,7 @@
  */
 import { attemptDeviceUnlock } from './crypto/identity';
 import { previewPacket } from './messaging';
+import { readHiddenSet } from './hidden-chats';
 import { readSessionToken } from './session';
 import { get, getAll, put } from '@/db/idb';
 import { notifyPreview } from '@/utils/notify-preview';
@@ -135,13 +136,16 @@ async function loadShown(): Promise<string[]> {
  *  frame carries nothing to alert on (reactions, votes, silent membership/profile
  *  side effects). Mirrors db/queries.ts `receiveIncoming` + the notifyIncoming
  *  calls it makes: requests/invites always notify; plain messages honor showMessages. */
-function noteForPayload(
+// Exported for unit tests (spec 1019 hidden-chat generic rendering, spec 1015
+// content prefs). Otherwise internal to `previewPending`.
+export function noteForPayload(
   f: MsgFrame,
   payload: MessagePayload,
   chats: Chat[],
   contacts: Contact[],
   showMessages: boolean,
   showPreview: boolean,
+  hidden: Set<string> = new Set(),
 ): { note: SwNote | null; wasMessage: boolean; silenced?: boolean } {
   const from = f.from as string;
   const known = contacts.find((c) => c.id === from)?.name;
@@ -196,6 +200,16 @@ function noteForPayload(
   // marks this as an INTENTIONAL per-chat silence, so the caller shows no generic
   // placeholder (vs. a cold-start undecryptable frame, which still needs one) — the
   // badge still counts it.
+  // Hidden chat (spec 1019, FR-007/FR-008): a content-free notification with no
+  // sender, avatar, or body, and a tap that lands on the Chats tab (never the
+  // hidden chat). The per-chat tag stays internal (not user-visible) so bursts
+  // still coalesce. This wins over per-chat content prefs — hidden overrides them.
+  if (chat && hidden.has(chat.id)) {
+    return {
+      note: { ids: [f.id as string], title: 'Ring', body: 'New message', url: '/tabs/chats', tag: `ring:${chat.id}` },
+      wasMessage: true,
+    };
+  }
   if (chat?.mutedUntil && chat.mutedUntil > Date.now()) return { note: null, wasMessage: true, silenced: true };
   // Per-chat web push off (spec 1015 FR-022): suppress the system notification for
   // the closed app — the server still sent the content-free tickle (it can't know
@@ -392,10 +406,11 @@ export async function previewPending(): Promise<PreviewResult> {
   }
 
   const showPreview = await setting<boolean>('notifications.showPreview', true);
-  const [chats, contacts, shown] = await Promise.all([
+  const [chats, contacts, shown, hidden] = await Promise.all([
     getAll<Chat>('chats'),
     getAll<Contact>('contacts'),
     loadShown(),
+    readHiddenSet(), // spec 1019: hidden chats get a generic, content-free notification
   ]);
   const seen = new Set(shown);
 
@@ -414,7 +429,7 @@ export async function previewPending(): Promise<PreviewResult> {
       continue; // can't decrypt this one (session not reachable yet) → leave it for the page
     }
     seen.add(f.id);
-    const { note, wasMessage, silenced } = noteForPayload(f, payload, chats, contacts, showMessages, showPreview);
+    const { note, wasMessage, silenced } = noteForPayload(f, payload, chats, contacts, showMessages, showPreview, hidden);
     if (note) raw.push(note);
     else if (silenced) silencedMessage = true;
     else if (wasMessage && !showMessages) withheldMessage = true;

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -109,8 +109,8 @@ import {
   addHidden as hcAdd,
   removeHidden as hcRemove,
   getHiddenSet as hcGetSet,
-  startHiddenChat as hcStartChat,
 } from '@/services/hidden-chats';
+import { startHiddenChat as hcStartChat } from '@/services/hidden-chats-start';
 import { revealWithPin as hcReveal, relockHidden as hcRelock } from '@/composables/useHiddenChats';
 import { downloadBlob } from '@/services/media-transfer';
 import {

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -104,6 +104,14 @@ import {
   listCloseFriends as dbListCloseFriends,
   listFriends as dbListFriends,
 } from '@/db/queries';
+import {
+  enableHiddenPin as hcEnablePin,
+  addHidden as hcAdd,
+  removeHidden as hcRemove,
+  getHiddenSet as hcGetSet,
+  startHiddenChat as hcStartChat,
+} from '@/services/hidden-chats';
+import { revealWithPin as hcReveal, relockHidden as hcRelock } from '@/composables/useHiddenChats';
 import { downloadBlob } from '@/services/media-transfer';
 import {
   chatMatchesFilter,
@@ -363,6 +371,25 @@ export function installTestHook(): void {
     /** The VISIBLE (non-pending) 1:1 chat id for a peer, or '' if hidden/none. */
     visibleChatWith: async (peerId: string): Promise<string> =>
       (await listChats()).find((c) => !c.isGroup && c.participantIds[0] === peerId)?.id ?? '',
+
+    /* ---- hidden chats (spec 1019) ---- */
+    /** Set/replace the dedicated Hidden Chats PIN. */
+    hiddenSetPin: (pin: string) => hcEnablePin(pin),
+    /** Hide / unhide a conversation by id. */
+    hiddenAdd: (chatId: string) => hcAdd(chatId),
+    hiddenRemove: (chatId: string) => hcRemove(chatId),
+    /** The hidden-set ids on this device. */
+    hiddenIds: async (): Promise<string[]> => [...(await hcGetSet())],
+    /** Start a distinct hidden chat with a contact; returns the new chat id. */
+    hiddenStartChat: (contactId: string) => hcStartChat(contactId),
+    /** Reveal (verify PIN → start session). Returns whether the PIN was correct. */
+    hiddenReveal: (pin: string) => hcReveal(pin),
+    /** End the reveal session. */
+    hiddenRelock: () => {
+      hcRelock();
+    },
+    /** Visible chat ids right now (what `listChats` returns) — for exclusion asserts. */
+    visibleChatIds: async (): Promise<string[]> => (await listChats()).map((c) => c.id),
 
     /* ---- account lifecycle: termination ("Ghosted") + blocking ---- */
     /** Terminate THIS account server-side (drives the peer's ghost detection). */

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -111,6 +111,7 @@ import {
   getHiddenSet as hcGetSet,
 } from '@/services/hidden-chats';
 import { startHiddenChat as hcStartChat } from '@/services/hidden-chats-start';
+import { resetHiddenChats as hcReset } from '@/services/hidden-chats-reset';
 import { revealWithPin as hcReveal, relockHidden as hcRelock } from '@/composables/useHiddenChats';
 import { downloadBlob } from '@/services/media-transfer';
 import {
@@ -388,6 +389,8 @@ export function installTestHook(): void {
     hiddenRelock: () => {
       hcRelock();
     },
+    /** Reset: wipe hidden chats locally + block re-sync. Returns the wiped ids. */
+    hiddenReset: () => hcReset(),
     /** Visible chat ids right now (what `listChats` returns) — for exclusion asserts. */
     visibleChatIds: async (): Promise<string[]> => (await listChats()).map((c) => c.id),
 

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -315,6 +315,19 @@ export const SETTINGS: Record<string, SettingNode> = {
         items: [{ type: 'choice', key: 'privacy.hiddenChatsGrace', default: '1m', options: HIDDEN_GRACE }],
         footer: 'How long revealed chats stay visible when you briefly switch apps. A full app close always re-locks immediately.',
       },
+      {
+        items: [
+          {
+            type: 'action',
+            title: 'Reset PIN & delete hidden chats',
+            action: 'hidden-reset',
+            danger: true,
+            confirm:
+              'This permanently deletes every hidden chat on this device and cannot be undone — they will not come back from the server. Continue?',
+          },
+        ],
+        footer: 'Forgot your PIN? Resetting permanently deletes the hidden chats on this device so they can never be exposed.',
+      },
     ],
   },
   'privacy-last-seen': {

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -23,6 +23,7 @@ import {
   trashOutline,
   archiveOutline,
   eyeOutline,
+  eyeOffOutline,
   timeOutline,
   imageOutline,
   documentOutline,
@@ -56,6 +57,7 @@ export const ICONS: Record<string, string> = {
   trash: trashOutline,
   archive: archiveOutline,
   eye: eyeOutline,
+  eyeOff: eyeOffOutline,
   time: timeOutline,
   image: imageOutline,
   document: documentOutline,
@@ -159,6 +161,13 @@ const APP_LOCK_TIMEOUT: ChoiceOption[] = [
   { value: '1h', label: '1 hour' },
   { value: '8h', label: '8 hours' },
   { value: '24h', label: '24 hours' },
+];
+
+// Hidden Chats reveal grace window (spec 1019, FR-020). Default '1m'.
+const HIDDEN_GRACE: ChoiceOption[] = [
+  { value: 'immediately', label: 'Immediately' },
+  { value: '1m', label: 'After 1 minute' },
+  { value: '5m', label: 'After 5 minutes' },
 ];
 
 /** A backend-dependent screen we keep in the IA but can't implement yet. */
@@ -274,6 +283,7 @@ export const SETTINGS: Record<string, SettingNode> = {
         items: [
           { type: 'link', id: 'privacy-app-lock', title: 'App lock', icon: 'key' },
           { type: 'link', id: 'privacy-chat-lock', title: 'Chat lock', icon: 'lock' },
+          { type: 'link', id: 'privacy-hidden-chats', title: 'Hidden chats', icon: 'eyeOff' },
         ],
       },
       {
@@ -285,6 +295,25 @@ export const SETTINGS: Record<string, SettingNode> = {
           { type: 'link', id: 'privacy-advanced', title: 'Advanced', icon: 'shield' },
           { type: 'link', id: 'privacy-checkup', title: 'Privacy checkup', icon: 'shield' },
         ],
+      },
+    ],
+  },
+  'privacy-hidden-chats': {
+    id: 'privacy-hidden-chats',
+    title: 'Hidden chats',
+    groups: [
+      {
+        items: [{ type: 'toggle', title: 'Enable hidden chats', key: 'privacy.hiddenChatsEnabled', default: false }],
+        footer:
+          'Hide chats behind a separate PIN. A hidden chat is removed from your chat list, search, calls, and notification previews until you type the PIN into the chat search bar. Hiding stays on this device only — it never leaves your phone.',
+      },
+      {
+        items: [{ type: 'action', title: 'Set or change PIN', action: 'hidden-set-pin', icon: 'key' }],
+      },
+      {
+        header: 'Re-lock hidden chats',
+        items: [{ type: 'choice', key: 'privacy.hiddenChatsGrace', default: '1m', options: HIDDEN_GRACE }],
+        footer: 'How long revealed chats stay visible when you briefly switch apps. A full app close always re-locks immediately.',
       },
     ],
   },

--- a/src/views/detail/SettingDetailPage.vue
+++ b/src/views/detail/SettingDetailPage.vue
@@ -173,6 +173,8 @@ import { clearToken } from '@/services/auth';
 import { isUnlockedNow, rotateRecoveryCode, enableLock, disableLock, getPinLength } from '@/services/crypto/identity';
 import { disablePasskey } from '@/services/crypto/passkey';
 import { syncRecoveryWrap } from '@/services/ownsync';
+import { hasHiddenPin, verifyHiddenPin, changeHiddenPin } from '@/services/hidden-chats';
+import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
 import type { Setting } from '@/db/types';
 import {
   ICONS, settingNode, linkSummary, type SettingItem,
@@ -413,6 +415,23 @@ const ACTIONS: Record<string, () => void | Promise<void>> = {
   },
   'reset-network': () => setSetting('network.resetAt', Date.now()),
   'clear-all-media': () => clearAllMedia(),
+  'hidden-set-pin': async () => {
+    // No PIN yet → create one (also flips the feature on). Existing PIN → change
+    // it, requiring the current PIN first.
+    if (!(await hasHiddenPin())) {
+      if (await ensureHiddenPin()) await setSetting('privacy.hiddenChatsEnabled', true);
+      return;
+    }
+    const current = await promptPin('Enter your current Hidden Chats PIN');
+    if (current === null) return;
+    if (!(await verifyHiddenPin(current))) {
+      return notice('Hidden chats', 'That PIN is incorrect.');
+    }
+    const next = await promptPin('Enter a new PIN (4+ digits)', true);
+    if (next === null) return;
+    await changeHiddenPin(current, next);
+    notice('Hidden chats', 'Your PIN has been changed.');
+  },
   invite: async () => {
     const data = { title: 'Ring', text: 'Join me on Ring', url: location.origin };
     if (navigator.share) {
@@ -434,6 +453,38 @@ async function notice(header: string, message: string) {
     buttons: ['OK'],
   });
   await a.present();
+}
+
+// Prompt for a numeric PIN. With `confirm`, requires a matching second entry and
+// 4+ digits (used for setting a NEW PIN); otherwise just returns the entry (used
+// for verifying the current PIN). Resolves null on cancel.
+async function promptPin(header: string, confirm = false): Promise<string | null> {
+  return new Promise((resolve) => {
+    const inputs = [
+      { name: 'pin', type: 'password' as const, attributes: { inputmode: 'numeric' }, placeholder: 'PIN' },
+      ...(confirm
+        ? [{ name: 'confirm', type: 'password' as const, attributes: { inputmode: 'numeric' }, placeholder: 'Confirm PIN' }]
+        : []),
+    ];
+    void alertController
+      .create({
+        header,
+        inputs,
+        buttons: [
+          { text: 'Cancel', role: 'cancel', handler: () => resolve(null) },
+          {
+            text: 'OK',
+            handler: (data: { pin?: string; confirm?: string }) => {
+              const pin = (data.pin ?? '').trim();
+              if (confirm && (!/^\d{4,}$/.test(pin) || pin !== (data.confirm ?? '').trim())) return false;
+              resolve(pin);
+              return true;
+            },
+          },
+        ],
+      })
+      .then((a) => a.present());
+  });
 }
 
 // Present the freshly-rotated recovery code with a copy action. The code goes in

--- a/src/views/detail/SettingDetailPage.vue
+++ b/src/views/detail/SettingDetailPage.vue
@@ -174,6 +174,7 @@ import { isUnlockedNow, rotateRecoveryCode, enableLock, disableLock, getPinLengt
 import { disablePasskey } from '@/services/crypto/passkey';
 import { syncRecoveryWrap } from '@/services/ownsync';
 import { hasHiddenPin, verifyHiddenPin, changeHiddenPin } from '@/services/hidden-chats';
+import { resetHiddenChats } from '@/services/hidden-chats-reset';
 import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
 import type { Setting } from '@/db/types';
 import {
@@ -431,6 +432,14 @@ const ACTIONS: Record<string, () => void | Promise<void>> = {
     if (next === null) return;
     await changeHiddenPin(current, next);
     notice('Hidden chats', 'Your PIN has been changed.');
+  },
+  'hidden-reset': async () => {
+    // The destructive confirm is enforced by runAction (schema `confirm`). Wipe the
+    // hidden chats locally + block re-sync, then clear the PIN/feature so the user
+    // starts fresh.
+    const { wiped } = await resetHiddenChats();
+    await setSetting('privacy.hiddenChatsEnabled', false);
+    notice('Hidden chats', wiped.length ? `${wiped.length} hidden chat(s) deleted on this device.` : 'Hidden chats reset.');
   },
   invite: async () => {
     const data = { title: 'Ring', text: 'Join me on Ring', url: location.origin };

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -184,7 +184,8 @@ import { useChatFilters } from '@/services/chat-filters';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useConnect } from '@/composables/useConnect';
 import { useHiddenChats } from '@/composables/useHiddenChats';
-import { hiddenPinLength, startHiddenChat } from '@/services/hidden-chats';
+import { hiddenPinLength } from '@/services/hidden-chats';
+import { startHiddenChat } from '@/services/hidden-chats-start';
 import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
 import type { Chat, Contact } from '@/db/types';
 

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -208,6 +208,7 @@ onMounted(async () => {
 async function onSearchInput(val: string): Promise<void> {
   search.value = val;
   if (revealed.value) return;
+  if (!hiddenEnabled.value) return; // FR-013a: disabled → the reveal gesture is inert
   if (!/^\d{4,}$/.test(val)) return; // only attempt on a numeric, PIN-shaped query
   if (pinLen.value == null) pinLen.value = await hiddenPinLength(); // PIN may have been set this session
   if (pinLen.value && val.length === pinLen.value && (await reveal(val))) {

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -13,7 +13,7 @@
         <ion-searchbar
           :value="search"
           placeholder="Search"
-          @ion-input="search = $event.detail.value ?? ''"
+          @ion-input="onSearchInput($event.detail.value ?? '')"
         />
       </ion-toolbar>
       <ion-toolbar>
@@ -39,6 +39,12 @@
         <ion-item v-if="hasLocked" button :detail="true" @click="router.push('/chats/locked')">
           <ion-icon slot="start" :icon="lockClosedOutline" color="medium" />
           <ion-label>Locked chats</ion-label>
+        </ion-item>
+        <!-- Reveal-session affordance: only present WHILE revealed, so it leaks no
+             signal otherwise. Tapping re-hides immediately (spec 1019, FR-006/US3). -->
+        <ion-item v-if="revealed" button :detail="false" lines="full" @click="relock">
+          <ion-icon slot="start" :icon="eyeOffOutline" color="medium" />
+          <ion-label>Hide hidden chats</ion-label>
         </ion-item>
 
         <ChatListItem
@@ -122,6 +128,15 @@
             <ion-icon slot="start" :icon="personAddOutline" color="primary" />
             <ion-label>Add contact</ion-label>
           </ion-item>
+          <!-- New hidden chat (spec 1019, US2): a distinct conversation that
+               coexists with any normal 1:1 with the same person. Only shown when
+               the feature is enabled. -->
+          <ion-item v-if="hiddenEnabled" button :detail="false" @click="hiddenMode = !hiddenMode">
+            <ion-icon slot="start" :icon="eyeOffOutline" :color="hiddenMode ? 'primary' : 'medium'" />
+            <ion-label :color="hiddenMode ? 'primary' : undefined">
+              {{ hiddenMode ? 'Pick a contact for the hidden chat…' : 'New hidden chat' }}
+            </ion-label>
+          </ion-item>
         </ion-list>
         <ion-list>
           <ion-list-header><ion-label>Contacts</ion-label></ion-list-header>
@@ -147,7 +162,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton,
@@ -156,6 +171,7 @@ import {
 } from '@ionic/vue';
 import {
   createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline,
+  eyeOffOutline,
 } from 'ionicons/icons';
 import ChatListItem from '@/components/ChatListItem.vue';
 import ChatActionsHost from '@/components/ChatActionsHost.vue';
@@ -163,16 +179,40 @@ import ChatFilterBar from '@/components/ChatFilterBar.vue';
 import ChatListsSheet from '@/components/ChatListsSheet.vue';
 import EditChatTabsModal from '@/components/EditChatTabsModal.vue';
 import NewListModal from '@/components/NewListModal.vue';
-import { listArchivedChats, listLockedChats, listContacts, startDirectChat } from '@/db/queries';
+import { listArchivedChats, listLockedChats, listContacts, startDirectChat, getSetting } from '@/db/queries';
 import { useChatFilters } from '@/services/chat-filters';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useConnect } from '@/composables/useConnect';
+import { useHiddenChats } from '@/composables/useHiddenChats';
+import { hiddenPinLength, startHiddenChat } from '@/services/hidden-chats';
+import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
 import type { Chat, Contact } from '@/db/types';
 
 const router = useRouter();
 const search = ref('');
 const actions = ref<InstanceType<typeof ChatActionsHost> | null>(null);
 const { connect, requireProfile } = useConnect();
+
+// Hidden Chats reveal gesture (spec 1019, US3): typing the dedicated PIN into the
+// chat search bar reveals hidden chats — the only entry point, so it leaks nothing
+// when unused. A non-matching query behaves as ordinary search.
+const { revealed, reveal, relock } = useHiddenChats();
+const pinLen = ref<number | null>(null);
+const hiddenEnabled = ref(false);
+const hiddenMode = ref(false); // New-chat modal: next contact tap starts a hidden chat
+onMounted(async () => {
+  pinLen.value = await hiddenPinLength();
+  hiddenEnabled.value = await getSetting<boolean>('privacy.hiddenChatsEnabled', false);
+});
+async function onSearchInput(val: string): Promise<void> {
+  search.value = val;
+  if (revealed.value) return;
+  if (!/^\d{4,}$/.test(val)) return; // only attempt on a numeric, PIN-shaped query
+  if (pinLen.value == null) pinLen.value = await hiddenPinLength(); // PIN may have been set this session
+  if (pinLen.value && val.length === pinLen.value && (await reveal(val))) {
+    search.value = ''; // clear the PIN so the revealed list shows, not a filtered-by-PIN view
+  }
+}
 
 // Filtered chat list + chips (All / Unread / Favorites / Groups + lists).
 const { chats, activeFilter, setActive, chips, lists, tabFilters, allChats, loaded } = useChatFilters(search);
@@ -241,6 +281,15 @@ const pickContacts = useLiveQuery(
 
 async function startChat(person: Contact) {
   if (!(await requireProfile())) return;
+  if (hiddenMode.value) {
+    // Start a distinct hidden conversation that coexists with any normal 1:1.
+    if (!(await ensureHiddenPin())) return; // need a PIN to ever reveal it
+    const id = await startHiddenChat(person.id);
+    hiddenMode.value = false;
+    newOpen.value = false;
+    router.push(`/chat/${id}`); // open by id works regardless of hidden state
+    return;
+  }
   const chatId = await startDirectChat(person);
   newOpen.value = false;
   router.push(`/chat/${chatId}`);


### PR DESCRIPTION
## Hidden Chats Locked Behind a PIN (spec 1019)

A local, **zero-knowledge** privacy layer: hide specific conversations so they
vanish from the chat list, search, chat pickers, the Calls tab, and notification
previews — revealed only by typing a **separate dedicated PIN** into the chat
search bar. Hiding is per-device and adds **nothing** to the wire (a hidden chat
is indistinguishable from any other to the server).

Inspired by Viber's hidden chats, with Kamran's refinements: a hidden chat is a
**distinct conversation** (built on the group mechanism) that coexists with a
normal 1:1 with the same person; revealing is **sticky** across brief
app-switching but always re-locks on a full close; and reset is a true wipe.

### What's included
- **US1 — Hide behind a PIN.** "Hide chat" action; first hide creates the PIN
  (confirmed double-entry). Single `listChats()` choke point excludes hidden
  chats everywhere (Chats tab, filters, ForwardPicker, warm stores).
- **US2 — Coexisting distinct chat.** "New hidden chat" starts a separate
  conversation with a contact; the normal 1:1 is untouched.
- **US3 — Reveal & grace window.** PIN-in-search-bar reveal; sticky grace window
  measured with a monotonic clock (FR-023); re-locks on app auto-lock (FR-025)
  and cold start (FR-005).
- **US4 — Private notifications.** Hidden-chat messages show a generic,
  content-free notification that taps through to the Chats tab; fail-safe to
  generic when locked.
- **US5 — No call-history trace.** Hidden chats are excluded from the Calls tab
  and missed/unread badges; incoming calls show a generic pre-answer caller.
- **US7 — Reset.** "Reset PIN & delete hidden chats" permanently wipes hidden
  conversations locally and records a **local-only** do-not-resync tombstone (never
  uploaded), so they can't re-download — without affecting other devices.

### Scope notes
- **US6 (optional biometric unlock) is deferred** — a correct WebAuthn credential
  lifecycle is a clean follow-up; the PIN reveal fully covers the feature. Its 3
  issues (#523–#525) are intentionally left open.
- **Zero IndexedDB schema change, no `DB_VERSION` bump, no server changes.**

### Constitution
- **Zero-Knowledge (I):** no new wire field/request/log; hidden set + PIN are
  master-key-sealed, device-local, never synced (guard test included).
- **Crypto (IV):** reuses libsodium primitives + the wrapSecret/verifyPin pattern
  and sender keys; no new schemes. ⚠️ **A human security review of the at-rest
  wrapping, separate-PIN handling, reveal lifecycle, and local-only block is still
  recommended before a production (`develop → main`) release.**
- **TDD (III):** unit tests for the set/PIN, reveal session, notification builder,
  call-exclusion keys, tombstones, reset; e2e for hide → reveal → unhide,
  coexistence, restart re-lock, search-bar reveal, and reset.

### Verification
- `npm run build` ✅ · 391 unit tests ✅ · `go build/vet/test` ✅ · e2e
  (hidden-chats + chat-filters + call-history + notifications-inapp) ✅
- Visual walkthrough via `drive/scenarios/hidden-chats-1019.mjs`.

Bumps version to **0.3.0** (new feature).

Closes #490
Closes #491
Closes #492
Closes #493
Closes #494
Closes #495
Closes #496
Closes #497
Closes #498
Closes #499
Closes #500
Closes #501
Closes #502
Closes #503
Closes #504
Closes #505
Closes #506
Closes #507
Closes #508
Closes #509
Closes #510
Closes #511
Closes #512
Closes #513
Closes #514
Closes #515
Closes #516
Closes #517
Closes #518
Closes #519
Closes #520
Closes #521
Closes #522
Closes #526
Closes #527
Closes #528
Closes #529
Closes #530
Closes #531
Closes #532
Closes #533
Closes #534
Closes #535
Closes #536
Closes #537
Closes #538
Closes #539
Closes #540
Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)
