### PR TITLE
fix(contacts): a reliable way to delete a contact

### DIFF
--- a/drive/scenarios/contact-delete-button.mjs
+++ b/drive/scenarios/contact-delete-button.mjs
@@ -1,0 +1,21 @@
+import { createAccount, pair, shot, sweep, done } from '../driver.mjs';
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+const ids = (cli) => cli.page.evaluate(() => window.__ringTest.contactIds());
+console.log('[before] %j', await ids(alice));
+
+await alice.page.goto(`/contact/${bob.id}`);
+await alice.page.waitForTimeout(1000);
+await shot(alice, 'contact-page', {});
+const hasDelete = await alice.page.evaluate(() => Array.from(document.querySelectorAll('ion-item')).some(i => /Delete contact/.test(i.textContent)));
+console.log('[Delete contact item present]', hasDelete);
+
+await alice.page.locator('ion-item', { hasText: 'Delete contact' }).first().click();
+await alice.page.waitForTimeout(700);
+const alertBtns = await alice.page.evaluate(() => Array.from(document.querySelectorAll('ion-alert button')).map(b => b.textContent.trim()));
+console.log('[confirm alert]', JSON.stringify(alertBtns));
+await alice.page.locator('ion-alert button', { hasText: 'Delete' }).click();
+await alice.page.waitForTimeout(1500);
+console.log('[after delete] url=%s contacts=%j', alice.page.url(), await ids(alice));
+await sweep([alice, bob]); await done();

--- a/e2e/contact-delete.spec.ts
+++ b/e2e/contact-delete.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const hasContact = (p: { page: any }, id: string): Promise<boolean> =>
+  p.page.evaluate((cid: string) => (window as any).__ringTest.contactIds().then((ids: string[]) => ids.includes(cid)), id);
+const chatWith = (p: { page: any }, id: string): Promise<string> =>
+  p.page.evaluate((cid: string) => (window as any).__ringTest.chatWith(cid), id);
+
+/**
+ * Deleting a contact (spec: "delete a user"). Removing a contact must drop both the
+ * contact record AND its 1:1 conversation on this device. The Contacts-list swipe and
+ * the contact page's "Delete contact" both call deleteContact under the hood; this pins
+ * that core behavior deterministically (the UI affordance is covered by drive scenarios).
+ */
+test('delete contact: removes the contact and its 1:1 chat', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'RINGTST1');
+  const b = await createAccount(ctxB, 'RINGTST2');
+  await pair(a, b);
+
+  // A has B as a contact, with a 1:1 chat (a sent message guarantees the chat exists).
+  const chatId = await a.page.evaluate((bid) => (window as any).__ringTest.startChat(bid), b.id);
+  await a.page.evaluate((cid) => (window as any).__ringTest.sendChatMessage(cid, 'hi'), chatId);
+  expect(await hasContact(a, b.id)).toBe(true);
+  expect(await chatWith(a, b.id)).toBeTruthy();
+
+  // Delete B.
+  await a.page.evaluate((bid) => (window as any).__ringTest.deleteContact(bid), b.id);
+
+  // The contact AND the conversation are gone on A's device.
+  await a.page.waitForFunction(
+    (bid) => (window as any).__ringTest.contactIds().then((ids: string[]) => !ids.includes(bid)),
+    b.id,
+    { timeout: 15_000 },
+  );
+  expect(await hasContact(a, b.id)).toBe(false);
+  expect(await chatWith(a, b.id)).toBe('');
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/server/internal/api/auth_handlers_test.go
+++ b/server/internal/api/auth_handlers_test.go
@@ -460,3 +460,45 @@ func TestProtectedRoutesRequireAuth(t *testing.T) {
 		t.Fatalf("bad-token status = %d, want 401", rr.Code)
 	}
 }
+
+// TestDeleteMe: DELETE /v1/me deletes the account (and requires auth). Afterwards a
+// peer sees the user as "terminated" via /v1/status — the Ghost signal clients use.
+func TestDeleteMe(t *testing.T) {
+	srv := newTestServer()
+	aliceTok, aliceID := registerUser(t, srv)
+	bobTok, _ := registerUser(t, srv)
+
+	// Unauthenticated delete is rejected.
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, httptest.NewRequest(http.MethodDelete, "/v1/me", nil))
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("no-token delete = %d, want 401", rr.Code)
+	}
+
+	// Alice deletes her own account → 204.
+	rr = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/me", nil)
+	req.Header.Set("Authorization", "Bearer "+aliceTok)
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("delete = %d, want 204, body = %s", rr.Code, rr.Body.String())
+	}
+
+	// Bob now sees Alice as terminated.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/v1/status", strings.NewReader(`{"ids":["`+aliceID+`"]}`))
+	req.Header.Set("Authorization", "Bearer "+bobTok)
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Statuses map[string]string `json:"statuses"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if resp.Statuses[aliceID] != "terminated" {
+		t.Fatalf("alice status = %q, want terminated", resp.Statuses[aliceID])
+	}
+}

--- a/src/views/detail/ContactDetailPage.vue
+++ b/src/views/detail/ContactDetailPage.vue
@@ -137,6 +137,15 @@
             <ion-label color="danger">Block contact</ion-label>
           </ion-item>
         </ion-list>
+
+        <!-- An explicit, tap-only Delete (the Contacts-list swipe gesture is easy to
+             miss and unreliable on iOS); available for ghosted contacts too. -->
+        <ion-list :inset="true">
+          <ion-item button :detail="false" class="danger" @click="confirmDelete">
+            <ion-icon slot="start" :icon="trashOutline" color="danger" />
+            <ion-label color="danger">Delete contact</ion-label>
+          </ion-item>
+        </ion-list>
       </template>
     </ion-content>
   </ion-page>
@@ -152,13 +161,14 @@ import {
 import {
   chatbubbleOutline, searchOutline, banOutline, imagesOutline,
   notificationsOutline, notificationsOffOutline, starOutline, timerOutline, eyeOutline, documentTextOutline,
-  createOutline, cameraOutline, refreshOutline, personOutline,
+  createOutline, cameraOutline, refreshOutline, personOutline, trashOutline,
 } from 'ionicons/icons';
 import { computed, ref } from 'vue';
 import {
   getContact, startDirectChat, blockContact, unblockContact, listChats, setChatMute, setChatTtl,
   getPresenceOverrides, setPresenceOverride, setChatNotifyPrefs, type ChatNotifyContent,
   setContactLocalProfile, resetContactToRemote, adoptContactProfile, dismissContactProfile, downscaleAvatar,
+  deleteContact,
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
 import { refetchContactProfile } from '@/services/directory';
@@ -392,6 +402,33 @@ async function block() {
               await blockContact(contactId);
             } catch {
               void appToast({ message: 'Could not block. Try again.', duration: 1500, color: 'danger' });
+            }
+          })();
+        },
+      },
+    ],
+  });
+  await alert.present();
+}
+
+async function confirmDelete() {
+  const alert = await alertController.create({
+    header: 'Delete contact?',
+    message:
+      'This removes them from your contacts and deletes this conversation on this device. It cannot be undone.',
+    buttons: [
+      { text: 'Cancel', role: 'cancel' },
+      {
+        text: 'Delete',
+        role: 'destructive',
+        handler: () => {
+          void (async () => {
+            try {
+              await deleteContact(contactId);
+              // The contact (and its page) no longer exist → return to the list.
+              router.replace('/tabs/contacts');
+            } catch {
+              void appToast({ message: 'Could not delete. Try again.', duration: 1500, color: 'danger' });
             }
           })();
         },

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -218,7 +218,13 @@ import { peerPresence } from '@/composables/usePresence';
 const PAGE = 15;
 const router = useRouter();
 const open = (id: string) => router.push(`/contact/${id}`);
-const removeContact = (id: string) => deleteContact(id);
+const removeContact = async (id: string): Promise<void> => {
+  try {
+    await deleteContact(id);
+  } catch {
+    void appToast({ message: 'Could not delete. Try again.', duration: 1500, color: 'danger' });
+  }
+};
 
 // Shared add-contact flow (also used by the New-chat modal).
 const { connect } = useConnect();


### PR DESCRIPTION
## Problem
On the installed **iOS PWA**, contacts effectively **couldn't be deleted**: the only delete affordance was the Contacts-list swipe gesture, which is easy to miss and unreliable on iOS WebKit. The contact page itself had Block but no Delete.

## Fix
- Add an explicit **"Delete contact"** action on the contact page (a plain tap with a confirm) — works regardless of the swipe gesture, and is available for ghosted contacts too. It removes the contact + its 1:1 conversation and returns to the Contacts list.
- Harden the Contacts-list swipe handler (`await` the delete + show an error toast on failure) instead of a fire-and-forget call.

## Tests (the ask: "put proper tests around it")
- **`e2e/contact-delete.spec.ts`** — deleting a contact removes both the contact record AND its 1:1 chat on the device.
- **`TestDeleteMe`** (server) — `DELETE /v1/me` requires auth, returns 204, and a peer then sees the account as `terminated` via `/v1/status` (the Ghost signal).
- A `drive/` scenario drives the new button end-to-end (confirm → navigates away → contact gone).

## Verification
`npm run build` (vue-tsc) · `go build/vet/test` · the new e2e — all green locally. The deeper deletion logic (`deleteContact`, account delete, group member removal) was reproduced and confirmed working; this PR closes the missing/unreliable **affordance** that made deletion feel broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)