### PR TITLE
feat(wall): show post upload progress, and let feed videos play with sound

### DIFF
--- a/e2e/wall-autoplay.spec.ts
+++ b/e2e/wall-autoplay.spec.ts
@@ -64,3 +64,34 @@ test('autoplay is suppressed under prefers-reduced-motion (tap-to-play fallback)
 
   await ctx.close();
 });
+
+test('the sound toggle unmutes feed videos and the choice sticks across videos', async ({ browser }) => {
+  const ctx = await browser.newContext();
+  const a = await createAccount(ctx, 'WALLMUTE1');
+
+  await a.page.evaluate(() => (window as any).__ringTest.seedWallVideoPosts(3));
+  await a.page.goto('/tabs/wall');
+  await expect(a.page.locator('.thumb video')).toHaveCount(3, { timeout: 30_000 });
+
+  // The on-screen video autoplays MUTED to start (browsers require it).
+  await expect(active(a)).toHaveCount(1, { timeout: 10_000 });
+  expect(await active(a).evaluate((v: HTMLVideoElement) => v.muted)).toBe(true);
+
+  // Tapping the speaker toggle (a user gesture) unmutes the playing video.
+  await a.page.locator('.vol-toggle').first().click();
+  await expect.poll(() => active(a).evaluate((v: HTMLVideoElement) => v.muted)).toBe(false);
+
+  // Scroll to the next video — it autoplays UNMUTED too: the choice is respected for every video.
+  await a.page.evaluate(async () => {
+    const el = await (document.querySelector('ion-content') as any).getScrollElement();
+    el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+  });
+  await expect
+    .poll(async () => {
+      const c = await active(a).count();
+      return c === 1 ? active(a).evaluate((v: HTMLVideoElement) => v.muted) : null;
+    })
+    .toBe(false);
+
+  await ctx.close();
+});

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2169,6 +2169,8 @@ export async function createPost(opts: {
   // the chosen quality, encrypted + uploaded, and all the media-refs ride sealed inside
   // the one post payload.
   media?: PostMediaInput | PostMediaInput[];
+  // Progress for the composer's "encoding / uploading …" bar (per media item, 0–1).
+  onProgress?: (p: { phase: 'encoding' | 'uploading'; index: number; total: number; value: number }) => void;
 }): Promise<Post> {
   const self = getSelfUserId();
   if (!self) throw new Error('not signed in');
@@ -2194,15 +2196,17 @@ export async function createPost(opts: {
   const mediaIds: string[] = [];
   const refs: NonNullable<PostPayload['album']> = [];
   const payload: PostPayload = { kind, body };
+  const total = mediaList.length;
   for (const m of mediaList) {
+    const index = mediaIds.length; // 0-based position of this item
     // Posts only ship SD or HD (never the original): compress images/videos to the
-    // chosen quality before upload; voice is left as-is.
+    // chosen quality before upload; voice is left as-is. Video reports encode progress.
     const q = m.quality ?? 'hd';
     const toUpload =
       m.kind === 'image'
         ? await compressImage(m.blob, q)
         : m.kind === 'video'
-          ? await compressVideo(m.blob, q)
+          ? await compressVideo(m.blob, q, (value) => opts.onProgress?.({ phase: 'encoding', index, total, value }))
           : m.blob;
     // Honest badge (spec 2007): label by the quality actually achieved (a transcode that
     // can't shrink the clip returns the original). Voice isn't transcoded — keep requested.
@@ -2212,7 +2216,13 @@ export async function createPost(opts: {
     let h: number | undefined;
     if (m.kind === 'image') ({ width: w, height: h } = await readImageMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
     else if (m.kind === 'video') ({ width: w, height: h } = await readVideoMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
-    const ref = await prepareOutgoingMedia(toUpload, m.name, m.durationSec, { width: w, height: h, quality: achieved });
+    const ref = await prepareOutgoingMedia(
+      toUpload,
+      m.name,
+      m.durationSec,
+      { width: w, height: h, quality: achieved },
+      (value) => opts.onProgress?.({ phase: 'uploading', index, total, value }),
+    );
     refs.push(ref);
     const id = uid();
     mediaIds.push(id);

--- a/src/directives/autoplay-visible.ts
+++ b/src/directives/autoplay-visible.ts
@@ -13,7 +13,23 @@
  * so styling can hide the manual play affordance and so tests can assert the visibility logic
  * deterministically without depending on a real decode succeeding.
  */
-import type { Directive } from 'vue';
+import { ref, type Directive } from 'vue';
+
+// Shared mute state for feed autoplay. Videos START muted (browsers block UNMUTED autoplay
+// without a user gesture). The inline speaker toggle flips this for ALL feed videos at once —
+// once you unmute (the tap is the gesture), every video that autoplays plays WITH sound until
+// you mute again. Persisting "muted" is the social-feed norm (TikTok/Reels).
+export const autoplayMuted = ref(true);
+
+// Toggle/set the shared mute state and apply it to the video playing right now. Unmuting is a
+// user gesture, so we (re)start the current clip to make sure it actually plays with audio.
+export function setAutoplayMuted(muted: boolean): void {
+  autoplayMuted.value = muted;
+  if (current) {
+    current.muted = muted;
+    if (!muted) void current.play().catch(() => {});
+  }
+}
 
 // Visible fraction at which a video starts playing / stops. The gap (hysteresis) keeps a
 // video that's hovering around the boundary from flickering between play and pause.
@@ -46,7 +62,7 @@ function setActive(el: HTMLVideoElement | null): void {
   current = el;
   if (el) {
     el.setAttribute('data-autoplaying', 'true');
-    el.muted = true; // muted inline playback is the only kind browsers allow without a gesture
+    el.muted = autoplayMuted.value; // respect the shared feed mute state (starts muted)
     void el.play().catch(() => {
       /* autoplay blocked — leave the poster frame showing */
     });
@@ -93,7 +109,7 @@ function observer(): IntersectionObserver {
 
 export const vAutoplayVisible: Directive<HTMLVideoElement> = {
   mounted(el) {
-    el.muted = true;
+    el.muted = autoplayMuted.value;
     el.setAttribute('playsinline', '');
     if (!el.getAttribute('preload')) el.setAttribute('preload', 'metadata');
     registered.add(el);

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -26,6 +26,16 @@
         @ion-input="onInput"
       />
 
+      <!-- While sharing media: a real progress bar (encode % then upload %) so a video
+           post isn't just a frozen, unexplained wait. -->
+      <div v-if="sharing && mediaItems.length" class="share-progress">
+        <ion-progress-bar
+          :type="progress ? 'determinate' : 'indeterminate'"
+          :value="progress?.value ?? 0"
+        />
+        <span class="share-label">{{ progressLabel }}</span>
+      </div>
+
       <!-- Voice preview (a voice post is always on its own) -->
       <div v-if="hasVoice" class="preview">
         <audio class="vpreview" :src="mediaItems[0].url" controls />
@@ -113,7 +123,7 @@ import { computed, ref, onUnmounted } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
   IonContent, IonTextarea, IonList, IonListHeader, IonItem, IonSegment, IonSegmentButton,
-  IonLabel, IonIcon, alertController,
+  IonLabel, IonIcon, IonProgressBar, alertController,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
 import { imageOutline, closeOutline, micOutline } from 'ionicons/icons';
@@ -125,6 +135,15 @@ const body = ref('');
 const audience = ref<'friends' | 'close'>('friends');
 const lifetime = ref<PostLifetime>('72h');
 const sharing = ref(false);
+// Encode/upload progress while a post with media is being shared (drives the progress bar).
+const progress = ref<{ phase: 'encoding' | 'uploading'; index: number; total: number; value: number } | null>(null);
+const progressLabel = computed(() => {
+  const p = progress.value;
+  if (!p) return 'Sharing…';
+  const which = p.total > 1 ? ` ${p.index + 1}/${p.total}` : '';
+  const pct = Math.round((p.value ?? 0) * 100);
+  return p.phase === 'encoding' ? `Processing${which}… ${pct}%` : `Uploading${which}… ${pct}%`;
+});
 
 // Staged attachments. Several photos/videos compose an ALBUM post (spec 1022, FR-019); a
 // recorded voice clip is always on its own. Object URLs back the previews, revoked on
@@ -252,6 +271,7 @@ onUnmounted(() => {
 async function share(): Promise<void> {
   if (!canShare.value || sharing.value) return;
   sharing.value = true;
+  progress.value = mediaItems.value.length ? { phase: 'encoding', index: 0, total: mediaItems.value.length, value: 0 } : null;
   try {
     await createPost({
       body: body.value,
@@ -268,6 +288,9 @@ async function share(): Promise<void> {
             quality: 'hd' as const,
           }))
         : undefined,
+      onProgress: (p) => {
+        progress.value = p;
+      },
     });
     router.back();
   } catch (err) {
@@ -279,6 +302,7 @@ async function share(): Promise<void> {
     await a.present();
   } finally {
     sharing.value = false;
+    progress.value = null;
   }
 }
 </script>
@@ -310,6 +334,16 @@ async function share(): Promise<void> {
 }
 .vpreview {
   width: 100%;
+}
+.share-progress {
+  margin: 10px 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.share-label {
+  font-size: 13px;
+  color: var(--app-text-muted, #8e8e93);
 }
 /* Album staging: a horizontal row of removable thumbnails + an "add more" tile. */
 .album-stage {

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -107,6 +107,17 @@
               <span v-if="p.mediaIds && p.mediaIds.length > 1" class="album-badge">
                 <ion-icon :icon="copyOutline" />{{ p.mediaIds.length }}
               </span>
+              <!-- Sound toggle for autoplaying feed videos. Tapping it (a user gesture) lets
+                   videos play WITH audio; the choice sticks for every video until muted again. -->
+              <button
+                v-if="p.kind === 'video' && (p.mediaUrl || p.posterUrl)"
+                type="button"
+                class="vol-toggle"
+                :aria-label="autoplayMuted ? 'Unmute videos' : 'Mute videos'"
+                @click.stop="setAutoplayMuted(!autoplayMuted)"
+              >
+                <ion-icon :icon="autoplayMuted ? volumeMuteOutline : volumeHighOutline" />
+              </button>
             </div>
             <div v-else-if="p.mediaUrl && p.kind === 'voice'" class="voice" @click="open(p.id)">
               <ion-icon :icon="micOutline" /> Voice message
@@ -196,13 +207,13 @@ import {
 import { useRouter } from 'vue-router';
 import {
   createOutline, sparklesOutline, micOutline, playCircleOutline, happyOutline, timeOutline,
-  notificationsOutline, notificationsOffOutline, copyOutline,
+  notificationsOutline, notificationsOffOutline, copyOutline, volumeMuteOutline, volumeHighOutline,
 } from 'ionicons/icons';
 import { appToast } from '@/services/toast';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
 import { vEnterSend } from '@/directives/enter-send';
-import { vAutoplayVisible } from '@/directives/autoplay-visible';
+import { vAutoplayVisible, autoplayMuted, setAutoplayMuted } from '@/directives/autoplay-visible';
 import { useWall, type WallPost } from '@/composables/useWall';
 import { useReactionPicker } from '@/composables/useReactionPicker';
 import {
@@ -527,6 +538,23 @@ ion-item-sliding ion-item-option {
 }
 .album-badge ion-icon {
   font-size: 14px;
+}
+/* Sound toggle for autoplaying videos (bottom-right of the cover). */
+.vol-toggle {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 50%;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 18px;
 }
 .body {
   margin: 8px 14px;


### PR DESCRIPTION
Two reported Wall-post issues:

**1. No progress while a post's media uploads.** The composer now shows a real progress bar — **processing %** (video encode) then **uploading %**, with per-item progress for an album — instead of a silent frozen wait. `createPost` reports encode + upload progress through to the composer.

**2. Feed videos were always muted** — you had to open a video for sound. Now a **speaker toggle** on the cover unmutes feed videos: the tap is the user gesture browsers require for unmuted autoplay, and the choice **sticks** — every video then autoplays *with sound* until you mute again (the social-feed norm). Videos still start muted (browser policy) and reduced-motion still suppresses autoplay.

**Tests:** new e2e — the sound toggle unmutes the playing video and the unmuted state is respected as you scroll to the next one. Composer share + album e2e still green. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)