### PR TITLE
ci: publish images to Docker Hub (mirror) + synced Overview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,10 +200,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Mirror to Docker Hub for discoverability (that's where people `docker pull`).
+      # ghcr.io stays the canonical/CI registry; both get the same tags.
+      - uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/zuptalo/ring
+          images: |
+            ghcr.io/zuptalo/ring
+            docker.io/zuptalo/ring
           tags: |
             type=raw,value=develop
             type=sha,format=short,prefix=develop-
@@ -220,3 +229,13 @@ jobs:
             RELEASE_NOTES_B64=${{ steps.notes.outputs.b64 }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      # Keep the Docker Hub repo's Overview (README + short description) in sync with
+      # docs/DOCKERHUB.md on every develop publish, so the listing never drifts.
+      - name: Sync Docker Hub Overview
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: zuptalo/ring
+          short-description: 'Private, end-to-end-encrypted messenger & calling app — self-hostable PWA + Go backend (AGPL).'
+          readme-filepath: ./docs/DOCKERHUB.md

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -56,10 +56,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Mirror the RC image to Docker Hub (canonical registry stays ghcr.io).
+      - uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/zuptalo/ring
+          images: |
+            ghcr.io/zuptalo/ring
+            docker.io/zuptalo/ring
           # The exact RC version only - never latest, never X.Y (those belong to
           # stable releases and must keep pointing at the last GA build).
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,20 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Mirror the production image to Docker Hub (canonical registry stays ghcr.io).
+      - uses: docker/login-action@v3
+        if: steps.check.outputs.exists == 'false'
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/metadata-action@v5
         id: meta
         if: steps.check.outputs.exists == 'false'
         with:
-          images: ghcr.io/zuptalo/ring
+          images: |
+            ghcr.io/zuptalo/ring
+            docker.io/zuptalo/ring
           # latest + full semver + major.minor, all pointing at this release.
           tags: |
             type=raw,value=latest

--- a/docs/DOCKERHUB.md
+++ b/docs/DOCKERHUB.md
@@ -1,0 +1,62 @@
+# Ring
+
+**A private, end-to-end-encrypted messenger and calling app** — shipped as one small,
+stateless container that serves an installable PWA and its Go backend. The server only
+ever relays sealed envelopes and stores opaque ciphertext: it never sees message bodies,
+contacts, profiles, or media.
+
+- 🔒 **Zero-knowledge** — Double Ratchet / X3DH E2EE (libsodium); the server is blind to plaintext.
+- 📱 **Installable PWA** — Vue 3 + Ionic, offline-first, Web Push.
+- 📞 **1:1 & group calls** — WebRTC with an embedded TURN relay + SFU, E2EE media.
+- 🗂️ **One stateless image** — all state (including encrypted-at-rest secrets) lives in PostgreSQL.
+- 🪪 **AGPL-3.0**, self-hostable, invite-only.
+
+## Quick start
+
+```sh
+export PUBLIC_URL=https://ring.example.com
+export POSTGRES_PASSWORD=$(openssl rand -hex 16)
+export SECRETS_KEY=$(openssl rand -hex 32)   # keep this stable + backed up
+docker compose up -d
+```
+
+Then grab the first-run invite code:
+
+```sh
+docker compose logs ring | grep FIRST-RUN
+```
+
+The container is **stateless** — on first boot it generates its own secrets (VAPID,
+token-signing, TURN) and stores them **encrypted in Postgres** under `SECRETS_KEY`, so
+only the database needs a volume. Full compose file, TLS/calling scenarios, configuration,
+and backups: see the [GitHub repository](https://github.com/zuptalo/ring).
+
+## Tags
+
+| Tag | What it is |
+| --- | --- |
+| `latest`, `X.Y.Z`, `X.Y` | Production releases. |
+| `X.Y.Z-rc.N` | Immutable release candidates (never moves `latest`). |
+| `develop`, `develop-<sha>` | Rolling development build. |
+
+Images are multi-arch (`linux/amd64`, `linux/arm64`). The canonical registry is
+`ghcr.io/zuptalo/ring`; this Docker Hub repo mirrors the same tags.
+
+## Screenshots
+
+<p>
+  <img src="https://raw.githubusercontent.com/zuptalo/ring/develop/showcase/output/iphone/light/02-chats.png" width="240" alt="Chats" />
+  <img src="https://raw.githubusercontent.com/zuptalo/ring/develop/showcase/output/iphone/light/03-chat.png" width="240" alt="Conversation" />
+  <img src="https://raw.githubusercontent.com/zuptalo/ring/develop/showcase/output/iphone/dark/06-group.png" width="240" alt="Group chat (dark)" />
+</p>
+
+## Support
+
+Ring is free and open-source, with no paywall. If it's useful to you, you can chip in
+whatever you think it's worth: **[Ko-fi](https://ko-fi.com/zuptalo)** ·
+**[Liberapay](https://liberapay.com/zuptalo)** ·
+**[GitHub Sponsors](https://github.com/sponsors/zuptalo)**.
+
+## License
+
+[AGPL-3.0-only](https://github.com/zuptalo/ring/blob/develop/LICENSE). © 2026 Zuptalo.


### PR DESCRIPTION
Mirrors every build (develop, releases, RCs) to **docker.io/zuptalo/ring** alongside ghcr.io, so the image is discoverable where people `docker pull`. ghcr.io stays the canonical/CI registry; both registries get the same multi-arch tags.

- Adds a Docker Hub login + `docker.io/zuptalo/ring` image target to `ci.yml`, `release.yml`, `release-candidate.yml`.
- Adds a Docker Hub **Overview** (`docs/DOCKERHUB.md`) kept in sync on each develop publish via `peter-evans/dockerhub-description`.

Requires the `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` repo secrets (already configured) and the `zuptalo/ring` Docker Hub repo (already created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)