### PR TITLE
feat(mentions): @mention people in group chats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1019-hidden-chats-pin/plan.md`
+`specs/1020-mentions-group-chats/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ Specs are grouped by category band; status moves
 | [1017](specs/1017-cache-reusable-assets/spec.md) | Cache reusable assets (animated emoji + avatars) so they aren't refetched | 🔵 in-review |
 | [1018](specs/1018-media-sharing-and/spec.md) | Media Sharing & Viewer Improvements | 🔵 in-review |
 | [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | 🔵 in-review |
-| [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | ⚪ planned |
+| [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,6 +43,7 @@ Specs are grouped by category band; status moves
 | [1017](specs/1017-cache-reusable-assets/spec.md) | Cache reusable assets (animated emoji + avatars) so they aren't refetched | 🔵 in-review |
 | [1018](specs/1018-media-sharing-and/spec.md) | Media Sharing & Viewer Improvements | 🔵 in-review |
 | [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | 🔵 in-review |
+| [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/mention-chip.mjs
+++ b/drive/scenarios/mention-chip.mjs
@@ -1,0 +1,28 @@
+import { createAccount, pair, group, shot, sweep, done } from '../driver.mjs';
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+const carol = await createAccount({ name: 'Carol' });
+await pair(alice, bob); await pair(alice, carol); await pair(bob, carol);
+const gid = await group(alice, 'Squad', [bob, carol]);
+const bobU = await bob.page.evaluate(() => window.__ringTest.selfUsername());
+console.log('[bob username] %s', bobU);
+
+await alice.page.evaluate(([id, u, bid]) => window.__ringTest.sendWithMentions(id, `hello @${u} look here`, [bid]), [gid, bobU, bob.id]);
+
+const readChips = async (cli) => {
+  await cli.page.goto(`/chat/${gid}`);
+  await cli.page.waitForFunction(() => document.querySelector('.text'), null, { timeout: 10000 }).catch(()=>{});
+  await cli.page.waitForTimeout(900);
+  return cli.page.evaluate(() => Array.from(document.querySelectorAll('.mention')).map(e => ({ text: e.textContent.trim(), me: e.classList.contains('me') })));
+};
+const carolChips = await readChips(carol);
+const bobChips = await readChips(bob);
+console.log('[carol chips] %j', carolChips);
+console.log('[bob   chips] %j', bobChips);
+await shot(bob, 'mention-chip', {});
+
+const pass =
+  carolChips.some(c => /@Bob/.test(c.text) && !c.me) &&
+  bobChips.some(c => c.me);
+console.log(pass ? '[PASS] mention renders as a chip; self-mention emphasized on the mentioned user' : '[FAIL] see above');
+await sweep([alice, bob, carol]); await done();

--- a/drive/scenarios/mention-composer.mjs
+++ b/drive/scenarios/mention-composer.mjs
@@ -1,0 +1,46 @@
+import { createAccount, pair, group, shot, sweep, done } from '../driver.mjs';
+const alice = await createAccount({ name: 'Alice' });   // owner
+const bob = await createAccount({ name: 'Bob' });
+const carol = await createAccount({ name: 'Carol' });
+await pair(alice, bob); await pair(alice, carol); await pair(bob, carol);
+const gid = await group(alice, 'Squad', [bob, carol]);
+const bobU = await bob.page.evaluate(() => window.__ringTest.selfUsername());
+
+const rowsFor = async (cli, q) => {
+  await cli.page.goto(`/chat/${gid}`);
+  await cli.page.waitForSelector('#chat-footer textarea', { timeout: 10000 });
+  const ta = cli.page.locator('#chat-footer textarea');
+  await ta.fill(q);
+  await cli.page.waitForTimeout(400);
+  return cli.page.evaluate(() => Array.from(document.querySelectorAll('.mention-row')).map(e => e.textContent.replace(/\s+/g,' ').trim()));
+};
+
+const ownerAt = await rowsFor(alice, '@');           // owner sees members + Everyone
+const ownerBo = await rowsFor(alice, 'hey @Bo');     // filters to Bob
+const bobAt = await rowsFor(bob, '@');               // non-owner: NO Everyone
+console.log('[owner @ ] %j', ownerAt);
+console.log('[owner @Bo] %j', ownerBo);
+console.log('[bob   @ ] %j', bobAt);
+await shot(alice, 'mention-composer', {});
+
+// Pick Bob from the filtered list, then finish + send.
+// Pick from the autocomplete → the @token is inserted into the draft.
+await alice.page.goto(`/chat/${gid}`); await alice.page.waitForSelector('#chat-footer textarea');
+const ta = alice.page.locator('#chat-footer textarea');
+await ta.fill('hey @Bo');
+await alice.page.waitForTimeout(400);
+await alice.page.locator('.mention-row', { hasText: 'Bob' }).first().click();
+await alice.page.waitForTimeout(300);
+const inserted = await ta.inputValue();
+console.log('[inserted] "%s"', inserted);
+// (The send()→resolveMentions→sendMessage(mentions) path is proven end-to-end by
+// mention-core.mjs; the Send button can't be reliably tapped here because Ionic caches
+// pages in the DOM and raw selectors hit a stale instance — not a product issue.)
+
+const pass =
+  ownerAt.some(r => /Everyone/.test(r)) && ownerAt.some(r => /Bob/.test(r)) &&
+  ownerBo.length >= 1 && ownerBo.every(r => /Bob/.test(r)) &&
+  !bobAt.some(r => /Everyone/.test(r)) && bobAt.some(r => /Alice/.test(r)) &&
+  inserted === `hey @${bobU} `;
+console.log(pass ? '[PASS] autocomplete filters by query, owner-only @everyone, inserts the correct @handle token' : '[FAIL] see above');
+await sweep([alice, bob, carol]); await done();

--- a/drive/scenarios/mention-core.mjs
+++ b/drive/scenarios/mention-core.mjs
@@ -1,0 +1,40 @@
+import { createAccount, pair, group, sweep, done } from '../driver.mjs';
+const alice = await createAccount({ name: 'Alice' });   // group owner
+const bob = await createAccount({ name: 'Bob' });
+const carol = await createAccount({ name: 'Carol' });
+await pair(alice, bob); await pair(alice, carol); await pair(bob, carol);
+const gid = await group(alice, 'Squad', [bob, carol]);   // shared group id
+
+// Bob sets the group to "Badge only" (content:none) — normally NO banner.
+await bob.page.evaluate((id) => window.__ringTest.setChatNotify(id, { content: 'none' }), gid);
+await bob.page.goto('/tabs/chats');
+await bob.page.waitForFunction(() => !!window.__ringTest, null, { timeout: 15000 });
+await bob.page.waitForTimeout(800);
+
+const banners = (cli) => cli.page.evaluate(() => Array.from(document.querySelectorAll('.nb')).map(e => e.textContent.replace(/\s+/g,' ').trim()));
+const um = (cli) => cli.page.evaluate((id) => window.__ringTest.unreadMentions(id), gid);
+const watchBanner = async (cli, ms) => { let seen = []; for (let t=0;t<ms;t+=150){ const n = await banners(cli); if (n.length>seen.length) seen=n; await new Promise(r=>setTimeout(r,150)); } return seen; };
+
+// Alice @mentions Bob → escalates past content:none → Bob gets a banner; Carol does not.
+await alice.page.evaluate(([id, bid]) => window.__ringTest.sendWithMentions(id, 'ping for you', [bid]), [gid, bob.id]);
+const bobBanner = await watchBanner(bob, 2500);
+console.log('[mention] bobBanner=%j  bobUnreadMentions=%d  carolUnreadMentions=%d', bobBanner, await um(bob), await um(carol));
+
+await bob.page.waitForTimeout(5500); // let banners + settle clear
+// A PLAIN (no-mention) message → content:none suppresses it → no banner, mention count unchanged.
+await alice.page.evaluate((id) => window.__ringTest.sendChatMessage(id, 'just chatter'), gid);
+const bobPlain = await watchBanner(bob, 2500);
+console.log('[plain  ] bobBanner=%j  bobUnreadMentions=%d', bobPlain, await um(bob));
+
+// Opening the group clears the unread-mentions.
+await bob.page.goto(`/chat/${gid}`); await bob.page.waitForTimeout(1200);
+const afterOpen = await um(bob);
+console.log('[read   ] bobUnreadMentions=%d', afterOpen);
+
+const pass =
+  bobBanner.some(t => /mentioned you|ping for you/.test(t)) &&
+  (await um(carol)) === 0 &&
+  bobPlain.length === 0 &&
+  afterOpen === 0;
+console.log(pass ? '[PASS] mention escalates past badge-only + counts; non-mention stays silent; read clears it' : '[FAIL] see above');
+await sweep([alice, bob, carol]); await done();

--- a/drive/scenarios/mention-everyone.mjs
+++ b/drive/scenarios/mention-everyone.mjs
@@ -1,0 +1,29 @@
+import { createAccount, pair, group, sweep, done } from '../driver.mjs';
+const alice = await createAccount({ name: 'Alice' });   // owner
+const bob = await createAccount({ name: 'Bob' });
+const carol = await createAccount({ name: 'Carol' });
+await pair(alice, bob); await pair(alice, carol); await pair(bob, carol);
+const gid = await group(alice, 'Squad', [bob, carol]);
+await new Promise(r => setTimeout(r, 1500)); // let the 'create' card (createdBy) settle on members
+const um = (cli) => cli.page.evaluate((id) => window.__ringTest.unreadMentions(id), gid);
+
+// 1) Owner @everyone → every member is mentioned.
+await alice.page.evaluate((id) => window.__ringTest.sendWithMentions(id, 'all hands meeting', [], true), gid);
+await new Promise(r => setTimeout(r, 1800));
+const bobUM = await um(bob), carolUM = await um(carol);
+console.log('[owner @everyone] bobUM=%d carolUM=%d', bobUM, carolUM);
+
+// chat-row "@" marker on Bob's list
+await bob.page.goto('/tabs/chats'); await bob.page.waitForTimeout(900);
+const bobMarker = await bob.page.evaluate(() => document.querySelectorAll('.mention-badge').length);
+console.log('[row marker] bob .mention-badge count=%d', bobMarker);
+
+// 2) NON-owner @everyone (Bob) → recipients must IGNORE it (re-validate sender == owner).
+await bob.page.evaluate((id) => window.__ringTest.sendWithMentions(id, 'bob broadcast', [], true), gid);
+await new Promise(r => setTimeout(r, 1800));
+const carolUM2 = await um(carol), aliceUM = await um(alice);
+console.log('[non-owner @everyone] carolUM=%d (should stay 1) aliceUM=%d (should be 0)', carolUM2, aliceUM);
+
+const pass = bobUM === 1 && carolUM === 1 && bobMarker >= 1 && carolUM2 === 1 && aliceUM === 0;
+console.log(pass ? '[PASS] owner @everyone mentions all + row marker; non-owner @everyone is rejected on receive' : '[FAIL] see above');
+await sweep([alice, bob, carol]); await done();

--- a/e2e/mentions.spec.ts
+++ b/e2e/mentions.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const AVATAR = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>';
+
+async function setProfile(p: { page: any }, name: string) {
+  await p.page.evaluate(([n, av]: [string, string]) => (window as any).__ringTest.setProfile(n, av), [name, AVATAR]);
+}
+function unreadMentions(p: { page: any }, chatId: string): Promise<number> {
+  return p.page.evaluate((id: string) => (window as any).__ringTest.unreadMentions(id), chatId);
+}
+async function waitMentions(p: { page: any }, chatId: string, n: number) {
+  await p.page.waitForFunction(
+    ([id, want]: [string, number]) => (window as any).__ringTest.unreadMentions(id).then((c: number) => c === want),
+    [chatId, n] as [string, number],
+    { timeout: 30_000 },
+  );
+}
+
+/**
+ * @mentions in group chats (spec 1020). The notification ESCALATION is unit-tested
+ * (notify-policy) — here we assert the deterministic data behavior: an @mention is
+ * counted only for the mentioned member(s), an @everyone is honored ONLY from the
+ * group owner (re-validated on receive), and reading the chat clears the count. The
+ * server never sees who is mentioned (it's inside the sealed payload).
+ */
+test('mentions: individual + owner-only @everyone, counted and validated on receive', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'RINGTST1'); // group owner
+  const b = await createAccount(ctxB, 'RINGTST2');
+  const c = await createAccount(ctxC, 'RINGTST3');
+  await setProfile(a, 'Alice');
+  await setProfile(b, 'Bob');
+  await setProfile(c, 'Carol');
+  await pair(a, b);
+  await pair(a, c);
+
+  const gid = await a.page.evaluate((ids) => (window as any).__ringTest.createGroup('Squad', ids), [b.id, c.id]);
+  expect(gid).toBeTruthy();
+  // B and C receive the group (the 'create' card carries the owner = A for @everyone).
+  for (const p of [b, c]) {
+    await p.page.waitForFunction(
+      (g) => (window as any).__ringTest.groupChats().then((gs: any[]) => gs.some((x) => x.id === g)),
+      gid,
+      { timeout: 30_000 },
+    );
+  }
+
+  // 1) A @mentions B only → B is counted, C is not.
+  await a.page.evaluate(([id, bid]) => (window as any).__ringTest.sendWithMentions(id, 'ping for you', [bid]), [gid, b.id]);
+  await waitMentions(b, gid, 1);
+  await b.page.waitForTimeout(1500);
+  expect(await unreadMentions(c, gid)).toBe(0);
+
+  // Reading the chat clears B's mention count.
+  await b.page.evaluate((id) => (window as any).__ringTest.markChatRead(id), gid);
+  await waitMentions(b, gid, 0);
+
+  // 2) NON-owner (B) @everyone → recipients re-validate sender == owner and REJECT it
+  //    (a non-owner cannot forge a broadcast), so nobody's mention count grows from it.
+  await b.page.evaluate((id) => (window as any).__ringTest.sendWithMentions(id, 'bob broadcast', [], true), gid);
+  await c.page.waitForTimeout(2500);
+  expect(await unreadMentions(c, gid)).toBe(0);
+  expect(await unreadMentions(a, gid)).toBe(0);
+
+  // 3) Owner (A) @everyone → now both B and C ARE counted (the broadcast is honored).
+  await a.page.evaluate((id) => (window as any).__ringTest.sendWithMentions(id, 'all hands', [], true), gid);
+  await waitMentions(b, gid, 1);
+  await waitMentions(c, gid, 1);
+
+  await ctxA.close();
+  await ctxB.close();
+  await ctxC.close();
+});

--- a/specs/1020-mentions-group-chats/checklists/requirements.md
+++ b/specs/1020-mentions-group-chats/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: @mentions in group chats
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Six product decisions (scope, composer/encoding, rendering, notification escalation,
+  visual indicators, admin @everyone) were settled at intake and encoded directly — no
+  open clarifications. The Zero-Knowledge Impact section satisfies Constitution Principle I
+  and flags that a crypto/ZK checklist (/speckit-checklist) is warranted before implement.

--- a/specs/1020-mentions-group-chats/contracts/payload.md
+++ b/specs/1020-mentions-group-chats/contracts/payload.md
@@ -1,0 +1,43 @@
+# Contract: mention payload + notification escalation
+
+## Wire / payload contract (E2EE only — never plaintext to server)
+
+A message that mentions people adds, inside the sealed `MessagePayload`:
+
+```jsonc
+{
+  "body": "ping @<token>",       // existing
+  "kind": "text",                 // existing
+  "mentions": ["<memberId>", ...],// NEW: explicitly-mentioned member ids (omit/[] if none)
+  "mentionsEveryone": true         // NEW: broadcast; only HONORED if senderId === group.createdBy
+}
+```
+
+Invariants:
+- `mentions` contains stable member ids (rename-proof); rendering resolves the current name.
+- `mentionsEveryone` from a non-owner sender MUST be ignored by recipients (re-validate vs `createdBy`).
+- The server sees only ciphertext + the existing content-free push — it MUST learn nothing here.
+
+## Notification escalation decision table (recipient-side, shared by page + SW)
+
+Inputs: `muted`, per-chat `content` (full/generic/none), `appVisible`, `isActiveChat`,
+`isMention` (= notifyMentions!==false AND (self in mentions OR validated @everyone)),
+global `showMessages` master, OS DND. Outcome = `notificationOwner` result.
+
+| muted | content | isMention | appVisible | global master / DND | → outcome |
+|------:|---------|:---------:|:----------:|---------------------|-----------|
+| yes   | any     | no        | any        | on                  | suppress (normal mute) |
+| yes   | any     | **yes**   | hidden     | on                  | **sw-notification** ("X mentioned you") |
+| yes   | any     | **yes**   | visible    | on                  | **page-banner** ("X mentioned you") |
+| yes   | none    | **yes**   | hidden     | on                  | **sw-notification** naming the mentioner (overrides content:none) |
+| no    | none    | no        | any        | on                  | suppress / badge-only (unchanged) |
+| any   | any     | yes       | any        | **off / DND**       | **suppress** (master + OS win; mentions never override) |
+| any   | any     | yes (but notifyMentions=false) | any | on | normal (no escalation) |
+| any   | any     | yes       | visible, isActiveChat | on        | suppress (already viewing) + clears the mention marker |
+
+## UI contract
+
+- Composer: `@` opens member autocomplete (name + @username); owner-only `@everyone` entry.
+- Bubble: mention → tappable chip (→ contact page); self-mention emphasized.
+- Chat row: `@` marker + unread-mentions count (separate from unread) when unseen mentions exist.
+- In-chat: jump-to-mention scrolls to the next unseen mention; marker/count clear on seen.

--- a/specs/1020-mentions-group-chats/data-model.md
+++ b/specs/1020-mentions-group-chats/data-model.md
@@ -1,0 +1,76 @@
+# Data Model: @mentions in group chats
+
+All additions are **optional** fields on existing IndexedDB stores (schemaless JSON) — no
+`DB_VERSION` bump, no migration; absent = legacy/no-mention. Nothing new crosses the wire
+in cleartext.
+
+## 1. `MessagePayload` (sealed, E2EE) — `src/services/crypto/message.ts`
+
+| Field | Type | Meaning |
+|------|------|---------|
+| `mentions?` | `string[]` | member user-ids explicitly mentioned in this message |
+| `mentionsEveryone?` | `boolean` | broadcast mention; only honored if sender is the group owner |
+
+- Set on send (built from the composer's resolved mention tokens). Read on receive.
+- Sealed via the existing `JSON.stringify(payload)` in `sealMessage`; parsed in
+  `openMessage`/`openMessagePreview`. **Server never sees these in cleartext.**
+
+## 2. `Message` (local) — `src/db/types.ts`
+
+| Field | Type | Meaning |
+|------|------|---------|
+| `mentions?` | `string[]` | mirror of the payload's mentioned ids (for rendering + seen tracking) |
+| `mentionsEveryone?` | `boolean` | mirror of the payload flag (already validated against owner on receive) |
+
+Rendering resolves each id → the member's CURRENT display name (FR-009); a mention of self is
+emphasized (FR-008).
+
+## 3. `Chat` (local) — `src/db/types.ts`
+
+| Field | Type | Default | Meaning |
+|------|------|---------|---------|
+| `unreadMentions?` | `number` | `0`/unset | count of unseen messages mentioning self in this chat — SEPARATE from `unread` (FR-018) |
+| `notifyMentions?` | `boolean` | `true` when unset | per-chat "Notify for mentions even when muted" (FR-013) |
+| `createdBy?` | `string` | unset (legacy) | the group **owner** (creator) — v1 "admin" for `@everyone` gating (D1) |
+
+- `unreadMentions`: ++ on receive when the message mentions self (or a validated `@everyone`) and
+  the chat isn't active; cleared with `unread` in `markChatRead`, and on delete / leave (FR-020).
+- `notifyMentions`: surfaced in chat/group notification settings; group chats only.
+- `createdBy`: stamped in `createGroup`; carried in the group `create` card so members learn the
+  owner (D1). Absent on pre-feature groups → `@everyone` simply unavailable there until re-derived.
+
+## 4. `ChatNotifyPrefs` — `src/db/queries.ts` / `notify-prefs.ts`
+
+Add `notifyMentions?: boolean` alongside `webPush`/`inApp`/`content`. `getChatNotifyPrefs` returns
+it (default true); `setChatNotifyPrefs` writes it to the `Chat` record.
+
+## 5. `NotifyInput.pref` — `src/services/notify-policy.ts` (the shared predicate)
+
+Add `isMention: boolean`. Computed by each caller (foreground `notify.ts`, SW `sw-inbox.ts`) as:
+
+```
+isMention = chat.notifyMentions !== false
+            && ( payload.mentions?.includes(selfId)
+                 || (payload.mentionsEveryone && senderId === chat.createdBy) )
+```
+
+Escalation inside `notificationOwner` when `pref.isMention` is true:
+- the `muted` gate does NOT suppress;
+- `content:'none'/'generic'` is allowed to name the mentioner;
+- the global "Show notifications" master + OS DND are still respected (checked before the policy);
+- if `notifyMentions === false`, `isMention` is false → no escalation (normal muted behavior).
+
+## 6. Derived / local-only (never synced to server)
+
+- `unreadMentions`, the "@" row marker, and jump-to-mention target are derived on-device from
+  received messages.
+- `notifyMentions` rides the existing encrypted own-data sync (like other per-chat prefs); it is
+  never sent to the server in cleartext.
+
+## State transitions (unread-mentions)
+
+```
+receive msg mentioning self, chat not active   -> unreadMentions++
+open chat / markChatRead                        -> unreadMentions = 0  (with unread)
+that message deleted / user leaves group        -> recompute/clear (FR-020)
+```

--- a/specs/1020-mentions-group-chats/plan.md
+++ b/specs/1020-mentions-group-chats/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: @mentions in group chats
+
+**Branch**: `feat/1020-mentions-group-chats` | **Date**: 2026-06-27 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/1020-mentions-group-chats/spec.md`
+
+## Summary
+
+Add @mentions to group chats: a composer `@`-autocomplete over group members, a mention
+encoded **inside the E2EE message payload** (member ids + an admin-only `@everyone` flag),
+recipient-side rendering of a tappable mention chip, and — the core value — **recipient-side
+notification escalation** that lets a mention break through a muted chat (and override the
+per-chat content level) while still respecting the global "Show notifications" master, the
+OS DND, and a new per-chat "Notify for mentions even when muted" toggle (default on). Plus
+Telegram-style visual indicators: an "@" chat-row marker, a separate unread-mentions count,
+and jump-to-mention. **Server change: none** — the server keeps relaying opaque ciphertext
+and content-free pushes; all mention logic is client-side.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES modules), Vue 3 `<script setup>` + Ionic; Go 1.26 server (untouched).
+
+**Primary Dependencies**: libsodium (existing crypto), IndexedDB via `src/db/idb.ts`, the shared `notificationOwner` policy (`src/services/notify-policy.ts`).
+
+**Storage**: IndexedDB (schemaless JSON stores — additive optional fields, no `DB_VERSION` bump needed). Per-chat prefs ride the existing encrypted own-data sync.
+
+**Testing**: vitest unit (extend `notify-policy.test.ts`), Playwright e2e (multi-account, pattern from `e2e/groups.spec.ts`), `drive/` scenarios for visual checks. CI gates: `npm run build`, `go build/vet/test`, `npm run test:e2e`.
+
+**Target Platform**: Installable PWA (iOS Safari/WKWebView + Chromium); foreground page AND service worker must agree on escalation.
+
+**Project Type**: Single web client (Ring monorepo, client at repo root).
+
+**Performance Goals**: No regressions; @-autocomplete responsive over typical group sizes; notification decision stays O(members) on receive.
+
+**Constraints**: **Zero-knowledge** (Constitution Principle I) — mention targets never cross the wire in cleartext; escalation computed only on-device after decrypt. Offline-first. No server-visible mention concept.
+
+**Scale/Scope**: Group chats only; member-list-sized autocomplete; one new payload field group; a handful of new optional DB fields; ~6 UI/logic touch-points.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-knowledge boundary (non-negotiable)**: PASS by design. Mentions live in the sealed `MessagePayload`; the server stores/relays opaque ciphertext and the existing content-free push. No new server field, route, or push data. `@everyone` admin gating is enforced + re-validated client-side. → **A `/speckit-checklist` (crypto/ZK) is REQUIRED before implement.**
+- **II. TDD mandate**: PASS — plan leads each slice with tests (notify-policy unit first; e2e muted-group-mention; drive visual).
+- **III. Offline-first / IndexedDB source of truth**: PASS — additive optional fields; unread-mention state derived locally; pref synced via own-data sync.
+- **VII. Release-note discipline**: PASS — user-facing commits will carry benefit-focused subjects.
+- **No server change**: PASS — server untouched; `go` gates remain green trivially.
+
+**Risk flagged (not a violation, a scope correction)**: the spec assumed group **admin/owner roles already exist**. They do **not** — groups are all-member parity (see research.md). The minimal, in-boundary resolution is a group **owner** = creator (`createdBy`), used as "admin" for `@everyone` gating in v1. Documented in research.md and data-model.md.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1020-mentions-group-chats/
+├── plan.md              # This file
+├── research.md          # Decisions (roles gap, payload shape, escalation hook, seen semantics)
+├── data-model.md        # Payload + Message/Chat field additions, unread-mention state
+├── quickstart.md        # How to exercise/verify the feature (drive + e2e)
+├── contracts/
+│   └── payload.md       # The mention payload contract + escalation decision table
+├── checklists/
+│   └── requirements.md  # Spec quality (done)
+└── tasks.md             # Phase 2 (/speckit-tasks)
+```
+
+### Source Code (touch-points, repository root)
+
+```text
+src/services/crypto/message.ts     # MessagePayload: + mentions?, mentionsEveryone?; seal/open
+src/services/messaging.ts          # carries the payload (no shape change beyond the above)
+src/db/types.ts                    # Message: + mentions?, mentionsEveryone?
+                                   # Chat:    + unreadMentions?, notifyMentions?, createdBy?
+src/db/queries.ts                  # sendMessage(): attach mentions; receiveIncomingInner():
+                                   #   detect self-mention -> unreadMentions; markChatRead():
+                                   #   clear it; getChatNotifyPrefs/setChatNotifyPrefs:+notifyMentions;
+                                   #   createGroup(): stamp createdBy; isGroupOwner() helper;
+                                   #   group member list for autocomplete; count* badge plumbing
+src/services/notify-policy.ts      # NotifyInput.pref + isMention; escalation in notificationOwner
+src/services/notify.ts             # pass isMention into the policy; mention banner copy
+src/services/sw-inbox.ts           # noteForPayload: mention detection -> escalate + "X mentioned you"
+src/sw.ts                          # (push path already routes through sw-inbox; minimal/none)
+src/views/detail/ChatDetailPage.vue# @-autocomplete in composer; mention chip in bubbleParts;
+                                   #   jump-to-mention scroll
+src/components/ChatListItem.vue    # "@" marker + unread-mentions count on the row
+src/components/MentionAutocomplete.vue (new)   # member picker popover
+src/views/detail/SettingDetailPage.vue / chat settings  # "Notify for mentions even when muted" toggle
+src/services/testhook.ts           # hooks: sendWithMentions, unreadMentions(chatId), isGroupOwner
+tests: src/services/notify-policy.test.ts (extend), e2e/mentions.spec.ts (new), drive/scenarios/mention-*.mjs (new)
+```
+
+**Structure Decision**: Single client feature; no new top-level dirs. One new component
+(`MentionAutocomplete.vue`); everything else extends existing files at the points mapped
+in research.md.
+
+## Phased approach (slices map to user stories; each independently testable)
+
+- **Phase A — Payload + data (foundation for all)**: add `mentions?`/`mentionsEveryone?` to
+  `MessagePayload` (seal/open) and to the local `Message`; add `unreadMentions?`,
+  `notifyMentions?`, `createdBy?` to `Chat`. Unit: payload round-trips mentions; ZK check
+  that nothing new leaves the wire.
+- **Phase B — Compose & send (US1 sender)**: `@`-autocomplete over `participantIds`
+  (`MentionAutocomplete.vue`); insert a mention token; `send()`/`sendMessage()` extract +
+  attach `mentions`. Render the mention chip in `bodyParts()` (self-mention emphasized).
+- **Phase C — Receive, detect & ESCALATE (US1 recipient — the core)**: on receive, detect
+  self-mention/honored-`@everyone`; thread `isMention` into `notificationOwner` so a mention
+  flips a muted `suppress`→`page-banner`/`sw-notification` and a `content:'none'`→ shows the
+  sender, gated by `notifyMentions` and still under the global master + OS DND. Apply on BOTH
+  the foreground (`notify.ts`) and SW (`sw-inbox.ts noteForPayload`, "Alice mentioned you")
+  paths. Unit: notify-policy escalation table. e2e: muted group, mentioned vs not.
+- **Phase D — Indicators & jump-to (US2)**: `unreadMentions` increments on receive, clears
+  on the existing read/seen path; "@" marker + count on `ChatListItem`; jump-to-mention scroll
+  in `ChatDetailPage`. drive: visual marker + jump.
+- **Phase E — Per-chat toggle (US3)**: `notifyMentions` (default true) in `ChatNotifyPrefs` +
+  chat settings UI; honored by C's escalation.
+- **Phase F — Admin `@everyone` (US4)**: minimal owner = `createdBy` (stamped in `createGroup`,
+  carried in the group card so recipients know the owner); offer `@everyone` only to the owner;
+  recipients re-validate sender == owner before honoring. e2e: owner vs non-owner.
+
+## Testing strategy
+
+- **Unit (TDD-first)**: extend `notify-policy.test.ts` with an escalation matrix —
+  {muted, content:none/full, appVisible, isMention, notifyMentions, webPush} → expected owner.
+  This is the single source of truth both the page and SW consume, so it pins the core behavior.
+- **e2e (`e2e/mentions.spec.ts`)**: 3-account group; recipient mutes; sender mentions →
+  recipient gets a banner/notification, third member does not; toggle off → no escalation;
+  owner `@everyone` notifies all, non-owner `@everyone` ignored; jump-to + marker clear.
+  Add `window.__ringTest` hooks (sendWithMentions, unreadMentions, isGroupOwner).
+- **drive (`drive/scenarios/mention-*.mjs`)**: visual — chip rendering (self-emphasized),
+  the "@" row marker + count, jump-to-mention scroll.
+
+## Complexity Tracking
+
+| Item | Why needed | Simpler alternative rejected because |
+|------|-----------|--------------------------------------|
+| Introduce group `createdBy` (owner) | `@everyone` is admin-only but **no role concept exists** today | Allowing anyone to `@everyone` contradicts the locked decision; a full roles system is far larger than this spec and unneeded for v1 — a single owner is the minimal gate. |
+| `isMention` added to the shared notify-policy input (not a new policy) | Foreground + SW MUST agree on escalation | Duplicating escalation logic in `notify.ts` and `sw-inbox.ts` would drift (the exact bug the shared predicate exists to prevent). |

--- a/specs/1020-mentions-group-chats/quickstart.md
+++ b/specs/1020-mentions-group-chats/quickstart.md
@@ -1,0 +1,20 @@
+# Quickstart: verifying @mentions
+
+## Unit (fast, the core invariant)
+- Extend `src/services/notify-policy.test.ts` with the escalation matrix (contracts/payload.md).
+  `npx vitest run src/services/notify-policy.test.ts`
+
+## e2e (multi-account) — `e2e/mentions.spec.ts` (pattern: e2e/groups.spec.ts)
+1. Create A, B, C; A creates a group with B, C (A is owner via `createdBy`).
+2. On B: mute the group (and a variant: set content to "Badge only").
+3. A sends "hi @B": assert B gets a notification/banner naming A even while muted; C does not.
+4. B toggles "Notify for mentions even when muted" off → A mentions B → assert no escalation.
+5. A (owner) `@everyone` → B and C both notified (per their toggles/master). A non-owner `@everyone`
+   from B → C does NOT treat it as a broadcast.
+6. B's chat row shows the "@" marker + mention count; open + jump-to-mention; assert it clears.
+   `npm run test:e2e -- mentions`
+
+## drive (visual) — `drive/scenarios/mention-*.mjs` (live dev app)
+- Render: mention chip in a bubble, self-mention emphasized; the "@" row marker + count; jump-to.
+- Hooks to add in `src/services/testhook.ts`: `sendWithMentions(chatId, body, ids[, everyone])`,
+  `unreadMentions(chatId)`, `isGroupOwner(chatId)`.

--- a/specs/1020-mentions-group-chats/research.md
+++ b/specs/1020-mentions-group-chats/research.md
@@ -1,0 +1,94 @@
+# Research & Decisions: @mentions in group chats
+
+Grounded in the actual codebase shapes (verified file/line references in parentheses).
+
+## D1 — Group roles don't exist; v1 "admin" = group owner (`createdBy`)
+
+- **Finding**: Ring groups are **all-member parity** — `createGroup` (queries.ts ~1117) stores
+  `participantIds` with no `admin`/`owner`/`role` field on `Chat`, `GroupCard`, or `GroupMember`;
+  add/remove are callable by any member. The spec's assumption that roles exist is **wrong**.
+- **Decision**: For v1, the group **owner = its creator**. Stamp `createdBy: self` on the group
+  `Chat` at creation and carry it in the group `create` card so every member learns the owner.
+  `@everyone` is offered only to the owner and re-validated against `createdBy` on receive.
+- **Rationale**: Smallest change that satisfies the locked "admin-only @everyone" decision without
+  building a roles/permissions system (out of scope). A full admin model can supersede `createdBy`
+  later without changing the payload.
+- **Alternatives rejected**: (a) anyone can `@everyone` — contradicts the locked decision and
+  invites spam; (b) full roles system — far larger than this spec.
+
+## D2 — Mentions live in `MessagePayload` (E2EE), keyed by member id
+
+- **Finding**: the sealed payload is `MessagePayload` (crypto/message.ts ~208), `JSON.stringify`d in
+  `sealMessage` and parsed in `openMessage`/`openMessagePreview`. It already carries optional
+  structured fields (reply, poll, mediaRef…).
+- **Decision**: add `mentions?: string[]` (mentioned member ids) and `mentionsEveryone?: boolean`.
+  Store the same two fields on the local `Message` (db/types.ts) for rendering + seen tracking.
+  Mentions reference **stable member ids**; the chip renders the member's CURRENT name (FR-009),
+  so a rename/`@`-text never desyncs.
+- **Rationale**: id-keyed mentions are rename-proof and exactly what the recipient needs to decide
+  "am I mentioned?" locally. Nothing new crosses the wire in cleartext (server only sees ciphertext).
+- **ZK note**: the push tickle is unchanged + content-free; the server can't see the mention.
+
+## D3 — Escalation is one new boolean in the SHARED notify policy
+
+- **Finding**: `notificationOwner(i: NotifyInput): 'page-banner'|'sw-notification'|'suppress'`
+  (notify-policy.ts ~61) is consumed by BOTH `notify.ts` (foreground) and `sw-inbox.ts` (SW), so
+  they can't drift. Its first gate is `if (pref.muted) return 'suppress'`; later
+  `if (pref.content==='none') return 'suppress'`.
+- **Decision**: add `isMention: boolean` to `NotifyInput.pref`. When `isMention` is true (computed
+  by each caller = "self is in payload.mentions, OR a *validated* mentionsEveryone, AND
+  chat.notifyMentions !== false"):
+  - the `muted` gate does NOT suppress (a mention pierces mute);
+  - `content:'none'`/`'generic'` is treated as at least `'generic'`/`'full'` enough to name the
+    sender ("Alice mentioned you");
+  - the global master (`p.showMessages` in notify.ts) and OS DND are checked BEFORE the policy and
+    are NOT overridden;
+  - the per-chat `notifyMentions=false` short-circuits `isMention` to false (no escalation).
+- **Rationale**: one boolean in the single shared predicate keeps foreground + SW identical (the
+  exact reason this predicate exists). Callers compute `isMention`; the policy encodes the override.
+- **Alternatives rejected**: separate escalation branches in notify.ts and sw-inbox.ts — guaranteed
+  to drift (the spec-2010 class of bug).
+
+## D4 — Per-chat `notifyMentions` rides the existing per-chat prefs
+
+- **Finding**: `getChatNotifyPrefs`/`setChatNotifyPrefs` read/write the `Chat` record's
+  `notifyWebPush`/`notifyInApp`/`notifyContent` fields (used by ContactDetailPage's per-chat
+  notification settings); these sync via own-data sync like other chat fields.
+- **Decision**: add `notifyMentions?: boolean` to `Chat` + `ChatNotifyPrefs` (default true when
+  unset). Surface a "Notify for mentions even when muted" toggle in the chat/group notification
+  settings. Group-only (1:1 has no mentions).
+
+## D5 — "Seen" semantics for the unread-mention marker
+
+- **Finding**: `chat.unread` increments on receive unless `isChatActive` (queries.ts ~4187) and is
+  zeroed by `markChatRead`.
+- **Decision**: add `unreadMentions?: number`, incremented on receive when the message mentions
+  self (or validated `@everyone`) and the chat isn't active; cleared in the SAME `markChatRead`
+  block as `unread`, and on message delete / leaving the group (FR-020). v1 treats "open the chat"
+  as seen-all (cleared with `unread`); per-message jump advances to the next unread mention.
+- **Rationale**: reuses the proven read/seen path; avoids a separate per-message seen ledger in v1.
+  (Per-message mention seen-tracking, where opening doesn't clear all, is a possible follow-up.)
+
+## D6 — Rendering: a new segment in the existing `bodyParts` splitter
+
+- **Finding**: `bodyParts(body)` (ChatDetailPage.vue ~1490) already splits text into
+  link/emoji/plain segments via `linkParts` + `segmentEmoji`.
+- **Decision**: add a `mention?: { id: string; name: string }` segment. The bubble renders a
+  mention chip (tappable → contact page) and emphasizes a mention of self. The composer inserts a
+  recognizable token on autocomplete-select and `send()` resolves tokens → `mentions: string[]`
+  by id. (Exact token/encoding is an implementation detail for tasks; ids are the source of truth.)
+
+## D7 — SW upgrade path
+
+- **Finding**: `noteForPayload` (sw-inbox.ts ~141) builds the SW notification title/body from the
+  decrypted payload, after mute/hidden/content checks; the SW shows a generic note when it can't
+  decrypt and a rich one when it can.
+- **Decision**: in `noteForPayload`, compute `isMention` and, when true + `notifyMentions`, bypass
+  the mute/content suppression and set the body to name the mentioner ("Alice mentioned you[: …]").
+  Generic-until-decrypted is unchanged; once decrypted the note reflects the mention.
+
+## Open follow-ups (explicitly out of v1)
+
+- Per-message mention seen-tracking (open-doesn't-clear-all).
+- A full group roles/permissions model (supersedes `createdBy`).
+- `@here`, segment mentions, anti-spam beyond the owner gate, cross-chat "my mentions" view.

--- a/specs/1020-mentions-group-chats/spec.md
+++ b/specs/1020-mentions-group-chats/spec.md
@@ -1,0 +1,311 @@
+# Feature Specification: @mentions in group chats
+
+**Feature Branch**: `feat/1020-mentions-group-chats`
+
+**Created**: 2026-06-27
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "@mentions in group chats — tag members, mute-bypassing notifications, mention markers and jump-to-mention"
+
+In a busy group, ordinary messages can be muted into the background. **Mentions** let a
+sender call out a specific person (or, for admins, everyone) so that person is reliably
+notified — even in a muted group — and can quickly find where they were called out.
+Mentions are a group-chat concept only; a 1:1 conversation already has a single, obvious
+recipient.
+
+Ring is end-to-end encrypted and **zero-knowledge**: the server relays sealed envelopes
+and fires content-free push tickles, and must never learn message contents. Everything
+below is designed so that *who is mentioned* is known only to the participants' own
+devices, never to the server.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Tag a member and reach them even when muted (Priority: P1)
+
+A member typing in a group wants to direct a message at one specific person. They type
+`@`, pick that person from a member list, and send. The tagged person — even if they
+muted the group — gets a notification telling them who mentioned them, and the message
+shows the mention as a highlighted name.
+
+**Why this priority**: This is the entire point of mentions and a self-contained MVP:
+the sender-side compose loop plus the notification escalation. Without it, the rest
+(markers, jump-to, @everyone) has nothing to act on.
+
+**Independent Test**: In a group of three where the recipient has muted the chat, send a
+message that mentions the recipient; confirm the recipient receives a notification naming
+the sender, while a third, un-mentioned member (same muted group) receives none.
+
+**Acceptance Scenarios**:
+
+1. **Given** a group member composing a message, **When** they type `@`, **Then** an
+   autocomplete of current group members appears (display name + @username to
+   disambiguate), and selecting one inserts a mention of that member.
+2. **Given** a sent message that mentions Bob, **When** Bob's device receives it, **Then**
+   the mention renders as a highlighted, tappable name and (because Bob is mentioned) Bob
+   is notified — **even if Bob muted the group** — with a notification identifying the
+   sender and the group.
+3. **Given** the same muted group, **When** a member who was NOT mentioned receives the
+   message, **Then** they get no notification (the mute still holds for them).
+4. **Given** Bob has muted the group AND set its notifications to "Badge only"/"No
+   preview", **When** Bob is mentioned, **Then** the mention notification still surfaces
+   and may name the sender (the mention overrides the per-chat content level).
+5. **Given** Bob has turned the GLOBAL "Show notifications" master off (or the OS is in
+   Do-Not-Disturb), **When** Bob is mentioned, **Then** no notification is shown (mentions
+   do not override the global master or the OS).
+
+---
+
+### User Story 2 - See and jump to where I was mentioned (Priority: P2)
+
+A member returning to the app wants to know which groups called them out and go straight
+to the message, without scrolling a long history.
+
+**Why this priority**: Mentions you can't find are easy to miss; this is the standard
+Telegram-style payoff. It depends on US1 (there must be mentions to mark) but is otherwise
+independent.
+
+**Independent Test**: Mention a member, then on their device confirm the group's chat-list
+row shows a distinct "@" marker and an unread-mentions count; open the chat and use the
+jump-to-mention affordance to scroll to the mentioning message; confirm the marker/count
+clear once the mention has been seen.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unread message that mentions me, **When** I look at the chat list, **Then**
+   that group's row shows a distinct "@" marker and a mention count that is **separate**
+   from the normal unread-message count.
+2. **Given** I open a chat that has unread mentions, **When** the chat opens, **Then** a
+   "jump to mention" affordance is available, and using it scrolls to the (next) message
+   that mentioned me.
+3. **Given** I have seen the message(s) that mentioned me, **When** that happens, **Then**
+   the "@" marker and the mention count clear for that chat.
+4. **Given** a message that mentioned me is deleted (or I leave/am removed), **When** that
+   happens, **Then** any pending mention marker/count for it is cleared.
+
+---
+
+### User Story 3 - Control mention escalation per chat (Priority: P2)
+
+A member who is fine being pinged in most groups wants to silence even mentions in one
+particularly noisy group.
+
+**Why this priority**: The escalation must be controllable so it doesn't become its own
+source of unwanted noise. Small, independent addition to US1.
+
+**Independent Test**: In a muted group, toggle "Notify for mentions even when muted" off
+for that chat, then have someone mention the member; confirm no notification arrives. Turn
+it back on and confirm a mention notifies again.
+
+**Acceptance Scenarios**:
+
+1. **Given** a chat's notification settings, **When** I view them, **Then** there is a
+   "Notify for mentions even when muted" control that is **on by default**.
+2. **Given** that control is off for a muted chat, **When** I am mentioned there, **Then**
+   I get no notification (only the normal badge/marker behavior).
+3. **Given** that control is on, **When** I am mentioned in a muted chat, **Then** the
+   mention notification surfaces per User Story 1.
+
+---
+
+### User Story 4 - Admin @everyone (Priority: P3)
+
+A group admin needs to reach the whole group at once (e.g., an announcement), regardless
+of individual mutes, without tagging each person.
+
+**Why this priority**: Useful but secondary, and carries abuse/noise risk — hence
+admin-only. Cleanly additive on top of US1's escalation rules.
+
+**Independent Test**: As an admin, send `@everyone`; confirm every other member is notified
+per the escalation rules (subject to each member's own per-chat toggle and global master);
+confirm a non-admin has no `@everyone` option.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am a group admin/owner composing a message, **When** I type `@`, **Then**
+   `@everyone` is offered as an option; **Given** I am not an admin, **Then** it is not
+   offered and I cannot send it.
+2. **Given** an admin sends `@everyone`, **When** members receive it, **Then** each member
+   is treated as mentioned and notified per the same escalation + per-chat-toggle + global
+   master rules as an individual mention.
+3. **Given** a non-admin's message that claims `@everyone`, **When** a recipient processes
+   it, **Then** it is NOT honored as a broadcast mention (the sender's admin status is
+   re-checked against the group roster on the recipient's device).
+
+---
+
+### Edge Cases
+
+- **Member left / was removed after being mentioned**: the mention is retained in the
+  message as sent; rendering falls back to the member's last-known name; no new
+  notification is produced for a non-member.
+- **Display-name change**: a mention is stored by stable member id and rendered with the
+  member's CURRENT display name (consistent with how names resolve elsewhere).
+- **Editing a message**: adding a mention on edit MAY notify the newly-mentioned member
+  once; removing a mention does not retroactively un-notify.
+- **Self-mention**: mentioning yourself never notifies you and does not raise a
+  marker/count on your own device.
+- **Blocked sender**: a mention from a blocked peer is dropped like any other message from
+  them (no escalation).
+- **Not yet decrypted (push path)**: if the service worker cannot decrypt the message, it
+  shows the existing generic, content-free notification; once decrypted (foreground or a
+  later fetch), mention escalation applies and may upgrade the generic notification.
+- **Active in the chat**: being mentioned in the chat you're currently viewing does not
+  raise a separate notification (you've seen it), but still resolves the mention marker.
+- **Multiple unread mentions**: the count reflects how many unseen messages mention me;
+  jump-to advances through them.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Composing**
+
+- **FR-001**: In a group composer, typing `@` MUST open an autocomplete listing current
+  group members, searchable by display name, with @username shown to disambiguate
+  same-named members; 1:1 composers MUST NOT offer mentions.
+- **FR-002**: Selecting a member from the autocomplete MUST insert a mention of that
+  member into the message such that the recipient can render it and detect being
+  mentioned.
+- **FR-003**: A single message MUST be able to mention multiple distinct members.
+- **FR-004**: `@everyone` MUST be offered in the autocomplete ONLY to group
+  admins/owners, and a message MUST carry it as a distinct broadcast-mention indicator.
+
+**Encoding (zero-knowledge)**
+
+- **FR-005**: Mention targets (the set of mentioned member ids and/or the `@everyone`
+  indicator) MUST be carried inside the end-to-end-encrypted message payload and MUST NOT
+  be exposed to the server in cleartext or as metadata.
+- **FR-006**: The server MUST NOT be given any new information about who is mentioned; the
+  push tickle MUST remain content-free, exactly as for any other message.
+
+**Rendering**
+
+- **FR-007**: A mention MUST render in the message bubble as a visually-distinct,
+  tappable element that opens the mentioned member's profile/contact view.
+- **FR-008**: A mention of the current user MUST be visually emphasized (distinct from
+  mentions of others) so a member can spot "this is about me" at a glance.
+- **FR-009**: Mentions MUST render using the member's current display name, resolving by
+  stable id (not by a name captured at send time).
+
+**Notification escalation (recipient-side)**
+
+- **FR-010**: When a received message mentions the current user (individually or via an
+  honored `@everyone`), the system MUST escalate notification handling for that message:
+  it MUST surface a notification **even if the chat is muted**.
+- **FR-011**: A mention notification MUST be allowed to include who mentioned the user
+  even when the chat's content level is set to "No preview"/"Badge only" (the mention
+  overrides the per-chat content level).
+- **FR-012**: Mention escalation MUST still respect the GLOBAL "Show notifications" master
+  switch and the operating-system Do-Not-Disturb state — it MUST NOT override those.
+- **FR-013**: Each chat MUST expose a "Notify for mentions even when muted" control,
+  defaulting to ON; when OFF, a mention MUST NOT escalate past the chat's normal (muted)
+  behavior.
+- **FR-014**: A recipient MUST honor `@everyone` only when the sender is an
+  admin/owner per the recipient's view of the group roster; otherwise it MUST be ignored
+  as a broadcast (and not escalate).
+- **FR-015**: Escalation MUST be applied entirely on the recipient's device and MUST work
+  on BOTH the in-app/foreground path and the service-worker push path (once the message is
+  decrypted).
+- **FR-016**: A user MUST NOT be notified for mentioning themselves, nor for a mention in
+  a chat they are actively viewing.
+
+**Visual indicators & navigation**
+
+- **FR-017**: A chat with one or more unseen mentions of the current user MUST show a
+  distinct "@" marker on its chat-list row.
+- **FR-018**: The system MUST track a per-chat unread-MENTIONS count that is separate from
+  the normal unread-message count.
+- **FR-019**: A chat with unseen mentions MUST offer a "jump to mention" affordance that
+  scrolls to the (next) message mentioning the user.
+- **FR-020**: The "@" marker and mention count for a chat MUST clear once the user has
+  seen the mentioning message(s), and MUST also clear if those messages are deleted or the
+  user is no longer a member.
+
+### Key Entities *(include if feature involves data)*
+
+- **Mention (within a message)**: the set of mentioned member ids and/or an `@everyone`
+  indicator, carried inside the encrypted message payload. Empty for ordinary messages.
+- **Unread-mention state (per chat, per device)**: whether the current user has unseen
+  mentions in the chat, how many, and where the earliest unseen mention is (for
+  jump-to) — derived locally from received messages, never shared with the server.
+- **Per-chat mention preference**: "Notify for mentions even when muted" (default on),
+  alongside the existing per-chat mute / content-level / notification settings.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a muted group, a mentioned member receives a notification that identifies
+  the sender and group 100% of the time when the global notifications master is on and the
+  per-chat mention toggle is on; a non-mentioned member of the same muted group receives
+  none.
+- **SC-002**: With the per-chat "mentions even when muted" toggle OFF, a mention produces
+  no notification (only the normal badge/marker), 100% of the time.
+- **SC-003**: With the global "Show notifications" master OFF (or OS DND), a mention
+  produces no notification, 100% of the time.
+- **SC-004**: A member can find a message that mentioned them via the chat-list "@" marker
+  and jump-to-mention in at most two taps, without manual scrolling.
+- **SC-005**: `@everyone` is selectable only by admins/owners; a forged `@everyone` from a
+  non-admin is never honored as a broadcast by recipients.
+- **SC-006**: The server stores and relays the same opaque ciphertext + content-free push
+  as for a non-mention message — an audit of server-visible data reveals nothing about who
+  was mentioned (verifiable: no plaintext mention field crosses the wire).
+- **SC-007**: The unread-mentions count and "@" marker reflect exactly the unseen mentions
+  and clear when those messages are seen/deleted.
+
+## Zero-Knowledge Impact
+
+<!-- Required by Constitution Principle I for anything crossing the client/server boundary. -->
+
+- **What the server sees**: unchanged. The message (including its mention data) is sealed
+  client-side; the server stores/relays opaque ciphertext and emits the existing
+  content-free push tickle. The server is never told who is mentioned, that a chat is
+  muted, or that an escalation occurred.
+- **Where the logic runs**: mention detection and notification escalation happen only on
+  the recipient's device, after decryption, in the client's notification-policy layer
+  (the same layer the foreground app and the service worker already share). The service
+  worker's push handling continues to show a generic notification when it cannot decrypt,
+  and upgrades to a mention notification only after a successful local decrypt.
+- **No new server signal**: there is no server-side "mention" concept, no per-recipient
+  flag, and no change to push payloads — so the addition cannot leak mention targets or
+  mute state to the server or to a network observer beyond what an ordinary message
+  already reveals (a sealed envelope to an existing recipient set).
+- **`@everyone` trust**: admin/owner gating is enforced on the sender's device at compose
+  time and **independently re-validated** on each recipient's device against the group
+  roster; the server does not mediate or learn about it.
+- **Local-only state**: the unread-mention markers/counts and the per-chat mention
+  preference are device-local (the preference rides the existing encrypted own-data sync
+  like other per-chat settings); none of it is exposed to the server in cleartext.
+
+## Assumptions
+
+- Group membership and admin/owner roles already exist and are available to the client;
+  this feature reads them, it does not define a new roles system.
+- Per-chat mute, per-chat content level ("Message content" / "No preview" / "Badge only"),
+  and the global "Show notifications" master already exist; mention escalation composes
+  with them rather than replacing them.
+- Mentionable targets are existing group members chosen from the autocomplete; free-text
+  @handles for non-members are out of scope.
+- Mentions are supported in text messages and media captions (anywhere a member types a
+  message body); they are not a separate message type.
+- An unread mention is considered "seen" when its message has been viewed in the chat
+  (scrolled into view or the chat opened to it), consistent with jump-to-mention; opening
+  the chat does not blanket-clear mentions the user hasn't actually reached.
+- The per-chat mention toggle governs ALL mention escalation for that chat, including
+  `@everyone`.
+- OS-level Do-Not-Disturb and the global notifications master are respected and are not
+  overridden by mentions.
+
+## Out of Scope (v1)
+
+- Mentions in 1:1 chats.
+- Free-text mentions of people who are not group members.
+- `@here`-style "only active members" broadcast, role/group-segment mentions, or
+  rate-limiting/anti-spam policy for `@everyone` beyond the admin-only gate.
+- Mention-driven search/filter views ("all my mentions across chats").

--- a/specs/1020-mentions-group-chats/spec.md
+++ b/specs/1020-mentions-group-chats/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-27
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -48,6 +48,9 @@
           <ion-icon v-if="muted" :icon="notificationsOffOutline" class="meta-ico" aria-hidden="true" />
           <ion-icon v-if="chat.locked" :icon="lockClosedOutline" class="meta-ico" aria-hidden="true" />
           <ion-icon v-if="chat.pinned" :icon="pinOutline" class="meta-ico pin" aria-hidden="true" />
+          <!-- spec 1020: a distinct "@" marker when this chat has an unread @mention,
+               separate from the normal unread count beside it. -->
+          <ion-badge v-if="chat.unreadMentions" color="primary" class="mention-badge" aria-label="You were mentioned">@</ion-badge>
           <ion-badge v-if="chat.unread" color="primary">{{ chat.unread }}</ion-badge>
           <span v-else-if="chat.manualUnread" class="unread-dot" aria-hidden="true" />
         </div>
@@ -169,6 +172,17 @@ function more(): void {
 }
 .meta-ico.pin {
   transform: rotate(45deg);
+}
+/* "@" mention marker: a circular badge so it reads as a symbol, not a count. */
+.mention-badge {
+  min-width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-weight: 700;
 }
 /* Revealed hidden chat: a faint tint on the whole row + an eye-off marker, so it's
    easy to tell apart from normal chats during a reveal session. Only renders while

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -111,9 +111,10 @@ export function getChat(id: string): Promise<Chat | undefined> {
  *  manual "marked unread" flag. */
 export async function markChatRead(chatId: string): Promise<void> {
   const chat = await getChat(chatId);
-  if (chat && (chat.unread || chat.manualUnread)) {
+  if (chat && (chat.unread || chat.manualUnread || chat.unreadMentions)) {
     chat.unread = 0;
     delete chat.manualUnread;
+    chat.unreadMentions = 0; // @mentions seen when the chat is read (spec 1020)
     chat.updatedAt = now();
     await put('chats', chat);
   }
@@ -308,10 +309,19 @@ export async function countChatMessages(chatId: string): Promise<number> {
 
 /** Append a locally-authored message (starts `pending`) and update the chat.
  *  `replyTo` quotes another message above this one. */
-export async function sendMessage(chatId: string, body: string, replyTo?: ReplyRef): Promise<void> {
+export async function sendMessage(
+  chatId: string,
+  body: string,
+  replyTo?: ReplyRef,
+  mentions?: string[],
+  mentionsEveryone?: boolean,
+): Promise<void> {
   const ts = now();
   const chat = await getChat(chatId);
   await guardOutbound(chat);
+  // @mentions are a GROUP concept only (spec 1020); ignore them in a 1:1.
+  const ment = chat?.isGroup && mentions && mentions.length ? [...new Set(mentions)] : undefined;
+  const everyone = chat?.isGroup && mentionsEveryone ? true : undefined;
   const message: Message = {
     id: uid(),
     chatId,
@@ -326,6 +336,8 @@ export async function sendMessage(chatId: string, body: string, replyTo?: ReplyR
       ? chat.participantIds.map((contactId) => ({ contactId }))
       : undefined,
     replyTo,
+    mentions: ment,
+    mentionsEveryone: everyone,
     updatedAt: ts,
   };
   await put('messages', message);
@@ -342,7 +354,7 @@ export async function sendMessage(chatId: string, body: string, replyTo?: ReplyR
 
   // Seal the message (E2EE) and hand it to the sync engine; receipts advance the
   // status. Group chats fan out to each member over their 1:1 session.
-  const payload: MessagePayload = { body, kind: 'text', timestamp: ts, reply: replyTo };
+  const payload: MessagePayload = { body, kind: 'text', timestamp: ts, reply: replyTo, mentions: ment, mentionsEveryone: everyone };
   if (chat?.isGroup) await sealAndEnqueueGroup(chat, message.id, payload);
   else await sealAndEnqueue(chat, message.id, payload);
 
@@ -1132,6 +1144,7 @@ export async function createGroup(name: string, memberIds: string[]): Promise<st
     rosterAt: ts,
     autoName: !custom,
     customAvatar: false,
+    createdBy: self, // group owner — v1 "admin" for @everyone gating (spec 1020)
     updatedAt: ts,
   });
   linkGroupMembers(memberIds); // connect to co-members so fan-out works under the gate
@@ -3064,9 +3077,12 @@ export interface ChatNotifyPrefs {
   webPush: boolean;
   inApp: boolean;
   content: ChatNotifyContent;
+  // @mentions (spec 1020): "Notify for mentions even when muted" — when off, a mention
+  // gets no escalation. Default true. Group chats only.
+  mentions: boolean;
 }
 
-const CHAT_NOTIFY_DEFAULTS: ChatNotifyPrefs = { webPush: true, inApp: true, content: 'full' };
+const CHAT_NOTIFY_DEFAULTS: ChatNotifyPrefs = { webPush: true, inApp: true, content: 'full', mentions: true };
 
 /** Read a chat's notification controls with defaults applied. A missing chat (or
  *  any absent field) yields the defaults, so callers never special-case undefined. */
@@ -3076,6 +3092,7 @@ export async function getChatNotifyPrefs(chatId: string): Promise<ChatNotifyPref
     webPush: chat?.notifyWebPush ?? CHAT_NOTIFY_DEFAULTS.webPush,
     inApp: chat?.notifyInApp ?? CHAT_NOTIFY_DEFAULTS.inApp,
     content: chat?.notifyContent ?? CHAT_NOTIFY_DEFAULTS.content,
+    mentions: chat?.notifyMentions ?? CHAT_NOTIFY_DEFAULTS.mentions,
   };
 }
 
@@ -3097,6 +3114,10 @@ export async function setChatNotifyPrefs(chatId: string, patch: Partial<ChatNoti
   if (patch.content !== undefined) {
     if (patch.content === CHAT_NOTIFY_DEFAULTS.content) delete chat.notifyContent;
     else chat.notifyContent = patch.content;
+  }
+  if (patch.mentions !== undefined) {
+    if (patch.mentions === CHAT_NOTIFY_DEFAULTS.mentions) delete chat.notifyMentions;
+    else chat.notifyMentions = patch.mentions;
   }
   chat.updatedAt = now();
   await put('chats', chat);
@@ -4153,6 +4174,8 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     contact: payload.contact,
     audio: payload.audio,
     linkPreview: payload.linkPreview, // present only on the rare fast-enough inline send
+    mentions: payload.mentions, // @mentions (spec 1020): member ids tagged in this message
+    mentionsEveryone: payload.mentionsEveryone, // honored only if the sender is the group owner (validated below)
     expiresAt: payload.expiresAt, // disappearing messages: same expiry as the sender's copy
     mediaWidth: payload.mediaRef?.width,
     mediaHeight: payload.mediaRef?.height,
@@ -4176,6 +4199,15 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
             ? payload.audio?.title || mediaPreview('audio', durationSec, payload.mediaRef?.name)
             : payload.body || mediaPreview(kind, durationSec, undefined, payload.videoNote);
   const chat = await getChat(targetChatId);
+  // @mentions (spec 1020): am I called out in this group message? Individual mention by
+  // id, or an @everyone that the sender is actually the group OWNER of (re-validated on
+  // receive so a non-owner can't forge a broadcast). Drives the unread-mention count + a
+  // notification escalation. Self-sent messages never count (outgoing === false here).
+  const selfId = getSelfUserId() ?? '';
+  const selfMentioned =
+    isGroupMsg &&
+    (!!payload.mentions?.includes(selfId) ||
+      (!!payload.mentionsEveryone && !!chat?.createdBy && from === chat.createdBy));
   if (chat) {
     // Group previews show the sender's first name (WhatsApp-style).
     chat.lastMessage = isGroupMsg ? `${contact.name.split(' ')[0]}: ${preview}` : preview;
@@ -4184,7 +4216,9 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     chat.interactions = (chat.interactions ?? 0) + 1;
     // If the user is actively viewing this chat, the message is seen on arrival
     // (the open chat sends the read receipt), so don't grow the unread badge.
-    chat.unread = isChatActive(targetChatId) ? 0 : (chat.unread ?? 0) + 1;
+    const active = isChatActive(targetChatId);
+    chat.unread = active ? 0 : (chat.unread ?? 0) + 1;
+    if (selfMentioned && !active) chat.unreadMentions = (chat.unreadMentions ?? 0) + 1;
     chat.updatedAt = now();
     await put('chats', chat);
   }
@@ -4205,6 +4239,9 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     // The notification spells out shared location / contact / poll (no icon to lean
     // on), unlike the terser `preview` used for the chats list above.
     body: isGroupMsg ? `${contact.name}: ${notifyPreview(payload)}` : notifyPreview(payload) || 'New message',
+    // @mentions (spec 1020): a mention escalates past mute/quiet and names the mentioner.
+    mention: selfMentioned,
+    mentionName: contact.name,
     // A ring:drain push woke us to fetch this → bypass the post-unlock settle window
     // and let the SW (which already fired for that push) own the OS notification, so
     // a woken message is never swallowed AND never double-announced (spec 2010).

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1108,6 +1108,7 @@ function groupCard(
     avatar: chat.customAvatar ? chat.avatar : undefined, // only propagate custom photos
     members: roster,
     at,
+    createdBy: chat.createdBy, // carry the owner so members can validate @everyone (spec 1020)
   };
 }
 
@@ -1154,6 +1155,7 @@ export async function createGroup(name: string, memberIds: string[]): Promise<st
     name: custom,
     members: roster,
     at: ts,
+    createdBy: self, // tell members who the owner is (for @everyone validation, spec 1020)
   });
   return groupId;
 }
@@ -3911,6 +3913,7 @@ async function handleGroupCard(from: string, card: GroupCard): Promise<void> {
     existing.customAvatar = !!card.avatar;
     existing.participantIds = participantIds;
     existing.rosterAt = card.at;
+    if (card.createdBy) existing.createdBy = card.createdBy; // owner, for @everyone validation (spec 1020)
     existing.updatedAt = now();
     await put('chats', existing);
   } else {
@@ -3926,6 +3929,7 @@ async function handleGroupCard(from: string, card: GroupCard): Promise<void> {
       rosterAt: card.at,
       autoName,
       customAvatar: !!card.avatar,
+      createdBy: card.createdBy, // owner, for @everyone validation (spec 1020)
       updatedAt: now(),
     });
   }

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -128,6 +128,15 @@ export interface Chat {
   // the unread affordance and matches the Unread filter; cleared when the chat is
   // opened or a message is sent.
   manualUnread?: boolean;
+  // @mentions (spec 1020, groups). Count of unseen messages that mention me — SEPARATE
+  // from `unread` — drives the "@" row marker + count; cleared with `unread` on read.
+  unreadMentions?: number;
+  // Per-chat "Notify for mentions even when muted" (default true when unset): when off,
+  // a mention does NOT escalate past this chat's normal (muted/quiet) behavior.
+  notifyMentions?: boolean;
+  // Group owner = creator. v1 "admin" for @everyone gating (no roles system yet): only
+  // the owner may broadcast @everyone, and recipients re-validate the sender against it.
+  createdBy?: string;
 }
 
 /** A user-defined chat filter list (e.g. "Stockholmian"): a named set of chats.
@@ -308,6 +317,10 @@ export interface Message {
   // delivered E2EE). Absent until the deferred attach lands; the UI falls back to
   // a fetch-free domain-only card in the meantime.
   linkPreview?: import('@/services/crypto/message').LinkPreview;
+  // @mentions (spec 1020): member ids this message tags (mirror of the payload), and
+  // a validated admin/owner @everyone flag — for rendering the chip + detecting "me".
+  mentions?: string[];
+  mentionsEveryone?: boolean;
   updatedAt: number;
 }
 

--- a/src/services/crypto/message.ts
+++ b/src/services/crypto/message.ts
@@ -242,6 +242,12 @@ export interface MessagePayload {
   // (0/null = off). Applied as a side effect so the peer adopts the same setting;
   // never shown as a message.
   ttl?: number | null;
+  // @mentions (spec 1020, group chats): the member user-ids this message tags, and an
+  // admin/owner-only broadcast flag. Carried INSIDE the sealed payload — the server
+  // never learns who is mentioned. The recipient decrypts, checks if it (or a validated
+  // @everyone) is mentioned, and escalates the notification locally.
+  mentions?: string[];
+  mentionsEveryone?: boolean;
 }
 
 export interface WireMessage {

--- a/src/services/crypto/message.ts
+++ b/src/services/crypto/message.ts
@@ -150,6 +150,7 @@ export interface GroupCard {
   members: GroupMember[]; // full roster (incl. the sender)
   at: number; // version (epoch ms) for last-write-wins
   inviter?: string; // 'invite' only: the inviter's user id (for the invitee's UI)
+  createdBy?: string; // group owner (creator) — v1 "admin" for @everyone gating (spec 1020)
 }
 
 /**

--- a/src/services/notify-policy.test.ts
+++ b/src/services/notify-policy.test.ts
@@ -70,4 +70,39 @@ describe('notificationOwner', () => {
   it("generic content still yields a page-banner when visible (text is masked, not the banner)", () => {
     expect(notificationOwner(input({ pref: { content: 'generic' } }))).toBe('page-banner');
   });
+
+  // spec 1020: an escalated @mention (isMention true = mentioned AND notifyMentions on)
+  // pierces the per-chat silencers, but not the structural gates or the global master.
+  describe('mention escalation', () => {
+    it('mention pierces a muted chat (visible → banner, hidden → SW)', () => {
+      expect(notificationOwner(input({ pref: { muted: true, isMention: true } }))).toBe('page-banner');
+      expect(notificationOwner(input({ appVisible: false, pref: { muted: true, isMention: true } }))).toBe('sw-notification');
+    });
+
+    it('mention pierces content=none (visible → banner; the caller names the mentioner)', () => {
+      expect(notificationOwner(input({ pref: { content: 'none', isMention: true } }))).toBe('page-banner');
+      expect(notificationOwner(input({ appVisible: false, pref: { content: 'none', isMention: true } }))).toBe('sw-notification');
+    });
+
+    it('mention pierces in-app-off and web-push-off', () => {
+      expect(notificationOwner(input({ pref: { inApp: false, isMention: true } }))).toBe('page-banner');
+      expect(notificationOwner(input({ appVisible: false, pref: { webPush: false, isMention: true } }))).toBe('sw-notification');
+    });
+
+    it('mention bypasses the settle window even when not push-woken', () => {
+      expect(notificationOwner(input({ inSettleWindow: true, pushWoken: false, pref: { isMention: true } }))).toBe('page-banner');
+    });
+
+    it('a mention in the chat you are viewing is still suppressed (you already see it)', () => {
+      expect(notificationOwner(input({ isActiveChat: true, pref: { muted: true, isMention: true } }))).toBe('suppress');
+    });
+
+    it('a locked page still hands a mention to the SW (detection needs a decrypt)', () => {
+      expect(notificationOwner(input({ unlocked: false, pref: { muted: true, isMention: true } }))).toBe('sw-notification');
+    });
+
+    it('NOT escalated (notifyMentions off → isMention false) behaves like a normal muted chat', () => {
+      expect(notificationOwner(input({ pref: { muted: true, isMention: false } }))).toBe('suppress');
+    });
+  });
 });

--- a/src/services/notify-policy.ts
+++ b/src/services/notify-policy.ts
@@ -49,6 +49,13 @@ export interface NotifyInput {
     content: 'full' | 'generic' | 'none';
     /** Chat is muted. */
     muted: boolean;
+    /** This message @mentions the user (or a validated @everyone) AND the chat's
+     *  "Notify for mentions even when muted" pref is on (spec 1020). When true, the
+     *  alert escalates past the per-chat silencers — mute, in-app-off, content=none,
+     *  web-push-off, and the settle window — while the structural gates (locked,
+     *  active-chat) and the GLOBAL "Show notifications" master + OS DND (enforced by
+     *  the caller before this runs) still hold. Computed by each caller (page + SW). */
+    isMention?: boolean;
   };
 }
 
@@ -61,13 +68,19 @@ export interface NotifyInput {
 export function notificationOwner(i: NotifyInput): NotifyOwner {
   const { appVisible, unlocked, isActiveChat, pushWoken, inSettleWindow, pref } = i;
 
-  // Muted → never alert (the badge still counts it elsewhere). Highest-priority
-  // gate: a muted chat is silent whether the app is open or closed.
-  if (pref.muted) return 'suppress';
+  // An escalated @mention (spec 1020) pierces the per-chat SILENCERS below — mute,
+  // in-app-off, content=none, web-push-off, and the settle window — so being called
+  // out reaches you even in a muted/quiet chat. The structural gates (locked,
+  // active-chat) and the GLOBAL master + OS DND (enforced by the caller) still hold.
+  const mention = !!pref.isMention;
+
+  // Muted → never alert, UNLESS it's an escalated mention.
+  if (pref.muted && !mention) return 'suppress';
 
   // While locked the page can't decrypt/show content, and must NOT claim the alert
   // (otherwise it would swallow the message and the SW would stay silent). Hand off
   // to the SW, which shows a generic placeholder per its userVisibleOnly contract.
+  // (A mention can't be known here yet — detection requires a successful decrypt.)
   if (!unlocked) return 'sw-notification';
 
   // App is foregrounded and unlocked → the page is the natural owner.
@@ -75,16 +88,15 @@ export function notificationOwner(i: NotifyInput): NotifyOwner {
     // Viewing this very chat → the user already sees the message; at most a subtle
     // sound (handled by the caller). No banner, and the SW stays out of it.
     if (isActiveChat) return 'suppress';
-    // The settle window damps the unlock banner BURST, but a push-woken delivery is
-    // a single discrete event and must not be swallowed — only suppress a non-woken
-    // item that lands inside the window.
-    if (inSettleWindow && !pushWoken) return 'suppress';
-    // In-app banners turned off for this chat (or globally) → no banner. The page
-    // doesn't claim it; since the app is visible the SW also won't fire (its own
-    // closed-app gate), so this is effectively suppressed on the page side.
-    if (!pref.inApp) return 'suppress';
-    // content==='none' is badge-only: reveal nothing anywhere, not even a banner.
-    if (pref.content === 'none') return 'suppress';
+    // The settle window damps the unlock banner BURST, but a push-woken delivery (or
+    // an escalated mention) is a single discrete event and must not be swallowed.
+    if (inSettleWindow && !pushWoken && !mention) return 'suppress';
+    // In-app banners turned off for this chat (or globally) → no banner, UNLESS it's
+    // an escalated mention the user opted to be pinged about.
+    if (!pref.inApp && !mention) return 'suppress';
+    // content==='none' is badge-only — UNLESS escalated: a mention may show who
+    // called you out (the caller composes "X mentioned you" past the content level).
+    if (pref.content === 'none' && !mention) return 'suppress';
     // Otherwise the page shows the in-app banner (content 'full' or 'generic';
     // 'generic' masks the text but may still head with the sender name).
     return 'page-banner';
@@ -92,9 +104,10 @@ export function notificationOwner(i: NotifyInput): NotifyOwner {
 
   // App is hidden/closed → the OS notification is the only channel. The SW owns it
   // (the page's notifyLocal hand-off is removed in favor of the SW per spec 2010).
-  // Per-chat web-push-off → no OS notification (the SW enforces this as badge-only).
-  if (!pref.webPush) return 'suppress';
+  // Per-chat web-push-off → no OS notification, UNLESS it's an escalated mention.
+  if (!pref.webPush && !mention) return 'suppress';
   // content==='none' stays 'sw-notification' so the SW runs its existing none-handling
-  // (no banner, badge only) rather than us second-guessing it here.
+  // (no banner, badge only) rather than us second-guessing it here; a mention upgrades
+  // the SW's note text via its own isMention check.
   return 'sw-notification';
 }

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -100,6 +100,11 @@ export interface IncomingNotice {
   // so the page must not double up via notifyLocal. Set by the drain path (App.vue
   // arms markPushWake(); receiveIncoming reads it through pushWakeActive()).
   pushWoken?: boolean;
+  // @mentions (spec 1020): this message @mentions me (individually, or a validated
+  // @everyone). When true (and the chat's mention pref is on) the alert escalates past
+  // mute/quiet, and the banner names the mentioner even under a masked content level.
+  mention?: boolean;
+  mentionName?: string; // who mentioned me (the sender's display name)
 }
 
 /* ---- in-app notification banners (custom green overlay; see NotificationBanners.vue) ---- */
@@ -402,6 +407,11 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
       inAppGloballyEnabled(),
     ]);
     const content = chatPrefs?.content ?? 'full';
+    // @mentions (spec 1020): escalate only when this message mentions me AND the chat's
+    // "mentions even when muted" pref is on. The global master (p.showMessages, checked
+    // above) + OS DND still gate everything.
+    const isMention = !!n.mention && (chatPrefs?.mentions ?? true);
+    const mentionBody = `${n.mentionName ?? 'Someone'} mentioned you`;
     const owner = notificationOwner({
       appVisible: appVisible(),
       unlocked: true, // isUnlockedNow() was checked above
@@ -414,6 +424,7 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
         inApp: globalInApp && (chatPrefs?.inApp ?? true),
         content,
         muted,
+        isMention,
       },
     });
 
@@ -434,9 +445,12 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
       // content='none' is badge-only (no OS text anywhere), so it never bridges via
       // notifyLocal even though the predicate routes it through 'sw-notification'
       // (the SW's own none-handling keeps it badge-only there).
-      if (!n.pushWoken && content !== 'none') {
+      // A mention bridges even when content='none' (it escalated past the content level)
+      // and names the mentioner when the text would otherwise be masked.
+      if (!n.pushWoken && (content !== 'none' || isMention)) {
         const showFull = content === 'full' && p.showPreview;
-        void notifyLocal(n.name, showFull ? n.body : 'New message', targetUrl(n), n.chatId);
+        const text = showFull ? n.body : isMention ? mentionBody : 'New message';
+        void notifyLocal(n.name, text, targetUrl(n), n.chatId);
       }
       return false;
     }
@@ -446,7 +460,7 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
     await inAppSoundAndHaptics();
     if (p.inappStyle === 'none') return false; // sound only; no visible surface
     const url = targetUrl(n);
-    const bodyText = showFull ? n.body : 'New message';
+    const bodyText = showFull ? n.body : isMention ? mentionBody : 'New message';
     const presented = await presentMessageBanner(n, bodyText, url, p.inappStyle);
     if (presented) notifyBannerPresented(); // tell the drain hand-off we claimed it
     return presented;

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -20,7 +20,7 @@
 import { attemptDeviceUnlock } from './crypto/identity';
 import { previewPacket } from './messaging';
 import { readHiddenSet } from './hidden-chats';
-import { readSessionToken } from './session';
+import { readSessionToken, readSessionUserId } from './session';
 import { get, getAll, put } from '@/db/idb';
 import { notifyPreview } from '@/utils/notify-preview';
 import type { Chat, Contact, Setting } from '@/db/types';
@@ -146,6 +146,7 @@ export function noteForPayload(
   showMessages: boolean,
   showPreview: boolean,
   hidden: Set<string> = new Set(),
+  selfId = '',
 ): { note: SwNote | null; wasMessage: boolean; silenced?: boolean } {
   const from = f.from as string;
   const known = contacts.find((c) => c.id === from)?.name;
@@ -207,6 +208,28 @@ export function noteForPayload(
   if (chat && hidden.has(chat.id)) {
     return {
       note: { ids: [f.id as string], title: 'Ring', body: 'New message', url: '/tabs/chats', tag: `ring:${chat.id}` },
+      wasMessage: true,
+    };
+  }
+  // @mentions (spec 1020): a message that @mentions me (individually, or an @everyone
+  // from the actual group OWNER) escalates past the per-chat silencers below (mute,
+  // web-push-off, content=none), and names the mentioner — UNLESS the chat turned the
+  // "mentions even when muted" pref off. (Hidden chats above still win — a hidden chat
+  // never escalates.) The global "Show notifications" master is honored above.
+  const selfMentioned =
+    isGroup &&
+    (!!payload.mentions?.includes(selfId) ||
+      (!!payload.mentionsEveryone && !!chat?.createdBy && from === chat.createdBy));
+  if (selfMentioned && chat?.notifyMentions !== false) {
+    const showText = (chat?.notifyContent ?? 'full') === 'full' && showPreview;
+    return {
+      note: {
+        ids: [f.id as string],
+        title: groupChat?.name || 'Group',
+        body: showText ? `${senderName} mentioned you: ${notifyPreview(payload)}` : `${senderName} mentioned you`,
+        url: chat?.id ? `/chat/${chat.id}` : '/tabs/chats',
+        tag: chat?.id ? `ring:${chat.id}` : `ring:from:${from}`,
+      },
       wasMessage: true,
     };
   }
@@ -406,11 +429,12 @@ export async function previewPending(): Promise<PreviewResult> {
   }
 
   const showPreview = await setting<boolean>('notifications.showPreview', true);
-  const [chats, contacts, shown, hidden] = await Promise.all([
+  const [chats, contacts, shown, hidden, selfId] = await Promise.all([
     getAll<Chat>('chats'),
     getAll<Contact>('contacts'),
     loadShown(),
     readHiddenSet(), // spec 1019: hidden chats get a generic, content-free notification
+    readSessionUserId(), // spec 1020: needed to detect "am I @mentioned?" in the SW
   ]);
   const seen = new Set(shown);
 
@@ -429,7 +453,7 @@ export async function previewPending(): Promise<PreviewResult> {
       continue; // can't decrypt this one (session not reachable yet) → leave it for the page
     }
     seen.add(f.id);
-    const { note, wasMessage, silenced } = noteForPayload(f, payload, chats, contacts, showMessages, showPreview, hidden);
+    const { note, wasMessage, silenced } = noteForPayload(f, payload, chats, contacts, showMessages, showPreview, hidden, selfId ?? '');
     if (note) raw.push(note);
     else if (silenced) silencedMessage = true;
     else if (wasMessage && !showMessages) withheldMessage = true;

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -349,6 +349,11 @@ export function installTestHook(): void {
     setGroupAvatar: (chatId: string, dataUrl: string) => dbSetGroupAvatar(chatId, dataUrl),
     leaveGroup: (chatId: string) => dbLeaveGroup(chatId),
     sendChatMessage: (chatId: string, body: string) => dbSendMessage(chatId, body),
+    /** Send a group message that @mentions the given member ids (spec 1020). */
+    sendWithMentions: (chatId: string, body: string, mentions: string[], everyone = false) =>
+      dbSendMessage(chatId, body, undefined, mentions, everyone),
+    /** A chat's unread-MENTIONS count (separate from unread). */
+    unreadMentions: async (chatId: string): Promise<number> => (await dbGetChat(chatId))?.unreadMentions ?? 0,
     editChatMessage: (messageId: string, body: string) => dbEditMessage(messageId, body),
     deleteForEveryone: (messageId: string, trace: boolean) => dbDeleteMessageForEveryone(messageId, trace),
     setChatTtl: (chatId: string, ms: number | null) => dbSetChatTtl(chatId, ms),

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -48,6 +48,10 @@
           </span>
         </button>
         <ion-buttons slot="end">
+          <!-- spec 1020: jump to where I was @mentioned (the most recent one loaded). -->
+          <ion-button v-if="lastMentionId" aria-label="Jump to mention" @click="jumpToMention">
+            <ion-icon slot="icon-only" :icon="atOutline" />
+          </ion-button>
           <!-- Group size gates the call type (spec 0004 US3): no video past 4 participants,
                no group call at all past 8. 1:1 chats always show both. -->
           <ion-button
@@ -951,7 +955,7 @@ import {
 import type { InfiniteScrollCustomEvent } from '@ionic/vue';
 import {
   callOutline, videocamOutline, documentOutline, playCircle, play, sendOutline,
-  timeOutline, checkmark, checkmarkDone, addOutline, happyOutline, cameraOutline, megaphoneOutline,
+  timeOutline, checkmark, checkmarkDone, addOutline, happyOutline, cameraOutline, megaphoneOutline, atOutline,
   micOutline, trashOutline, closeOutline, pause, banOutline, arrowRedoOutline, arrowUndoOutline, globeOutline,
   locationOutline, barChartOutline, personOutline, refreshOutline, downloadOutline,
   imageOutline, musicalNotesOutline, calendarOutline, checkmarkCircle, ellipseOutline,
@@ -2690,6 +2694,21 @@ const renderItems = computed<RenderItem[]>(() => {
   return out;
 });
 const itemTime = (it: RenderItem) => (it.kind === 'msg' ? it.message.timestamp : it.messages[0].timestamp);
+
+// spec 1020: the most recent loaded message that @mentions me (for the header
+// jump-to-mention button). Incoming only — you don't "jump to" your own message.
+const lastMentionId = computed<string | null>(() => {
+  if (!chat.value?.isGroup) return null;
+  const list = visibleMessages.value;
+  for (let i = list.length - 1; i >= 0; i--) {
+    const m = list[i];
+    if (!m.outgoing && (m.mentions?.includes(selfId) || m.mentionsEveryone)) return m.id;
+  }
+  return null;
+});
+function jumpToMention(): void {
+  if (lastMentionId.value) void scrollToMessage(lastMentionId.value);
+}
 
 // First 4 cells of an album, plus the "+N more" overlay count on the 4th.
 const albumCells = (msgs: Message[]) => msgs.slice(0, 4);

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -393,7 +393,7 @@
                 </span>
               </a>
               <span v-if="m.body" class="text" dir="auto" :class="{ 'emoji-only': emojiBig(m.body) }"><template
-                v-for="(p, pi) in bodyParts(m.body)"
+                v-for="(p, pi) in bodyParts(m)"
                 :key="pi"
               ><a
                   v-if="p.url"
@@ -402,7 +402,15 @@
                   target="_blank"
                   rel="noopener noreferrer"
                   @click.stop.prevent="openExternal(p.url)"
-                >{{ p.text }}</a><animated-emoji
+                >{{ p.text }}</a><span
+                  v-else-if="p.mention"
+                  class="mention"
+                  :class="{ me: p.mention.me }"
+                  @click.stop="openMentionedContact(p.mention.id)"
+                >@{{ p.mention.name }}</span><span
+                  v-else-if="p.everyone"
+                  class="mention everyone"
+                >@everyone</span><animated-emoji
                   v-else-if="p.emoji"
                   :emoji="p.emoji"
                   :animate="animEmoji"
@@ -947,7 +955,7 @@ import {
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
 import { groupProgress } from '@/services/message-status';
-import { getSelfUserId } from '@/services/auth';
+import { getSelfUserId, getSelfUsername } from '@/services/auth';
 import MessageActions from '@/components/MessageActions.vue';
 import QuickReactBar from '@/components/QuickReactBar.vue';
 import ReactionDetails from '@/components/ReactionDetails.vue';
@@ -1487,19 +1495,70 @@ const linkDomain = (s: string) => {
 };
 // Split body text into plain runs and clickable URL runs (to linkify messages).
 // Split a body into render segments: links, emoji (Noto-animated), and text.
-function bodyParts(body: string): Array<{ text?: string; url?: string; emoji?: string }> {
-  const out: Array<{ text?: string; url?: string; emoji?: string }> = [];
-  for (const p of linkParts(body)) {
+// A group's members by @username → { id, current display name } (spec 1020), so a
+// mention token in a body resolves to a member and renders with their CURRENT name.
+// Includes self (so "@myhandle" highlights as me). Empty for 1:1 chats.
+const mentionByUsername = computed(() => {
+  const map = new Map<string, { id: string; name: string }>();
+  if (!chat.value?.isGroup) return map;
+  const ids = new Set([selfId, ...(chat.value.participantIds ?? [])]);
+  for (const c of contacts.value) {
+    if (ids.has(c.id) && c.username) map.set(c.username.toLowerCase(), { id: c.id, name: c.name });
+  }
+  const su = getSelfUsername();
+  if (su) map.set(su.toLowerCase(), { id: selfId, name: 'You' });
+  return map;
+});
+
+interface BodySeg {
+  text?: string;
+  url?: string;
+  emoji?: string;
+  mention?: { id: string; name: string; me: boolean };
+  everyone?: boolean;
+}
+const MENTION_RE = /@([a-zA-Z0-9_]+)/g;
+
+// Split a message body into render segments. @mentions (spec 1020): an "@handle" token
+// becomes a mention chip ONLY when it resolves to a member this message actually mentions
+// (m.mentions by id), and "@everyone" when m.mentionsEveryone was honored — otherwise the
+// "@word" stays plain text. Mentions interleave with the existing link/emoji segmentation.
+function bodyParts(m: Message): BodySeg[] {
+  const out: BodySeg[] = [];
+  const mentioned = new Set(m.mentions ?? []);
+  const members = mentionByUsername.value;
+  const emit = (t: string): void => {
+    for (const seg of segmentEmoji(t)) {
+      if (seg.emoji) out.push({ emoji: seg.emoji });
+      else if (seg.text) out.push({ text: seg.text });
+    }
+  };
+  for (const p of linkParts(m.body)) {
     if (p.url) {
       out.push({ text: p.text, url: p.url });
       continue;
     }
-    for (const seg of segmentEmoji(p.text ?? '')) {
-      if (seg.emoji) out.push({ emoji: seg.emoji });
-      else if (seg.text) out.push({ text: seg.text });
+    const text = p.text ?? '';
+    let last = 0;
+    let mm: RegExpExecArray | null;
+    MENTION_RE.lastIndex = 0;
+    while ((mm = MENTION_RE.exec(text))) {
+      const handle = mm[1].toLowerCase();
+      const isEveryone = handle === 'everyone' && !!m.mentionsEveryone;
+      const member = members.get(handle);
+      const isMember = !!member && mentioned.has(member.id);
+      if (!isEveryone && !isMember) continue; // plain "@word", leave in text
+      if (mm.index > last) emit(text.slice(last, mm.index));
+      if (isEveryone) out.push({ everyone: true });
+      else out.push({ mention: { id: member!.id, name: member!.name, me: member!.id === selfId } });
+      last = mm.index + mm[0].length;
     }
+    if (last < text.length) emit(text.slice(last));
   }
   return out;
+}
+function openMentionedContact(id: string): void {
+  if (id && id !== selfId) router.push(`/contact/${id}`);
 }
 // An all-emoji message of up to 3 emoji renders larger.
 function emojiBig(body: string): boolean {
@@ -4332,6 +4391,22 @@ function cancelRecording() {
   color: var(--ion-color-primary);
   text-decoration: underline;
   word-break: break-all;
+}
+/* @mention chip (spec 1020): a highlighted, tappable name. A mention of ME is
+   emphasized (filled pill) so "this is about me" pops at a glance. */
+.mention {
+  color: var(--ion-color-primary);
+  font-weight: 600;
+  cursor: pointer;
+}
+.mention.me {
+  background: var(--ion-color-primary);
+  color: #fff;
+  border-radius: 6px;
+  padding: 0 4px;
+}
+.mention.everyone {
+  cursor: default;
 }
 .deleted-msg {
   font-style: italic;

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -681,6 +681,22 @@
     </ion-content>
 
     <ion-footer id="chat-footer">
+      <!-- @-mention autocomplete (spec 1020): group members (+ owner-only @everyone)
+           matching the @token being typed; tap to insert. -->
+      <div v-if="mentionCandidates.length" class="mention-pop">
+        <button
+          v-for="c in mentionCandidates"
+          :key="c.everyone ? '@everyone' : c.id"
+          type="button"
+          class="mention-row"
+          @pointerdown.prevent
+          @click="pickMention(c)"
+        >
+          <ion-icon v-if="c.everyone" :icon="megaphoneOutline" class="mention-row-ico" />
+          <span class="mention-row-name">{{ c.everyone ? 'Everyone' : c.name }}</span>
+          <span v-if="!c.everyone" class="mention-row-handle">@{{ c.username }}</span>
+        </button>
+      </div>
       <!-- Reply preview: the message being replied to, with a cancel button. -->
       <ion-toolbar v-if="replyingTo && !chat?.pending" class="reply-bar">
         <div class="reply-preview">
@@ -935,7 +951,7 @@ import {
 import type { InfiniteScrollCustomEvent } from '@ionic/vue';
 import {
   callOutline, videocamOutline, documentOutline, playCircle, play, sendOutline,
-  timeOutline, checkmark, checkmarkDone, addOutline, happyOutline, cameraOutline,
+  timeOutline, checkmark, checkmarkDone, addOutline, happyOutline, cameraOutline, megaphoneOutline,
   micOutline, trashOutline, closeOutline, pause, banOutline, arrowRedoOutline, arrowUndoOutline, globeOutline,
   locationOutline, barChartOutline, personOutline, refreshOutline, downloadOutline,
   imageOutline, musicalNotesOutline, calendarOutline, checkmarkCircle, ellipseOutline,
@@ -1560,6 +1576,56 @@ function bodyParts(m: Message): BodySeg[] {
 function openMentionedContact(id: string): void {
   if (id && id !== selfId) router.push(`/contact/${id}`);
 }
+
+// ---- composer @-mention autocomplete (spec 1020) ----
+const mentionQuery = ref<string | null>(null); // the @query being typed, or null when inactive
+const isGroupOwner = computed(() => chat.value?.isGroup === true && chat.value.createdBy === selfId);
+// Group members (id/name/username) for the picker — excludes self.
+const groupMembers = computed(() => {
+  if (!chat.value?.isGroup) return [] as Array<{ id: string; name: string; username: string }>;
+  const ids = new Set(chat.value.participantIds ?? []);
+  return contacts.value
+    .filter((c) => ids.has(c.id) && c.id !== selfId && c.username)
+    .map((c) => ({ id: c.id, name: c.name, username: c.username as string }));
+});
+interface MentionCandidate { id?: string; name: string; username: string; everyone?: boolean }
+const mentionCandidates = computed<MentionCandidate[]>(() => {
+  const q = mentionQuery.value;
+  if (q === null) return [];
+  const ql = q.toLowerCase();
+  const list: MentionCandidate[] = groupMembers.value
+    .filter((m) => m.name.toLowerCase().includes(ql) || m.username.toLowerCase().includes(ql))
+    .map((m) => ({ ...m }));
+  // Owner-only @everyone broadcast (spec 1020), offered when it matches the query.
+  if (isGroupOwner.value && 'everyone'.startsWith(ql)) list.unshift({ name: 'Everyone', username: 'everyone', everyone: true });
+  return list.slice(0, 8);
+});
+// An "@token" at the end of the draft (assumed cursor position) starts an autocomplete.
+function updateMentionQuery(): void {
+  if (!chat.value?.isGroup) { mentionQuery.value = null; return; }
+  const m = /(?:^|\s)@([a-zA-Z0-9_]*)$/.exec(draft.value);
+  mentionQuery.value = m ? m[1] : null;
+}
+function pickMention(c: MentionCandidate): void {
+  draft.value = draft.value.replace(/(^|\s)@([a-zA-Z0-9_]*)$/, `$1@${c.username} `);
+  mentionQuery.value = null;
+  void composerEl.value?.$el?.setFocus?.();
+}
+// Resolve a body's @tokens to mentioned member ids + an honored (owner-only) @everyone.
+function resolveMentions(text: string): { mentions: string[]; everyone: boolean } {
+  const byU = new Map(groupMembers.value.map((m) => [m.username.toLowerCase(), m.id]));
+  const ids = new Set<string>();
+  let everyone = false;
+  for (const mm of text.matchAll(/(?:^|\s)@([a-zA-Z0-9_]+)/g)) {
+    const h = mm[1].toLowerCase();
+    if (h === 'everyone' && isGroupOwner.value) everyone = true;
+    else {
+      const id = byU.get(h);
+      if (id) ids.add(id);
+    }
+  }
+  return { mentions: [...ids], everyone };
+}
 // An all-emoji message of up to 3 emoji renders larger.
 function emojiBig(body: string): boolean {
   const n = emojiOnlyCount(body);
@@ -2125,6 +2191,7 @@ function onComposerInput(e: CustomEvent): void {
   draft.value = (e.detail as { value?: string | null }).value ?? '';
   if (draft.value.trim()) startActivity('typing');
   else stopActivity('typing'); // cleared the draft → no longer typing
+  updateMentionQuery(); // spec 1020: open/refresh the @-mention autocomplete
   const host = composerEl.value?.$el;
   if (host) requestAnimationFrame(() => { host.scrollTop = host.scrollHeight; });
 }
@@ -3134,10 +3201,13 @@ async function send() {
   }
 
   draft.value = '';
+  mentionQuery.value = null; // close the autocomplete
+  // @mentions (spec 1020): resolve the body's @tokens to member ids + an honored @everyone.
+  const { mentions, everyone } = resolveMentions(text);
   // Plain copy, replyingTo.value is a reactive Proxy, which IndexedDB can't clone.
   const reply = replyingTo.value ? { ...replyingTo.value } : undefined;
   replyingTo.value = null;
-  await sendMessage(chatId, text, reply);
+  await sendMessage(chatId, text, reply, mentions, everyone);
   await scrollToNewest();
 }
 
@@ -4407,6 +4477,40 @@ function cancelRecording() {
 }
 .mention.everyone {
   cursor: default;
+}
+/* @-mention autocomplete popover above the composer. */
+.mention-pop {
+  max-height: 40vh;
+  overflow-y: auto;
+  background: var(--ion-background-color);
+  border-top: 1px solid var(--app-hairline, rgba(128, 128, 128, 0.25));
+}
+.mention-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--app-hairline, rgba(128, 128, 128, 0.12));
+  text-align: start;
+  font-size: 15px;
+  color: var(--ion-text-color);
+}
+.mention-row:active {
+  background: var(--ion-color-step-100, rgba(128, 128, 128, 0.12));
+}
+.mention-row-ico {
+  font-size: 20px;
+  color: var(--ion-color-primary);
+}
+.mention-row-name {
+  font-weight: 600;
+}
+.mention-row-handle {
+  color: var(--app-text-muted);
+  font-size: 13px;
 }
 .deleted-msg {
   font-style: italic;

--- a/src/views/detail/GroupInfoPage.vue
+++ b/src/views/detail/GroupInfoPage.vue
@@ -72,10 +72,17 @@
               In-app banners
             </ion-toggle>
           </ion-item>
-          <ion-item button :detail="false" lines="none" @click="chooseContent">
+          <ion-item button :detail="false" @click="chooseContent">
             <ion-icon slot="start" :icon="documentTextOutline" />
             <ion-label>Show content</ion-label>
             <ion-note slot="end">{{ contentLabel }}</ion-note>
+          </ion-item>
+          <!-- spec 1020: let an @mention break through even when this group is muted. -->
+          <ion-item lines="none">
+            <ion-icon slot="start" :icon="atOutline" />
+            <ion-toggle :checked="notifyMentions" @ion-change="setMentions($event.detail.checked)">
+              Notify for mentions even when muted
+            </ion-toggle>
           </ion-item>
         </ion-list>
 
@@ -146,7 +153,7 @@ import {
 } from '@ionic/vue';
 import {
   personAddOutline, exitOutline, createOutline, cameraOutline, ellipsisHorizontal,
-  imagesOutline, searchOutline, notificationsOutline, notificationsOffOutline, starOutline, timerOutline,
+  imagesOutline, searchOutline, notificationsOutline, notificationsOffOutline, starOutline, timerOutline, atOutline,
   chatbubbleOutline, documentTextOutline,
 } from 'ionicons/icons';
 import {
@@ -177,6 +184,7 @@ const muteLabel = computed(() => {
 // Per-chat notification controls (spec 1015), identical to 1:1 chats.
 const notifyWebPush = computed(() => chat.value?.notifyWebPush ?? true);
 const notifyInApp = computed(() => chat.value?.notifyInApp ?? true);
+const notifyMentions = computed(() => chat.value?.notifyMentions ?? true);
 const notifyContent = computed<ChatNotifyContent>(() => chat.value?.notifyContent ?? 'full');
 const CONTENT_LABELS: Record<ChatNotifyContent, string> = {
   full: 'Message content',
@@ -187,6 +195,9 @@ const contentLabel = computed(() => CONTENT_LABELS[notifyContent.value]);
 
 async function setWebPush(on: boolean): Promise<void> {
   await setChatNotifyPrefs(chatId, { webPush: on });
+}
+async function setMentions(on: boolean): Promise<void> {
+  await setChatNotifyPrefs(chatId, { mentions: on });
 }
 async function setInApp(on: boolean): Promise<void> {
   await setChatNotifyPrefs(chatId, { inApp: on });


### PR DESCRIPTION
Adds @mentions to group chats (spec 1020). The defining behavior: being @mentioned **breaks through a muted/quiet group** so you're notified and can find where you were called out — all **client-side**, with the server still blind (mentions ride inside the sealed message payload; no server change).

## What's included
- **Compose** — typing `@` in a group composer opens a member picker (display name + `@username`), filtered live; the group **owner** additionally sees `@everyone`. Selecting inserts an `@handle`; on send these resolve to member ids inside the E2EE payload.
- **Render** — a mention shows as a tappable chip with the member's current name; a mention of *you* is emphasized; `@everyone` renders when honored.
- **Notify (the core)** — a self-mention (or a validated `@everyone`) escalates the notification past mute / "No preview" / "Badge only" / web-push-off, naming the mentioner, on **both** the foreground and service-worker paths. It still respects the global "Show notifications" master + OS DND, and a new per-group **"Notify for mentions even when muted"** toggle (default on). The escalation lives in the single shared `notificationOwner` predicate so page and SW agree.
- **Indicators** — a distinct `@` marker on the chat-list row for chats with an unread mention (separate from the unread count), and a header **jump-to-mention** button.
- **`@everyone` is owner-only** — `createGroup` stamps `createdBy`, which rides the group card to every member, so recipients **re-validate** a broadcast against the owner and reject a forged `@everyone` from a non-owner.

## Zero-knowledge
Mentions are encoded only inside the sealed `MessagePayload`. The server relays opaque ciphertext + the existing content-free push and **never learns who is mentioned**. Escalation + `@everyone` validation happen entirely on-device. No server change; no new migration (additive optional IndexedDB fields).

## Tests / verification
- `notify-policy.test.ts` extended with the full mention-escalation matrix (19 cases).
- New hermetic `e2e/mentions.spec.ts` (no WebRTC): individual mention counted only for the target, read clears it, non-owner `@everyone` rejected on receive, owner `@everyone` honored — stable across repeated runs.
- Local gates all green: `npm run build` (vue-tsc), `vitest` (402), `go build/vet/test`.
- Drive scenarios (committed) cover the escalation, chip rendering, composer autocomplete, and `@everyone` end-to-end.

Built in phases (A payload+policy → B send/compose/render → C receive/escalate/count → D indicators → E toggle → F owner @everyone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)