### PR TITLE
feat(chat): HD-only media sends — drop the quality picker (spec 1023)

### DIFF
--- a/e2e/chat-media-scroll.spec.ts
+++ b/e2e/chat-media-scroll.spec.ts
@@ -26,7 +26,7 @@ async function pasteImage(p: any): Promise<void> {
     ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
   });
   await p.page.getByRole('button', { name: 'Send' }).click();
-  await p.page.getByText('Original quality').click();
+  // HD-only (spec 1023): no quality picker — the send goes through directly.
 }
 
 test('image renders in the list and the full-screen viewer opens on tap', async ({ browser }) => {

--- a/e2e/message-menu.spec.ts
+++ b/e2e/message-menu.spec.ts
@@ -68,7 +68,7 @@ test('a single tap on an image opens the viewer directly (no menu step)', async 
     ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
   });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  await a.page.getByText('Original quality').click();
+  // HD-only (spec 1023): no quality picker — the send goes through directly.
 
   const image = a.page.locator('.bubble .bubble-image').last();
   await expect(image).toBeVisible({ timeout: 30_000 });

--- a/e2e/paste-image.spec.ts
+++ b/e2e/paste-image.spec.ts
@@ -41,10 +41,12 @@ test('pasted image sends with the typed caption', async ({ browser }) => {
   await expect(a.page.locator('.paste-thumb img')).toBeVisible({ timeout: 10_000 });
   await expect(composer).toHaveAttribute('placeholder', 'Add a caption');
 
-  // Type the caption below the thumbnail and send (Original skips compression).
+  // Type the caption below the thumbnail and send. HD-only (spec 1023): there is NO
+  // quality picker — the send goes through directly at the HD tier.
   await composer.pressSequentially('From my clipboard', { delay: 15 });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  await a.page.getByText('Original quality').click();
+  // The old "Send quality" action sheet must not appear anymore.
+  await expect(a.page.getByText('Send quality')).toHaveCount(0);
 
   // Sender side: an image bubble with the caption under the photo, staging row gone.
   await expect(a.page.locator('.bubble .bubble-image').last()).toBeVisible({ timeout: 30_000 });

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1005,9 +1005,9 @@ import AnimatedEmoji from '@/components/AnimatedEmoji.vue';
 import { segmentEmoji, emojiOnlyCount } from '@/utils/emoji';
 import { userColorBright } from '@/utils/user-color';
 import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
-import { type Quality, availableQualities, qualityLabel, isPreservedImageMime } from '@/services/media-encode';
+import { type Quality } from '@/services/media-encode';
 import { jobProgress } from '@/services/media-jobs';
-import { generateVideoPoster, generateImageThumb, isAnimatedImage, readImageMeta, readVideoMeta } from '@/utils/media-meta';
+import { generateVideoPoster, generateImageThumb, isAnimatedImage } from '@/utils/media-meta';
 import { openExternal } from '@/utils/external';
 import { selectEvictions } from '@/utils/lru';
 import { normalizeOutgoing } from '@/utils/text';
@@ -3199,20 +3199,10 @@ async function send() {
   // Pasted images go out with the typed text as the caption (on the first image
   // when several were pasted — they share an album grid like the picker flow).
   if (pendingImages.value.length) {
-    // GIF / WebP are always sent untouched (animation/alpha preserved), so a quality
-    // prompt would be a no-op — skip it when every pending image is one of those. A
-    // mixed batch still asks, since the JPEG/PNG items genuinely have tiers to choose.
-    let quality: Quality;
-    if (pendingImages.value.every((p) => isPreservedImageMime(p.blob.type))) {
-      quality = 'original';
-    } else {
-      const longEdge = await maxSourceLongEdge(
-        pendingImages.value.map((p) => ({ blob: p.blob, kind: 'image' as const })),
-      );
-      const picked = await pickQuality(longEdge);
-      if (picked === null) return; // cancelled: keep the images and the draft
-      quality = picked;
-    }
+    // HD-only (spec 1023): chat media is for viewing, not downloading/saving, so there is
+    // no quality picker — everything sends at the HD tier. GIF/WebP still pass through
+    // untouched downstream (compressImage preserves animation/alpha regardless of tier).
+    const quality: Quality = 'hd';
     const images = pendingImages.value.slice();
     pendingImages.value = [];
     draft.value = '';
@@ -3365,54 +3355,7 @@ function promptAlbumName(suggestedDate?: string): Promise<string | null> {
   });
 }
 
-// The longest pixel edge across the chosen photos/videos (the largest source in the
-// batch), used to decide which quality tiers are worth offering. Best-effort + bounded
-// by the meta readers; a 'file' or an unreadable item contributes nothing.
-async function maxSourceLongEdge(
-  items: { blob: Blob; kind: 'image' | 'video' | 'file' }[],
-): Promise<number | undefined> {
-  let max = 0;
-  for (const it of items) {
-    if (it.kind === 'image') {
-      const m = await readImageMeta(it.blob).catch(() => ({}) as { width?: number; height?: number });
-      if (m.width && m.height) max = Math.max(max, m.width, m.height);
-    } else if (it.kind === 'video') {
-      const m = await readVideoMeta(it.blob).catch(() => ({}) as { width?: number; height?: number });
-      if (m.width && m.height) max = Math.max(max, m.width, m.height);
-    }
-  }
-  return max || undefined;
-}
 
-// Ask the send quality for photos/videos (WhatsApp-style), offering ONLY the tiers a
-// source of this resolution can actually produce — no upscaling, no "4K" on a 720p clip
-// (spec 2007). `longEdge` is the largest source's longest pixel edge. The sheet always
-// appears for photos/videos (predictable, and the existing flows depend on it); when the
-// source is below the smallest tier it simply lists Original alone. Returns null on cancel.
-function pickQuality(longEdge?: number): Promise<Quality | null> {
-  const opts = availableQualities(longEdge);
-  // Highest fidelity first (Original, then Full HD → SD), mirroring WhatsApp's ordering.
-  const tiers = opts.filter((q) => q !== 'original').reverse();
-  return new Promise((resolve) => {
-    const buttons: import('@ionic/vue').ActionSheetButton[] = [
-      { text: 'Original quality', handler: () => resolve('original') },
-      ...tiers.map((q) => ({
-        text: q === 'sd' ? 'SD quality (smaller)' : `${qualityLabel(q)} quality`,
-        handler: () => resolve(q),
-      })),
-      { text: 'Cancel', role: 'cancel', handler: () => resolve(null) },
-    ];
-    void actionSheetController
-      .create({ header: 'Send quality', buttons })
-      .then((s) => {
-        // Tapping the backdrop also dismisses → treat as cancel.
-        s.onDidDismiss().then((d) => {
-          if (d.role === 'backdrop') resolve(null);
-        });
-        return s.present();
-      });
-  });
-}
 
 async function onPick(e: Event, mode: 'auto' | 'file') {
   const input = e.target as HTMLInputElement;
@@ -3440,22 +3383,10 @@ async function onPick(e: Event, mode: 'auto' | 'file') {
   let replyLeft = reply; // the quote attaches to the first item sent
 
   if (otherFiles.length) {
-    // Photos/videos can be sent at HD/SD/Original; ask once for the whole batch — but
-    // only when something in it actually has tiers to choose. GIF/WebP are always sent
-    // untouched, so a batch of only those (no other photos/videos) skips the prompt.
-    const needsQuality = otherFiles.some((f) => {
-      const k = kindOf(f);
-      return (k === 'image' || k === 'video') && !isPreservedImageMime(f.type);
-    });
-    let quality: Quality = 'original';
-    if (needsQuality) {
-      const longEdge = await maxSourceLongEdge(
-        otherFiles.map((f) => ({ blob: f, kind: kindOf(f) as 'image' | 'video' | 'file' })),
-      );
-      const q = await pickQuality(longEdge);
-      if (q === null) return; // cancelled
-      quality = q;
-    }
+    // HD-only (spec 1023): chat media is for viewing, not downloading/saving, so there is
+    // no quality picker — send everything at the HD tier (GIF/WebP stay untouched
+    // downstream regardless of the tier).
+    const quality: Quality = 'hd';
     // Several photos/videos chosen together share an album id → rendered as a grid.
     const allMedia = otherFiles.every((f) => kindOf(f) === 'image' || kindOf(f) === 'video');
     const albumId = otherFiles.length > 1 && allMedia ? crypto.randomUUID() : undefined;


### PR DESCRIPTION
First increment of **spec 1023**. Chat media is for viewing in-chat, not downloading/saving, so there's no quality choice anymore — every photo/video/file sends at the **HD tier** (GIF/WebP still pass through untouched, preserving animation/alpha).

- Removes the 'Send quality' action sheet from both the pick and paste flows, plus the now-dead `pickQuality` / `maxSourceLongEdge` helpers and their imports.
- The media-quality engine + `availableQualities` are untouched (the spec-2007 e2e drive explicit-quality hooks, so they still pass).
- The three UI-picker e2e (paste-image, message-menu, chat-media-scroll) are updated to the new no-picker behavior; paste-image now asserts the 'Send quality' sheet does **not** appear.

Build clean; 12 affected media e2e green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)