### PR TITLE
feat(wall): show post thumbnails instantly instead of a blank box (spec 1022, US1)

### DIFF
--- a/e2e/wall-thumbnails.spec.ts
+++ b/e2e/wall-thumbnails.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { createAccount } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 1022 — US1: the feed must never show a blank/broken media box while the full media
+ * loads. A post whose full blob hasn't downloaded still has its small poster (it rode the
+ * sealed envelope), so the card shows the poster immediately.
+ */
+
+test('a post with only a poster (full media not downloaded) still shows a thumbnail', async ({ browser }) => {
+  const ctx = await browser.newContext();
+  const a = await createAccount(ctx, 'WALLTHUMB1');
+
+  // Seed an image post that has ONLY a poster tier (no full blob) — a received,
+  // not-yet-downloaded post.
+  await a.page.evaluate(() => (window as any).__ringTest.seedWallPosterOnlyImage());
+  await a.page.goto('/tabs/wall');
+
+  // The feed shows the poster as the thumbnail — a real <img> with a resolved blob URL,
+  // not a blank box.
+  const img = a.page.locator('.thumb img').first();
+  await expect(img).toBeVisible({ timeout: 30_000 });
+  await expect(img).toHaveAttribute('src', /^blob:/);
+
+  await ctx.close();
+});

--- a/src/composables/useWall.ts
+++ b/src/composables/useWall.ts
@@ -32,7 +32,8 @@ export interface WallPost extends Post {
   authorAvatar: string;
   authorUsername?: string;
   muted: boolean; // author's Wall notifications are muted
-  mediaUrl?: string;
+  mediaUrl?: string; // full-resolution blob (video src; image fallback) — may be absent
+  posterUrl?: string; // small poster tier — shows instantly so the feed never blanks (US1)
   reactions: ReactionGroup[];
   myEmojis: string[];
   comments: CommentView[];
@@ -53,30 +54,44 @@ export function useWall() {
   const tick = setInterval(() => (now.value = Date.now()), 30_000);
   onUnmounted(() => clearInterval(tick));
 
-  // Media object URLs by post id (created/revoked as posts come and go).
+  // Media object URLs by post id (created/revoked as posts come and go). We resolve TWO
+  // tiers: the small poster (shows instantly so the feed never flashes a blank tile — it
+  // rode the sealed envelope, so it's local even before the full media downloads) and the
+  // full blob (the video src; the image fallback when there's no poster).
   const mediaUrls = ref<Record<string, string>>({});
+  const posterUrls = ref<Record<string, string>>({});
   watch(
     () => posts.value.map((p) => `${p.id}:${p.mediaId ?? ''}`).join('|'),
     async () => {
-      const next: Record<string, string> = {};
+      const nextMedia: Record<string, string> = {};
+      const nextPoster: Record<string, string> = {};
       for (const p of posts.value) {
         if (!p.mediaId) continue;
-        if (mediaUrls.value[p.id]) {
-          next[p.id] = mediaUrls.value[p.id];
+        // Reuse already-resolved URLs (both tiers were resolved together on a prior pass).
+        if (mediaUrls.value[p.id] || posterUrls.value[p.id]) {
+          if (mediaUrls.value[p.id]) nextMedia[p.id] = mediaUrls.value[p.id];
+          if (posterUrls.value[p.id]) nextPoster[p.id] = posterUrls.value[p.id];
           continue;
         }
         const md = await getMedia(p.mediaId);
-        if (md?.blob) next[p.id] = URL.createObjectURL(md.blob);
+        if (md?.blob) nextMedia[p.id] = URL.createObjectURL(md.blob);
+        const poster = md?.posterBlob ?? md?.posterGrid;
+        if (poster) nextPoster[p.id] = URL.createObjectURL(poster);
       }
       for (const [pid, url] of Object.entries(mediaUrls.value)) {
-        if (next[pid] !== url) URL.revokeObjectURL(url);
+        if (nextMedia[pid] !== url) URL.revokeObjectURL(url);
       }
-      mediaUrls.value = next;
+      for (const [pid, url] of Object.entries(posterUrls.value)) {
+        if (nextPoster[pid] !== url) URL.revokeObjectURL(url);
+      }
+      mediaUrls.value = nextMedia;
+      posterUrls.value = nextPoster;
     },
     { immediate: true },
   );
   onUnmounted(() => {
     for (const url of Object.values(mediaUrls.value)) URL.revokeObjectURL(url);
+    for (const url of Object.values(posterUrls.value)) URL.revokeObjectURL(url);
   });
 
   const wall = computed<WallPost[]>(() => {
@@ -128,6 +143,7 @@ export function useWall() {
         authorUsername: isOwn ? undefined : c?.username,
         muted: !!mutedUsers.value[p.author],
         mediaUrl: mediaUrls.value[p.id],
+        posterUrl: posterUrls.value[p.id],
         reactions,
         myEmojis,
         comments,

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -942,6 +942,41 @@ export function installTestHook(): void {
       const p = await dbCreatePost({ body: opts.body, audience: opts.audience ?? 'friends', lifetime: opts.lifetime ?? '24h' });
       return p.id;
     },
+    /** Seed one own IMAGE post that has ONLY a poster tier and no full blob — i.e. a
+     *  received post whose full media hasn't downloaded yet. The feed must still show the
+     *  poster instantly (US1: no blank tile), which is what the thumbnail test asserts. */
+    seedWallPosterOnlyImage: async (): Promise<string> => {
+      const self = getSelfUserId() ?? 'me';
+      const now = Date.now();
+      const png = Uint8Array.from(
+        atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='),
+        (c) => c.charCodeAt(0),
+      );
+      const mediaId = `imgseed-${now}`;
+      const postId = `postimg-${now}`;
+      await put<Media>('media', {
+        id: mediaId,
+        kind: 'image',
+        mime: 'image/png',
+        name: 'photo.png',
+        size: 0, // full blob freed/not-downloaded
+        posterBlob: new Blob([png], { type: 'image/png' }), // the only tier we have locally
+        updatedAt: now,
+      });
+      await put<Post>('posts', {
+        id: postId,
+        author: self,
+        kind: 'image',
+        mediaId,
+        mediaW: 1,
+        mediaH: 1,
+        audience: 'friends',
+        createdAt: now,
+        outgoing: true,
+        updatedAt: now,
+      });
+      return postId;
+    },
     /** Seed `n` own VIDEO posts straight into IndexedDB (no real encrypt/transcode), so the
      *  Wall feed renders `n` tall <video> cards for the autoplay-on-visible test. The stub
      *  bytes don't decode, but the autoplay directive observes the element regardless, so the

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -73,16 +73,22 @@
               :style="mediaStyle(p)"
               @click="open(p.id)"
             >
+              <!-- Prefer the small poster: it's local immediately (it rode the sealed
+                   envelope), so the feed shows it at once instead of a blank box while the
+                   full image downloads. The full blob is loaded in the viewer on tap. -->
               <img
-                v-if="p.kind === 'image' && p.mediaUrl"
-                :src="p.mediaUrl"
+                v-if="p.kind === 'image' && (p.posterUrl || p.mediaUrl)"
+                :src="p.posterUrl || p.mediaUrl"
                 :alt="p.body || 'Photo'"
                 @load="onMediaLoad(p.id)"
               />
+              <!-- Video: the poster attribute shows a frame instantly; the full clip plays
+                   (and autoplays on screen) once its blob is present. -->
               <video
-                v-else-if="p.kind === 'video' && p.mediaUrl"
+                v-else-if="p.kind === 'video' && (p.mediaUrl || p.posterUrl)"
                 v-autoplay-visible
                 :src="p.mediaUrl"
+                :poster="p.posterUrl"
                 muted
                 playsinline
                 preload="metadata"
@@ -92,7 +98,7 @@
               <!-- The play glyph is the "tap to open" hint; hide it while the clip is
                    autoplaying inline so it isn't a button-over-moving-video. -->
               <ion-icon
-                v-if="p.kind === 'video' && p.mediaUrl"
+                v-if="p.kind === 'video' && (p.mediaUrl || p.posterUrl)"
                 class="play"
                 :icon="playCircleOutline"
               />


### PR DESCRIPTION
**Spec 1022, US1.** The feed resolves a post's small poster tier (it rode the sealed envelope, so it's local immediately) and shows it at once — an image renders its poster, a video shows a poster frame — instead of a blank/skeleton box while the full media downloads. The full blob still loads for video playback and on tap into the viewer.

New e2e: a poster-only post (full media not yet downloaded) still shows a thumbnail. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)