### PR TITLE
feat(wall): share photo & video albums — swipe through them in the post (spec 1022)

### DIFF
--- a/e2e/album-ui.spec.ts
+++ b/e2e/album-ui.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 1022 — FR-019 album posts (UI): the composer stages several photos into one album,
+ * the feed shows the cover with a count badge, and the full post is a swipeable gallery.
+ */
+
+const PNG = Uint8Array.from(
+  atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='),
+  (c) => c.charCodeAt(0),
+);
+const pngFile = (name: string) => ({ name, mimeType: 'image/png', buffer: Buffer.from(PNG) });
+
+test('an album shows a count badge in the feed and a swipeable gallery in the post', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'ALBUMUI1');
+  const b = await createAccount(ctxB, 'ALBUMUI2');
+  await pair(a, b);
+
+  // A shares a 3-photo album.
+  const postId = (await a.page.evaluate(() => (window as any).__ringTest.postAlbum(3, 'our trip'))) as string;
+
+  // Feed: the cover shows with a "3" album badge.
+  await a.page.goto('/tabs/wall');
+  const badge = a.page.locator('.album-badge');
+  await expect(badge).toBeVisible({ timeout: 30_000 });
+  await expect(badge).toContainText('3');
+
+  // Full post: a swipeable gallery of all three, with a "1 / 3" position counter.
+  await a.page.goto(`/wall/post/${postId}`);
+  await expect(a.page.locator('.album-slide')).toHaveCount(3, { timeout: 30_000 });
+  await expect(a.page.locator('.album-count')).toContainText('1 / 3');
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('the post composer stages several photos and shares them as one album', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'ALBUMUI3');
+  const b = await createAccount(ctxB, 'ALBUMUI4');
+  await pair(a, b);
+
+  // Open the composer from the Wall and pick three photos. (The header button carries the
+  // aria-label; the empty-state button only has visible text, so getByLabel is unambiguous.)
+  await a.page.goto('/tabs/wall');
+  await a.page.getByLabel('New post').click();
+  const input = a.page.locator('input[type="file"]');
+  await input.waitFor({ state: 'attached', timeout: 30_000 });
+  await input.setInputFiles([pngFile('a.png'), pngFile('b.png'), pngFile('c.png')]);
+
+  // They stage as three removable thumbnails.
+  await expect(a.page.locator('.stage-thumb')).toHaveCount(3, { timeout: 10_000 });
+
+  // Share → back on the Wall, the post is an album (count badge of 3).
+  await a.page.getByRole('button', { name: 'Share' }).click();
+  await expect(a.page.locator('.album-badge')).toContainText('3', { timeout: 30_000 });
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -18,7 +18,7 @@
         class="composer"
         :auto-grow="true"
         :rows="3"
-        :placeholder="media ? 'Add a caption…' : 'Share something with your friends…'"
+        :placeholder="mediaItems.length ? 'Add a caption…' : 'Share something with your friends…'"
         autocapitalize="sentences"
         :spellcheck="true"
         dir="auto"
@@ -26,14 +26,27 @@
         @ion-input="onInput"
       />
 
-      <!-- Attachment preview -->
-      <div v-if="mediaUrl" class="preview">
-        <img v-if="mediaKind === 'image'" :src="mediaUrl" alt="Selected photo" />
-        <video v-else-if="mediaKind === 'video'" :src="mediaUrl" controls playsinline />
-        <audio v-else class="vpreview" :src="mediaUrl" controls />
+      <!-- Voice preview (a voice post is always on its own) -->
+      <div v-if="hasVoice" class="preview">
+        <audio class="vpreview" :src="mediaItems[0].url" controls />
         <ion-button class="remove" fill="solid" color="dark" size="small" @click="clearMedia">
           <ion-icon slot="icon-only" :icon="closeOutline" />
         </ion-button>
+      </div>
+
+      <!-- Photo/video staging: several compose an album (FR-019). A row of removable
+           thumbnails (their order is the album order) plus an "add more" tile. -->
+      <div v-else-if="mediaItems.length" class="album-stage">
+        <div v-for="(m, i) in mediaItems" :key="m.url" class="stage-thumb">
+          <img v-if="m.kind === 'image'" :src="m.url" alt="" />
+          <video v-else :src="m.url" muted playsinline />
+          <button type="button" class="stage-x" aria-label="Remove" @click="removeMedia(i)">
+            <ion-icon :icon="closeOutline" />
+          </button>
+        </div>
+        <button type="button" class="stage-add" aria-label="Add more photos or videos" @click="pickMedia">
+          <ion-icon :icon="imageOutline" />
+        </button>
       </div>
 
       <!-- Recording a voice post in progress -->
@@ -49,7 +62,7 @@
       <ion-list v-else :inset="true">
         <ion-item button :detail="false" @click="pickMedia">
           <ion-icon slot="start" :icon="imageOutline" color="primary" />
-          <ion-label color="primary">Add photo or video</ion-label>
+          <ion-label color="primary">Add photos or videos</ion-label>
         </ion-item>
         <ion-item button :detail="false" @click="startRecording">
           <ion-icon slot="start" :icon="micOutline" color="primary" />
@@ -60,6 +73,7 @@
         ref="fileInput"
         type="file"
         accept="image/*,video/*"
+        multiple
         style="display: none"
         @change="onFile"
       />
@@ -112,17 +126,21 @@ const audience = ref<'friends' | 'close'>('friends');
 const lifetime = ref<PostLifetime>('72h');
 const sharing = ref(false);
 
-// One attachment slot, shared by a picked photo/video file and a recorded voice clip.
-// `mediaKind` is set explicitly when the attachment is chosen (a recorded Blob has no
-// filename, so we can't derive the kind from a File like the picker can).
+// Staged attachments. Several photos/videos compose an ALBUM post (spec 1022, FR-019); a
+// recorded voice clip is always on its own. Object URLs back the previews, revoked on
+// remove/unmount. `kind` is explicit (a recorded Blob has no filename to derive it from).
+interface PostMedia {
+  blob: Blob;
+  kind: 'image' | 'video' | 'voice';
+  name: string;
+  durationSec?: number;
+  url: string;
+}
 const fileInput = ref<HTMLInputElement | null>(null);
-const media = ref<Blob | null>(null);
-const mediaUrl = ref<string | undefined>(undefined);
-const mediaKind = ref<'image' | 'video' | 'voice'>('image');
-const mediaName = ref('attachment');
-const mediaDuration = ref<number | undefined>(undefined);
+const mediaItems = ref<PostMedia[]>([]);
+const hasVoice = computed(() => mediaItems.value.some((m) => m.kind === 'voice'));
 
-const canShare = computed(() => body.value.trim().length > 0 || !!media.value);
+const canShare = computed(() => body.value.trim().length > 0 || mediaItems.value.length > 0);
 
 function onInput(e: CustomEvent): void {
   body.value = (e.detail as { value?: string | null }).value ?? '';
@@ -138,19 +156,27 @@ function pickMedia(): void {
   fileInput.value?.click();
 }
 function onFile(e: Event): void {
-  const f = (e.target as HTMLInputElement).files?.[0];
-  if (!f) return;
-  clearMedia();
-  media.value = f;
-  mediaKind.value = f.type.startsWith('video/') ? 'video' : 'image';
-  mediaName.value = f.name || 'attachment';
-  mediaUrl.value = URL.createObjectURL(f);
+  // Picking several photos/videos stages them all → one album on Send. A voice clip in the
+  // stage means it's a voice post; clear it before adding files (the two don't mix).
+  if (hasVoice.value) clearMedia();
+  const files = Array.from((e.target as HTMLInputElement).files ?? []);
+  for (const f of files) {
+    mediaItems.value.push({
+      blob: f,
+      kind: f.type.startsWith('video/') ? 'video' : 'image',
+      name: f.name || 'attachment',
+      url: URL.createObjectURL(f),
+    });
+  }
+  if (fileInput.value) fileInput.value.value = '';
+}
+function removeMedia(i: number): void {
+  const [gone] = mediaItems.value.splice(i, 1);
+  if (gone) URL.revokeObjectURL(gone.url);
 }
 function clearMedia(): void {
-  if (mediaUrl.value) URL.revokeObjectURL(mediaUrl.value);
-  mediaUrl.value = undefined;
-  media.value = null;
-  mediaDuration.value = undefined;
+  for (const m of mediaItems.value) URL.revokeObjectURL(m.url);
+  mediaItems.value = [];
   if (fileInput.value) fileInput.value.value = '';
 }
 
@@ -206,15 +232,19 @@ function finishRecording(): void {
   const durationSec = Math.max(1, Math.round((Date.now() - recStart) / 1000));
   const blob = new Blob(recChunks, { type: mime });
   clearMedia();
-  media.value = blob;
-  mediaKind.value = 'voice';
-  mediaName.value = `voice.${mime.includes('mp4') ? 'm4a' : mime.includes('ogg') ? 'ogg' : 'webm'}`;
-  mediaDuration.value = durationSec;
-  mediaUrl.value = URL.createObjectURL(blob);
+  mediaItems.value = [
+    {
+      blob,
+      kind: 'voice',
+      name: `voice.${mime.includes('mp4') ? 'm4a' : mime.includes('ogg') ? 'ogg' : 'webm'}`,
+      durationSec,
+      url: URL.createObjectURL(blob),
+    },
+  ];
 }
 
 onUnmounted(() => {
-  if (mediaUrl.value) URL.revokeObjectURL(mediaUrl.value);
+  for (const m of mediaItems.value) URL.revokeObjectURL(m.url);
   if (recTimer) clearInterval(recTimer);
   recStream?.getTracks().forEach((t) => t.stop());
 });
@@ -227,10 +257,16 @@ async function share(): Promise<void> {
       body: body.value,
       audience: audience.value,
       lifetime: lifetime.value,
-      media: media.value
-        ? // HD-only on the Wall (spec 1022, FR-020): feed media is for viewing, not
-          // downloading, so there's no quality choice — every post ships at HD.
-          { blob: media.value, kind: mediaKind.value, name: mediaName.value, durationSec: mediaDuration.value, quality: 'hd' }
+      // HD-only on the Wall (spec 1022, FR-020): no quality choice — every post ships at HD.
+      // One item → a single-media post; several photos/videos → an album (FR-019).
+      media: mediaItems.value.length
+        ? mediaItems.value.map((m) => ({
+            blob: m.blob,
+            kind: m.kind,
+            name: m.name,
+            durationSec: m.durationSec,
+            quality: 'hd' as const,
+          }))
         : undefined,
     });
     router.back();
@@ -274,6 +310,57 @@ async function share(): Promise<void> {
 }
 .vpreview {
   width: 100%;
+}
+/* Album staging: a horizontal row of removable thumbnails + an "add more" tile. */
+.album-stage {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 8px 16px;
+}
+.stage-thumb {
+  position: relative;
+  flex: 0 0 auto;
+  padding: 6px 6px 0 0; /* room for the overhanging × */
+}
+.stage-thumb img,
+.stage-thumb video {
+  width: 84px;
+  height: 84px;
+  object-fit: cover;
+  border-radius: 12px;
+  display: block;
+  background: #000;
+}
+.stage-x {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ion-color-medium);
+  color: var(--ion-color-medium-contrast);
+  font-size: 15px;
+}
+.stage-add {
+  flex: 0 0 auto;
+  width: 84px;
+  height: 84px;
+  margin-top: 6px;
+  border-radius: 12px;
+  border: 1.5px dashed var(--app-border);
+  background: var(--app-surface);
+  color: var(--ion-color-primary);
+  font-size: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 /* Pulse the mic glyph while a voice post is being recorded. */
 .recdot {

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -28,7 +28,22 @@
           </div>
         </div>
 
-        <div v-if="mediaUrl && (post.kind === 'image' || post.kind === 'video')" class="media" :style="mediaBoxStyle">
+        <!-- Album (FR-019): a swipeable horizontal gallery — slide between items — with a
+             live position counter. Mixed image+video is fine; each slide plays on tap. -->
+        <div v-if="albumMedia.length > 1" class="album">
+          <div class="album-track" @scroll="onAlbumScroll">
+            <div v-for="(m, i) in albumMedia" :key="i" class="album-slide">
+              <img v-if="m.kind === 'image'" :src="m.url" alt="" />
+              <video v-else :src="m.url" controls playsinline />
+            </div>
+          </div>
+          <div class="album-count">{{ albumIndex + 1 }} / {{ albumMedia.length }}</div>
+        </div>
+        <div
+          v-else-if="mediaUrl && (post.kind === 'image' || post.kind === 'video')"
+          class="media"
+          :style="mediaBoxStyle"
+        >
           <img v-if="post.kind === 'image'" :src="mediaUrl" :alt="post.body || 'Photo'" />
           <video v-else :src="mediaUrl" controls playsinline />
         </div>
@@ -151,6 +166,13 @@ const authorName = ref('Unknown');
 const authorAvatar = ref('');
 const authorUsername = ref<string | undefined>(undefined);
 const mediaUrl = ref<string | undefined>(undefined);
+// Album posts (FR-019): every media resolved to an object URL, shown as a swipeable gallery.
+const albumMedia = ref<{ url: string; kind: 'image' | 'video' }[]>([]);
+const albumIndex = ref(0);
+function onAlbumScroll(e: Event): void {
+  const el = e.target as HTMLElement;
+  albumIndex.value = el.clientWidth ? Math.round(el.scrollLeft / el.clientWidth) : 0;
+}
 const leftLabel = computed(() => (post.value?.expiresAt ? timeLeft(post.value.expiresAt, Date.now()) : ''));
 // Reserve the media's aspect ratio so the page doesn't reflow as it decodes.
 const mediaBoxStyle = computed(() =>
@@ -244,8 +266,15 @@ onIonViewWillEnter(async () => {
   void syncEngagement(postId); // refresh reactions from the server
   post.value = await getPost(postId);
   if (!post.value) return;
-  if (post.value.mediaId) {
-    const md = await getMedia(post.value.mediaId);
+  const ids = post.value.mediaIds?.length ? post.value.mediaIds : post.value.mediaId ? [post.value.mediaId] : [];
+  if (ids.length > 1) {
+    // Album: resolve every item in order for the swipeable gallery.
+    for (const id of ids) {
+      const md = await getMedia(id);
+      if (md?.blob) albumMedia.value.push({ url: URL.createObjectURL(md.blob), kind: md.kind === 'video' ? 'video' : 'image' });
+    }
+  } else if (ids.length === 1) {
+    const md = await getMedia(ids[0]);
     if (md?.blob) mediaUrl.value = URL.createObjectURL(md.blob);
   }
   if (post.value.author === getSelfUserId()) {
@@ -271,6 +300,8 @@ onIonViewWillLeave(() => {
     URL.revokeObjectURL(mediaUrl.value);
     mediaUrl.value = undefined;
   }
+  for (const m of albumMedia.value) URL.revokeObjectURL(m.url);
+  albumMedia.value = [];
 });
 
 function initial(name: string): string {
@@ -354,6 +385,47 @@ async function confirmDelete(): Promise<void> {
   height: 100%;
   object-fit: contain;
   display: block;
+}
+/* Swipeable album gallery: scroll-snap row, one item per view + a position counter. */
+.album {
+  position: relative;
+  margin: 16px 0 0;
+}
+.album-track {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  border-radius: 14px;
+  background: #000;
+  scrollbar-width: none;
+}
+.album-track::-webkit-scrollbar {
+  display: none;
+}
+.album-slide {
+  flex: 0 0 100%;
+  scroll-snap-align: center;
+}
+.album-slide img,
+.album-slide video {
+  width: 100%;
+  max-height: 70vh;
+  object-fit: contain;
+  display: block;
+  background: #000;
+}
+.album-count {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  pointer-events: none;
 }
 .vaudio {
   width: 100%;

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -102,6 +102,11 @@
                 class="play"
                 :icon="playCircleOutline"
               />
+              <!-- Album post (FR-019): the feed shows the cover with a count badge; the
+                   swipeable gallery is in the full post. -->
+              <span v-if="p.mediaIds && p.mediaIds.length > 1" class="album-badge">
+                <ion-icon :icon="copyOutline" />{{ p.mediaIds.length }}
+              </span>
             </div>
             <div v-else-if="p.mediaUrl && p.kind === 'voice'" class="voice" @click="open(p.id)">
               <ion-icon :icon="micOutline" /> Voice message
@@ -191,7 +196,7 @@ import {
 import { useRouter } from 'vue-router';
 import {
   createOutline, sparklesOutline, micOutline, playCircleOutline, happyOutline, timeOutline,
-  notificationsOutline, notificationsOffOutline,
+  notificationsOutline, notificationsOffOutline, copyOutline,
 } from 'ionicons/icons';
 import { appToast } from '@/services/toast';
 import Emoji from '@/components/Emoji.vue';
@@ -504,6 +509,24 @@ ion-item-sliding ion-item-option {
 /* While the clip is autoplaying inline, drop the tap-to-open glyph (tapping still works). */
 .thumb video[data-autoplaying] + .play {
   opacity: 0;
+}
+/* Album count badge over the cover (top-right). */
+.album-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 8px 3px 6px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+}
+.album-badge ion-icon {
+  font-size: 14px;
 }
 .body {
   margin: 8px 14px;


### PR DESCRIPTION
**Spec 1022, FR-019 — increment 2 (the user-facing album feature).** Builds on the plumbing (#559), thumbnails (#560), HD-only (#558), and autoplay (#557).

- **Composer multi-select** — pick several photos/videos at once; they stage as a removable thumbnail row with an "add more" tile (one item = an ordinary post; several = an album). A voice clip is always on its own.
- **Feed** — an album shows its cover with a **count badge**.
- **Full post** — a **swipeable horizontal gallery** with a live "1 / N" position counter; **mixed image + video** works, each slide plays on tap.

All E2EE — the album's media all ride sealed in the one post payload (server untouched).

**Tests** — `e2e/album-ui.spec.ts` (2): composer multi-select → album, and the feed badge + swipeable gallery. With increment 1's round-trip e2e, the album feature is covered compose → seal → send → receive → render. Build clean.

This completes spec 1022 (Wall): post rendering/thumbnails, audience-correct push (already shipped), follow/mute (already shipped), autoplay-on-visible, HD-only, and album posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)