### PR TITLE
fix(audio): floating player hide-in-chat + theming, S25 update reload & voice overflow

### DIFF
--- a/drive/scenarios/audio-player-fixes.mjs
+++ b/drive/scenarios/audio-player-fixes.mjs
@@ -1,0 +1,43 @@
+// Verify the floating audio controller fixes:
+//  - while INSIDE the owning chat the floating controller is hidden (the in-message
+//    player owns the controls)
+//  - after leaving the chat it appears COLLAPSED, and expands on demand
+//  - it follows the dark theme (was stuck light due to undefined Ionic step colors)
+import { createAccount, pair, chatWith, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Aud', mobile: true });
+const b = await createAccount({ name: 'Bob', mobile: true });
+await pair(a, b);
+const aChat = await chatWith(a, b.id);
+
+// Create a (music) audio message locally and open the chat.
+await a.page.evaluate((cid) => window.__ringTest.sendAudio(cid, 'demo.mp3', 'Demo Track', 'Ring'), aChat);
+await a.page.waitForTimeout(700);
+await shot(a, 'audio-1-inchat-before', { route: `/chat/${aChat}` });
+
+// Navigate INTO the chat via the SPA (no reload, so audio state persists), then start audio.
+await a.page.evaluate((cid) => window.__ringTest.navigate(`/chat/${cid}`), aChat);
+await a.page.waitForTimeout(700);
+await a.page.evaluate((cid) => window.__ringTest.playAudioTest(cid, 'Demo Track'), aChat);
+await a.page.waitForTimeout(500);
+await shot(a, 'audio-2-inchat-hidden'); // still in chat → floating controller must NOT show
+
+// Leave the chat via SPA nav → floating controller appears COLLAPSED.
+await a.page.evaluate(() => window.__ringTest.navigate('/tabs/chats'));
+await a.page.waitForTimeout(700);
+const dbg = await a.page.evaluate(() => ({ mini: document.querySelectorAll('.audio-mini').length }));
+console.log('DEBUG', JSON.stringify(dbg));
+await shot(a, 'audio-3-left-collapsed');
+
+// Expand it.
+await a.page.evaluate(() => document.querySelector('.am-toggle')?.click());
+await a.page.waitForTimeout(300);
+await shot(a, 'audio-4-expanded');
+
+// Dark theme.
+await a.page.evaluate(() => window.__ringTest.setSetting('appearance.theme', 'dark'));
+await a.page.waitForTimeout(800);
+await shot(a, 'audio-5-dark');
+
+await sweep([a, b]);
+await done();

--- a/src/components/MinimizedAudio.vue
+++ b/src/components/MinimizedAudio.vue
@@ -1,41 +1,68 @@
 <template>
   <!-- Hovering audio mini-controller (spec 1007 US3), mirroring the minimized-call
-       pill. Shown whenever audio is playing through the global player, from anywhere
-       in the app; offers play/pause and stop. A thin progress rail fills as it plays. -->
-  <div v-if="track" class="audio-mini" role="group" aria-label="Now playing">
+       pill. It exists so audio keeps playing — and stays controllable — AFTER you leave
+       the chat. While you're INSIDE the chat that owns the playing audio, the in-message
+       player is the control, so this hides itself (track.chatId === current chat). Once
+       you leave, it reappears COLLAPSED (a compact pill) and can be expanded on demand. -->
+  <div
+    v-if="track && !inOwningChat"
+    class="audio-mini"
+    :class="{ collapsed: !expanded }"
+    role="group"
+    aria-label="Now playing"
+  >
     <div class="am-cover" :class="{ voice: track.isVoice }">
       <img v-if="track.coverUrl" :src="track.coverUrl" alt="" />
       <ion-icon v-else :icon="track.isVoice ? mic : musicalNotes" />
     </div>
-    <div class="am-info">
+    <div v-if="expanded" class="am-info">
       <div class="am-title">{{ track.title }}</div>
       <div v-if="track.subtitle" class="am-sub">{{ track.subtitle }}</div>
     </div>
     <button class="am-btn" :aria-label="audioPlaying ? 'Pause' : 'Play'" @click="toggleAudioPlayback">
       <ion-icon :icon="audioPlaying ? pause : play" />
     </button>
-    <button class="am-btn am-stop" aria-label="Stop" @click="stopAudio">
+    <button v-if="expanded" class="am-btn am-stop" aria-label="Stop" @click="stopAudio">
       <ion-icon :icon="stop" />
+    </button>
+    <button class="am-toggle" :aria-label="expanded ? 'Collapse' : 'Expand'" @click="expanded = !expanded">
+      <ion-icon :icon="expanded ? chevronDownOutline : chevronUpOutline" />
     </button>
     <div class="am-rail"><div class="am-prog" :style="{ width: audioProgress * 100 + '%' }" /></div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
 import { IonIcon } from '@ionic/vue';
-import { play, pause, stop, mic, musicalNotes } from 'ionicons/icons';
+import { play, pause, stop, mic, musicalNotes, chevronUpOutline, chevronDownOutline } from 'ionicons/icons';
 import {
   audioTrack as track, audioPlaying, audioProgress, toggleAudioPlayback, stopAudio,
 } from '@/composables/useAudioPlayer';
+
+const route = useRoute();
+
+// Hide while viewing the chat the audio belongs to — there the in-message player owns
+// the controls. Reactive on the route, so it appears/disappears as you enter/leave.
+const inOwningChat = computed(
+  // Exact conversation view only — NOT its /media, /info, /starred sub-pages, where the
+  // in-message player isn't on screen and this control should still be available.
+  () => !!track.value?.chatId && route.path === `/chat/${track.value.chatId}`,
+);
+
+// Start collapsed every time a new track begins (it should reappear minimized when you
+// leave the chat, expandable only on demand).
+const expanded = ref(false);
+watch(() => track.value?.id, () => { expanded.value = false; });
 </script>
 
 <style scoped>
-/* Sits above the tab bar / safe-area, mirroring the minimized-call pill's placement
-   and surface. Stock tokens only (Constitution XI). */
+/* Sits above the tab bar / safe-area, mirroring the minimized-call pill's placement.
+   Uses the app's own theme tokens (this codebase doesn't define Ionic's stepped colors,
+   so --ion-color-step-* silently fell back to light values and never went dark). */
 .audio-mini {
   position: fixed;
-  left: 8px;
-  right: 8px;
   bottom: calc(var(--ion-safe-area-bottom, 0px) + 64px);
   z-index: 40;
   display: flex;
@@ -43,10 +70,21 @@ import {
   gap: 10px;
   padding: 8px 10px;
   border-radius: 14px;
-  background: var(--ion-color-step-100, #f2f2f7);
+  background: var(--ion-card-background, #ffffff);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+  /* Expanded: a full-width bar, centered. */
+  left: 8px;
+  right: 8px;
   max-width: 520px;
   margin: 0 auto;
+}
+/* Collapsed: a compact pill that hugs its content at the bottom-left. */
+.audio-mini.collapsed {
+  right: auto;
+  width: auto;
+  max-width: calc(100% - 16px);
+  gap: 8px;
+  padding: 6px 8px;
 }
 .am-cover {
   flex: none;
@@ -60,6 +98,11 @@ import {
   background: var(--ion-color-primary);
   color: #fff;
   font-size: 20px;
+}
+.audio-mini.collapsed .am-cover {
+  width: 34px;
+  height: 34px;
+  font-size: 18px;
 }
 .am-cover img {
   width: 100%;
@@ -76,7 +119,7 @@ import {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: var(--ion-text-color);
+  color: var(--app-text);
 }
 .am-sub {
   font-size: 12px;
@@ -99,9 +142,28 @@ import {
   justify-content: center;
   cursor: pointer;
 }
+.audio-mini.collapsed .am-btn {
+  width: 34px;
+  height: 34px;
+  font-size: 18px;
+}
 .am-stop {
-  background: var(--ion-color-step-300, #c7c7cc);
-  color: var(--ion-text-color);
+  background: var(--app-border);
+  color: var(--app-text);
+}
+.am-toggle {
+  flex: none;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--app-text-muted, #8e8e93);
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
 }
 .am-rail {
   position: absolute;
@@ -110,7 +172,7 @@ import {
   bottom: 3px;
   height: 2px;
   border-radius: 1px;
-  background: var(--ion-color-step-200, rgba(0, 0, 0, 0.1));
+  background: var(--app-border);
 }
 .am-prog {
   height: 100%;

--- a/src/components/VoicePlayer.vue
+++ b/src/components/VoicePlayer.vue
@@ -40,6 +40,7 @@ import {
 
 const props = defineProps<{
   mid: string; // message id — this voice message's id in the global player
+  chatId?: string; // owning chat — lets the hovering controller hide while we're in it
   sender: string; // who it's from (shown in the hovering controller)
   src: string;
   outgoing: boolean;
@@ -100,7 +101,7 @@ async function decodeWaveform(): Promise<void> {
 // Play this voice message (or toggle it if it's already the active one) through the
 // global player, which replaces any other audio and keeps playing across navigation.
 function toggle(): void {
-  playAudio({ id: props.mid, url: props.src, title: 'Voice message', subtitle: props.sender, isVoice: true });
+  playAudio({ id: props.mid, url: props.src, title: 'Voice message', subtitle: props.sender, isVoice: true, chatId: props.chatId });
 }
 function cycleRate(): void {
   cycleAudioRate();
@@ -124,7 +125,12 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: 10px;
-  min-width: 200px;
+  /* Shrink to fit the bubble on narrow phones (Galaxy S25 ~360px): a hard min-width
+     plus the fixed-width play/time/avatar children used to overflow the bubble and
+     spill outside the chat frame. max-width:100% caps it; the flexible waveform
+     (.vp-wave, min-width:0) absorbs the slack. */
+  min-width: 0;
+  max-width: 100%;
   padding: 2px 0;
 }
 .vp-play {
@@ -148,7 +154,9 @@ onMounted(() => {
   gap: 2px;
   height: 24px;
   cursor: pointer;
-  min-width: 100px;
+  /* min-width:0 (not 100px) so the waveform can shrink below its content on a narrow
+     bubble instead of forcing the whole row wider than the chat frame. */
+  min-width: 0;
 }
 .vp-bar {
   flex: 1;

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -104,16 +104,34 @@ async function applyUpdate(updateServiceWorker: (reload?: boolean) => Promise<vo
   if (!router.currentRoute.value.path.startsWith('/tabs')) {
     await router.replace('/tabs/chats').catch(() => {});
   }
+  const reloadOnce = (): void => {
+    if (reloading) return;
+    reloading = true;
+    window.location.reload();
+  };
   // Guarantee the reload even if workbox's isUpdate-gated listener no-ops. Installed
-  // before SKIP_WAITING so we never miss the controllerchange it triggers.
+  // before SKIP_WAITING so we never miss the controllerchange it triggers. Wrapped in
+  // try/catch because some Android WebViews throw on addEventListener here — the timeout
+  // fallback below still reloads.
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      if (reloading) return;
-      reloading = true;
-      window.location.reload();
-    });
+    try {
+      navigator.serviceWorker.addEventListener('controllerchange', reloadOnce, { once: true });
+    } catch {
+      /* listener unavailable; covered by the timeout fallback */
+    }
   }
-  await updateServiceWorker(true); // posts SKIP_WAITING → new worker activates → controllerchange → reload
+  try {
+    await updateServiceWorker(true); // posts SKIP_WAITING → new worker activates → controllerchange → reload
+  } catch {
+    /* SKIP_WAITING post failed; the new worker may still take over → fallback reload */
+  }
+  // Fallback for devices where `controllerchange` never fires after the new worker
+  // claims clients — observed on some Samsung builds (Galaxy S25): the prompt dismissed
+  // but the page never refreshed, so the old JS kept running. By the time this fires,
+  // skipWaiting + clients.claim have run, so a plain reload picks up the new build.
+  // `reloading` makes this and the controllerchange path mutually exclusive (no double
+  // reload). 2.5s comfortably exceeds the activate/claim round-trip.
+  window.setTimeout(reloadOnce, 2500);
 }
 
 export function useAppUpdate(): void {

--- a/src/composables/useAudioPlayer.ts
+++ b/src/composables/useAudioPlayer.ts
@@ -21,6 +21,10 @@ export interface AudioTrackMeta {
   subtitle?: string;
   coverUrl?: string;
   isVoice?: boolean;
+  // The chat this audio belongs to. Lets the hovering controller (MinimizedAudio) hide
+  // itself while you're INSIDE that chat — there the in-message player is the control —
+  // and reappear (collapsed) once you leave. Absent → the controller always shows.
+  chatId?: string;
 }
 
 const el = new Audio();

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -130,6 +130,8 @@ import { runInviteSync } from '@/services/invites';
 import { notifyBanners, showActionBanner } from '@/services/notify';
 import { recordCues, recordedCues } from '@/services/sound';
 import { syncContactEdges } from '@/services/directory';
+import { audioTrack, audioCurId, audioPlaying } from '@/composables/useAudioPlayer';
+import appRouter from '@/router';
 import {
   requestConnect as storeRequestConnect, acceptConnect as storeAcceptConnect,
   rejectConnect as storeRejectConnect, withdrawConnect as storeWithdrawConnect,
@@ -517,6 +519,18 @@ export function installTestHook(): void {
       dbSendMediaMessage(chatId, 'audio', new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'audio/mpeg' }), name, 12, {
         audio: { title, artist },
       }),
+    /** Pin a fake "now playing" track on the global player (no real audio element), so
+     *  tests can exercise the hovering controller (spec 1007) — including its hide-while-
+     *  in-the-owning-chat behavior — without a decodable blob that would 'end' instantly.
+     *  Pass the owning chatId so the controller hides while that chat is on screen. */
+    playAudioTest: (chatId: string, title = 'Demo Track'): void => {
+      audioCurId.value = `test-audio:${chatId}`;
+      audioTrack.value = { id: `test-audio:${chatId}`, url: '', title, subtitle: 'Ring', isVoice: false, chatId };
+      audioPlaying.value = true;
+    },
+    /** SPA navigation via the app router (preserves in-memory state, unlike a full
+     *  page reload) — e.g. to leave a chat without tearing down the global audio. */
+    navigate: (path: string): Promise<unknown> => appRouter.push(path),
     /** Send a round video-note ("video message"). */
     sendVideoNote: (chatId: string, name: string) =>
       dbSendMediaMessage(chatId, 'video', new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'video/mp4' }), name, 8, {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -294,6 +294,7 @@
                 <voice-player
                   v-else-if="m.kind === 'voice'"
                   :mid="m.id"
+                  :chat-id="chatId"
                   :sender="m.outgoing ? 'You' : chat?.isGroup ? m.senderName : chat?.name ?? m.senderName"
                   :src="mediaInfo[m.mediaId].url || ''"
                   :outgoing="m.outgoing"
@@ -3519,9 +3520,10 @@ function audioMetaFor(id: string): AudioTrackMeta | undefined {
       subtitle: m.audio?.artist,
       coverUrl: mediaInfo.value[m.mediaId]?.posterUrl,
       isVoice: false,
+      chatId, // so the hovering controller hides while we're in this chat
     };
   }
-  return { id, url, title: 'Voice message', subtitle: who, isVoice: true };
+  return { id, url, title: 'Voice message', subtitle: who, isVoice: true, chatId };
 }
 function toggleAudio(id: string): void {
   const meta = audioMetaFor(id);


### PR DESCRIPTION
## Summary
Three device-reported fixes, verified with the drive/ Playwright harness.

### Floating audio player
- **Hides inside its own chat.** While you're in the chat that owns the playing audio, the in-message player is the control, so the hovering controller no longer doubles up; it reappears once you leave.
- **Collapsed + expandable.** After you leave the chat it shows as a compact pill and expands on demand.
- **Themed.** It followed the light palette even in dark mode because it used Ionic step colors this app doesn't define; switched to the app's own theme tokens.

### Galaxy S25
- **In-app update reliably refreshes.** Some Samsung builds never fire the service-worker `controllerchange` event, so the toast dismissed but the page never reloaded. Added a guaranteed timeout-fallback reload (mutually exclusive with the existing controllerchange reload) plus error-safety around the listener.
- **Voice messages stay inside the bubble.** A hard `min-width` on the voice player + a non-shrinkable waveform overflowed the chat frame on ~360px screens; fixed with `min-width:0` / `max-width:100%`.

## Testing
- `npm run build` clean; 408 unit tests pass.
- Visually verified all four floating-player states (hidden-in-chat, collapsed, expanded, dark) via `drive/scenarios/audio-player-fixes.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
