### PR TITLE
fix(chat): keyboard stays during reactions, Android composer re-pin, and a hidden-chat loophole

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3655,22 +3655,30 @@ export async function addContact(name: string, phone: string): Promise<string> {
  */
 export async function startDirectChat(contact: Contact): Promise<string> {
   const chats = await getAll<Chat>('chats');
+  // NEVER resolve to a hidden chat (spec 1019): starting a chat from the contact must
+  // not open a PIN-locked hidden conversation — that would reveal it without the PIN.
+  // A hidden chat coexists with a normal one; this path only ever uses/creates the
+  // normal (non-hidden) chat, creating a fresh one when the sole match is hidden.
+  const hiddenSet = await ensureHiddenLoaded();
   const matches = chats.filter(
-    (c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === contact.id,
+    (c) =>
+      !c.isGroup &&
+      c.participantIds.length === 1 &&
+      c.participantIds[0] === contact.id &&
+      !hiddenSet.has(c.id),
   );
-  // Prefer a real (visible) chat over a hidden one, e.g. a group session-carrier
-  // chat or an unaccepted-request placeholder.
+  // Prefer a real (visible) chat over an unaccepted-request placeholder.
   const visible = matches.find((c) => !c.pending);
   if (visible) return visible.id;
-  const hidden = matches[0];
-  if (hidden) {
+  const placeholder = matches[0];
+  if (placeholder) {
     // Opening a chat with an already-accepted friend → make it visible.
-    if (hidden.pending && (await isPeerConnected(contact.id))) {
-      hidden.pending = false;
-      hidden.updatedAt = now();
-      await put('chats', hidden);
+    if (placeholder.pending && (await isPeerConnected(contact.id))) {
+      placeholder.pending = false;
+      placeholder.updatedAt = now();
+      await put('chats', placeholder);
     }
-    return hidden.id;
+    return placeholder.id;
   }
   const ts = now();
   const id = uid();

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -432,6 +432,7 @@
                   class="react-btn"
                   aria-label="React"
                   @click.stop="openQuickReact(m, $event)"
+                  @pointerdown.prevent
                 >
                   <ion-icon :icon="happyOutline" />
                 </button>
@@ -578,6 +579,7 @@
                   class="react-btn"
                   aria-label="React"
                   @click.stop="openQuickReact(item.messages[0], $event)"
+                  @pointerdown.prevent
                 >
                   <ion-icon :icon="happyOutline" />
                 </button>
@@ -810,6 +812,7 @@
             :spellcheck="true"
             enterkeyhint="enter"
             @ion-input="onComposerInput"
+            @ion-focus="onComposerFocus"
             @ion-blur="onComposerBlur"
             @keydown.enter="onComposerEnter"
             @paste="onComposerPaste"
@@ -1405,6 +1408,7 @@ async function openQuickReact(m: Message, ev: Event): Promise<void> {
     side: popoverSide(ev),
     alignment: 'center',
     showBackdrop: false, // don't dim the chat behind the popover
+    keyboardClose: false, // reacting must NOT dismiss the keyboard if the composer is focused
   });
   openPopover = popover;
   await popover.present();
@@ -2072,6 +2076,18 @@ function onComposerInput(e: CustomEvent): void {
 
 function onComposerBlur(): void {
   stopActivity('typing'); // blurring the field ends typing (not a recording)
+}
+
+// Focusing the composer raises the keyboard. The ResizeObserver re-pins to newest on
+// the viewport shrink, but on Android the keyboard-resize settles in steps and that
+// single observation can fire before the layout is final, leaving the last message
+// partially behind the composer. Re-assert scroll-to-newest a few times after focus —
+// but only while the user is already at the bottom (stickBottom), so it never yanks
+// someone out of reading history.
+function onComposerFocus(): void {
+  if (!stickBottom) return;
+  void scrollToNewest();
+  for (const ms of [150, 350, 600]) setTimeout(() => { if (stickBottom) void scrollToNewest(); }, ms);
 }
 
 // Block Return while the composer is empty (or only whitespace) so a message can't


### PR DESCRIPTION
Three independent chat fixes (not part of the @mentions feature spec).

## 1. Reacting dismisses the keyboard
The quick-react popover used Ionic's default `keyboardClose: true`, and tapping the react button blurred the focused composer. Now the popover sets `keyboardClose: false` and the react buttons `preventDefault` on `pointerdown`, so the keyboard stays up when you react while typing.

## 2. Android: composer covers the last message
On Android the on-screen keyboard settles in steps, so the single ResizeObserver re-pin could fire before layout was final and leave the last message tucked behind the composer. The composer's `@ion-focus` now re-asserts scroll-to-newest a few times (only while already at the bottom, so it never interrupts reading history). *Best-effort — needs a real Android device to fully confirm; low-risk + additive (no change to the tuned iOS path).*

## 3. Hidden-chat loophole (privacy)
Starting a chat from a contact resolved to the existing 1:1 even when it was a **PIN-locked hidden chat** — reaching it without the reveal PIN. `startDirectChat` now excludes the hidden set and creates a fresh **normal** chat when the only match is hidden (a hidden chat coexists with the normal one, per spec 1019).

## Verification
- `npm run build` (vue-tsc) ✅.
- Loophole verified via the drive harness: hide the chat → "start a chat" returns a NEW, non-hidden chat (≠ the hidden one), visible without the PIN; the hidden chat stays locked.
- (1) and (2) are keyboard/Android behaviors not reproducible in headless CI — verified by code path; (1) is a well-understood Ionic flag + focus fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)