### PR TITLE
refactor(wall): carry multiple media per post — album groundwork (spec 1022)

### DIFF
--- a/e2e/album-posts.spec.ts
+++ b/e2e/album-posts.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 1022 — FR-019 album posts (plumbing): a single post can carry an ordered set of
+ * media. This drives the REAL createPost → seal-N-refs → upload → register path and the
+ * receive path, asserting the album round-trips with all its media (E2EE end-to-end).
+ */
+
+const mediaCount = (p: any, postId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.postMediaCount(id), postId) as Promise<number>;
+
+test('an album post round-trips with all of its media', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'ALBUMPOST1');
+  const b = await createAccount(ctxB, 'ALBUMPOST2');
+  await pair(a, b);
+
+  // A shares a 3-photo album through the real compose/seal/upload path.
+  const postId = (await a.page.evaluate(() => (window as any).__ringTest.postAlbum(3, 'our trip'))) as string;
+  expect(postId).toBeTruthy();
+
+  // The author has all three media locally right away.
+  expect(await mediaCount(a, postId)).toBe(3);
+
+  // B pulls posts → receives the album with ALL three media (not just the cover).
+  await expect
+    .poll(
+      async () => {
+        await b.page.evaluate(() => (window as any).__ringTest.syncPosts());
+        return mediaCount(b, postId);
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(3);
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2145,6 +2145,15 @@ async function peerPostKey(userId: string): Promise<Uint8Array | null> {
   return b64urlToBytes(bundle.xPub);
 }
 
+/** One media attachment for a post: a picked/recorded blob + how to send it. */
+export interface PostMediaInput {
+  blob: Blob;
+  kind: 'image' | 'video' | 'voice';
+  name: string;
+  durationSec?: number;
+  quality?: 'sd' | 'hd';
+}
+
 /**
  * Create a Wall post: seal the payload under a fresh per-post key, wrap that key to
  * each audience member, upload the opaque blob, register the post server-side, then
@@ -2155,10 +2164,11 @@ export async function createPost(opts: {
   body?: string;
   audience: 'friends' | 'close';
   lifetime: PostLifetime;
-  // Optional attachment (image/video/voice). When present, it is compressed to the
-  // chosen quality (SD or HD — never original), encrypted + uploaded, and the media-ref
-  // rides sealed inside the post payload.
-  media?: { blob: Blob; kind: 'image' | 'video' | 'voice'; name: string; durationSec?: number; quality?: 'sd' | 'hd' };
+  // Optional attachment(s). A single item is an ordinary media post; an array of 2+
+  // image/video items is an ALBUM post (spec 1022, FR-019) — every item is compressed to
+  // the chosen quality, encrypted + uploaded, and all the media-refs ride sealed inside
+  // the one post payload.
+  media?: PostMediaInput | PostMediaInput[];
 }): Promise<Post> {
   const self = getSelfUserId();
   if (!self) throw new Error('not signed in');
@@ -2175,35 +2185,45 @@ export async function createPost(opts: {
 
   // Encrypt + upload the attachment first (its key rides sealed in the payload), and
   // keep a local Media copy so the author renders it immediately.
-  const kind: Post['kind'] = opts.media ? opts.media.kind : 'text';
-  let mediaId: string | undefined;
+  // Normalise to a list: one item = a single-media post; 2+ image/video items = an album.
+  const mediaList: PostMediaInput[] = opts.media ? (Array.isArray(opts.media) ? opts.media : [opts.media]) : [];
+  const kind: Post['kind'] = mediaList.length ? mediaList[0].kind : 'text';
+  let mediaId: string | undefined; // the cover (first item) — keeps single-media paths working
   let mediaW: number | undefined;
   let mediaH: number | undefined;
+  const mediaIds: string[] = [];
+  const refs: NonNullable<PostPayload['album']> = [];
   const payload: PostPayload = { kind, body };
-  if (opts.media) {
+  for (const m of mediaList) {
     // Posts only ship SD or HD (never the original): compress images/videos to the
     // chosen quality before upload; voice is left as-is.
-    const q = opts.media.quality ?? 'hd';
+    const q = m.quality ?? 'hd';
     const toUpload =
-      opts.media.kind === 'image'
-        ? await compressImage(opts.media.blob, q)
-        : opts.media.kind === 'video'
-          ? await compressVideo(opts.media.blob, q)
-          : opts.media.blob;
-    // Honest badge (spec 2007): label posts by the quality actually achieved. When a
-    // transcode can't shrink the clip it returns the original, so we don't claim an
-    // SD/HD the feed item isn't. (Voice isn't transcoded — keep its requested value.)
-    const achieved =
-      opts.media.kind === 'voice' ? q : achievedQuality(q, opts.media.blob.size, toUpload);
+      m.kind === 'image'
+        ? await compressImage(m.blob, q)
+        : m.kind === 'video'
+          ? await compressVideo(m.blob, q)
+          : m.blob;
+    // Honest badge (spec 2007): label by the quality actually achieved (a transcode that
+    // can't shrink the clip returns the original). Voice isn't transcoded — keep requested.
+    const achieved = m.kind === 'voice' ? q : achievedQuality(q, m.blob.size, toUpload);
     // Dimensions → reserve an aspect-ratio box in the feed (no layout jump).
-    if (opts.media.kind === 'image') ({ width: mediaW, height: mediaH } = await readImageMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
-    else if (opts.media.kind === 'video') ({ width: mediaW, height: mediaH } = await readVideoMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
-    const ref = await prepareOutgoingMedia(toUpload, opts.media.name, opts.media.durationSec, { width: mediaW, height: mediaH, quality: achieved });
-    payload.media = ref;
-    mediaId = uid();
+    let w: number | undefined;
+    let h: number | undefined;
+    if (m.kind === 'image') ({ width: w, height: h } = await readImageMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
+    else if (m.kind === 'video') ({ width: w, height: h } = await readVideoMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
+    const ref = await prepareOutgoingMedia(toUpload, m.name, m.durationSec, { width: w, height: h, quality: achieved });
+    refs.push(ref);
+    const id = uid();
+    mediaIds.push(id);
+    if (mediaIds.length === 1) {
+      mediaId = id; // cover
+      mediaW = w;
+      mediaH = h;
+    }
     await put<Media>('media', {
-      id: mediaId,
-      kind: opts.media.kind,
+      id,
+      kind: m.kind,
       mime: ref.mime,
       name: ref.name,
       size: ref.size,
@@ -2212,6 +2232,9 @@ export async function createPost(opts: {
       updatedAt: now(),
     });
   }
+  // Single item rides in `media`; an album rides as the ordered `album` list.
+  if (refs.length === 1) payload.media = refs[0];
+  else if (refs.length > 1) payload.album = refs;
 
   const built = buildPost(payload, audience);
   const blobId = await uploadBlob(new Blob([built.blob as BlobPart]));
@@ -2228,6 +2251,7 @@ export async function createPost(opts: {
     kind,
     body,
     mediaId,
+    mediaIds: mediaIds.length > 1 ? mediaIds : undefined,
     mediaW,
     mediaH,
     audience: opts.audience,
@@ -2261,19 +2285,36 @@ async function receivePost(sp: ServerPost): Promise<void> {
   }
   // Pull + decrypt the attachment (if any) and store it as a local Media record so the
   // Wall renders it like any other media.
+  // Pull + decrypt each attachment (a single `media`, or every item of an `album`) and
+  // store them as local Media records, preserving order, so the Wall renders them like
+  // any other media. The first becomes the cover (mediaId), matching createPost.
   let mediaId: string | undefined;
-  if (payload.media && payload.kind !== 'text') {
-    const mblob = await receiveIncomingMedia(payload.media).catch(() => null);
-    if (mblob) {
-      mediaId = uid();
+  let mediaW: number | undefined;
+  let mediaH: number | undefined;
+  const mediaIds: string[] = [];
+  const refsToGet = payload.album ?? (payload.media ? [payload.media] : []);
+  if (payload.kind !== 'text') {
+    for (const ref of refsToGet) {
+      const mblob = await receiveIncomingMedia(ref).catch(() => null);
+      if (!mblob) continue;
+      const id = uid();
+      mediaIds.push(id);
+      if (mediaIds.length === 1) {
+        mediaId = id;
+        mediaW = ref.width;
+        mediaH = ref.height;
+      }
+      // A mixed album can carry both images and videos, so derive each item's kind from
+      // its mime rather than the post's overall kind.
+      const itemKind = ref.mime.startsWith('video/') ? 'video' : ref.mime.startsWith('audio/') ? 'voice' : 'image';
       await put<Media>('media', {
-        id: mediaId,
-        kind: payload.kind,
-        mime: payload.media.mime,
-        name: payload.media.name,
-        size: payload.media.size,
+        id,
+        kind: itemKind,
+        mime: ref.mime,
+        name: ref.name,
+        size: ref.size,
         blob: mblob,
-        durationSec: payload.media.durationSec,
+        durationSec: ref.durationSec,
         updatedAt: now(),
       });
     }
@@ -2285,8 +2326,9 @@ async function receivePost(sp: ServerPost): Promise<void> {
     kind: payload.kind,
     body: payload.body,
     mediaId,
-    mediaW: payload.media?.width,
-    mediaH: payload.media?.height,
+    mediaIds: mediaIds.length > 1 ? mediaIds : undefined,
+    mediaW,
+    mediaH,
     createdAt: sp.createdAt,
     lastActivityAt: Math.max(prev?.lastActivityAt ?? 0, sp.createdAt),
     expiresAt: sp.expiresAt,

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -383,9 +383,14 @@ export interface Post {
   author: string; // userId; self for own posts, the peer for received
   kind: 'text' | 'voice' | 'video' | 'image';
   body?: string; // decrypted text / caption
-  mediaId?: string; // local `media` store id for voice/video/image
-  // Pixel dimensions of the attachment, so the feed can reserve an aspect-ratio box
-  // (with a skeleton) before the media loads — no layout jump as it decodes.
+  mediaId?: string; // local `media` store id for voice/video/image (the cover, for albums)
+  // An album post (spec 1022, FR-019) carries an ORDERED set of image/video media in one
+  // post — these are the local `media` ids in order. `mediaId` is set to the first (the
+  // cover) so single-media code paths keep working; album-aware UI uses the full list.
+  // Absent / length ≤ 1 ⇒ an ordinary single-media post.
+  mediaIds?: string[];
+  // Pixel dimensions of the attachment (the cover, for albums), so the feed can reserve an
+  // aspect-ratio box (with a skeleton) before the media loads — no layout jump as it decodes.
   mediaW?: number;
   mediaH?: number;
   audience?: 'friends' | 'close'; // own posts only (display-only on received)

--- a/src/services/crypto/post.ts
+++ b/src/services/crypto/post.ts
@@ -34,6 +34,10 @@ export interface PostPayload {
   kind: 'text' | 'voice' | 'video' | 'image';
   body?: string;
   media?: import('./message').MediaRef;
+  // An album post (spec 1022, FR-019) seals an ORDERED set of image/video media-refs here
+  // instead of the single `media`. Every ref rides sealed under K_post, so the server still
+  // sees only opaque ciphertext regardless of how many media a post carries.
+  album?: import('./message').MediaRef[];
 }
 
 /** Generate a fresh per-post content key. */

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -942,6 +942,26 @@ export function installTestHook(): void {
       const p = await dbCreatePost({ body: opts.body, audience: opts.audience ?? 'friends', lifetime: opts.lifetime ?? '24h' });
       return p.id;
     },
+    /** Compose + share an ALBUM post of `n` tiny images through the REAL createPost path
+     *  (compress → seal N refs → upload → register), so e2e exercises album round-trip. */
+    postAlbum: async (n: number, body?: string): Promise<string> => {
+      const png = Uint8Array.from(
+        atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='),
+        (c) => c.charCodeAt(0),
+      );
+      const media = Array.from({ length: n }, (_, i) => ({
+        blob: new Blob([png], { type: 'image/png' }),
+        kind: 'image' as const,
+        name: `album-${i}.png`,
+      }));
+      const p = await dbCreatePost({ body, audience: 'friends', lifetime: '24h', media });
+      return p.id;
+    },
+    /** How many media a post carries locally (album size; 1 for single; 0 for text). */
+    postMediaCount: async (id: string): Promise<number> => {
+      const p = await dbGetPost(id);
+      return p?.mediaIds?.length ?? (p?.mediaId ? 1 : 0);
+    },
     /** Pull posts addressed to us (and apply revocations). */
     syncPosts: () => dbSyncPosts(),
     /** Ids of the non-expired, non-hidden posts on this device (feed order). */


### PR DESCRIPTION
**Spec 1022, FR-019 — increment 1 (plumbing).** Foundation for **album posts**: a Wall post can now seal an *ordered set* of image/video media in one payload instead of a single attachment.

- `Post.mediaIds[]` + `PostPayload.album: MediaRef[]` (additive; single-media posts unchanged — `mediaId` stays as the cover).
- `createPost` compresses + seals N refs; the receive path opens them all, deriving each item's kind from its mime so a **mixed image+video** album works.
- **Server untouched** — it still relays one opaque sealed blob regardless of media count.
- **No user-facing surface yet** — the composer multi-select + swipeable rendering are increment 2 (hence `refactor`, not `feat`: nothing changes for users yet).

**Test:** `e2e/album-posts.spec.ts` — a 3-photo album seals → uploads → is received by the peer with all three media (E2EE round-trip).

Next: composer multi-select + feed album preview + swipeable detail (reusing the existing `MediaViewer`), built on the US1 poster work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)