### PR TITLE
feat(chat): keep the Original/HD/SD send-quality choice for photos and videos

### DIFF
--- a/e2e/chat-media-captions.spec.ts
+++ b/e2e/chat-media-captions.spec.ts
@@ -51,6 +51,7 @@ test('media picked from the library can be captioned before sending (not just pa
   await composer.click();
   await composer.pressSequentially('from my library', { delay: 12 });
   await a.page.getByRole('button', { name: 'Send' }).click();
+  await a.page.getByText('Original quality').click(); // tiny PNGs only offer Original
 
   // The image bubble carries the caption; the staging row is cleared.
   await expect(a.page.locator('.bubble .bubble-image').last()).toBeVisible({ timeout: 30_000 });
@@ -95,6 +96,7 @@ test('multiple picked photos can be sent individually, each carrying the shared 
   await composer.click();
   await composer.pressSequentially('trip', { delay: 12 });
   await a.page.getByRole('button', { name: 'Send' }).click();
+  await a.page.getByText('Original quality').click(); // tiny PNGs only offer Original
 
   // Three SEPARATE image messages (no shared albumId), each carrying the shared caption.
   await expect
@@ -142,6 +144,7 @@ test('a per-item caption overrides the shared caption for just that item', async
   await composer.pressSequentially('the others', { delay: 12 });
   await a.page.locator('.send-mode ion-segment-button').nth(1).click(); // Individual
   await a.page.getByRole('button', { name: 'Send' }).click();
+  await a.page.getByText('Original quality').click(); // tiny PNGs only offer Original
 
   // The first item carries its own caption; the second falls back to the shared one.
   await expect
@@ -181,6 +184,7 @@ test('multiple picked photos sent as an album share one album id with a single c
   await composer.click();
   await composer.pressSequentially('holiday', { delay: 12 });
   await a.page.getByRole('button', { name: 'Send' }).click();
+  await a.page.getByText('Original quality').click(); // tiny PNGs only offer Original
 
   // All three images share ONE album id, and exactly one of them carries the caption.
   await expect

--- a/e2e/chat-media-scroll.spec.ts
+++ b/e2e/chat-media-scroll.spec.ts
@@ -26,7 +26,7 @@ async function pasteImage(p: any): Promise<void> {
     ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
   });
   await p.page.getByRole('button', { name: 'Send' }).click();
-  // HD-only (spec 1023): no quality picker — the send goes through directly.
+  await p.page.getByText('Original quality').click();
 }
 
 test('image renders in the list and the full-screen viewer opens on tap', async ({ browser }) => {

--- a/e2e/message-menu.spec.ts
+++ b/e2e/message-menu.spec.ts
@@ -68,7 +68,7 @@ test('a single tap on an image opens the viewer directly (no menu step)', async 
     ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
   });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  // HD-only (spec 1023): no quality picker — the send goes through directly.
+  await a.page.getByText('Original quality').click();
 
   const image = a.page.locator('.bubble .bubble-image').last();
   await expect(image).toBeVisible({ timeout: 30_000 });

--- a/e2e/paste-image.spec.ts
+++ b/e2e/paste-image.spec.ts
@@ -41,12 +41,10 @@ test('pasted image sends with the typed caption', async ({ browser }) => {
   await expect(a.page.locator('.paste-thumb img')).toBeVisible({ timeout: 10_000 });
   await expect(composer).toHaveAttribute('placeholder', 'Add a caption');
 
-  // Type the caption below the thumbnail and send. HD-only (spec 1023): there is NO
-  // quality picker — the send goes through directly at the HD tier.
+  // Type the caption below the thumbnail and send (Original skips compression).
   await composer.pressSequentially('From my clipboard', { delay: 15 });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  // The old "Send quality" action sheet must not appear anymore.
-  await expect(a.page.getByText('Send quality')).toHaveCount(0);
+  await a.page.getByText('Original quality').click();
 
   // Sender side: an image bubble with the caption under the photo, staging row gone.
   await expect(a.page.locator('.bubble .bubble-image').last()).toBeVisible({ timeout: 30_000 });

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1041,7 +1041,8 @@ import { segmentEmoji, emojiOnlyCount } from '@/utils/emoji';
 import { userColorBright } from '@/utils/user-color';
 import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
 import { jobProgress } from '@/services/media-jobs';
-import { generateVideoPoster, generateImageThumb, isAnimatedImage } from '@/utils/media-meta';
+import { generateVideoPoster, generateImageThumb, isAnimatedImage, readImageMeta, readVideoMeta } from '@/utils/media-meta';
+import { type Quality, availableQualities, qualityLabel, isPreservedImageMime } from '@/services/media-encode';
 import { openExternal } from '@/utils/external';
 import { selectEvictions } from '@/utils/lru';
 import { normalizeOutgoing } from '@/utils/text';
@@ -3313,8 +3314,24 @@ async function send() {
   // Staged media (picked OR pasted) go out with the typed text as the caption. With 2+
   // photos/videos the user picks Album (one swipeable post, default) or Individual: an
   // album carries the caption once (on the first item); individual messages each carry it.
-  // Files are never part of an album. HD-only (spec 1023): everything sends at the HD tier.
+  // Files are never part of an album.
   if (pendingMedia.value.length) {
+    // Ask the send quality once for the whole batch (photos/videos), as the chat composer
+    // has always done — quality is a per-chat choice (the HD-only rule is a Wall thing, not
+    // chats). GIF/WebP are sent untouched, so a batch with nothing compressible skips the
+    // no-op prompt. Cancelling keeps the staged media + the draft intact.
+    const compressible = pendingMedia.value.filter(
+      (it) => (it.kind === 'image' || it.kind === 'video') && !isPreservedImageMime(it.blob.type),
+    );
+    let quality: Quality = 'original';
+    if (compressible.length) {
+      const longEdge = await maxSourceLongEdge(
+        compressible.map((it) => ({ blob: it.blob, kind: it.kind as 'image' | 'video' })),
+      );
+      const picked = await pickQuality(longEdge);
+      if (picked === null) return; // cancelled
+      quality = picked;
+    }
     const items = pendingMedia.value.slice();
     pendingMedia.value = [];
     const caption = text;
@@ -3338,7 +3355,7 @@ async function send() {
         it.blob,
         it.blob.name || (it.kind === 'file' ? 'file' : 'photo'),
         undefined,
-        { replyTo: i === 0 ? reply : undefined, caption: cap, albumId: inAlbum ? albumId : undefined, quality: 'hd' },
+        { replyTo: i === 0 ? reply : undefined, caption: cap, albumId: inAlbum ? albumId : undefined, quality },
       );
       if (it.url) URL.revokeObjectURL(it.url);
     }
@@ -3454,6 +3471,54 @@ async function onVideoNoteSend(blob: Blob, dur: number, poster?: string): Promis
   const reply = replyingTo.value ? { ...replyingTo.value } : undefined;
   replyingTo.value = null;
   await sendMediaMessage(chatId, 'video', blob, 'video-note', dur, { videoNote: true, replyTo: reply, poster });
+}
+
+// Ask the send quality for photos/videos (WhatsApp-style), offering ONLY the tiers a
+// source of this resolution can actually produce — no upscaling, no "4K" on a 720p clip
+// (spec 2007). `longEdge` is the largest source's longest pixel edge. When the source is
+// below the smallest tier it simply lists Original alone. Returns null on cancel.
+function pickQuality(longEdge?: number): Promise<Quality | null> {
+  const opts = availableQualities(longEdge);
+  // Highest fidelity first (Original, then Full HD → SD), mirroring WhatsApp's ordering.
+  const tiers = opts.filter((q) => q !== 'original').reverse();
+  return new Promise((resolve) => {
+    const buttons: import('@ionic/vue').ActionSheetButton[] = [
+      { text: 'Original quality', handler: () => resolve('original') },
+      ...tiers.map((q) => ({
+        text: q === 'sd' ? 'SD quality (smaller)' : `${qualityLabel(q)} quality`,
+        handler: () => resolve(q),
+      })),
+      { text: 'Cancel', role: 'cancel', handler: () => resolve(null) },
+    ];
+    void actionSheetController
+      .create({ header: 'Send quality', buttons })
+      .then((s) => {
+        // Tapping the backdrop also dismisses → treat as cancel.
+        s.onDidDismiss().then((d) => {
+          if (d.role === 'backdrop') resolve(null);
+        });
+        return s.present();
+      });
+  });
+}
+
+// The longest pixel edge across the chosen photos/videos (the largest source in the
+// batch), used to decide which quality tiers are worth offering. Best-effort + bounded
+// by the meta readers; an unreadable item contributes nothing.
+async function maxSourceLongEdge(
+  items: { blob: Blob; kind: 'image' | 'video' }[],
+): Promise<number | undefined> {
+  let max = 0;
+  for (const it of items) {
+    if (it.kind === 'image') {
+      const m = await readImageMeta(it.blob).catch(() => ({}) as { width?: number; height?: number });
+      if (m.width && m.height) max = Math.max(max, m.width, m.height);
+    } else {
+      const m = await readVideoMeta(it.blob).catch(() => ({}) as { width?: number; height?: number });
+      if (m.width && m.height) max = Math.max(max, m.width, m.height);
+    }
+  }
+  return max || undefined;
 }
 
 function onPick(e: Event, mode: 'auto' | 'file') {


### PR DESCRIPTION
**Reverts the HD-only behaviour in chats** — the HD-only rule was only meant for the **Wall**, not chats. This restores the chat composer's send-quality picker, now integrated into the unified staging flow (#554):

- On **Send**, it asks once for the whole batch (Original / Full HD / HD / SD, only the tiers the source can actually produce). GIF/WebP skip the no-op prompt. **Cancel** keeps your staged media + draft.
- Re-adds the `pickQuality` / `maxSourceLongEdge` helpers and the quality imports that the HD-only change (#553) had removed.
- Restores the quality-picker step across the media e2e (paste, message-menu, scroll, and the captions/albums suite).

The Wall's HD-only stays as the Wall's own concern (spec 1022, FR-020). Build clean; the captions/albums suite (4) + paste/menu/scroll media e2e are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)