### PR TITLE
feat(wall): voice posts, an instantly-loading feed, and pull to refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,11 @@ jobs:
           cache-to: type=gha,mode=max
       # Keep the Docker Hub repo's Overview (README + short description) in sync with
       # docs/DOCKERHUB.md on every develop publish, so the listing never drifts.
+      # Best-effort: editing the Hub Overview needs a token scope an image-push PAT lacks
+      # (returns 403 Forbidden), so DON'T fail the whole develop publish on a cosmetic README
+      # sync — the image itself (the step above) is already pushed. Fix the token to re-enable.
       - name: Sync Docker Hub Overview
+        continue-on-error: true
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/e2e/album-ui.spec.ts
+++ b/e2e/album-ui.spec.ts
@@ -24,13 +24,13 @@ test('an album shows a count badge in the feed and a swipeable gallery in the po
   // A shares a 3-photo album.
   const postId = (await a.page.evaluate(() => (window as any).__ringTest.postAlbum(3, 'our trip'))) as string;
 
-  // Feed: the cover shows with a "3" album badge.
+  // Feed: the album renders inline as a swipeable gallery — three slides + a "1 / 3" counter
+  // (the cover+badge was replaced by showing the whole album right in the feed).
   await a.page.goto('/tabs/wall');
-  const badge = a.page.locator('.album-badge');
-  await expect(badge).toBeVisible({ timeout: 30_000 });
-  await expect(badge).toContainText('3');
+  await expect(a.page.locator('.album-slide')).toHaveCount(3, { timeout: 30_000 });
+  await expect(a.page.locator('.album-count')).toContainText('1 / 3');
 
-  // Full post: a swipeable gallery of all three, with a "1 / 3" position counter.
+  // The full-post route still renders the same swipeable gallery.
   await a.page.goto(`/wall/post/${postId}`);
   await expect(a.page.locator('.album-slide')).toHaveCount(3, { timeout: 30_000 });
   await expect(a.page.locator('.album-count')).toContainText('1 / 3');
@@ -57,9 +57,9 @@ test('the post composer stages several photos and shares them as one album', asy
   // They stage as three removable thumbnails.
   await expect(a.page.locator('.stage-thumb')).toHaveCount(3, { timeout: 10_000 });
 
-  // Share → back on the Wall, the post is an album (count badge of 3).
+  // Share → back on the Wall, the post renders as an inline swipeable album ("1 / 3" counter).
   await a.page.getByRole('button', { name: 'Share' }).click();
-  await expect(a.page.locator('.album-badge')).toContainText('3', { timeout: 30_000 });
+  await expect(a.page.locator('.album-count')).toContainText('1 / 3', { timeout: 30_000 });
 
   await ctxA.close();
   await ctxB.close();

--- a/e2e/wall-autoplay.spec.ts
+++ b/e2e/wall-autoplay.spec.ts
@@ -58,8 +58,9 @@ test('autoplay is suppressed under prefers-reduced-motion (tap-to-play fallback)
   await a.page.goto('/tabs/wall');
   await expect(a.page.locator('.thumb video')).toHaveCount(2, { timeout: 30_000 });
 
-  // With reduced-motion on, nothing autoplays — the play glyph stays and no video is active.
-  await expect(a.page.locator('.thumb .play').first()).toBeVisible();
+  // With reduced-motion on, nothing autoplays — the inline play control stays (tap-to-play) and
+  // no video is active.
+  await expect(a.page.locator('.thumb .wv-play').first()).toBeVisible();
   await expect(active(a)).toHaveCount(0);
 
   await ctx.close();

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -452,9 +452,98 @@ func (h *Handlers) deletePost(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusBadRequest, "invalid id")
 		return
 	}
-	if err := h.Posts.DeletePost(r.Context(), uid, id); err != nil {
+	recipients, err := h.Posts.DeletePost(r.Context(), uid, id)
+	if err != nil {
 		httpx.Error(w, http.StatusInternalServerError, "could not delete post")
 		return
+	}
+	// Live prune: tell every online recipient to drop its local copy right now (offline ones
+	// catch it via listPosts.revoked on their next sync — the post_deletions tombstone).
+	if h.Hub != nil {
+		if b, err := json.Marshal(map[string]any{"t": "post-revoke", "post": id}); err == nil {
+			for _, rec := range recipients {
+				h.Hub.Send(rec, b)
+			}
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// keepAlivePost (author-only) pushes a post's auto-delete back to a full window from now —
+// the explicit "Keep for longer" action. 404 if it isn't the caller's post.
+func (h *Handlers) keepAlivePost(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	id := r.PathValue("id")
+	if !uuidRE.MatchString(id) {
+		httpx.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	ok, err := h.Posts.KeepAlive(r.Context(), uid, id)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not extend post")
+		return
+	}
+	if !ok {
+		httpx.Error(w, http.StatusNotFound, "post not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// addPostEnvelopes broadens a post's audience (author-only): the client re-wraps K_post to
+// the newly-included friends and posts their envelopes here. Newly-added recipients get a
+// SILENT live delivery (a `post-new` frame with no `from` → the device syncs the post into its
+// feed without a banner) — a visibility change must NOT notify anyone (the explicit ask).
+func (h *Handlers) addPostEnvelopes(w http.ResponseWriter, r *http.Request) {
+	uid, ok := auth.UserID(r.Context())
+	if !ok || uid == "" {
+		httpx.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	id := r.PathValue("id")
+	if !uuidRE.MatchString(id) {
+		httpx.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	var req createPostReq // reuse: it carries Envelopes []{Recipient, WrappedKey}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 256<<10)).Decode(&req); err != nil ||
+		len(req.Envelopes) == 0 || len(req.Envelopes) > maxPostEnvelopes {
+		httpx.Error(w, http.StatusBadRequest, "invalid envelopes")
+		return
+	}
+	envs := make([]store.NewPostEnvelope, 0, len(req.Envelopes))
+	for _, e := range req.Envelopes {
+		if !uuidRE.MatchString(e.Recipient) || e.Recipient == uid || e.WrappedKey == "" {
+			httpx.Error(w, http.StatusBadRequest, "invalid recipient")
+			return
+		}
+		// Same audience rule as createPost: recipients must be accepted, non-blocked friends.
+		connected, err := h.Connections.Connected(r.Context(), uid, e.Recipient)
+		if err != nil {
+			httpx.Error(w, http.StatusInternalServerError, "could not verify audience")
+			return
+		}
+		if !connected {
+			httpx.Error(w, http.StatusForbidden, "recipient is not a friend")
+			return
+		}
+		envs = append(envs, store.NewPostEnvelope{Recipient: e.Recipient, WrappedKey: e.WrappedKey})
+	}
+	added, err := h.Posts.AddEnvelopes(r.Context(), uid, id, envs)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "could not update audience")
+		return
+	}
+	if h.Hub != nil {
+		if b, err := json.Marshal(map[string]any{"t": "post-new"}); err == nil {
+			for _, rec := range added {
+				h.Hub.Send(rec, b)
+			}
+		}
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	"ring/server/internal/store"
 	"ring/server/internal/ws"
@@ -171,11 +172,58 @@ func (f *fakePostStore) ListPosts(_ context.Context, recipient string, _ int64) 
 	}
 	return out, nil
 }
-func (f *fakePostStore) DeletePost(_ context.Context, author, id string) error {
-	if p, ok := f.posts[id]; ok && p.Author == author {
-		delete(f.posts, id)
+func (f *fakePostStore) DeletePost(_ context.Context, author, id string) ([]string, error) {
+	p, ok := f.posts[id]
+	if !ok || p.Author != author {
+		return nil, nil
 	}
-	return nil
+	var recipients []string
+	for _, e := range p.Envelopes {
+		recipients = append(recipients, e.Recipient)
+		f.revoked[e.Recipient] = append(f.revoked[e.Recipient], id) // durable deletion tombstone
+	}
+	delete(f.posts, id)
+	return recipients, nil
+}
+func (f *fakePostStore) KeepAlive(_ context.Context, author, id string) (bool, error) {
+	p, ok := f.posts[id]
+	if !ok || p.Author != author {
+		return false, nil
+	}
+	exp := time.Now().Add(time.Duration(p.TtlMs) * time.Millisecond)
+	p.ExpiresAt = &exp
+	f.posts[id] = p
+	return true, nil
+}
+func (f *fakePostStore) AddEnvelopes(_ context.Context, author, postID string, envs []store.NewPostEnvelope) ([]string, error) {
+	p, ok := f.posts[postID]
+	if !ok || p.Author != author {
+		return nil, nil
+	}
+	have := map[string]bool{}
+	for _, e := range p.Envelopes {
+		have[e.Recipient] = true
+	}
+	var added []string
+	for _, e := range envs {
+		if !have[e.Recipient] {
+			p.Envelopes = append(p.Envelopes, e)
+			have[e.Recipient] = true
+			added = append(added, e.Recipient)
+		}
+		// Undo any tombstone for this recipient (broaden-back).
+		if ids := f.revoked[e.Recipient]; len(ids) > 0 {
+			kept := ids[:0:0]
+			for _, rid := range ids {
+				if rid != postID {
+					kept = append(kept, rid)
+				}
+			}
+			f.revoked[e.Recipient] = kept
+		}
+	}
+	f.posts[postID] = p
+	return added, nil
 }
 func (f *fakePostStore) RemovePostRecipient(_ context.Context, postID, author, recipient string) (bool, error) {
 	p, ok := f.posts[postID]
@@ -466,6 +514,102 @@ func TestDeletePostAuthorOnly(t *testing.T) {
 // TestRemovePostRecipientAuthorOnly: dropping a recipient is author-only, removes the
 // post from that recipient's feed, and surfaces in their `revoked` list so an offline
 // device can prune it (the un-close-friend revocation path).
+func TestKeepAlivePostAuthorOnly(t *testing.T) {
+	conn := newFakePostConn()
+	st := newFakePostStore()
+	srv := newPostTestServer(conn, st)
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	body := `{"id":"` + postID + `","blobId":"cap1","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Bob (not the author) → 404; nothing is extended.
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/keepalive", tokB, ""); rr.Code != http.StatusNotFound {
+		t.Fatalf("non-author keepalive status = %d, want 404", rr.Code)
+	}
+	// Alice (the author) → 204 and the expiry is (re)set.
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/keepalive", tokA, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("author keepalive status = %d, want 204", rr.Code)
+	}
+	if p := st.posts[postID]; p.ExpiresAt == nil {
+		t.Errorf("keepalive did not set the post's expiry")
+	}
+}
+
+func TestDeletePostTombstonesRecipients(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	tokB, bobID, _ := registerNamed(t, srv, "bob")
+	conn.befriend(aliceID, bobID)
+
+	body := `{"id":"` + postID + `","blobId":"cap1","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WK"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Alice deletes her post → 204.
+	if rr := do(t, srv, http.MethodDelete, "/v1/posts/"+postID, tokA, ""); rr.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", rr.Code)
+	}
+
+	// Bob no longer sees it, AND it surfaces in his `revoked` set so an OFFLINE device prunes
+	// its local copy on next sync (the durable tombstone, beyond the live websocket push).
+	rr := do(t, srv, http.MethodGet, "/v1/posts", tokB, "")
+	var resp struct {
+		Posts   []json.RawMessage `json:"posts"`
+		Revoked []string          `json:"revoked"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(resp.Posts) != 0 {
+		t.Errorf("after delete, bob still sees %d posts, want 0", len(resp.Posts))
+	}
+	if len(resp.Revoked) != 1 || resp.Revoked[0] != postID {
+		t.Errorf("revoked = %v, want [%s]", resp.Revoked, postID)
+	}
+}
+
+func TestAddPostEnvelopesBroadensAudience(t *testing.T) {
+	conn := newFakePostConn()
+	srv := newPostTestServer(conn, newFakePostStore())
+	tokA, aliceID, _ := registerNamed(t, srv, "alice")
+	_, bobID, _ := registerNamed(t, srv, "bob")
+	tokC, carolID, _ := registerNamed(t, srv, "carol")
+	conn.befriend(aliceID, bobID)
+	conn.befriend(aliceID, carolID)
+
+	// Alice posts to ONLY bob (a "close friends" audience).
+	body := `{"id":"` + postID + `","blobId":"cap1","envelopes":[{"recipient":"` + bobID + `","wrappedKey":"WKb"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts", tokA, body); rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if ids := listPostIDs(t, srv, tokC); len(ids) != 0 {
+		t.Fatalf("carol sees %v before broaden, want []", ids)
+	}
+
+	// Alice broadens the audience to include carol (re-wrapped envelope).
+	add := `{"envelopes":[{"recipient":"` + carolID + `","wrappedKey":"WKc"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/envelopes", tokA, add); rr.Code != http.StatusNoContent {
+		t.Fatalf("add envelopes status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if ids := listPostIDs(t, srv, tokC); len(ids) != 1 || ids[0] != postID {
+		t.Errorf("carol sees %v after broaden, want [%s]", ids, postID)
+	}
+
+	// A non-friend recipient is rejected (same audience rule as createPost).
+	_, eveID, _ := registerNamed(t, srv, "eve")
+	bad := `{"envelopes":[{"recipient":"` + eveID + `","wrappedKey":"WKe"}]}`
+	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/envelopes", tokA, bad); rr.Code != http.StatusForbidden {
+		t.Errorf("add non-friend status = %d, want 403", rr.Code)
+	}
+}
+
 func TestRemovePostRecipientAuthorOnly(t *testing.T) {
 	conn := newFakePostConn()
 	srv := newPostTestServer(conn, newFakePostStore())

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -116,7 +116,9 @@ type InviteStore interface {
 type PostStore interface {
 	CreatePost(ctx context.Context, p store.NewPost) error
 	ListPosts(ctx context.Context, recipient string, sinceMs int64) ([]store.PostForRecipient, error)
-	DeletePost(ctx context.Context, author, id string) error
+	DeletePost(ctx context.Context, author, id string) ([]string, error)
+	KeepAlive(ctx context.Context, author, id string) (bool, error)
+	AddEnvelopes(ctx context.Context, author, postID string, envs []store.NewPostEnvelope) ([]string, error)
 	RemovePostRecipient(ctx context.Context, postID, author, recipient string) (bool, error)
 	ListRevocations(ctx context.Context, recipient string) ([]string, error)
 	RecentPostCount(ctx context.Context, author string, withinSec int) (int, error)
@@ -241,6 +243,8 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	mux.Handle("POST /v1/posts", authMW(http.HandlerFunc(h.createPost)))
 	mux.Handle("GET /v1/posts", authMW(http.HandlerFunc(h.listPosts)))
 	mux.Handle("DELETE /v1/posts/{id}", authMW(http.HandlerFunc(h.deletePost)))
+	mux.Handle("POST /v1/posts/{id}/keepalive", authMW(http.HandlerFunc(h.keepAlivePost)))
+	mux.Handle("POST /v1/posts/{id}/envelopes", authMW(http.HandlerFunc(h.addPostEnvelopes)))
 	mux.Handle("DELETE /v1/posts/{id}/recipient/{userId}", authMW(http.HandlerFunc(h.removePostRecipient)))
 	mux.Handle("POST /v1/posts/{id}/engagement", authMW(http.HandlerFunc(h.submitEngagement)))
 	mux.Handle("GET /v1/posts/{id}/engagement", authMW(http.HandlerFunc(h.listEngagement)))

--- a/server/internal/db/migrations/0027_post_deletions.sql
+++ b/server/internal/db/migrations/0027_post_deletions.sql
@@ -1,0 +1,18 @@
+-- Durable per-recipient tombstones for DELETED posts.
+--
+-- post_revocations FKs post_id ON DELETE CASCADE, so it vanishes the moment the post row is
+-- deleted — fine for the "remove one recipient" flow (the post lives on) but useless for a
+-- full delete (an OFFLINE recipient would never learn the post is gone). This table has NO FK
+-- to posts, so a tombstone survives the post's deletion: the author deletes the post, we record
+-- one row per recipient here, and listPosts surfaces these (UNIONed into `revoked`) so every
+-- recipient device prunes its local copy on its next sync. Online recipients also get an
+-- immediate `post-revoke` websocket frame; this table is the catch-up for everyone else.
+CREATE TABLE IF NOT EXISTS post_deletions (
+    post_id    text NOT NULL,
+    recipient  uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (post_id, recipient)
+);
+
+-- The recipient lookup listPosts runs every sync.
+CREATE INDEX IF NOT EXISTS post_deletions_recipient_idx ON post_deletions (recipient, created_at);

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -8,6 +8,7 @@ package push
 
 import (
 	"context"
+	"encoding/base64"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -155,6 +156,15 @@ func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p push
 	// address (a leading "mailto:" would yield "mailto:mailto:…", which Apple
 	// rejects as BadJwtToken). An https URL is left untouched.
 	subscriber := strings.TrimPrefix(s.subject, "mailto:")
+	// The Web Push "Topic" (RFC 8030, used to collapse a burst of tickles) must be a
+	// URL-safe-base64 string of at most 32 bytes. Apple enforces this strictly and 400s
+	// with {"reason":"BadWebPushTopic"} on a plain label like "ring-conn" (which isn't a
+	// decodable base64 string); FCM is lenient, which is why only iOS push was failing.
+	// Encode our short labels so collapsing works on every push service.
+	topic := p.topic
+	if topic != "" {
+		topic = base64.RawURLEncoding.EncodeToString([]byte(topic))
+	}
 	resp, err := webpush.SendNotificationWithContext(ctx, p.payload, &webpush.Subscription{
 		Endpoint: sub.Endpoint,
 		Keys:     webpush.Keys{P256dh: sub.P256dh, Auth: sub.Auth},
@@ -164,7 +174,7 @@ func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p push
 		VAPIDPrivateKey: s.vapidPrivate,
 		TTL:             p.ttl,
 		Urgency:         p.urgency,
-		Topic:           p.topic,
+		Topic:           topic,
 	})
 	if err != nil {
 		return 0, 0, err

--- a/server/internal/push/push_test.go
+++ b/server/internal/push/push_test.go
@@ -123,8 +123,8 @@ func TestNotifyHeaders(t *testing.T) {
 	if cap.urgency != "high" {
 		t.Errorf("message Urgency = %q, want high", cap.urgency)
 	}
-	if cap.topic != "ring-msg" {
-		t.Errorf("message Topic = %q, want ring-msg", cap.topic)
+	if want := base64.RawURLEncoding.EncodeToString([]byte("ring-msg")); cap.topic != want {
+		t.Errorf("message Topic = %q, want %q (base64url of ring-msg — Apple rejects a non-base64 topic)", cap.topic, want)
 	}
 
 	n.NotifyCall(context.Background(), "u1")
@@ -163,8 +163,8 @@ func TestNotifyConnHeaders(t *testing.T) {
 	if cap.urgency != "high" {
 		t.Errorf("conn Urgency = %q, want high", cap.urgency)
 	}
-	if cap.topic != "ring-conn" {
-		t.Errorf("conn Topic = %q, want ring-conn", cap.topic)
+	if want := base64.RawURLEncoding.EncodeToString([]byte("ring-conn")); cap.topic != want {
+		t.Errorf("conn Topic = %q, want %q (base64url of ring-conn)", cap.topic, want)
 	}
 }
 
@@ -317,8 +317,8 @@ func TestSendVersionHeaders(t *testing.T) {
 	if cap.urgency != "low" {
 		t.Errorf("version Urgency = %q, want low", cap.urgency)
 	}
-	if cap.topic != "ring-version" {
-		t.Errorf("version Topic = %q, want ring-version", cap.topic)
+	if want := base64.RawURLEncoding.EncodeToString([]byte("ring-version")); cap.topic != want {
+		t.Errorf("version Topic = %q, want %q (base64url of ring-version)", cap.topic, want)
 	}
 }
 

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -103,9 +103,118 @@ func (s *Store) ListPosts(ctx context.Context, recipient string, sinceMs int64) 
 
 // DeletePost removes a post (and, via cascade, its envelopes/engagement/views). The
 // author-only guard is the `author` predicate, so a non-author delete is a no-op.
-func (s *Store) DeletePost(ctx context.Context, author, id string) error {
-	_, err := s.pool.Exec(ctx, `DELETE FROM posts WHERE id = $1 AND author::text = $2`, id, author)
-	return err
+// DeletePost removes the author's own post and records a durable per-recipient tombstone so
+// every recipient prunes its local copy (offline → next sync; online → the caller WS-pushes).
+// Returns the recipient ids that held it (for the live push). No-op + nil if not the author's.
+func (s *Store) DeletePost(ctx context.Context, author, id string) ([]string, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var owned bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM posts WHERE id = $1 AND author::text = $2)`, id, author).Scan(&owned); err != nil {
+		return nil, err
+	}
+	if !owned {
+		return nil, nil
+	}
+
+	rows, err := tx.Query(ctx, `SELECT recipient::text FROM post_envelopes WHERE post_id = $1`, id)
+	if err != nil {
+		return nil, err
+	}
+	var recipients []string
+	for rows.Next() {
+		var r string
+		if err := rows.Scan(&r); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		recipients = append(recipients, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Tombstone each recipient BEFORE deleting the post (this table has no cascade FK, so the
+	// rows persist past the DELETE below and reach offline recipients via listPosts.revoked).
+	for _, r := range recipients {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO post_deletions (post_id, recipient) VALUES ($1, $2) ON CONFLICT DO NOTHING`, id, r); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM posts WHERE id = $1 AND author::text = $2`, id, author); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return recipients, nil
+}
+
+// KeepAlive (author-only): explicitly push a post's expiry back to now + its own window —
+// the manual version of the engagement keep-alive. Never shortens. Returns false if the
+// post isn't the caller's (or doesn't exist).
+func (s *Store) KeepAlive(ctx context.Context, author, id string) (bool, error) {
+	ct, err := s.pool.Exec(ctx,
+		`UPDATE posts SET expires_at = GREATEST(expires_at, now() + (ttl_ms * interval '1 millisecond'))
+		  WHERE id = $1 AND author::text = $2`,
+		id, author)
+	if err != nil {
+		return false, err
+	}
+	return ct.RowsAffected() > 0, nil
+}
+
+// AddEnvelopes broadens a post's audience (author-only): inserts new recipient key-envelopes
+// and clears any prior revocation/deletion tombstone for those recipients (so broadening back
+// re-grants access). Returns the recipients actually ADDED (newly inserted), for a silent live
+// delivery. No-op + nil if the post isn't the author's.
+func (s *Store) AddEnvelopes(ctx context.Context, author, postID string, envs []NewPostEnvelope) ([]string, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var owned bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM posts WHERE id = $1 AND author::text = $2)`, postID, author).Scan(&owned); err != nil {
+		return nil, err
+	}
+	if !owned {
+		return nil, nil
+	}
+
+	var added []string
+	for _, e := range envs {
+		ct, err := tx.Exec(ctx,
+			`INSERT INTO post_envelopes (post_id, recipient, wrapped_key) VALUES ($1, $2, $3)
+			 ON CONFLICT (post_id, recipient) DO NOTHING`,
+			postID, e.Recipient, e.WrappedKey)
+		if err != nil {
+			return nil, err
+		}
+		if ct.RowsAffected() > 0 {
+			added = append(added, e.Recipient)
+		}
+		// Undo any prior tombstone so a re-granted recipient re-fetches the post.
+		if _, err := tx.Exec(ctx, `DELETE FROM post_revocations WHERE post_id = $1 AND recipient::text = $2`, postID, e.Recipient); err != nil {
+			return nil, err
+		}
+		if _, err := tx.Exec(ctx, `DELETE FROM post_deletions WHERE post_id = $1 AND recipient::text = $2`, postID, e.Recipient); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return added, nil
 }
 
 // RemovePostRecipient drops `recipient` from a post's audience (author-only): it
@@ -143,6 +252,9 @@ func (s *Store) RemovePostRecipient(ctx context.Context, postID, author, recipie
 func (s *Store) ListRevocations(ctx context.Context, recipient string) ([]string, error) {
 	rows, err := s.pool.Query(ctx,
 		`SELECT post_id FROM post_revocations
+		  WHERE recipient::text = $1 AND created_at > now() - interval '30 days'
+		 UNION
+		 SELECT post_id FROM post_deletions
 		  WHERE recipient::text = $1 AND created_at > now() - interval '30 days'`, recipient)
 	if err != nil {
 		return nil, err

--- a/src/App.vue
+++ b/src/App.vue
@@ -52,6 +52,7 @@ import { stopAudio } from '@/composables/useAudioPlayer';
 import { useSync, nudgeReconnect } from '@/composables/useSync';
 import { useAppUpdate, checkForUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
+import { takePendingNav } from '@/services/pending-nav';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import type { Message } from '@/db/types';
 
@@ -74,8 +75,15 @@ const router = useRouter();
 watch(
   isUnlocked,
   (unlocked) => {
-    if (unlocked) void warmAll();
-    else {
+    if (unlocked) {
+      void warmAll();
+      // Cold-launched from a notification? The SW stashed where to go (iOS PWAs can't deep-link
+      // via openWindow); now that we're unlocked and the tabs are reachable, route there. The
+      // microtask defer lets the auth gate's default landing settle first so this wins.
+      void takePendingNav().then((url) => {
+        if (url) void routeRelevant(url);
+      });
+    } else {
       clearWarm();
       stopAudio(); // never leave media audio playing once locked / signed out
     }

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -252,6 +252,11 @@ ion-label h2 {
      start-aligning (which would right-align RTL). */
   unicode-bidi: plaintext;
   text-align: left;
+  /* Never wrap the name to a second line (e.g. a long group title like "Kamran, Macbook &
+     iPad" on a narrow screen) — keep it one line and truncate with an ellipsis. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .avatar-wrap {
   position: relative;

--- a/src/components/MediaViewer.vue
+++ b/src/components/MediaViewer.vue
@@ -20,10 +20,10 @@
                where you are in a multi-item album. Auto-hides with the chrome. FR-011. -->
           <div v-if="items.length > 1" class="v-count" aria-live="polite">{{ index + 1 }} / {{ items.length }}</div>
         </div>
-        <button v-if="cur?.outgoing" class="v-icon" aria-label="Caption" @click="$emit('caption', cur.id)">
+        <button v-if="cur?.outgoing && !minimal" class="v-icon" aria-label="Caption" @click="$emit('caption', cur.id)">
           <ion-icon :icon="pencil" />
         </button>
-        <button class="v-icon" aria-label="More" @click="menu = !menu">
+        <button v-if="!minimal" class="v-icon" aria-label="More" @click="menu = !menu">
           <ion-icon :icon="ellipsisHorizontal" />
         </button>
         <div v-if="menu" class="v-menu" @click="menu = false">
@@ -72,6 +72,7 @@
               v-else-if="i === index || nearby(i)"
               :ref="(c) => bindVideo(c, i)"
               :src="it.url"
+              :poster="it.thumb"
               :embedded="true"
               :chrome-hidden="chromeHidden"
               :start-at="positions[it.id]"
@@ -138,8 +139,9 @@
         </div>
 
         <!-- Action buttons sit on a translucent dark pill so they stay legible over a
-             bright or tall image showing behind them. -->
-        <div class="v-actions">
+             bright or tall image showing behind them. Hidden entirely in the minimal Wall
+             viewer — a post is reacted to from the feed/detail, not in the viewer. -->
+        <div v-if="!minimal" class="v-actions">
           <button aria-label="React" @click="showEmojis = !showEmojis"><ion-icon :icon="happyOutline" /></button>
           <button aria-label="Reply" @click="$emit('reply', cur.id)"><ion-icon :icon="arrowUndoOutline" /></button>
           <button aria-label="Save" @click="$emit('save', cur.id)"><ion-icon :icon="downloadOutline" /></button>
@@ -202,7 +204,7 @@ interface VideoApi {
   togglePip: () => void;
 }
 
-interface ViewerItem {
+export interface ViewerItem {
   id: string;
   url: string;
   thumb: string;
@@ -214,7 +216,9 @@ interface ViewerItem {
   favorite: boolean;
   reactions: Array<{ emoji: string; count: number }>;
 }
-const props = defineProps<{ open: boolean; items: ViewerItem[]; start: number }>();
+// `minimal` = a read-only viewer (Wall posts): keep the zoom/pan/swipe/fullscreen, drop the
+// chat-only chrome (caption pen, overflow menu, reply/save/forward/favorite/delete actions).
+const props = defineProps<{ open: boolean; items: ViewerItem[]; start: number; minimal?: boolean }>();
 const emit = defineEmits<{
   (e: 'close'): void;
   (e: 'dismiss', id: string): void;
@@ -291,6 +295,9 @@ function goToStart(): void {
 // stops it — only the on-screen video is ever active.
 async function playCurrentIfVideo(): Promise<void> {
   await nextTick();
+  // Minimal (Wall) viewer: never autoplay — show the poster + play button and let the user
+  // start it. (The chat viewer keeps the slide-onto-it-plays behaviour.)
+  if (props.minimal) return;
   if (cur.value?.kind !== 'video') return;
   const api = videoApis.get(index.value);
   if (api && !api.playing) api.toggle();

--- a/src/components/MinimizedAudio.vue
+++ b/src/components/MinimizedAudio.vue
@@ -5,7 +5,7 @@
        player is the control, so this hides itself (track.chatId === current chat). Once
        you leave, it reappears COLLAPSED (a compact pill) and can be expanded on demand. -->
   <div
-    v-if="track && !inOwningChat"
+    v-if="track && !inOwningChat && track.id !== controllerHiddenForId"
     class="audio-mini"
     :class="{ collapsed: !expanded }"
     role="group"
@@ -38,7 +38,7 @@ import { useRoute } from 'vue-router';
 import { IonIcon } from '@ionic/vue';
 import { play, pause, stop, mic, musicalNotes, chevronUpOutline, chevronDownOutline } from 'ionicons/icons';
 import {
-  audioTrack as track, audioPlaying, audioProgress, toggleAudioPlayback, stopAudio,
+  audioTrack as track, audioPlaying, audioProgress, toggleAudioPlayback, stopAudio, controllerHiddenForId,
 } from '@/composables/useAudioPlayer';
 
 const route = useRoute();

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -11,6 +11,7 @@
       ref="el"
       class="vid-el"
       :src="src"
+      :poster="poster"
       playsinline
       preload="metadata"
       @timeupdate="onTime"
@@ -56,7 +57,7 @@ import SpeedPill from '@/components/SpeedPill.vue';
 import { nextRate, playWhenReady } from '@/utils/playback';
 import { useScrub } from '@/composables/useScrub';
 
-const props = defineProps<{ src: string; embedded?: boolean; chromeHidden?: boolean; startAt?: number }>();
+const props = defineProps<{ src: string; poster?: string; embedded?: boolean; chromeHidden?: boolean; startAt?: number }>();
 const emit = defineEmits<{ (e: 'tap'): void; (e: 'time', seconds: number): void }>();
 
 const el = ref<HTMLVideoElement>();

--- a/src/components/VoicePlayer.vue
+++ b/src/components/VoicePlayer.vue
@@ -2,7 +2,7 @@
   <!-- Voice message player: play/pause + a real waveform (decoded from the audio)
        that fills as it plays and is seekable, with elapsed/total time and the
        sender's avatar + mic badge. -->
-  <div class="vp" :class="{ out: outgoing }">
+  <div ref="vpEl" class="vp" :class="{ out: outgoing }">
     <button type="button" class="vp-play" :aria-label="playing ? 'Pause' : 'Play'" @click.stop="toggle">
       <ion-icon :icon="playing ? pause : play" />
     </button>
@@ -29,12 +29,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { IonIcon } from '@ionic/vue';
 import { play, pause, mic } from 'ionicons/icons';
 import SpeedPill from '@/components/SpeedPill.vue';
 import {
-  audioCurId, audioPlaying, audioProgress, audioRate,
+  audioCurId, audioPlaying, audioProgress, audioRate, controllerHiddenForId,
   playAudio, seekAudioFrac, cycleAudioRate,
 } from '@/composables/useAudioPlayer';
 
@@ -46,6 +46,9 @@ const props = defineProps<{
   outgoing: boolean;
   avatar?: string;
   durationSec?: number;
+  // Wall feed: hide the floating controller while THIS inline player is on screen, and reveal it
+  // the moment the post is swiped/scrolled out of view (so you don't see both at once).
+  floatWhenAway?: boolean;
 }>();
 
 const BAR_COUNT = 44;
@@ -115,8 +118,34 @@ function seek(ev: MouseEvent): void {
   seekAudioFrac(Math.min(1, Math.max(0, (ev.clientX - rect.left) / rect.width)));
 }
 
+// Wall feed only: track whether this inline player is on screen. While it's the active track AND
+// visible, hide the floating controller (the inline player is right here); release it the instant
+// it swipes/scrolls out of view. IntersectionObserver clips through the album's horizontal scroll
+// container too, so left/right swipes count as "away" just like up/down feed scrolls.
+const vpEl = ref<HTMLElement>();
+const onScreen = ref(true);
+let io: IntersectionObserver | null = null;
+watch([isActive, onScreen], ([active, vis]) => {
+  if (!props.floatWhenAway) return;
+  if (active && vis) controllerHiddenForId.value = props.mid;
+  else if (controllerHiddenForId.value === props.mid) controllerHiddenForId.value = null;
+});
+
 onMounted(() => {
   void decodeWaveform();
+  if (props.floatWhenAway && vpEl.value && 'IntersectionObserver' in window) {
+    io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) onScreen.value = e.isIntersecting && e.intersectionRatio >= 0.5;
+      },
+      { threshold: [0, 0.5, 1] },
+    );
+    io.observe(vpEl.value);
+  }
+});
+onUnmounted(() => {
+  io?.disconnect();
+  if (controllerHiddenForId.value === props.mid) controllerHiddenForId.value = null;
 });
 </script>
 

--- a/src/components/VoicePlayer.vue
+++ b/src/components/VoicePlayer.vue
@@ -157,10 +157,15 @@ onMounted(() => {
   /* min-width:0 (not 100px) so the waveform can shrink below its content on a narrow
      bubble instead of forcing the whole row wider than the chat frame. */
   min-width: 0;
+  /* overflow:hidden is the actual safety net: when the box shrinks below the bars' natural
+     width, the 1px-floor bars would otherwise SPILL to the right — past the bubble and off the
+     screen edge. Clipping keeps the player inside its bubble (a few trailing bars just drop). */
+  overflow: hidden;
 }
 .vp-bar {
   flex: 1;
-  min-width: 2px;
+  /* 1px floor (was 2px) lets more bars fit a narrow waveform before any get clipped. */
+  min-width: 1px;
   border-radius: 1px;
   background: var(--app-text-muted, #8e8e93);
   opacity: 0.45;

--- a/src/components/WallVideo.vue
+++ b/src/components/WallVideo.vue
@@ -1,0 +1,185 @@
+<template>
+  <!-- Inline Wall video player (NOT the chat MediaViewer): autoplays while visible, with a
+       bottom bar — play/pause · mute · time + drag-scrubber · native fullscreen. Tapping the
+       frame toggles play/pause. Full-screen uses the OS player (rotatable) on iOS. -->
+  <div class="wv" @click="toggle">
+    <video
+      ref="el"
+      v-autoplay-visible
+      class="wv-video"
+      :src="src"
+      :poster="poster"
+      muted
+      playsinline
+      @ended="onEnded"
+      @play="onPlay"
+      @pause="playing = false"
+      @timeupdate="onTime"
+      @loadedmetadata="onMeta"
+    />
+    <div class="wv-bar" @click.stop>
+      <button class="wv-btn" :aria-label="playing ? 'Pause' : 'Play'" @click="toggle">
+        <ion-icon :icon="playing ? pauseIcon : playIcon" />
+      </button>
+      <button class="wv-btn" :aria-label="autoplayMuted ? 'Unmute' : 'Mute'" @click="setAutoplayMuted(!autoplayMuted)">
+        <ion-icon :icon="autoplayMuted ? volumeMuteOutline : volumeHighOutline" />
+      </button>
+      <span class="wv-time">{{ fmt(cur) }}</span>
+      <div
+        class="wv-track"
+        @click.stop
+        @pointerdown="scrub.onPointerDown"
+        @pointermove="scrub.onPointerMove"
+        @pointerup="scrub.onPointerUp"
+        @pointercancel="scrub.onPointerUp"
+      >
+        <div class="wv-rail"><div class="wv-prog" :style="{ width: pct }"></div></div>
+      </div>
+      <span class="wv-time">{{ fmt(dur) }}</span>
+      <button class="wv-btn" aria-label="Full screen" @click="fullscreen">
+        <ion-icon :icon="expandOutline" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { IonIcon } from '@ionic/vue';
+import { play as playIcon, pause as pauseIcon, volumeHighOutline, volumeMuteOutline, expandOutline } from 'ionicons/icons';
+import { vAutoplayVisible, autoplayMuted, setAutoplayMuted } from '@/directives/autoplay-visible';
+import { useScrub } from '@/composables/useScrub';
+
+defineProps<{ src?: string; poster?: string }>();
+
+const el = ref<HTMLVideoElement>();
+const playing = ref(false);
+const cur = ref(0);
+const dur = ref(0);
+const pct = computed(() => (dur.value ? Math.min(100, (cur.value / dur.value) * 100) : 0) + '%');
+const fmt = (s: number): string => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
+
+// iOS leaves a freshly-mounted clip's audio output disconnected even with muted=false — it
+// plays "unmuted" but silent until you mute→unmute (which reconnects the route). Each album
+// swipe mounts a NEW <video>, hitting this. So on the first play, if we intend sound, toggle
+// muted off→on→off across a frame to reconnect the audio — programmatically doing the manual
+// workaround. Runs once per mount; the brief (~1 frame) mute is imperceptible.
+let routed = false;
+function onPlay(): void {
+  playing.value = true;
+  const v = el.value;
+  if (routed || !v || autoplayMuted.value || v.muted) return;
+  routed = true;
+  v.muted = true;
+  requestAnimationFrame(() => {
+    const vv = el.value;
+    if (vv && !autoplayMuted.value) vv.muted = false;
+  });
+}
+function onTime(): void {
+  const v = el.value;
+  if (!v) return;
+  cur.value = v.currentTime;
+  if (Number.isFinite(v.duration)) dur.value = v.duration;
+}
+function onMeta(): void {
+  const v = el.value;
+  if (v && Number.isFinite(v.duration)) dur.value = v.duration;
+}
+function toggle(): void {
+  const v = el.value;
+  if (!v) return;
+  if (v.paused) void v.play().catch(() => {});
+  else v.pause();
+}
+// Manual loop instead of the native `loop` attribute: a fresh play() each cycle re-establishes
+// audio output, which iOS Safari otherwise drops on the 2nd loop of a once-muted clip.
+function onEnded(): void {
+  const v = el.value;
+  if (!v) return;
+  v.currentTime = 0;
+  void v.play().catch(() => {});
+}
+const scrub = useScrub((ratio) => {
+  const v = el.value;
+  if (v && dur.value) v.currentTime = Math.min(1, Math.max(0, ratio)) * dur.value;
+});
+// Native fullscreen → the OS video player, which rotates to landscape and plays audio reliably.
+function fullscreen(): void {
+  const v = el.value as (HTMLVideoElement & { webkitEnterFullscreen?: () => void }) | undefined;
+  if (!v) return;
+  v.muted = autoplayMuted.value;
+  if (typeof v.webkitEnterFullscreen === 'function') v.webkitEnterFullscreen();
+  else if (v.requestFullscreen) void v.requestFullscreen().catch(() => {});
+}
+</script>
+
+<style scoped>
+.wv {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+.wv-video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+/* Bottom control bar, promoted to its own layer (translateZ) so it paints ABOVE the
+   playing <video> on iOS. */
+.wv-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.55));
+  z-index: 20;
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
+}
+.wv-btn {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: #fff;
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.wv-time {
+  flex: 0 0 auto;
+  color: #fff;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+/* Tall hitbox around a thin rail so a finger can grab it; touch-action:none lets the drag scrub. */
+.wv-track {
+  flex: 1 1 auto;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  touch-action: none;
+  cursor: pointer;
+}
+.wv-rail {
+  width: 100%;
+  height: 3px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.35);
+  overflow: hidden;
+}
+.wv-prog {
+  height: 100%;
+  background: #fff;
+}
+</style>

--- a/src/components/WallVideo.vue
+++ b/src/components/WallVideo.vue
@@ -18,10 +18,10 @@
       @loadedmetadata="onMeta"
     />
     <div class="wv-bar" @click.stop>
-      <button class="wv-btn" :aria-label="playing ? 'Pause' : 'Play'" @click="toggle">
+      <button class="wv-btn wv-play" :aria-label="playing ? 'Pause' : 'Play'" @click="toggle">
         <ion-icon :icon="playing ? pauseIcon : playIcon" />
       </button>
-      <button class="wv-btn" :aria-label="autoplayMuted ? 'Unmute' : 'Mute'" @click="setAutoplayMuted(!autoplayMuted)">
+      <button class="wv-btn vol-toggle" :aria-label="autoplayMuted ? 'Unmute' : 'Mute'" @click="setAutoplayMuted(!autoplayMuted)">
         <ion-icon :icon="autoplayMuted ? volumeMuteOutline : volumeHighOutline" />
       </button>
       <span class="wv-time">{{ fmt(cur) }}</span>
@@ -59,22 +59,8 @@ const dur = ref(0);
 const pct = computed(() => (dur.value ? Math.min(100, (cur.value / dur.value) * 100) : 0) + '%');
 const fmt = (s: number): string => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
 
-// iOS leaves a freshly-mounted clip's audio output disconnected even with muted=false — it
-// plays "unmuted" but silent until you mute→unmute (which reconnects the route). Each album
-// swipe mounts a NEW <video>, hitting this. So on the first play, if we intend sound, toggle
-// muted off→on→off across a frame to reconnect the audio — programmatically doing the manual
-// workaround. Runs once per mount; the brief (~1 frame) mute is imperceptible.
-let routed = false;
 function onPlay(): void {
   playing.value = true;
-  const v = el.value;
-  if (routed || !v || autoplayMuted.value || v.muted) return;
-  routed = true;
-  v.muted = true;
-  requestAnimationFrame(() => {
-    const vv = el.value;
-    if (vv && !autoplayMuted.value) vv.muted = false;
-  });
 }
 function onTime(): void {
   const v = el.value;

--- a/src/composables/useAudioPlayer.ts
+++ b/src/composables/useAudioPlayer.ts
@@ -100,3 +100,17 @@ export function stopAudio(): void {
 export function detachAudioEnded(): void {
   endedCb = null;
 }
+
+/** Stop + clear the player IF `url` is the source it's currently playing. Call this right
+ *  before revoking a blob URL — e.g. the voice post being played is deleted/expired — so the
+ *  floating controller doesn't linger over a now-dead source (it would otherwise show a stuck
+ *  track and error on the revoked blob). Resets all now-playing state (hides the controller). */
+export function stopIfPlaying(url: string): void {
+  if (url && audioTrack.value?.url === url) stopAudio();
+}
+
+// Last-resort: if the element itself errors on its source (e.g. the blob was revoked out from
+// under it), don't sit in a stuck "playing" state — tear the player down and hide the controller.
+el.addEventListener('error', () => {
+  if (audioTrack.value) stopAudio();
+});

--- a/src/composables/useAudioPlayer.ts
+++ b/src/composables/useAudioPlayer.ts
@@ -35,6 +35,11 @@ export const audioPlaying = ref(false);
 export const audioProgress = ref(0); // 0..1
 export const audioRate = ref(1);
 export const audioTrack = ref<AudioTrackMeta | null>(null);
+// The id of a track whose OWN inline player is currently on screen (a Wall voice post the user
+// is looking at) — the floating controller hides for it, since the inline player is right there.
+// Cleared the moment that player scrolls/swipes out of view, so the floater takes over. Only the
+// Wall sets this (chat keeps its existing "hide while in the owning chat" behaviour).
+export const controllerHiddenForId = ref<string | null>(null);
 
 // Optional, caller-scoped "what to do when the track ends" (e.g. the chat's playlist
 // auto-advance). Cleared when the owning view goes away so a finished track just stops.

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -252,6 +252,9 @@ function start(): void {
         await replenishPreKeysIfLow();
       })();
       void runOwnSync(); // back up recovery wrap + sync own data (no-op if locked)
+      // Pull Wall posts on reconnect too (not just messages): a post published — or deleted —
+      // while we were offline is otherwise missed until the next app open / visibility change.
+      if (isUnlocked.value) void syncPosts();
       if (isUnlocked.value) void runInviteSync(); // connect inviter↔invitee on redemption
       if (isUnlocked.value) {
         void refreshBlocks(); // reconcile the local block ledger with the server

--- a/src/composables/useWall.ts
+++ b/src/composables/useWall.ts
@@ -6,10 +6,12 @@
  * "disappears in …" countdowns fresh. Ordering is by last activity (queries side), so
  * new posts and newly-interacted posts both rise to the top.
  */
-import { computed, ref, watch, onUnmounted } from 'vue';
+import { computed, ref, watch, onMounted, onUnmounted } from 'vue';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useSelfProfile } from '@/composables/useSelfProfile';
-import { listWallPosts, listContacts, listAllPostEngagement, getMedia, getWallMutedUsers } from '@/db/queries';
+import { listWallPosts, listContacts, listAllPostEngagement, getMedia, getWallMutedUsers, syncPosts } from '@/db/queries';
+import { wallSyncedOnce } from '@/services/wall-load';
+import { stopIfPlaying } from '@/composables/useAudioPlayer';
 import { getSelfUserId } from '@/services/auth';
 import type { Post, Contact, PostEngagement } from '@/db/types';
 
@@ -34,6 +36,7 @@ export interface WallPost extends Post {
   muted: boolean; // author's Wall notifications are muted
   mediaUrl?: string; // full-resolution blob (video src; image fallback) — may be absent
   posterUrl?: string; // small poster tier — shows instantly so the feed never blanks (US1)
+  album?: { url: string; kind: 'image' | 'video' | 'voice'; poster?: string }[]; // all media, for the inline feed gallery
   reactions: ReactionGroup[];
   myEmojis: string[];
   comments: CommentView[];
@@ -60,38 +63,102 @@ export function useWall() {
   // full blob (the video src; the image fallback when there's no poster).
   const mediaUrls = ref<Record<string, string>>({});
   const posterUrls = ref<Record<string, string>>({});
+  // For ALBUM posts (FR-019): every media resolved in order, so the feed can swipe the whole
+  // gallery inline without diving into the post.
+  const albumUrls = ref<Record<string, { url: string; kind: 'image' | 'video' | 'voice'; poster?: string }[]>>({});
+  // `updatedAt` is in the key so a background-downloaded blob (which touches the post) re-runs
+  // resolution — the post is on the Wall instantly via its poster, and each blob fills in after.
   watch(
-    () => posts.value.map((p) => `${p.id}:${p.mediaId ?? ''}`).join('|'),
+    () => posts.value.map((p) => `${p.id}:${p.mediaId ?? ''}:${p.mediaIds?.length ?? 0}:${p.updatedAt}`).join('|'),
     async () => {
       const nextMedia: Record<string, string> = {};
       const nextPoster: Record<string, string> = {};
+      const nextAlbum: Record<string, { url: string; kind: 'image' | 'video' | 'voice'; poster?: string }[]> = {};
       for (const p of posts.value) {
         if (!p.mediaId) continue;
-        // Reuse already-resolved URLs (both tiers were resolved together on a prior pass).
-        if (mediaUrls.value[p.id] || posterUrls.value[p.id]) {
-          if (mediaUrls.value[p.id]) nextMedia[p.id] = mediaUrls.value[p.id];
+        // Cover: reuse the full media URL once resolved; otherwise re-resolve so a freshly
+        // downloaded blob is picked up. The poster is reused if already created.
+        if (mediaUrls.value[p.id]) {
+          nextMedia[p.id] = mediaUrls.value[p.id];
           if (posterUrls.value[p.id]) nextPoster[p.id] = posterUrls.value[p.id];
-          continue;
+        } else {
+          const md = await getMedia(p.mediaId);
+          if (md?.blob) nextMedia[p.id] = URL.createObjectURL(md.blob);
+          if (posterUrls.value[p.id]) nextPoster[p.id] = posterUrls.value[p.id];
+          else {
+            const poster = md?.posterBlob ?? md?.posterGrid;
+            if (poster) nextPoster[p.id] = URL.createObjectURL(poster);
+          }
         }
-        const md = await getMedia(p.mediaId);
-        if (md?.blob) nextMedia[p.id] = URL.createObjectURL(md.blob);
-        const poster = md?.posterBlob ?? md?.posterGrid;
-        if (poster) nextPoster[p.id] = URL.createObjectURL(poster);
+        // Album (2+ items): reuse when every item already has its full blob; otherwise resolve
+        // per-item — keep an item that already has a URL (so a playing clip isn't recreated) and
+        // resolve the rest, rendering from the poster (empty url) while the blob streams in.
+        if (p.mediaIds && p.mediaIds.length > 1) {
+          const prev = albumUrls.value[p.id];
+          if (prev && prev.length === p.mediaIds.length && prev.every((it) => it.url)) {
+            nextAlbum[p.id] = prev;
+          } else {
+            const items: { url: string; kind: 'image' | 'video' | 'voice'; poster?: string }[] = [];
+            for (let k = 0; k < p.mediaIds.length; k++) {
+              const cached = prev?.[k];
+              if (cached?.url) {
+                items.push(cached);
+                continue;
+              }
+              const md = await getMedia(p.mediaIds[k]);
+              if (!md) continue;
+              const kind = md.kind === 'video' ? 'video' : md.kind === 'voice' ? 'voice' : 'image';
+              const posterBlob = kind === 'video' ? (md.posterBlob ?? md.posterGrid) : undefined;
+              items.push({
+                url: md.blob ? URL.createObjectURL(md.blob) : '',
+                kind,
+                poster: cached?.poster ?? (posterBlob ? URL.createObjectURL(posterBlob) : undefined),
+              });
+            }
+            if (items.length) nextAlbum[p.id] = items;
+          }
+        }
       }
-      for (const [pid, url] of Object.entries(mediaUrls.value)) {
-        if (nextMedia[pid] !== url) URL.revokeObjectURL(url);
-      }
-      for (const [pid, url] of Object.entries(posterUrls.value)) {
-        if (nextPoster[pid] !== url) URL.revokeObjectURL(url);
-      }
+      // Revoke per-URL (not per-post), so URLs reused above survive while truly-dropped ones go.
+      const live = new Set<string>();
+      for (const u of Object.values(nextMedia)) live.add(u);
+      for (const u of Object.values(nextPoster)) live.add(u);
+      for (const items of Object.values(nextAlbum))
+        for (const it of items) {
+          if (it.url) live.add(it.url);
+          if (it.poster) live.add(it.poster);
+        }
+      // If a URL we're about to revoke is the one the floating audio player is playing (e.g. a
+      // voice post just got deleted/expired mid-playback), stop + dismiss the player first so it
+      // doesn't linger over a dead blob.
+      for (const u of Object.values(mediaUrls.value))
+        if (!live.has(u)) {
+          stopIfPlaying(u);
+          URL.revokeObjectURL(u);
+        }
+      for (const u of Object.values(posterUrls.value)) if (!live.has(u)) URL.revokeObjectURL(u);
+      for (const items of Object.values(albumUrls.value))
+        for (const it of items) {
+          if (it.url && !live.has(it.url)) {
+            stopIfPlaying(it.url);
+            URL.revokeObjectURL(it.url);
+          }
+          if (it.poster && !live.has(it.poster)) URL.revokeObjectURL(it.poster);
+        }
       mediaUrls.value = nextMedia;
       posterUrls.value = nextPoster;
+      albumUrls.value = nextAlbum;
     },
     { immediate: true },
   );
   onUnmounted(() => {
     for (const url of Object.values(mediaUrls.value)) URL.revokeObjectURL(url);
     for (const url of Object.values(posterUrls.value)) URL.revokeObjectURL(url);
+    for (const items of Object.values(albumUrls.value))
+      for (const it of items) {
+        URL.revokeObjectURL(it.url);
+        if (it.poster) URL.revokeObjectURL(it.poster);
+      }
   });
 
   const wall = computed<WallPost[]>(() => {
@@ -144,6 +211,7 @@ export function useWall() {
         muted: !!mutedUsers.value[p.author],
         mediaUrl: mediaUrls.value[p.id],
         posterUrl: posterUrls.value[p.id],
+        album: albumUrls.value[p.id],
         reactions,
         myEmojis,
         comments,
@@ -152,7 +220,27 @@ export function useWall() {
     });
   });
 
+  // Pull from the server whenever the Wall is opened (cursor-based, so it only fetches what's
+  // new). This also guarantees `wallSyncedOnce` flips — dropping the first-load spinner — even
+  // if the global sync loop hasn't fired yet for this session.
+  let firstSyncFailsafe: number | undefined;
+  onMounted(() => {
+    void syncPosts();
+    // Failsafe so the loader can NEVER spin forever: syncPosts flips `wallSyncedOnce` in its
+    // finally, but it early-returns (skipping that) while the keystore is still settling at
+    // mount, and a request can also stall. After a short grace period, resolve the spinner
+    // regardless — any real posts still stream in via the live query once a sync lands.
+    firstSyncFailsafe = window.setTimeout(() => {
+      wallSyncedOnce.value = true;
+    }, 5000);
+  });
+  onUnmounted(() => {
+    if (firstSyncFailsafe) clearTimeout(firstSyncFailsafe);
+  });
+
   // `loaded` flips true after the first query resolves, so the UI can avoid flashing
-  // the empty state / "New post" button before posts have loaded.
-  return { wall, now, loaded: posts.loaded };
+  // the empty state / "New post" button before posts have loaded. `synced` flips true after
+  // the first server sync attempt — distinguishing "still pulling" (spinner) from "really
+  // empty" (the empty state) on a fresh device.
+  return { wall, now, loaded: posts.loaded, synced: wallSyncedOnce };
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -11,11 +11,12 @@ import { uid } from '@/utils/uid';
 import { capitalizeFirst } from '@/utils/text';
 import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination';
 import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
-import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, removePostRecipient as apiRemovePostRecipient, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
+import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, keepAlivePost as apiKeepAlivePost, addPostEnvelopes as apiAddPostEnvelopes, removePostRecipient as apiRemovePostRecipient, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
 import { sealForChat, openPacket } from '@/services/messaging';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
 import { autoSaveIncomingMedia } from '@/services/media-autosave';
-import { buildPost, openReceivedPost, sealPostEngagement, openPostEngagement, type AudienceMember, type PostPayload } from '@/services/posts';
+import { wallSyncedOnce } from '@/services/wall-load';
+import { buildPost, wrapForNewAudience, openReceivedPost, sealPostEngagement, openPostEngagement, type AudienceMember, type PostPayload } from '@/services/posts';
 import { b64urlToBytes } from '@/services/crypto/envelope';
 import { getSecret, setSecret } from '@/db/secrets';
 import { isUnlockedNow, getIdentityKeys } from '@/services/crypto/identity';
@@ -2145,6 +2146,21 @@ async function peerPostKey(userId: string): Promise<Uint8Array | null> {
   return b64urlToBytes(bundle.xPub);
 }
 
+// Decode a base64 data URL to a Blob WITHOUT fetch() — fetch of a `data:` URL can hang in the
+// iOS PWA webview, which would freeze a video post on poster generation. Returns undefined on
+// a malformed input.
+function dataUrlToBlobSafe(dataUrl: string): Blob | undefined {
+  try {
+    const comma = dataUrl.indexOf(',');
+    if (comma < 0) return undefined;
+    const mime = dataUrl.slice(0, comma).match(/data:([^;]+)/)?.[1] ?? 'image/jpeg';
+    const bytes = Uint8Array.from(atob(dataUrl.slice(comma + 1)), (c) => c.charCodeAt(0));
+    return new Blob([bytes], { type: mime });
+  } catch {
+    return undefined;
+  }
+}
+
 /** One media attachment for a post: a picked/recorded blob + how to send it. */
 export interface PostMediaInput {
   blob: Blob;
@@ -2231,6 +2247,27 @@ export async function createPost(opts: {
       mediaW = w;
       mediaH = h;
     }
+    // A first-frame poster for videos: the feed (and a not-yet-downloaded recipient) shows a
+    // thumbnail before/without playback instead of a blank box. Stored as a Blob (+ derived
+    // tiers) so the Wall's posterUrl resolves it like an image poster.
+    let posterBlob: Blob | undefined;
+    let posterGrid: Blob | undefined;
+    let posterStrip: Blob | undefined;
+    if (m.kind === 'video') {
+      const dataUrl = await generateVideoPoster(toUpload).catch(() => undefined);
+      // Embed the poster (a small JPEG data URL, ≤~40KB) in the sealed MediaRef so a RECIPIENT
+      // shows the thumbnail without downloading/decoding the clip — exactly how chat video
+      // messages carry MediaRef.poster. It rides in the one sealed post blob, not per envelope.
+      if (dataUrl) ref.poster = dataUrl;
+      // Decode the data URL to a Blob directly (NOT fetch(dataUrl) — that can hang in the iOS
+      // PWA webview) so a video post never stalls on poster generation.
+      if (dataUrl) posterBlob = dataUrlToBlobSafe(dataUrl);
+      if (posterBlob) {
+        const tiers = await deriveTiers(posterBlob).catch(() => ({}) as { grid?: Blob; strip?: Blob });
+        posterGrid = tiers.grid;
+        posterStrip = tiers.strip;
+      }
+    }
     await put<Media>('media', {
       id,
       kind: m.kind,
@@ -2238,6 +2275,9 @@ export async function createPost(opts: {
       name: ref.name,
       size: ref.size,
       blob: toUpload,
+      posterBlob,
+      posterGrid,
+      posterStrip,
       durationSec: ref.durationSec,
       updatedAt: now(),
     });
@@ -2303,10 +2343,9 @@ async function receivePost(sp: ServerPost): Promise<void> {
   let mediaH: number | undefined;
   const mediaIds: string[] = [];
   const refsToGet = payload.album ?? (payload.media ? [payload.media] : []);
+  const pending: { id: string; ref: MediaRef }[] = [];
   if (payload.kind !== 'text') {
     for (const ref of refsToGet) {
-      const mblob = await receiveIncomingMedia(ref).catch(() => null);
-      if (!mblob) continue;
       const id = uid();
       mediaIds.push(id);
       if (mediaIds.length === 1) {
@@ -2317,16 +2356,35 @@ async function receivePost(sp: ServerPost): Promise<void> {
       // A mixed album can carry both images and videos, so derive each item's kind from
       // its mime rather than the post's overall kind.
       const itemKind = ref.mime.startsWith('video/') ? 'video' : ref.mime.startsWith('audio/') ? 'voice' : 'image';
+      // Persist the embedded poster (videos) NOW so the post renders a thumbnail immediately.
+      let posterBlob: Blob | undefined;
+      let posterGrid: Blob | undefined;
+      let posterStrip: Blob | undefined;
+      if (itemKind === 'video' && ref.poster) {
+        posterBlob = dataUrlToBlobSafe(ref.poster);
+        if (posterBlob) {
+          const tiers = await deriveTiers(posterBlob).catch(() => ({}) as { grid?: Blob; strip?: Blob });
+          posterGrid = tiers.grid;
+          posterStrip = tiers.strip;
+        }
+      }
+      // Store the Media record WITHOUT the heavy blob (it's optional — the same shape as a
+      // "kept preview"). The full blob streams in afterwards (downloadPostMedia) so the post +
+      // its Wall badge appear AT ONCE instead of waiting on a full video download. The feed
+      // shows the poster meanwhile and the idb bus live-updates each item as its blob lands.
       await put<Media>('media', {
         id,
         kind: itemKind,
         mime: ref.mime,
         name: ref.name,
         size: ref.size,
-        blob: mblob,
+        posterBlob,
+        posterGrid,
+        posterStrip,
         durationSec: ref.durationSec,
         updatedAt: now(),
       });
+      pending.push({ id, ref });
     }
   }
   const prev = await get<Post>('posts', sp.id);
@@ -2350,6 +2408,24 @@ async function receivePost(sp: ServerPost): Promise<void> {
   // Pull any engagement (reactions/comments) that already exists on this post (also
   // applies keep-alive from past interactions).
   void syncEngagement(sp.id);
+  // Stream the full media in the BACKGROUND — the post is already visible (posters); each blob
+  // landing live-updates the feed (video becomes playable, image fills in).
+  void downloadPostMedia(sp.id, pending);
+}
+
+// Download a received post's media blobs after the post is already on the Wall, attaching each
+// to its (poster-only) Media record. Best-effort + sequential so one slow video doesn't block
+// the others' visibility — they're all already showing their posters. After each blob lands we
+// touch the post so useWall re-resolves it (the freshly-downloaded blob becomes a playable URL).
+async function downloadPostMedia(postId: string, pending: { id: string; ref: MediaRef }[]): Promise<void> {
+  for (const { id, ref } of pending) {
+    const mblob = await receiveIncomingMedia(ref).catch(() => null);
+    if (!mblob) continue;
+    const md = await get<Media>('media', id);
+    if (md) await put<Media>('media', { ...md, blob: mblob, size: ref.size, updatedAt: now() });
+    const post = await get<Post>('posts', postId);
+    if (post) await put<Post>('posts', { ...post, updatedAt: now() });
+  }
 }
 
 /** Pull new posts addressed to us and persist them (called on app open, on the
@@ -2366,6 +2442,9 @@ export async function syncPosts(): Promise<void> {
     if (next > cursor) await setSetting('postsCursor', next);
   } catch {
     /* offline / transient — retried on the next nudge */
+  } finally {
+    // First real sync attempt done (success or transient fail) → drop the Wall first-load spinner.
+    wallSyncedOnce.value = true;
   }
 }
 
@@ -2522,6 +2601,42 @@ export async function getMedia(id: string): Promise<Media | null> {
 export async function deletePost(id: string): Promise<void> {
   await apiDeletePost(id).catch(() => {});
   await remove('posts', id);
+}
+
+/** Explicitly extend one of our own posts' lifetime ("Keep for longer"): the server pushes
+ *  its expiry back to a full window, and we mirror that locally so the countdown updates. */
+export async function keepAlivePost(id: string): Promise<void> {
+  await apiKeepAlivePost(id);
+  await bumpPostActivity(id, now());
+}
+
+/** Change one of our own posts' visibility after the fact (close ↔ all friends). Broadening
+ *  re-wraps K_post to the newly-included friends and adds their envelopes (they receive it
+ *  SILENTLY — no new notification); narrowing revokes the non-close friends' copies (their
+ *  device prunes it). Those already in the audience are never re-notified. */
+export async function setPostAudience(id: string, audience: 'friends' | 'close'): Promise<void> {
+  const post = await get<Post>('posts', id);
+  if (!post || !post.outgoing || !post.postKey || post.audience === audience) return;
+  const closeIds = new Set((await listCloseFriends()).map((c) => c.id));
+  const friends = await listFriends();
+  if (audience === 'friends') {
+    // Broaden: add every friend not already a recipient (i.e. the non-close ones).
+    const members: AudienceMember[] = [];
+    for (const f of friends) {
+      if (closeIds.has(f.id)) continue;
+      const pub = await peerPostKey(f.id);
+      if (pub) members.push({ userId: f.id, pubKey: pub });
+    }
+    if (members.length) await apiAddPostEnvelopes(id, wrapForNewAudience(post.postKey, members));
+  } else {
+    // Narrow: revoke every friend who isn't a close friend (reuses the existing revoke path).
+    for (const f of friends) {
+      if (!closeIds.has(f.id)) await apiRemovePostRecipient(id, f.id).catch(() => {});
+    }
+  }
+  post.audience = audience;
+  post.updatedAt = now();
+  await put<Post>('posts', post);
 }
 
 /** Remove posts (and their engagement) whose lifetime has elapsed. Wired into the

--- a/src/directives/autoplay-visible.ts
+++ b/src/directives/autoplay-visible.ts
@@ -72,11 +72,12 @@ function setActive(el: HTMLVideoElement | null): void {
   if (el) {
     el.setAttribute('data-autoplaying', 'true');
     el.muted = autoplayMuted.value; // respect the shared feed mute state (default: sound on)
-    void el.play().catch(() => {
-      // Unmuted autoplay is blocked until the page has a user gesture. Don't freeze on the
-      // poster — fall back to MUTED playback (keeping the intent "sound on", so the next tap
-      // brings audio in). If it was already muted, nothing more we can do.
-      if (!el.muted) {
+    void el.play().catch((err: unknown) => {
+      // Fall back to MUTED playback ONLY when the browser BLOCKED unmuted autoplay
+      // (NotAllowedError) — so a clip the user chose to hear still plays (muted) instead of
+      // freezing on its poster. Do NOT mute on other rejections (media not yet loaded / can't
+      // decode): that would wrongly silence an unmuted clip and break "unmute sticks".
+      if ((err as { name?: string } | null)?.name === 'NotAllowedError' && !el.muted) {
         el.muted = true;
         void el.play().catch(() => {});
       }

--- a/src/directives/autoplay-visible.ts
+++ b/src/directives/autoplay-visible.ts
@@ -15,10 +15,10 @@
  */
 import { ref, type Directive } from 'vue';
 
-// Shared mute state for feed autoplay. Videos START muted (browsers block UNMUTED autoplay
-// without a user gesture). The inline speaker toggle flips this for ALL feed videos at once —
-// once you unmute (the tap is the gesture), every video that autoplays plays WITH sound until
-// you mute again. Persisting "muted" is the social-feed norm (TikTok/Reels).
+// Shared mute state for feed autoplay. Default is MUTED — clips autoplay silently and the
+// inline speaker toggle unmutes them (a tap that also satisfies the browser's autoplay-with-
+// sound gate). The choice then sticks for every feed video until changed. Muted-by-default is
+// the social-feed norm and sidesteps iOS's per-element audio-routing quirks on autoplay.
 export const autoplayMuted = ref(true);
 
 // Toggle/set the shared mute state and apply it to the video playing right now. Unmuting is a
@@ -40,6 +40,15 @@ const registered = new Set<HTMLVideoElement>();
 const ratios = new Map<HTMLVideoElement, number>();
 let current: HTMLVideoElement | null = null;
 let io: IntersectionObserver | null = null;
+// When a full-screen viewer (or any modal) is open over the feed, the feed videos are still
+// "intersecting" the viewport behind it, so suspend autoplay outright — otherwise a clip keeps
+// playing (now with sound) behind the overlay.
+let suspended = false;
+export function suspendAutoplay(on: boolean): void {
+  suspended = on;
+  if (on) setActive(null);
+  else reconcile();
+}
 
 // Respect the platform/user signals that say "don't autoplay": reduced-motion and the
 // Save-Data hint. When either is on we never autoplay (tap-to-play still works).
@@ -62,9 +71,15 @@ function setActive(el: HTMLVideoElement | null): void {
   current = el;
   if (el) {
     el.setAttribute('data-autoplaying', 'true');
-    el.muted = autoplayMuted.value; // respect the shared feed mute state (starts muted)
+    el.muted = autoplayMuted.value; // respect the shared feed mute state (default: sound on)
     void el.play().catch(() => {
-      /* autoplay blocked — leave the poster frame showing */
+      // Unmuted autoplay is blocked until the page has a user gesture. Don't freeze on the
+      // poster — fall back to MUTED playback (keeping the intent "sound on", so the next tap
+      // brings audio in). If it was already muted, nothing more we can do.
+      if (!el.muted) {
+        el.muted = true;
+        void el.play().catch(() => {});
+      }
     });
   }
 }
@@ -72,7 +87,7 @@ function setActive(el: HTMLVideoElement | null): void {
 // Pick the most-visible registered video and make it the single active one; drop the
 // current one once it's mostly off screen.
 function reconcile(): void {
-  if (lowData()) {
+  if (lowData() || suspended) {
     setActive(null);
     return;
   }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -128,6 +128,26 @@ export async function deletePost(id: string): Promise<void> {
   if (!res.ok && res.status !== 404) throw new Error(`delete post failed: ${res.status}`);
 }
 
+/** Push one of the caller's own posts' auto-delete back to a full window (author-only). */
+export async function keepAlivePost(id: string): Promise<void> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts/${encodeURIComponent(id)}/keepalive`, {
+    method: 'POST',
+    headers: authHeaders(),
+  });
+  if (!res.ok && res.status !== 404) throw new Error(`extend post failed: ${res.status}`);
+}
+
+/** Broaden one of the caller's own posts' audience by adding recipient key-envelopes
+ *  (author-only). The added recipients get the post silently (no notification). */
+export async function addPostEnvelopes(postId: string, envelopes: PostEnvelopeWire[]): Promise<void> {
+  const res = await fetch(`${apiBaseUrl()}/v1/posts/${encodeURIComponent(postId)}/envelopes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ envelopes }),
+  });
+  if (!res.ok) throw new Error(`add post envelopes failed: ${res.status}`);
+}
+
 /** Remove one recipient from one of the caller's own posts (author-only). Used when
  *  un-close-friending someone to revoke close-only posts: their key envelope is deleted
  *  and a revocation is recorded so their device prunes the local copy. Idempotent. */

--- a/src/services/media-video-webcodecs.ts
+++ b/src/services/media-video-webcodecs.ts
@@ -80,7 +80,11 @@ function audioSpecificConfig(file: any, trackId: number): Uint8Array | undefined
     while (stack.length) {
       const node = stack.shift();
       if (!node) continue;
-      if (node.data) return new Uint8Array(node.data);
+      // A valid AudioSpecificConfig is ≥2 bytes. Some containers nest a stray 1-byte
+      // descriptor (e.g. an SLConfig) ahead of the real DecoderSpecificInfo, so skip
+      // too-short `.data` and keep walking — returning it would mux a broken (silent)
+      // track. If nothing valid is found we fall back to a synthesized ASC.
+      if (node.data && node.data.length >= 2) return new Uint8Array(node.data);
       if (Array.isArray(node.descs)) stack.push(...node.descs);
     }
     return undefined;

--- a/src/services/pending-nav.ts
+++ b/src/services/pending-nav.ts
@@ -1,0 +1,30 @@
+import { get, put } from '@/db/idb';
+import type { Setting } from '@/db/types';
+
+/**
+ * Pending-navigation handshake for cold launches from a notification.
+ *
+ * On iOS, a fully-closed PWA opened via `clients.openWindow(path)` ignores the path and lands
+ * on the app's default tab — so a tapped Wall/notification deep-link was lost. Instead the
+ * service worker stashes the target here before opening the window, and the app consumes it
+ * once it's unlocked and routes there. A tiny leaf module so both the SW bundle and the app can
+ * import it without pulling in heavy deps or creating a cycle.
+ */
+const KEY = 'sw.pendingNav';
+// Only honor a very fresh target: a stale one (a launch that never happened, or a target left
+// over from a previous session) must not hijack a later manual open.
+const MAX_AGE_MS = 60_000;
+
+/** SW side: stash the tapped notification's target just before opening the window. */
+export async function setPendingNav(url: string): Promise<void> {
+  await put<Setting<{ url: string; ts: number }>>('settings', { key: KEY, value: { url, ts: Date.now() } });
+}
+
+/** App side: read AND clear the stash. Returns the url only if it was set within MAX_AGE_MS. */
+export async function takePendingNav(): Promise<string | null> {
+  const s = await get<Setting<{ url: string; ts: number } | null>>('settings', KEY);
+  const v = s?.value ?? null;
+  if (!v) return null;
+  await put<Setting<null>>('settings', { key: KEY, value: null });
+  return Date.now() - v.ts < MAX_AGE_MS ? v.url : null;
+}

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -62,6 +62,20 @@ export function buildPost(payload: PostPayload, audience: AudienceMember[]): Bui
   return { blob, envelopes, postKey: bytesToB64url(k) };
 }
 
+/** Re-wrap an EXISTING post's content key K_post to additional audience members. Used to
+ *  broaden a post's audience (close → all friends) WITHOUT rebuilding or re-sealing the
+ *  payload — only new key-envelopes are produced for the added recipients. */
+export function wrapForNewAudience(
+  postKeyB64: string,
+  audience: AudienceMember[],
+): { recipient: string; wrappedKey: string }[] {
+  const k = b64urlToBytes(postKeyB64);
+  return audience.map((m) => ({
+    recipient: m.userId,
+    wrappedKey: JSON.stringify(wrapPostKey(k, m.pubKey)),
+  }));
+}
+
 /**
  * Recover a received post: unwrap K_post from the caller's envelope, then open the
  * sealed payload blob. Returns the payload AND K_post (b64url) — the recipient keeps

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -564,9 +564,35 @@ interface ConnReq {
  * All bodies are identity-safe (no names / ids), so nothing about who is exposed,
  * and no decryption is needed. Returns [] on any auth/network failure.
  */
-export async function previewConnections(): Promise<ConnNote[]> {
+/** A requester's/target's name for a friend-request notification: their public
+ *  directory profile (display name, else @username). Fetched LOCALLY by the SW — the
+ *  identity never rides in the content-free push. 'Someone' if it can't be resolved. */
+async function connName(userId: string, token: string): Promise<string> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), PENDING_FETCH_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(`${API}/users/${encodeURIComponent(userId)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: ctrl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (res.ok) {
+      const u = (await res.json()) as { displayName?: string; username?: string };
+      return u.displayName?.trim() || (u.username ? `@${u.username}` : 'Someone');
+    }
+  } catch {
+    /* fall through to a generic, identity-safe label */
+  }
+  return 'Someone';
+}
+
+export async function previewConnections(): Promise<{ notes: ConnNote[]; pendingIncoming: number }> {
   const token = await readSessionToken();
-  if (!token) return [];
+  if (!token) return { notes: [], pendingIncoming: 0 };
   let data: { incoming?: ConnReq[]; outgoing?: ConnReq[] };
   try {
     const ctrl = new AbortController();
@@ -577,27 +603,81 @@ export async function previewConnections(): Promise<ConnNote[]> {
     } finally {
       clearTimeout(timer);
     }
-    if (!res.ok) return [];
+    if (!res.ok) return { notes: [], pendingIncoming: 0 };
     data = (await res.json()) as { incoming?: ConnReq[]; outgoing?: ConnReq[] };
   } catch {
-    return [];
+    return { notes: [], pendingIncoming: 0 };
   }
   const seen = new Set((await loadConnShownEntries()).map((e) => e.id));
   const notes: ConnNote[] = [];
-  const add = (key: string, body: string, tag: string): void => {
+  // Title = WHO, body = the action — so iOS renders "<name>: wants to be friends". The app
+  // name ("Ring") is already the notification's source line, so the old "Ring / New friend
+  // request" was doubly redundant.
+  const add = (key: string, title: string, body: string, tag: string): void => {
     if (seen.has(key)) return;
     seen.add(key);
-    notes.push({ keys: [key], title: 'Ring', body, url: '/tabs/contacts', tag });
+    notes.push({ keys: [key], title, body, url: '/tabs/contacts', tag });
   };
+  let pendingIncoming = 0;
   for (const r of data.incoming ?? []) {
-    if (r.state === 'pending' && r.requester) add(`req:${r.requester}`, 'New friend request', 'ring:conn:req');
+    if (r.state === 'pending' && r.requester) {
+      pendingIncoming++;
+      add(`req:${r.requester}`, await connName(r.requester, token), 'wants to be friends', 'ring:conn:req');
+    }
   }
   for (const r of data.outgoing ?? []) {
     if (!r.target) continue;
-    if (r.state === 'accepted') add(`acc:${r.target}`, 'Your friend request was accepted', `ring:conn:acc:${r.target}`);
-    else if (r.state === 'rejected') add(`rej:${r.target}`, 'Your friend request was declined', `ring:conn:rej:${r.target}`);
+    if (r.state === 'accepted') add(`acc:${r.target}`, await connName(r.target, token), 'accepted your friend request', `ring:conn:acc:${r.target}`);
+    else if (r.state === 'rejected') add(`rej:${r.target}`, await connName(r.target, token), 'declined your friend request', `ring:conn:rej:${r.target}`);
   }
-  return notes;
+  return { notes, pendingIncoming };
+}
+
+// Wall: on a "new post" tickle (app closed), name the author instead of a generic placeholder.
+// The author is server-visible metadata (not E2EE content), so this needs NO decryption — we
+// resolve their public directory name, exactly like a friend request. Recent-window + a cursor
+// keep us from re-announcing old posts; collapsed by author so 3 posts from X = one "X posted".
+const POST_SINCE_KEY = 'sw.postNotifySince';
+const POST_RECENT_MS = 10 * 60 * 1000;
+export async function previewPosts(): Promise<{ notes: ConnNote[]; newCount: number }> {
+  const token = await readSessionToken();
+  if (!token) return { notes: [], newCount: 0 };
+  const self = await readSessionUserId();
+  const since = (await setting<number>(POST_SINCE_KEY, 0)) || 0;
+  let data: { posts?: Array<{ id: string; author: string; createdAt: number }>; cursor?: number };
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), PENDING_FETCH_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(`${API}/posts?since=${since}`, { headers: { Authorization: `Bearer ${token}` }, signal: ctrl.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) return { notes: [], newCount: 0 };
+    data = (await res.json()) as typeof data;
+  } catch {
+    return { notes: [], newCount: 0 };
+  }
+  const cutoff = Date.now() - POST_RECENT_MS;
+  const fresh = (data.posts ?? []).filter((p) => p.author && p.author !== self && (p.createdAt ?? 0) > cutoff);
+  const notes: ConnNote[] = [];
+  const seen = new Set<string>();
+  for (const p of fresh) {
+    if (seen.has(p.author)) continue;
+    seen.add(p.author);
+    notes.push({
+      keys: [`post:${p.id}`],
+      title: await connName(p.author, token),
+      body: 'posted on their Wall',
+      url: '/tabs/wall',
+      tag: `ring:post:${p.author}`,
+    });
+  }
+  if (data.cursor && data.cursor > since) {
+    await put<Setting<number>>('settings', { key: POST_SINCE_KEY, value: data.cursor });
+  }
+  return { notes, newCount: fresh.length };
 }
 
 /** Persist the conn-ledger keys we displayed, so the same event doesn't re-notify

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -91,6 +91,7 @@ import {
   createPost as dbCreatePost,
   syncPosts as dbSyncPosts,
   getPost as dbGetPost,
+  getMedia as dbGetMedia,
   listWallPosts as dbListWallPosts,
   reactToPost as dbReactToPost,
   syncEngagement as dbSyncEngagement,
@@ -1028,6 +1029,91 @@ export function installTestHook(): void {
       }));
       const p = await dbCreatePost({ body, audience: 'friends', lifetime: '24h', media });
       return p.id;
+    },
+    /** Share an album of MIXED aspect ratios (portrait, square, landscape) so the gallery's
+     *  fixed-frame + blurred-fill presentation can be checked visually. */
+    postMixedAlbum: async (): Promise<string> => {
+      const make = async (w: number, h: number, color: string, label: string): Promise<Blob> => {
+        const c = document.createElement('canvas');
+        c.width = w;
+        c.height = h;
+        const ctx = c.getContext('2d')!;
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, w, h);
+        // A thick white border on all four edges: if the whole image is shown (contain) the
+        // border is fully visible; if it's cover-cropped, the top/bottom (or sides) are cut off.
+        ctx.strokeStyle = '#ffffff';
+        ctx.lineWidth = Math.round(Math.min(w, h) / 12);
+        ctx.strokeRect(ctx.lineWidth / 2, ctx.lineWidth / 2, w - ctx.lineWidth, h - ctx.lineWidth);
+        ctx.fillStyle = 'rgba(255,255,255,0.95)';
+        ctx.font = `${Math.round(Math.min(w, h) / 7)}px sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(label, w / 2, h / 2);
+        return await new Promise<Blob>((res) => c.toBlob((b) => res(b!), 'image/png'));
+      };
+      const media = [
+        { blob: await make(600, 800, '#3b82f6', 'PORTRAIT'), kind: 'image' as const, name: 'p.png' },
+        { blob: await make(800, 800, '#10b981', 'SQUARE'), kind: 'image' as const, name: 's.png' },
+        { blob: await make(1280, 720, '#f59e0b', 'LANDSCAPE'), kind: 'image' as const, name: 'l.png' },
+      ];
+      const p = await dbCreatePost({ audience: 'friends', lifetime: '24h', media });
+      return p.id;
+    },
+    /** Share a post with a REAL (decodable) H.264 video, through the actual createPost path —
+     *  so we can verify the video post gets a poster thumbnail and autoplays in the feed. */
+    postVideo: async (): Promise<string> => {
+      const blob = await makeTestVideo(640, 360, 2);
+      const p = await dbCreatePost({
+        audience: 'friends',
+        lifetime: '24h',
+        media: { blob, kind: 'video', name: 'clip.mp4' },
+      });
+      return p.id;
+    },
+    /** Post an album of 2 real videos + 2 images through createPost, timing each progress
+     *  phase, to reproduce the "stuck while processing" report. Returns elapsed ms + last
+     *  progress seen (so a hang shows up as a never-resolving promise / frozen last phase). */
+    postVideoAlbumTimed: async (): Promise<{ ms: number; id: string }> => {
+      const png = Uint8Array.from(
+        atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='),
+        (c) => c.charCodeAt(0),
+      );
+      const v1 = await makeTestVideo(480, 360, 1);
+      const v2 = await makeTestVideo(480, 360, 1);
+      const media = [
+        { blob: v1, kind: 'video' as const, name: 'a.mp4' },
+        { blob: v2, kind: 'video' as const, name: 'b.mp4' },
+        { blob: new Blob([png], { type: 'image/png' }), kind: 'image' as const, name: 'c.png' },
+        { blob: new Blob([png], { type: 'image/png' }), kind: 'image' as const, name: 'd.png' },
+      ];
+      const t0 = performance.now();
+      const p = await dbCreatePost({
+        audience: 'friends',
+        lifetime: '24h',
+        media,
+        onProgress: (pr) => console.log('[post-progress]', pr.phase, pr.index + 1, '/', pr.total, Math.round(pr.value * 100) + '%'),
+      });
+      return { ms: Math.round(performance.now() - t0), id: p.id };
+    },
+    /** Does a post's cover Media have a poster thumbnail stored? (sender-side thumbnail check) */
+    postHasPoster: async (id: string): Promise<boolean> => {
+      const p = await dbGetPost(id);
+      const md = p?.mediaId ? await dbGetMedia(p.mediaId) : null;
+      return !!(md?.posterBlob || md?.posterGrid);
+    },
+    /** The latest own post's cover media as base64 + mime — to inspect what was actually
+     *  stored (e.g. ffprobe the transcoded video off-device to check the audio track). */
+    lastPostMediaB64: async (): Promise<{ b64: string; mime: string; bytes: number } | null> => {
+      const posts = await dbListWallPosts();
+      const self = getSelfUserId() ?? '';
+      const own = posts.find((p) => p.author === self && p.mediaId);
+      const md = own?.mediaId ? await dbGetMedia(own.mediaId) : null;
+      if (!md?.blob) return null;
+      const buf = new Uint8Array(await md.blob.arrayBuffer());
+      let s = '';
+      for (let i = 0; i < buf.length; i += 8192) s += String.fromCharCode(...buf.subarray(i, i + 8192));
+      return { b64: btoa(s), mime: md.mime, bytes: buf.length };
     },
     /** How many media a post carries locally (album size; 1 for single; 0 for text). */
     postMediaCount: async (id: string): Promise<number> => {

--- a/src/services/wall-load.ts
+++ b/src/services/wall-load.ts
@@ -1,0 +1,9 @@
+import { ref } from 'vue';
+
+/**
+ * True once the FIRST unlocked Wall sync attempt has completed. Drives the Wall's first-load
+ * spinner: a fresh device (empty local store) should show a loader while it pulls from the
+ * server, not the "No posts yet" empty state. A leaf module so both the data layer (syncPosts
+ * sets it) and the composable (useWall reads it) can import it without a cycle.
+ */
+export const wallSyncedOnce = ref(false);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -21,11 +21,12 @@ import { registerRoute, NavigationRoute } from 'workbox-routing';
 import { CacheFirst } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import {
-  previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, markConnShown,
+  previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, previewPosts, markConnShown,
   coalesceForShow, loadShownSummary, setting,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import { resubscribePush } from '@/services/sw-push';
+import { setPendingNav } from '@/services/pending-nav';
 import { userFacing, prettify, displayVersion } from '@/services/release-notes';
 
 declare const self: ServiceWorkerGlobalScope & {
@@ -320,7 +321,21 @@ async function showVersionNotification(): Promise<void> {
  *  app is closed; a live page shows the rich in-app banner / live update via the WS
  *  frame, so the SW stays silent there to avoid a duplicate. "Activity" rather than
  *  "post" so it reads honestly for a reaction/comment too. */
-async function showPostNotification(): Promise<void> {
+async function showPostNotification(): Promise<number> {
+  let notes: ConnNote[] = [];
+  let newCount = 0;
+  try {
+    const r = await previewPosts();
+    notes = r.notes;
+    newCount = r.newCount;
+  } catch {
+    /* fall through to the generic placeholder */
+  }
+  if (notes.length) {
+    // notes carry "<author> · posted on their Wall"; reuse the conn-note renderer (same shape).
+    await showConnNotes(notes);
+    return newCount;
+  }
   await self.registration.showNotification('Ring', {
     body: 'New activity on your Wall',
     icon: ICON,
@@ -328,6 +343,7 @@ async function showPostNotification(): Promise<void> {
     tag: 'ring:post',
     data: { url: '/tabs/wall' },
   });
+  return newCount;
 }
 
 /** Show the generic friend-request notifications (identity-safe; no decryption). */
@@ -355,27 +371,31 @@ async function showConnNotes(notes: ConnNote[]): Promise<void> {
  * device is PIN-locked. Always shows at least a generic placeholder to honor the
  * userVisibleOnly contract when something is pending but can't be reconciled.
  */
-async function showConnNotification(): Promise<void> {
+async function showConnNotification(): Promise<number> {
   let notes: ConnNote[] = [];
+  let pendingIncoming = 0;
   try {
-    notes = await previewConnections();
+    const r = await previewConnections();
+    notes = r.notes;
+    pendingIncoming = r.pendingIncoming;
   } catch {
     /* fall through to the placeholder below */
   }
   if (notes.length) {
     await showConnNotes(notes);
     await markConnShown(notes.flatMap((n) => n.keys));
-    return;
+    return pendingIncoming;
   }
   // Couldn't reconcile (offline / already-seen) but a tickle implies activity →
   // a single generic placeholder keeps the userVisibleOnly contract.
-  await self.registration.showNotification('Ring', {
-    body: 'New friend request',
+  await self.registration.showNotification('New friend request', {
+    body: 'Tap to review',
     icon: ICON,
     badge: BADGE,
     tag: 'ring:conn:req',
     data: { url: '/tabs/contacts' },
   });
+  return pendingIncoming;
 }
 
 /**
@@ -558,7 +578,12 @@ self.addEventListener('push', (event) => {
         // SW only notifies when the app is fully CLOSED (no client to claim it),
         // avoiding a duplicate. Still nudge any live client to reconcile its lists.
         for (const client of clients) client.postMessage({ type: 'ring:conn' });
-        if (!clients.length) await showConnNotification();
+        if (!clients.length) {
+          // Show the notification AND bump the app-icon badge (messages + pending requests);
+          // the conn path previously never touched the badge, so a friend request didn't count.
+          const pendingIncoming = await showConnNotification();
+          await updateAppBadge(pendingIncoming);
+        }
         return;
       }
       if (kind === 'post') {
@@ -569,7 +594,9 @@ self.addEventListener('push', (event) => {
         // Honor the Wall notifications toggle (the foreground banner is already gated
         // by notifyNewPost; this gates the app-closed system notification to match).
         if (!clients.length && (await setting('notifications.wall.show', true))) {
-          await showPostNotification();
+          // Name the author AND bump the app-icon badge (the post path previously did neither).
+          const newCount = await showPostNotification();
+          await updateAppBadge(newCount);
         }
         return;
       }
@@ -620,7 +647,11 @@ self.addEventListener('notificationclick', (event) => {
           return client.focus();
         }
       }
-      // No window open → cold start at the deep-link (or the app root).
+      // No window open → cold start. iOS PWAs ignore openWindow's path (they land on the
+      // default tab post-unlock), so ALSO stash the target; the app consumes it once unlocked
+      // and routes there. On platforms where openWindow honors the path it's a harmless no-op
+      // (the app is already there; the consume just re-routes to the same place).
+      if (data.url) await setPendingNav(data.url);
       return self.clients.openWindow(data.url || '/');
     })(),
   );

--- a/src/views/detail/ContactQrPage.vue
+++ b/src/views/detail/ContactQrPage.vue
@@ -24,19 +24,21 @@
         <ion-text v-else color="medium"><p>QR code unavailable, register first.</p></ion-text>
       </div>
 
-      <ion-list v-if="username" :inset="true">
-        <ion-item lines="none">
-          <ion-label class="ion-text-center">
-            <p>Your username</p>
+      <!-- Tap a row to copy it. Username for a friend to search; user ID for an exact add. -->
+      <ion-list :inset="true">
+        <ion-item v-if="username" button :detail="false" lines="full" @click="copy('Username', `@${username}`, 'username')">
+          <ion-label class="ion-text-wrap">
+            <p>{{ copiedKey === 'username' ? 'Copied!' : 'Your username — tap to copy' }}</p>
             <h2 class="ring-id">@{{ username }}</h2>
           </ion-label>
         </ion-item>
+        <ion-item v-if="userId" button :detail="false" lines="none" @click="copy('User ID', userId, 'userId')">
+          <ion-label class="ion-text-wrap">
+            <p>{{ copiedKey === 'userId' ? 'Copied!' : 'Your user ID — tap to copy' }}</p>
+            <h2 class="ring-id">{{ userId }}</h2>
+          </ion-label>
+        </ion-item>
       </ion-list>
-      <div v-if="username" class="ion-text-center">
-        <ion-button size="small" fill="outline" @click="copyHandle">
-          {{ copied ? 'Copied' : 'Copy' }}
-        </ion-button>
-      </div>
 
       <ion-list :inset="true">
         <ion-item lines="none">
@@ -54,7 +56,6 @@ import { onMounted, ref } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
   IonContent, IonAvatar, IonText, IonImg, IonSpinner, IonList, IonItem, IonLabel,
-  IonButton,
 } from '@ionic/vue';
 import { appToast } from '@/services/toast';
 import { getSecret } from '@/db/secrets';
@@ -66,13 +67,22 @@ const avatar = ref(initialsAvatar('You'));
 const qr = ref<string | null>(null);
 const loading = ref(true);
 const username = ref<string | null>(null);
-const copied = ref(false);
+const userId = ref<string | null>(null);
+// Which row just copied — drives the per-row checkmark; reset after a beat.
+const copiedKey = ref<string | null>(null);
 
-function copyHandle(): void {
-  if (!username.value) return;
-  void navigator.clipboard?.writeText(`@${username.value}`);
-  copied.value = true;
-  void appToast({ message: 'Username copied', duration: 1200 });
+async function copy(label: string, value: string, key: string): Promise<void> {
+  if (!value) return;
+  try {
+    await navigator.clipboard?.writeText(value);
+    copiedKey.value = key;
+    setTimeout(() => {
+      if (copiedKey.value === key) copiedKey.value = null;
+    }, 1500);
+    void appToast({ message: `${label} copied`, duration: 1200 });
+  } catch {
+    void appToast({ message: 'Copy failed — long-press to select instead', duration: 1600 });
+  }
 }
 
 onMounted(async () => {
@@ -81,6 +91,7 @@ onMounted(async () => {
   avatar.value = photo || initialsAvatar(name.value);
   username.value = getSelfUsername();
   const uid = getSelfUserId();
+  userId.value = uid;
   if (!uid) {
     loading.value = false;
     return;
@@ -100,11 +111,12 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-/* Render the 36-char UUID on a single line (no wrapping). */
+/* Show the full 36-char UUID — wrap rather than clip so it's always entirely visible. */
 .ring-id {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.72rem;
-  white-space: nowrap;
+  font-size: 0.95rem;
+  white-space: normal;
+  word-break: break-all;
   margin-top: 2px;
 }
 </style>

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -36,31 +36,47 @@
         <span class="share-label">{{ progressLabel }}</span>
       </div>
 
-      <!-- Voice preview (a voice post is always on its own) -->
-      <div v-if="hasVoice" class="preview">
-        <audio class="vpreview" :src="mediaItems[0].url" controls />
-        <ion-button class="remove" fill="solid" color="dark" size="small" @click="clearMedia">
-          <ion-icon slot="icon-only" :icon="closeOutline" />
-        </ion-button>
-      </div>
-
-      <!-- Photo/video staging: several compose an album (FR-019). A row of removable
-           thumbnails (their order is the album order) plus an "add more" tile. -->
-      <div v-else-if="mediaItems.length" class="album-stage">
-        <div v-for="(m, i) in mediaItems" :key="m.url" class="stage-thumb">
-          <img v-if="m.kind === 'image'" :src="m.url" alt="" />
-          <video v-else :src="m.url" muted playsinline />
+      <!-- Media staging (FR-019): photos, videos AND voice clips compose ONE post as a row of
+           reorderable thumbnails (their order is the album order). Voice mixes in like any other
+           item — record it and it joins the row; tap its ▶ to review it through the same player
+           the chat and feed use. -->
+      <div v-if="mediaItems.length" ref="stageRow" class="album-stage">
+        <div
+          v-for="(m, i) in mediaItems"
+          :key="m.url"
+          class="stage-thumb"
+          :class="{ dragging: dragIndex === i }"
+          @touchstart.passive="onThumbTouchStart(i, $event)"
+        >
+          <button v-if="m.kind === 'voice'" type="button" class="stage-voice" @click="previewVoice(m)">
+            <ion-icon :icon="micOutline" />
+            <span>{{ fmtDur(m.durationSec) }}</span>
+            <ion-icon class="stage-play" :icon="playCircle" aria-hidden="true" />
+          </button>
+          <template v-else>
+            <img v-if="m.kind === 'image' || m.poster" :src="m.kind === 'image' ? m.url : m.poster" alt="" />
+            <div v-else class="stage-vid">
+              <ion-spinner v-if="!m.posterTried" name="crescent" class="stage-spin" />
+            </div>
+            <ion-icon v-if="m.kind === 'video'" class="stage-play" :icon="playCircle" aria-hidden="true" />
+          </template>
           <button type="button" class="stage-x" aria-label="Remove" @click="removeMedia(i)">
             <ion-icon :icon="closeOutline" />
           </button>
         </div>
-        <button type="button" class="stage-add" aria-label="Add more photos or videos" @click="pickMedia">
+        <button type="button" class="stage-add" aria-label="Add more photos or videos" :disabled="atMaxMedia" @click="pickMedia">
           <ion-icon :icon="imageOutline" />
         </button>
+        <button type="button" class="stage-add" aria-label="Record a voice clip" :disabled="recording || atMaxMedia" @click="startRecording">
+          <ion-icon :icon="micOutline" />
+        </button>
       </div>
+      <p v-if="mediaItems.length > 1" class="stage-hint">
+        Hold &amp; drag a thumbnail to reorder.<span v-if="atMaxMedia"> · {{ MAX_MEDIA }}-item max reached</span>
+      </p>
 
-      <!-- Recording a voice post in progress -->
-      <ion-list v-else-if="recording" :inset="true">
+      <!-- Recording in progress — can be the first item or added to an existing album. -->
+      <ion-list v-if="recording" :inset="true">
         <ion-item lines="none">
           <ion-icon slot="start" :icon="micOutline" color="danger" class="recdot" />
           <ion-label>Recording… {{ recElapsed }}</ion-label>
@@ -68,8 +84,8 @@
         </ion-item>
       </ion-list>
 
-      <!-- Attachment options: a photo/video file, or a recorded voice post -->
-      <ion-list v-else :inset="true">
+      <!-- First-attachment options: only when nothing is staged yet and not already recording. -->
+      <ion-list v-if="!mediaItems.length && !recording" :inset="true">
         <ion-item button :detail="false" @click="pickMedia">
           <ion-icon slot="start" :icon="imageOutline" color="primary" />
           <ion-label color="primary">Add photos or videos</ion-label>
@@ -119,16 +135,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onUnmounted } from 'vue';
+import { computed, ref, onMounted, onUnmounted } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
   IonContent, IonTextarea, IonList, IonListHeader, IonItem, IonSegment, IonSegmentButton,
-  IonLabel, IonIcon, IonProgressBar, alertController,
+  IonLabel, IonIcon, IonProgressBar, IonSpinner, alertController,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
-import { imageOutline, closeOutline, micOutline } from 'ionicons/icons';
+import { imageOutline, closeOutline, micOutline, playCircle } from 'ionicons/icons';
 import { vEnterSend } from '@/directives/enter-send';
 import { createPost, type PostLifetime } from '@/db/queries';
+import { generateVideoPoster } from '@/utils/media-meta';
+import { playAudio, stopIfPlaying } from '@/composables/useAudioPlayer';
+import { appToast } from '@/services/toast';
 
 const router = useRouter();
 const body = ref('');
@@ -137,6 +156,7 @@ const lifetime = ref<PostLifetime>('72h');
 const sharing = ref(false);
 // Encode/upload progress while a post with media is being shared (drives the progress bar).
 const progress = ref<{ phase: 'encoding' | 'uploading'; index: number; total: number; value: number } | null>(null);
+let lastProgressTs = 0; // throttle progress re-renders so they don't starve the encoder
 const progressLabel = computed(() => {
   const p = progress.value;
   if (!p) return 'Sharing…';
@@ -154,12 +174,28 @@ interface PostMedia {
   name: string;
   durationSec?: number;
   url: string;
+  poster?: string; // first-frame thumbnail for a staged video (a <video> tile paints black)
+  posterTried?: boolean; // poster generation has settled (succeeded or given up) — stop the spinner
 }
 const fileInput = ref<HTMLInputElement | null>(null);
 const mediaItems = ref<PostMedia[]>([]);
-const hasVoice = computed(() => mediaItems.value.some((m) => m.kind === 'voice'));
+// Cap items per post (photos + videos + voice clips combined). Keeps the album swipe + the
+// upload manageable, and bounds the encode/upload work.
+const MAX_MEDIA = 10;
+const atMaxMedia = computed(() => mediaItems.value.length >= MAX_MEDIA);
 
 const canShare = computed(() => body.value.trim().length > 0 || mediaItems.value.length > 0);
+
+// mm:ss for a staged voice clip's thumbnail.
+const fmtDur = (s?: number): string => {
+  const n = Math.round(s ?? 0);
+  return `${Math.floor(n / 60)}:${String(n % 60).padStart(2, '0')}`;
+};
+// Review a staged clip through the SAME single-source player the chat + feed use (so the
+// minimized controller behaves identically and only one thing ever plays).
+function previewVoice(m: PostMedia): void {
+  playAudio({ id: m.url, url: m.url, title: 'Voice clip', subtitle: 'Your recording', isVoice: true });
+}
 
 function onInput(e: CustomEvent): void {
   body.value = (e.detail as { value?: string | null }).value ?? '';
@@ -175,29 +211,129 @@ function pickMedia(): void {
   fileInput.value?.click();
 }
 function onFile(e: Event): void {
-  // Picking several photos/videos stages them all → one album on Send. A voice clip in the
-  // stage means it's a voice post; clear it before adding files (the two don't mix).
-  if (hasVoice.value) clearMedia();
-  const files = Array.from((e.target as HTMLInputElement).files ?? []);
+  // Picking several photos/videos stages them all → one album on Send. Voice clips mix in as
+  // their own items now, so we just APPEND — never clear what's already staged. Cap at MAX_MEDIA.
+  const picked = Array.from((e.target as HTMLInputElement).files ?? []);
+  const room = MAX_MEDIA - mediaItems.value.length;
+  const files = picked.slice(0, Math.max(0, room));
+  if (picked.length > files.length) {
+    void appToast(`You can share up to ${MAX_MEDIA} items in one post.`);
+  }
   for (const f of files) {
-    mediaItems.value.push({
-      blob: f,
-      kind: f.type.startsWith('video/') ? 'video' : 'image',
-      name: f.name || 'attachment',
-      url: URL.createObjectURL(f),
-    });
+    const url = URL.createObjectURL(f);
+    const kind = f.type.startsWith('video/') ? 'video' : 'image';
+    mediaItems.value.push({ blob: f, kind, name: f.name || 'attachment', url });
+    // A <video> tile paints black until it seeks — generate a first-frame poster and drop it
+    // onto the (reactive) staged item so the preview shows a real thumbnail. Match by url since
+    // the index can shift if another item is removed while this resolves.
+    if (kind === 'video') {
+      void generateVideoPoster(f)
+        .then((poster) => {
+          const it = mediaItems.value.find((m) => m.url === url);
+          if (it && poster) it.poster = poster;
+        })
+        .catch(() => {})
+        .finally(() => {
+          const it = mediaItems.value.find((m) => m.url === url);
+          if (it) it.posterTried = true; // stop the spinner whether or not we got a frame
+        });
+    }
   }
   if (fileInput.value) fileInput.value.value = '';
 }
 function removeMedia(i: number): void {
   const [gone] = mediaItems.value.splice(i, 1);
-  if (gone) URL.revokeObjectURL(gone.url);
+  if (gone) {
+    stopIfPlaying(gone.url); // dismiss the player if we're previewing this clip
+    URL.revokeObjectURL(gone.url);
+  }
 }
 function clearMedia(): void {
-  for (const m of mediaItems.value) URL.revokeObjectURL(m.url);
+  for (const m of mediaItems.value) {
+    stopIfPlaying(m.url);
+    URL.revokeObjectURL(m.url);
+  }
   mediaItems.value = [];
   if (fileInput.value) fileInput.value.value = '';
 }
+
+/* ---- press-and-hold to reorder the staged album ----
+   The row scrolls natively (smooth, with momentum) — we never touch that. A press-and-hold on
+   a thumbnail "lifts" it; only THEN do we take over the gesture (preventDefault) and reorder
+   live as the finger passes its neighbours. A swipe that moves before the hold fires cancels
+   the lift, so it just scrolls. Touch events (not pointer) + a non-passive document listener,
+   which is what actually works on iOS. */
+const stageRow = ref<HTMLElement | null>(null);
+const dragIndex = ref<number | null>(null);
+let holdTimer: ReturnType<typeof setTimeout> | undefined;
+let touchId: number | null = null;
+let downX = 0;
+let downY = 0;
+let lifted = false;
+
+function thumbAt(clientX: number): number {
+  const thumbs = Array.from(stageRow.value?.querySelectorAll('.stage-thumb') ?? []) as HTMLElement[];
+  for (let k = 0; k < thumbs.length; k++) {
+    if (clientX < thumbs[k].getBoundingClientRect().right) return k;
+  }
+  return thumbs.length - 1;
+}
+function tracked(e: TouchEvent): Touch | null {
+  for (const t of Array.from(e.changedTouches)) if (t.identifier === touchId) return t;
+  return null;
+}
+function onThumbTouchStart(i: number, e: TouchEvent): void {
+  if (touchId !== null) return; // ignore a second finger mid-gesture
+  if ((e.target as HTMLElement).closest('.stage-x')) return; // the remove button owns its taps
+  const t = e.changedTouches[0];
+  touchId = t.identifier;
+  downX = t.clientX;
+  downY = t.clientY;
+  lifted = false;
+  clearTimeout(holdTimer);
+  holdTimer = setTimeout(() => {
+    lifted = true;
+    dragIndex.value = i;
+    navigator.vibrate?.(8);
+  }, 300);
+}
+function onDocTouchMove(e: TouchEvent): void {
+  if (touchId === null) return;
+  const t = tracked(e);
+  if (!t) return;
+  if (!lifted) {
+    // Still deciding: any real travel before the hold means the user is scrolling — stand down
+    // and let the browser scroll natively (do NOT preventDefault).
+    if (Math.abs(t.clientX - downX) > 10 || Math.abs(t.clientY - downY) > 10) {
+      clearTimeout(holdTimer);
+      touchId = null;
+    }
+    return;
+  }
+  // Lifted — we own the gesture now: stop the scroll and reorder.
+  e.preventDefault();
+  const over = thumbAt(t.clientX);
+  if (dragIndex.value !== null && over >= 0 && over !== dragIndex.value) {
+    const arr = mediaItems.value;
+    const [moved] = arr.splice(dragIndex.value, 1);
+    arr.splice(over, 0, moved);
+    dragIndex.value = over;
+  }
+}
+function onDocTouchEnd(e: TouchEvent): void {
+  if (touchId === null || !tracked(e)) return;
+  clearTimeout(holdTimer);
+  dragIndex.value = null;
+  touchId = null;
+  lifted = false;
+}
+onMounted(() => {
+  // Non-passive so preventDefault works once a thumbnail is lifted; on document so the gesture
+  // keeps tracking even as the finger leaves the row.
+  document.addEventListener('touchmove', onDocTouchMove, { passive: false });
+  document.addEventListener('touchend', onDocTouchEnd);
+  document.addEventListener('touchcancel', onDocTouchEnd);
+});
 
 /* ---- voice post recording (mirrors the chat voice recorder, minus the live
    waveform/pause/preview — a post is a single take, kept simple) ---- */
@@ -210,6 +346,10 @@ let recStart = 0;
 let recTimer: number | undefined;
 
 async function startRecording(): Promise<void> {
+  if (atMaxMedia.value) {
+    void appToast(`You can share up to ${MAX_MEDIA} items in one post.`);
+    return;
+  }
   try {
     recStream = await navigator.mediaDevices.getUserMedia({ audio: true });
     const types = ['audio/webm', 'audio/mp4', 'audio/ogg'];
@@ -250,22 +390,27 @@ function finishRecording(): void {
   if (!recChunks.length) return;
   const durationSec = Math.max(1, Math.round((Date.now() - recStart) / 1000));
   const blob = new Blob(recChunks, { type: mime });
-  clearMedia();
-  mediaItems.value = [
-    {
-      blob,
-      kind: 'voice',
-      name: `voice.${mime.includes('mp4') ? 'm4a' : mime.includes('ogg') ? 'ogg' : 'webm'}`,
-      durationSec,
-      url: URL.createObjectURL(blob),
-    },
-  ];
+  // APPEND the clip as its own album item (it mixes with photos/videos and is reorderable) —
+  // don't replace what's already staged.
+  mediaItems.value.push({
+    blob,
+    kind: 'voice',
+    name: `voice.${mime.includes('mp4') ? 'm4a' : mime.includes('ogg') ? 'ogg' : 'webm'}`,
+    durationSec,
+    url: URL.createObjectURL(blob),
+  });
 }
 
 onUnmounted(() => {
-  for (const m of mediaItems.value) URL.revokeObjectURL(m.url);
+  for (const m of mediaItems.value) {
+    stopIfPlaying(m.url); // leaving the composer discards the draft → stop any preview playing
+    URL.revokeObjectURL(m.url);
+  }
   if (recTimer) clearInterval(recTimer);
   recStream?.getTracks().forEach((t) => t.stop());
+  document.removeEventListener('touchmove', onDocTouchMove);
+  document.removeEventListener('touchend', onDocTouchEnd);
+  document.removeEventListener('touchcancel', onDocTouchEnd);
 });
 
 async function share(): Promise<void> {
@@ -289,7 +434,15 @@ async function share(): Promise<void> {
           }))
         : undefined,
       onProgress: (p) => {
-        progress.value = p;
+        // Throttle: a per-frame bar update during video encoding starves the (main-thread)
+        // encoder on slower devices (the post would appear stuck). Update on a phase/item
+        // change, on completion, or at most ~8×/sec.
+        const t = performance.now();
+        const cur = progress.value;
+        if (!cur || cur.phase !== p.phase || cur.index !== p.index || p.value >= 1 || t - lastProgressTs > 120) {
+          lastProgressTs = t;
+          progress.value = p;
+        }
       },
     });
     router.back();
@@ -350,21 +503,86 @@ async function share(): Promise<void> {
   display: flex;
   gap: 8px;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch; /* momentum scroll on iOS */
   padding: 8px 16px;
 }
 .stage-thumb {
   position: relative;
   flex: 0 0 auto;
   padding: 6px 6px 0 0; /* room for the overhanging × */
+  transition:
+    transform 0.15s ease,
+    opacity 0.15s ease;
+}
+.stage-thumb.dragging {
+  transform: scale(1.08);
+  opacity: 0.92;
+  z-index: 2;
 }
 .stage-thumb img,
-.stage-thumb video {
+.stage-thumb .stage-vid {
   width: 84px;
   height: 84px;
   object-fit: cover;
   border-radius: 12px;
   display: block;
   background: #000;
+  pointer-events: none; /* taps/drags belong to the thumb, not the media element */
+}
+.stage-vid {
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  background: #1c1c1c;
+}
+/* Voice clip tile: a mic + duration, same 84px square as the photo/video thumbs, with a ▶
+   overlay so it reads as tappable (reviews through the shared player). */
+.stage-voice {
+  width: 84px;
+  height: 84px;
+  border: none;
+  border-radius: 12px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: var(--ion-color-primary);
+  color: #fff;
+  font-size: 22px;
+}
+.stage-voice span {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.stage-voice .stage-play {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  font-size: 18px;
+  opacity: 0.9;
+}
+.stage-spin {
+  width: 24px;
+  height: 24px;
+  color: rgba(255, 255, 255, 0.75);
+}
+/* play glyph marking a staged video (over its poster) */
+.stage-play {
+  position: absolute;
+  left: 50%;
+  top: calc(50% + 3px);
+  transform: translate(-50%, -50%);
+  font-size: 28px;
+  color: #fff;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.6));
+  pointer-events: none;
+}
+.stage-hint {
+  margin: 2px 16px 0;
+  font-size: 12px;
+  color: var(--ion-color-medium);
 }
 .stage-x {
   position: absolute;
@@ -395,6 +613,9 @@ async function share(): Promise<void> {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+.stage-add:disabled {
+  opacity: 0.35;
 }
 /* Pulse the mic glyph while a voice post is being recorded. */
 .recdot {

--- a/src/views/detail/PostDetailPage.vue
+++ b/src/views/detail/PostDetailPage.vue
@@ -32,9 +32,17 @@
              live position counter. Mixed image+video is fine; each slide plays on tap. -->
         <div v-if="albumMedia.length > 1" class="album">
           <div class="album-track" @scroll="onAlbumScroll">
-            <div v-for="(m, i) in albumMedia" :key="i" class="album-slide">
-              <img v-if="m.kind === 'image'" :src="m.url" alt="" />
-              <video v-else :src="m.url" controls playsinline />
+            <!-- Mixed aspect ratios: each item shown whole (contain) with its own blurred
+                 copy filling the letterbox — same treatment as the feed gallery. -->
+            <div v-for="(m, i) in albumMedia" :key="i" class="album-slide" @click="openViewer(i)">
+              <!-- Stills only here (no per-slide <video>): the blurred fill + the item are
+                   images; a video shows its poster + play glyph and plays in the viewer on tap. -->
+              <img class="aslide-fill" :src="m.kind === 'video' ? m.poster : m.url" alt="" aria-hidden="true" />
+              <img v-if="m.kind === 'image'" class="aslide-main" :src="m.url" alt="" />
+              <template v-else>
+                <img class="aslide-main" :src="m.poster" alt="" />
+                <ion-icon class="aslide-play" :icon="playCircleOutline" aria-hidden="true" />
+              </template>
             </div>
           </div>
           <div class="album-count">{{ albumIndex + 1 }} / {{ albumMedia.length }}</div>
@@ -43,9 +51,14 @@
           v-else-if="mediaUrl && (post.kind === 'image' || post.kind === 'video')"
           class="media"
           :style="mediaBoxStyle"
+          @click="openViewer(0)"
         >
           <img v-if="post.kind === 'image'" :src="mediaUrl" :alt="post.body || 'Photo'" />
-          <video v-else :src="mediaUrl" controls playsinline />
+          <template v-else>
+            <img v-if="posterUrl" :src="posterUrl" :alt="post.body || 'Video'" />
+            <div v-else class="media-vid" />
+            <ion-icon class="aslide-play" :icon="playCircleOutline" aria-hidden="true" />
+          </template>
         </div>
         <audio v-else-if="mediaUrl && post.kind === 'voice'" class="vaudio" :src="mediaUrl" controls />
 
@@ -126,11 +139,21 @@
       </div>
       <div v-else class="missing">This post is no longer available.</div>
     </ion-content>
+
+    <!-- Stills in the gallery → full-screen viewer (minimal: just close + react) on tap. -->
+    <media-viewer
+      :open="viewer.open"
+      :items="viewer.items"
+      :start="viewer.start"
+      minimal
+      @close="viewer.open = false"
+      @dismiss="viewer.open = false"
+    />
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, reactive, ref } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
   IonContent, IonAvatar, IonIcon, IonTextarea, IonList, IonItem, IonLabel,
@@ -138,7 +161,8 @@ import {
   onIonViewWillEnter, onIonViewWillLeave, alertController,
 } from '@ionic/vue';
 import { useRoute, useRouter } from 'vue-router';
-import { trashOutline, happyOutline, timeOutline } from 'ionicons/icons';
+import { trashOutline, happyOutline, timeOutline, playCircleOutline } from 'ionicons/icons';
+import MediaViewer, { type ViewerItem } from '@/components/MediaViewer.vue';
 import { timeLeft, formatPostDateTime } from '@/utils/post-time';
 import { appToast } from '@/services/toast';
 import Emoji from '@/components/Emoji.vue';
@@ -166,8 +190,9 @@ const authorName = ref('Unknown');
 const authorAvatar = ref('');
 const authorUsername = ref<string | undefined>(undefined);
 const mediaUrl = ref<string | undefined>(undefined);
+const posterUrl = ref<string | undefined>(undefined); // single-video poster (still shown until tapped)
 // Album posts (FR-019): every media resolved to an object URL, shown as a swipeable gallery.
-const albumMedia = ref<{ url: string; kind: 'image' | 'video' }[]>([]);
+const albumMedia = ref<{ url: string; kind: 'image' | 'video'; poster?: string }[]>([]);
 const albumIndex = ref(0);
 function onAlbumScroll(e: Event): void {
   const el = e.target as HTMLElement;
@@ -212,6 +237,30 @@ async function react(emoji: string): Promise<void> {
       duration: 1600,
     });
   }
+}
+// Full-screen viewer (minimal mode): the gallery shows stills, the clip plays here on tap.
+const viewer = reactive<{ open: boolean; items: ViewerItem[]; start: number }>({ open: false, items: [], start: 0 });
+function openViewer(start: number): void {
+  const list: { url: string; kind: 'image' | 'video'; poster?: string }[] = albumMedia.value.length
+    ? albumMedia.value
+    : mediaUrl.value
+      ? [{ url: mediaUrl.value, kind: post.value?.kind === 'video' ? 'video' : 'image', poster: posterUrl.value }]
+      : [];
+  if (!list.length) return;
+  viewer.items = list.map((m, i) => ({
+    id: `${postId}:${i}`,
+    url: m.url,
+    thumb: (m.kind === 'video' ? m.poster : m.url) ?? m.url,
+    kind: m.kind,
+    caption: post.value?.body ?? '',
+    senderName: authorName.value,
+    when: '',
+    outgoing: post.value?.author === selfId,
+    favorite: false,
+    reactions: [],
+  }));
+  viewer.start = Math.min(start, viewer.items.length - 1);
+  viewer.open = true;
 }
 function openPicker(ev: Event): void {
   const existing = grouped.value.map((g) => g.emoji);
@@ -268,14 +317,24 @@ onIonViewWillEnter(async () => {
   if (!post.value) return;
   const ids = post.value.mediaIds?.length ? post.value.mediaIds : post.value.mediaId ? [post.value.mediaId] : [];
   if (ids.length > 1) {
-    // Album: resolve every item in order for the swipeable gallery.
+    // Album: resolve every item in order for the swipeable gallery. Video slides carry a poster
+    // so the gallery shows a still (no live <video> per slide) and only plays in the viewer.
     for (const id of ids) {
       const md = await getMedia(id);
-      if (md?.blob) albumMedia.value.push({ url: URL.createObjectURL(md.blob), kind: md.kind === 'video' ? 'video' : 'image' });
+      if (!md?.blob) continue;
+      const kind = md.kind === 'video' ? 'video' : 'image';
+      const posterBlob = kind === 'video' ? (md.posterBlob ?? md.posterGrid) : undefined;
+      albumMedia.value.push({
+        url: URL.createObjectURL(md.blob),
+        kind,
+        poster: posterBlob ? URL.createObjectURL(posterBlob) : undefined,
+      });
     }
   } else if (ids.length === 1) {
     const md = await getMedia(ids[0]);
     if (md?.blob) mediaUrl.value = URL.createObjectURL(md.blob);
+    const posterBlob = md?.kind === 'video' ? (md.posterBlob ?? md.posterGrid) : undefined;
+    if (posterBlob) posterUrl.value = URL.createObjectURL(posterBlob);
   }
   if (post.value.author === getSelfUserId()) {
     authorName.value = 'You';
@@ -300,7 +359,14 @@ onIonViewWillLeave(() => {
     URL.revokeObjectURL(mediaUrl.value);
     mediaUrl.value = undefined;
   }
-  for (const m of albumMedia.value) URL.revokeObjectURL(m.url);
+  if (posterUrl.value) {
+    URL.revokeObjectURL(posterUrl.value);
+    posterUrl.value = undefined;
+  }
+  for (const m of albumMedia.value) {
+    URL.revokeObjectURL(m.url);
+    if (m.poster) URL.revokeObjectURL(m.poster);
+  }
   albumMedia.value = [];
 });
 
@@ -372,12 +438,18 @@ async function confirmDelete(): Promise<void> {
   font-size: 13px;
 }
 .media {
+  position: relative;
   margin: 16px 0 0;
   width: 100%;
   max-height: 70vh;
   border-radius: 14px;
   overflow: hidden;
   background: #000;
+}
+.media-vid {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  background: #1c1c1c;
 }
 .media img,
 .media video {
@@ -399,21 +471,47 @@ async function confirmDelete(): Promise<void> {
   border-radius: 14px;
   background: #000;
   scrollbar-width: none;
+  /* One stable frame for the whole mixed-aspect album (4:5, capped to most of the screen). */
+  aspect-ratio: 4 / 5;
+  max-height: 74vh;
 }
 .album-track::-webkit-scrollbar {
   display: none;
 }
 .album-slide {
+  position: relative;
   flex: 0 0 100%;
+  height: 100%;
   scroll-snap-align: center;
+  overflow: hidden;
 }
-.album-slide img,
-.album-slide video {
+/* Blurred, zoomed copy fills the letterbox; the item itself is shown whole (contain). */
+.aslide-fill {
+  position: absolute;
+  inset: 0;
   width: 100%;
-  max-height: 70vh;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.15);
+  filter: blur(22px) brightness(0.85) saturate(1.1);
+}
+.aslide-main {
+  position: relative;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   display: block;
-  background: #000;
+}
+.aslide-play {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 56px;
+  color: rgba(255, 255, 255, 0.92);
+  filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.55));
+  pointer-events: none;
+  z-index: 2;
 }
 .album-count {
   position: absolute;

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -22,6 +22,11 @@
     </ion-header>
 
     <ion-content :fullscreen="true">
+      <!-- Pull down to recover: force a fresh reconnect so the server re-runs its on-connect
+           queue flush and we pull anything missed while the socket was dropped. -->
+      <ion-refresher slot="fixed" @ion-refresh="onPullRefresh">
+        <ion-refresher-content pulling-text="Pull to reconnect &amp; catch up" refreshing-text="Reconnecting…" />
+      </ion-refresher>
       <ion-header collapse="condense">
         <ion-toolbar>
           <ion-title size="large">Chats</ion-title>
@@ -163,7 +168,8 @@ import { useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton,
   IonIcon, IonSearchbar, IonContent, IonList, IonListHeader, IonItem, IonAvatar,
-  IonLabel, IonNote, IonModal,
+  IonLabel, IonNote, IonModal, IonRefresher, IonRefresherContent,
+  type RefresherCustomEvent,
 } from '@ionic/vue';
 import {
   createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline,
@@ -185,6 +191,18 @@ import { isUnlocked } from '@/services/crypto/identity';
 import type { Chat, Contact } from '@/db/types';
 
 const router = useRouter();
+
+// Pull-to-refresh = recovery: force a fresh socket so the server re-flushes its on-connect
+// queue (pulling anything missed while it was dropped). It's fire-and-forget, so hold the
+// control briefly to give the reconnect + drain a moment, then release.
+// NB: import useSync DYNAMICALLY here, not statically — a static edge from this page reorders
+// module eval and trips a useSync↔useCall circular-import TDZ (`syncState` before init).
+async function onPullRefresh(e: RefresherCustomEvent): Promise<void> {
+  const { forceReconnect } = await import('@/composables/useSync');
+  forceReconnect();
+  await new Promise((r) => setTimeout(r, 1200));
+  void e.detail.complete();
+}
 const search = ref('');
 const actions = ref<InstanceType<typeof ChatActionsHost> | null>(null);
 const { connect, requireProfile } = useConnect();

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -19,6 +19,11 @@
     </ion-header>
 
     <ion-content :fullscreen="true">
+      <!-- Pull down to refresh: re-pull pending/accepted connection state AND any friend's
+           latest name/avatar from the directory (changes otherwise only land opportunistically). -->
+      <ion-refresher slot="fixed" @ion-refresh="onPullRefresh">
+        <ion-refresher-content pulling-text="Pull to refresh requests &amp; friends" refreshing-text="Refreshing…" />
+      </ion-refresher>
       <ion-header collapse="condense">
         <ion-toolbar>
           <ion-title size="large">Contacts</ion-title>
@@ -192,9 +197,11 @@ import {
   IonItemDivider, IonAvatar, IonLabel, IonNote,
   IonInfiniteScroll, IonInfiniteScrollContent,
   IonItemSliding, IonItemOptions, IonItemOption,
+  IonRefresher, IonRefresherContent,
   actionSheetController, alertController, onIonViewWillEnter,
 } from '@ionic/vue';
-import type { InfiniteScrollCustomEvent } from '@ionic/vue';
+import type { InfiniteScrollCustomEvent, RefresherCustomEvent } from '@ionic/vue';
+import { refreshContactProfiles } from '@/services/directory';
 import { personAddOutline, trashOutline, ellipsisHorizontal, compassOutline, banOutline } from 'ionicons/icons';
 import {
   incomingRequests, outgoingRequests, acceptConnect, rejectConnect, withdrawConnect, refreshConnections,
@@ -217,6 +224,16 @@ import { peerPresence } from '@/composables/usePresence';
 
 const PAGE = 15;
 const router = useRouter();
+
+// Pull-to-refresh: re-pull connection state (pending/accepted requests) and refresh every
+// friend's name/avatar from the directory, in parallel; release when both settle.
+async function onPullRefresh(e: RefresherCustomEvent): Promise<void> {
+  try {
+    await Promise.all([refreshConnections(), refreshContactProfiles()]);
+  } finally {
+    void e.detail.complete();
+  }
+}
 const open = (id: string) => router.push(`/contact/${id}`);
 const removeContact = async (id: string): Promise<void> => {
   try {

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -23,13 +23,25 @@
     </ion-header>
 
     <ion-content :fullscreen="true">
+      <!-- Pull down to re-pull the feed from the server (the same cursor-based syncPosts behind
+           the loader). The natural gesture for a feed; the only other way to re-pull is to
+           leave and re-open the tab. -->
+      <ion-refresher slot="fixed" @ion-refresh="onPullRefresh">
+        <ion-refresher-content pulling-text="Pull to check for new posts" refreshing-text="Checking for new posts…" />
+      </ion-refresher>
       <ion-header collapse="condense">
         <ion-toolbar>
           <ion-title size="large">Wall</ion-title>
         </ion-toolbar>
       </ion-header>
 
-      <div v-if="loaded && !wall.length" class="empty">
+      <!-- Fresh device, nothing local yet AND the first server sync hasn't returned → show a
+           loader instead of the "No posts yet" empty state (which would flash misleadingly). -->
+      <div v-if="loaded && !wall.length && !synced" class="empty">
+        <ion-spinner name="crescent" />
+        <p>Loading your Wall…</p>
+      </div>
+      <div v-else-if="loaded && !wall.length && synced" class="empty">
         <ion-icon :icon="sparklesOutline" />
         <p>No posts yet. Share a moment with your friends.</p>
         <ion-button fill="solid" @click="compose">New post</ion-button>
@@ -41,16 +53,15 @@
 
       <!-- Each post is a sliding item: swipe LEFT to delete your own post (or hide
            someone else's), swipe RIGHT to mute/unmute their Wall notifications. -->
-      <ion-item-sliding v-for="p in filteredWall" :key="p.id">
-        <ion-item lines="none" class="postitem">
-          <div class="post">
+      <ion-item v-for="p in filteredWall" :key="p.id" lines="none" class="postitem">
+          <div class="post" :class="{ own: p.isOwn }">
             <!-- Header: avatar + name + a subtle "disappears in …" countdown. -->
             <div class="phead">
-              <ion-avatar class="avatar" @click="open(p.id)">
+              <ion-avatar class="avatar">
                 <img v-if="p.authorAvatar" :src="p.authorAvatar" :alt="p.authorName" />
                 <div v-else class="ph">{{ initial(p.authorName) }}</div>
               </ion-avatar>
-              <div class="who" @click="open(p.id)">
+              <div class="who">
                 <div class="name">
                   {{ p.authorName }}<span v-if="p.authorUsername" class="user"> @{{ p.authorUsername }}</span>
                 </div>
@@ -61,68 +72,110 @@
               <span v-if="left(p)" class="countdown" :title="'This post auto-deletes'">
                 <ion-icon :icon="timeOutline" />{{ left(p) }}
               </span>
-            </div>
-
-            <!-- Media + body (tap → full post). The image/video box reserves the
-                 media's aspect ratio with a skeleton so the feed doesn't jump as it
-                 decodes; a placeholder box also shows before the blob URL resolves. -->
-            <div
-              v-if="p.kind === 'image' || p.kind === 'video'"
-              class="thumb"
-              :class="{ loading: !mediaLoaded[p.id] }"
-              :style="mediaStyle(p)"
-              @click="open(p.id)"
-            >
-              <!-- Prefer the small poster: it's local immediately (it rode the sealed
-                   envelope), so the feed shows it at once instead of a blank box while the
-                   full image downloads. The full blob is loaded in the viewer on tap. -->
-              <img
-                v-if="p.kind === 'image' && (p.posterUrl || p.mediaUrl)"
-                :src="p.posterUrl || p.mediaUrl"
-                :alt="p.body || 'Photo'"
-                @load="onMediaLoad(p.id)"
-              />
-              <!-- Video: the poster attribute shows a frame instantly; the full clip plays
-                   (and autoplays on screen) once its blob is present. -->
-              <video
-                v-else-if="p.kind === 'video' && (p.mediaUrl || p.posterUrl)"
-                v-autoplay-visible
-                :src="p.mediaUrl"
-                :poster="p.posterUrl"
-                muted
-                playsinline
-                preload="metadata"
-                loop
-                @loadeddata="onMediaLoad(p.id)"
-              />
-              <!-- The play glyph is the "tap to open" hint; hide it while the clip is
-                   autoplaying inline so it isn't a button-over-moving-video. -->
-              <ion-icon
-                v-if="p.kind === 'video' && (p.mediaUrl || p.posterUrl)"
-                class="play"
-                :icon="playCircleOutline"
-              />
-              <!-- Album post (FR-019): the feed shows the cover with a count badge; the
-                   swipeable gallery is in the full post. -->
-              <span v-if="p.mediaIds && p.mediaIds.length > 1" class="album-badge">
-                <ion-icon :icon="copyOutline" />{{ p.mediaIds.length }}
-              </span>
-              <!-- Sound toggle for autoplaying feed videos. Tapping it (a user gesture) lets
-                   videos play WITH audio; the choice sticks for every video until muted again. -->
-              <button
-                v-if="p.kind === 'video' && (p.mediaUrl || p.posterUrl)"
-                type="button"
-                class="vol-toggle"
-                :aria-label="autoplayMuted ? 'Unmute videos' : 'Mute videos'"
-                @click.stop="setAutoplayMuted(!autoplayMuted)"
-              >
-                <ion-icon :icon="autoplayMuted ? volumeMuteOutline : volumeHighOutline" />
+              <!-- Post actions moved off the swipe (which fought the album swipe) into this
+                   menu: own posts → keep-for-longer / delete; others' → mute / hide. -->
+              <button type="button" class="postmenu" aria-label="Post actions" @click="openPostMenu(p)">
+                <ion-icon :icon="ellipsisHorizontal" />
               </button>
             </div>
-            <div v-else-if="p.mediaUrl && p.kind === 'voice'" class="voice" @click="open(p.id)">
-              <ion-icon :icon="micOutline" /> Voice message
+
+            <!-- Album (FR-019): swipe through every photo/video right here in the feed —
+                 no need to open the post. A live "n / N" counter tracks the slide. -->
+            <div
+              v-if="p.album && p.album.length > 1"
+              class="thumb album-feed"
+              :style="albumFrameStyle(p)"
+            >
+              <div class="album-track" @scroll="onAlbumScroll(p.id, $event)">
+                <!-- Mixed aspect ratios: one stable frame; each item shown WHOLE (contain),
+                     with its own blurred copy filling the letterbox so nothing is cropped and
+                     the height never jumps as you swipe portrait → square → landscape. -->
+                <div v-for="(m, i) in p.album" :key="i" class="album-slide">
+                  <!-- Blurred backdrop is ALWAYS an image (a video's poster) — never a second
+                       <video> — so the letterbox fill costs nothing to decode. Voice has none. -->
+                  <img v-if="(m.kind === 'image' && m.url) || (m.kind === 'video' && m.poster)" class="aslide-fill" :src="m.kind === 'video' ? m.poster : m.url" alt="" aria-hidden="true" />
+                  <!-- Image: tap or the ⤢ button opens a minimal full-screen image (rotatable,
+                       pinch-zoom) — no thumbnail strip. A shimmer shows while the blob downloads. -->
+                  <template v-if="m.kind === 'image'">
+                    <img v-if="m.url" class="aslide-main" :src="m.url" alt="" @click="openImageFullscreen(p, m.url)" />
+                    <div v-else class="aslide-main aslide-skel" aria-label="Loading photo"></div>
+                    <button v-if="m.url" type="button" class="vid-fs" aria-label="Full screen" @click.stop="openImageFullscreen(p, m.url)">
+                      <ion-icon :icon="expandOutline" />
+                    </button>
+                  </template>
+                  <!-- Voice: a centered waveform player (the chat's), no autoplay. -->
+                  <template v-else-if="m.kind === 'voice'">
+                    <div class="aslide-voice">
+                      <voice-player
+                        v-if="m.url"
+                        :mid="`${p.id}:${i}`"
+                        :sender="p.isOwn ? 'You' : p.authorName"
+                        :src="m.url"
+                        :outgoing="!!p.isOwn"
+                        :avatar="p.authorAvatar"
+                      />
+                      <div v-else class="voice-loading"><ion-icon :icon="micOutline" /><ion-spinner name="crescent" /></div>
+                    </div>
+                  </template>
+                  <!-- Video: only the in-view slide mounts the inline player (autoplay + a bottom
+                       bar: play/pause · mute · time + scrubber · native fullscreen). -->
+                  <template v-else>
+                    <wall-video v-if="(albumIndex[p.id] ?? 0) === i" class="aslide-main" :src="m.url" :poster="m.poster" />
+                    <template v-else>
+                      <img class="aslide-main" :src="m.poster" alt="" />
+                      <ion-icon class="aslide-play" :icon="playCircleOutline" aria-hidden="true" />
+                    </template>
+                  </template>
+                </div>
+              </div>
+              <div class="album-count">{{ (albumIndex[p.id] ?? 0) + 1 }} / {{ p.album.length }}</div>
             </div>
-            <p v-if="p.body" class="body" @click="open(p.id)"><EmojiText :text="p.body" /></p>
+
+            <!-- Single media. The image/video box reserves the media's aspect ratio with a
+                 skeleton so the feed doesn't jump as it decodes. -->
+            <div
+              v-else-if="p.kind === 'image' || p.kind === 'video'"
+              class="thumb"
+              :class="{ loading: p.kind === 'image' && !mediaLoaded[p.id] }"
+              :style="mediaStyle(p)"
+            >
+              <!-- Image: poster shows instantly; tap or ⤢ opens the minimal full-screen image. -->
+              <template v-if="p.kind === 'image' && (p.posterUrl || p.mediaUrl)">
+                <img
+                  :src="p.posterUrl || p.mediaUrl"
+                  :alt="p.body || 'Photo'"
+                  @load="onMediaLoad(p.id)"
+                  @click="openImageFullscreen(p, p.mediaUrl || p.posterUrl)"
+                />
+                <button type="button" class="vid-fs" aria-label="Full screen" @click.stop="openImageFullscreen(p, p.mediaUrl || p.posterUrl)">
+                  <ion-icon :icon="expandOutline" />
+                </button>
+              </template>
+              <!-- Video: inline player (autoplay + bottom bar with scrubber + native fullscreen). -->
+              <wall-video
+                v-else-if="p.kind === 'video' && (p.mediaUrl || p.posterUrl)"
+                :src="p.mediaUrl"
+                :poster="p.posterUrl"
+              />
+            </div>
+            <!-- Voice: the chat's waveform player (single-source global playback + seek), not a
+                 bare <audio> (which errors on a blob URL on iOS). Shows a loader until the clip's
+                 blob has streamed in. -->
+            <div v-else-if="p.kind === 'voice'" class="voice">
+              <voice-player
+                v-if="p.mediaUrl"
+                :mid="p.id"
+                :sender="p.isOwn ? 'You' : p.authorName"
+                :src="p.mediaUrl"
+                :outgoing="!!p.isOwn"
+                :avatar="p.authorAvatar"
+              />
+              <div v-else class="voice-loading">
+                <ion-icon :icon="micOutline" />
+                <ion-spinner name="crescent" />
+              </div>
+            </div>
+            <p v-if="p.body" class="body"><EmojiText :text="p.body" /></p>
 
             <!-- Reactions: pills + a quick-react button opening the shared picker. -->
             <div class="rrow">
@@ -140,27 +193,27 @@
               </button>
             </div>
 
-            <!-- Comment preview: first comment → "view all" → last comment (with avatars). -->
+            <!-- Comments, expandable inline: the latest one by default, "View all" expands the
+                 whole thread right here in the feed (no diving into the post). -->
             <div v-if="p.commentCount" class="cpreview">
-              <div class="crow">
-                <ion-avatar class="cmini">
-                  <img v-if="p.comments[0].authorAvatar" :src="p.comments[0].authorAvatar" :alt="p.comments[0].authorName" />
-                  <div v-else class="ph">{{ initial(p.comments[0].authorName) }}</div>
-                </ion-avatar>
-                <span class="cname">{{ p.comments[0].authorName }}</span>
-                <EmojiText :text="p.comments[0].text" />
-              </div>
-              <a v-if="p.commentCount > 2" class="more" @click="open(p.id)">
+              <a v-if="p.commentCount > 1 && !expanded[p.id]" class="more" @click="expanded[p.id] = true">
                 View all {{ p.commentCount }} comments
               </a>
-              <div v-if="p.commentCount > 1" class="crow">
+              <div
+                v-for="cm in expanded[p.id] ? p.comments : p.comments.slice(-1)"
+                :key="cm.id"
+                class="crow"
+              >
                 <ion-avatar class="cmini">
-                  <img v-if="p.comments[p.commentCount - 1].authorAvatar" :src="p.comments[p.commentCount - 1].authorAvatar" :alt="p.comments[p.commentCount - 1].authorName" />
-                  <div v-else class="ph">{{ initial(p.comments[p.commentCount - 1].authorName) }}</div>
+                  <img v-if="cm.authorAvatar" :src="cm.authorAvatar" :alt="cm.authorName" />
+                  <div v-else class="ph">{{ initial(cm.authorName) }}</div>
                 </ion-avatar>
-                <span class="cname">{{ p.comments[p.commentCount - 1].authorName }}</span>
-                <EmojiText :text="p.comments[p.commentCount - 1].text" />
+                <span class="cname">{{ cm.authorName }}</span>
+                <EmojiText :text="cm.text" />
               </div>
+              <a v-if="p.commentCount > 1 && expanded[p.id]" class="more" @click="expanded[p.id] = false">
+                Show less
+              </a>
             </div>
 
             <!-- Quick comment from the feed. -->
@@ -182,17 +235,19 @@
               </ion-button>
             </div>
           </div>
-        </ion-item>
-
-        <ion-item-options v-if="!p.isOwn" side="start">
-          <ion-item-option color="medium" @click="toggleMute(p)">{{ p.muted ? 'Unmute' : 'Mute' }}</ion-item-option>
-        </ion-item-options>
-        <ion-item-options side="end">
-          <ion-item-option v-if="p.isOwn" color="danger" @click="confirmDeletePost(p)">Delete</ion-item-option>
-          <ion-item-option v-else color="dark" @click="hideUser(p)">Hide</ion-item-option>
-        </ion-item-options>
-      </ion-item-sliding>
+      </ion-item>
     </ion-content>
+
+    <!-- Tap any post photo/video → full-screen viewer: pinch-zoom, pan, swipe between an
+         album's items. Minimal mode hides the chat-only actions (reply/forward/delete/…). -->
+    <media-viewer
+      :open="viewer.open"
+      :items="viewer.items"
+      :start="viewer.start"
+      minimal
+      @close="viewer.open = false"
+      @dismiss="viewer.open = false"
+    />
   </ion-page>
 </template>
 
@@ -200,32 +255,92 @@
 import { computed, reactive, ref, watch } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent,
-  IonItem, IonItemSliding, IonItemOption, IonItemOptions, IonAvatar, IonIcon, IonTextarea, IonSearchbar,
+  IonItem, IonAvatar, IonIcon, IonTextarea, IonSearchbar, IonSpinner,
+  IonRefresher, IonRefresherContent,
   actionSheetController, alertController,
   onIonViewWillEnter, onIonViewWillLeave,
+  type RefresherCustomEvent,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
 import {
   createOutline, sparklesOutline, micOutline, playCircleOutline, happyOutline, timeOutline,
-  notificationsOutline, notificationsOffOutline, copyOutline, volumeMuteOutline, volumeHighOutline,
+  notificationsOutline, notificationsOffOutline, copyOutline,
+  ellipsisHorizontal, expandOutline,
 } from 'ionicons/icons';
 import { appToast } from '@/services/toast';
 import Emoji from '@/components/Emoji.vue';
 import EmojiText from '@/components/EmojiText.vue';
+import MediaViewer, { type ViewerItem } from '@/components/MediaViewer.vue';
 import { vEnterSend } from '@/directives/enter-send';
-import { vAutoplayVisible, autoplayMuted, setAutoplayMuted } from '@/directives/autoplay-visible';
+import { suspendAutoplay } from '@/directives/autoplay-visible';
+import WallVideo from '@/components/WallVideo.vue';
+import VoicePlayer from '@/components/VoicePlayer.vue';
 import { useWall, type WallPost } from '@/composables/useWall';
 import { useReactionPicker } from '@/composables/useReactionPicker';
 import {
-  reactToPost, commentOnPost, deletePost, MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS,
+  reactToPost, commentOnPost, deletePost, keepAlivePost, setPostAudience,
+  listFriends, listCloseFriends, syncPosts,
+  MAX_REACTIONS_PER_USER, MAX_DISTINCT_REACTIONS,
   markWallSeen, setWallMuteUntil, isWallTempMuted, setWallUserMuted, setWallUserHidden,
 } from '@/db/queries';
 import { timeLeft, ago } from '@/utils/post-time';
 
 const router = useRouter();
-const { wall, now, loaded } = useWall();
+const { wall, now, loaded, synced } = useWall();
+
+// Pull-to-refresh: re-pull the feed (new posts stream in via the live query) and release the
+// control when the sync settles.
+async function onPullRefresh(e: RefresherCustomEvent): Promise<void> {
+  try {
+    await syncPosts();
+  } finally {
+    void e.detail.complete();
+  }
+}
 const { openQuick } = useReactionPicker();
 const draft = reactive<Record<string, string>>({});
+// Inline-feed state: which album slide is showing (for the "n / N" counter), and which
+// posts have their full comment thread expanded.
+const albumIndex = reactive<Record<string, number>>({});
+const expanded = reactive<Record<string, boolean>>({});
+function onAlbumScroll(postId: string, e: Event): void {
+  const el = e.target as HTMLElement;
+  albumIndex[postId] = el.clientWidth ? Math.round(el.scrollLeft / el.clientWidth) : 0;
+}
+
+// Minimal full-screen IMAGE overlay (videos use native OS fullscreen via WallVideo). Reuses the
+// chat MediaViewer in minimal mode with a SINGLE image → no thumbnail strip, no actions, just
+// the photo with pinch-zoom; the PWA rotates freely so the phone can be turned landscape.
+const viewer = reactive<{ open: boolean; items: ViewerItem[]; start: number }>({
+  open: false,
+  items: [],
+  start: 0,
+});
+function openImageFullscreen(p: WallPost, url?: string): void {
+  if (!url) return;
+  viewer.items = [
+    {
+      id: `${p.id}:img`,
+      url,
+      thumb: url,
+      kind: 'image',
+      caption: p.body ?? '',
+      senderName: p.isOwn ? 'You' : p.authorName,
+      when: ago(p.createdAt, now.value),
+      outgoing: p.isOwn,
+      favorite: false,
+      reactions: [],
+    },
+  ];
+  viewer.start = 0;
+  viewer.open = true;
+}
+// Pause the feed's inline autoplay while the full-screen overlay is up (it sits over the feed,
+// which would otherwise keep a clip playing — with sound — behind it), and resume on close.
+watch(
+  () => viewer.open,
+  (open) => suspendAutoplay(open),
+);
 
 // Reserve the media's aspect ratio (fallback 4:3) so the card height is fixed before
 // the image/video decodes; track which have loaded to drop the skeleton shimmer.
@@ -235,6 +350,13 @@ function onMediaLoad(id: string): void {
 }
 function mediaStyle(p: WallPost): Record<string, string> {
   return { aspectRatio: p.mediaW && p.mediaH ? `${p.mediaW} / ${p.mediaH}` : '4 / 3' };
+}
+// One stable, slightly-vertical 4:5 frame for a whole mixed-aspect album (Instagram-style):
+// portraits — the common case — nearly fill it, while squares/landscapes sit contained with
+// the blurred fill. Every slide is letterboxed into this frame, so the album height is constant
+// regardless of the mix. (`p` kept for a possible future per-post override.)
+function albumFrameStyle(_p: WallPost): Record<string, string> {
+  return { aspectRatio: '4 / 5' };
 }
 
 // Search across a post's body, its comments, and the author's name/username.
@@ -260,9 +382,6 @@ const filteredWall = computed(() => {
 
 function compose(): void {
   void router.push('/wall/compose');
-}
-function open(id: string): void {
-  void router.push(`/wall/post/${id}`);
 }
 function initial(name: string): string {
   return (name.trim()[0] ?? '?').toUpperCase();
@@ -349,7 +468,81 @@ async function mute(until: number): Promise<void> {
   muted.value = await isWallTempMuted();
 }
 
-// --- per-user mute / hide (swipe-right = mute, swipe-left = hide) ---
+// Post actions menu (the "…" button), replacing the swipe gestures so a multi-item post's
+// horizontal album swipe is unobstructed. Own posts: keep-for-longer / delete. Others': mute / hide.
+async function openPostMenu(post: WallPost): Promise<void> {
+  const buttons = post.isOwn
+    ? [
+        post.audience === 'close'
+          ? { text: 'Change to All friends', handler: () => void changeAudience(post, 'friends') }
+          : { text: 'Change to Close friends only', handler: () => void changeAudience(post, 'close') },
+        { text: 'Keep for longer', handler: () => void extendPost(post) },
+        { text: 'Delete post', role: 'destructive' as const, handler: () => void confirmDeletePost(post) },
+      ]
+    : [
+        // These are per-PERSON, not per-post (the header shows whose). Spell that out so
+        // "Hide this post" / "Mute notifications" don't read as affecting just this one.
+        {
+          text: post.muted ? 'Unmute their wall notifications' : 'Mute their wall notifications',
+          handler: () => void toggleMute(post),
+        },
+        { text: 'Hide all their posts', handler: () => void hideUser(post) },
+      ];
+  const sheet = await actionSheetController.create({
+    header: post.isOwn ? 'Your post' : post.authorName,
+    buttons: [...buttons, { text: 'Cancel', role: 'cancel' as const }],
+  });
+  await sheet.present();
+}
+
+// Change a post's visibility after the fact. Broadening adds the rest of your friends
+// (silently — they aren't notified); narrowing revokes the non-close friends' copies.
+// Confirm first, spelling out exactly who it reaches with live counts.
+async function changeAudience(post: WallPost, audience: 'friends' | 'close'): Promise<void> {
+  const [friends, close] = await Promise.all([listFriends(), listCloseFriends()]);
+  const n = audience === 'friends' ? friends.length : close.length;
+  const noun = n === 1 ? 'friend' : 'friends';
+  const message =
+    audience === 'friends'
+      ? `This will be visible to all your ${n} ${noun}.`
+      : `It will now only be visible to your ${n} close ${noun}.`;
+  const alert = await alertController.create({
+    header: 'Change who can see this',
+    message,
+    buttons: [
+      { text: 'Cancel', role: 'cancel' },
+      {
+        text: audience === 'friends' ? 'All friends' : 'Close friends',
+        handler: () => {
+          void (async () => {
+            try {
+              await setPostAudience(post.id, audience);
+              await appToast({
+                message: audience === 'friends' ? 'Now visible to all friends.' : 'Now visible to close friends only.',
+                duration: 1400,
+              });
+            } catch {
+              await appToast({ message: 'Couldn’t change who can see this — try again.', duration: 1800 });
+            }
+          })();
+        },
+      },
+    ],
+  });
+  await alert.present();
+}
+
+// Push the auto-delete back to a full window from now (server keep-alive + local bump).
+async function extendPost(post: WallPost): Promise<void> {
+  try {
+    await keepAlivePost(post.id);
+    await appToast({ message: 'Post kept for longer.', duration: 1400 });
+  } catch {
+    await appToast({ message: 'Couldn’t extend that post — try again.', duration: 1800 });
+  }
+}
+
+// --- per-user mute / hide ---
 async function toggleMute(post: WallPost): Promise<void> {
   await setWallUserMuted(post.author, !post.muted);
   await appToast({
@@ -408,7 +601,10 @@ async function confirmDeletePost(post: WallPost): Promise<void> {
   margin: 8px 0;
   border-radius: 16px;
   overflow: hidden;
-  background: var(--ion-card-background, var(--ion-item-background, #fff));
+  /* Every post uses the SAME green card colour (the chat "outgoing" bubble) — own and others'
+     alike — so the feed reads as one consistent surface. Opaque, like the bubbles, so the
+     background pattern doesn't bleed through. */
+  background: var(--app-bubble-out);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
 }
 /* Swipe actions are shaped like the card they sit under: same 8px vertical inset and
@@ -472,6 +668,22 @@ ion-item-sliding ion-item-option {
   padding: 3px 8px;
   border-radius: 999px;
 }
+/* The "…" post-actions button, top-right of the header next to the countdown. */
+.postmenu {
+  flex: none;
+  width: 30px;
+  height: 30px;
+  margin-left: 2px;
+  border: none;
+  border-radius: 50%;
+  padding: 0;
+  background: transparent;
+  color: var(--app-text-muted, var(--ion-color-medium));
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 .thumb {
   position: relative;
   cursor: pointer;
@@ -479,6 +691,109 @@ ion-item-sliding ion-item-option {
   max-height: 60vh;
   overflow: hidden;
   background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+}
+/* Inline album gallery: a horizontal scroll-snap row inside the aspect-ratio box, so you
+   can swipe every photo/video right in the feed. */
+.album-feed {
+  cursor: default;
+}
+.album-track {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.album-track::-webkit-scrollbar {
+  display: none;
+}
+.album-slide {
+  position: relative;
+  flex: 0 0 100%;
+  height: 100%;
+  scroll-snap-align: center;
+  overflow: hidden;
+  background: #000;
+}
+/* A blurred, zoomed copy of the slide fills the letterbox, so a portrait/square/landscape
+   item in the shared frame reads as intentional rather than bars. */
+.aslide-fill {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.15); /* hide the blur's soft edge */
+  filter: blur(22px) brightness(0.85) saturate(1.1);
+}
+/* The item itself, shown WHOLE — never cropped. */
+.aslide-main {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+/* Shimmer for an album photo whose blob is still streaming in (the post is already visible). */
+.aslide-skel {
+  background: linear-gradient(
+    100deg,
+    rgba(128, 128, 128, 0.15) 30%,
+    rgba(128, 128, 128, 0.28) 50%,
+    rgba(128, 128, 128, 0.15) 70%
+  );
+  background-size: 200% 100%;
+  animation: aslideShimmer 1.4s ease-in-out infinite;
+}
+@keyframes aslideShimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+/* Voice slide in an album: center the waveform player on a neutral panel (no media to fill). */
+.aslide-voice {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 18px;
+  /* Darken the post's own (green) card into a panel rather than a glaring white box, so a voice
+     slide reads as part of the post and stays on-theme in dark + light. */
+  background: rgba(0, 0, 0, 0.2);
+}
+.aslide-voice > * {
+  width: 100%;
+  max-width: 420px;
+}
+/* Play glyph over a video slide's poster (the slides not currently in view). */
+.aslide-play {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 52px;
+  color: rgba(255, 255, 255, 0.92);
+  filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.55));
+  pointer-events: none;
+}
+.album-count {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  pointer-events: none;
 }
 /* Skeleton shimmer while the media hasn't painted yet (box height is already
    reserved by aspect-ratio, so nothing jumps when it loads). */
@@ -493,33 +808,55 @@ ion-item-sliding ion-item-option {
     background-color: var(--ion-color-step-200, rgba(120, 120, 128, 0.22));
   }
 }
-.thumb img,
-.thumb video {
+/* DIRECT children only — a single image/video fills its own (matched) frame. Must NOT cascade
+   into the nested album-gallery slides, which use contain + a blurred fill (.aslide-*). */
+.thumb > img,
+.thumb > video {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
+/* A single voice post: a darkened rounded panel inside the green card, so the green play button
+   and waveform read clearly (instead of green-on-green) and it matches the album voice slide. */
 .voice {
+  margin: 8px 12px 4px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.2);
+}
+.voice-loading {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 14px;
+  gap: 8px;
+  height: 38px;
   color: var(--ion-color-medium);
-  cursor: pointer;
 }
-.thumb .play {
+/* Full-screen ⤢ button over a photo (videos carry their own bar in WallVideo). Promoted to its
+   own layer so it sits above the media on iOS. */
+.vid-fs {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+  color: #fff;
+  font-size: 19px;
+}
+/* Full-screen button — bottom-right, opposite the play/mute cluster. */
+.vid-fs {
   position: absolute;
-  inset: 0;
-  margin: auto;
-  font-size: 52px;
-  color: rgba(255, 255, 255, 0.92);
-  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.5));
-  transition: opacity 0.2s ease;
-}
-/* While the clip is autoplaying inline, drop the tap-to-open glyph (tapping still works). */
-.thumb video[data-autoplaying] + .play {
-  opacity: 0;
+  right: 8px;
+  bottom: 8px;
+  z-index: 20;
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
 }
 /* Album count badge over the cover (top-right). */
 .album-badge {

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -113,6 +113,7 @@
                         :src="m.url"
                         :outgoing="!!p.isOwn"
                         :avatar="p.authorAvatar"
+                        :float-when-away="true"
                       />
                       <div v-else class="voice-loading"><ion-icon :icon="micOutline" /><ion-spinner name="crescent" /></div>
                     </div>
@@ -169,6 +170,7 @@
                 :src="p.mediaUrl"
                 :outgoing="!!p.isOwn"
                 :avatar="p.authorAvatar"
+                :float-when-away="true"
               />
               <div v-else class="voice-loading">
                 <ion-icon :icon="micOutline" />


### PR DESCRIPTION
A broad polish pass over the Social Wall plus a few cross-cutting fixes, accumulated together.

## Wall
- **Voice posts** — record a clip that mixes into an album as a reorderable item; feed + composer use the chat's waveform player (fixes the iOS blob-URL "Error"); muted-by-default inline video with scrubber + native fullscreen.
- **Instant feed** — posts appear immediately with their poster and stream full media in the background; album photos shimmer until they land.
- **First-load spinner** with a failsafe so it can never spin forever.
- **Pull-to-refresh** with tailored pull/refresh copy.
- Consistent **green post cards** (own + others'), themed voice panel, **10-item cap**, rotatable photo fullscreen.

## Notifications / SW
- Friend-request + new-post push **name the actor** ("X posted on their Wall") and bump the app badge; cold-launch **deep-link handshake** routes to the Wall.
- Apple Web Push topic as **base64url** (fixes `BadWebPushTopic` 400s).

## Chat / Contacts
- Pull-to-refresh (Chats = reconnect+catch-up, Contacts = requests+profiles).
- Chat name truncates to one line; voice player can't overflow its bubble.
- Audio player stops + dismisses the floating controller when its post is deleted mid-playback.

## Media
- Audio preserved through transcode; embedded video poster so recipients render instantly.

**Testing:** `npm run build` (typecheck+build), `go build/vet/test ./...` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)