### PR TITLE
feat: animated GIFs, contact renaming, hidden-chat polish, and iOS reliability

### DIFF
--- a/drive/scenarios/contact-rename.mjs
+++ b/drive/scenarios/contact-rename.mjs
@@ -1,0 +1,55 @@
+import { createAccount, pair, shot, sweep, done } from '../driver.mjs';
+const bob = await createAccount({ name: 'Bob' });
+const alice = await createAccount({ name: 'Alice' });
+await pair(bob, alice);
+
+const AV = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>';
+const readContact = (id) => bob.page.evaluate((aid) => new Promise((res) => {
+  const r = indexedDB.open('ring');
+  r.onsuccess = () => { const db = r.result; const c = db.transaction('contacts','readonly').objectStore('contacts').get(aid);
+    c.onsuccess = () => res(c.result ? { name: c.result.name, pendingName: c.result.pendingName ?? null, remoteName: c.result.remoteName ?? null, localProfile: !!c.result.localProfile } : null); }; }), id);
+const banners = () => bob.page.evaluate(() => Array.from(document.querySelectorAll('.nb')).map(e => e.textContent.replace(/\s+/g,' ').trim()));
+
+// Bootstrap: pull Alice's current profile so remoteName is recorded (applies directly).
+await bob.page.evaluate(() => window.__ringTest.syncDirectory());
+await bob.page.waitForTimeout(600);
+console.log('[baseline]', JSON.stringify(await readContact(alice.id)));
+
+// Alice renames + republishes; Bob pulls → should STAGE a pending change (not auto-apply).
+await alice.page.evaluate((av) => window.__ringTest.setProfile('Alice Renamed', av), AV);
+await bob.page.evaluate(() => window.__ringTest.syncDirectory());
+await bob.page.waitForTimeout(800);
+const staged = await readContact(alice.id);
+console.log('[staged  ]', JSON.stringify(staged), 'banners=', JSON.stringify(await banners()));
+
+// Adopt via the banner's "Use it" button.
+await bob.page.evaluate(() => {
+  const btns = Array.from(document.querySelectorAll('.nb .nb-action'));
+  const use = btns.find(b => /use it/i.test(b.textContent));
+  if (use) use.click();
+});
+await bob.page.waitForTimeout(600);
+const adopted = await readContact(alice.id);
+console.log('[adopted ]', JSON.stringify(adopted));
+
+// Dismiss path + no re-prompt: rename again, dismiss, re-sync same value → no new pending.
+await alice.page.evaluate((av) => window.__ringTest.setProfile('Alice Third', av), AV);
+await bob.page.evaluate(() => window.__ringTest.syncDirectory());
+await bob.page.waitForTimeout(700);
+const staged2 = await readContact(alice.id);
+await bob.page.evaluate(() => { const b = Array.from(document.querySelectorAll('.nb .nb-action')).find(x=>/not now/i.test(x.textContent)); if (b) b.click(); });
+await bob.page.waitForTimeout(500);
+await bob.page.evaluate(() => window.__ringTest.syncDirectory()); // same value again
+await bob.page.waitForTimeout(700);
+const afterDismiss = await readContact(alice.id);
+console.log('[staged2 ]', JSON.stringify(staged2));
+console.log('[dismiss ]', JSON.stringify(afterDismiss), 'banners=', JSON.stringify(await banners()));
+
+const pass =
+  staged.name === 'Alice' && staged.pendingName === 'Alice Renamed' &&
+  adopted.name === 'Alice Renamed' && adopted.pendingName === null &&
+  staged2.pendingName === 'Alice Third' &&
+  afterDismiss.name === 'Alice Renamed' && afterDismiss.pendingName === null;
+console.log(pass ? '[PASS] rename stages a prompt; adopt applies; dismiss keeps old + no re-prompt' : '[FAIL] see above');
+await shot(bob, 'contact-rename-banner', {});
+await sweep([bob, alice]); await done();

--- a/drive/scenarios/contact-reset.mjs
+++ b/drive/scenarios/contact-reset.mjs
@@ -1,0 +1,30 @@
+import { createAccount, pair, sweep, done } from '../driver.mjs';
+const bob = await createAccount({ name: 'Bob' });
+const alice = await createAccount({ name: 'Alice' });
+await pair(bob, alice);
+const AV = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>';
+const readC = (id) => bob.page.evaluate((aid) => new Promise((res) => {
+  const r = indexedDB.open('ring'); r.onsuccess = () => { const c = r.result.transaction('contacts','readonly').objectStore('contacts').get(aid);
+    c.onsuccess = () => res(c.result ? { name: c.result.name, remoteName: c.result.remoteName ?? null, localProfile: !!c.result.localProfile } : null); }; }), id);
+
+await bob.page.evaluate(() => window.__ringTest.syncDirectory());
+await bob.page.waitForTimeout(500);
+console.log('[1 baseline    ]', JSON.stringify(await readC(alice.id)));
+
+// Bob overrides the name locally.
+await bob.page.evaluate((id) => window.__ringTest.setContactLocalProfile(id, 'My Nickname', undefined), alice.id);
+console.log('[2 overridden  ]', JSON.stringify(await readC(alice.id)));
+
+// Meanwhile Alice changes her server name to something NEW (different from the cached remoteName).
+await alice.page.evaluate((av) => window.__ringTest.setProfile('Alice Current', av), AV);
+await bob.page.waitForTimeout(400);
+
+// Reset → must pull Alice's CURRENT server value ("Alice Current"), not stale cache or the override.
+await bob.page.evaluate((id) => window.__ringTest.resetContactProfile(id), alice.id);
+await bob.page.waitForTimeout(800);
+const afterReset = await readC(alice.id);
+console.log('[3 after reset ]', JSON.stringify(afterReset));
+
+const pass = afterReset.name === 'Alice Current' && afterReset.localProfile === false;
+console.log(pass ? '[PASS] reset pulled the peer’s CURRENT name from the server and dropped the override' : '[FAIL] see above');
+await sweep([bob, alice]); await done();

--- a/drive/scenarios/gif-autoplay.mjs
+++ b/drive/scenarios/gif-autoplay.mjs
@@ -1,0 +1,88 @@
+// Verify animated GIF + animated WebP autoplay in the chat bubble while visible.
+//
+// Sends both at quality 'hd' (NOT 'original') to prove the compression bypass: the
+// pipeline must NOT flatten them to a static JPEG. On the receiver we sample the
+// rendered bubble's pixels over time — a real animation cycles colours; a JPEG-
+// flattened still would not. The test images cycle red → blue → green every 200ms.
+import { readFileSync } from 'node:fs';
+import { createAccount, pair, chatWith, shot, sweep, done } from '../driver.mjs';
+
+const gifB64 = readFileSync('.tmp/anim.gif.b64', 'utf8').trim();
+const webpB64 = readFileSync('.tmp/anim.webp.b64', 'utf8').trim();
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+// Alice sends an animated GIF and an animated WebP at HD quality.
+await alice.page.evaluate(
+  ([peer, b64]) => window.__ringTest.chatWith(peer).then((id) => window.__ringTest.sendImageData(id, b64, 'image/gif', 'wave.gif', 'hd')),
+  [bob.id, gifB64],
+);
+await alice.page.evaluate(
+  ([peer, b64]) => window.__ringTest.chatWith(peer).then((id) => window.__ringTest.sendImageData(id, b64, 'image/webp', 'wave.webp', 'hd')),
+  [bob.id, webpB64],
+);
+
+// Bob opens the chat; wait for both image bubbles to decode (naturalWidth > 0).
+const bobChat = await chatWith(bob, alice.id);
+await bob.page.goto(`/chat/${bobChat}`);
+await bob.page.waitForFunction(
+  () => {
+    const imgs = Array.from(document.querySelectorAll('.media-wrap img.bubble-image'));
+    return imgs.length >= 2 && imgs.every((im) => im.naturalWidth > 0);
+  },
+  null,
+  { timeout: 20_000 },
+);
+
+// Byte-level proof (headless-robust): the bytes BEHIND each bubble must still be the
+// animated original the recipient received — an animated GIF (NETSCAPE loop block) or
+// animated WebP (ANIM chunk), NOT a JPEG the compressor flattened it to. Also sample
+// pixels over time: headed Chromium advances the frames, so colours cycle (headless
+// won't paint, so that signal is informational only).
+const result = await bob.page.evaluate(async () => {
+  const imgs = Array.from(document.querySelectorAll('.media-wrap img.bubble-image'));
+  const sample = (img) => {
+    const c = document.createElement('canvas');
+    c.width = 8; c.height = 8;
+    const cx = c.getContext('2d');
+    cx.drawImage(img, 0, 0, 8, 8);
+    const d = cx.getImageData(4, 4, 1, 1).data;
+    return `${d[0]},${d[1]},${d[2]}`;
+  };
+  const out = [];
+  for (const img of imgs) {
+    const blob = await fetch(img.currentSrc || img.src).then((r) => r.blob());
+    const head = new Uint8Array(await blob.slice(0, 64).arrayBuffer());
+    let sig = '';
+    for (const b of head) sig += String.fromCharCode(b);
+    const colors = new Set();
+    for (let t = 0; t < 6; t++) { colors.add(sample(img)); await new Promise((r) => setTimeout(r, 140)); }
+    out.push({
+      alt: img.getAttribute('alt'),
+      mime: blob.type,
+      bytes: blob.size,
+      animatedMarker: sig.includes('NETSCAPE') ? 'gif:NETSCAPE' : sig.includes('ANIM') ? 'webp:ANIM' : 'NONE',
+      framesCyclingHeaded: colors.size > 1,
+    });
+  }
+  return out;
+});
+
+console.log('[bubbles]', JSON.stringify(result));
+const preserved = result.length >= 2
+  && result.every((r) => r.alt === 'gif' && (r.mime === 'image/gif' || r.mime === 'image/webp') && r.animatedMarker !== 'NONE');
+console.log(preserved
+  ? '[PASS] animated originals preserved end-to-end + rendered as autoplaying bubbles' + (result.every((r) => r.framesCyclingHeaded) ? ' (frames cycling)' : ' (run HEADED=1 to see frames cycle)')
+  : '[FAIL] an image was flattened or not rendered as animated');
+
+// Visual proof of autoplay: three composited screenshots ~200ms apart. The test
+// images cycle red → blue → green every 200ms, so the bubbles differ across frames
+// only if they are actually animating on screen.
+for (let i = 0; i < 3; i++) {
+  await shot(bob, `gif-autoplay-${i}`, {});
+  await bob.page.waitForTimeout(200);
+}
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/hidden-badge.mjs
+++ b/drive/scenarios/hidden-badge.mjs
@@ -1,0 +1,30 @@
+// privacy.hiddenChatsBadge: 'always' (default) counts hidden chats in the unread badge,
+// 'never' excludes them, 'revealed' counts them only during a reveal session.
+import { createAccount, pair, say, waitForMessage, chatWith, sweep, done } from '../driver.mjs';
+const bob = await createAccount({ name: 'Bob' });
+const alice = await createAccount({ name: 'Alice' }); // hidden
+await pair(bob, alice);
+await say(alice, bob.id, 'hi'); await waitForMessage(bob, alice.id, /hi/);
+const hiddenId = await chatWith(bob, alice.id);
+await bob.page.evaluate(() => window.__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+await bob.page.evaluate((p) => window.__ringTest.hiddenSetPin(p), '4321');
+await bob.page.evaluate((id) => window.__ringTest.hiddenAdd(id), hiddenId);
+
+const badge = () => bob.page.evaluate(() => window.__ringTest.unreadBadge());
+const setMode = async (m) => { await bob.page.evaluate((x) => window.__ringTest.setGlobalSetting('privacy.hiddenChatsBadge', x), m); await bob.page.waitForTimeout(200); };
+
+await setMode('always');
+const always = await badge();
+await setMode('never');
+const never = await badge();
+await setMode('revealed');
+const revealedLocked = await badge();
+await bob.page.evaluate((p) => window.__ringTest.hiddenReveal(p), '4321');
+await bob.page.waitForTimeout(300);
+const revealedOpen = await badge();
+await bob.page.evaluate(() => window.__ringTest.hiddenRelock());
+
+console.log('always=%d  never=%d  revealed(locked)=%d  revealed(open)=%d  (hidden chat unread=1)', always, never, revealedLocked, revealedOpen);
+const pass = always === 1 && never === 0 && revealedLocked === 0 && revealedOpen === 1;
+console.log(pass ? '[PASS] always counts hidden; never excludes; revealed only during reveal' : '[FAIL] see above');
+await sweep([bob, alice]); await done();

--- a/drive/scenarios/hidden-flash.mjs
+++ b/drive/scenarios/hidden-flash.mjs
@@ -1,0 +1,115 @@
+// Verify the hidden-chats STARTUP FLASH fix (spec 1019).
+//
+// Bug: on app open the chat-list query (listChats) could run while the keystore
+// was still locked behind the unlock gate; ensureHiddenLoaded then returned an
+// EMPTY set (indistinguishable from "nothing hidden"), so hidden chats briefly
+// appeared before the post-unlock re-query filtered them out — a visible flash.
+//
+// Fix: listChats fails CLOSED until the hidden set is definitively known
+// (isHiddenKnown()). This scenario installs a high-frequency sampler that records
+// exactly what listChats returns across the locked→unlocked window on EVERY reload,
+// and asserts the hidden chat id NEVER appears there — it only shows up after the
+// PIN is typed into the search bar.
+import { createAccount, pair, say, waitForMessage, chatWith, shot, sweep, done } from '../driver.mjs';
+
+const bob = await createAccount({ name: 'Bob' });
+const alice = await createAccount({ name: 'Alice' }); // becomes Bob's HIDDEN chat
+const carol = await createAccount({ name: 'Carol' }); // stays a normal VISIBLE chat
+
+await pair(bob, alice);
+await pair(bob, carol);
+await say(alice, bob.id, 'secret hello');
+await say(carol, bob.id, 'normal hello');
+await waitForMessage(bob, alice.id, /secret hello/);
+await waitForMessage(bob, carol.id, /normal hello/);
+
+// Bob's per-device chat ids (stable across reloads).
+const hiddenId = await chatWith(bob, alice.id);
+const visibleId = await chatWith(bob, carol.id);
+console.log(`[ids] hidden(Alice)=${hiddenId}  visible(Carol)=${visibleId}`);
+
+// Enable the feature, set the reveal PIN, and hide the Alice chat.
+await bob.page.evaluate(() => window.__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+await bob.page.evaluate((pin) => window.__ringTest.hiddenSetPin(pin), '4321');
+await bob.page.evaluate((id) => window.__ringTest.hiddenAdd(id), hiddenId);
+
+// Sanity (fully unlocked): the hidden chat is excluded, the normal one is present.
+const beforeReload = await bob.page.evaluate(() => window.__ringTest.visibleChatIds());
+console.log(`[sanity] visible before reload: ${JSON.stringify(beforeReload)} (hidden excluded: ${!beforeReload.includes(hiddenId)})`);
+
+// Install a sampler that runs on EVERY navigation (persists across reloads): from
+// the first instant window.__ringTest exists, poll listChats() as fast as it can,
+// recording the unlocked flag + the visible ids, so we capture the startup window.
+await bob.page.addInitScript(() => {
+  window.__flash = [];
+  // The ACTUAL on-screen chat names (rendered DOM rows), not just the data layer —
+  // this is what the user sees flash. h2 inside the chat list rows holds the name.
+  const domNames = () =>
+    Array.from(document.querySelectorAll('ion-content ion-list ion-item ion-label h2')).map((e) => (e.textContent || '').trim());
+  (async () => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < 4000) {
+      const t = window.__ringTest;
+      if (t && t.visibleChatIds) {
+        try {
+          const visible = await t.visibleChatIds();
+          window.__flash.push({ ms: Date.now() - t0, unlocked: !!t.isUnlocked(), visible, dom: domNames() });
+        } catch (e) {
+          window.__flash.push({ ms: Date.now() - t0, err: String((e && e.message) || e), dom: domNames() });
+        }
+      } else {
+        window.__flash.push({ ms: Date.now() - t0, noHook: true, dom: domNames() });
+      }
+      await new Promise((r) => setTimeout(r, 12));
+    }
+  })();
+});
+
+// Reload onto the Chats tab so the list actually renders during the startup window.
+await bob.page.goto('/tabs/chats');
+
+// Hard-reload several times and analyze the captured startup window each time.
+let dataLeaks = 0, domLeaks = 0, emptyFlashes = 0;
+for (let i = 1; i <= 6; i++) {
+  await bob.page.reload();
+  await bob.page.waitForFunction(() => Array.isArray(window.__flash) && window.__flash.length > 0, null, { timeout: 15_000 });
+  await bob.page.waitForTimeout(2500); // let the sampler span the unlock transition
+  const samples = await bob.page.evaluate(() => window.__flash);
+  const withVisible = samples.filter((s) => Array.isArray(s.visible));
+  const leakedData = withVisible.filter((s) => s.visible.includes(hiddenId));
+  // DOM-level: did the hidden contact's NAME ever render on screen during startup?
+  const domHidAlice = samples.filter((s) => Array.isArray(s.dom) && s.dom.includes('Alice'));
+  // The "Start a conversation" empty-state hint must NEVER render while this user
+  // actually HAS chats (it would be a transient empty-list flash before they load).
+  const emptyFlash = samples.filter((s) => Array.isArray(s.dom) && s.dom.includes('Start a conversation'));
+  const firstDomNonEmpty = samples.find((s) => Array.isArray(s.dom) && s.dom.length);
+  dataLeaks += leakedData.length;
+  domLeaks += domHidAlice.length;
+  emptyFlashes += emptyFlash.length;
+  console.log(
+    `[reload ${i}] samples=${withVisible.length} dataLeaks=${leakedData.length} ` +
+    `domLeaks(Alice)=${domHidAlice.length} emptyHintFlash=${emptyFlash.length}` +
+    (domHidAlice.length ? `  !! ALICE @${domHidAlice[0].ms}ms` : '') +
+    (emptyFlash.length ? `  !! "Start a conversation" @${emptyFlash[0].ms}ms` : ''),
+  );
+  if (firstDomNonEmpty) console.log(`           first rendered rows @${firstDomNonEmpty.ms}ms = ${JSON.stringify(firstDomNonEmpty.dom)}`);
+}
+console.log(`\n[summary] across 6 reloads: dataLeaks=${dataLeaks}  domVisualLeaks=${domLeaks}  emptyHintFlashes=${emptyFlashes}`);
+console.log(dataLeaks === 0 && domLeaks === 0 && emptyFlashes === 0
+  ? '[PASS] no hidden-chat leak and no empty-state flash during startup'
+  : '[FAIL] something flashed at startup');
+
+// First paint after a fresh reload, on the Chats tab: Carol present, Alice absent.
+await shot(bob, 'hidden-flash-1-firstpaint', { route: '/tabs/chats' });
+
+// Now reveal through the REAL search bar (the only entry point): typing the PIN.
+const input = bob.page.locator('ion-searchbar input').first();
+await input.click();
+await input.pressSequentially('4321', { delay: 80 });
+await bob.page.waitForTimeout(900);
+const afterPin = await bob.page.evaluate(() => window.__ringTest.visibleChatIds());
+console.log(`[reveal] visible after typing PIN: ${JSON.stringify(afterPin)} (hidden now shown: ${afterPin.includes(hiddenId)})`);
+await shot(bob, 'hidden-flash-2-after-pin', {});
+
+await sweep([bob, alice, carol]);
+await done();

--- a/drive/scenarios/hidden-marker.mjs
+++ b/drive/scenarios/hidden-marker.mjs
@@ -1,0 +1,32 @@
+import { createAccount, pair, say, waitForMessage, chatWith, shot, sweep, done } from '../driver.mjs';
+const bob = await createAccount({ name: 'Bob' });
+const alice = await createAccount({ name: 'Alice' });   // will be hidden
+const carol = await createAccount({ name: 'Carol' });   // stays visible
+await pair(bob, alice); await pair(bob, carol);
+await say(alice, bob.id, 'secret'); await say(carol, bob.id, 'normal');
+await waitForMessage(bob, alice.id, /secret/); await waitForMessage(bob, carol.id, /normal/);
+const hiddenId = await chatWith(bob, alice.id);
+await bob.page.evaluate(() => window.__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+await bob.page.evaluate((p) => window.__ringTest.hiddenSetPin(p), '4321');
+await bob.page.evaluate((id) => window.__ringTest.hiddenAdd(id), hiddenId);
+
+await bob.page.goto('/tabs/chats');
+await bob.page.waitForTimeout(800);
+const locked = await bob.page.evaluate(() => document.querySelectorAll('.hidden-row, .hidden-ico').length);
+console.log('[locked] hidden markers on screen =', locked, '(expected 0)');
+await shot(bob, 'hidden-marker-locked', {});
+
+// Reveal via the PIN in the search bar.
+const input = bob.page.locator('ion-searchbar input').first();
+await input.click(); await input.pressSequentially('4321', { delay: 70 });
+await bob.page.waitForTimeout(900);
+const revealed = await bob.page.evaluate(() => {
+  const rows = Array.from(document.querySelectorAll('ion-item.hidden-row'));
+  const names = rows.map(r => r.querySelector('h2')?.textContent?.trim());
+  return { tinted: rows.length, eyeIcons: document.querySelectorAll('.hidden-ico').length, names };
+});
+console.log('[revealed]', JSON.stringify(revealed));
+await shot(bob, 'hidden-marker-revealed', {});
+console.log(locked === 0 && revealed.tinted === 1 && revealed.eyeIcons === 1 && revealed.names.includes('Alice')
+  ? '[PASS] marker only while revealed; tints+marks the hidden row (Alice), not normal ones' : '[FAIL] see above');
+await sweep([bob, alice, carol]); await done();

--- a/drive/scenarios/hidden-notify.mjs
+++ b/drive/scenarios/hidden-notify.mjs
@@ -1,0 +1,38 @@
+import { createAccount, pair, say, waitForMessage, chatWith, sweep, done } from '../driver.mjs';
+const bob = await createAccount({ name: 'Bob' });
+const alice = await createAccount({ name: 'Alice' });   // hidden
+const carol = await createAccount({ name: 'Carol' });   // normal
+await pair(bob, alice); await pair(bob, carol);
+await say(alice, bob.id, 'hi-a'); await say(carol, bob.id, 'hi-c');
+await waitForMessage(bob, alice.id, /hi-a/); await waitForMessage(bob, carol.id, /hi-c/);
+const hiddenId = await chatWith(bob, alice.id);
+await bob.page.evaluate(() => window.__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+await bob.page.evaluate((p) => window.__ringTest.hiddenSetPin(p), '4321');
+await bob.page.evaluate((id) => window.__ringTest.hiddenAdd(id), hiddenId);
+await bob.page.goto('/tabs/chats');
+
+// Poll .nb banners for `ms`, returning the max snapshot of texts seen.
+const watchBanners = async (ms) => {
+  let seen = [];
+  for (let t = 0; t < ms; t += 150) {
+    const now = await bob.page.evaluate(() => Array.from(document.querySelectorAll('.nb')).map(e => e.textContent.replace(/\s+/g,' ').trim()));
+    if (now.length > seen.length) seen = now;
+    await new Promise(r => setTimeout(r, 150));
+  }
+  return seen;
+};
+
+await bob.page.waitForTimeout(4000);              // clear the post-load settle window
+await say(carol, bob.id, 'normal ping');
+const carolBanners = await watchBanners(3000);
+console.log('[carol] banners=%j', carolBanners);
+
+await bob.page.waitForTimeout(5000);              // let banners + any settle clear
+await say(alice, bob.id, 'secret ping');
+const aliceBanners = await watchBanners(3000);
+const gotAlice = await bob.page.evaluate((c) => window.__ringTest.messages(c).then(ms => ms.some(m => /secret ping/.test(m.body||''))), hiddenId);
+console.log('[alice] banners=%j receivedHidden=%s', aliceBanners, gotAlice);
+
+const pass = carolBanners.some(t => /Carol/.test(t)) && aliceBanners.length === 0 && gotAlice;
+console.log(pass ? '[PASS] normal chat banners; hidden chat = NO banner, message still received' : '[FAIL] see above');
+await sweep([bob, alice, carol]); await done();

--- a/drive/scenarios/hidden-pin-pad.mjs
+++ b/drive/scenarios/hidden-pin-pad.mjs
@@ -1,0 +1,18 @@
+import { createAccount, shot, sweep, done } from '../driver.mjs';
+const a = await createAccount({ name: 'Pat' });
+await a.page.goto('/settings/privacy-hidden-chats');
+await a.page.waitForSelector('ion-toggle', { timeout: 8000 });
+// Toggle "Enable hidden chats" → should present the numeric PIN pad (PasscodeModal).
+await a.page.locator('ion-toggle').first().click();
+await a.page.waitForTimeout(1000);
+const view = await a.page.evaluate(() => ({
+  hasPad: !!document.querySelector('.pinpad, .pc-pick'),
+  pickTitle: document.querySelector('.pc-title')?.textContent?.trim() ?? null,
+  pickDesc: document.querySelector('.pc-desc')?.textContent?.trim()?.slice(0, 60) ?? null,
+  hasTextInputs: !!document.querySelector('ion-alert input'),
+}));
+console.log('[hidden-pin]', JSON.stringify(view));
+await shot(a, 'hidden-pin-pad', {});
+console.log(view.hasPad && /Hidden Chats PIN/.test(view.pickTitle ?? '') && !view.hasTextInputs
+  ? '[PASS] hidden PIN uses the numeric pad (not text boxes)' : '[FAIL] see above');
+await sweep([a]); await done();

--- a/drive/scenarios/media-footer-meta.mjs
+++ b/drive/scenarios/media-footer-meta.mjs
@@ -1,0 +1,80 @@
+// (1) Media metadata (quality · resolution · size) now lives in the message FOOTER,
+//     not overlaid on the thumbnail — screenshot to see how it looks.
+// (2) A GIF/WebP send skips the quality prompt (always sent as original).
+import http from 'node:http';
+import { readFileSync } from 'node:fs';
+import { createAccount, pair, chatWith, shot, sweep, done } from '../driver.mjs';
+
+const pngB64 = readFileSync('.tmp/photo.png.b64', 'utf8').trim();
+const gifB64 = readFileSync('.tmp/anim.gif.b64', 'utf8').trim();
+const gif = readFileSync('.tmp/anim.gif');
+
+// Local CORS-ok CDN stand-in (for the paste→send skip-prompt check).
+const server = http.createServer((_req, res) => {
+  res.writeHead(200, { 'Content-Type': 'image/gif', 'Access-Control-Allow-Origin': '*' });
+  res.end(gif);
+});
+await new Promise((r) => server.listen(8098, '127.0.0.1', r));
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+const aliceChat = await chatWith(alice, bob.id);
+await alice.page.goto(`/chat/${aliceChat}`);
+await alice.page.waitForSelector('ion-textarea.composer textarea');
+
+// ---- Part 1: footer metadata ----
+// A real photo requested at HD (genuinely re-encodes → footer shows "HD …") and an
+// animated GIF requested at HD (bypassed → footer shows "Original …").
+await alice.page.evaluate(
+  ([id, b64]) => window.__ringTest.sendImageData(id, b64, 'image/png', 'sunset.png', 'hd'),
+  [aliceChat, pngB64],
+);
+await alice.page.evaluate(
+  ([id, b64]) => window.__ringTest.sendImageData(id, b64, 'image/gif', 'wave.gif', 'hd'),
+  [aliceChat, gifB64],
+);
+
+const bobChat = await chatWith(bob, alice.id);
+await bob.page.goto(`/chat/${bobChat}`);
+await bob.page.waitForFunction(
+  () => document.querySelectorAll('.media-meta-foot').length >= 2,
+  null,
+  { timeout: 20_000 },
+);
+const footers = await bob.page.evaluate(() =>
+  Array.from(document.querySelectorAll('.media-meta-foot')).map((e) => ({
+    text: e.textContent.trim(),
+    align: getComputedStyle(e).textAlign,
+    overlaid: getComputedStyle(e).position === 'absolute',
+  })),
+);
+console.log('[footers]', JSON.stringify(footers));
+await shot(bob, 'media-footer-meta', {});
+
+// ---- Part 2: GIF send skips the quality prompt ----
+const beforeOut = await alice.page.evaluate(() => document.querySelectorAll('.bubble.out, .out .bubble').length);
+await alice.page.evaluate((u) => {
+  const ta = document.querySelector('ion-textarea.composer textarea');
+  const dt = new DataTransfer();
+  dt.setData('text/plain', u);
+  ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+}, 'http://127.0.0.1:8098/x.gif');
+await alice.page.waitForFunction(() => document.querySelectorAll('.paste-thumb').length > 0, null, { timeout: 8000 });
+await alice.page.locator('ion-textarea.composer textarea').press('Enter');
+await alice.page.waitForTimeout(1200);
+const alertShown = await alice.page.evaluate(() => !!document.querySelector('ion-alert'));
+const sent = await alice.page.evaluate(() => document.querySelectorAll('.media-wrap img.bubble-image').length > 0);
+console.log(`[skip-prompt] qualityDialogShown=${alertShown} gifSent=${sent}`);
+
+// Every media footer must be a real footer line (not overlaid) carrying quality ·
+// resolution · size. The exact quality label is data-dependent (HD only when the
+// re-encode actually shrinks the source), so we don't pin it.
+const metaInFooter = footers.length >= 2 && footers.every((f) => !f.overlaid && /·/.test(f.text) && /\d+×\d+/.test(f.text));
+console.log(metaInFooter && !alertShown && sent
+  ? '[PASS] metadata shown in the footer (not overlaid); GIF send skips the quality prompt'
+  : '[FAIL] see above');
+
+server.close();
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/message-info-media.mjs
+++ b/drive/scenarios/message-info-media.mjs
@@ -1,0 +1,44 @@
+// Media metadata lives in Message info now (not on the bubble), and is reachable for
+// media in BOTH directions — incoming shows the metadata WITHOUT receipt sections.
+import { readFileSync } from 'node:fs';
+import { createAccount, pair, chatWith, poll, shot, sweep, done } from '../driver.mjs';
+const gifB64 = readFileSync('.tmp/anim.gif.b64', 'utf8').trim();
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+const aChat = await chatWith(alice, bob.id);
+await alice.page.evaluate(([id, b]) => window.__ringTest.chatWith(id).then(c => window.__ringTest.sendImageData(c, b, 'image/gif', 'wave.gif', 'hd')), [bob.id, gifB64]);
+
+// Wait until Bob actually has the chat AND the decoded image message.
+const bChat = await poll(
+  async () => {
+    const c = await chatWith(bob, alice.id);
+    if (!c) return null;
+    const ok = await bob.page.evaluate((cc) => window.__ringTest.messages(cc).then((ms) => ms.some((m) => m.kind === 'image')), c);
+    return ok ? c : null;
+  },
+  Boolean,
+  { label: 'bob has the image', timeout: 30000 },
+);
+
+const readInfo = async (cli, chatId, label) => {
+  const mid = await cli.page.evaluate((c) => window.__ringTest.messages(c).then((ms) => ms.find((m) => m.kind === 'image')?.id), chatId);
+  await cli.page.goto(`/chat/${chatId}/info/${mid}`);
+  await cli.page.waitForFunction(() => document.querySelectorAll('ion-list').length > 0, null, { timeout: 8000 }).catch(() => {});
+  await cli.page.waitForTimeout(500);
+  const data = await cli.page.evaluate(() => ({
+    headers: Array.from(document.querySelectorAll('ion-list-header ion-label')).map((e) => e.textContent.trim()),
+    rows: Array.from(document.querySelectorAll('ion-item')).map((e) => e.textContent.replace(/\s+/g, ' ').trim()).filter(Boolean),
+  }));
+  console.log(`[${label}] headers=${JSON.stringify(data.headers)} rows=${JSON.stringify(data.rows)}`);
+  await shot(cli, `msginfo-${label}`, {});
+  return data;
+};
+const inc = await readInfo(bob, bChat, 'incoming');
+const out = await readInfo(alice, aChat, 'outgoing');
+
+const incOk = inc.headers.includes('Media') && inc.rows.some((r) => /Format.*GIF/.test(r)) && inc.rows.some((r) => /96×96/.test(r)) && !inc.rows.some((r) => /Delivered|Seen|^Sent/.test(r));
+const outOk = out.headers.includes('Media') && out.rows.some((r) => /Format.*GIF/.test(r)) && out.rows.some((r) => /Delivered|^Sent|Sent/.test(r));
+console.log(incOk && outOk ? '[PASS] metadata in Message info; incoming = metadata only, outgoing = metadata + receipts' : '[FAIL] see above');
+await sweep([alice, bob]); await done();

--- a/drive/scenarios/paste-url-image.mjs
+++ b/drive/scenarios/paste-url-image.mjs
@@ -1,0 +1,74 @@
+// Verify pasting a remote image URL into the composer: the sender's client fetches the
+// bytes and attaches them as a pending media message. A CORS-permissive URL succeeds;
+// a CORS-blocked one falls back to pasting the link as text (never silently lost).
+import http from 'node:http';
+import { readFileSync } from 'node:fs';
+import { createAccount, pair, chatWith, sweep, done } from '../driver.mjs';
+
+const gif = readFileSync('.tmp/anim.gif'); // a real animated GIF (NETSCAPE loop)
+
+// Local CDN stand-in: /ok.* sends Access-Control-Allow-Origin:* (readable cross-origin);
+// /blocked.* omits it (browser blocks the read — like a typical hotlink-only CDN).
+const server = http.createServer((req, res) => {
+  const headers = { 'Content-Type': 'image/gif' };
+  if (req.url.startsWith('/ok')) headers['Access-Control-Allow-Origin'] = '*';
+  res.writeHead(200, headers);
+  res.end(gif);
+});
+await new Promise((r) => server.listen(8099, '127.0.0.1', r));
+const okUrl = 'http://127.0.0.1:8099/ok.gif?width=300';
+const blockedUrl = 'http://127.0.0.1:8099/blocked.gif?width=300';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+const chat = await chatWith(alice, bob.id);
+await alice.page.goto(`/chat/${chat}`);
+await alice.page.waitForSelector('ion-textarea.composer textarea');
+
+// Simulate a real text paste of a URL into the composer.
+const pasteUrl = (url) =>
+  alice.page.evaluate((u) => {
+    const ta = document.querySelector('ion-textarea.composer textarea');
+    const dt = new DataTransfer();
+    dt.setData('text/plain', u);
+    ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+  }, url);
+
+// 1) CORS-permissive URL → fetched and attached as a pending image.
+await pasteUrl(okUrl);
+await alice.page.waitForFunction(() => document.querySelectorAll('.paste-thumb').length > 0, null, { timeout: 8000 }).catch(() => {});
+const ok = await alice.page.evaluate(async () => {
+  const img = document.querySelector('.paste-thumb img');
+  if (!img) return { attached: false };
+  const blob = await fetch(img.src).then((r) => r.blob());
+  const head = new Uint8Array(await blob.slice(0, 64).arrayBuffer());
+  let sig = ''; for (const b of head) sig += String.fromCharCode(b);
+  return { attached: true, mime: blob.type, bytes: blob.size, animated: sig.includes('NETSCAPE') };
+});
+console.log('[cors-ok ] ', JSON.stringify(ok));
+
+// Clear the attachment before the next case (remove button on the thumb).
+await alice.page.evaluate(() => {
+  const btn = document.querySelector('.paste-thumb ion-button, .paste-thumb button, .paste-thumb .remove');
+  if (btn) btn.click();
+});
+await alice.page.waitForTimeout(300);
+
+// 2) CORS-blocked URL → no attachment; the link drops into the draft instead.
+await pasteUrl(blockedUrl);
+await alice.page.waitForTimeout(1500);
+const blocked = await alice.page.evaluate(() => ({
+  attachments: document.querySelectorAll('.paste-thumb').length,
+  draft: document.querySelector('ion-textarea.composer textarea')?.value ?? '',
+}));
+console.log('[blocked ] ', JSON.stringify(blocked));
+
+const pass =
+  ok.attached && ok.mime === 'image/gif' && ok.animated &&
+  blocked.attachments === 0 && blocked.draft.includes('blocked.gif');
+console.log(pass ? '[PASS] URL paste fetches + attaches; CORS-blocked falls back to text' : '[FAIL] see above');
+
+server.close();
+await sweep([alice, bob]);
+await done();

--- a/server/cmd/ringd/main.go
+++ b/server/cmd/ringd/main.go
@@ -411,11 +411,22 @@ func run() error {
 	// the app host's :443 here, and this listener also answers TLS-ALPN-01 challenges.
 	var tlsSrv *http.Server
 	if certMgr != nil {
+		// Force HTTP/1.1 (disable HTTP/2). iOS Safari/WKWebView is prone to dropping
+		// HTTP/2 connections mid-request — "the network connection was lost"
+		// (NSURLErrorNetworkConnectionLost, -1005) — which manifests here as larger
+		// media POSTs failing the upload and notification cold-starts showing Safari's
+		// "can't open the page" interstitial. HTTP/1.1 is markedly more reliable for
+		// these clients, and the WebSocket relay (/v1/ws) requires HTTP/1.1 anyway.
+		// We keep "acme-tls/1" so TLS-ALPN-01 cert issuance/renewal still works.
+		tlsConf := certMgr.TLSConfig()
+		tlsConf.NextProtos = []string{"http/1.1", "acme-tls/1"} // drop "h2"
 		tlsSrv = &http.Server{
 			Addr:              ":" + cfg.TLSPort,
 			Handler:           handler,
-			TLSConfig:         certMgr.TLSConfig(),
+			TLSConfig:         tlsConf,
 			ReadHeaderTimeout: 10 * time.Second,
+			// Empty (non-nil) map disables net/http's automatic HTTP/2 handler.
+			TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		}
 		go func() {
 			slog.Info("listening (https/acme)", "addr", tlsSrv.Addr)

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,7 @@ import { useViewportHeight } from '@/composables/useViewportHeight';
 import { useTheme } from '@/composables/useTheme';
 import { useAppBadge } from '@/composables/useAppBadge';
 import { useAutoLock } from '@/composables/useAutoLock';
+import { useContactProfilePrompts } from '@/composables/useContactProfilePrompts';
 import KeyGuard from '@/components/KeyGuard.vue';
 import InstallGuard from '@/components/InstallGuard.vue';
 import IncomingCallOverlay from '@/components/IncomingCallOverlay.vue';
@@ -232,6 +233,9 @@ useTheme();
 // Re-lock the keystore after the app has been backgrounded longer than the
 // configured grace period (Privacy, App lock), when a passkey is enrolled.
 useAutoLock();
+
+// Offer to adopt a contact's new name/photo when the peer changes it (in-app prompt).
+useContactProfilePrompts();
 </script>
 
 <style>

--- a/src/components/AnimatedImage.vue
+++ b/src/components/AnimatedImage.vue
@@ -1,0 +1,57 @@
+<!--
+  An animated image (GIF / animated WebP) in a chat bubble that plays ONLY while it is
+  visible on screen. An `<img>` whose src is an animated file autoplays and loops with
+  no JS control, and continues decoding off-screen; to honour "play when visible" we
+  swap the src to a static poster whenever the bubble scrolls out of view (which freezes
+  it) and back to the moving original when it returns (a GIF/WebP restarts from frame 0
+  when its src is re-set, so it visibly autoplays again).
+
+  Mirrors the IntersectionObserver visibility pattern used by VideoNote/AnimatedEmoji.
+  Falls back gracefully: with no poster it just keeps the original (still animates); with
+  no original (the full blob was evicted from the LRU) it shows the poster.
+-->
+<template>
+  <img
+    ref="el"
+    class="bubble-image"
+    :src="shownUrl"
+    :alt="alt"
+    decoding="async"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+
+const props = defineProps<{
+  animatedUrl?: string; // the moving original (GIF / animated WebP) blob URL
+  posterUrl?: string; // a static first-frame poster to freeze on while off-screen
+  alt?: string;
+}>();
+
+const el = ref<HTMLImageElement | null>(null);
+const visible = ref(false);
+let io: IntersectionObserver | undefined;
+
+// Visible → the animated source (plays); off-screen → the static poster (frozen). Each
+// branch falls back to the other url so a missing poster or evicted original still renders.
+const shownUrl = computed(() =>
+  visible.value
+    ? props.animatedUrl ?? props.posterUrl ?? ''
+    : props.posterUrl ?? props.animatedUrl ?? '',
+);
+
+onMounted(() => {
+  if (!el.value) return;
+  io = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) visible.value = e.isIntersecting;
+    },
+    // A small threshold so it starts playing as soon as it scrolls meaningfully into
+    // view and freezes once it leaves — matching AnimatedEmoji's gentle trigger.
+    { threshold: 0.1 },
+  );
+  io.observe(el.value);
+});
+onBeforeUnmount(() => io?.disconnect());
+</script>

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -17,7 +17,7 @@
       </ion-item-option>
     </ion-item-options>
 
-    <ion-item button :detail="false" @click="$emit('open', chat.id)">
+    <ion-item button :detail="false" :class="{ 'hidden-row': isHidden }" @click="$emit('open', chat.id)">
       <div class="avatar-wrap" slot="start">
         <ion-avatar>
           <img :src="chat.avatar" :alt="chat.name" />
@@ -25,7 +25,7 @@
         <span v-if="isOnline" class="presence-dot" aria-hidden="true" />
       </div>
       <ion-label>
-        <h2>{{ capitalizeFirst(chat.name) }}</h2>
+        <h2>{{ chat.name }}</h2>
         <p class="preview-row">
           <template v-if="activityLabel">
             <span class="preview activity">{{ activityLabel }}</span>
@@ -44,6 +44,7 @@
       <div class="meta" slot="end">
         <ion-note :class="{ unread: unread }">{{ formatTime(chat.lastMessageTime) }}</ion-note>
         <div class="meta-icons">
+          <ion-icon v-if="isHidden" :icon="eyeOffOutline" class="meta-ico hidden-ico" aria-label="Hidden chat" />
           <ion-icon v-if="muted" :icon="notificationsOffOutline" class="meta-ico" aria-hidden="true" />
           <ion-icon v-if="chat.locked" :icon="lockClosedOutline" class="meta-ico" aria-hidden="true" />
           <ion-icon v-if="chat.pinned" :icon="pinOutline" class="meta-ico pin" aria-hidden="true" />
@@ -75,7 +76,7 @@ import {
 } from '@ionic/vue';
 import {
   pinOutline, archiveOutline, ellipsisHorizontal, mailOpenOutline, mailUnreadOutline,
-  notificationsOffOutline, lockClosedOutline,
+  notificationsOffOutline, lockClosedOutline, eyeOffOutline,
   cameraOutline, videocamOutline, micOutline, documentOutline, imagesOutline,
   locationOutline, barChartOutline, personOutline, musicalNotesOutline, callOutline,
 } from 'ionicons/icons';
@@ -83,10 +84,10 @@ import {
   markChatRead, markChatUnread, setChatPinned, setChatArchived, MAX_PINNED_CHATS,
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
+import { isHiddenId } from '@/services/hidden-state';
 import { peerPresence } from '@/composables/usePresence';
 import { activityFor, activityKindLabel } from '@/composables/useTyping';
 import { formatTime } from '@/utils/time';
-import { capitalizeFirst } from '@/utils/text';
 import type { Chat } from '@/db/types';
 
 const props = defineProps<{ chat: Chat }>();
@@ -105,6 +106,10 @@ const PREVIEW_ICONS: Record<NonNullable<Chat['lastKind']>, string | null> = {
 };
 const previewIcon = computed(() => (props.chat.lastKind ? PREVIEW_ICONS[props.chat.lastKind] : null));
 
+// A hidden chat only ever appears in the list during an active reveal session
+// (listChats excludes it otherwise), so membership here is enough to mark it. Keyed
+// on the chat id so it re-evaluates when the list re-queries on reveal/relock/hide.
+const isHidden = computed(() => isHiddenId(props.chat.id));
 const unread = computed(() => props.chat.unread > 0 || !!props.chat.manualUnread);
 const muted = computed(() => !!props.chat.mutedUntil && props.chat.mutedUntil > Date.now());
 const isOnline = computed(
@@ -165,6 +170,15 @@ function more(): void {
 .meta-ico.pin {
   transform: rotate(45deg);
 }
+/* Revealed hidden chat: a faint tint on the whole row + an eye-off marker, so it's
+   easy to tell apart from normal chats during a reveal session. Only renders while
+   revealed (the row isn't in the list otherwise), so it leaks nothing when locked. */
+.hidden-row {
+  --background: var(--ring-hidden-tint, rgba(var(--ion-color-medium-rgb, 146, 148, 156), 0.1));
+}
+.hidden-ico {
+  color: var(--ion-color-medium);
+}
 .unread-dot {
   width: 11px;
   height: 11px;
@@ -219,8 +233,11 @@ ion-item-option ion-icon {
   text-align: start;
 }
 ion-label h2 {
+  /* Keep correct bidi CHARACTER order for RTL/mixed names (plaintext), but always
+     LEFT-align the name in the chats list (incl. RTL names + group names), rather than
+     start-aligning (which would right-align RTL). */
   unicode-bidi: plaintext;
-  text-align: start;
+  text-align: left;
 }
 .avatar-wrap {
   position: relative;

--- a/src/components/MessageActions.vue
+++ b/src/components/MessageActions.vue
@@ -32,7 +32,7 @@
         <ion-icon slot="start" :icon="happyOutline" />
         <ion-label>Reactions ({{ reactionCount }})</ion-label>
       </ion-item>
-      <ion-item v-if="isOutgoing" button :detail="false" @click="choose('info')">
+      <ion-item v-if="canInfo ?? isOutgoing" button :detail="false" @click="choose('info')">
         <ion-icon slot="start" :icon="informationCircleOutline" />
         <ion-label>Message info</ion-label>
       </ion-item>
@@ -61,6 +61,7 @@ import {
 
 defineProps<{
   isOutgoing: boolean;
+  canInfo?: boolean; // show "Message info" — outgoing (receipts) or any media (metadata, both directions)
   canCopy: boolean;
   canView?: boolean; // image/video/album: offer "View" (open the full-screen viewer)
   canEdit?: boolean; // own, not-deleted text message: offer "Edit"

--- a/src/components/PasscodeModal.vue
+++ b/src/components/PasscodeModal.vue
@@ -9,11 +9,8 @@
 
       <!-- SET, step 1: choose 4 or 6 digits (auto-verify needs a fixed length). -->
       <div v-if="variant === 'set' && step === 'pick'" class="pc-pick ion-text-center">
-        <p class="pc-title">Set a passcode</p>
-        <p class="pc-desc">
-          You'll enter it each time you open Ring. While a passcode is set, background
-          notifications won't show message previews.
-        </p>
+        <p class="pc-title">{{ pickTitle }}</p>
+        <p class="pc-desc">{{ pickDesc }}</p>
         <ion-segment v-model="lenChoice" class="pc-seg">
           <ion-segment-button value="4"><ion-label>4 digits</ion-label></ion-segment-button>
           <ion-segment-button value="6"><ion-label>6 digits</ion-label></ion-segment-button>
@@ -57,8 +54,22 @@ const props = withDefaults(
     length?: number;
     busy?: boolean;
     error?: string;
+    /** Copy overrides so the same pad can set/verify things other than the app
+     *  passcode (e.g. the Hidden Chats PIN), with fitting wording. */
+    pickTitle?: string;
+    pickDesc?: string;
+    noun?: string; // the thing being entered, used in the pad titles ("Enter {noun}")
   }>(),
-  { variant: 'set', length: undefined, busy: false, error: '' },
+  {
+    variant: 'set',
+    length: undefined,
+    busy: false,
+    error: '',
+    pickTitle: 'Set a passcode',
+    pickDesc:
+      "You'll enter it each time you open Ring. While a passcode is set, background notifications won't show message previews.",
+    noun: 'passcode',
+  },
 );
 
 const step = ref<'pick' | 'choose' | 'confirm'>(props.variant === 'set' ? 'pick' : 'choose');
@@ -72,11 +83,11 @@ const attempt = ref(0); // bump to clear the pad
 const activeLen = computed(() => (props.variant === 'verify' ? props.length : chosenLen.value));
 
 const padTitle = computed(() => {
-  if (props.variant === 'verify') return 'Enter passcode';
-  return step.value === 'confirm' ? 'Confirm passcode' : 'Choose a passcode';
+  if (props.variant === 'verify') return `Enter ${props.noun}`;
+  return step.value === 'confirm' ? `Confirm ${props.noun}` : `Choose a ${props.noun}`;
 });
 const padDesc = computed(() =>
-  props.variant === 'set' && step.value === 'choose' ? `Enter a ${chosenLen.value}-digit passcode.` : '',
+  props.variant === 'set' && step.value === 'choose' ? `Enter a ${chosenLen.value}-digit ${props.noun}.` : '',
 );
 
 function onSubmit(code: string): void {

--- a/src/components/PinPad.vue
+++ b/src/components/PinPad.vue
@@ -126,17 +126,38 @@ const keys: Cell[] = [
   { k: 'ok', t: 'ok' },
 ];
 
+// The tap that completes a PIN runs on `pointerdown`; the browser still synthesizes a
+// `click` ~300ms later. If this submit closes the pad's overlay (the unlock gate or a
+// PasscodeModal), that click lands on whatever is now under the finger — e.g. a chat
+// row — and "ghost-taps" it. Arm a one-shot capture-phase swallow on `window` (not the
+// component, so it survives the pad unmounting) to eat exactly that next click.
+function armClickSwallow(): void {
+  let timer = 0;
+  const swallow = (e: Event) => {
+    e.stopPropagation();
+    e.preventDefault();
+    window.clearTimeout(timer);
+    window.removeEventListener('click', swallow, true);
+  };
+  window.addEventListener('click', swallow, true);
+  timer = window.setTimeout(() => window.removeEventListener('click', swallow, true), 800);
+}
+function fireSubmit(): void {
+  armClickSwallow();
+  emit('submit', code.value);
+}
+
 function press(d: string): void {
   if (props.busy || code.value.length >= maxLen.value) return;
   code.value += d;
   // Auto-verify the instant the fixed length is reached (no confirm tap).
-  if (autoSubmit.value && code.value.length === props.length) emit('submit', code.value);
+  if (autoSubmit.value && code.value.length === props.length) fireSubmit();
 }
 function backspace(): void {
   if (!props.busy) code.value = code.value.slice(0, -1);
 }
 function submit(): void {
-  if (!props.busy && code.value.length >= minLen.value) emit('submit', code.value);
+  if (!props.busy && code.value.length >= minLen.value) fireSubmit();
 }
 
 // Hardware keyboard (desktop / external keyboards): digits append, Backspace

--- a/src/composables/hiddenPinPrompt.ts
+++ b/src/composables/hiddenPinPrompt.ts
@@ -1,49 +1,43 @@
 /**
- * Shared UI helper for creating the Hidden Chats PIN (spec 1019). Used by both the
- * "Hide chat" action and the "New hidden chat" flow so the first-time create flow
- * (double-entry with confirmation, FR-003) lives in exactly one place.
+ * Hidden Chats PIN entry. Reuses the numeric PinPad (via PasscodeModal) that the app
+ * passcode uses, instead of a text-box alert, so setting/changing the reveal PIN looks
+ * and feels the same as the app lock. The PIN is a fixed 4 or 6 digits (chosen on the
+ * pad's first step) — that fixed length is what lets the search-bar reveal auto-verify.
  *
- * Kept out of `useHiddenChats.ts` so that composable stays free of `@ionic/vue`
- * (and unit-testable in the node env without pulling Ionic in).
+ * Kept out of `useHiddenChats.ts` so that composable stays free of `@ionic/vue` (and
+ * unit-testable in the node env without pulling Ionic in).
  */
-import { alertController } from '@ionic/vue';
+import { modalController } from '@ionic/vue';
+import PasscodeModal from '@/components/PasscodeModal.vue';
 import { hasHiddenPin, enableHiddenPin } from '@/services/hidden-chats';
 
-/** Prompt for a new PIN with confirmation; resolves the PIN, or null on cancel. */
-export async function promptCreateHiddenPin(): Promise<string | null> {
-  return new Promise((resolve) => {
-    void alertController
-      .create({
-        header: 'Create a Hidden Chats PIN',
-        message:
-          'Enter this PIN in the chat search bar to reveal hidden chats. Keep it safe — it is the only key.',
-        inputs: [
-          { name: 'pin', type: 'password', attributes: { inputmode: 'numeric' }, placeholder: 'PIN (4+ digits)' },
-          { name: 'confirm', type: 'password', attributes: { inputmode: 'numeric' }, placeholder: 'Confirm PIN' },
-        ],
-        buttons: [
-          { text: 'Cancel', role: 'cancel', handler: () => resolve(null) },
-          {
-            text: 'Create',
-            handler: (data: { pin?: string; confirm?: string }) => {
-              const pin = (data.pin ?? '').trim();
-              const confirm = (data.confirm ?? '').trim();
-              // Keep the alert open on an invalid or mismatched entry.
-              if (!/^\d{4,}$/.test(pin) || pin !== confirm) return false;
-              resolve(pin);
-              return true;
-            },
-          },
-        ],
-      })
-      .then((a) => a.present());
+const PICK_DESC = 'Type this PIN into the chat search bar to reveal your hidden chats. Keep it safe — it is the only key.';
+
+/**
+ * Present the PIN pad to set (pick length → enter → confirm) or verify the Hidden
+ * Chats PIN. Resolves the entered PIN, or null on cancel. Pass the known `length` for
+ * 'verify' so the pad auto-submits at the right digit count.
+ */
+export async function presentHiddenPinPad(variant: 'set' | 'verify', length?: number): Promise<string | null> {
+  const modal = await modalController.create({
+    component: PasscodeModal,
+    componentProps: {
+      variant,
+      length,
+      noun: 'PIN',
+      pickTitle: 'Set a Hidden Chats PIN',
+      pickDesc: PICK_DESC,
+    },
   });
+  await modal.present();
+  const { data, role } = await modal.onWillDismiss();
+  return role === 'confirm' && typeof data === 'string' ? data : null;
 }
 
-/** Ensure a Hidden Chats PIN exists, prompting to create one if not. */
+/** Ensure a Hidden Chats PIN exists, prompting to create one (on the pad) if not. */
 export async function ensureHiddenPin(): Promise<boolean> {
   if (await hasHiddenPin()) return true;
-  const pin = await promptCreateHiddenPin();
+  const pin = await presentHiddenPinPad('set');
   if (!pin) return false;
   await enableHiddenPin(pin);
   return true;

--- a/src/composables/useAutoLock.ts
+++ b/src/composables/useAutoLock.ts
@@ -16,17 +16,14 @@ import { onMounted, onUnmounted } from 'vue';
 import { getSetting, setSetting } from '@/db/queries';
 import { isUnlockedNow, lock, isLockEnabled } from '@/services/crypto/identity';
 
-// Setting value → grace period in ms. 'instant' = lock on any return. There is no
-// 'never': a never-locking passcode just risks a forgotten-passcode lockout (you
-// can't disable the lock without the passcode), so to stop locking you turn the
-// lock OFF. Any stale 'never' from before falls back to '1m' below.
+// Setting value → grace period in ms used on a foreground return. 'never' = Infinity,
+// so the app is never re-locked while it stays alive (backgrounded included); only a
+// full close re-locks (the keystore is PIN-wrapped at rest, so a relaunch always
+// gates regardless). Any value no longer offered falls back to '1m' below; onMounted
+// also migrates stale picks to the nearest current option.
 const TIMEOUT_MS: Record<string, number> = {
-  instant: 0,
-  '30s': 30_000,
+  never: Infinity,
   '1m': 60_000,
-  '2m': 120_000,
-  '3m': 180_000,
-  '4m': 240_000,
   '5m': 300_000,
   '15m': 900_000,
   '30m': 1_800_000,
@@ -56,12 +53,13 @@ export function useAutoLock(): void {
 
   onMounted(async () => {
     document.addEventListener('visibilitychange', onVisibilityChange);
-    // One-time migration: the removed 'Never' option becomes '24h' (the gentlest
-    // finite grace), so an existing 'never' user gets a real-but-rare lock and the
-    // picker shows a valid selection instead of nothing.
-    if ((await getSetting<string>('privacy.appLock.timeout', '1m')) === 'never') {
-      await setSetting('privacy.appLock.timeout', '24h');
-    }
+    // One-time normalization: the picker was trimmed (Immediately/30s/2-4m removed,
+    // Never (re)added), so map any stored value no longer offered to the nearest
+    // current option — otherwise the picker shows no selection. 'never' is now a
+    // valid choice and is preserved.
+    const cur = await getSetting<string>('privacy.appLock.timeout', '1m');
+    const remap: Record<string, string> = { instant: '1m', '30s': '1m', '2m': '5m', '3m': '5m', '4m': '5m' };
+    if (remap[cur]) await setSetting('privacy.appLock.timeout', remap[cur]);
   });
   onUnmounted(() => document.removeEventListener('visibilitychange', onVisibilityChange));
 }

--- a/src/composables/useBadges.ts
+++ b/src/composables/useBadges.ts
@@ -33,7 +33,9 @@ function setAppBadge(total: number): void {
 }
 
 export function useBadges() {
-  const chats = useLiveQuery(() => countUnread(), ['chats'], 0);
+  // 'settings' too: the hidden-chats badge mode (privacy.hiddenChatsBadge) changes
+  // what counts, so the badge should react the moment that preference is changed.
+  const chats = useLiveQuery(() => countUnread(), ['chats', 'settings'], 0);
   const calls = useLiveQuery(() => countMissedUnseen(), ['calls'], 0);
   // Contacts badge = group invites + legacy db requests (countPendingRequests) PLUS
   // incoming friend requests, which live in the connections store (server-driven,

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -34,7 +34,6 @@ import { isHidden } from '@/services/hidden-chats';
 // the incoming surface must reveal nothing identifying. A neutral name + avatar.
 const HIDDEN_CALL_NAME = 'Private caller';
 const hiddenCallAvatar = (): string => initialsAvatar('•');
-import { capitalizeFirst } from '@/utils/text';
 import { getSelfUserId } from '@/services/auth';
 import { isUnlockedNow, isUnlocked } from '@/services/crypto/identity';
 import { getTurnConfig, warmTurnConfig, rtcConfig } from '@/services/call/turn';
@@ -1433,7 +1432,7 @@ async function deriveGroupCallTitle(ids: string[]): Promise<string> {
   let unknown = 0;
   for (const id of ids) {
     const c = await getContact(id);
-    if (c?.name) names.push(capitalizeFirst(c.name));
+    if (c?.name) names.push(c.name);
     else unknown++;
   }
   if (names.length === 0) return 'Group call';

--- a/src/composables/useContactProfilePrompts.ts
+++ b/src/composables/useContactProfilePrompts.ts
@@ -1,0 +1,63 @@
+/**
+ * Surfaces "a contact changed their name/photo — adopt it?" prompts.
+ *
+ * When a peer publishes a NEW name/avatar, `updateContactProfile` (queries.ts) stages it
+ * on the contact as `pendingName`/`pendingAvatar` instead of silently overwriting the
+ * displayed name. This composable watches for those staged changes and raises a
+ * persistent in-app action banner (the same overlay as the update prompt) offering
+ * "Use it" (adopt) / "Not now" (dismiss). Dismiss won't re-prompt until the peer changes
+ * again — `remoteName`/`remoteAvatar` already track the last-seen value.
+ *
+ * Mounted once (App.vue). One banner per contact, keyed `profile:<id>` so a second change
+ * replaces rather than stacks.
+ */
+import { watch } from 'vue';
+import { personOutline } from 'ionicons/icons';
+import { useLiveQuery } from './useLiveQuery';
+import { listContacts, adoptContactProfile, dismissContactProfile } from '@/db/queries';
+import { showActionBanner } from '@/services/notify';
+import type { Contact } from '@/db/types';
+
+export function useContactProfilePrompts(): void {
+  const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+  // Contacts already shown a banner this session, so a reactive re-run doesn't re-raise it.
+  const shown = new Set<string>();
+
+  watch(
+    contacts,
+    (list) => {
+      const pending = list.filter((c) => c.pendingName != null || c.pendingAvatar != null);
+      const pendingIds = new Set(pending.map((c) => c.id));
+      // Forget contacts that are no longer pending (adopted/dismissed) so a FUTURE
+      // change re-raises the banner.
+      for (const id of [...shown]) if (!pendingIds.has(id)) shown.delete(id);
+
+      for (const c of pending) {
+        if (shown.has(c.id)) continue;
+        shown.add(c.id);
+        const newName = c.pendingName ?? c.name;
+        const nameChanged = c.pendingName != null && c.pendingName !== c.name;
+        const body = nameChanged
+          ? `Updated their name to “${newName}”. Use it?`
+          : 'Updated their photo. Use it?';
+        // A tapped action also closes the banner (firing onDismiss); guard so the
+        // swipe-dismiss fallback doesn't race the handler and clear the pending out
+        // from under "Use it".
+        let acted = false;
+        showActionBanner({
+          name: c.name,
+          body,
+          icon: personOutline,
+          url: `profile:${c.id}`, // distinct id per contact → replace, don't stack
+          actions: [
+            { text: 'Use it', handler: () => { acted = true; void adoptContactProfile(c.id); } },
+            { text: 'Not now', role: 'cancel', handler: () => { acted = true; void dismissContactProfile(c.id); } },
+          ],
+          // Swipe-dismiss (no action tapped) counts as "Not now".
+          onDismiss: () => { if (!acted) void dismissContactProfile(c.id); },
+        });
+      }
+    },
+    { immediate: true },
+  );
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -26,7 +26,7 @@ import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deri
 import { THUMB_TIERS } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview } from '@/services/link-preview';
-import { ensureHiddenLoaded, isRevealed } from '@/services/hidden-state';
+import { ensureHiddenLoaded, isRevealed, isHiddenKnown } from '@/services/hidden-state';
 import { hiddenCallKeys } from '@/db/hidden-calls';
 import type {
   MessagePayload, ContactCard, GroupCard, GroupMember, ReactionSignal, PollVoteSignal, MediaRef,
@@ -61,12 +61,31 @@ export async function listChats(q = ''): Promise<Chat[]> {
   // then most-recent.
   const hidden = await ensureHiddenLoaded();
   const showHidden = isRevealed();
+  // Fail CLOSED while the hidden set is still unknown (the keystore can be briefly
+  // locked when the app opens — the list query may run behind the unlock gate). An
+  // empty cache then is "we don't know yet", NOT "nothing hidden", so showing chats
+  // would flash hidden ones before they're filtered. Return nothing until the set
+  // loads; its success nudges a re-query (hidden-state), so this lasts only until
+  // unlock. Users with no hidden set load an empty set even while locked → known →
+  // unaffected.
+  if (!showHidden && !isHiddenKnown()) return [];
   const chats = (await getAll<Chat>('chats')).filter(
     (c) => !c.pending && !c.archived && !c.locked && (showHidden || !hidden.has(c.id)),
   );
   const filtered = q
     ? chats.filter((c) => matches(c.name, q) || matches(c.lastMessage, q))
     : chats;
+  // During a reveal session, surface the just-revealed hidden chats at the VERY top
+  // (above pins) so they're easy to find for the short time they're visible; the
+  // rest keep their normal pinned-then-recent order. Outside a reveal, hidden chats
+  // aren't in the list at all, so this is a no-op.
+  if (showHidden) {
+    return filtered.sort((a, b) => {
+      const ah = hidden.has(a.id), bh = hidden.has(b.id);
+      if (ah !== bh) return ah ? -1 : 1;
+      return chatOrder(a, b);
+    });
+  }
   return filtered.sort(chatOrder);
 }
 
@@ -1889,6 +1908,10 @@ export interface CallGroup extends Call {
 export async function listCallGroups(q = ''): Promise<CallGroup[]> {
   let calls = await listCalls(q); // newest first
   const hidden = await ensureHiddenLoaded();
+  // Fail closed while the hidden set is unknown (locked at open): an empty cache is
+  // "not loaded yet", not "nothing hidden", so showing calls could flash a hidden
+  // chat's call history. Re-queries once the set loads (see listChats).
+  if (!isHiddenKnown()) return [];
   if (hidden.size > 0) {
     const exclude = hiddenCallKeys(await getAll<Chat>('chats'), hidden);
     calls = calls.filter((c) => !exclude.has(c.contactId));
@@ -3102,27 +3125,110 @@ async function setChatPending(chatId: string, pending: boolean): Promise<void> {
   await put('chats', chat);
 }
 
-export async function updateContactProfile(id: string, name: string, avatar: string): Promise<void> {
-  const c = await getContact(id);
-  if (!c) return;
-  c.name = name || c.name;
-  c.avatar = avatar || c.avatar;
-  c.updatedAt = now();
-  await put('contacts', c);
-
-  // The 1:1 chat keeps its own name/avatar snapshot (taken at creation, when the
-  // contact was still a placeholder); refresh it so the chat list + header show
-  // the peer's real name/photo from their contact card.
+// Mirror a contact's display name/avatar onto its paired 1:1 chat (the chat keeps its
+// own snapshot, taken at creation when the contact was still a placeholder), so the
+// chat list + header reflect the current name/photo.
+async function syncChatFromContact(id: string, name: string, avatar: string): Promise<void> {
   const chats = await getAll<Chat>('chats');
   const chat = chats.find(
     (ch) => !ch.isGroup && ch.participantIds.length === 1 && ch.participantIds[0] === id,
   );
-  if (chat) {
-    chat.name = c.name;
-    chat.avatar = c.avatar;
+  if (chat && (chat.name !== name || chat.avatar !== avatar)) {
+    chat.name = name;
+    chat.avatar = avatar;
     chat.updatedAt = now();
     await put('chats', chat);
   }
+}
+
+/**
+ * Ingest a peer's published profile (name/avatar) from a contact card or the directory.
+ * The FIRST profile we learn is applied directly; any later CHANGE is STAGED (pending)
+ * and the user is asked whether to adopt it (so a peer can't silently relabel themselves,
+ * and a user's local override is preserved). A re-send of an unchanged (incl. previously
+ * dismissed) profile is a no-op — `remoteName`/`remoteAvatar` track the last seen value,
+ * so a dismissed change never re-prompts until the peer changes it again.
+ */
+export async function updateContactProfile(id: string, name: string, avatar: string, force = false): Promise<void> {
+  const c = await getContact(id);
+  if (!c) return;
+  const newName = (name || '').trim() || c.remoteName || c.name;
+  const newAvatar = avatar || c.remoteAvatar || c.avatar;
+  const hadRemote = c.remoteName != null || c.remoteAvatar != null;
+  if (!force && hadRemote && c.remoteName === newName && c.remoteAvatar === newAvatar) return; // unchanged
+  c.remoteName = newName;
+  c.remoteAvatar = newAvatar;
+  if (force || (!hadRemote && !c.localProfile)) {
+    // Apply directly (no prompt): the FIRST profile we learn, or a forced refetch when
+    // the user resets a local override back to the peer's own name/photo.
+    c.name = newName;
+    c.avatar = newAvatar;
+    delete c.pendingName;
+    delete c.pendingAvatar;
+    if (force) delete c.localProfile; // a reset/refetch drops the override
+    c.updatedAt = now();
+    await put('contacts', c);
+    await syncChatFromContact(id, newName, newAvatar);
+    return;
+  }
+  // A genuine change to a known profile → stage it; the user adopts/dismisses via the
+  // in-app prompt (useContactProfilePrompts). The displayed name/avatar are untouched.
+  c.pendingName = newName;
+  c.pendingAvatar = newAvatar;
+  c.updatedAt = now();
+  await put('contacts', c);
+}
+
+/** Adopt a staged remote name/avatar change (the user said yes to the prompt). */
+export async function adoptContactProfile(id: string): Promise<void> {
+  const c = await getContact(id);
+  if (!c || (c.pendingName == null && c.pendingAvatar == null)) return;
+  if (c.pendingName != null) c.name = c.pendingName;
+  if (c.pendingAvatar != null) c.avatar = c.pendingAvatar;
+  delete c.pendingName;
+  delete c.pendingAvatar;
+  delete c.localProfile; // adopting the peer's profile clears any local override
+  c.updatedAt = now();
+  await put('contacts', c);
+  await syncChatFromContact(id, c.name, c.avatar);
+}
+
+/** Decline a staged remote change. It won't re-prompt until the peer changes again
+ *  (remoteName/remoteAvatar already hold the new value). */
+export async function dismissContactProfile(id: string): Promise<void> {
+  const c = await getContact(id);
+  if (!c || (c.pendingName == null && c.pendingAvatar == null)) return;
+  delete c.pendingName;
+  delete c.pendingAvatar;
+  c.updatedAt = now();
+  await put('contacts', c);
+}
+
+/** Set a LOCAL override of a contact's display name and/or avatar (takes precedence
+ *  over the peer's; future remote changes still prompt). */
+export async function setContactLocalProfile(id: string, opts: { name?: string; avatar?: string }): Promise<void> {
+  const c = await getContact(id);
+  if (!c) return;
+  if (opts.name != null && opts.name.trim()) c.name = opts.name.trim();
+  if (opts.avatar) c.avatar = opts.avatar;
+  c.localProfile = true;
+  c.updatedAt = now();
+  await put('contacts', c);
+  await syncChatFromContact(id, c.name, c.avatar);
+}
+
+/** Revert a local override back to the peer's current name/avatar. */
+export async function resetContactToRemote(id: string): Promise<void> {
+  const c = await getContact(id);
+  if (!c) return;
+  if (c.remoteName) c.name = c.remoteName;
+  if (c.remoteAvatar) c.avatar = c.remoteAvatar;
+  delete c.localProfile;
+  delete c.pendingName;
+  delete c.pendingAvatar;
+  c.updatedAt = now();
+  await put('contacts', c);
+  await syncChatFromContact(id, c.name, c.avatar);
 }
 
 /** Add a peer by Ring id and send them a friend request (our name + photo).
@@ -3297,16 +3403,26 @@ export async function resolveAlert(id: string): Promise<void> {
 /* ---- badge counts ---- */
 
 export async function countUnread(): Promise<number> {
-  // Hidden chats (spec 1019) never contribute to the badge — always, even while
-  // revealed — so the count can't reveal or attribute a hidden chat's existence.
-  const hidden = await ensureHiddenLoaded();
+  // How hidden chats (spec 1019) affect the unread badge is user-chosen
+  // (privacy.hiddenChatsBadge):
+  //   'always'   (default) — hidden chats count, so you always know something is
+  //               waiting (the badge can hint a hidden chat exists; the user opted in).
+  //   'revealed' — hidden chats count only during an active reveal session.
+  //   'never'    — hidden chats never contribute, so the badge can't betray one.
+  const mode = await getSetting<string>('privacy.hiddenChatsBadge', 'always');
   const chats = await getAll<Chat>('chats');
-  return chats.reduce((n, c) => n + (hidden.has(c.id) ? 0 : c.unread || 0), 0);
+  if (mode === 'always') return chats.reduce((n, c) => n + (c.unread || 0), 0);
+  // 'never' / 'revealed' need the hidden set to know what to exclude.
+  const hidden = await ensureHiddenLoaded();
+  if (!isHiddenKnown()) return 0; // unknown set (locked at open) → fail closed
+  const countHidden = mode === 'revealed' && isRevealed();
+  return chats.reduce((n, c) => n + (!countHidden && hidden.has(c.id) ? 0 : c.unread || 0), 0);
 }
 
 export async function countMissedUnseen(): Promise<number> {
   const calls = await getAll<Call>('calls');
   const hidden = await ensureHiddenLoaded();
+  if (!isHiddenKnown()) return 0; // unknown set (locked at open) → fail closed so a hidden missed call can't leak into the badge
   if (hidden.size === 0) return calls.filter((c) => c.missed && !c.seen).length;
   const exclude = hiddenCallKeys(await getAll<Chat>('chats'), hidden);
   return calls.filter((c) => c.missed && !c.seen && !exclude.has(c.contactId)).length;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -32,6 +32,18 @@ export interface Contact {
   // so it cannot tell the "all friends" tier from "close friends"). Distinct from the
   // per-CHAT `Chat.favorite` pin.
   closeFriend?: boolean;
+  // Local name/avatar override + remote-change tracking. `name`/`avatar` stay the
+  // DISPLAYED values (a local override or the last-adopted remote). `remoteName`/
+  // `remoteAvatar` mirror the latest profile the peer published — used to DETECT a
+  // change and as the source when the user adopts it. `pendingName`/`pendingAvatar`
+  // stage a remote change awaiting the user's adopt/dismiss decision (drives the
+  // in-app prompt). `localProfile` marks that the user set their own override, so we
+  // can offer "reset to their name & photo".
+  remoteName?: string;
+  remoteAvatar?: string;
+  pendingName?: string;
+  pendingAvatar?: string;
+  localProfile?: boolean;
   updatedAt: number;
 }
 

--- a/src/services/chat-filters.ts
+++ b/src/services/chat-filters.ts
@@ -8,6 +8,7 @@
 import { computed, ref, watch, type Ref, type ComputedRef } from 'vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { warmChats, warmChatsLoaded, warmWhenIdle } from '@/composables/warmStores';
+import { isUnlocked } from '@/services/crypto/identity';
 import { listChats, listChatLists, getSetting, setSetting, chatIsUnread } from '@/db/queries';
 import type { Chat, ChatList } from '@/db/types';
 
@@ -103,7 +104,11 @@ export function useChatFilters(search: Ref<string>): {
     () => listChats(search.value),
     ['chats', 'messages', 'chatlists'],
     [] as Chat[],
-    () => search.value,
+    // Re-run on search changes AND on unlock: at cold open listChats fails CLOSED
+    // (returns []) while the keystore is still locked, so we must re-query the moment
+    // it unlocks to replace that transient empty with the real list. The Chats page
+    // gates its empty state on this fresh resolution (see its `ready`).
+    () => [search.value, isUnlocked.value],
     warmWhenIdle(warmChats, warmChatsLoaded, search),
   );
   const lists = useLiveQuery(() => listChatLists(), ['chatlists'], [] as ChatList[]);

--- a/src/services/directory.ts
+++ b/src/services/directory.ts
@@ -18,7 +18,7 @@ import {
 } from './api';
 import { getSelfUserId } from './auth';
 import { get, put } from '@/db/idb';
-import { isPeerBlocked, getSetting, downscaleAvatar, listContacts } from '@/db/queries';
+import { isPeerBlocked, getSetting, downscaleAvatar, listContacts, updateContactProfile } from '@/db/queries';
 import { getSecret } from '@/db/secrets';
 import { isUnlockedNow } from '@/services/crypto/identity';
 import { initialsAvatar } from '@/db/avatars';
@@ -40,30 +40,51 @@ export async function upsertDirectoryContact(u: DirectoryUser): Promise<void> {
   const avatar = u.avatar || existing?.avatar || initialsAvatar(name);
   const about = u.about ?? existing?.about ?? '';
 
-  // Skip the write when nothing the directory owns has changed, avoids churning
-  // the contacts store (and its reactive subscribers) on every poll.
-  if (
-    existing &&
-    existing.name === name &&
-    existing.username === u.username &&
-    existing.avatar === avatar &&
-    existing.about === about
-  ) {
-    return; // nothing the directory owns changed
+  if (!existing) {
+    // New contact: apply the directory profile directly (nothing to prompt about yet).
+    // Mirror the PROFILE only — this does not make them a friend (set by the accept flow).
+    await put('contacts', {
+      id: u.id,
+      name,
+      username: u.username,
+      avatar,
+      phone: '',
+      about,
+      remoteName: name,
+      remoteAvatar: avatar,
+      updatedAt: u.profileAt || Date.now(),
+    });
+    return;
   }
 
-  const contact: Contact = {
-    id: u.id,
-    name,
-    username: u.username,
-    avatar,
-    phone: existing?.phone ?? '',
-    about,
-    updatedAt: u.profileAt || Date.now(),
-  };
-  // Mirror the PROFILE only — this does not make them a friend. Friendship is set
-  // (markContactConnected) by the accept flow; the server gate enforces it.
-  await put('contacts', contact);
+  // Existing contact: update the directory-owned, non-prompting fields (username/about)
+  // directly; route the DISPLAY name/avatar through updateContactProfile so a real change
+  // is staged for the user's adopt/dismiss decision and any local override is preserved.
+  if (existing.username !== u.username || (existing.about ?? '') !== about) {
+    existing.username = u.username;
+    existing.about = about;
+    existing.updatedAt = u.profileAt || Date.now();
+    await put('contacts', existing);
+  }
+  await updateContactProfile(u.id, name, avatar);
+}
+
+/**
+ * Drop a contact's local name/photo override and re-pull their CURRENT profile from the
+ * directory, applying it DIRECTLY (no adopt prompt) — what "Reset to their name & photo"
+ * does. Falls back to the last-known remote values offline (handled by the queries layer
+ * before this runs). Best-effort: a network failure leaves the optimistic revert in place.
+ */
+export async function refetchContactProfile(id: string): Promise<void> {
+  try {
+    const u = await fetchDirectoryUser(id);
+    if (!u) return;
+    const name = (u.displayName || u.username || '').trim();
+    const avatar = u.avatar || '';
+    await updateContactProfile(id, name, avatar, true); // force-apply the server's current profile
+  } catch {
+    /* offline / not found → keep the optimistic local revert the caller already applied */
+  }
 }
 
 /** Pull the whole directory and mirror it into contacts. Paged; best-effort

--- a/src/services/hidden-chats.test.ts
+++ b/src/services/hidden-chats.test.ts
@@ -39,7 +39,7 @@ import {
   changeHiddenPin,
   hiddenPinLength,
 } from './hidden-chats';
-import { clearHiddenState, isRevealed } from './hidden-state';
+import { clearHiddenState, isRevealed, isHiddenKnown } from './hidden-state';
 
 beforeAll(async () => {
   await ready();
@@ -86,6 +86,39 @@ describe('hidden set (membership)', () => {
     const saved = h.mk.key;
     h.mk.key = null; // simulate locked
     expect([...(await getHiddenSet())]).toEqual([]); // no leak, no throw
+    h.mk.key = saved;
+  });
+});
+
+// `isHiddenKnown()` is the signal the chat/call-list choke points use to fail
+// CLOSED on startup: an empty cache could mean "nothing hidden" OR "couldn't
+// decrypt yet" (keystore still locked behind the unlock gate). Conflating them is
+// what caused the flash of hidden chats before they were filtered, so the lists
+// must show nothing until this flips true.
+describe('isHiddenKnown (startup fail-closed signal)', () => {
+  it('is false until loaded, stays false while a configured set is locked, true after it decrypts', async () => {
+    clearHiddenState();
+    expect(isHiddenKnown()).toBe(false); // nothing loaded yet
+
+    await addHidden('chat-A'); // writes the (sealed) SET_KEY
+    clearHiddenState(); // forget the cache → simulate a fresh page load
+    const saved = h.mk.key;
+    h.mk.key = null; // keystore locked at open
+    expect([...(await getHiddenSet())]).toEqual([]); // fails closed (empty)
+    expect(isHiddenKnown()).toBe(false); // ...and NOT mistaken for "nothing hidden"
+
+    h.mk.key = saved; // unlock → the next read decrypts and the set becomes known
+    expect([...(await getHiddenSet())]).toEqual(['chat-A']);
+    expect(isHiddenKnown()).toBe(true);
+  });
+
+  it('is known (true) even while locked when no hidden set was ever configured', async () => {
+    clearHiddenState();
+    h.settings.clear(); // no SET_KEY at all → nothing to decrypt
+    const saved = h.mk.key;
+    h.mk.key = null; // locked, but irrelevant with no set
+    expect([...(await getHiddenSet())]).toEqual([]);
+    expect(isHiddenKnown()).toBe(true); // definitively empty → lists render normally, no blank flash
     h.mk.key = saved;
   });
 });

--- a/src/services/hidden-state.ts
+++ b/src/services/hidden-state.ts
@@ -74,6 +74,18 @@ export function hiddenIdsSync(): Set<string> {
   return ids;
 }
 
+/**
+ * Whether the hidden set is DEFINITIVELY known (a successful load, or no hidden
+ * set configured at all — both leave `loaded` true). False means we couldn't
+ * decrypt it yet (keystore still locked at open), so callers must NOT trust the
+ * empty cache as "nothing hidden": they fail closed until this flips true. The
+ * load's success path nudges the lists to re-query (see `ensureHiddenLoaded`), so
+ * the fail-closed window lasts only until the keystore unlocks.
+ */
+export function isHiddenKnown(): boolean {
+  return loaded;
+}
+
 /** True if `id` is currently hidden (per the cache). */
 export function isHiddenId(id: string): boolean {
   return ids.has(id);

--- a/src/services/media-encode.test.ts
+++ b/src/services/media-encode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { achievedQuality, availableQualities, qualityLabel } from './media-encode';
+import { achievedQuality, availableQualities, qualityLabel, compressImage, isPreservedImageMime } from './media-encode';
 
 // spec 2007 — the badge must reflect the quality actually sent, never the one
 // requested. achievedQuality() is the single source of truth for that invariant.
@@ -44,6 +44,29 @@ describe('availableQualities (picker suitability)', () => {
 
   it('offers all tiers when the source size is unknown (honest labeling demotes later)', () => {
     expect(availableQualities(undefined)).toEqual(['sd', 'hd', 'fhd', 'original']);
+  });
+});
+
+// Animated/efficient formats must never be re-encoded on send: the canvas+JPEG path
+// would flatten a GIF/animated-WebP to one static frame (and drop WebP alpha). compressImage
+// returns the ORIGINAL blob untouched for these, so animation survives to the recipient.
+describe('compressImage preserves animated/efficient formats', () => {
+  it('flags GIF and WebP as preserved, others not', () => {
+    expect(isPreservedImageMime('image/gif')).toBe(true);
+    expect(isPreservedImageMime('image/webp')).toBe(true);
+    expect(isPreservedImageMime('image/jpeg')).toBe(false);
+    expect(isPreservedImageMime('image/png')).toBe(false);
+  });
+
+  it('returns the original GIF/WebP blob unchanged even at a non-original tier', async () => {
+    const gif = new Blob([new Uint8Array([0x47, 0x49, 0x46])], { type: 'image/gif' });
+    const webp = new Blob([new Uint8Array([0x52, 0x49, 0x46, 0x46])], { type: 'image/webp' });
+    // hd would normally re-encode to JPEG; for these it must hand back the SAME blob.
+    expect(await compressImage(gif, 'hd')).toBe(gif);
+    expect(await compressImage(webp, 'sd')).toBe(webp);
+    // 'original' is a passthrough for everything, as before.
+    const png = new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' });
+    expect(await compressImage(png, 'original')).toBe(png);
   });
 });
 

--- a/src/services/media-encode.ts
+++ b/src/services/media-encode.ts
@@ -65,10 +65,24 @@ const IMAGE_PRESETS: Record<Tier, ImagePreset> = {
   fhd: { maxEdge: 1920, quality: 0.8 },
 };
 
+// Formats we NEVER re-encode on send. Re-encoding goes through a canvas + JPEG export,
+// which flattens an animated GIF / animated WebP to a single static frame (and drops
+// WebP's alpha + already-efficient compression). Passing the original bytes through
+// keeps animation intact for the recipient and preserves transparency. WebP is already
+// well-compressed, so skipping the JPEG re-encode costs little even for static ones.
+const PRESERVED_IMAGE_MIME = new Set(['image/gif', 'image/webp']);
+
+/** Whether outgoing media of this MIME type must be sent untouched (animation/alpha). */
+export function isPreservedImageMime(mime: string): boolean {
+  return PRESERVED_IMAGE_MIME.has(mime);
+}
+
 /** Re-encode a photo to the SD/HD preset (downscaled JPEG). Returns the original
- *  blob for 'original', if the re-encode would be larger, or on any error. */
+ *  blob for 'original', for animated/efficient formats (GIF/WebP), if the re-encode
+ *  would be larger, or on any error. */
 export async function compressImage(blob: Blob, quality: Quality): Promise<Blob> {
   if (quality === 'original') return blob;
+  if (isPreservedImageMime(blob.type)) return blob; // keep GIF/WebP animation + alpha
   const preset = IMAGE_PRESETS[quality];
   if (!preset) return blob;
   try {

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -25,6 +25,7 @@ import { subscribe } from '@/db/idb';
 import { notifyLocal } from '@/services/push';
 import { inAppGloballyEnabled, getChatNotifyPrefs } from '@/services/notify-prefs';
 import { isUnlockedNow } from '@/services/crypto/identity';
+import { ensureHiddenLoaded, isRevealed } from '@/services/hidden-state';
 import { playTone } from '@/services/sound';
 import { notificationOwner } from '@/services/notify-policy';
 
@@ -375,6 +376,24 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
   // (Requests / system notices have no chat and always-surface semantics — handled
   // below the predicate, unchanged.)
   if (n.kind === 'message') {
+    // Hidden chats (spec 1019): a LOCKED hidden chat must leave no foreground trace —
+    // never a banner, sound, or a name/content notification. (When revealed, the user
+    // is actively in hidden mode → fall through to the normal policy.)
+    if (n.chatId && !isRevealed() && (await ensureHiddenLoaded()).has(n.chatId)) {
+      if (appVisible()) {
+        // Foreground: stay completely silent (no banner, no sound). Claim it so a
+        // co-arriving push doesn't make the SW fire its own notification either. The
+        // unread badge still reflects it (counted separately in useBadges/countUnread).
+        notifyBannerPresented();
+        return true;
+      }
+      // Backgrounded but connected via WS (no push woke us): the OS push didn't cover
+      // this, so bridge a GENERIC, content-free notification — NEVER the sender name or
+      // message text — mirroring the SW's hidden-chat handling. A push-woken drain
+      // leaves the (already-generic) OS notification to the SW.
+      if (!n.pushWoken) void notifyLocal('Ring', 'New message', '/tabs/chats', undefined);
+      return false;
+    }
     const p = await ensurePrefs();
     if (!p.showMessages) return false; // the global "Show notifications" toggle
     const [muted, chatPrefs, globalInApp] = await Promise.all([

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -37,7 +37,6 @@ import {
   removeMember as dbRemoveMember,
   renameGroup as dbRenameGroup,
   setGroupAvatar as dbSetGroupAvatar,
-  updateContactProfile as dbUpdateContactProfile,
   leaveGroup as dbLeaveGroup,
   sendMessage as dbSendMessage,
   editMessage as dbEditMessage,
@@ -334,7 +333,7 @@ export function installTestHook(): void {
     /** Ids of current (non-pending) contacts. */
     contactIds: async (): Promise<string[]> => (await listContacts()).map((c) => c.id),
     /** Set a known contact's display name (the name you'd have saved locally). */
-    setContactName: (id: string, name: string) => dbUpdateContactProfile(id, name, ''),
+    setContactName: (id: string, name: string) => dbSetContactLocalProfile(id, { name }),
 
     /* ---- group chat ---- */
     createGroup: (name: string, memberIds: string[]) => dbCreateGroup(name, memberIds),

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -8,7 +8,7 @@
  * out of production builds entirely.
  */
 import { register, getSelfUserId, getSelfUsername } from '@/services/auth';
-import { syncDirectory, importDirectoryUser, searchDirectory, publishOwnProfile } from '@/services/directory';
+import { syncDirectory, importDirectoryUser, searchDirectory, publishOwnProfile, refetchContactProfile } from '@/services/directory';
 import { previewPending } from '@/services/sw-inbox';
 import { disconnectTransport, nudgeReconnect, forceReconnect, sendDownloadedReceipts, sendSeenReceipts, applySeenPref } from '@/composables/useSync';
 import {
@@ -103,6 +103,10 @@ import {
   setCloseFriend as dbSetCloseFriend,
   listCloseFriends as dbListCloseFriends,
   listFriends as dbListFriends,
+  countUnread as dbCountUnread,
+  setContactLocalProfile as dbSetContactLocalProfile,
+  resetContactToRemote as dbResetContactToRemote,
+  adoptContactProfile as dbAdoptContactProfile,
 } from '@/db/queries';
 import {
   enableHiddenPin as hcEnablePin,
@@ -393,6 +397,8 @@ export function installTestHook(): void {
     hiddenReset: () => hcReset(),
     /** Visible chat ids right now (what `listChats` returns) — for exclusion asserts. */
     visibleChatIds: async (): Promise<string[]> => (await listChats()).map((c) => c.id),
+    /** The unread badge total (countUnread) — for hidden-chat badge-mode asserts. */
+    unreadBadge: (): Promise<number> => dbCountUnread(),
 
     /* ---- account lifecycle: termination ("Ghosted") + blocking ---- */
     /** Terminate THIS account server-side (drives the peer's ghost detection). */
@@ -554,6 +560,20 @@ export function installTestHook(): void {
       const blob = await new Promise<Blob>((res) => c.toBlob((b) => res(b!), 'image/png'));
       await dbSendMediaMessage(chatId, 'image', blob, name, undefined, { quality: 'original' });
     },
+    /** Send a raw image (base64 bytes + MIME) through the real send pipeline — used to
+     *  exercise GIF / animated-WebP handling, which the canvas helpers above can't make.
+     *  Pass a non-'original' quality to prove animated formats survive compression. */
+    sendImageData: async (
+      chatId: string,
+      base64: string,
+      mime: string,
+      name: string,
+      quality: 'sd' | 'hd' | 'fhd' | 'original' = 'hd',
+    ): Promise<void> => {
+      const bytes = Uint8Array.from(atob(base64), (ch) => ch.charCodeAt(0));
+      const blob = new Blob([bytes], { type: mime });
+      await dbSendMediaMessage(chatId, 'image', blob, name, undefined, { quality });
+    },
     /** Seed a REAL, decodable image as a Media record with NO thumbnail tiers (mimicking media
      *  that predates spec 1014) so the on-open backfill (T011) can be exercised. */
     seedLegacyImage: async (chatId: string, w = 1024, h = 768): Promise<string> => {
@@ -694,6 +714,15 @@ export function installTestHook(): void {
     /** A contact's display name (to verify profiles propagated), or '' if none.
      *  Reads the contact record directly (listContacts hides ghosted ones). */
     contactName: async (id: string): Promise<string> => (await dbGetContact(id))?.name ?? '',
+    /** Set a LOCAL name/avatar override for a contact. */
+    setContactLocalProfile: (id: string, name?: string, avatar?: string) => dbSetContactLocalProfile(id, { name, avatar }),
+    /** Reset a contact to the peer's CURRENT name/photo (revert + re-pull from directory). */
+    resetContactProfile: async (id: string): Promise<void> => {
+      await dbResetContactToRemote(id);
+      await refetchContactProfile(id);
+    },
+    /** Adopt a staged remote name/avatar change. */
+    adoptContactProfile: (id: string) => dbAdoptContactProfile(id),
     /** Ids of incoming pending friend requests (to accept). */
     pendingRequestIds: async (): Promise<string[]> => {
       const reqs = await getAll<FriendRequest>('requests');

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -143,18 +143,15 @@ const TIMER: ChoiceOption[] = [
   { value: 'off', label: 'Off' },
 ];
 // App-lock grace period: how long Ring can sit in the background before it asks
-// for the passcode/passkey again. 'instant' = always; the longest is 24h. There is
-// deliberately NO 'Never': a lock that never engages just lulls you into forgetting
-// the passcode, then locks you out the moment it does engage (a relaunch, or after
-// you change this setting), and you can't turn the lock off without the passcode.
-// To stop locking, turn App lock OFF entirely while you still know your passcode.
+// for the passcode/passkey again. 'never' never re-locks while the app stays alive
+// (backgrounded included) — but a FULL app close still locks at rest, so reopening
+// Ring always asks for the passcode. Tradeoff to be aware of: a 'never' user who
+// forgets the passcode is fine until the next relaunch, then is locked out and can't
+// turn the lock off without it. To stop locking entirely, turn App lock OFF while
+// you still know your passcode.
 const APP_LOCK_TIMEOUT: ChoiceOption[] = [
-  { value: 'instant', label: 'Immediately' },
-  { value: '30s', label: '30 seconds' },
+  { value: 'never', label: 'Never' },
   { value: '1m', label: '1 minute' },
-  { value: '2m', label: '2 minutes' },
-  { value: '3m', label: '3 minutes' },
-  { value: '4m', label: '4 minutes' },
   { value: '5m', label: '5 minutes' },
   { value: '15m', label: '15 minutes' },
   { value: '30m', label: '30 minutes' },
@@ -168,6 +165,14 @@ const HIDDEN_GRACE: ChoiceOption[] = [
   { value: 'immediately', label: 'Immediately' },
   { value: '1m', label: 'After 1 minute' },
   { value: '5m', label: 'After 5 minutes' },
+];
+
+// Whether messages in hidden chats add to the unread badge. Default 'always' so a new
+// hidden message is never missed; 'never' keeps the badge from ever hinting one exists.
+const HIDDEN_BADGE: ChoiceOption[] = [
+  { value: 'always', label: 'Always' },
+  { value: 'revealed', label: 'Only while revealed' },
+  { value: 'never', label: 'Never (most private)' },
 ];
 
 /** A backend-dependent screen we keep in the IA but can't implement yet. */
@@ -316,6 +321,12 @@ export const SETTINGS: Record<string, SettingNode> = {
         footer: 'How long revealed chats stay visible when you briefly switch apps. A full app close always re-locks immediately.',
       },
       {
+        header: 'Unread badge',
+        items: [{ type: 'choice', key: 'privacy.hiddenChatsBadge', default: 'always', options: HIDDEN_BADGE }],
+        footer:
+          'Whether messages in hidden chats add to the unread badge. “Always” means you never miss one, but the count can hint a hidden chat exists. “Never” keeps the badge from ever revealing hidden activity. Hidden chats never show a notification preview or play a sound, regardless of this setting.',
+      },
+      {
         items: [
           {
             type: 'action',
@@ -425,7 +436,7 @@ export const SETTINGS: Record<string, SettingNode> = {
         header: 'Require passcode after being away for',
         items: [{ type: 'choice', key: 'privacy.appLock.timeout', default: '1m', options: APP_LOCK_TIMEOUT }],
         footer:
-          'When a passcode is set and Ring has been in the background longer than this, it asks for your passcode again on return.',
+          'When a passcode is set and Ring has been in the background longer than this, it asks for your passcode again on return. “Never” skips that on-return prompt — but fully closing and reopening Ring still asks for your passcode.',
       },
     ],
   },

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -16,8 +16,8 @@
  * dismisses stale notifications when it foregrounds (useAppBadge), and consistent
  * per-chat tags collapse the page- and SW-shown notes so there's never a duplicate.
  */
-import { precacheAndRoute } from 'workbox-precaching';
-import { registerRoute } from 'workbox-routing';
+import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching';
+import { registerRoute, NavigationRoute } from 'workbox-routing';
 import { CacheFirst } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import {
@@ -34,6 +34,23 @@ declare const self: ServiceWorkerGlobalScope & {
 
 // App-shell precache (manifest injected at build time).
 precacheAndRoute(self.__WB_MANIFEST);
+
+// SPA app-shell navigation fallback: serve the precached index.html for ALL page
+// navigations (any deep link), so a cold start — notably tapping a push notification,
+// which opens the app at /chat/<id> — loads instantly FROM CACHE instead of fetching
+// the document over the network. On iOS that first cold network request often fails
+// with "the network connection was lost" (NSURLErrorNetworkConnectionLost), which is
+// the "Safari can't open the page" interstitial users hit on notification taps. The
+// SPA router then resolves the deep link client-side. API/relay/WS/blob paths are
+// denylisted so only document navigations are served the shell. Dev is served by Vite
+// (index.html isn't precached there), so this is production-only.
+if (!import.meta.env.DEV) {
+  registerRoute(
+    new NavigationRoute(createHandlerBoundToURL('/index.html'), {
+      denylist: [/^\/v1\//, /^\/healthz\b/, /^\/relay\//],
+    }),
+  );
+}
 
 // Reusable-asset runtime cache (spec 1017): a given animated emoji's Noto Lottie is immutable and
 // served from our own first-party proxy, so cache-first it persistently across sessions — a repeat

--- a/src/utils/media-meta.ts
+++ b/src/utils/media-meta.ts
@@ -192,6 +192,29 @@ export function generateImageThumb(blob: Blob, maxEdge = THUMB_TIERS.bubble): Pr
   return posterLimiter(() => generateImageThumbUnlimited(blob, maxEdge));
 }
 
+/**
+ * Whether an image is animated, so the chat bubble knows to render the moving
+ * original (autoplaying while visible) rather than a static poster. All GIFs are
+ * treated as animated — a single-frame GIF rendered as an `<img>` is identical to a
+ * still anyway, and GIFs are small. WebP is only animated when its RIFF container
+ * carries an `ANIM` chunk (the extended VP8X animation header), so static WebP photos
+ * keep the lightweight static-poster path. Cheap: sniffs only the file header.
+ */
+export async function isAnimatedImage(mime: string, blob: Blob): Promise<boolean> {
+  if (mime === 'image/gif') return true;
+  if (mime === 'image/webp') {
+    try {
+      const head = new Uint8Array(await blob.slice(0, 64).arrayBuffer());
+      let sig = '';
+      for (const b of head) sig += String.fromCharCode(b);
+      return sig.includes('ANIM'); // animated WebP carries an ANIM chunk near the header
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 async function generateImageThumbUnlimited(blob: Blob, maxEdge: number): Promise<Blob | undefined> {
   try {
     const bmp = await createImageBitmap(blob);

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -43,7 +43,7 @@
             <img :src="chat.avatar" :alt="chat.name" />
           </ion-avatar>
           <span class="chat-header-text">
-            <span class="chat-header-name">{{ capitalizeFirst(chat.name) }}</span>
+            <span class="chat-header-name">{{ chat.name }}</span>
             <span v-if="statusLine" class="chat-header-status">{{ statusLine }}</span>
           </span>
         </button>
@@ -244,10 +244,17 @@
               <!-- Tap the image → open the viewer directly; tap the empty/footer area
                    of the bubble → the action menu. -->
               <div v-if="m.kind === 'image' && m.mediaId" class="media-wrap" @click.stop="openMediaViewer(m.id)">
-                <img v-if="mediaInfo[m.mediaId]?.posterUrl" class="bubble-image" :src="mediaInfo[m.mediaId]!.posterUrl" alt="photo" loading="lazy" decoding="async" />
-                <ion-skeleton-text v-else :animated="true" class="media-skel" />
-                <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
-              </div>
+                <!-- Animated GIF / WebP: play the moving original while it's visible
+                     on screen (freezes to the poster off-screen). Needs the full blob
+                     resolved; if it was freed from the LRU, fall through to the poster. -->
+                <AnimatedImage
+                  v-if="mediaInfo[m.mediaId]?.animated && mediaInfo[m.mediaId]?.url"
+                  :animated-url="mediaInfo[m.mediaId]!.url"
+                  :poster-url="mediaInfo[m.mediaId]!.posterUrl"
+                  alt="gif"
+                />
+                <img v-else-if="mediaInfo[m.mediaId]?.posterUrl" class="bubble-image" :src="mediaInfo[m.mediaId]!.posterUrl" alt="photo" loading="lazy" decoding="async" />
+                <ion-skeleton-text v-else :animated="true" class="media-skel" />              </div>
               <!-- Video: a still thumbnail with a play button. Tapping the poster opens the
                    action menu (whole bubble is the hit target); the play button is the
                    direct affordance to the full-screen viewer. The sender-embedded
@@ -264,9 +271,7 @@
                 <ion-skeleton-text v-else :animated="true" class="media-skel" />
                 <!-- Visual play affordance only; a tap anywhere on the poster opens
                      the viewer via the bubble's tap handler. -->
-                <ion-icon class="play-overlay" :icon="playCircle" aria-hidden="true" />
-                <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
-              </div>
+                <ion-icon class="play-overlay" :icon="playCircle" aria-hidden="true" />              </div>
 
               <!-- Non-square media (round note / voice / audio card / file chip) stays gated
                    on mediaInfo: these are text-height cards with no fixed-square frame, so
@@ -330,9 +335,7 @@
                 <span class="dl-btn">
                   <ion-spinner v-if="downloadingVideo[m.id]" name="crescent" />
                   <ion-icon v-else :icon="downloadOutline" />
-                </span>
-                <span v-if="mediaMetaLabel(m)" class="video-meta">{{ mediaMetaLabel(m) }}</span>
-              </div>
+                </span>              </div>
 
               <!-- Media removed from THIS device to free space: a placeholder so the
                    chat still shows something was here (distinct from a sender-deleted
@@ -418,6 +421,8 @@
                   <span class="job-num">{{ jobPct(m.id, 'upload') }}</span>
                 </div>
               </div>
+              <!-- Media facts (quality · resolution · size) live in Message info now
+                   (long-press → Message info), not on the bubble. -->
               <!-- Direction-aware foot: react button opposite the timestamp; sent →
                    time+tick right / react left, received → time left / react right. -->
               <div class="msg-foot" :class="m.outgoing ? 'out' : 'in'">
@@ -948,6 +953,7 @@ import QuickReactBar from '@/components/QuickReactBar.vue';
 import ReactionDetails from '@/components/ReactionDetails.vue';
 import VoicePlayer from '@/components/VoicePlayer.vue';
 import VideoNote from '@/components/VideoNote.vue';
+import AnimatedImage from '@/components/AnimatedImage.vue';
 import VideoNoteRecorder from '@/components/VideoNoteRecorder.vue';
 import MediaViewer from '@/components/MediaViewer.vue';
 import { saveMessagesMedia } from '@/services/media-save';
@@ -967,12 +973,12 @@ import AnimatedEmoji from '@/components/AnimatedEmoji.vue';
 import { segmentEmoji, emojiOnlyCount } from '@/utils/emoji';
 import { userColorBright } from '@/utils/user-color';
 import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
-import { type Quality, availableQualities, qualityLabel } from '@/services/media-encode';
+import { type Quality, availableQualities, qualityLabel, isPreservedImageMime } from '@/services/media-encode';
 import { jobProgress } from '@/services/media-jobs';
-import { resolutionLabel, fileSizeLabel, generateVideoPoster, generateImageThumb, readImageMeta, readVideoMeta } from '@/utils/media-meta';
+import { generateVideoPoster, generateImageThumb, isAnimatedImage, readImageMeta, readVideoMeta } from '@/utils/media-meta';
 import { openExternal } from '@/utils/external';
 import { selectEvictions } from '@/utils/lru';
-import { normalizeOutgoing, capitalizeFirst } from '@/utils/text';
+import { normalizeOutgoing } from '@/utils/text';
 import { vEnterSend } from '@/directives/enter-send';
 import { readAudioTags, readAudioDuration } from '@/utils/id3';
 import { get, put } from '@/db/idb';
@@ -1121,25 +1127,6 @@ async function downloadVideo(id: string): Promise<void> {
   }
 }
 
-// Badge on a photo/video bubble (same facts both sides), e.g. for a video
-// "HD · 720p · 0:34 · 4.2 MB", for a photo "Full HD · 1.2 MB".
-function mediaMetaLabel(m: Message): string {
-  const parts: string[] = [];
-  if (m.mediaQuality) parts.push(qualityLabel(m.mediaQuality));
-  if (m.kind === 'video') {
-    const res = resolutionLabel(m.mediaWidth, m.mediaHeight);
-    if (res) parts.push(res);
-    if (m.durationSec) {
-      const t = Math.round(m.durationSec);
-      parts.push(`${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`);
-    }
-  } else if (m.kind === 'image' && m.mediaWidth && m.mediaHeight) {
-    parts.push(`${m.mediaWidth}×${m.mediaHeight}`);
-  }
-  const size = fileSizeLabel(m.mediaSize);
-  if (size) parts.push(size);
-  return parts.filter(Boolean).join(' · ');
-}
 
 // Encode / upload progress as a "42%" string for the in-flight bars.
 function jobPct(id: string, phase: 'compress' | 'upload'): string {
@@ -1438,11 +1425,16 @@ async function openMenu(m: Message, ev: Event) {
   const canSave = !canSaveAll && SAVE_KINDS.includes(m.kind) && (!!m.mediaId || !!m.pendingMedia);
   // Media is reachable by tapping it, but "View" stays in the menu as a fallback.
   const canView = (m.kind === 'image' || m.kind === 'video') && !m.videoNote && !!m.mediaId;
+  // Message info is offered for every outgoing message (receipts) AND for any media
+  // message in either direction (so the metadata — quality/resolution/size — is
+  // reachable on received media too, not just your own).
+  const hasMedia = !!m.mediaId && ['image', 'video', 'file', 'audio', 'voice'].includes(m.kind);
   const popover = await popoverController.create({
     component: MessageActions,
     cssClass: 'reaction-popover',
     componentProps: {
       isOutgoing: m.outgoing,
+      canInfo: m.outgoing || hasMedia,
       canCopy: !!m.body,
       canView,
       canEdit: m.outgoing && m.kind === 'text' && !m.deleted,
@@ -2096,15 +2088,66 @@ function onComposerEnter(e: KeyboardEvent): void {
    and are revoked on remove/send/unmount. */
 const pendingImages = ref<{ blob: File; url: string }[]>([]);
 
+// A bare image URL (single token, ends in a known image extension, query/hash allowed).
+const IMAGE_URL_RE = /^https?:\/\/[^\s]+\.(?:gif|webp|png|jpe?g|jfif|avif|bmp|svg)(?:[?#][^\s]*)?$/i;
+function isImageUrl(s: string): boolean {
+  return !!s && !/\s/.test(s) && IMAGE_URL_RE.test(s);
+}
+
 function onComposerPaste(e: ClipboardEvent): void {
   const images = Array.from(e.clipboardData?.items ?? [])
     .filter((it) => it.kind === 'file' && it.type.startsWith('image/'))
     .map((it) => it.getAsFile())
     .filter((f): f is File => !!f);
-  if (!images.length) return; // plain text paste → default textarea behavior
-  // Don't also insert the image's file name/uri as text.
-  e.preventDefault();
-  for (const f of images) pendingImages.value.push({ blob: f, url: URL.createObjectURL(f) });
+  if (images.length) {
+    // Don't also insert the image's file name/uri as text.
+    e.preventDefault();
+    for (const f of images) pendingImages.value.push({ blob: f, url: URL.createObjectURL(f) });
+    return;
+  }
+  // No image file on the clipboard, but the pasted text is a bare image URL → fetch it
+  // on THIS client and attach it as a normal media message. Fetching here (not on the
+  // server) keeps the zero-knowledge boundary intact: the bytes are encrypted client-side
+  // like any attachment; the server only ever relays the sealed blob.
+  const text = e.clipboardData?.getData('text/plain')?.trim() ?? '';
+  if (isImageUrl(text)) {
+    e.preventDefault();
+    void attachImageFromUrl(text);
+  }
+  // else: ordinary text paste — let the textarea handle it.
+}
+
+// Best-effort fetch of a remote image URL into a pending attachment. Many third-party
+// CDNs block cross-origin reads (CORS) or fail offline; in that case we can't read the
+// bytes, so we fall back to pasting the link as text rather than losing the paste.
+async function attachImageFromUrl(url: string): Promise<void> {
+  try {
+    const res = await fetch(url, { mode: 'cors', credentials: 'omit', redirect: 'follow' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob = await res.blob();
+    if (!blob.type.startsWith('image/')) throw new Error(`not an image (${blob.type || 'unknown'})`);
+    const name = imageNameFromUrl(url, blob.type);
+    pendingImages.value.push({ blob: new File([blob], name, { type: blob.type }), url: URL.createObjectURL(blob) });
+  } catch {
+    // CORS-blocked / offline / not an image: don't swallow the paste — put the link in
+    // the draft and tell the user why it wasn't attached.
+    draft.value = draft.value ? `${draft.value} ${url}` : url;
+    void appToast({ message: 'Couldn’t fetch that image (the site blocks it) — pasted the link instead.', duration: 2600 });
+  }
+}
+
+// Derive a filename (with a sane extension) from the URL + actual MIME.
+function imageNameFromUrl(url: string, mime: string): string {
+  let base = 'image';
+  try {
+    const path = new URL(url).pathname;
+    const last = path.split('/').pop() || '';
+    base = decodeURIComponent(last.split('.').slice(0, -1).join('.') || last) || 'image';
+  } catch {
+    /* keep default */
+  }
+  const ext = (mime.split('/')[1] || 'img').replace('jpeg', 'jpg').replace('svg+xml', 'svg');
+  return /\.[a-z0-9]+$/i.test(base) ? base : `${base}.${ext}`;
 }
 
 function removePendingImage(i: number): void {
@@ -2602,6 +2645,7 @@ interface MediaInfo {
   posterUrl?: string; // bubble tier (≤512) — chat bubble + viewer main fallback
   gridUrl?: string; // grid tier (≤320) — album grid cells (spec 1014)
   stripUrl?: string; // strip tier (≤128) — viewer bottom thumbnail strip (spec 1014)
+  animated?: boolean; // GIF / animated WebP → bubble plays the moving original while visible
   mime: string;
   name: string;
 }
@@ -2712,6 +2756,17 @@ async function resolveMediaFor(list: Message[]): Promise<void> {
         } catch {
           /* best-effort cache */
         }
+      });
+    }
+    // Images: flag animated GIF / animated WebP so the bubble renders the moving
+    // original (autoplaying while visible) instead of a static poster (spec: GIFs
+    // autoplay in chat). Static images/photos keep the lightweight poster path.
+    if (m.kind === 'image' && media.blob) {
+      const blob = media.blob;
+      const mid = m.mediaId;
+      const mime = media.mime;
+      void isAnimatedImage(mime, blob).then((animated) => {
+        if (animated && mediaInfo.value[mid]) mediaInfo.value[mid] = { ...mediaInfo.value[mid], animated: true };
       });
     }
     // Audio (shared music): pull embedded cover art for the track card.
@@ -2982,11 +3037,20 @@ async function send() {
   // Pasted images go out with the typed text as the caption (on the first image
   // when several were pasted — they share an album grid like the picker flow).
   if (pendingImages.value.length) {
-    const longEdge = await maxSourceLongEdge(
-      pendingImages.value.map((p) => ({ blob: p.blob, kind: 'image' as const })),
-    );
-    const quality = await pickQuality(longEdge);
-    if (quality === null) return; // cancelled: keep the images and the draft
+    // GIF / WebP are always sent untouched (animation/alpha preserved), so a quality
+    // prompt would be a no-op — skip it when every pending image is one of those. A
+    // mixed batch still asks, since the JPEG/PNG items genuinely have tiers to choose.
+    let quality: Quality;
+    if (pendingImages.value.every((p) => isPreservedImageMime(p.blob.type))) {
+      quality = 'original';
+    } else {
+      const longEdge = await maxSourceLongEdge(
+        pendingImages.value.map((p) => ({ blob: p.blob, kind: 'image' as const })),
+      );
+      const picked = await pickQuality(longEdge);
+      if (picked === null) return; // cancelled: keep the images and the draft
+      quality = picked;
+    }
     const images = pendingImages.value.slice();
     pendingImages.value = [];
     draft.value = '';
@@ -3211,10 +3275,15 @@ async function onPick(e: Event, mode: 'auto' | 'file') {
   let replyLeft = reply; // the quote attaches to the first item sent
 
   if (otherFiles.length) {
-    // Photos/videos can be sent at HD/SD/Original; ask once for the whole batch.
-    const hasMedia = otherFiles.some((f) => kindOf(f) === 'image' || kindOf(f) === 'video');
+    // Photos/videos can be sent at HD/SD/Original; ask once for the whole batch — but
+    // only when something in it actually has tiers to choose. GIF/WebP are always sent
+    // untouched, so a batch of only those (no other photos/videos) skips the prompt.
+    const needsQuality = otherFiles.some((f) => {
+      const k = kindOf(f);
+      return (k === 'image' || k === 'video') && !isPreservedImageMime(f.type);
+    });
     let quality: Quality = 'original';
-    if (hasMedia) {
+    if (needsQuality) {
       const longEdge = await maxSourceLongEdge(
         otherFiles.map((f) => ({ blob: f, kind: kindOf(f) as 'image' | 'video' | 'file' })),
       );
@@ -4174,20 +4243,6 @@ function cancelRecording() {
 .dl-btn ion-spinner {
   width: 26px;
   height: 26px;
-}
-/* Resolution · length · size badge on a video thumbnail (both sides). */
-.video-meta {
-  position: absolute;
-  left: 6px;
-  bottom: 6px;
-  display: inline-block;
-  padding: 2px 7px;
-  border-radius: 10px;
-  background: rgba(0, 0, 0, 0.55);
-  color: #fff;
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  pointer-events: none;
 }
 /* Link preview card (privacy-safe: domain + icon, no remote fetch). */
 .link-card {

--- a/src/views/detail/ContactDetailPage.vue
+++ b/src/views/detail/ContactDetailPage.vue
@@ -33,6 +33,32 @@
           </ion-button>
         </div>
 
+        <!-- Local name/photo override + a staged remote change to adopt. -->
+        <ion-list v-if="!contact.ghosted" :inset="true">
+          <ion-item v-if="contact.pendingName != null || contact.pendingAvatar != null" lines="full">
+            <ion-icon slot="start" :icon="personOutline" color="primary" />
+            <ion-label class="ion-text-wrap">
+              <p>They updated their profile</p>
+              <h2>{{ contact.pendingName ?? contact.name }}</h2>
+            </ion-label>
+            <ion-button slot="end" size="small" fill="clear" @click="dismissPending">Not now</ion-button>
+            <ion-button slot="end" size="small" @click="adoptPending">Use it</ion-button>
+          </ion-item>
+          <ion-item button :detail="false" @click="editName">
+            <ion-icon slot="start" :icon="createOutline" />
+            <ion-label>Edit name</ion-label>
+          </ion-item>
+          <ion-item button :detail="false" @click="photoInput?.click()">
+            <ion-icon slot="start" :icon="cameraOutline" />
+            <ion-label>Change photo</ion-label>
+          </ion-item>
+          <ion-item v-if="contact.localProfile" button :detail="false" @click="resetProfile">
+            <ion-icon slot="start" :icon="refreshOutline" color="medium" />
+            <ion-label>Reset to their name &amp; photo</ion-label>
+          </ion-item>
+        </ion-list>
+        <input ref="photoInput" type="file" accept="image/*" hidden @change="onPickPhoto" />
+
         <ion-list v-if="!contact.ghosted && contact.about" :inset="true">
           <ion-item lines="none">
             <ion-label class="ion-text-wrap">
@@ -126,13 +152,16 @@ import {
 import {
   chatbubbleOutline, searchOutline, banOutline, imagesOutline,
   notificationsOutline, notificationsOffOutline, starOutline, timerOutline, eyeOutline, documentTextOutline,
+  createOutline, cameraOutline, refreshOutline, personOutline,
 } from 'ionicons/icons';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import {
   getContact, startDirectChat, blockContact, unblockContact, listChats, setChatMute, setChatTtl,
   getPresenceOverrides, setPresenceOverride, setChatNotifyPrefs, type ChatNotifyContent,
+  setContactLocalProfile, resetContactToRemote, adoptContactProfile, dismissContactProfile, downscaleAvatar,
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
+import { refetchContactProfile } from '@/services/directory';
 import { ensureProfile } from '@/composables/useProfileGate';
 import { forceReconnect } from '@/composables/useSync';
 import type { Contact, Chat } from '@/db/types';
@@ -142,6 +171,57 @@ import { peerPresence, presenceLabel } from '@/composables/usePresence';
 const route = useRoute();
 const router = useRouter();
 const contactId = route.params.id as string;
+const photoInput = ref<HTMLInputElement | null>(null);
+
+// ---- local name/photo override + adopt a staged remote change ----
+async function editName(): Promise<void> {
+  const a = await alertController.create({
+    header: 'Edit name',
+    message: 'This name is stored only on your device.',
+    inputs: [{ name: 'name', type: 'text', value: contact.value?.name ?? '', placeholder: 'Name' }],
+    buttons: [
+      { text: 'Cancel', role: 'cancel' },
+      {
+        text: 'Save',
+        handler: async (d: { name?: string }) => {
+          const n = (d.name ?? '').trim();
+          if (n) await setContactLocalProfile(contactId, { name: n });
+        },
+      },
+    ],
+  });
+  await a.present();
+}
+async function onPickPhoto(e: Event): Promise<void> {
+  const input = e.target as HTMLInputElement;
+  const file = input.files?.[0];
+  input.value = ''; // allow re-picking the same file
+  if (!file) return;
+  try {
+    const dataUrl = await new Promise<string>((res, rej) => {
+      const r = new FileReader();
+      r.onload = () => res(r.result as string);
+      r.onerror = () => rej(r.error);
+      r.readAsDataURL(file);
+    });
+    const avatar = await downscaleAvatar(dataUrl);
+    await setContactLocalProfile(contactId, { avatar });
+  } catch {
+    await appToast({ message: "Couldn't use that image.", color: 'danger' });
+  }
+}
+async function resetProfile(): Promise<void> {
+  // Optimistic: drop the override + revert to the last-known remote (works offline),
+  // then re-pull the peer's CURRENT name/photo from the directory and apply it.
+  await resetContactToRemote(contactId);
+  await refetchContactProfile(contactId);
+}
+async function adoptPending(): Promise<void> {
+  await adoptContactProfile(contactId);
+}
+async function dismissPending(): Promise<void> {
+  await dismissContactProfile(contactId);
+}
 
 const contact = useLiveQuery<Contact | undefined>(
   () => getContact(contactId),

--- a/src/views/detail/MessageInfoPage.vue
+++ b/src/views/detail/MessageInfoPage.vue
@@ -18,6 +18,7 @@
           <ion-note slot="end">
             {{ formatTime(message.timestamp) }}
             <ion-icon
+              v-if="isOutgoingMsg"
               class="tick"
               :icon="statusIcon(message.status)"
               :color="seenReceiptsOn && message.status === 'seen' ? 'primary' : undefined"
@@ -26,10 +27,39 @@
         </ion-item>
       </ion-list>
 
+      <!-- Media facts (quality · resolution · size · format · duration). Shown for
+           media in BOTH directions — the metadata that used to sit on the bubble. -->
+      <ion-list :inset="true" v-if="message && hasMediaMeta">
+        <ion-list-header>
+          <ion-icon :icon="informationCircleOutline" />
+          <ion-label>Media</ion-label>
+        </ion-list-header>
+        <ion-item v-if="formatLabel" lines="inset">
+          <ion-label>Format</ion-label>
+          <ion-note slot="end">{{ formatLabel }}</ion-note>
+        </ion-item>
+        <ion-item v-if="resolution" lines="inset">
+          <ion-label>Resolution</ion-label>
+          <ion-note slot="end">{{ resolution }}</ion-note>
+        </ion-item>
+        <ion-item v-if="durationText" lines="inset">
+          <ion-label>Duration</ion-label>
+          <ion-note slot="end">{{ durationText }}</ion-note>
+        </ion-item>
+        <ion-item v-if="qualityText" lines="inset">
+          <ion-label>Quality</ion-label>
+          <ion-note slot="end">{{ qualityText }}</ion-note>
+        </ion-item>
+        <ion-item v-if="sizeText" lines="none">
+          <ion-label>Size</ion-label>
+          <ion-note slot="end">{{ sizeText }}</ion-note>
+        </ion-item>
+      </ion-list>
+
       <!-- Group: per-member Seen by / Delivered / Not yet delivered, covering every
            member of the roster (spec 1010 FR-006). Each tier shows a capped avatar
            stack (5 + "+N") plus the members' names. -->
-      <template v-if="isGroup">
+      <template v-if="isGroup && isOutgoingMsg">
         <!-- Seen by — suppressed entirely when "Seen receipts" is off (reciprocity:
              you don't get to see others' seen on your own messages). -->
         <ion-list :inset="true" v-if="seenReceiptsOn">
@@ -90,8 +120,8 @@
         </ion-list>
       </template>
 
-      <!-- 1:1: simple status timeline -->
-      <ion-list :inset="true" v-else-if="message">
+      <!-- 1:1: simple status timeline (outgoing only — receipts don't apply to received). -->
+      <ion-list :inset="true" v-else-if="message && isOutgoingMsg">
         <ion-item v-if="seenReceiptsOn && reached('seen')">
           <ion-icon slot="start" :icon="checkmarkDone" color="primary" />
           <ion-label>Seen</ion-label>
@@ -120,11 +150,14 @@ import {
   IonContent, IonList, IonListHeader, IonItem, IonAvatar, IonLabel,
   IonNote, IonIcon,
 } from '@ionic/vue';
-import { checkmark, checkmarkDone, timeOutline } from 'ionicons/icons';
+import { checkmark, checkmarkDone, timeOutline, informationCircleOutline } from 'ionicons/icons';
 import { getMessage, getChat, listContacts, getSetting } from '@/db/queries';
+import { get } from '@/db/idb';
 import { initialsAvatar } from '@/db/avatars';
-import type { Chat, Contact, Message, MessageStatus } from '@/db/types';
+import type { Chat, Contact, Media, Message, MessageStatus } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
+import { isPreservedImageMime, qualityLabel } from '@/services/media-encode';
+import { fileSizeLabel } from '@/utils/media-meta';
 import { formatTime } from '@/utils/time';
 
 const route = useRoute();
@@ -138,6 +171,47 @@ const message = useLiveQuery<Message | undefined>(
 );
 const chat = useLiveQuery<Chat | undefined>(() => getChat(chatId), ['chats'], undefined);
 const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+
+// The on-device media record (for the MIME type → format label + preserved check).
+// Re-runs once the message resolves and we learn its mediaId.
+const media = useLiveQuery<Media | undefined>(
+  () => (message.value?.mediaId ? get<Media>('media', message.value.mediaId) : Promise.resolve(undefined)),
+  ['media'],
+  undefined,
+  () => message.value?.mediaId,
+);
+
+const isOutgoingMsg = computed(() => message.value?.outgoing === true);
+
+// Media facts (formerly a badge on the bubble) — shown here for media in BOTH
+// directions, so received media's quality/resolution/size is inspectable too.
+const formatLabel = computed(() => {
+  const mime = media.value?.mime;
+  if (!mime) return '';
+  const sub = mime.split('/')[1] ?? '';
+  const friendly: Record<string, string> = { jpeg: 'JPEG', 'svg+xml': 'SVG', mpeg: 'MP3', quicktime: 'MOV', 'octet-stream': '' };
+  return friendly[sub] ?? (sub ? sub.toUpperCase() : '');
+});
+const resolution = computed(() =>
+  message.value?.mediaWidth && message.value?.mediaHeight ? `${message.value.mediaWidth}×${message.value.mediaHeight}` : '',
+);
+const durationText = computed(() => {
+  const s = message.value?.durationSec;
+  if (!s) return '';
+  const t = Math.round(s);
+  return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`;
+});
+// GIF/WebP are always sent untouched, so "Original" is noise — drop it for those.
+const qualityText = computed(() => {
+  const q = message.value?.mediaQuality;
+  const mime = media.value?.mime;
+  if (!q || (mime && isPreservedImageMime(mime))) return '';
+  return qualityLabel(q);
+});
+const sizeText = computed(() => fileSizeLabel(message.value?.mediaSize));
+const hasMediaMeta = computed(
+  () => !!(formatLabel.value || resolution.value || durationText.value || qualityText.value || sizeText.value),
+);
 
 // "Seen receipts" privacy preference (default on), reactive. Reciprocity DISPLAY
 // gate (spec 1010 FR-009): when off, we don't render the seen tier on our own

--- a/src/views/detail/NewGroupCallPage.vue
+++ b/src/views/detail/NewGroupCallPage.vue
@@ -89,7 +89,6 @@ import { startAdHocGroupCall } from '@/composables/useCall';
 import { VIDEO_MAX, AUDIO_MAX } from '@/services/call/types';
 import { appToast } from '@/services/toast';
 import { ensureProfile } from '@/composables/useProfileGate';
-import { capitalizeFirst } from '@/utils/text';
 
 const router = useRouter();
 const search = ref('');
@@ -128,7 +127,7 @@ function toggle(id: string): void {
 // callees see a generic "Group call" since the room has no chat behind it.
 const selectedContacts = computed(() => contacts.value.filter((c) => selected.value.has(c.id)));
 const selectedNames = computed(() => {
-  const names = selectedContacts.value.map((c) => capitalizeFirst(c.name));
+  const names = selectedContacts.value.map((c) => c.name);
   if (names.length <= 1) return names.join('');
   if (names.length === 2) return `${names[0]} and ${names[1]}`;
   return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;

--- a/src/views/detail/SettingDetailPage.vue
+++ b/src/views/detail/SettingDetailPage.vue
@@ -173,9 +173,9 @@ import { clearToken } from '@/services/auth';
 import { isUnlockedNow, rotateRecoveryCode, enableLock, disableLock, getPinLength } from '@/services/crypto/identity';
 import { disablePasskey } from '@/services/crypto/passkey';
 import { syncRecoveryWrap } from '@/services/ownsync';
-import { hasHiddenPin, verifyHiddenPin, changeHiddenPin } from '@/services/hidden-chats';
+import { hasHiddenPin, verifyHiddenPin, changeHiddenPin, hiddenPinLength } from '@/services/hidden-chats';
 import { resetHiddenChats } from '@/services/hidden-chats-reset';
-import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
+import { ensureHiddenPin, presentHiddenPinPad } from '@/composables/hiddenPinPrompt';
 import type { Setting } from '@/db/types';
 import {
   ICONS, settingNode, linkSummary, type SettingItem,
@@ -228,7 +228,28 @@ async function onToggle(key: string, checked: boolean): Promise<void> {
     await onAppLockToggle(checked);
     return;
   }
+  if (key === 'privacy.hiddenChatsEnabled') {
+    await onHiddenChatsToggle(checked);
+    return;
+  }
   await setSetting(key, checked);
+}
+
+// Enabling hidden chats is meaningless without a reveal PIN — there'd be no way to
+// ever get a hidden chat back. So turning it on prompts to create the PIN up front
+// (ensureHiddenPin no-ops if one already exists), and a cancel reverts the toggle
+// to off rather than leaving the feature half-armed. Turning it off just persists;
+// the PIN/hidden set stay put (use "Reset PIN & delete hidden chats" to wipe them).
+async function onHiddenChatsToggle(enable: boolean): Promise<void> {
+  if (!enable) {
+    await setSetting('privacy.hiddenChatsEnabled', false);
+    return;
+  }
+  if (!(await ensureHiddenPin())) {
+    await setSetting('privacy.hiddenChatsEnabled', false); // cancelled → stay off
+    return;
+  }
+  await setSetting('privacy.hiddenChatsEnabled', true);
 }
 
 // Ring auto-unlocks without a passcode by default (the device key keeps the keys
@@ -423,12 +444,12 @@ const ACTIONS: Record<string, () => void | Promise<void>> = {
       if (await ensureHiddenPin()) await setSetting('privacy.hiddenChatsEnabled', true);
       return;
     }
-    const current = await promptPin('Enter your current Hidden Chats PIN');
+    const current = await presentHiddenPinPad('verify', (await hiddenPinLength()) ?? undefined);
     if (current === null) return;
     if (!(await verifyHiddenPin(current))) {
       return notice('Hidden chats', 'That PIN is incorrect.');
     }
-    const next = await promptPin('Enter a new PIN (4+ digits)', true);
+    const next = await presentHiddenPinPad('set');
     if (next === null) return;
     await changeHiddenPin(current, next);
     notice('Hidden chats', 'Your PIN has been changed.');
@@ -462,38 +483,6 @@ async function notice(header: string, message: string) {
     buttons: ['OK'],
   });
   await a.present();
-}
-
-// Prompt for a numeric PIN. With `confirm`, requires a matching second entry and
-// 4+ digits (used for setting a NEW PIN); otherwise just returns the entry (used
-// for verifying the current PIN). Resolves null on cancel.
-async function promptPin(header: string, confirm = false): Promise<string | null> {
-  return new Promise((resolve) => {
-    const inputs = [
-      { name: 'pin', type: 'password' as const, attributes: { inputmode: 'numeric' }, placeholder: 'PIN' },
-      ...(confirm
-        ? [{ name: 'confirm', type: 'password' as const, attributes: { inputmode: 'numeric' }, placeholder: 'Confirm PIN' }]
-        : []),
-    ];
-    void alertController
-      .create({
-        header,
-        inputs,
-        buttons: [
-          { text: 'Cancel', role: 'cancel', handler: () => resolve(null) },
-          {
-            text: 'OK',
-            handler: (data: { pin?: string; confirm?: string }) => {
-              const pin = (data.pin ?? '').trim();
-              if (confirm && (!/^\d{4,}$/.test(pin) || pin !== (data.confirm ?? '').trim())) return false;
-              resolve(pin);
-              return true;
-            },
-          },
-        ],
-      })
-      .then((a) => a.present());
-  });
 }
 
 // Present the freshly-rotated recovery code with a copy action. The code goes in

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -59,7 +59,7 @@
       <!-- Empty states. With no chats at all, a hint row points to Contacts to
            start a conversation (mirrors the Contacts "Browse user directory" row);
            a filtered view that happens to be empty just says so. -->
-      <ion-list v-if="loaded && activeFilter === 'all' && allChats.length === 0" class="hint-list">
+      <ion-list v-if="ready && activeFilter === 'all' && allChats.length === 0" class="hint-list">
         <!-- router.replace (not push): switching to a tab is terminal, like tapping
              the tab bar — it must not grow history (see navigation.spec). -->
         <ion-item button :detail="true" lines="full" @click="router.replace('/tabs/contacts')">
@@ -70,7 +70,7 @@
           </ion-label>
         </ion-item>
       </ion-list>
-      <div v-else-if="loaded && chats.length === 0" class="empty">
+      <div v-else-if="ready && chats.length === 0" class="empty">
         <ion-note>{{ emptyMessage }}</ion-note>
       </div>
 
@@ -128,15 +128,11 @@
             <ion-icon slot="start" :icon="personAddOutline" color="primary" />
             <ion-label>Add contact</ion-label>
           </ion-item>
-          <!-- New hidden chat (spec 1019, US2): a distinct conversation that
-               coexists with any normal 1:1 with the same person. Only shown when
-               the feature is enabled. -->
-          <ion-item v-if="hiddenEnabled" button :detail="false" @click="hiddenMode = !hiddenMode">
-            <ion-icon slot="start" :icon="eyeOffOutline" :color="hiddenMode ? 'primary' : 'medium'" />
-            <ion-label :color="hiddenMode ? 'primary' : undefined">
-              {{ hiddenMode ? 'Pick a contact for the hidden chat…' : 'New hidden chat' }}
-            </ion-label>
-          </ion-item>
+          <!-- Deliberately NO "New hidden chat" entry here (spec 1019): surfacing it
+               in the New-chat sheet would advertise the feature to anyone who opens
+               it, undercutting the plausible deniability the whole design rests on.
+               A hidden chat is only ever created by hiding an existing conversation
+               (the swipe → More → "Hide chat" action). -->
         </ion-list>
         <ion-list>
           <ion-list-header><ion-label>Contacts</ion-label></ion-list-header>
@@ -162,7 +158,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, watch, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton,
@@ -185,8 +181,7 @@ import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useConnect } from '@/composables/useConnect';
 import { useHiddenChats } from '@/composables/useHiddenChats';
 import { hiddenPinLength } from '@/services/hidden-chats';
-import { startHiddenChat } from '@/services/hidden-chats-start';
-import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
+import { isUnlocked } from '@/services/crypto/identity';
 import type { Chat, Contact } from '@/db/types';
 
 const router = useRouter();
@@ -200,7 +195,6 @@ const { connect, requireProfile } = useConnect();
 const { revealed, reveal, relock } = useHiddenChats();
 const pinLen = ref<number | null>(null);
 const hiddenEnabled = ref(false);
-const hiddenMode = ref(false); // New-chat modal: next contact tap starts a hidden chat
 onMounted(async () => {
   pinLen.value = await hiddenPinLength();
   hiddenEnabled.value = await getSetting<boolean>('privacy.hiddenChatsEnabled', false);
@@ -218,6 +212,19 @@ async function onSearchInput(val: string): Promise<void> {
 
 // Filtered chat list + chips (All / Unread / Favorites / Groups + lists).
 const { chats, activeFilter, setActive, chips, lists, tabFilters, allChats, loaded } = useChatFilters(search);
+// Don't render an empty state until the list has settled on a result we can trust.
+// At cold open the query can resolve to [] while the keystore is still locked
+// (listChats fails CLOSED until the hidden set is known — see queries.ts), and that
+// transient empty must NOT be read as "you have no chats" and flash the
+// "Start a conversation" hint before the real chats load. Gating on isUnlocked alone
+// isn't enough: there's a sub-frame window where the keystore is unlocked but the
+// list hasn't re-queried yet, so allChats still holds the stale []. We therefore flip
+// `ready` only when a query RESOLVES while unlocked — i.e. allChats changes after
+// unlock — at which point allChats holds the real result and the checks below are
+// consistent with what we render. A re-lock resets it so we wait again.
+const ready = ref(false);
+watch(isUnlocked, (u) => { if (!u) ready.value = false; });
+watch(allChats, () => { if (isUnlocked.value) ready.value = true; }, { immediate: true });
 const listsSheetOpen = ref(false);
 const editTabsOpen = ref(false);
 const newListOpen = ref(false);
@@ -283,15 +290,6 @@ const pickContacts = useLiveQuery(
 
 async function startChat(person: Contact) {
   if (!(await requireProfile())) return;
-  if (hiddenMode.value) {
-    // Start a distinct hidden conversation that coexists with any normal 1:1.
-    if (!(await ensureHiddenPin())) return; // need a PIN to ever reveal it
-    const id = await startHiddenChat(person.id);
-    hiddenMode.value = false;
-    newOpen.value = false;
-    router.push(`/chat/${id}`); // open by id works regardless of hidden state
-    return;
-  }
   const chatId = await startDirectChat(person);
   newOpen.value = false;
   router.push(`/chat/${chatId}`);

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -131,7 +131,7 @@
                 <span v-if="peerPresence(person.id)?.online" class="presence-dot" aria-hidden="true" />
               </div>
               <ion-label>
-                <h2>{{ capitalizeFirst(person.name) }}</h2>
+                <h2>{{ person.name }}</h2>
                 <p>{{ person.about }}</p>
               </ion-label>
             </ion-item>
@@ -161,7 +161,7 @@
               <img :src="person.avatar" :alt="person.name" />
             </ion-avatar>
             <ion-label>
-              <h2>{{ capitalizeFirst(person.name) }}</h2>
+              <h2>{{ person.name }}</h2>
               <p>Blocked</p>
             </ion-label>
             <ion-icon slot="end" :icon="banOutline" color="medium" />
@@ -214,7 +214,6 @@ import { useLiveQuery } from '@/composables/useLiveQuery';
 import { warmContacts, warmContactsLoaded, warmWhenIdle } from '@/composables/warmStores';
 import { useConnect } from '@/composables/useConnect';
 import { peerPresence } from '@/composables/usePresence';
-import { capitalizeFirst } from '@/utils/text';
 
 const PAGE = 15;
 const router = useRouter();


### PR DESCRIPTION
A round of UX, media, privacy, and reliability improvements (no spec — direct improvements).

## Media
- **GIFs & animated WebP autoplay** in chat while visible (freeze off-screen); sent untouched so animation survives; quality prompt skipped for them.
- **Paste an image URL** → fetched on the sender's device and sent as a media message (CORS-blocked links fall back to pasting the link).
- Photo/video **metadata moved to Message info** (and now visible for received media too).

## Contacts
- **Local name/photo override** per contact (Contact info → Edit name / Change photo) + **Reset** (re-pulls their current profile from the directory).
- **Adopt-or-dismiss prompt** when a peer changes their name/photo (decline = not re-asked until they change again).
- Names shown **verbatim** (no forced capitalization, so "iPad" stays "iPad"); chat-list names left-aligned (incl. RTL/group).

## Privacy / hidden chats
- No **startup flash** of hidden chats; revealed ones sort to the top with a marker.
- Locked hidden chats make **no banner/sound**; a new **badge** preference (Always / Only while revealed / Never).
- Hidden Chats **PIN uses the keypad** (not text boxes); removed the discoverable "New hidden chat" entry; enabling now prompts for the PIN.

## App lock & input
- Auto-lock timing: **Never** + tidier intervals.
- **PIN keypad ghost-tap fixed** (last digit no longer opens the chat underneath after unlock).

## Reliability (iOS)
- ringd forces **HTTP/1.1** (keeps acme-tls/1) and the SW gains an **app-shell navigation fallback** — fixes large media uploads failing and the "Safari can't open the page" interstitial on notification taps.

## Verification
- `npm run build` (vue-tsc) ✅, `vitest run` 395/395 ✅, server `go build`/`vet`/`test` ✅ locally.
- Each behaviour verified against the live dev app via new `drive/scenarios/*` harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)