### PR TITLE
feat(wall): share photos and videos at HD — drop the quality picker (spec 1022)

### DIFF
--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -64,17 +64,6 @@
         @change="onFile"
       />
 
-      <!-- Quality applies to photos/videos only; voice is sent as recorded. -->
-      <ion-list v-if="media && mediaKind !== 'voice'" :inset="true">
-        <ion-list-header>Quality</ion-list-header>
-        <ion-item lines="none">
-          <ion-segment :value="quality" @ion-change="onQuality">
-            <ion-segment-button value="sd"><ion-label>SD</ion-label></ion-segment-button>
-            <ion-segment-button value="hd"><ion-label>HD</ion-label></ion-segment-button>
-          </ion-segment>
-        </ion-item>
-      </ion-list>
-
       <ion-list :inset="true">
         <ion-list-header>Who can see this</ion-list-header>
         <ion-item lines="none">
@@ -132,7 +121,6 @@ const mediaUrl = ref<string | undefined>(undefined);
 const mediaKind = ref<'image' | 'video' | 'voice'>('image');
 const mediaName = ref('attachment');
 const mediaDuration = ref<number | undefined>(undefined);
-const quality = ref<'sd' | 'hd'>('hd');
 
 const canShare = computed(() => body.value.trim().length > 0 || !!media.value);
 
@@ -144,9 +132,6 @@ function onAudience(e: CustomEvent): void {
 }
 function onLifetime(e: CustomEvent): void {
   lifetime.value = ((e.detail as { value?: string }).value as PostLifetime) ?? '72h';
-}
-function onQuality(e: CustomEvent): void {
-  quality.value = ((e.detail as { value?: string }).value as 'sd' | 'hd') ?? 'hd';
 }
 
 function pickMedia(): void {
@@ -243,7 +228,9 @@ async function share(): Promise<void> {
       audience: audience.value,
       lifetime: lifetime.value,
       media: media.value
-        ? { blob: media.value, kind: mediaKind.value, name: mediaName.value, durationSec: mediaDuration.value, quality: quality.value }
+        ? // HD-only on the Wall (spec 1022, FR-020): feed media is for viewing, not
+          // downloading, so there's no quality choice — every post ships at HD.
+          { blob: media.value, kind: mediaKind.value, name: mediaName.value, durationSec: mediaDuration.value, quality: 'hd' }
         : undefined,
     });
     router.back();


### PR DESCRIPTION
**Spec 1022, FR-020.** Wall media is for viewing in the feed, not downloading/saving, so there's no quality choice — every post ships at **HD**. Removes the SD/HD picker from the post composer.

This is the HD-only rule you meant — it lives on the **Wall**, not chats (chats keep their Original/HD/SD picker, restored in #556). Touches only `PostComposerPage`; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)