### PR TITLE
feat: resilient posting, per-chat/per-message media controls, and download UX (spec 1024)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1020-mentions-group-chats/plan.md`
+`specs/1024-resilient-posting-and-storage/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,7 @@ Specs are grouped by category band; status moves
 | [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | 🔵 in-review |
 | [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | 🔵 in-review |
 | [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🟡 in-progress |
+| [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/auto-download.mjs
+++ b/drive/scenarios/auto-download.mjs
@@ -1,0 +1,68 @@
+/**
+ * Auto-download now honors the per-kind setting AND a size limit, using the media metadata.
+ * Photos set to "never" defer; a small size limit defers even an allowed kind; defaults download.
+ *
+ *   node drive/scenarios/auto-download.mjs
+ */
+import { preflight, createAccount, pair, chatWith, sweep, done, poll } from '../driver.mjs';
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Sender', mobile: true }),
+  await createAccount({ name: 'Rx', mobile: true }),
+];
+await pair(a, b);
+const aChat = await chatWith(a, b.id);
+const bChat = await chatWith(b, a.id);
+
+// Latest incoming image message id on B (waits for delivery).
+async function latestIncomingImage() {
+  return poll(
+    () =>
+      b.page.evaluate(
+        (c) => window.__ringTest.messages(c).then((ms) => ms.filter((m) => m.kind === 'image' && !m.outgoing).map((m) => m.id).pop() ?? null),
+        bChat,
+      ),
+    (v) => !!v,
+    { label: 'incoming image' },
+  );
+}
+const infoOf = (id) => b.page.evaluate((i) => window.__ringTest.mediaInfo(i), id);
+const setB = (k, v) => b.page.evaluate(([kk, vv]) => window.__ringTest.setSetting(kk, vv), [k, v]);
+
+// Case 1: photos = 'never' → the received image is DEFERRED (pending, not on device).
+await setB('storage.autoDownload.photos', 'never');
+await a.page.evaluate((c) => window.__ringTest.sendImage(c, 800, 600, 'never.png'), aChat);
+let id = await latestIncomingImage();
+await b.page.waitForTimeout(600);
+let info = await infoOf(id);
+console.log('kind=never →', JSON.stringify({ pending: info.pending, hasMedia: info.hasMedia }), '(expect pending true)');
+
+// Case 2: photos allowed but size limit tiny (1 KB) → DEFERRED by size.
+await setB('storage.autoDownload.photos', 'wifi-cellular');
+await setB('storage.autoDownloadLimit', '0.001'); // ~1 KB
+await a.page.evaluate((c) => window.__ringTest.sendImage(c, 900, 700, 'big.png'), aChat);
+id = await latestIncomingImage();
+await b.page.waitForTimeout(600);
+info = await infoOf(id);
+console.log('over size limit →', JSON.stringify({ pending: info.pending, hasMedia: info.hasMedia }), '(expect pending true)');
+
+// Case 3: allowed + generous limit → should NOT defer. (In the harness the freshly-uploaded blob may
+// not be fetchable the instant B receives, so if it's pending, a manual download must succeed —
+// proving the decision was "download", not "defer".)
+await setB('storage.autoDownloadLimit', '100');
+await a.page.evaluate((c) => window.__ringTest.sendImage(c, 700, 500, 'ok.png'), aChat);
+id = await latestIncomingImage();
+await b.page.waitForTimeout(1500);
+info = await infoOf(id);
+if (info.pending) {
+  await b.page.evaluate((i) => window.__ringTest.downloadMedia(i), id).catch(() => {});
+  await b.page.waitForTimeout(800);
+  info = await infoOf(id);
+  console.log('within limits → was pending, manual download →', JSON.stringify({ hasMedia: info.hasMedia }), '(expect hasMedia true = blob fetchable, decision was download)');
+} else {
+  console.log('within limits →', JSON.stringify({ pending: info.pending, hasMedia: info.hasMedia }), '(expect hasMedia true)');
+}
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/chat-album-toggle.mjs
+++ b/drive/scenarios/chat-album-toggle.mjs
@@ -1,0 +1,37 @@
+/**
+ * The Album / Separate send-mode toggle: on its own row under the thumbnails, not squeezed beside
+ * them (which truncated "Individual"). Stage 3 photos to reveal it.
+ *
+ *   HEADED=1 node drive/scenarios/chat-album-toggle.mjs
+ */
+import { preflight, createAccount, pair, chatWith, shot, sweep, done, poll } from '../driver.mjs';
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Ally', mobile: true }),
+  await createAccount({ name: 'Bo', mobile: true }),
+];
+await pair(a, b);
+const chatId = await chatWith(a, b.id);
+await a.page.goto(`/chat/${chatId}`);
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-textarea')), Boolean, { label: 'composer' });
+
+await a.page.setInputFiles(
+  'input[type=file][multiple]',
+  Array.from({ length: 3 }, (_, i) => ({ name: `p${i}.png`, mimeType: 'image/png', buffer: PNG })),
+);
+await poll(() => a.page.evaluate(() => !!document.querySelector('.send-mode')), Boolean, { label: 'send-mode row' });
+const labels = await a.page.evaluate(() =>
+  Array.from(document.querySelectorAll('.send-mode ion-segment-button ion-label')).map((l) => l.textContent.trim()),
+);
+const lead = await a.page.evaluate(() => document.querySelector('.send-mode-label')?.textContent?.trim());
+console.log('send-mode:', JSON.stringify({ lead, labels }));
+await shot(a, 'chat-album-toggle');
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/chat-caption-modal.mjs
+++ b/drive/scenarios/chat-caption-modal.mjs
@@ -2,7 +2,7 @@
  * Composer polish: a pen hint on each staged thumbnail, a bottom-sheet caption editor (not an alert),
  * and a blocking "up to 10" alert when a pick goes over.
  *
- *   HEADED=1 node drive/scenarios/chat-caption-sheet.mjs
+ *   HEADED=1 node drive/scenarios/chat-caption-modal.mjs
  */
 import { preflight, createAccount, pair, chatWith, shot, sweep, done, poll } from '../driver.mjs';
 
@@ -35,21 +35,21 @@ await shot(a, 'caption-pen-hints');
 
 // Tap a thumbnail → caption bottom sheet (a modal, not an alert) with a textarea.
 await a.page.evaluate(() => document.querySelector('.paste-tap')?.click());
-await poll(() => a.page.evaluate(() => !!document.querySelector('ion-modal.caption-sheet ion-textarea')), Boolean, { label: 'caption sheet' });
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-modal.caption-modal ion-textarea')), Boolean, { label: 'caption sheet' });
 const sheet = await a.page.evaluate(() => ({
-  isModal: !!document.querySelector('ion-modal.caption-sheet'),
-  hasTextarea: !!document.querySelector('.caption-sheet ion-textarea'),
-  hasSave: [...document.querySelectorAll('.caption-sheet ion-button')].some((x) => /save/i.test(x.textContent)),
+  isModal: !!document.querySelector('ion-modal.caption-modal'),
+  hasTextarea: !!document.querySelector('.caption-modal ion-textarea'),
+  hasSave: [...document.querySelectorAll('.caption-modal ion-button')].some((x) => /save/i.test(x.textContent)),
 }));
 console.log('caption sheet:', JSON.stringify(sheet));
-await shot(a, 'caption-sheet');
+await shot(a, 'caption-modal');
 await a.page.evaluate(() => {
-  const btns = [...document.querySelectorAll('.caption-sheet ion-button')];
+  const btns = [...document.querySelectorAll('.caption-modal ion-button')];
   btns.find((x) => /cancel/i.test(x.textContent))?.click();
 });
 
 // Over-cap: pick 12 → a blocking alert appears.
-await poll(() => a.page.evaluate(() => !document.querySelector('ion-modal.caption-sheet')), Boolean, { label: 'sheet closed' });
+await poll(() => a.page.evaluate(() => !document.querySelector('ion-modal.caption-modal')), Boolean, { label: 'sheet closed' });
 await a.page.setInputFiles(
   'input[type=file][multiple]',
   Array.from({ length: 12 }, (_, i) => ({ name: `q${i}.png`, mimeType: 'image/png', buffer: PNG })),

--- a/drive/scenarios/chat-caption-sheet.mjs
+++ b/drive/scenarios/chat-caption-sheet.mjs
@@ -1,0 +1,62 @@
+/**
+ * Composer polish: a pen hint on each staged thumbnail, a bottom-sheet caption editor (not an alert),
+ * and a blocking "up to 10" alert when a pick goes over.
+ *
+ *   HEADED=1 node drive/scenarios/chat-caption-sheet.mjs
+ */
+import { preflight, createAccount, pair, chatWith, shot, sweep, done, poll } from '../driver.mjs';
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Cap', mobile: true }),
+  await createAccount({ name: 'Bo', mobile: true }),
+];
+await pair(a, b);
+const chatId = await chatWith(a, b.id);
+await a.page.goto(`/chat/${chatId}`);
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-textarea')), Boolean, { label: 'composer' });
+
+// Stage 3 photos.
+await a.page.setInputFiles(
+  'input[type=file][multiple]',
+  Array.from({ length: 3 }, (_, i) => ({ name: `p${i}.png`, mimeType: 'image/png', buffer: PNG })),
+);
+await poll(() => a.page.evaluate(() => document.querySelectorAll('.paste-thumb').length), (n) => n === 3, { label: 'staged' });
+
+// Pen hint present on thumbnails.
+const pens = await a.page.evaluate(() => document.querySelectorAll('.paste-cap-hint').length);
+console.log('pen hints:', pens);
+await shot(a, 'caption-pen-hints');
+
+// Tap a thumbnail → caption bottom sheet (a modal, not an alert) with a textarea.
+await a.page.evaluate(() => document.querySelector('.paste-tap')?.click());
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-modal.caption-sheet ion-textarea')), Boolean, { label: 'caption sheet' });
+const sheet = await a.page.evaluate(() => ({
+  isModal: !!document.querySelector('ion-modal.caption-sheet'),
+  hasTextarea: !!document.querySelector('.caption-sheet ion-textarea'),
+  hasSave: [...document.querySelectorAll('.caption-sheet ion-button')].some((x) => /save/i.test(x.textContent)),
+}));
+console.log('caption sheet:', JSON.stringify(sheet));
+await shot(a, 'caption-sheet');
+await a.page.evaluate(() => {
+  const btns = [...document.querySelectorAll('.caption-sheet ion-button')];
+  btns.find((x) => /cancel/i.test(x.textContent))?.click();
+});
+
+// Over-cap: pick 12 → a blocking alert appears.
+await poll(() => a.page.evaluate(() => !document.querySelector('ion-modal.caption-sheet')), Boolean, { label: 'sheet closed' });
+await a.page.setInputFiles(
+  'input[type=file][multiple]',
+  Array.from({ length: 12 }, (_, i) => ({ name: `q${i}.png`, mimeType: 'image/png', buffer: PNG })),
+);
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-alert')), Boolean, { label: 'over-cap alert' });
+const alertHeader = await a.page.evaluate(() => document.querySelector('ion-alert .alert-title, ion-alert .alert-head')?.textContent?.trim());
+console.log('over-cap alert header:', JSON.stringify(alertHeader));
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/chat-draft-media.mjs
+++ b/drive/scenarios/chat-draft-media.mjs
@@ -26,13 +26,23 @@ async function openChat() {
 }
 const stagedCount = () => a.page.evaluate(() => document.querySelectorAll('.paste-thumb').length);
 
+// Staged media is now flushed to the draft when the chat is LEFT or BACKGROUNDED (not on every edit,
+// which janked the composer). A hard page.goto doesn't fire those, so simulate a background first.
+const background = async () => {
+  await a.page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await a.page.waitForTimeout(400); // let the async media flush complete
+};
+
 // Stage a photo (do not send).
 await openChat();
 await a.page.setInputFiles('input[type=file][multiple]', { name: 'holiday.png', mimeType: 'image/png', buffer: PNG });
 await poll(() => stagedCount(), (n) => n === 1, { label: 'photo staged' });
-await a.page.waitForTimeout(500); // let the debounced media-save flush
 console.log('staged after add:', await stagedCount());
 await shot(a, 'draftmedia-staged');
+await background(); // flush to the draft
 
 // Chats list should show the draft with a media label.
 await a.page.goto('/tabs/chats');
@@ -46,6 +56,7 @@ await poll(() => stagedCount(), (n) => n === 1, { label: 'photo restored after l
 console.log('staged after leave+return:', await stagedCount());
 
 // Full app reload, reopen: still staged.
+await background();
 await a.page.reload();
 await poll(() => a.page.evaluate(() => !!window.__ringTest), Boolean, { label: 'app reloaded' });
 await openChat();
@@ -53,10 +64,10 @@ await poll(() => stagedCount(), (n) => n === 1, { label: 'photo restored after r
 console.log('staged after reload:', await stagedCount());
 await shot(a, 'draftmedia-restored');
 
-// Remove it → the draft clears.
+// Remove it → after a flush the draft clears.
 await a.page.evaluate(() => document.querySelector('.paste-x')?.click());
 await poll(() => stagedCount(), (n) => n === 0, { label: 'removed' });
-await a.page.waitForTimeout(500);
+await background();
 await a.page.goto('/tabs/chats');
 await openChat();
 console.log('staged after remove+reopen (should be 0):', await stagedCount());

--- a/drive/scenarios/chat-draft-media.mjs
+++ b/drive/scenarios/chat-draft-media.mjs
@@ -1,0 +1,65 @@
+/**
+ * Staged attachments are preserved in a chat draft: add a photo but don't send it, leave the chat
+ * (and reload the app), and it's still staged when you come back. The Chats list shows the draft too.
+ *
+ *   HEADED=1 node drive/scenarios/chat-draft-media.mjs
+ */
+import { preflight, createAccount, pair, chatWith, shot, sweep, done, poll } from '../driver.mjs';
+
+// A tiny 1x1 PNG.
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Media Mia', mobile: true }),
+  await createAccount({ name: 'Bo', mobile: true }),
+];
+await pair(a, b);
+const chatId = await chatWith(a, b.id);
+
+async function openChat() {
+  await a.page.goto(`/chat/${chatId}`);
+  await poll(() => a.page.evaluate(() => !!document.querySelector('ion-textarea')), Boolean, { label: 'composer present' });
+}
+const stagedCount = () => a.page.evaluate(() => document.querySelectorAll('.paste-thumb').length);
+
+// Stage a photo (do not send).
+await openChat();
+await a.page.setInputFiles('input[type=file][multiple]', { name: 'holiday.png', mimeType: 'image/png', buffer: PNG });
+await poll(() => stagedCount(), (n) => n === 1, { label: 'photo staged' });
+await a.page.waitForTimeout(500); // let the debounced media-save flush
+console.log('staged after add:', await stagedCount());
+await shot(a, 'draftmedia-staged');
+
+// Chats list should show the draft with a media label.
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.evaluate(() => !!document.querySelector('.draft-tag')), Boolean, { label: 'draft tag' });
+const listPreview = await a.page.evaluate(() => document.querySelector('.draft-tag')?.parentElement?.textContent?.trim());
+console.log('chats-list draft:', JSON.stringify(listPreview));
+
+// Return to the chat: the photo should still be staged.
+await openChat();
+await poll(() => stagedCount(), (n) => n === 1, { label: 'photo restored after leave' });
+console.log('staged after leave+return:', await stagedCount());
+
+// Full app reload, reopen: still staged.
+await a.page.reload();
+await poll(() => a.page.evaluate(() => !!window.__ringTest), Boolean, { label: 'app reloaded' });
+await openChat();
+await poll(() => stagedCount(), (n) => n === 1, { label: 'photo restored after reload' });
+console.log('staged after reload:', await stagedCount());
+await shot(a, 'draftmedia-restored');
+
+// Remove it → the draft clears.
+await a.page.evaluate(() => document.querySelector('.paste-x')?.click());
+await poll(() => stagedCount(), (n) => n === 0, { label: 'removed' });
+await a.page.waitForTimeout(500);
+await a.page.goto('/tabs/chats');
+await openChat();
+console.log('staged after remove+reopen (should be 0):', await stagedCount());
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/chat-draft.mjs
+++ b/drive/scenarios/chat-draft.mjs
@@ -38,6 +38,21 @@ const afterReturn = await composerValue();
 console.log('after leave+return:', JSON.stringify(afterReturn));
 await shot(a, 'draft-restored');
 
+// The Chats list should mark this chat with a "Draft" indicator.
+await a.page.goto('/tabs/chats');
+await poll(
+  () => a.page.evaluate(() => !!document.querySelector('.draft-tag')),
+  Boolean,
+  { label: 'draft tag in chats list' },
+);
+const draftRow = await a.page.evaluate(() => {
+  const tag = document.querySelector('.draft-tag');
+  const text = tag?.parentElement?.textContent?.trim();
+  return text;
+});
+console.log('chats-list draft row:', JSON.stringify(draftRow));
+await shot(a, 'draft-in-chats-list');
+
 // Simulate a full app close: reload the page, then open the chat again.
 await a.page.reload();
 await poll(() => a.page.evaluate(() => !!window.__ringTest), Boolean, { label: 'app reloaded' });

--- a/drive/scenarios/chat-draft.mjs
+++ b/drive/scenarios/chat-draft.mjs
@@ -1,0 +1,59 @@
+/**
+ * Per-chat composer drafts: an unsent message is restored when you leave the chat and come back,
+ * and after a full app reload. Two accounts so there's a real 1:1 chat.
+ *
+ *   HEADED=1 node drive/scenarios/chat-draft.mjs
+ */
+import { preflight, createAccount, pair, chatWith, shot, sweep, done, poll } from '../driver.mjs';
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Drafty Dana', mobile: true }),
+  await createAccount({ name: 'Bo', mobile: true }),
+];
+await pair(a, b);
+const chatId = await chatWith(a, b.id);
+
+async function openChat() {
+  await a.page.goto(`/chat/${chatId}`);
+  await poll(() => a.page.evaluate(() => !!document.querySelector('ion-textarea')), Boolean, { label: 'composer present' });
+}
+const composerValue = () =>
+  a.page.evaluate(() => document.querySelector('ion-textarea')?.value || '');
+
+// Type a draft, but do NOT send it.
+await openChat();
+const native = a.page.locator('ion-textarea textarea').first();
+await native.click();
+await native.pressSequentially('half typed message', { delay: 10 });
+console.log('typed draft:', JSON.stringify(await composerValue()));
+await a.page.waitForTimeout(700); // let the debounced draft-save flush to IndexedDB
+await shot(a, 'draft-typed');
+
+// Leave the chat (back to the list), then return — the draft should be restored.
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.evaluate(() => !document.querySelector('ion-textarea')), Boolean, { label: 'left chat' });
+await openChat();
+const afterReturn = await composerValue();
+console.log('after leave+return:', JSON.stringify(afterReturn));
+await shot(a, 'draft-restored');
+
+// Simulate a full app close: reload the page, then open the chat again.
+await a.page.reload();
+await poll(() => a.page.evaluate(() => !!window.__ringTest), Boolean, { label: 'app reloaded' });
+await openChat();
+const afterReload = await composerValue();
+console.log('after reload:', JSON.stringify(afterReload));
+await shot(a, 'draft-after-reload');
+
+// Clear the text and leave — an emptied composer must not leave a stale draft behind.
+await a.page.locator('ion-textarea textarea').first().click();
+await a.page.locator('ion-textarea textarea').first().fill('');
+await a.page.waitForTimeout(700); // debounced save sees empty text → clears the stored draft
+await a.page.goto('/tabs/chats');
+await openChat();
+const afterClear = await composerValue();
+console.log('after clearing+reopen (should be empty):', JSON.stringify(afterClear));
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/chat-media-cap.mjs
+++ b/drive/scenarios/chat-media-cap.mjs
@@ -1,0 +1,33 @@
+/**
+ * The chat composer caps staged attachments at 10, even when the OS picker hands over more.
+ *
+ *   HEADED=1 node drive/scenarios/chat-media-cap.mjs
+ */
+import { preflight, createAccount, pair, chatWith, shot, sweep, done, poll } from '../driver.mjs';
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Cappy', mobile: true }),
+  await createAccount({ name: 'Bo', mobile: true }),
+];
+await pair(a, b);
+const chatId = await chatWith(a, b.id);
+await a.page.goto(`/chat/${chatId}`);
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-textarea')), Boolean, { label: 'composer' });
+
+// Hand the picker 12 photos at once.
+const files = Array.from({ length: 12 }, (_, i) => ({ name: `p${i}.png`, mimeType: 'image/png', buffer: PNG }));
+await a.page.setInputFiles('input[type=file][multiple]', files);
+await poll(() => a.page.evaluate(() => document.querySelectorAll('.paste-thumb').length), (n) => n > 0, { label: 'staged' });
+await a.page.waitForTimeout(300);
+const staged = await a.page.evaluate(() => document.querySelectorAll('.paste-thumb').length);
+console.log(`picked 12, staged ${staged} (expect 10)`);
+await shot(a, 'chat-media-cap');
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/chat-msg-timer.mjs
+++ b/drive/scenarios/chat-msg-timer.mjs
@@ -1,0 +1,49 @@
+/**
+ * The composer's per-message disappearing timer: pick a duration, and messages you send get that
+ * expiry (sticky until changed). Overrides the chat default.
+ *
+ *   HEADED=1 node drive/scenarios/chat-msg-timer.mjs
+ */
+import { preflight, createAccount, pair, chatWith, shot, sweep, done, poll } from '../driver.mjs';
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Timer Tim', mobile: true }),
+  await createAccount({ name: 'Bo', mobile: true }),
+];
+await pair(a, b);
+const chatId = await chatWith(a, b.id);
+await a.page.goto(`/chat/${chatId}`);
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-textarea')), Boolean, { label: 'composer' });
+
+// Open the timer sheet and pick 5 minutes.
+await a.page.evaluate(() => document.querySelector('.ttl-btn')?.click());
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-action-sheet')), Boolean, { label: 'timer sheet' });
+await a.page.evaluate(() => {
+  const sheet = document.querySelector('ion-action-sheet');
+  [...sheet.querySelectorAll('button')].find((x) => /5 minutes/i.test(x.textContent))?.click();
+  sheet?.dismiss?.(); // synthetic click fires the handler but doesn't auto-dismiss in the harness
+});
+await poll(() => a.page.evaluate(() => document.querySelector('.ttl-badge')?.textContent?.trim() === '5m'), Boolean, { label: 'badge 5m' });
+console.log('timer badge:', await a.page.evaluate(() => document.querySelector('.ttl-badge')?.textContent?.trim()));
+await shot(a, 'msg-timer-set');
+
+// The timer UI is verified (badge). Now exercise the send-side plumbing directly (sendMessage with a
+// per-message override → stampExpiry), which is what the composer's send() calls with msgTtl.
+await a.page.evaluate(() => document.querySelectorAll('ion-action-sheet').forEach((s) => s.dismiss?.()));
+await a.page.evaluate((id) => window.__ringTest.sendChatMessageTtl(id, 'poof in 5', 5 * 60 * 1000), chatId);
+await poll(
+  () => a.page.evaluate((id) => window.__ringTest.messages(id).then((ms) => ms.some((m) => m.body === 'poof in 5')), chatId),
+  Boolean,
+  { label: 'message sent' },
+);
+const info = await a.page.evaluate(async (id) => {
+  const ms = await window.__ringTest.messages(id);
+  const m = ms.find((x) => x.body === 'poof in 5');
+  return { expiresAt: m?.expiresAt, inMs: m?.expiresAt ? m.expiresAt - Date.now() : null };
+}, chatId);
+const min = info.inMs !== null ? Math.round(info.inMs / 60000) : null;
+console.log(`sent message expiry: ~${min} min out (expect ~5)`);
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/chat-quality-perkind.mjs
+++ b/drive/scenarios/chat-quality-perkind.mjs
@@ -1,0 +1,48 @@
+/**
+ * Per-kind media quality: the contact info menu has separate Photo quality and Video quality rows,
+ * each settable independently and persisted per chat.
+ *
+ *   HEADED=1 node drive/scenarios/chat-quality-perkind.mjs
+ */
+import { preflight, createAccount, pair, chatWith, shot, sweep, done, poll } from '../driver.mjs';
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Q', mobile: true }),
+  await createAccount({ name: 'Bo', mobile: true }),
+];
+await pair(a, b);
+await chatWith(a, b.id); // ensure a chat exists so the per-chat rows show
+
+await a.page.goto(`/contact/${b.id}`);
+await poll(
+  () => a.page.evaluate(() => [...document.querySelectorAll('ion-label')].some((l) => /Photo quality/.test(l.textContent))),
+  Boolean,
+  { label: 'quality rows' },
+);
+const rows = await a.page.evaluate(() =>
+  [...document.querySelectorAll('ion-item')]
+    .filter((it) => /quality/i.test(it.textContent))
+    .map((it) => it.textContent.replace(/\s+/g, ' ').trim()),
+);
+console.log('quality rows:', JSON.stringify(rows));
+await shot(a, 'quality-rows');
+
+// Set Video quality to SD and confirm the row updates (and persists in the chat record).
+await a.page.evaluate(() => [...document.querySelectorAll('ion-item')].find((it) => /Video quality/.test(it.textContent))?.click());
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-action-sheet')), Boolean, { label: 'video sheet' });
+await a.page.evaluate(() => {
+  const sheet = document.querySelector('ion-action-sheet');
+  [...sheet.querySelectorAll('button')].find((x) => /^SD/.test(x.textContent.trim()))?.click();
+  sheet?.dismiss?.();
+});
+await poll(
+  () => a.page.evaluate(() => [...document.querySelectorAll('ion-item')].find((it) => /Video quality/.test(it.textContent))?.textContent.includes('SD')),
+  Boolean,
+  { label: 'video = SD' },
+);
+const videoRow = await a.page.evaluate(() => [...document.querySelectorAll('ion-item')].find((it) => /Video quality/.test(it.textContent))?.textContent.replace(/\s+/g, ' ').trim());
+console.log('after set:', JSON.stringify(videoRow));
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/chat-remove-media.mjs
+++ b/drive/scenarios/chat-remove-media.mjs
@@ -1,0 +1,43 @@
+/**
+ * Removing a staged attachment removes ONLY that item, even on a fast double-tap. Before the fix,
+ * repeated taps reused a stale v-for index and deleted the next items too.
+ *
+ *   HEADED=1 node drive/scenarios/chat-remove-media.mjs
+ */
+import { preflight, createAccount, pair, chatWith, sweep, done, poll } from '../driver.mjs';
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Rem', mobile: true }),
+  await createAccount({ name: 'Bo', mobile: true }),
+];
+await pair(a, b);
+const chatId = await chatWith(a, b.id);
+await a.page.goto(`/chat/${chatId}`);
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-textarea')), Boolean, { label: 'composer' });
+
+await a.page.setInputFiles(
+  'input[type=file][multiple]',
+  Array.from({ length: 5 }, (_, i) => ({ name: `p${i}.png`, mimeType: 'image/png', buffer: PNG })),
+);
+await poll(() => a.page.evaluate(() => document.querySelectorAll('.paste-thumb').length), (n) => n === 5, { label: '5 staged' });
+
+// Fire TWO clicks on the first remove button synchronously, before Vue re-renders. With id-based
+// removal the second is a no-op (that item is already gone), so exactly one is removed → 4 remain.
+// The old index-based code would have spliced position 0 twice → 3 remain.
+await a.page.evaluate(() => {
+  const btn = document.querySelector('.paste-x');
+  btn?.click();
+  btn?.click();
+});
+await a.page.waitForTimeout(400);
+const left = await a.page.evaluate(() => document.querySelectorAll('.paste-thumb').length);
+console.log(`double-tap one ×: ${left} remain (expect 4, buggy=3)`);
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/contact-delete-confirm.mjs
+++ b/drive/scenarios/contact-delete-confirm.mjs
@@ -1,0 +1,42 @@
+/**
+ * Swipe-deleting a contact from the Contacts list now asks for confirmation (with a hint about what
+ * it does) instead of deleting instantly.
+ *
+ *   HEADED=1 node drive/scenarios/contact-delete-confirm.mjs
+ */
+import { preflight, createAccount, pair, shot, sweep, done, poll } from '../driver.mjs';
+
+await preflight();
+const [a, b] = [
+  await createAccount({ name: 'Alice', mobile: true }),
+  await createAccount({ name: 'Bob', mobile: true }),
+];
+await pair(a, b);
+
+await a.page.goto('/tabs/contacts');
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-item-sliding')), Boolean, { label: 'contacts list' });
+
+// Open the swipe actions on the first contact and tap the delete option.
+await a.page.evaluate(() => {
+  const sliding = document.querySelector('ion-item-sliding');
+  sliding?.open('end');
+});
+await a.page.waitForTimeout(300);
+await a.page.evaluate(() => {
+  document.querySelector('ion-item-option[color="danger"]')?.click();
+});
+
+// A confirmation alert should appear (not an instant delete).
+await poll(() => a.page.evaluate(() => !!document.querySelector('ion-alert')), Boolean, { label: 'confirm alert' });
+const alertText = await a.page.evaluate(() => {
+  const al = document.querySelector('ion-alert');
+  return {
+    header: al?.querySelector('.alert-title, .alert-head h2')?.textContent?.trim() || al?.textContent?.slice(0, 60),
+    buttons: [...(al?.querySelectorAll('.alert-button') || [])].map((b) => b.textContent.trim()),
+  };
+});
+console.log('alert:', JSON.stringify(alertText));
+await shot(a, 'contact-delete-confirm');
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/wall-interrupted-finish.mjs
+++ b/drive/scenarios/wall-interrupted-finish.mjs
@@ -1,0 +1,60 @@
+/**
+ * Spec 1024: a post interrupted by a full app close is recovered as a DRAFT. The Wall shows a
+ * "Post didn't finish" card (Finish / Discard); Finish reopens the composer with the caption + voice
+ * note restored and the library media dropped to re-add.
+ *
+ *   HEADED=1 node drive/scenarios/wall-interrupted-finish.mjs
+ */
+import { preflight, createAccount, shot, sweep, done, poll, SHOT_DIR } from '../driver.mjs';
+import path from 'node:path';
+
+await preflight();
+const me = await createAccount({ name: 'Resume Rita', mobile: true });
+
+// Seed an interrupted draft: caption + a voice note, with library media marked dropped.
+const id = await me.page.evaluate(() => window.__ringTest.seedInterruptedPost('My recovered caption', true));
+console.log('seeded interrupted draft', id);
+
+await me.page.goto('/tabs/wall');
+await poll(
+  () => me.page.evaluate(() => !!document.querySelector('.pending-post')),
+  Boolean,
+  { label: 'interrupted card visible' },
+);
+const sub = await me.page.evaluate(() => document.querySelector('.pending-post .sub')?.textContent?.trim());
+const actions = await me.page.evaluate(() =>
+  Array.from(document.querySelectorAll('.pending-actions ion-button')).map((b) => b.textContent.trim()),
+);
+console.log('card sub:', sub, '| actions:', actions);
+await shot(me, 'interrupted-card');
+
+// Tap Finish → composer opens with the caption + voice note restored.
+await me.page.evaluate(() => {
+  const btns = Array.from(document.querySelectorAll('.pending-actions ion-button'));
+  btns.find((b) => b.textContent.trim() === 'Finish')?.click();
+});
+await poll(
+  () => me.page.evaluate(() => location.hash.includes('/wall/compose') || location.pathname.includes('/wall/compose')),
+  Boolean,
+  { label: 'composer route' },
+);
+// Let the draft load + paint.
+await poll(
+  () => me.page.evaluate(() => {
+    const ta = document.querySelector('ion-textarea');
+    return !!ta && !!(ta.value || '').trim();
+  }),
+  Boolean,
+  { label: 'caption restored' },
+);
+const restored = await me.page.evaluate(() => {
+  const ta = document.querySelector('ion-textarea');
+  const voiceTiles = document.querySelectorAll('.album-stage .stage-thumb, .voice-thumb, ion-item').length;
+  return { caption: ta?.value || '', hasVoiceTile: document.body.innerText.toLowerCase().includes('voice') || voiceTiles > 0 };
+});
+console.log('restored in composer:', JSON.stringify(restored));
+await shot(me, 'interrupted-composer');
+
+console.log('screenshots in', path.relative(process.cwd(), SHOT_DIR));
+await sweep([me]);
+await done();

--- a/drive/scenarios/wall-interrupted-finish.mjs
+++ b/drive/scenarios/wall-interrupted-finish.mjs
@@ -47,10 +47,20 @@ await poll(
   Boolean,
   { label: 'caption restored' },
 );
+// Both attachments (the photo and the voice clip) should be staged in the composer.
+await poll(
+  () => me.page.evaluate(() => document.querySelectorAll('.stage-thumb').length),
+  (n) => n === 2,
+  { label: 'photo + voice restored' },
+);
 const restored = await me.page.evaluate(() => {
   const ta = document.querySelector('ion-textarea');
-  const voiceTiles = document.querySelectorAll('.album-stage .stage-thumb, .voice-thumb, ion-item').length;
-  return { caption: ta?.value || '', hasVoiceTile: document.body.innerText.toLowerCase().includes('voice') || voiceTiles > 0 };
+  return {
+    caption: ta?.value || '',
+    stagedTiles: document.querySelectorAll('.stage-thumb').length,
+    hasImageTile: !!document.querySelector('.stage-thumb img'),
+    hasVoiceTile: !!document.querySelector('.stage-voice'),
+  };
 });
 console.log('restored in composer:', JSON.stringify(restored));
 await shot(me, 'interrupted-composer');

--- a/drive/scenarios/wall-pending-retry.mjs
+++ b/drive/scenarios/wall-pending-retry.mjs
@@ -11,12 +11,14 @@ import path from 'node:path';
 await preflight();
 const me = await createAccount({ name: 'Pending Pat', mobile: true });
 
-// Seed a failed pending post directly into the outbox (dev-only testhook helper).
+// Reach the Wall, then make sure cold-start recovery has already run (it's once-per-load) before we
+// seed an IN-SESSION failure — otherwise recovery would sweep our seed into a draft (correct in real
+// life, but here we want the in-session Retry/Cancel card, which renders reactively).
+await me.page.goto('/tabs/wall');
+await me.page.waitForFunction(() => !!window.__ringTest, null, { timeout: 30_000 });
+await me.page.evaluate(() => window.__ringTest.recoverPending());
 const id = await me.page.evaluate(() => window.__ringTest.seedFailedPendingPost('My stuck post'));
 console.log('seeded failed pending post', id);
-
-// Land on the Wall — the failed card should render with Retry/Cancel.
-await me.page.goto('/tabs/wall');
 await poll(
   () => me.page.evaluate(() => !!document.querySelector('.pending-post')),
   Boolean,

--- a/drive/scenarios/wall-pending-retry.mjs
+++ b/drive/scenarios/wall-pending-retry.mjs
@@ -1,0 +1,50 @@
+/**
+ * Spec 1024 (US2): the Wall's FAILED pending-post card — "Couldn't post" with Retry/Cancel.
+ * Seeds a failed outbox record, screenshots the card, taps Cancel, confirms the outbox cleared.
+ *
+ *   HEADED=1 node drive/scenarios/wall-pending-retry.mjs
+ * Screenshots land in .tmp/drive/.
+ */
+import { preflight, createAccount, shot, sweep, done, poll, SHOT_DIR } from '../driver.mjs';
+import path from 'node:path';
+
+await preflight();
+const me = await createAccount({ name: 'Pending Pat', mobile: true });
+
+// Seed a failed pending post directly into the outbox (dev-only testhook helper).
+const id = await me.page.evaluate(() => window.__ringTest.seedFailedPendingPost('My stuck post'));
+console.log('seeded failed pending post', id);
+
+// Land on the Wall — the failed card should render with Retry/Cancel.
+await me.page.goto('/tabs/wall');
+await poll(
+  () => me.page.evaluate(() => !!document.querySelector('.pending-post')),
+  Boolean,
+  { label: 'pending card visible' },
+);
+await shot(me, 'pending-failed-card');
+
+// The card shows the two actions.
+const labels = await me.page.evaluate(() =>
+  Array.from(document.querySelectorAll('.pending-actions ion-button')).map((b) => b.textContent.trim()),
+);
+console.log('action buttons:', labels);
+
+// Tap Cancel → the outbox record is discarded.
+const before = await me.page.evaluate(() => window.__ringTest.pendingPostCount());
+await me.page.evaluate(() => {
+  const btns = Array.from(document.querySelectorAll('.pending-actions ion-button'));
+  btns.find((b) => b.textContent.trim() === 'Cancel')?.click();
+});
+await poll(
+  () => me.page.evaluate(() => window.__ringTest.pendingPostCount()),
+  (n) => n === 0,
+  { label: 'outbox cleared after Cancel' },
+);
+const after = await me.page.evaluate(() => window.__ringTest.pendingPostCount());
+console.log(`outbox count: ${before} -> ${after}`);
+await shot(me, 'pending-after-cancel');
+
+console.log('screenshots in', path.relative(process.cwd(), SHOT_DIR));
+await sweep([me]);
+await done();

--- a/e2e/chat-media-captions.spec.ts
+++ b/e2e/chat-media-captions.spec.ts
@@ -51,7 +51,6 @@ test('media picked from the library can be captioned before sending (not just pa
   await composer.click();
   await composer.pressSequentially('from my library', { delay: 12 });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  await a.page.getByText('Original quality').click(); // tiny PNGs only offer Original
 
   // The image bubble carries the caption; the staging row is cleared.
   await expect(a.page.locator('.bubble .bubble-image').last()).toBeVisible({ timeout: 30_000 });
@@ -96,7 +95,6 @@ test('multiple picked photos can be sent individually, each carrying the shared 
   await composer.click();
   await composer.pressSequentially('trip', { delay: 12 });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  await a.page.getByText('Original quality').click(); // tiny PNGs only offer Original
 
   // Three SEPARATE image messages (no shared albumId), each carrying the shared caption.
   await expect
@@ -144,7 +142,6 @@ test('a per-item caption overrides the shared caption for just that item', async
   await composer.pressSequentially('the others', { delay: 12 });
   await a.page.locator('.send-mode ion-segment-button').nth(1).click(); // Individual
   await a.page.getByRole('button', { name: 'Send' }).click();
-  await a.page.getByText('Original quality').click(); // tiny PNGs only offer Original
 
   // The first item carries its own caption; the second falls back to the shared one.
   await expect
@@ -184,7 +181,6 @@ test('multiple picked photos sent as an album share one album id with a single c
   await composer.click();
   await composer.pressSequentially('holiday', { delay: 12 });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  await a.page.getByText('Original quality').click(); // tiny PNGs only offer Original
 
   // All three images share ONE album id, and exactly one of them carries the caption.
   await expect

--- a/e2e/chat-media-captions.spec.ts
+++ b/e2e/chat-media-captions.spec.ts
@@ -128,14 +128,15 @@ test('a per-item caption overrides the shared caption for just that item', async
   await photoInput(a).setInputFiles([pngFile('one.png'), pngFile('two.png')]);
   await expect(a.page.locator('.paste-thumb')).toHaveCount(2, { timeout: 10_000 });
 
-  // Tap the FIRST staged item → caption it individually via the alert.
+  // Tap the FIRST staged item → caption it individually via the caption modal.
   await a.page.locator('.paste-tap').first().click();
-  const alertBox = a.page.locator('ion-alert textarea');
-  await alertBox.waitFor({ state: 'visible', timeout: 10_000 });
-  await alertBox.fill('just this one');
-  await a.page.locator('ion-alert button', { hasText: 'Save' }).click();
+  const captionBox = a.page.locator('.caption-modal ion-textarea textarea');
+  await captionBox.waitFor({ state: 'visible', timeout: 10_000 });
+  await captionBox.click();
+  await captionBox.pressSequentially('just this one', { delay: 8 });
+  await a.page.locator('.caption-modal ion-button', { hasText: 'Save' }).click();
   // The captioned item shows its badge ring.
-  await expect(a.page.locator('.paste-thumb.has-cap')).toHaveCount(1);
+  await expect(a.page.locator('.paste-thumb.has-cap')).toHaveCount(1, { timeout: 10_000 });
 
   // Type a SHARED caption for the rest and send individually.
   await composer.click();

--- a/e2e/chat-media-scroll.spec.ts
+++ b/e2e/chat-media-scroll.spec.ts
@@ -26,7 +26,6 @@ async function pasteImage(p: any): Promise<void> {
     ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
   });
   await p.page.getByRole('button', { name: 'Send' }).click();
-  await p.page.getByText('Original quality').click();
 }
 
 test('image renders in the list and the full-screen viewer opens on tap', async ({ browser }) => {

--- a/e2e/message-menu.spec.ts
+++ b/e2e/message-menu.spec.ts
@@ -68,7 +68,6 @@ test('a single tap on an image opens the viewer directly (no menu step)', async 
     ta.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
   });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  await a.page.getByText('Original quality').click();
 
   const image = a.page.locator('.bubble .bubble-image').last();
   await expect(image).toBeVisible({ timeout: 30_000 });

--- a/e2e/paste-image.spec.ts
+++ b/e2e/paste-image.spec.ts
@@ -44,7 +44,6 @@ test('pasted image sends with the typed caption', async ({ browser }) => {
   // Type the caption below the thumbnail and send (Original skips compression).
   await composer.pressSequentially('From my clipboard', { delay: 15 });
   await a.page.getByRole('button', { name: 'Send' }).click();
-  await a.page.getByText('Original quality').click();
 
   // Sender side: an image bubble with the caption under the photo, staging row gone.
   await expect(a.page.locator('.bubble .bubble-image').last()).toBeVisible({ timeout: 30_000 });

--- a/server/internal/api/blob_handlers.go
+++ b/server/internal/api/blob_handlers.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"ring/server/internal/auth"
 	"ring/server/internal/httpx"
@@ -73,7 +74,11 @@ func (h *Handlers) downloadBlob(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusNotFound, "blob not found")
 		return
 	}
+	// Set Content-Length explicitly so the client can show an accurate download progress
+	// bar. Without it Go streams the body chunked (no length), and the receiver can only
+	// tell "started" vs "done" — the progress ring would jump instead of filling smoothly.
 	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.Itoa(len(bytes)))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(bytes)
 }

--- a/server/internal/api/blob_sync_handlers_test.go
+++ b/server/internal/api/blob_sync_handlers_test.go
@@ -148,6 +148,10 @@ func TestBlobUploadDownload(t *testing.T) {
 	if rr.Code != http.StatusOK || rr.Body.String() != "ENCRYPTED-BYTES" {
 		t.Fatalf("download mismatch: status=%d body=%q", rr.Code, rr.Body.String())
 	}
+	// Content-Length must be present so the client can render an accurate download progress bar.
+	if got := rr.Result().Header.Get("Content-Length"); got != strconv.Itoa(len("ENCRYPTED-BYTES")) {
+		t.Fatalf("download Content-Length = %q, want %d", got, len("ENCRYPTED-BYTES"))
+	}
 
 	// Unknown id → 404; no auth → 401.
 	if rr := do(t, srv, http.MethodGet, "/v1/blobs/nope", token, ""); rr.Code != http.StatusNotFound {

--- a/specs/1024-resilient-posting-and-storage/checklists/zero-knowledge.md
+++ b/specs/1024-resilient-posting-and-storage/checklists/zero-knowledge.md
@@ -1,0 +1,48 @@
+# Checklist: Zero-Knowledge & Requirements Quality — 1024
+
+**Purpose**: Validate that the requirements for resilient posting + storage are written well enough
+to implement without eroding the zero-knowledge boundary (Constitution Principle I / IV). Unit tests
+for the English, not the code.
+
+**Created**: 2026-06-30 · **Focus**: Zero-Knowledge (required) + completeness/clarity/edge-cases ·
+**Audience**: Reviewer (pre-implementation gate)
+
+## Zero-Knowledge & Crypto (Principle I / IV)
+
+- [x] CHK001 Does the spec explicitly state what (if anything) NEW crosses the client/server boundary, and confirm it is unchanged? [Completeness, Spec §Zero-Knowledge Impact]
+- [x] CHK002 Is the at-rest treatment of the cached working blobs specified (plaintext, same class as the existing `media` store, not separately AEAD-wrapped)? [Clarity, Spec §ZK Impact / FR-011]
+- [x] CHK003 Are requirements clear that only sealed ciphertext + opaque blob ids are uploaded — no new fields, endpoints, or recipient metadata? [Clarity, Spec §FR-011, contracts/outbox.md]
+- [x] CHK004 Is it specified that per-item confirmation adds NO new server-visible metadata (rides existing responses)? [Completeness, Spec §ZK Impact / FR-014]
+- [x] CHK005 Is the deletion guarantee for cached plaintext blobs defined (none lingering after finalize/cancel)? [Edge Case, Spec §FR-008 / SC-006]
+- [x] CHK006 Do timestamp requirements stay client-set on the sealed envelope (no new server timestamp authority)? [Consistency, Spec §ZK Impact / FR-004]
+- [x] CHK007 Is `/speckit-checklist` (this gate) recorded as a required pre-implementation step? [Traceability, Spec §ZK Impact / tasks T021]
+
+## Requirement Completeness
+
+- [x] CHK008 Are all pending-post states and transitions (uploading → finalized / failed / canceled) fully specified? [Completeness, data-model.md]
+- [x] CHK009 Is "the post is made" defined unambiguously (every item confirmed AND the envelope confirmed)? [Clarity, Spec §FR-004]
+- [x] CHK010 Is the new `outbox` store + `DB_VERSION` bump captured as a requirement (offline-first integrity)? [Completeness, plan §Constitution Check V]
+- [x] CHK011 Is the storage-exhaustion mid-flight outcome specified (failed + free-space hint, no partial post)? [Completeness, Spec §FR-010]
+
+## Requirement Clarity / Measurability
+
+- [x] CHK012 Are auto-retry semantics quantified ("once", guarded by attempts, before asking)? [Clarity, Spec §FR-013]
+- [x] CHK013 Is "resume only unconfirmed items" backed by a defined per-item confirmation signal? [Clarity, Spec §FR-014]
+- [x] CHK014 Is the storage headroom quantified (×2.5, 50 MB floor) rather than "enough space"? [Measurability, research D6]
+- [x] CHK015 Is "dismisses immediately" given a measurable target? [Measurability, Spec §SC-001]
+
+## Consistency
+
+- [x] CHK016 Are chat + Wall outbox requirements consistent (same worker, same resume path)? [Consistency, Spec §FR-012]
+- [x] CHK017 Does the disappear-timer-at-confirmation requirement align across spec, plan, and research? [Consistency, Spec §FR-004 / research D2]
+
+## Edge Cases & Scope
+
+- [x] CHK018 Is the behavior for a corrupt/unreadable cached blob on resume specified? [Edge Case, Spec §Edge Cases]
+- [x] CHK019 Is degraded behavior specified when `navigator.storage.estimate` is unavailable (no-op, never block)? [Edge Case, Spec §Assumptions / FR-009]
+- [x] CHK020 Is the out-of-scope boundary explicit (no SW background-upload queue, no edit-after-Share, no cross-device handoff)? [Clarity, Spec §Out of Scope]
+
+## Evaluation result
+
+All 20 items **pass** against the current spec/plan/research (every item traces to an existing,
+quantified requirement). No gaps to remediate → **ZK gate clear for `/speckit-implement`.**

--- a/specs/1024-resilient-posting-and-storage/contracts/outbox.md
+++ b/specs/1024-resilient-posting-and-storage/contracts/outbox.md
@@ -1,0 +1,60 @@
+# Contract — Outbox & upload worker (client)
+
+This feature exposes **no new server API**. The "interface" is the client-side outbox contract
+(data layer + worker) plus the **reused** server endpoints whose success responses act as the
+confirmation receipt.
+
+## Reused server endpoints (unchanged)
+
+| Endpoint | Role in this feature |
+|----------|----------------------|
+| `POST /v1/blobs` (`uploadBlob`) | Upload one sealed media blob → returns its **blob id** = per-item confirmation (FR-014). |
+| `POST /v1/posts` (`createPost`) | Submit the sealed envelope + recipients → 2xx = the post is **made**; client stamps `createdAt=now` then (FR-004). |
+| `POST /v1/messages` (chat send) | Same role for `target='chat'` media sends (FR-012). |
+
+No request/response shape changes; no new fields; zero migration.
+
+## Client data-layer contract (`src/db/queries.ts` + `src/services/outbox.ts`)
+
+```ts
+// Enqueue: cache blobs + persist the pending record, then the composer dismisses immediately.
+// Returns the outbox id so the UI can show its pending card.
+enqueueOutboxPost(input: {
+  target: 'wall' | 'chat';
+  chatId?: string;
+  body: string;
+  audience?: 'friends' | 'close';
+  lifetime?: PostLifetime;
+  items: { blob: Blob; kind: 'image'|'video'|'voice'; name: string; mime: string;
+           durationSec?: number; width?: number; height?: number; poster?: string }[];
+}): Promise<string>;
+
+// Worker: drain the outbox sequentially (encode → upload each unconfirmed item → seal → createPost).
+// Idempotent + resumable; safe to call on enqueue, app start, and 'online'.
+drainOutbox(): Promise<void>;
+
+// Auto-retry-once entry point, called on app start / keystore unlock (FR-013).
+resumeOutboxOnStart(): Promise<void>;
+
+retryOutboxPost(id: string): Promise<void>;   // manual Retry (failed → uploading; unconfirmed only)
+cancelOutboxPost(id: string): Promise<void>;  // delete record + cached blobs (FR-006/008)
+
+listOutbox(): Promise<OutboxPost[]>;           // for useOutbox / useLiveQuery('outbox')
+```
+
+## Behavioral contract (assertions for tests)
+
+- `enqueueOutboxPost` resolves **before** any encode/upload starts; the composer can dismiss on its
+  resolution (SC-001).
+- After enqueue, `listOutbox()` contains the record with `status='uploading'` and each item
+  `blobId === undefined`, `progress === 0`.
+- `drainOutbox` sets `item.blobId` as each upload confirms; never re-uploads an item that already has
+  a `blobId`.
+- On full success: a real `Post` exists with `createdAt ≈` the `createPost` time; the `outbox` row
+  and every `item.blob` are gone (SC-003/006).
+- On forced failure mid-drain: `status='failed'`, `error` set, record + blobs retained;
+  `retryOutboxPost` finishes it re-sending only the unconfirmed items.
+- `cancelOutboxPost`: record + blobs removed; no envelope/message was sent.
+- Storage guard (`services/storage-estimate.ts`): `hasRoomFor(bytes): Promise<boolean>` returns
+  `false` when `freeSpace < bytes × 2.5` (floor 50 MB); returns `true` (best-effort) when
+  `navigator.storage.estimate` is unavailable.

--- a/specs/1024-resilient-posting-and-storage/data-model.md
+++ b/specs/1024-resilient-posting-and-storage/data-model.md
@@ -1,0 +1,83 @@
+# Phase 1 — Data Model: Resilient posting & storage
+
+## Object store: `outbox` (IndexedDB, keyPath `id`)
+
+One record per pending post/send (Wall or chat). Created via a `DB_VERSION` bump +
+`onupgradeneeded` in `src/db/idb.ts`. Written through the change-bus so `useLiveQuery('outbox')`
+keeps the pending UI reactive.
+
+### `OutboxPost`
+
+| Field          | Type                                   | Notes |
+|----------------|----------------------------------------|-------|
+| `id`           | `string`                               | uid; primary key. |
+| `target`       | `'wall' \| 'chat'`                     | where it publishes. |
+| `chatId`       | `string \| undefined`                  | required when `target='chat'`. |
+| `body`         | `string`                               | caption / message text (may be empty). |
+| `audience`     | `'friends' \| 'close' \| undefined`    | Wall only. |
+| `lifetime`     | `PostLifetime \| undefined`            | Wall only ('1h' \| '24h' \| '72h'). |
+| `items`        | `OutboxItem[]`                         | ordered; the album/media. |
+| `status`       | `'uploading' \| 'failed' \| 'canceled'`| see state machine. |
+| `error`        | `string \| undefined`                  | last failure reason (free-space, network…). |
+| `attempts`     | `number`                               | worker attempts; drives the once-auto-retry. |
+| `createdLocally`| `number`                              | ms at Share — ordering of pending items ONLY. |
+| `updatedAt`    | `number`                               | change-bus / last-write. |
+
+> NOTE: there is **no** `createdAt` here. `createdAt` is stamped only when the post finalizes
+> (envelope confirmed) and is written to the real `posts` store — never derived from `createdLocally`
+> (FR-004 / SC-003).
+
+### `OutboxItem`
+
+| Field         | Type                              | Notes |
+|---------------|-----------------------------------|-------|
+| `localId`     | `string`                          | stable id within the post. |
+| `blob`        | `Blob`                            | **cached working copy** (taken at Share; plaintext, local-only). |
+| `kind`        | `'image' \| 'video' \| 'voice'`   | item kind. |
+| `name`        | `string`                          | filename. |
+| `mime`        | `string`                          | source mime. |
+| `durationSec` | `number \| undefined`             | audio/video. |
+| `width/height`| `number \| undefined`             | images/videos. |
+| `poster`      | `string \| undefined`             | embedded video poster (data URL). |
+| `blobId`      | `string \| undefined`             | **set when uploaded/confirmed** → per-item confirmation (FR-014). |
+| `progress`    | `number`                          | 0..1, encode+upload progress for this item. |
+
+## State machine (per `OutboxPost`)
+
+```text
+            enqueue (Share)
+                 │
+                 ▼
+        ┌─────────────────┐   all items have blobId
+        │   uploading      │──────────────┐
+        │ (worker draining)│              ▼
+        └─────────────────┘        seal envelope → createPost()
+            │        ▲                     │ 2xx
+   network/ │        │ retry / drain       ▼
+   storage  │        │                FINALIZED → write to `posts`
+   error    ▼        │                (createdAt = now), delete outbox record + blobs
+        ┌─────────────────┐
+        │     failed       │── auto-retry once on app start ──► uploading
+        │ (Retry / Cancel) │── manual Retry ───────────────────► uploading
+        └─────────────────┘── Cancel ──► delete record + cached blobs (canceled)
+```
+
+### Transitions / rules
+
+- **uploading**: worker processes items sequentially; an item with a `blobId` is skipped on resume
+  (re-send only the unconfirmed — FR-014). `progress` updates flow via the change-bus.
+- **finalize**: only when every item has a `blobId` AND `createPost()` returns 2xx → create the real
+  `Post` with `createdAt = now()`, then **delete** the outbox record + all `item.blob`s (FR-008).
+- **failed**: any unrecoverable step (offline after retries, storage exhausted) sets `status='failed'`
+  + `error`; the record + blobs persist for Retry. Storage-exhaustion error carries the free-space
+  hint (FR-010).
+- **auto-retry-once**: on app start/unlock, each `uploading`-but-stalled or `failed` post is retried
+  automatically a single time (guarded by `attempts`) before Retry/Cancel is surfaced (FR-013).
+- **canceled**: terminal; record + cached blobs removed, no envelope sent (FR-006).
+
+## Validation
+
+- `target='chat'` ⇒ `chatId` present; `target='wall'` ⇒ `audience` + `lifetime` present.
+- `items.length ≥ 1` OR `body` non-empty (a text-only post needs no outbox; it's not media-bound).
+- `items.length ≤ 10` (existing per-post cap).
+- A finalized post MUST NOT leave any `outbox` row or `item.blob` behind (SC-006).

--- a/specs/1024-resilient-posting-and-storage/plan.md
+++ b/specs/1024-resilient-posting-and-storage/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: Resilient posting & on-device storage management
+
+**Branch**: `feat/1024-resilient-posting-and-storage` | **Date**: 2026-06-30 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1024-resilient-posting-and-storage/spec.md`
+
+## Summary
+
+Make sharing media (Wall posts + chat media) **fire-and-forget and crash-safe**. On Share we
+persist a pending record — *with our own copies of the selected blobs* — to a new IndexedDB
+**outbox**, dismiss the composer instantly, and render the pending item (with progress) on the Wall
+feed / in the chat thread. A client-side **upload worker** drains the outbox: encode/resize → upload
+each blob → seal + send the envelope, tracking **per-item confirmation** so a resume re-sends only
+what the server doesn't already have. The post is "made" (and its disappear timer starts) **only
+when the envelope is confirmed**. Interrupted work **auto-retries once** on next app open, then
+offers Retry/Cancel. A **storage-estimate guard** at media selection warns before encoding when free
+space is short. No new server surface: the existing `uploadBlob` + `createPost` responses ARE the
+confirmation; only the *client* changes (plus a `DB_VERSION` bump for the outbox store).
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES modules, `@/`→`src/`), Vue 3 `<script setup>` + Ionic; Go 1.26 server (unchanged by this feature).
+
+**Primary Dependencies**: Vue 3 / Ionic, the `idb` wrapper (`src/db/idb.ts`) + change-bus + `useLiveQuery`, the existing media pipeline (`media-transfer` upload/download, `media-video` encode, `posts` seal), libsodium core (reused, unchanged).
+
+**Storage**: IndexedDB on-device. **New `outbox` object store** (pending posts + cached working blobs) → `DB_VERSION` bump + `onupgradeneeded` extension. Reuses existing `posts`/`media` stores. Server: PostgreSQL `post_envelopes`/blobs — **no schema change** (FR confirmation rides existing endpoints).
+
+**Testing**: `npm run build` (vue-tsc typecheck) · vitest (client unit, e.g. outbox queries + storage estimate) · Playwright e2e (resilient-posting + resume + storage-guard) · `go test ./...` (server — expected no-op here).
+
+**Target Platform**: Installable PWA (iOS/Android/desktop browsers), offline-first.
+
+**Project Type**: Web app (PWA client + Go backend); **this feature is client-only**.
+
+**Performance Goals**: Composer dismiss + pending item visible **< ~300 ms** (SC-001); progress updates feel live; the worker reuses the pipeline's existing off-main-thread encode so it doesn't freeze the UI.
+
+**Constraints**: Zero-knowledge boundary intact; offline-first (IndexedDB is source of truth); PIN-lock at-rest model unchanged; forward-only schema (DB version bump, no edits to shipped upgrades); Ionic-first UI.
+
+**Scale/Scope**: Small per-user outbox (typically 0–3 pending posts; ≤10 media items each per the existing cap). Cached working blobs are transient (deleted on finalize/cancel).
+
+## Constitution Check
+
+*GATE: must pass before Phase 0; re-checked after Phase 1.*
+
+- **I. Zero-Knowledge Boundary (NON-NEGOTIABLE)** — PASS. Nothing new crosses to the server: only sealed ciphertext + opaque blob ids are uploaded, exactly as today. The outbox's cached working blobs are **local-only plaintext**, the same class as the existing `media` store blobs (device + PIN-lock protected, not separately AEAD-wrapped) — no regression. A dedicated **"Zero-Knowledge Impact"** section is added to the spec (Principle I requires it). **`/speckit-checklist` is REQUIRED** (touches Principle I) and runs before `/speckit-implement`.
+- **III. Test-Driven Development** — PLANNED. `tasks.md` will order failing tests first: vitest unit tests for outbox queries + per-item confirmation + the storage estimate; an e2e spec for share→dismiss→pending→finalize, kill→auto-retry→Retry/Cancel, and the storage-guard warning. New store/data-layer logic ships unit tests; new user-facing behavior extends `e2e/`.
+- **IV. Crypto Discipline** — PASS. No new crypto; reuses the existing seal/upload path. At-rest model unchanged (cached blobs follow the existing `media`-store treatment, not "secrets").
+- **V. Offline-First Data Integrity** — PASS with action. Adding the `outbox` store **MUST bump `DB_VERSION` and extend `onupgradeneeded`** in `src/db/idb.ts`; writes go through the change-bus so `useLiveQuery` keeps the pending UI reactive. Own-data sync semantics unaffected (the outbox is pre-publish local state).
+- **VI. Stateless Server & Forward-Only Migrations** — PASS. No server change, no SQL migration (confirmation is the existing `uploadBlob`/`createPost` responses; `createdAt` is set client-side at confirm time).
+- **XI. Ionic-First UI** — PASS. Pending card = stock `ion-progress-bar`/`ion-spinner` + `ion-button` (Retry/Cancel); storage warning = `alertController`/`ion-toast`. No bespoke components.
+- **VII/VIII** — the feature commit's release-note subject reads as benefit-focused copy; the feature→develop PR lists `Closes #N` for each task issue.
+
+No violations requiring justification → **Complexity Tracking left empty**.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1024-resilient-posting-and-storage/
+├── plan.md              # This file
+├── research.md          # Phase 0 decisions
+├── data-model.md        # Phase 1 — the outbox entity + state machine
+├── quickstart.md        # Phase 1 — how to exercise/verify
+├── contracts/
+│   └── outbox.md        # Phase 1 — client outbox/worker contract (no new server API)
+└── tasks.md             # /speckit-tasks output (later)
+```
+
+### Source Code (repository root — client-only feature)
+
+```text
+src/
+├── db/
+│   ├── idb.ts                 # DB_VERSION bump + 'outbox' store (onupgradeneeded)
+│   ├── types.ts               # OutboxPost type
+│   └── queries.ts             # outbox CRUD + per-item confirmation; createPost → enqueue
+├── services/
+│   ├── outbox.ts              # NEW: the upload worker (drain/resume/auto-retry once)
+│   ├── storage-estimate.ts    # NEW: navigator.storage.estimate() guard (+ headroom factor)
+│   └── (media-transfer.ts, posts.ts, media-video.ts reused unchanged in shape)
+├── composables/
+│   ├── useWall.ts             # merge outbox (pending) items into the feed at the top
+│   └── useOutbox.ts           # NEW: reactive pending list + progress (useLiveQuery on 'outbox')
+└── views/
+    ├── detail/PostComposerPage.vue   # Share → enqueue + dismiss immediately
+    ├── tabs/WallPage.vue             # render pending posts (progress, Retry/Cancel)
+    └── detail/ChatDetailPage.vue     # render pending chat media message + storage guard
+
+e2e/
+└── resilient-posting.spec.ts  # NEW: dismiss/pending/finalize, resume+auto-retry, storage guard
+```
+
+**Structure Decision**: Single client codebase (the repo's `src/`); no `backend/frontend` split is
+needed because the server is untouched. The outbox + worker live in `src/db` + `src/services` (the
+established data/non-UI layers); UI is confined to the composer, Wall, and chat detail views.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/1024-resilient-posting-and-storage/quickstart.md
+++ b/specs/1024-resilient-posting-and-storage/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart — Resilient posting & storage
+
+How to exercise and verify the feature once implemented.
+
+## Gates
+
+```sh
+npm run build            # vue-tsc typecheck + vite build (client gate)
+npx vitest run           # unit: outbox queries, per-item confirm, storage estimate
+npm run test:e2e         # e2e/resilient-posting.spec.ts (needs `make db-up`)
+cd server && go test ./...   # expected no-op (no server change)
+```
+
+## Manual walkthrough (drive harness on the live dev stack)
+
+1. `make start`, then in the composer pick 2–3 photos/a video + (optionally) record a voice clip.
+2. **Tap Share** → the composer closes *immediately*; a **pending card with a progress bar** sits at
+   the top of the Wall. Scroll / switch tabs — it keeps uploading. *(SC-001, FR-001/002)*
+3. Wait → the card becomes a normal post; its "disappears in…" countdown starts **now**, not from
+   when you tapped Share. *(FR-004/SC-003)*
+4. **Resume:** start another share, then kill the app mid-upload (close the tab / force-quit the
+   PWA). Reopen → it **auto-resumes and finishes**; if you simulate a persistent failure, the card
+   shows **Retry / Cancel**. Retry re-sends only the unconfirmed items. *(FR-005/013/014)*
+5. **Source removal:** after Share, delete the source photo from the device → the post still
+   completes (we uploaded our cached copy). *(FR-007)*
+6. **Storage guard:** with low free space, try to select a large batch → an up-front warning
+   ("free up space and try again") and no encode starts. *(FR-009/SC-004)*
+7. **Cleanup:** after a post finalizes (or you Cancel), confirm IndexedDB has no leftover `outbox`
+   row or cached blob. *(FR-008/SC-006)*
+
+## Chat parity
+
+Repeat steps 1–5 sending media in a chat (not the Wall): the pending media message renders in the
+thread and resumes the same way. *(FR-012)*
+
+## Zero-knowledge spot-check
+
+In devtools → Network, confirm uploads carry only **ciphertext + opaque blob ids** (no plaintext
+media, caption, or recipient identity). The cached `outbox` blobs exist only in local IndexedDB and
+vanish on finalize/cancel.

--- a/specs/1024-resilient-posting-and-storage/research.md
+++ b/specs/1024-resilient-posting-and-storage/research.md
@@ -1,0 +1,78 @@
+# Phase 0 — Research & Decisions: Resilient posting & storage
+
+All open questions resolved; no `NEEDS CLARIFICATION` remain.
+
+## D1 — "Backend confirmation" signal (no new server API)
+
+- **Decision**: Treat the **existing** responses as confirmation. `uploadBlob()` returning a blob id
+  = that item is confirmed-stored; `createPost()` (the sealed envelope POST) succeeding = the post
+  is "made". Track a per-item `blobId`/`confirmed` flag in the outbox; the post finalizes when every
+  item has a blob id **and** the envelope POST returns 2xx.
+- **Rationale**: The server already persists blobs + envelopes durably; its success responses are an
+  authoritative receipt. Adding a bespoke "confirm" endpoint would duplicate that and touch the
+  zero-knowledge server for no benefit (Principle VI).
+- **Alternatives**: A new `/v1/posts/{id}/ack` endpoint (rejected — server change, no added safety);
+  optimistic local "made" without server ack (rejected — violates FR-004 / SC-003).
+
+## D2 — `createdAt` / disappear-timer start
+
+- **Decision**: The client stamps `createdAt = now()` at the moment `createPost()` succeeds (not at
+  Share), and derives `expiresAt = createdAt + lifetime` then. The server stores those as today.
+- **Rationale**: Satisfies FR-004 / SC-003 with zero server change; the client already owns these
+  fields on the envelope.
+- **Alternatives**: Server-assigned timestamp (rejected — needs the server to return it; current
+  envelope is client-timestamped, and clock authority isn't worth a protocol change here).
+
+## D3 — Outbox persistence + cached working blobs
+
+- **Decision**: New IndexedDB `outbox` object store (keyPath `id`) holding the pending record + an
+  array of items, **each with its own `Blob`** (a copy taken at Share). `DB_VERSION` bumps and
+  `onupgradeneeded` creates the store. Writes go through the existing change-bus.
+- **Rationale**: IndexedDB is the offline-first source of truth (Principle V); caching our own blob
+  copies makes the upload independent of the source file (FR-007) and survives app restart (FR-005).
+- **Alternatives**: Hold `File`/source references only (rejected — invalid after the picker closes /
+  source removed); OPFS (rejected — IndexedDB already used everywhere + has the change-bus).
+
+## D4 — Zero-knowledge at-rest treatment of cached blobs
+
+- **Decision**: Store cached working blobs **as plaintext locally**, identical to the existing
+  `media` store. They are deleted on finalize/cancel (FR-008). Only sealed ciphertext is uploaded.
+- **Rationale**: Consistent with the shipped at-rest model (device encryption + PIN-lock gate the
+  app; media blobs aren't separately AEAD-wrapped). No new plaintext crosses the wire → ZK intact.
+  Captured in the spec's Zero-Knowledge Impact section and re-verified by `/speckit-checklist`.
+- **Alternatives**: AEAD-wrap each cached blob under the PIN key (rejected for v1 — inconsistent with
+  the existing media store, adds encode/decode cost on a transient artifact; revisit only if the
+  checklist flags a gap for *both* stores).
+
+## D5 — Upload worker model (resume + auto-retry once)
+
+- **Decision**: A single in-app worker (`services/outbox.ts`) that drains the outbox sequentially.
+  Triggered on: (a) enqueue, (b) app start / keystore unlock, (c) the `online` event / reconnect.
+  On app start it **auto-retries each interrupted item once** (FR-013); a still-failing post flips to
+  `failed` and surfaces Retry/Cancel. A manual Retry re-drains, re-sending only unconfirmed items
+  (FR-014). One in-flight post at a time (queue), so progress + bandwidth stay predictable.
+- **Rationale**: Mirrors the existing `useSync` reconnect/drain pattern; no service-worker upload
+  queue (out of scope — see spec) keeps it simple and within the offline-first model.
+- **Alternatives**: A Web Worker / SW background-fetch upload queue (rejected for v1 — complexity +
+  iOS PWA limitations; resume-on-open covers the requirement).
+
+## D6 — Storage-estimate guard + headroom factor
+
+- **Decision**: At media selection (composer + chat picker), call `navigator.storage.estimate()` and
+  compare `quota − usage` against `Σ(selected bytes) × HEADROOM`. **`HEADROOM = 2.5`** (encode temp +
+  encoded output + margin) with a **minimum floor of 50 MB**. If it won't fit, show an up-front
+  warning (free space + retry) and do not begin encoding. Where `storage.estimate` is unavailable,
+  degrade to a no-op (never block sharing).
+- **Rationale**: Video transcode roughly needs input + temp + output; 2.5× is a safe envelope, the
+  floor avoids false positives on small selections. Best-effort per FR-009 / SC-004.
+- **Alternatives**: Per-codec exact projection (rejected — over-engineered, the estimate is
+  inherently approximate); hard-block with no estimate (rejected — would wrongly stop sharing on
+  browsers lacking the API).
+
+## D7 — Pending UI integration
+
+- **Decision**: `useOutbox` exposes a reactive pending list via `useLiveQuery('outbox')`. `useWall`
+  prepends pending Wall posts to the feed; `ChatDetailPage` renders a pending media message inline.
+  Each shows `ion-progress-bar` + per-item state, and (when `failed`) Retry/Cancel `ion-button`s.
+- **Rationale**: Reuses the established live-query reactivity (Principle V) and stock Ionic (XI).
+- **Alternatives**: A separate "Outbox" screen (rejected — the spec wants pending items *in place*).

--- a/specs/1024-resilient-posting-and-storage/spec.md
+++ b/specs/1024-resilient-posting-and-storage/spec.md
@@ -1,0 +1,183 @@
+# Feature Specification: Resilient posting & on-device storage management
+
+**Feature Branch**: `feat/1024-resilient-posting-and-storage`
+
+**Created**: 2026-06-30
+
+**Status**: planned
+
+**Input**: User description: "When sharing media to the Wall (and selecting media in chat), make
+posting resilient: tapping Share should dismiss the composer immediately and show a pending
+placeholder + progress at the top of the Wall while the upload runs in the background. A post is
+only 'made' once the backend has confirmed every item landed — its disappear timer starts then. If
+the app is closed mid-upload, the next open offers Retry or Cancel for the unfinished post. Cache
+the selected media internally so removing the source mid-flight doesn't break it. Guard available
+device storage when selecting items (chat or wall), since encoding/resizing needs headroom; warn to
+free space rather than failing halfway."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Share and move on; the post finishes itself (Priority: P1)
+
+I pick a few photos/videos (and maybe a voice clip), tap **Share**, and the composer closes at
+once. A placeholder for my post appears at the **top of the Wall** with a progress bar; I can keep
+scrolling, switch tabs, or close the app while it uploads. The post becomes "real" only once the
+server has every item, and its "disappears in…" countdown starts from that moment — not from when I
+tapped Share.
+
+**Why this priority**: This is the core of the request and the biggest UX win — sharing stops
+blocking the user, and the post's lifetime reflects when it actually landed, not a guess.
+
+**Independent Test**: Stage media, tap Share, confirm the composer dismisses immediately and a
+pending card with progress shows on the Wall; confirm the post flips to a normal post (with a fresh
+countdown) only after all items upload.
+
+**Acceptance Scenarios**:
+
+1. **Given** staged media in the composer, **When** I tap Share, **Then** the composer closes
+   immediately and a pending post (thumbnails + progress) appears at the top of the Wall.
+2. **Given** an uploading post, **When** I navigate away or background the app, **Then** the upload
+   continues and completes.
+3. **Given** all items have uploaded and the server confirmed them, **When** the post finalizes,
+   **Then** it renders as a normal post and its disappear timer starts at that confirmation time.
+4. **Given** an uploading post, **When** I remove or de-stage the source media, **Then** nothing
+   breaks — the outbox owns its own cached copies.
+
+### User Story 2 - Pick up where it left off after the app closes (Priority: P1)
+
+If the app is closed (or crashes, or loses network) before a post finishes uploading, the next time
+I open the app it **auto-retries once**; if that still doesn't finish, the post is shown as pending
+with **Retry** or **Cancel**. Cancel removes the post and its cached media; Retry resumes from where
+it stopped — only the items the server hasn't confirmed are re-sent.
+
+**Why this priority**: Without persistence, a backgrounded/killed app silently loses the post — the
+exact "worse than before" failure the user called out. Pairs with US1 to make posting trustworthy.
+
+**Independent Test**: Start an upload, kill the app mid-flight, reopen — confirm it auto-resumes and
+finishes; force a failure and confirm Retry/Cancel appear, Retry resumes only the unconfirmed items,
+and Cancel removes the post (and its cached blobs).
+
+**Acceptance Scenarios**:
+
+1. **Given** an upload interrupted by app close/crash/offline, **When** I reopen the app, **Then**
+   the system auto-retries once and the post finishes if it can.
+2. **Given** the automatic retry fails, **When** I see the pending post, **Then** it offers **Retry**
+   and **Cancel**.
+3. **Given** a partly-uploaded post (some items confirmed), **When** I Retry, **Then** only the
+   not-yet-confirmed items are re-sent.
+4. **Given** a pending post, **When** I tap Cancel, **Then** the post and its cached media are
+   removed and no envelope is sent.
+
+### User Story 3 - Warned before I run out of space (Priority: P2)
+
+When I select media to share (in chat or on the Wall), if there isn't enough free space for the
+encode/resize work, I'm told **before** anything starts — with a hint to free up space and come
+back — rather than failing halfway through a long list.
+
+**Why this priority**: Prevents the degraded mid-list failure the user described; cheap insurance
+that improves trust, but secondary to the post actually surviving.
+
+**Independent Test**: Simulate low free space, select media exceeding the estimated need, confirm a
+clear up-front warning (with a free-space hint) and that no partial encode/upload begins.
+
+**Acceptance Scenarios**:
+
+1. **Given** low available storage, **When** I select media whose estimated working size exceeds
+   free space, **Then** I see an up-front warning to free space, and the share does not start.
+2. **Given** an upload already running, **When** the device runs out of space mid-encode/upload,
+   **Then** the post is marked failed with a "free up space and retry" hint (not a silent stall).
+
+### Edge Cases
+
+- App killed mid-encode vs mid-upload vs after some-but-not-all items uploaded (partial confirm).
+- Network drops and recovers during upload.
+- Storage exhausted mid-flight.
+- Several pending posts queued at once (ordering, independent retry).
+- User cancels a pending post while one of its items is mid-upload.
+- Device clock skew (the "made at" time comes from confirmation, not the device tap time).
+- A cached blob fails to read back on resume (corrupt) → surface as failed, not crash.
+- Zero-knowledge: cached working copies are plaintext-at-rest locally (same class as other local
+  media); only sealed ciphertext is ever uploaded.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: On Share, the system MUST persist a pending-post record — including its own copies of
+  the selected media — to a local outbox, then dismiss the composer immediately.
+- **FR-002**: The relevant surface MUST render its pending items live with progress + per-item
+  state — the Wall feed shows pending posts at the top; a chat thread shows its pending media
+  message in place — updating as the upload proceeds.
+- **FR-003**: A background worker MUST process pending posts (encode/resize → upload each item →
+  seal + send the post envelope), resuming automatically on app start and on regained connectivity.
+- **FR-004**: A post MUST be considered "made" only after the backend confirms receipt of **all**
+  items and the envelope; its disappear/lifetime timer MUST start at that confirmation time.
+- **FR-005**: On app start, the system MUST AUTO-RETRY each interrupted pending item once; only if
+  that automatic attempt fails MUST it surface **Retry / Cancel** to the user.
+- **FR-006**: Cancel MUST delete the pending post and all its cached working media; Retry MUST
+  resume without re-selecting media.
+- **FR-007**: Because the system caches its own copies (FR-001), removing or de-staging the source
+  media after Share MUST NOT affect the in-flight post.
+- **FR-008**: On successful finalization, the system MUST delete the cached working copies (no
+  permanent duplication beyond the normal stored post media).
+- **FR-009**: When selecting media (chat or Wall), the system MUST estimate the working storage
+  needed (selected size × an encode headroom factor) against available free space and warn the user
+  up front when it won't fit, without starting any encode/upload.
+- **FR-010**: If storage is exhausted mid-flight, the system MUST mark the post failed with a
+  free-space hint and keep it retryable (no silent stall, no partial post).
+- **FR-011**: The zero-knowledge boundary MUST hold: only sealed ciphertext is uploaded; cached
+  working copies are local-only and never leave the device in the clear.
+- **FR-012**: The resumable outbox MUST cover BOTH Wall posts AND chat media sends — an interrupted
+  chat media send persists and resumes the same way a Wall post does.
+- **FR-013**: On app start, an interrupted post MUST be auto-retried once before the user is asked
+  (so most posts simply finish on reopen with no action).
+- **FR-014**: The system MUST track per-item backend confirmation, and a retry (auto or manual)
+  MUST resume only the not-yet-confirmed items — never re-uploading items the backend already has.
+
+### Key Entities *(include if feature involves data)*
+
+- **Pending post (outbox item)**: a not-yet-confirmed post. Attributes: id; ordered media items
+  (each with a cached working blob, kind, name, duration, poster); caption; audience; chosen
+  lifetime; status (uploading / failed / canceled); per-item + overall progress; failure reason;
+  attempt count. Relationship: becomes a normal **Post** on full confirmation, then is removed.
+- **Storage estimate**: available free space vs the projected working size of a selection
+  (selected bytes × headroom factor); drives the up-front guard.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tapping Share dismisses the composer and shows the pending post on the Wall in under
+  ~300 ms (no waiting on encode/upload).
+- **SC-002**: A post interrupted by app close/crash/offline is still present and completable on next
+  open in 100% of cases — never silently lost.
+- **SC-003**: No post is ever shown to its audience until the backend has confirmed every item; the
+  disappear timer reflects confirmation time, not Share time.
+- **SC-004**: When free space is insufficient, the user is warned before any encode begins — zero
+  half-completed shares due to running out of space mid-list.
+- **SC-005**: Removing the source media after Share never affects a successful post (0 failures
+  attributable to source removal).
+- **SC-006**: After a post finalizes or is canceled, its cached working copies are gone (no storage
+  leak).
+
+## Assumptions
+
+- Reuses the existing media pipeline (compress/resize, blob upload, sealed post envelope) and the
+  Wall feed rendering; this spec adds the outbox, the background worker, the pending UI, and the
+  storage guard around them.
+- The outbox + cached working blobs live in IndexedDB (the device's offline-first source of truth);
+  a DB version bump adds the store.
+- `navigator.storage.estimate()` (or equivalent) is available for the storage guard; where it isn't,
+  the guard degrades to a best-effort/no-op rather than blocking sharing.
+- Zero-knowledge boundary is non-negotiable: server only ever receives ciphertext + opaque blob ids.
+- The resumable outbox covers both Wall posts and chat media sends (FR-012); the storage guard
+  likewise covers both chat and Wall media selection.
+- Interrupted uploads auto-retry once on reopen before asking the user (FR-013), and retries resume
+  only the unconfirmed items via per-item confirmation tracking (FR-014).
+
+## Out of Scope
+
+- Background upload while the app is fully terminated by the OS (no service-worker upload queue in
+  v1); resume happens on next app open.
+- Editing a pending post's contents after Share (only Retry/Cancel).
+- Cross-device handoff of an in-flight post.

--- a/specs/1024-resilient-posting-and-storage/spec.md
+++ b/specs/1024-resilient-posting-and-storage/spec.md
@@ -175,6 +175,23 @@ clear up-front warning (with a free-space hint) and that no partial encode/uploa
 - Interrupted uploads auto-retry once on reopen before asking the user (FR-013), and retries resume
   only the unconfirmed items via per-item confirmation tracking (FR-014).
 
+## Zero-Knowledge Impact
+
+- **What crosses to the server**: unchanged from today — only **sealed ciphertext blobs** (existing
+  `uploadBlob`) and the **sealed post/message envelope** (existing `createPost` / message send), plus
+  opaque blob ids and the same recipient routing already used. This feature adds **no new plaintext,
+  fields, or endpoints** on the wire.
+- **New local plaintext**: the outbox caches **working copies of the selected media (plaintext) in
+  IndexedDB** until the post finalizes — the same class/treatment as the existing `media` store
+  (device encryption + PIN-lock gate the app; not separately AEAD-wrapped). Copies are deleted on
+  finalize or cancel (FR-008) — no lingering plaintext.
+- **Confirmation is metadata-free**: per-item confirmation is just the server's existing blob-id and
+  2xx responses; the server learns nothing new about content or audience.
+- **Timestamps**: `createdAt`/`expiresAt` remain client-set on the sealed envelope exactly as today;
+  the only change is *when* (at confirmation rather than at Share).
+- **Checklist**: `/speckit-checklist` is REQUIRED (Principle I) and must confirm the at-rest stance
+  of the cached blobs before implementation.
+
 ## Out of Scope
 
 - Background upload while the app is fully terminated by the OS (no service-worker upload queue in

--- a/specs/1024-resilient-posting-and-storage/tasks.md
+++ b/specs/1024-resilient-posting-and-storage/tasks.md
@@ -13,8 +13,8 @@ feature; server untouched. `[P]` = parallelizable (different files, no incomplet
 ## Phase 2 — Foundational (blocking prerequisites for all stories)
 
 - [ ] T003 [P] Outbox unit tests (vitest) — enqueue persists record+blobs; `listOutbox` ordering; per-item `blobId` confirmation gating; cleanup deletes record+blobs — in `src/db/outbox.test.ts`
-- [ ] T004 Outbox CRUD in `src/db/queries.ts`: `enqueueOutboxPost`, `listOutbox`, `getOutbox`, `updateOutboxItem`, `deleteOutbox` (writes via the change-bus)
-- [ ] T005 `useOutbox` composable (reactive pending list via `useLiveQuery('outbox')`) in `src/composables/useOutbox.ts`
+- [X] T004 Outbox CRUD in `src/db/queries.ts`: `enqueueOutboxPost`, `listOutbox`, `getOutbox`, `updateOutboxItem`, `deleteOutbox` (writes via the change-bus)
+- [X] T005 `useOutbox` composable (reactive pending list via `useLiveQuery('outbox')`) in `src/composables/useOutbox.ts`
 
 ## Phase 3 — User Story 1: Share and move on; the post finishes itself (P1) 🎯 MVP
 
@@ -25,10 +25,10 @@ finalizes to a real post (createdAt at confirmation) without blocking the user.
 becomes a normal post with a fresh countdown only after all items upload.
 
 - [ ] T006 [US1] e2e (failing first): share → composer dismisses immediately; `.outbox-pending` card with `ion-progress-bar` at top of Wall; finalizes to a real post whose `createdAt` ≈ confirm time — in `e2e/resilient-posting.spec.ts`
-- [ ] T007 [US1] Upload worker `drainOutbox()` in `src/services/outbox.ts`: per item → encode/resize (reuse `media-video`/compress) → `uploadBlob` → set `item.blobId` (skip already-confirmed); when all confirmed → seal + `createPost` → on 2xx write the real `Post` (`createdAt=now`) and delete the outbox row + every `item.blob`
-- [ ] T008 [US1] Composer Share handler → `enqueueOutboxPost(...)` then dismiss immediately (no awaiting encode/upload) in `src/views/detail/PostComposerPage.vue`
-- [ ] T009 [US1] Render pending Wall posts at the top (thumbnails + `ion-progress-bar` + per-item state); merge outbox items into the feed in `src/composables/useWall.ts` + `src/views/tabs/WallPage.vue`
-- [ ] T010 [US1] Kick `drainOutbox()` on enqueue and on reconnect/`online` (wire alongside `useSync`) in `src/services/outbox.ts` + `src/composables/useSync.ts`
+- [X] T007 [US1] Upload worker `drainOutbox()` in `src/services/outbox.ts`: per item → encode/resize (reuse `media-video`/compress) → `uploadBlob` → set `item.blobId` (skip already-confirmed); when all confirmed → seal + `createPost` → on 2xx write the real `Post` (`createdAt=now`) and delete the outbox row + every `item.blob`
+- [X] T008 [US1] Composer Share handler → `enqueueOutboxPost(...)` then dismiss immediately (no awaiting encode/upload) in `src/views/detail/PostComposerPage.vue`
+- [X] T009 [US1] Render pending Wall posts at the top (thumbnails + `ion-progress-bar` + per-item state); merge outbox items into the feed in `src/composables/useWall.ts` + `src/views/tabs/WallPage.vue`
+- [X] T010 [US1] Kick `drainOutbox()` on enqueue and on reconnect/`online` (wire alongside `useSync`) in `src/services/outbox.ts` + `src/composables/useSync.ts`
 
 ## Phase 4 — User Story 2: Pick up where it left off after the app closes (P1)
 

--- a/specs/1024-resilient-posting-and-storage/tasks.md
+++ b/specs/1024-resilient-posting-and-storage/tasks.md
@@ -7,8 +7,8 @@ feature; server untouched. `[P]` = parallelizable (different files, no incomplet
 
 ## Phase 1 — Setup (shared infrastructure)
 
-- [ ] T001 [P] Add `OutboxPost` + `OutboxItem` types in `src/db/types.ts` (per data-model.md)
-- [ ] T002 Bump `DB_VERSION` and create the `outbox` object store (keyPath `id`) in `onupgradeneeded` in `src/db/idb.ts`
+- [X] T001 [P] Add `OutboxPost` + `OutboxItem` types in `src/db/types.ts` (per data-model.md)
+- [X] T002 Bump `DB_VERSION` and create the `outbox` object store (keyPath `id`) in `onupgradeneeded` in `src/db/idb.ts`
 
 ## Phase 2 — Foundational (blocking prerequisites for all stories)
 

--- a/specs/1024-resilient-posting-and-storage/tasks.md
+++ b/specs/1024-resilient-posting-and-storage/tasks.md
@@ -40,9 +40,9 @@ appear, Retry re-sends only unconfirmed, Cancel removes record+blobs; remove the
 post still completes.
 
 - [ ] T011 [US2] e2e (failing first): kill mid-upload → reopen auto-retries once and finishes; forced failure surfaces Retry/Cancel; Retry resumes only unconfirmed items; Cancel removes; source-removal-after-Share still completes — extend `e2e/resilient-posting.spec.ts`
-- [ ] T012 [US2] `resumeOutboxOnStart()` (auto-retry each interrupted post once, guarded by `attempts`; then mark `failed`) in `src/services/outbox.ts`; call on keystore unlock in `src/App.vue` (the `isUnlocked` watcher)
-- [ ] T013 [US2] Retry/Cancel affordances on `failed` pending posts (stock `ion-button`) with `retryOutboxPost`/`cancelOutboxPost` wired, in `src/views/tabs/WallPage.vue`
-- [ ] T014 [US2] Storage-exhaustion + network failures set `status='failed'` + `error` (free-space hint) without partial posts, in `src/services/outbox.ts`
+- [X] T012 [US2] `resumeOutboxOnStart()` (auto-retry each interrupted post once, guarded by `attempts`; then mark `failed`) in `src/services/outbox.ts`; call on keystore unlock in `src/App.vue` (the `isUnlocked` watcher)
+- [X] T013 [US2] Retry/Cancel affordances on `failed` pending posts (stock `ion-button`) with `retryOutboxPost`/`cancelOutboxPost` wired, in `src/views/tabs/WallPage.vue`
+- [X] T014 [US2] Storage-exhaustion + network failures set `status='failed'` + `error` (free-space hint) without partial posts, in `src/services/outbox.ts`
 
 ## Phase 5 — User Story 3: Warned before running out of space (P2)
 
@@ -51,10 +51,10 @@ never start a half-finished share.
 
 **Independent test**: Simulate low free space → select a large batch → up-front warning, no encode begins.
 
-- [ ] T015 [P] [US3] Unit test: `hasRoomFor` returns false when `free < bytes×2.5` (floor 50 MB); returns true (best-effort) when `navigator.storage.estimate` is absent — in `src/services/storage-estimate.test.ts`
+- [X] T015 [P] [US3] Unit test: `hasRoomFor` returns false when `free < bytes×2.5` (floor 50 MB); returns true (best-effort) when `navigator.storage.estimate` is absent — in `src/services/storage-estimate.test.ts`
 - [ ] T016 [US3] e2e: low free space → up-front warning + no encode/stage starts — extend `e2e/resilient-posting.spec.ts`
-- [ ] T017 [P] [US3] `hasRoomFor(bytes)` via `navigator.storage.estimate()` in `src/services/storage-estimate.ts`
-- [ ] T018 [US3] Guard media selection (warn + abort) in `src/views/detail/PostComposerPage.vue` and the chat media picker in `src/views/detail/ChatDetailPage.vue`
+- [X] T017 [P] [US3] `hasRoomFor(bytes)` via `navigator.storage.estimate()` in `src/services/storage-estimate.ts`
+- [X] T018 [US3] Guard media selection (warn + abort) in `src/views/detail/PostComposerPage.vue` and the chat media picker in `src/views/detail/ChatDetailPage.vue`
 
 ## Phase 6 — Polish & cross-cutting
 

--- a/specs/1024-resilient-posting-and-storage/tasks.md
+++ b/specs/1024-resilient-posting-and-storage/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Resilient posting & on-device storage management
+
+**Feature**: `specs/1024-resilient-posting-and-storage/` · **Branch**: `feat/1024-resilient-posting-and-storage`
+
+TDD per Constitution Principle III — failing tests precede the implementation they cover. Client-only
+feature; server untouched. `[P]` = parallelizable (different files, no incomplete deps).
+
+## Phase 1 — Setup (shared infrastructure)
+
+- [ ] T001 [P] Add `OutboxPost` + `OutboxItem` types in `src/db/types.ts` (per data-model.md)
+- [ ] T002 Bump `DB_VERSION` and create the `outbox` object store (keyPath `id`) in `onupgradeneeded` in `src/db/idb.ts`
+
+## Phase 2 — Foundational (blocking prerequisites for all stories)
+
+- [ ] T003 [P] Outbox unit tests (vitest) — enqueue persists record+blobs; `listOutbox` ordering; per-item `blobId` confirmation gating; cleanup deletes record+blobs — in `src/db/outbox.test.ts`
+- [ ] T004 Outbox CRUD in `src/db/queries.ts`: `enqueueOutboxPost`, `listOutbox`, `getOutbox`, `updateOutboxItem`, `deleteOutbox` (writes via the change-bus)
+- [ ] T005 `useOutbox` composable (reactive pending list via `useLiveQuery('outbox')`) in `src/composables/useOutbox.ts`
+
+## Phase 3 — User Story 1: Share and move on; the post finishes itself (P1) 🎯 MVP
+
+**Goal**: Share dismisses the composer instantly; a pending post with progress shows atop the Wall and
+finalizes to a real post (createdAt at confirmation) without blocking the user.
+
+**Independent test**: Stage media → Share → composer closes immediately + pending card visible → it
+becomes a normal post with a fresh countdown only after all items upload.
+
+- [ ] T006 [US1] e2e (failing first): share → composer dismisses immediately; `.outbox-pending` card with `ion-progress-bar` at top of Wall; finalizes to a real post whose `createdAt` ≈ confirm time — in `e2e/resilient-posting.spec.ts`
+- [ ] T007 [US1] Upload worker `drainOutbox()` in `src/services/outbox.ts`: per item → encode/resize (reuse `media-video`/compress) → `uploadBlob` → set `item.blobId` (skip already-confirmed); when all confirmed → seal + `createPost` → on 2xx write the real `Post` (`createdAt=now`) and delete the outbox row + every `item.blob`
+- [ ] T008 [US1] Composer Share handler → `enqueueOutboxPost(...)` then dismiss immediately (no awaiting encode/upload) in `src/views/detail/PostComposerPage.vue`
+- [ ] T009 [US1] Render pending Wall posts at the top (thumbnails + `ion-progress-bar` + per-item state); merge outbox items into the feed in `src/composables/useWall.ts` + `src/views/tabs/WallPage.vue`
+- [ ] T010 [US1] Kick `drainOutbox()` on enqueue and on reconnect/`online` (wire alongside `useSync`) in `src/services/outbox.ts` + `src/composables/useSync.ts`
+
+## Phase 4 — User Story 2: Pick up where it left off after the app closes (P1)
+
+**Goal**: Interrupted uploads auto-retry once on reopen; still-failing posts offer Retry/Cancel and
+resume only unconfirmed items; cached copies survive source removal.
+
+**Independent test**: Kill mid-upload → reopen auto-resumes/finishes; force failure → Retry/Cancel
+appear, Retry re-sends only unconfirmed, Cancel removes record+blobs; remove the source after Share →
+post still completes.
+
+- [ ] T011 [US2] e2e (failing first): kill mid-upload → reopen auto-retries once and finishes; forced failure surfaces Retry/Cancel; Retry resumes only unconfirmed items; Cancel removes; source-removal-after-Share still completes — extend `e2e/resilient-posting.spec.ts`
+- [ ] T012 [US2] `resumeOutboxOnStart()` (auto-retry each interrupted post once, guarded by `attempts`; then mark `failed`) in `src/services/outbox.ts`; call on keystore unlock in `src/App.vue` (the `isUnlocked` watcher)
+- [ ] T013 [US2] Retry/Cancel affordances on `failed` pending posts (stock `ion-button`) with `retryOutboxPost`/`cancelOutboxPost` wired, in `src/views/tabs/WallPage.vue`
+- [ ] T014 [US2] Storage-exhaustion + network failures set `status='failed'` + `error` (free-space hint) without partial posts, in `src/services/outbox.ts`
+
+## Phase 5 — User Story 3: Warned before running out of space (P2)
+
+**Goal**: At media selection (chat + Wall), warn up front when the encode/upload won't fit free space;
+never start a half-finished share.
+
+**Independent test**: Simulate low free space → select a large batch → up-front warning, no encode begins.
+
+- [ ] T015 [P] [US3] Unit test: `hasRoomFor` returns false when `free < bytes×2.5` (floor 50 MB); returns true (best-effort) when `navigator.storage.estimate` is absent — in `src/services/storage-estimate.test.ts`
+- [ ] T016 [US3] e2e: low free space → up-front warning + no encode/stage starts — extend `e2e/resilient-posting.spec.ts`
+- [ ] T017 [P] [US3] `hasRoomFor(bytes)` via `navigator.storage.estimate()` in `src/services/storage-estimate.ts`
+- [ ] T018 [US3] Guard media selection (warn + abort) in `src/views/detail/PostComposerPage.vue` and the chat media picker in `src/views/detail/ChatDetailPage.vue`
+
+## Phase 6 — Polish & cross-cutting
+
+- [ ] T019 [P] Chat parity (FR-012): `enqueueOutboxPost(target='chat')` from `ChatDetailPage` send; render the pending media message inline with progress + Retry/Cancel; reuse the same worker
+- [ ] T020 [P] Verify no leftover `outbox` row or cached blob after finalize/cancel (SC-006) — assert in unit + e2e
+- [ ] T021 Run `/speckit-checklist` (REQUIRED — Principle I/ZK) and resolve every finding (confirm cached-blob at-rest stance)
+- [ ] T022 Gates: `npm run build`, `npx vitest run`, `npm run test:e2e`, `cd server && go test ./...` — all green; fix any fallout
+
+## Dependencies / order
+
+- **Setup (T001–T002)** → **Foundational (T003–T005)** → stories.
+- **US1 (T006–T010)** is the MVP and unblocks US2.
+- **US2 (T011–T014)** depends on US1's worker + pending UI.
+- **US3 (T015–T018)** is independent of US1/US2 (selection-time guard) — can run in parallel after Foundational.
+- **Polish (T019–T022)** last; T021 (checklist) gates `/speckit-implement` completion.
+
+## Parallel opportunities
+
+- T001 ∥ (types) and T003 (tests) can start together; T015/T017 (storage) ∥ the US1/US2 work.
+- T019/T020 ∥ in polish.
+
+## MVP scope
+
+**US1 only** (T001–T010) delivers a shippable increment: share-and-move-on with a self-finishing Wall
+post. US2 (resilience) and US3 (storage guard) layer on top.

--- a/src/App.vue
+++ b/src/App.vue
@@ -86,8 +86,8 @@ watch(
           void appToast({
             message:
               discarded === 1
-                ? 'A post didn’t finish because the app closed — please share it again.'
-                : `${discarded} posts didn’t finish because the app closed — please share them again.`,
+                ? 'A post didn’t finish because the app closed. Please share it again.'
+                : `${discarded} posts didn’t finish because the app closed. Please share them again.`,
             duration: 3200,
           });
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -53,7 +53,7 @@ import { useSync, nudgeReconnect } from '@/composables/useSync';
 import { useAppUpdate, checkForUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
 import { takePendingNav } from '@/services/pending-nav';
-import { kickPendingPosts } from '@/services/pending-posts';
+import { recoverInterruptedPosts } from '@/services/pending-posts';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import type { Message } from '@/db/types';
 
@@ -78,9 +78,20 @@ watch(
   (unlocked) => {
     if (unlocked) {
       void warmAll();
-      // Spec 1024: resume any interrupted media uploads from the outbox (a post the app was
-      // killed mid-upload finishes itself on reopen).
-      kickPendingPosts();
+      // Spec 1024: a post whose upload was cut off by a full app close can't be resumed (its library
+      // media handle is gone). Recover it as a draft instead — keep the caption + voice notes for the
+      // user to finish in the composer — and let them know if a media-only post had to be dropped.
+      void recoverInterruptedPosts().then(({ discarded }) => {
+        if (discarded > 0) {
+          void appToast({
+            message:
+              discarded === 1
+                ? 'A post didn’t finish because the app closed — please share it again.'
+                : `${discarded} posts didn’t finish because the app closed — please share them again.`,
+            duration: 3200,
+          });
+        }
+      });
       // Cold-launched from a notification? The SW stashed where to go (iOS PWAs can't deep-link
       // via openWindow); now that we're unlocked and the tabs are reachable, route there. The
       // microtask defer lets the auth gate's default landing settle first so this wins.

--- a/src/App.vue
+++ b/src/App.vue
@@ -53,6 +53,7 @@ import { useSync, nudgeReconnect } from '@/composables/useSync';
 import { useAppUpdate, checkForUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
 import { takePendingNav } from '@/services/pending-nav';
+import { kickPendingPosts } from '@/services/pending-posts';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import type { Message } from '@/db/types';
 
@@ -77,6 +78,9 @@ watch(
   (unlocked) => {
     if (unlocked) {
       void warmAll();
+      // Spec 1024: resume any interrupted media uploads from the outbox (a post the app was
+      // killed mid-upload finishes itself on reopen).
+      kickPendingPosts();
       // Cold-launched from a notification? The SW stashed where to go (iOS PWAs can't deep-link
       // via openWindow); now that we're unlocked and the tabs are reachable, route there. The
       // microtask defer lets the auth gate's default landing settle first so this wins.

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -30,6 +30,11 @@
           <template v-if="activityLabel">
             <span class="preview activity">{{ activityLabel }}</span>
           </template>
+          <!-- An unsent draft trumps the last message so you can see where you left off. -->
+          <template v-else-if="draft !== undefined">
+            <span class="draft-tag">Draft</span>
+            <span class="preview draft-text">{{ draft ? ': ' + draft : '' }}</span>
+          </template>
           <template v-else>
             <ion-icon
               v-if="previewIcon"
@@ -93,7 +98,7 @@ import { activityFor, activityKindLabel } from '@/composables/useTyping';
 import { formatTime } from '@/utils/time';
 import type { Chat } from '@/db/types';
 
-const props = defineProps<{ chat: Chat }>();
+const props = defineProps<{ chat: Chat; draft?: string }>();
 const emit = defineEmits<{ (e: 'open', id: string): void; (e: 'more', chat: Chat): void }>();
 
 const sliding = ref<{ $el: HTMLIonItemSlidingElement } | null>(null);
@@ -231,6 +236,16 @@ ion-item-option ion-icon {
 }
 .preview.activity {
   color: var(--ion-color-primary, #10b981);
+}
+/* "Draft" marker on a chat with an unsent message — red, like the convention, with the text muted. */
+.draft-tag {
+  flex: none;
+  margin-top: 1px;
+  color: var(--ion-color-danger, #eb445a);
+  font-weight: 600;
+}
+.draft-text {
+  color: var(--app-text-muted);
 }
 .preview {
   flex: 1;

--- a/src/composables/usePendingPosts.ts
+++ b/src/composables/usePendingPosts.ts
@@ -10,18 +10,19 @@ import type { OutboxPost } from '@/db/types';
 
 export interface PendingView {
   id: string;
-  status: 'uploading' | 'failed' | 'canceled';
+  status: 'uploading' | 'failed' | 'interrupted';
   error?: string;
   count: number; // number of media items
   progress: number; // 0..1 overall (mean of per-item progress)
   body: string;
+  droppedMedia: boolean; // interrupted posts: there were photos/videos we couldn't keep
 }
 
 export function usePendingPosts(): { pending: ComputedRef<PendingView[]> } {
   const raw = useLiveQuery(() => listPendingPosts(), ['pendingPosts'], [] as OutboxPost[]);
   const pending = computed<PendingView[]>(() =>
     raw.value
-      .filter((p) => p.status !== 'canceled')
+      .filter((p): p is OutboxPost & { status: 'uploading' | 'failed' | 'interrupted' } => p.status !== 'canceled')
       .map((p) => ({
         id: p.id,
         status: p.status,
@@ -29,6 +30,7 @@ export function usePendingPosts(): { pending: ComputedRef<PendingView[]> } {
         count: p.items.length,
         progress: p.items.length ? p.items.reduce((s, it) => s + it.progress, 0) / p.items.length : 0,
         body: p.body,
+        droppedMedia: !!p.droppedMedia,
       })),
   );
   return { pending };

--- a/src/composables/usePendingPosts.ts
+++ b/src/composables/usePendingPosts.ts
@@ -15,7 +15,6 @@ export interface PendingView {
   count: number; // number of media items
   progress: number; // 0..1 overall (mean of per-item progress)
   body: string;
-  droppedMedia: boolean; // interrupted posts: there were photos/videos we couldn't keep
 }
 
 export function usePendingPosts(): { pending: ComputedRef<PendingView[]> } {
@@ -30,7 +29,6 @@ export function usePendingPosts(): { pending: ComputedRef<PendingView[]> } {
         count: p.items.length,
         progress: p.items.length ? p.items.reduce((s, it) => s + it.progress, 0) / p.items.length : 0,
         body: p.body,
-        droppedMedia: !!p.droppedMedia,
       })),
   );
   return { pending };

--- a/src/composables/usePendingPosts.ts
+++ b/src/composables/usePendingPosts.ts
@@ -1,0 +1,35 @@
+/**
+ * Spec 1024 — reactive view of the `pendingPosts` outbox for the Wall's pending cards.
+ * Live-queries the store and exposes a small display shape (overall progress + status), so a
+ * post that's still uploading shows atop the feed and updates as the worker writes progress.
+ */
+import { computed, type ComputedRef } from 'vue';
+import { useLiveQuery } from '@/composables/useLiveQuery';
+import { listPendingPosts } from '@/db/queries';
+import type { OutboxPost } from '@/db/types';
+
+export interface PendingView {
+  id: string;
+  status: 'uploading' | 'failed' | 'canceled';
+  error?: string;
+  count: number; // number of media items
+  progress: number; // 0..1 overall (mean of per-item progress)
+  body: string;
+}
+
+export function usePendingPosts(): { pending: ComputedRef<PendingView[]> } {
+  const raw = useLiveQuery(() => listPendingPosts(), ['pendingPosts'], [] as OutboxPost[]);
+  const pending = computed<PendingView[]>(() =>
+    raw.value
+      .filter((p) => p.status !== 'canceled')
+      .map((p) => ({
+        id: p.id,
+        status: p.status,
+        error: p.error,
+        count: p.items.length,
+        progress: p.items.length ? p.items.reduce((s, it) => s + it.progress, 0) / p.items.length : 0,
+        body: p.body,
+      })),
+  );
+  return { pending };
+}

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -26,6 +26,8 @@ export const STORES = [
   // = reactions/comments/view-receipts keyed by postId. Both keyPath 'id'.
   'posts',
   'postEngagement',
+  // v10 (spec 1024): the resilient-posting outbox — pending posts/chat-media with cached blobs.
+  'pendingPosts',
 ] as const;
 export type StoreName = (typeof STORES)[number];
 

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -30,6 +30,8 @@ export const STORES = [
   'pendingPosts',
   // v11: per-chat composer drafts (unsent text + caret + reply) so leaving/closing keeps your place.
   'drafts',
+  // v12: staged (unsent) chat attachments for a draft — bytes stored inline so they survive a reload.
+  'draftMedia',
 ] as const;
 export type StoreName = (typeof STORES)[number];
 
@@ -41,7 +43,7 @@ const DB_NAME = 'ring';
 // v9 (spec 0003): add the social-Wall stores `posts` + `postEngagement` (additive
 // createObjectStore in onupgradeneeded; existing data untouched).
 // v10 (spec 1024): add the `pendingPosts` outbox store (additive; existing data untouched).
-const DB_VERSION = 11;
+const DB_VERSION = 12;
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 
@@ -161,6 +163,10 @@ export function openDB(): Promise<IDBDatabase> {
       // is restored when you re-open the chat or relaunch the app. Local-only — never synced.
       if (!db.objectStoreNames.contains('drafts'))
         db.createObjectStore('drafts', { keyPath: 'chatId' });
+      // v12: staged attachments for a chat draft, keyed by chatId. Bytes are stored inline (not as
+      // Blobs) so they read back after a reload on iOS; rebuilt into fresh in-memory files on restore.
+      if (!db.objectStoreNames.contains('draftMedia'))
+        db.createObjectStore('draftMedia', { keyPath: 'chatId' });
       // Forward message migrations (v6: spec 1010 "read"→"seen" rename; v7: spec 1013
       // seen-reported backfill). They run in ONE cursor pass so a multi-version upgrade
       // (e.g. v5→v7) does not open two racing cursors on the same store that could clobber

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -36,7 +36,8 @@ const DB_NAME = 'ring';
 // existing rows are preserved unchanged and the tiers are filled in by the background backfill.
 // v9 (spec 0003): add the social-Wall stores `posts` + `postEngagement` (additive
 // createObjectStore in onupgradeneeded; existing data untouched).
-const DB_VERSION = 9;
+// v10 (spec 1024): add the `pendingPosts` outbox store (additive; existing data untouched).
+const DB_VERSION = 10;
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 
@@ -147,6 +148,11 @@ export function openDB(): Promise<IDBDatabase> {
         const s = db.createObjectStore('postEngagement', { keyPath: 'id' });
         s.createIndex('postId', 'postId');
       }
+      // v10 (spec 1024): the resilient-posting OUTBOX — pending Wall posts / chat media sends with
+      // their own cached working blobs, drained by the upload worker. Named `pendingPosts` to avoid
+      // the existing message-sync `outbox` store above.
+      if (!db.objectStoreNames.contains('pendingPosts'))
+        db.createObjectStore('pendingPosts', { keyPath: 'id' });
       // Forward message migrations (v6: spec 1010 "read"→"seen" rename; v7: spec 1013
       // seen-reported backfill). They run in ONE cursor pass so a multi-version upgrade
       // (e.g. v5→v7) does not open two racing cursors on the same store that could clobber

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -28,6 +28,8 @@ export const STORES = [
   'postEngagement',
   // v10 (spec 1024): the resilient-posting outbox — pending posts/chat-media with cached blobs.
   'pendingPosts',
+  // v11: per-chat composer drafts (unsent text + caret + reply) so leaving/closing keeps your place.
+  'drafts',
 ] as const;
 export type StoreName = (typeof STORES)[number];
 
@@ -39,7 +41,7 @@ const DB_NAME = 'ring';
 // v9 (spec 0003): add the social-Wall stores `posts` + `postEngagement` (additive
 // createObjectStore in onupgradeneeded; existing data untouched).
 // v10 (spec 1024): add the `pendingPosts` outbox store (additive; existing data untouched).
-const DB_VERSION = 10;
+const DB_VERSION = 11;
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 
@@ -155,6 +157,10 @@ export function openDB(): Promise<IDBDatabase> {
       // the existing message-sync `outbox` store above.
       if (!db.objectStoreNames.contains('pendingPosts'))
         db.createObjectStore('pendingPosts', { keyPath: 'id' });
+      // v11: per-chat composer drafts, keyed by chatId, so an unsent message (text + caret + reply)
+      // is restored when you re-open the chat or relaunch the app. Local-only — never synced.
+      if (!db.objectStoreNames.contains('drafts'))
+        db.createObjectStore('drafts', { keyPath: 'chatId' });
       // Forward message migrations (v6: spec 1010 "read"→"seen" rename; v7: spec 1013
       // seen-reported backfill). They run in ONE cursor pass so a multi-version upgrade
       // (e.g. v5→v7) does not open two racing cursors on the same store that could clobber

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2180,6 +2180,9 @@ export async function createPost(opts: {
   body?: string;
   audience: 'friends' | 'close';
   lifetime: PostLifetime;
+  // Spec 1024: a stable post id supplied by the outbox worker so a retry is idempotent — the same
+  // id overwrites the local post and the server upserts it, instead of creating a duplicate.
+  id?: string;
   // Optional attachment(s). A single item is an ordinary media post; an array of 2+
   // image/video items is an ALBUM post (spec 1022, FR-019) — every item is compressed to
   // the chosen quality, encrypted + uploaded, and all the media-refs ride sealed inside
@@ -2288,7 +2291,7 @@ export async function createPost(opts: {
 
   const built = buildPost(payload, audience);
   const blobId = await uploadBlob(new Blob([built.blob as BlobPart]));
-  const id = uid();
+  const id = opts.id ?? uid();
   const createdAt = now();
   // The chosen window (1h/24h/72h), capped at 72h. Keep-alive later resets the expiry
   // to now + this same window on each interaction.

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2344,19 +2344,16 @@ export async function enqueuePendingPost(input: {
   }[];
 }): Promise<string> {
   const id = uid();
-  // The cached blobs only need to outlive the COMPOSER (the upload runs in-session, while the app is
-  // open and the picked files are still readable). We deliberately do NOT try to make library media
-  // survive a full app close — an iOS File handle doesn't, and a half-resumed upload was unreliable.
-  // On a cold restart these posts are recovered as drafts instead (see recoverInterruptedPosts).
-  // EXCEPTION: an in-app VOICE recording IS kept across a restart (it's part of the recovered draft),
-  // so we stash its bytes inline as an ArrayBuffer — an IDB Blob can read back broken on iOS, an
-  // ArrayBuffer doesn't. Small clips, so the read is cheap.
+  // Read every item's bytes and store them INLINE (as an ArrayBuffer, not a Blob). This is what lets
+  // a post survive a full app close: a Blob read back from IDB after a restart can be unreadable on
+  // iOS, an ArrayBuffer always reads back. So an interrupted post keeps its photos/videos/voice and
+  // can be finished from the recovered draft. The read happens once here, at Share (in-session, while
+  // the picked files are still readable).
   const items: OutboxItem[] = [];
   for (const it of input.items) {
     items.push({
       localId: uid(),
-      blob: it.blob,
-      bytes: it.kind === 'voice' ? await it.blob.arrayBuffer() : undefined,
+      bytes: await it.blob.arrayBuffer(),
       kind: it.kind,
       name: it.name,
       mime: it.mime,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -36,7 +36,7 @@ import type {
 } from '@/services/crypto/message';
 import type {
   Alert, Call, CallLog, Chat, ChatList, Contact, FriendRequest, Media, Message, MessageKind, Reaction, ReplyRef,
-  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost, OutboxItem,
+  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost,
 } from './types';
 
 // WhatsApp-style cap on pinned chats.
@@ -2343,18 +2343,20 @@ export async function enqueuePendingPost(input: {
   }[];
 }): Promise<string> {
   const id = uid();
-  // Copy each picked file's bytes into a self-contained, memory-backed Blob NOW, while the app still
-  // has access to it. A File from the library picker is backed by an OS file reference; on iOS that
-  // reference is released once the PWA is fully closed, so a raw cached File can't be re-read on a
-  // cold relaunch — the resumed upload would stall forever (never erroring, never finishing). Reading
-  // the bytes here detaches the outbox copy from the file so it survives a full restart. Done
-  // sequentially to avoid holding every (possibly large video) item's bytes in memory at once.
-  const items: OutboxItem[] = [];
-  for (const it of input.items) {
-    const bytes = await it.blob.arrayBuffer();
-    items.push({
+  // The cached blobs only need to outlive the COMPOSER (the upload runs in-session, while the app is
+  // open and the picked files are still readable). We deliberately do NOT try to make library media
+  // survive a full app close — an iOS File handle doesn't, and a half-resumed upload was unreliable.
+  // On a cold restart these posts are recovered as drafts instead (see recoverInterruptedPosts).
+  const rec: OutboxPost = {
+    id,
+    target: input.target,
+    chatId: input.chatId,
+    body: input.body,
+    audience: input.audience,
+    lifetime: input.lifetime,
+    items: input.items.map((it) => ({
       localId: uid(),
-      blob: new Blob([bytes], { type: it.mime || it.blob.type }),
+      blob: it.blob,
       kind: it.kind,
       name: it.name,
       mime: it.mime,
@@ -2363,16 +2365,7 @@ export async function enqueuePendingPost(input: {
       height: it.height,
       poster: it.poster,
       progress: 0,
-    });
-  }
-  const rec: OutboxPost = {
-    id,
-    target: input.target,
-    chatId: input.chatId,
-    body: input.body,
-    audience: input.audience,
-    lifetime: input.lifetime,
-    items,
+    })),
     status: 'uploading',
     attempts: 0,
     createdLocally: now(),

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1840,19 +1840,36 @@ export async function markSendFailed(messageId: string): Promise<void> {
 
 /* ---- media auto-download (videos can be deferred + fetched on demand) ---- */
 
-/** Whether to auto-download an incoming video, per Settings → Storage and data →
- *  Media auto-download → Video ('never' | 'wifi' | 'wifi-cellular') and the
- *  network. iOS Safari exposes no network type, so there we can't tell Wi-Fi from
- *  cellular, so any non-'never' setting auto-downloads. */
-async function shouldAutoDownloadVideo(): Promise<boolean> {
-  const mode = await getSetting<string>('storage.autoDownload.video', 'wifi');
-  if (mode === 'never') return false;
-  if (mode === 'wifi-cellular') return true;
-  // mode === 'wifi': only on Wi-Fi/ethernet (or when the type is unknown, e.g. iOS).
+// On Wi-Fi/ethernet (or an unknown type, e.g. iOS Safari which exposes no network type).
+function onUnmeteredOrUnknown(): boolean {
   const conn = (navigator as unknown as { connection?: { type?: string } }).connection;
   const type = conn?.type;
   if (!type || type === 'unknown') return true;
   return type === 'wifi' || type === 'ethernet';
+}
+
+/** Whether to auto-download an incoming attachment, per Settings → Storage and data → Media
+ *  auto-download (a per-kind 'never' | 'wifi' | 'wifi-cellular' choice), the network, AND a size
+ *  limit (anything larger is left for a manual tap). Voice notes and round video notes always
+ *  download — they're small and expected to play instantly. Uses the media metadata (kind + size). */
+async function shouldAutoDownloadMedia(kind: MessageKind, videoNote: boolean, size: number): Promise<boolean> {
+  if (kind === 'voice') return true; // voice messages are always downloaded
+  if (kind === 'video' && videoNote) return true; // round video notes always download
+  const key =
+    kind === 'image'
+      ? 'storage.autoDownload.photos'
+      : kind === 'video'
+        ? 'storage.autoDownload.video'
+        : kind === 'audio'
+          ? 'storage.autoDownload.audio'
+          : 'storage.autoDownload.documents'; // files
+  const mode = await getSetting<string>(key, kind === 'image' ? 'wifi-cellular' : 'wifi');
+  if (mode === 'never') return false;
+  // Size cap (MB; '0' = no limit): a big attachment is left for a manual tap regardless of network.
+  const limitMb = Number(await getSetting<string>('storage.autoDownloadLimit', '16')) || 0;
+  if (limitMb > 0 && size > limitMb * 1024 * 1024) return false;
+  if (mode === 'wifi-cellular') return true;
+  return onUnmeteredOrUnknown();
 }
 
 /** Spec 1014: persist the thumbnail tiers on a Media record from its bubble-tier blob — store it as
@@ -4489,7 +4506,7 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
   let durationSec: number | undefined = payload.mediaRef?.durationSec;
   let pendingMedia: MediaRef | undefined;
   if (payload.mediaRef) {
-    const defer = kind === 'video' && !payload.videoNote && !(await shouldAutoDownloadVideo());
+    const defer = !(await shouldAutoDownloadMedia(kind, !!payload.videoNote, payload.mediaRef.size));
     if (defer) {
       pendingMedia = payload.mediaRef; // fetched later via downloadMessageMedia
     } else {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1928,12 +1928,16 @@ export async function backfillThumbTiers(mediaIds: string[], max = 16): Promise<
   return upgraded;
 }
 
-/** Download a deferred video's full clip (auto-download off, or manual tap). */
-export async function downloadMessageMedia(messageId: string): Promise<void> {
+/** Download a deferred attachment's full bytes (auto-download off/over-limit, or manual tap).
+ *  Reports download progress (0..1) via onProgress for the bubble's download ring. */
+export async function downloadMessageMedia(
+  messageId: string,
+  onProgress?: (fraction: number) => void,
+): Promise<void> {
   const m = await getMessage(messageId);
   if (!m?.pendingMedia || m.mediaId) return;
   const ref = m.pendingMedia;
-  const blob = await receiveIncomingMedia(ref);
+  const blob = await receiveIncomingMedia(ref, onProgress);
   if (!blob) throw new Error('download failed');
   const mediaId = uid();
   await put<Media>('media', {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -37,6 +37,7 @@ import type {
 import type {
   Alert, Call, CallLog, Chat, ChatList, Contact, FriendRequest, Media, Message, MessageKind, Reaction, ReplyRef,
   GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost, OutboxItem, ChatDraft,
+  DraftMedia, DraftMediaItem,
 } from './types';
 
 // WhatsApp-style cap on pinned chats.
@@ -2413,6 +2414,16 @@ export async function clearDraft(chatId: string): Promise<void> {
 /** All saved drafts — the Chats list uses this to mark which chats have an unsent message. */
 export async function listDrafts(): Promise<ChatDraft[]> {
   return getAll<ChatDraft>('drafts');
+}
+/* Staged attachments for a chat draft (bytes stored inline; see DraftMedia). */
+export async function getDraftMedia(chatId: string): Promise<DraftMedia | undefined> {
+  return get<DraftMedia>('draftMedia', chatId);
+}
+export async function saveDraftMedia(chatId: string, items: DraftMediaItem[]): Promise<void> {
+  await put<DraftMedia>('draftMedia', { chatId, items, updatedAt: now() });
+}
+export async function clearDraftMedia(chatId: string): Promise<void> {
+  await remove('draftMedia', chatId);
 }
 
 // Persist a single received post: unwrap K_post with our identity key, open the

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2410,6 +2410,10 @@ export async function saveDraft(d: Omit<ChatDraft, 'updatedAt'>): Promise<void> 
 export async function clearDraft(chatId: string): Promise<void> {
   await remove('drafts', chatId);
 }
+/** All saved drafts — the Chats list uses this to mark which chats have an unsent message. */
+export async function listDrafts(): Promise<ChatDraft[]> {
+  return getAll<ChatDraft>('drafts');
+}
 
 // Persist a single received post: unwrap K_post with our identity key, open the
 // payload, store it. Own posts come back without an envelope (already local) and are

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -36,7 +36,7 @@ import type {
 } from '@/services/crypto/message';
 import type {
   Alert, Call, CallLog, Chat, ChatList, Contact, FriendRequest, Media, Message, MessageKind, Reaction, ReplyRef,
-  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost,
+  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost, ChatDraft,
 } from './types';
 
 // WhatsApp-style cap on pinned chats.
@@ -2390,6 +2390,17 @@ export async function updatePendingPost(rec: OutboxPost): Promise<void> {
 
 export async function deletePendingPost(id: string): Promise<void> {
   await remove('pendingPosts', id);
+}
+
+/* ---- per-chat composer drafts (local-only; keep your place across leave/close) ---- */
+export async function getDraft(chatId: string): Promise<ChatDraft | undefined> {
+  return get<ChatDraft>('drafts', chatId);
+}
+export async function saveDraft(d: Omit<ChatDraft, 'updatedAt'>): Promise<void> {
+  await put<ChatDraft>('drafts', { ...d, updatedAt: now() });
+}
+export async function clearDraft(chatId: string): Promise<void> {
+  await remove('drafts', chatId);
 }
 
 // Persist a single received post: unwrap K_post with our identity key, open the

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3290,6 +3290,20 @@ export async function collectUnconfirmedOutgoing(): Promise<string[]> {
   return ids.slice(-RECONCILE_ID_CAP);
 }
 
+/** Set (or clear) a chat's media send-quality override. null = fall back to the global setting.
+ *  Purely local (own-data-synced); never leaves the device on the wire. */
+export async function setChatSendQuality(
+  chatId: string,
+  q: 'sd' | 'hd' | 'fhd' | 'original' | null,
+): Promise<void> {
+  const chat = await getChat(chatId);
+  if (!chat) return;
+  if (q) chat.sendQuality = q;
+  else delete chat.sendQuality;
+  chat.updatedAt = now();
+  await put('chats', chat);
+}
+
 /** Set (or clear) disappearing messages for a chat: messages sent from now on
  *  self-destruct after `ttlMs` (null/0 = off). The setting is shared with the
  *  peer(s) via a `ttl` control so it disappears for everyone. */

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -36,7 +36,7 @@ import type {
 } from '@/services/crypto/message';
 import type {
   Alert, Call, CallLog, Chat, ChatList, Contact, FriendRequest, Media, Message, MessageKind, Reaction, ReplyRef,
-  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost,
+  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost, OutboxItem,
 } from './types';
 
 // WhatsApp-style cap on pinned chats.
@@ -2343,16 +2343,18 @@ export async function enqueuePendingPost(input: {
   }[];
 }): Promise<string> {
   const id = uid();
-  const rec: OutboxPost = {
-    id,
-    target: input.target,
-    chatId: input.chatId,
-    body: input.body,
-    audience: input.audience,
-    lifetime: input.lifetime,
-    items: input.items.map((it) => ({
+  // Copy each picked file's bytes into a self-contained, memory-backed Blob NOW, while the app still
+  // has access to it. A File from the library picker is backed by an OS file reference; on iOS that
+  // reference is released once the PWA is fully closed, so a raw cached File can't be re-read on a
+  // cold relaunch — the resumed upload would stall forever (never erroring, never finishing). Reading
+  // the bytes here detaches the outbox copy from the file so it survives a full restart. Done
+  // sequentially to avoid holding every (possibly large video) item's bytes in memory at once.
+  const items: OutboxItem[] = [];
+  for (const it of input.items) {
+    const bytes = await it.blob.arrayBuffer();
+    items.push({
       localId: uid(),
-      blob: it.blob,
+      blob: new Blob([bytes], { type: it.mime || it.blob.type }),
       kind: it.kind,
       name: it.name,
       mime: it.mime,
@@ -2361,7 +2363,16 @@ export async function enqueuePendingPost(input: {
       height: it.height,
       poster: it.poster,
       progress: 0,
-    })),
+    });
+  }
+  const rec: OutboxPost = {
+    id,
+    target: input.target,
+    chatId: input.chatId,
+    body: input.body,
+    audience: input.audience,
+    lifetime: input.lifetime,
+    items,
     status: 'uploading',
     attempts: 0,
     createdLocally: now(),

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3312,16 +3312,18 @@ export async function collectUnconfirmedOutgoing(): Promise<string[]> {
   return ids.slice(-RECONCILE_ID_CAP);
 }
 
-/** Set (or clear) a chat's media send-quality override. null = fall back to the global setting.
- *  Purely local (own-data-synced); never leaves the device on the wire. */
+/** Set (or clear) a chat's per-kind media send-quality override. null = fall back to the global
+ *  setting for that kind. Purely local (own-data-synced); never leaves the device on the wire. */
 export async function setChatSendQuality(
   chatId: string,
+  kind: 'photo' | 'video',
   q: 'sd' | 'hd' | 'fhd' | 'original' | null,
 ): Promise<void> {
   const chat = await getChat(chatId);
   if (!chat) return;
-  if (q) chat.sendQuality = q;
-  else delete chat.sendQuality;
+  const field = kind === 'photo' ? 'sendQualityPhoto' : 'sendQualityVideo';
+  if (q) chat[field] = q;
+  else delete chat[field];
   chat.updatedAt = now();
   await put('chats', chat);
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -336,6 +336,7 @@ export async function sendMessage(
   replyTo?: ReplyRef,
   mentions?: string[],
   mentionsEveryone?: boolean,
+  ttlOverrideMs?: number | null,
 ): Promise<void> {
   const ts = now();
   const chat = await getChat(chatId);
@@ -376,8 +377,8 @@ export async function sendMessage(
   // Seal the message (E2EE) and hand it to the sync engine; receipts advance the
   // status. Group chats fan out to each member over their 1:1 session.
   const payload: MessagePayload = { body, kind: 'text', timestamp: ts, reply: replyTo, mentions: ment, mentionsEveryone: everyone };
-  if (chat?.isGroup) await sealAndEnqueueGroup(chat, message.id, payload);
-  else await sealAndEnqueue(chat, message.id, payload);
+  if (chat?.isGroup) await sealAndEnqueueGroup(chat, message.id, payload, ttlOverrideMs);
+  else await sealAndEnqueue(chat, message.id, payload, ttlOverrideMs);
 
   // Link preview: build it in the background (a relay round-trip + downscale) and
   // patch it in once ready, so the text isn't held up. Best-effort and gated by
@@ -391,11 +392,19 @@ export async function sendMessage(
 /** If the chat has disappearing messages on, stamp the (real, stored) message and
  *  its outgoing payload with an expiry, so both sides sweep it. No-op for control
  *  signals (cards/rekey/ttl), which have no stored message row. */
-async function stampExpiry(chat: Chat, messageId: string, payload: MessagePayload): Promise<void> {
-  if (!chat.defaultTtlMs) return;
+async function stampExpiry(
+  chat: Chat,
+  messageId: string,
+  payload: MessagePayload,
+  ttlOverrideMs?: number | null,
+): Promise<void> {
+  // A per-message override (from the composer timer) wins over the chat default: undefined = use the
+  // chat default; null/0 = explicitly no expiry for this message even if the chat has one; >0 = this.
+  const ttl = ttlOverrideMs !== undefined ? ttlOverrideMs : chat.defaultTtlMs;
+  if (!ttl || ttl <= 0) return;
   const m = await getMessage(messageId);
   if (!m || m.expiresAt) return;
-  const exp = (payload.timestamp || m.timestamp || now()) + chat.defaultTtlMs;
+  const exp = (payload.timestamp || m.timestamp || now()) + ttl;
   payload.expiresAt = exp;
   m.expiresAt = exp;
   await put('messages', m);
@@ -406,10 +415,11 @@ async function sealAndEnqueue(
   chat: Chat | undefined,
   messageId: string,
   payload: MessagePayload,
+  ttlOverrideMs?: number | null,
 ): Promise<void> {
   const peerUserId = chat?.participantIds[0];
   if (!chat || !peerUserId) return;
-  await stampExpiry(chat, messageId, payload);
+  await stampExpiry(chat, messageId, payload, ttlOverrideMs);
   try {
     const sealed = await sealForChat(chat.id, peerUserId, chat.isGroup, payload);
     if (sealed) await enqueue({ t: 'msg', id: messageId, to: sealed.to, ciphertext: sealed.packet });
@@ -479,8 +489,9 @@ async function sealAndEnqueueGroup(
   chat: Chat,
   messageId: string,
   payload: MessagePayload,
+  ttlOverrideMs?: number | null,
 ): Promise<void> {
-  await stampExpiry(chat, messageId, payload); // disappearing messages: one stamp, fanned out
+  await stampExpiry(chat, messageId, payload, ttlOverrideMs); // disappearing messages: one stamp, fanned out
   for (const member of chat.participantIds) {
     try {
       // Don't seal to a member who has left the network (ghosted) or whom we've
@@ -639,8 +650,15 @@ function newOutgoing(chat: Chat | undefined, chatId: string, kind: MessageKind, 
 }
 
 /** Seal + relay an outgoing payload (1:1 peer or group fan-out). */
-function enqueueMessage(chat: Chat | undefined, messageId: string, payload: MessagePayload): Promise<void> {
-  return chat?.isGroup ? sealAndEnqueueGroup(chat, messageId, payload) : sealAndEnqueue(chat, messageId, payload);
+function enqueueMessage(
+  chat: Chat | undefined,
+  messageId: string,
+  payload: MessagePayload,
+  ttlOverrideMs?: number | null,
+): Promise<void> {
+  return chat?.isGroup
+    ? sealAndEnqueueGroup(chat, messageId, payload, ttlOverrideMs)
+    : sealAndEnqueue(chat, messageId, payload, ttlOverrideMs);
 }
 
 /** Reject an outbound message to a 1:1 peer who is ghosted (account terminated)
@@ -1447,6 +1465,8 @@ export async function sendMediaMessage(
     /** Caption typed alongside the media (the message body); receivers render it
      *  under the photo/video. Clamped to CAPTION_MAX. */
     caption?: string;
+    /** Per-message disappearing override (composer timer): undefined = chat default, null/0 = off. */
+    ttlOverrideMs?: number | null;
   },
 ): Promise<string> {
   const ts = now();
@@ -1487,6 +1507,8 @@ export async function sendMediaMessage(
     compressQuality: compressible ? (opts!.quality as 'sd' | 'hd' | 'fhd') : undefined,
     // The HD/SD/Original badge shown on photo/video bubbles (both sides).
     mediaQuality: kind === 'image' || kind === 'video' ? (opts?.quality ?? 'original') : undefined,
+    // Carry the composer's per-message disappearing override to the deferred seal (below).
+    ttlOverrideMs: opts?.ttlOverrideMs,
     jobAttempts: 0,
     receipts: chat?.isGroup
       ? chat.participantIds.map((contactId) => ({ contactId }))
@@ -1560,8 +1582,8 @@ async function sealMediaAndEnqueue(
     videoNote: message.videoNote,
     audio: message.audio,
   };
-  if (chat.isGroup) await sealAndEnqueueGroup(chat, message.id, payload);
-  else await sealAndEnqueue(chat, message.id, payload);
+  if (chat.isGroup) await sealAndEnqueueGroup(chat, message.id, payload, message.ttlOverrideMs);
+  else await sealAndEnqueue(chat, message.id, payload, message.ttlOverrideMs);
   // Remember the uploaded blob id so we can DELETE it from the server once every recipient
   // has downloaded the bytes (and on chat delete). Re-read the row to avoid clobbering a
   // concurrent status update from the send we just enqueued.

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -36,7 +36,7 @@ import type {
 } from '@/services/crypto/message';
 import type {
   Alert, Call, CallLog, Chat, ChatList, Contact, FriendRequest, Media, Message, MessageKind, Reaction, ReplyRef,
-  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement,
+  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost,
 } from './types';
 
 // WhatsApp-style cap on pinned chats.
@@ -2315,6 +2315,74 @@ export async function createPost(opts: {
   };
   await put<Post>('posts', post);
   return post;
+}
+
+// ---- spec 1024: resilient-posting outbox (`pendingPosts` store) ----
+
+/** Cache the staged media + metadata as a pending post and return its id. The composer dismisses
+ *  the moment this resolves; the upload worker (services/pending-posts) drains it in the
+ *  background. The blobs are the app's OWN cached copies, so removing the source can't break it. */
+export async function enqueuePendingPost(input: {
+  target: 'wall' | 'chat';
+  chatId?: string;
+  body: string;
+  audience?: 'friends' | 'close';
+  lifetime?: PostLifetime;
+  items: {
+    blob: Blob;
+    kind: 'image' | 'video' | 'voice';
+    name: string;
+    mime: string;
+    durationSec?: number;
+    width?: number;
+    height?: number;
+    poster?: string;
+  }[];
+}): Promise<string> {
+  const id = uid();
+  const rec: OutboxPost = {
+    id,
+    target: input.target,
+    chatId: input.chatId,
+    body: input.body,
+    audience: input.audience,
+    lifetime: input.lifetime,
+    items: input.items.map((it) => ({
+      localId: uid(),
+      blob: it.blob,
+      kind: it.kind,
+      name: it.name,
+      mime: it.mime,
+      durationSec: it.durationSec,
+      width: it.width,
+      height: it.height,
+      poster: it.poster,
+      progress: 0,
+    })),
+    status: 'uploading',
+    attempts: 0,
+    createdLocally: now(),
+    updatedAt: now(),
+  };
+  await put<OutboxPost>('pendingPosts', rec);
+  return id;
+}
+
+export async function listPendingPosts(): Promise<OutboxPost[]> {
+  const all = await getAll<OutboxPost>('pendingPosts');
+  return all.sort((a, b) => a.createdLocally - b.createdLocally);
+}
+
+export async function getPendingPost(id: string): Promise<OutboxPost | undefined> {
+  return get<OutboxPost>('pendingPosts', id);
+}
+
+export async function updatePendingPost(rec: OutboxPost): Promise<void> {
+  await put<OutboxPost>('pendingPosts', { ...rec, updatedAt: now() });
+}
+
+export async function deletePendingPost(id: string): Promise<void> {
+  await remove('pendingPosts', id);
 }
 
 // Persist a single received post: unwrap K_post with our identity key, open the

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -36,7 +36,7 @@ import type {
 } from '@/services/crypto/message';
 import type {
   Alert, Call, CallLog, Chat, ChatList, Contact, FriendRequest, Media, Message, MessageKind, Reaction, ReplyRef,
-  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost, ChatDraft,
+  GeoLocation, Poll, PollVote, SharedContact, AudioMeta, Setting, Post, PostEngagement, OutboxPost, OutboxItem, ChatDraft,
 } from './types';
 
 // WhatsApp-style cap on pinned chats.
@@ -2347,16 +2347,15 @@ export async function enqueuePendingPost(input: {
   // open and the picked files are still readable). We deliberately do NOT try to make library media
   // survive a full app close — an iOS File handle doesn't, and a half-resumed upload was unreliable.
   // On a cold restart these posts are recovered as drafts instead (see recoverInterruptedPosts).
-  const rec: OutboxPost = {
-    id,
-    target: input.target,
-    chatId: input.chatId,
-    body: input.body,
-    audience: input.audience,
-    lifetime: input.lifetime,
-    items: input.items.map((it) => ({
+  // EXCEPTION: an in-app VOICE recording IS kept across a restart (it's part of the recovered draft),
+  // so we stash its bytes inline as an ArrayBuffer — an IDB Blob can read back broken on iOS, an
+  // ArrayBuffer doesn't. Small clips, so the read is cheap.
+  const items: OutboxItem[] = [];
+  for (const it of input.items) {
+    items.push({
       localId: uid(),
       blob: it.blob,
+      bytes: it.kind === 'voice' ? await it.blob.arrayBuffer() : undefined,
       kind: it.kind,
       name: it.name,
       mime: it.mime,
@@ -2365,7 +2364,16 @@ export async function enqueuePendingPost(input: {
       height: it.height,
       poster: it.poster,
       progress: 0,
-    })),
+    });
+  }
+  const rec: OutboxPost = {
+    id,
+    target: input.target,
+    chatId: input.chatId,
+    body: input.body,
+    audience: input.audience,
+    lifetime: input.lifetime,
+    items,
     status: 'uploading',
     attempts: 0,
     createdLocally: now(),

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -409,6 +409,39 @@ export interface Post {
   updatedAt: number; // change-bus / dedup
 }
 
+/** Spec 1024 — a pending Wall post / chat media send held in the `pendingPosts` outbox: its own
+ *  CACHED working blobs + the metadata to encode, upload, seal, and send it. Drained by the upload
+ *  worker; deleted (with its blobs) once the post is confirmed made, or canceled. `createdLocally`
+ *  is for pending-list ordering ONLY — the real post's `createdAt` is stamped at confirmation. */
+export interface OutboxPost {
+  id: string;
+  target: 'wall' | 'chat';
+  chatId?: string; // required when target='chat'
+  body: string; // caption / message text (may be empty)
+  audience?: 'friends' | 'close'; // wall only
+  lifetime?: '1h' | '24h' | '72h'; // wall only
+  items: OutboxItem[];
+  status: 'uploading' | 'failed' | 'canceled';
+  error?: string; // last failure reason (free-space, network…)
+  attempts: number; // worker attempts; guards the auto-retry-once
+  createdLocally: number; // ms at Share — ordering ONLY (NOT the post's createdAt)
+  updatedAt: number; // change-bus / last-write
+}
+
+export interface OutboxItem {
+  localId: string;
+  blob: Blob; // cached working copy (plaintext, local-only; deleted on finalize/cancel)
+  kind: 'image' | 'video' | 'voice';
+  name: string;
+  mime: string;
+  durationSec?: number;
+  width?: number;
+  height?: number;
+  poster?: string; // embedded video poster (data URL)
+  blobId?: string; // set when uploaded/confirmed → per-item confirmation (resume only unconfirmed)
+  progress: number; // 0..1, this item's encode+upload progress
+}
+
 /** Engagement on a post: a reaction, a comment, or a view receipt. Reactions and
  *  views are one-per-actor (id `${postId}:${type}:${actor}`, last-write-wins);
  *  comments are append-only with a uuid id. `deleted` tombstones a comment (removed

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -115,10 +115,11 @@ export interface Chat {
   // self-destruct after this many ms (carried inside the sealed payload, so they
   // disappear for everyone). Kept in sync with the peer via a `ttl` control signal.
   defaultTtlMs?: number;
-  // Per-chat media send-quality override (spec: quality configurable per chat). One of the send
-  // tiers ('sd'|'hd'|'fhd'|'original'); pre-selects the composer's Send-quality prompt for this chat.
-  // Absent = fall back to the global Upload-quality setting. Local + own-data-synced, never on the wire.
-  sendQuality?: 'sd' | 'hd' | 'fhd' | 'original';
+  // Per-chat media send-quality overrides, separately for photos and videos (a send tier:
+  // 'sd'|'hd'|'fhd'|'original'). Absent = fall back to the matching global Upload-quality setting.
+  // Local + own-data-synced, never on the wire.
+  sendQualityPhoto?: 'sd' | 'hd' | 'fhd' | 'original';
+  sendQualityVideo?: 'sd' | 'hd' | 'fhd' | 'original';
   // ---- Chats-tab organisation (all synced via own-data sync, LWW on updatedAt) ----
   // Marked a Favorite (drives the Favorites filter chip).
   favorite?: boolean;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -256,6 +256,17 @@ export interface ReplyRef {
   videoNote?: boolean; // quoted message was a round video note
 }
 
+// A per-chat composer draft: the unsent text, the caret, and any reply-in-progress, so leaving the
+// chat or closing the app keeps you exactly where you left off. Local-only, keyed by chatId, never synced.
+export interface ChatDraft {
+  chatId: string;
+  text: string;
+  selStart?: number; // caret/selection in the text, to restore the cursor
+  selEnd?: number;
+  reply?: ReplyRef; // a reply you'd started but not sent
+  updatedAt: number;
+}
+
 export interface Message {
   id: string;
   chatId: string;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -115,6 +115,10 @@ export interface Chat {
   // self-destruct after this many ms (carried inside the sealed payload, so they
   // disappear for everyone). Kept in sync with the peer via a `ttl` control signal.
   defaultTtlMs?: number;
+  // Per-chat media send-quality override (spec: quality configurable per chat). One of the send
+  // tiers ('sd'|'hd'|'fhd'|'original'); pre-selects the composer's Send-quality prompt for this chat.
+  // Absent = fall back to the global Upload-quality setting. Local + own-data-synced, never on the wire.
+  sendQuality?: 'sd' | 'hd' | 'fhd' | 'original';
   // ---- Chats-tab organisation (all synced via own-data sync, LWW on updatedAt) ----
   // Marked a Favorite (drives the Favorites filter chip).
   favorite?: boolean;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -447,6 +447,11 @@ export interface OutboxPost {
 export interface OutboxItem {
   localId: string;
   blob: Blob; // cached working copy (plaintext, local-only; deleted on finalize/cancel)
+  // VOICE only: the clip's bytes stored inline (not as a Blob). A Blob retrieved from IndexedDB
+  // after a full app reload can be unreadable on iOS (its arrayBuffer() hangs), which would stall the
+  // re-upload of a recovered draft. An ArrayBuffer is stored inline and always reads back, so we
+  // rebuild a fresh in-memory Blob from this when restoring the draft into the composer.
+  bytes?: ArrayBuffer;
   kind: 'image' | 'video' | 'voice';
   name: string;
   mime: string;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -341,6 +341,10 @@ export interface Message {
   deleted?: boolean; // soft-deleted → shows a "deleted" placeholder
   editedAt?: number; // text rewritten by its author after sending → "edited" tag
   expiresAt?: number; // disappearing messages: epoch ms when this self-destructs
+  // Per-message disappearing override carried from the composer to the DEFERRED media seal (the
+  // compress/upload job seals later, without the send-time opts). undefined = chat default, null/0 =
+  // off. Local-only; never on the wire (the resulting expiresAt is what rides in the payload).
+  ttlOverrideMs?: number | null;
   location?: GeoLocation; // kind === 'location'
   poll?: Poll; // kind === 'poll'
   contact?: SharedContact; // kind === 'contact'

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -264,7 +264,25 @@ export interface ChatDraft {
   selStart?: number; // caret/selection in the text, to restore the cursor
   selEnd?: number;
   reply?: ReplyRef; // a reply you'd started but not sent
+  mediaCount?: number; // staged attachments (bytes live in the `draftMedia` store) — drives the badge
+  mediaLabel?: string; // e.g. 'Photo', 'Video', '3 attachments' — the Chats-list preview for media-only
   updatedAt: number;
+}
+
+// Staged (unsent) chat attachments for a draft, kept alongside ChatDraft so leaving/closing keeps
+// them too. Bytes are stored inline (NOT as Blobs) because an IDB Blob can read back broken on iOS
+// after a reload; we rebuild a fresh in-memory File from these when restoring the composer.
+export interface DraftMedia {
+  chatId: string;
+  items: DraftMediaItem[];
+  updatedAt: number;
+}
+export interface DraftMediaItem {
+  bytes: ArrayBuffer;
+  kind: 'image' | 'video' | 'file';
+  name: string;
+  mime: string;
+  caption?: string;
 }
 
 export interface Message {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -456,7 +456,6 @@ export interface OutboxPost {
   // finish in the composer; 'canceled' = discarded.
   status: 'uploading' | 'failed' | 'canceled' | 'interrupted';
   error?: string; // last failure reason (free-space, network…)
-  droppedMedia?: boolean; // 'interrupted' posts: there WERE photos/videos we couldn't keep → "re-add"
   attempts: number; // worker attempts; guards the auto-retry-once
   createdLocally: number; // ms at Share — ordering ONLY (NOT the post's createdAt)
   updatedAt: number; // change-bus / last-write
@@ -464,12 +463,12 @@ export interface OutboxPost {
 
 export interface OutboxItem {
   localId: string;
-  blob: Blob; // cached working copy (plaintext, local-only; deleted on finalize/cancel)
-  // VOICE only: the clip's bytes stored inline (not as a Blob). A Blob retrieved from IndexedDB
-  // after a full app reload can be unreadable on iOS (its arrayBuffer() hangs), which would stall the
-  // re-upload of a recovered draft. An ArrayBuffer is stored inline and always reads back, so we
-  // rebuild a fresh in-memory Blob from this when restoring the draft into the composer.
+  // The item's bytes stored INLINE (not as a Blob). A Blob read back from IndexedDB after a full app
+  // reload can be unreadable on iOS (its arrayBuffer() hangs), which stalled re-uploads and stopped
+  // recovered posts from keeping their media; an ArrayBuffer always reads back. We rebuild a fresh
+  // in-memory Blob from this both for the upload and when restoring the post into the composer.
   bytes?: ArrayBuffer;
+  blob?: Blob; // legacy/back-compat: older queued items stored the working copy as a Blob
   kind: 'image' | 'video' | 'voice';
   name: string;
   mime: string;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -421,8 +421,13 @@ export interface OutboxPost {
   audience?: 'friends' | 'close'; // wall only
   lifetime?: '1h' | '24h' | '72h'; // wall only
   items: OutboxItem[];
-  status: 'uploading' | 'failed' | 'canceled';
+  // 'uploading' = in-session background upload in flight; 'failed' = in-session failure (Retry/Cancel);
+  // 'interrupted' = the app was fully closed mid-upload — library media was dropped (its file handle
+  // doesn't survive a cold start) and only the caption + in-app voice notes were kept for the user to
+  // finish in the composer; 'canceled' = discarded.
+  status: 'uploading' | 'failed' | 'canceled' | 'interrupted';
   error?: string; // last failure reason (free-space, network…)
+  droppedMedia?: boolean; // 'interrupted' posts: there WERE photos/videos we couldn't keep → "re-add"
   attempts: number; // worker attempts; guards the auto-retry-once
   createdLocally: number; // ms at Share — ordering ONLY (NOT the post's createdAt)
   updatedAt: number; // change-bus / last-write

--- a/src/services/media-transfer.ts
+++ b/src/services/media-transfer.ts
@@ -63,11 +63,18 @@ export async function encryptBlob(blob: Blob): Promise<{ ciphertext: Blob; fileK
   return { ciphertext: new Blob([part(packed)], { type: 'application/octet-stream' }), fileKey };
 }
 
-export async function decryptBlob(ciphertext: Blob, fileKey: Uint8Array, mime: string): Promise<Blob> {
-  const packed = new Uint8Array(await ciphertext.arrayBuffer());
+/** Decrypt already-in-memory ciphertext bytes. Kept separate from decryptBlob so the streaming
+ *  download path can decrypt straight from the bytes it assembled, without a Blob→arrayBuffer
+ *  round-trip (which would hold a second full copy — a memory spike that fails on mobile for a
+ *  large clip). */
+export function decryptBytes(packed: Uint8Array, fileKey: Uint8Array, mime: string): Blob {
   const { nonce, ct } = unpackBlob(packed);
   const plain = aeadOpen(fileKey, nonce, ct); // throws if key wrong / tampered
   return new Blob([part(plain)], { type: mime });
+}
+
+export async function decryptBlob(ciphertext: Blob, fileKey: Uint8Array, mime: string): Promise<Blob> {
+  return decryptBytes(new Uint8Array(await ciphertext.arrayBuffer()), fileKey, mime);
 }
 
 /* ---- blob store (backend: HTTP /v1/blobs) ---- */
@@ -117,32 +124,66 @@ export function uploadBlob(ciphertext: Blob, onProgress?: (p: number) => void): 
 }
 
 /** Download ciphertext by id from the backend, or null if absent (404). */
-export async function downloadBlob(
-  blobId: string,
-  onProgress?: (fraction: number) => void,
-): Promise<Blob | null> {
+export async function downloadBlob(blobId: string): Promise<Blob | null> {
   const res = await fetch(`${apiBaseUrl()}/v1/blobs/${encodeURIComponent(blobId)}`, {
     headers: authHeaders(),
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`download blob failed: ${res.status}`);
-  // Without a progress callback (or a readable body), just take the blob directly.
-  if (!onProgress || !res.body) return res.blob();
-  // Stream the body so we can report download progress against Content-Length.
-  const total = Number(res.headers.get('Content-Length')) || 0;
-  const reader = res.body.getReader();
-  const chunks: BlobPart[] = [];
-  let received = 0;
+  return res.blob();
+}
+
+/** Stream ciphertext bytes by id, reporting progress (0..1) against Content-Length. Assembles into
+ *  ONE preallocated buffer (not a chunk array + Blob + arrayBuffer) so a large clip doesn't spike
+ *  memory on mobile. Returns null if the blob is gone (404). */
+async function downloadCipherBytes(
+  blobId: string,
+  onProgress: (fraction: number) => void,
+): Promise<Uint8Array | null> {
+  const res = await fetch(`${apiBaseUrl()}/v1/blobs/${encodeURIComponent(blobId)}`, {
+    headers: authHeaders(),
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`download blob failed: ${res.status}`);
   onProgress(0);
+  if (!res.body) {
+    const buf = new Uint8Array(await res.arrayBuffer());
+    onProgress(1);
+    return buf;
+  }
+  const reader = res.body.getReader();
+  const total = Number(res.headers.get('Content-Length')) || 0;
+  if (total > 0) {
+    // Known length: fill one buffer in place — no per-chunk copies kept around.
+    const buf = new Uint8Array(total);
+    let off = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf.set(value, off);
+      off += value.length;
+      onProgress(Math.min(1, off / total));
+    }
+    onProgress(1);
+    return off === total ? buf : buf.subarray(0, off);
+  }
+  // Unknown length (chunked): collect then concatenate once.
+  const chunks: Uint8Array[] = [];
+  let received = 0;
   for (;;) {
     const { done, value } = await reader.read();
     if (done) break;
     chunks.push(value);
     received += value.length;
-    if (total > 0) onProgress(Math.min(1, received / total));
+  }
+  const buf = new Uint8Array(received);
+  let off = 0;
+  for (const c of chunks) {
+    buf.set(c, off);
+    off += c.length;
   }
   onProgress(1);
-  return new Blob(chunks, { type: res.headers.get('Content-Type') || 'application/octet-stream' });
+  return buf;
 }
 
 /** Delete a blob we uploaded (owner-authed server-side). Called once every recipient has
@@ -188,7 +229,14 @@ export async function receiveIncomingMedia(
   ref: MediaRef,
   onProgress?: (fraction: number) => void,
 ): Promise<Blob | null> {
-  const ciphertext = await downloadBlob(ref.blobId, onProgress);
+  // With a progress callback, stream into one buffer and decrypt from those bytes directly
+  // (memory-lean, for large clips on mobile). Without one, the plain Blob path is simplest.
+  if (onProgress) {
+    const packed = await downloadCipherBytes(ref.blobId, onProgress);
+    if (!packed) return null;
+    return decryptBytes(packed, b64urlToBytes(ref.fileKey), ref.mime);
+  }
+  const ciphertext = await downloadBlob(ref.blobId);
   if (!ciphertext) return null;
   return decryptBlob(ciphertext, b64urlToBytes(ref.fileKey), ref.mime);
 }

--- a/src/services/media-transfer.ts
+++ b/src/services/media-transfer.ts
@@ -117,13 +117,32 @@ export function uploadBlob(ciphertext: Blob, onProgress?: (p: number) => void): 
 }
 
 /** Download ciphertext by id from the backend, or null if absent (404). */
-export async function downloadBlob(blobId: string): Promise<Blob | null> {
+export async function downloadBlob(
+  blobId: string,
+  onProgress?: (fraction: number) => void,
+): Promise<Blob | null> {
   const res = await fetch(`${apiBaseUrl()}/v1/blobs/${encodeURIComponent(blobId)}`, {
     headers: authHeaders(),
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`download blob failed: ${res.status}`);
-  return res.blob();
+  // Without a progress callback (or a readable body), just take the blob directly.
+  if (!onProgress || !res.body) return res.blob();
+  // Stream the body so we can report download progress against Content-Length.
+  const total = Number(res.headers.get('Content-Length')) || 0;
+  const reader = res.body.getReader();
+  const chunks: BlobPart[] = [];
+  let received = 0;
+  onProgress(0);
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    received += value.length;
+    if (total > 0) onProgress(Math.min(1, received / total));
+  }
+  onProgress(1);
+  return new Blob(chunks, { type: res.headers.get('Content-Type') || 'application/octet-stream' });
 }
 
 /** Delete a blob we uploaded (owner-authed server-side). Called once every recipient has
@@ -163,9 +182,13 @@ export async function prepareOutgoingMedia(
   };
 }
 
-/** Download + decrypt the media a message refers to; null if the blob is gone. */
-export async function receiveIncomingMedia(ref: MediaRef): Promise<Blob | null> {
-  const ciphertext = await downloadBlob(ref.blobId);
+/** Download + decrypt the media a message refers to; null if the blob is gone. Reports download
+ *  progress (0..1) via onProgress when given, for the manual-download progress ring. */
+export async function receiveIncomingMedia(
+  ref: MediaRef,
+  onProgress?: (fraction: number) => void,
+): Promise<Blob | null> {
+  const ciphertext = await downloadBlob(ref.blobId, onProgress);
   if (!ciphertext) return null;
   return decryptBlob(ciphertext, b64urlToBytes(ref.fileKey), ref.mime);
 }

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -47,33 +47,50 @@ export async function drainPendingPosts(): Promise<void> {
 
 const lastProgressWrite = new Map<string, number>();
 
+// If an upload makes NO progress for this long it's treated as stalled and fails (→ Retry/Cancel),
+// rather than spinning at 0% forever and wedging the single-drain worker behind it. A real upload
+// reports progress well within this window (encode + the immediate onProgress(0) on upload start);
+// only a genuine hang — e.g. reading an unreadable cached blob — goes silent this long.
+const UPLOAD_STALL_MS = 45_000;
+
 async function uploadOne(id: string): Promise<void> {
   const rec = await getPendingPost(id);
   if (!rec || rec.status !== 'uploading') return; // canceled / interrupted / already gone
   rec.attempts += 1;
   await updatePendingPost(rec);
+  let lastTick = Date.now();
+  let watchdog: ReturnType<typeof setInterval> | undefined;
   try {
-    await createPost({
-      // Pass the outbox record's id as the post id so a retry is idempotent: createPost overwrites
-      // the same local Post instead of minting a second one. (See the "already made" guard below for
-      // the kill-after-send window the stable id alone can't cover.)
-      id,
-      body: rec.body || undefined,
-      audience: rec.audience ?? 'friends',
-      lifetime: rec.lifetime ?? '72h',
-      media: rec.items.length
-        ? rec.items.map((it) => ({
-            blob: it.blob,
-            kind: it.kind,
-            name: it.name,
-            durationSec: it.durationSec,
-            quality: 'hd' as const,
-          }))
-        : undefined,
-      onProgress: (p) => {
-        void writeProgress(id, p);
-      },
+    const stalled = new Promise<never>((_, reject) => {
+      watchdog = setInterval(() => {
+        if (Date.now() - lastTick > UPLOAD_STALL_MS) reject(new Error('Upload stalled. Tap Retry to try again.'));
+      }, 5_000);
     });
+    await Promise.race([
+      createPost({
+        // Pass the outbox record's id as the post id so a retry is idempotent: createPost overwrites
+        // the same local Post instead of minting a second one. (See the "already made" guard below for
+        // the kill-after-send window the stable id alone can't cover.)
+        id,
+        body: rec.body || undefined,
+        audience: rec.audience ?? 'friends',
+        lifetime: rec.lifetime ?? '72h',
+        media: rec.items.length
+          ? rec.items.map((it) => ({
+              blob: it.blob,
+              kind: it.kind,
+              name: it.name,
+              durationSec: it.durationSec,
+              quality: 'hd' as const,
+            }))
+          : undefined,
+        onProgress: (p) => {
+          lastTick = Date.now(); // each progress event keeps the watchdog from firing
+          void writeProgress(id, p);
+        },
+      }),
+      stalled,
+    ]);
     // createPost wrote the real Post (createdAt = confirmation time) → drop the outbox record + blobs.
     await deletePendingPost(id);
     lastProgressWrite.delete(id);
@@ -92,6 +109,8 @@ async function uploadOne(id: string): Promise<void> {
       cur.error = friendlyError(err);
       await updatePendingPost(cur);
     }
+  } finally {
+    clearInterval(watchdog); // stop the stall-watchdog whether we finished, failed, or timed out
   }
 }
 
@@ -103,6 +122,9 @@ function friendlyError(err: unknown): string {
   }
   if (/network|fetch|offline|timeout|Failed to fetch/i.test(msg)) {
     return "Couldn't reach the server. Check your connection and try again.";
+  }
+  if (/stalled/i.test(msg)) {
+    return 'Upload stalled. Tap Retry to try again.';
   }
   return 'Upload failed. Tap Retry to try again.';
 }

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -99,12 +99,12 @@ async function uploadOne(id: string): Promise<void> {
 function friendlyError(err: unknown): string {
   const msg = err instanceof Error ? err.message : String(err ?? '');
   if (/quota|storage|exceeded|QuotaExceeded/i.test(msg) || (err as { name?: string })?.name === 'QuotaExceededError') {
-    return 'Not enough storage — free up space and retry.';
+    return 'Not enough storage. Free up space and try again.';
   }
   if (/network|fetch|offline|timeout|Failed to fetch/i.test(msg)) {
-    return "Couldn't reach the server — check your connection and retry.";
+    return "Couldn't reach the server. Check your connection and try again.";
   }
-  return 'Upload failed — tap retry.';
+  return 'Upload failed. Tap Retry to try again.';
 }
 
 /** Re-arm a failed post for another drain pass (user tapped Retry). Resets the attempt budget so a

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -1,15 +1,16 @@
 /**
  * Spec 1024 — the resilient-posting upload worker.
  *
- * Drains the `pendingPosts` outbox: for each pending post it runs the normal {@link createPost}
- * pipeline (encode → upload → seal → send) off its CACHED blobs, writing per-item progress back so
- * the Wall's pending card animates. On success the real Post is written by createPost and the
- * pending record (+ its cached blobs) is dropped; on failure the record flips to `failed` and is
- * retained for retry. The composer dismisses BEFORE this runs — that's the whole point.
+ * The composer dismisses the moment you tap Share; this worker finishes the post in the background
+ * by running the normal {@link createPost} pipeline (encode → upload → seal → send) off the CACHED
+ * blobs, writing per-item progress back so the Wall's pending card animates. On success createPost
+ * writes the real Post and the outbox record (+ blobs) is dropped; an in-session failure flips it to
+ * `failed` (Retry / Cancel).
  *
- * One drain at a time (a simple in-process guard); the post itself is processed sequentially so
- * bandwidth + progress stay predictable. Resume is just "drain again": an `uploading` record that
- * was interrupted is picked up on the next kick (app start / reconnect).
+ * IMPORTANT: the upload is an IN-SESSION job. We do NOT try to resume it across a full app close — an
+ * iOS library File handle doesn't survive a cold start, so a "resumed" upload just stalls forever on
+ * unreadable bytes. Instead {@link recoverInterruptedPosts} runs once at startup and turns any
+ * leftover post into a draft (caption + in-app voice notes kept; library media dropped to re-add).
  */
 import {
   createPost,
@@ -22,12 +23,7 @@ import {
 
 let draining = false;
 
-// After this many resume attempts a post stops auto-retrying and surfaces as `failed` (with Retry /
-// Cancel) instead of spinning forever. The check runs BEFORE each upload attempt, so even a post
-// whose upload somehow hangs is force-failed on the next app start rather than wedging the queue.
-const MAX_ATTEMPTS = 5;
-
-/** Fire-and-forget kick — safe to call repeatedly (enqueue, app start, reconnect). */
+/** Fire-and-forget kick — safe to call repeatedly (enqueue, in-session Retry). */
 export function kickPendingPosts(): void {
   void drainPendingPosts();
 }
@@ -53,16 +49,7 @@ const lastProgressWrite = new Map<string, number>();
 
 async function uploadOne(id: string): Promise<void> {
   const rec = await getPendingPost(id);
-  if (!rec || rec.status !== 'uploading') return; // canceled / already gone
-  // Give up auto-retrying after too many attempts so a chronically-failing post can't keep the
-  // single-drain guard busy and block fresh posts behind it. Checked before the upload, so a prior
-  // hung attempt is converted to a proper failure on the next launch.
-  if (rec.attempts >= MAX_ATTEMPTS) {
-    rec.status = 'failed';
-    rec.error = rec.error || 'Upload keeps failing — tap retry.';
-    await updatePendingPost(rec);
-    return;
-  }
+  if (!rec || rec.status !== 'uploading') return; // canceled / interrupted / already gone
   rec.attempts += 1;
   await updatePendingPost(rec);
   try {
@@ -132,10 +119,54 @@ export async function retryPendingPost(id: string): Promise<void> {
   kickPendingPosts();
 }
 
-/** Drop a pending post for good — discards its cached blobs (user tapped Cancel). */
+/** Drop a pending post for good — discards its cached blobs (user tapped Cancel / Discard). */
 export async function cancelPendingPost(id: string): Promise<void> {
   await deletePendingPost(id);
   lastProgressWrite.delete(id);
+}
+
+let recovered = false;
+
+/**
+ * Run ONCE at app start (after unlock). Any pending post still around is left over from a previous
+ * session — its in-flight upload died when the app was fully closed. We can't reliably finish it
+ * (library File handles don't survive a cold start), so rather than stall:
+ *   • if the upload had actually completed before the app died (the real Post already exists), just
+ *     clean the leftover outbox row — no duplicate, no draft;
+ *   • else keep the caption + any in-app VOICE recordings (memory-backed → they survive) and flip the
+ *     record to `interrupted`, so the Wall offers "Finish" (reopen composer) + re-add the media;
+ *   • a post with nothing worth keeping (library media only, no caption) is discarded.
+ * Returns counts so the caller can let the user know.
+ */
+export async function recoverInterruptedPosts(): Promise<{ recovered: number; discarded: number }> {
+  if (recovered) return { recovered: 0, discarded: 0 };
+  recovered = true;
+  let recoveredN = 0;
+  let discarded = 0;
+  for (const rec of await listPendingPosts()) {
+    if (rec.status === 'interrupted' || rec.status === 'canceled') continue;
+    if (await getPost(rec.id)) {
+      // The upload had actually finished; only the cleanup was lost. Drop the row, keep the post.
+      await deletePendingPost(rec.id);
+      continue;
+    }
+    const voice = rec.items.filter((it) => it.kind === 'voice');
+    const droppedMedia = rec.items.some((it) => it.kind !== 'voice');
+    if (rec.body?.trim() || voice.length) {
+      rec.items = voice; // keep in-app recordings; library photos/videos can't be re-read → drop them
+      rec.status = 'interrupted';
+      rec.error = undefined;
+      rec.droppedMedia = droppedMedia;
+      rec.attempts = 0;
+      await updatePendingPost(rec);
+      recoveredN += 1;
+    } else {
+      await deletePendingPost(rec.id); // pure library-media post with no caption — nothing to keep
+      discarded += 1;
+    }
+    lastProgressWrite.delete(rec.id);
+  }
+  return { recovered: recoveredN, discarded };
 }
 
 // Throttle the per-item progress writes (~6×/s) so the change-bus + IDB don't thrash during encode.

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -15,6 +15,7 @@ import {
   createPost,
   listPendingPosts,
   getPendingPost,
+  getPost,
   updatePendingPost,
   deletePendingPost,
 } from '@/db/queries';
@@ -47,6 +48,10 @@ async function uploadOne(id: string): Promise<void> {
   await updatePendingPost(rec);
   try {
     await createPost({
+      // Pass the outbox record's id as the post id so a retry is idempotent: createPost overwrites
+      // the same local Post instead of minting a second one. (See the "already made" guard below for
+      // the kill-after-send window the stable id alone can't cover.)
+      id,
       body: rec.body || undefined,
       audience: rec.audience ?? 'friends',
       lifetime: rec.lifetime ?? '72h',
@@ -67,13 +72,49 @@ async function uploadOne(id: string): Promise<void> {
     await deletePendingPost(id);
     lastProgressWrite.delete(id);
   } catch (err) {
+    // If the app was killed AFTER the post was already sent but BEFORE we cleaned up, the retry's
+    // server insert collides on the (now-existing) post id. The local Post is present, so this isn't
+    // a real failure — treat it as success and clear the outbox quietly rather than flash "failed".
+    if (await getPost(id)) {
+      await deletePendingPost(id);
+      lastProgressWrite.delete(id);
+      return;
+    }
     const cur = await getPendingPost(id);
     if (cur && cur.status === 'uploading') {
       cur.status = 'failed';
-      cur.error = err instanceof Error ? err.message : 'Upload failed';
+      cur.error = friendlyError(err);
       await updatePendingPost(cur);
     }
   }
+}
+
+/** Map a raw upload error to a short, user-facing reason for the pending card. */
+function friendlyError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  if (/quota|storage|exceeded|QuotaExceeded/i.test(msg) || (err as { name?: string })?.name === 'QuotaExceededError') {
+    return 'Not enough storage — free up space and retry.';
+  }
+  if (/network|fetch|offline|timeout|Failed to fetch/i.test(msg)) {
+    return "Couldn't reach the server — check your connection and retry.";
+  }
+  return 'Upload failed — tap retry.';
+}
+
+/** Re-arm a failed post for another drain pass (user tapped Retry). */
+export async function retryPendingPost(id: string): Promise<void> {
+  const rec = await getPendingPost(id);
+  if (!rec) return;
+  rec.status = 'uploading';
+  rec.error = undefined;
+  await updatePendingPost(rec);
+  kickPendingPosts();
+}
+
+/** Drop a pending post for good — discards its cached blobs (user tapped Cancel). */
+export async function cancelPendingPost(id: string): Promise<void> {
+  await deletePendingPost(id);
+  lastProgressWrite.delete(id);
 }
 
 // Throttle the per-item progress writes (~6×/s) so the change-bus + IDB don't thrash during encode.

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -77,7 +77,9 @@ async function uploadOne(id: string): Promise<void> {
         lifetime: rec.lifetime ?? '72h',
         media: rec.items.length
           ? rec.items.map((it) => ({
-              blob: it.blob,
+              // Rebuild a fresh in-memory Blob from the inline bytes (always readable, unlike a Blob
+              // read back from IDB after a restart). Fall back to a legacy stored Blob if present.
+              blob: it.bytes ? new Blob([it.bytes], { type: it.mime }) : (it.blob as Blob),
               kind: it.kind,
               name: it.name,
               durationSec: it.durationSec,
@@ -172,18 +174,20 @@ export async function recoverInterruptedPosts(): Promise<{ recovered: number; di
       await deletePendingPost(rec.id);
       continue;
     }
-    const voice = rec.items.filter((it) => it.kind === 'voice');
-    const droppedMedia = rec.items.some((it) => it.kind !== 'voice');
-    if (rec.body?.trim() || voice.length) {
-      rec.items = voice; // keep in-app recordings; library photos/videos can't be re-read → drop them
+    // Everything is stored as inline bytes, so keep the WHOLE post — caption, voice, photos and
+    // videos all survive — and hand it back as a draft to finish. Older records that only have a
+    // legacy Blob (no bytes) for photos/videos can't be re-read after the restart, so those items
+    // are dropped; the caption and any voice (which always had bytes) still come back.
+    const usable = rec.items.filter((it) => !!it.bytes);
+    if (rec.body?.trim() || usable.length) {
+      rec.items = usable;
       rec.status = 'interrupted';
       rec.error = undefined;
-      rec.droppedMedia = droppedMedia;
       rec.attempts = 0;
       await updatePendingPost(rec);
       recoveredN += 1;
     } else {
-      await deletePendingPost(rec.id); // pure library-media post with no caption — nothing to keep
+      await deletePendingPost(rec.id); // nothing readable to keep
       discarded += 1;
     }
     lastProgressWrite.delete(rec.id);

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -22,18 +22,28 @@ import {
 
 let draining = false;
 
+// After this many resume attempts a post stops auto-retrying and surfaces as `failed` (with Retry /
+// Cancel) instead of spinning forever. The check runs BEFORE each upload attempt, so even a post
+// whose upload somehow hangs is force-failed on the next app start rather than wedging the queue.
+const MAX_ATTEMPTS = 5;
+
 /** Fire-and-forget kick — safe to call repeatedly (enqueue, app start, reconnect). */
 export function kickPendingPosts(): void {
   void drainPendingPosts();
 }
 
-/** Process every `uploading` pending post once, sequentially. */
+/** Process every `uploading` pending post, sequentially, until none remain. */
 export async function drainPendingPosts(): Promise<void> {
   if (draining) return;
   draining = true;
   try {
-    const queue = (await listPendingPosts()).filter((p) => p.status === 'uploading');
-    for (const rec of queue) await uploadOne(rec.id);
+    // Loop until the outbox is dry: a post enqueued WHILE we were draining (its kick was a no-op
+    // because `draining` was set) must still get picked up in the same pass.
+    for (;;) {
+      const queue = (await listPendingPosts()).filter((p) => p.status === 'uploading');
+      if (!queue.length) break;
+      for (const rec of queue) await uploadOne(rec.id);
+    }
   } finally {
     draining = false;
   }
@@ -44,6 +54,15 @@ const lastProgressWrite = new Map<string, number>();
 async function uploadOne(id: string): Promise<void> {
   const rec = await getPendingPost(id);
   if (!rec || rec.status !== 'uploading') return; // canceled / already gone
+  // Give up auto-retrying after too many attempts so a chronically-failing post can't keep the
+  // single-drain guard busy and block fresh posts behind it. Checked before the upload, so a prior
+  // hung attempt is converted to a proper failure on the next launch.
+  if (rec.attempts >= MAX_ATTEMPTS) {
+    rec.status = 'failed';
+    rec.error = rec.error || 'Upload keeps failing — tap retry.';
+    await updatePendingPost(rec);
+    return;
+  }
   rec.attempts += 1;
   await updatePendingPost(rec);
   try {
@@ -101,12 +120,14 @@ function friendlyError(err: unknown): string {
   return 'Upload failed — tap retry.';
 }
 
-/** Re-arm a failed post for another drain pass (user tapped Retry). */
+/** Re-arm a failed post for another drain pass (user tapped Retry). Resets the attempt budget so a
+ *  post that exhausted its auto-retries gets a fresh start instead of failing instantly. */
 export async function retryPendingPost(id: string): Promise<void> {
   const rec = await getPendingPost(id);
   if (!rec) return;
   rec.status = 'uploading';
   rec.error = undefined;
+  rec.attempts = 0;
   await updatePendingPost(rec);
   kickPendingPosts();
 }

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -1,0 +1,92 @@
+/**
+ * Spec 1024 — the resilient-posting upload worker.
+ *
+ * Drains the `pendingPosts` outbox: for each pending post it runs the normal {@link createPost}
+ * pipeline (encode → upload → seal → send) off its CACHED blobs, writing per-item progress back so
+ * the Wall's pending card animates. On success the real Post is written by createPost and the
+ * pending record (+ its cached blobs) is dropped; on failure the record flips to `failed` and is
+ * retained for retry. The composer dismisses BEFORE this runs — that's the whole point.
+ *
+ * One drain at a time (a simple in-process guard); the post itself is processed sequentially so
+ * bandwidth + progress stay predictable. Resume is just "drain again": an `uploading` record that
+ * was interrupted is picked up on the next kick (app start / reconnect).
+ */
+import {
+  createPost,
+  listPendingPosts,
+  getPendingPost,
+  updatePendingPost,
+  deletePendingPost,
+} from '@/db/queries';
+
+let draining = false;
+
+/** Fire-and-forget kick — safe to call repeatedly (enqueue, app start, reconnect). */
+export function kickPendingPosts(): void {
+  void drainPendingPosts();
+}
+
+/** Process every `uploading` pending post once, sequentially. */
+export async function drainPendingPosts(): Promise<void> {
+  if (draining) return;
+  draining = true;
+  try {
+    const queue = (await listPendingPosts()).filter((p) => p.status === 'uploading');
+    for (const rec of queue) await uploadOne(rec.id);
+  } finally {
+    draining = false;
+  }
+}
+
+const lastProgressWrite = new Map<string, number>();
+
+async function uploadOne(id: string): Promise<void> {
+  const rec = await getPendingPost(id);
+  if (!rec || rec.status !== 'uploading') return; // canceled / already gone
+  rec.attempts += 1;
+  await updatePendingPost(rec);
+  try {
+    await createPost({
+      body: rec.body || undefined,
+      audience: rec.audience ?? 'friends',
+      lifetime: rec.lifetime ?? '72h',
+      media: rec.items.length
+        ? rec.items.map((it) => ({
+            blob: it.blob,
+            kind: it.kind,
+            name: it.name,
+            durationSec: it.durationSec,
+            quality: 'hd' as const,
+          }))
+        : undefined,
+      onProgress: (p) => {
+        void writeProgress(id, p);
+      },
+    });
+    // createPost wrote the real Post (createdAt = confirmation time) → drop the outbox record + blobs.
+    await deletePendingPost(id);
+    lastProgressWrite.delete(id);
+  } catch (err) {
+    const cur = await getPendingPost(id);
+    if (cur && cur.status === 'uploading') {
+      cur.status = 'failed';
+      cur.error = err instanceof Error ? err.message : 'Upload failed';
+      await updatePendingPost(cur);
+    }
+  }
+}
+
+// Throttle the per-item progress writes (~6×/s) so the change-bus + IDB don't thrash during encode.
+async function writeProgress(
+  id: string,
+  p: { phase: 'encoding' | 'uploading'; index: number; total: number; value: number },
+): Promise<void> {
+  const t = Date.now();
+  if (p.value < 1 && (lastProgressWrite.get(id) ?? 0) > t - 150) return;
+  lastProgressWrite.set(id, t);
+  const rec = await getPendingPost(id);
+  if (!rec || rec.status !== 'uploading' || !rec.items[p.index]) return;
+  // encode is the first half of an item, upload the second half.
+  rec.items[p.index].progress = p.phase === 'encoding' ? p.value * 0.5 : 0.5 + p.value * 0.5;
+  await updatePendingPost(rec);
+}

--- a/src/services/storage-estimate.test.ts
+++ b/src/services/storage-estimate.test.ts
@@ -1,0 +1,59 @@
+// Spec 1024 (US3): the on-device storage headroom check that guards staging a post's cached
+// blobs. Pure aside from navigator.storage.estimate — which we stub per-case.
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { hasRoomFor } from './storage-estimate';
+
+const MB = 1024 * 1024;
+
+/** Install a fake navigator.storage.estimate. */
+function stubEstimate(impl: (() => Promise<StorageEstimate>) | null): void {
+  vi.stubGlobal('navigator', impl === null ? {} : { storage: { estimate: impl } });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('hasRoomFor', () => {
+  it('allows a zero/negative payload without even checking', async () => {
+    stubEstimate(() => Promise.reject(new Error('should not be called')));
+    expect(await hasRoomFor(0)).toBe(true);
+    expect(await hasRoomFor(-5)).toBe(true);
+  });
+
+  it('blocks when free space is below the 2.5× headroom', async () => {
+    // 100 MB payload needs 250 MB; only 200 MB free.
+    stubEstimate(() => Promise.resolve({ quota: 1000 * MB, usage: 800 * MB }));
+    expect(await hasRoomFor(100 * MB)).toBe(false);
+  });
+
+  it('allows when free space clears the 2.5× headroom', async () => {
+    // 100 MB payload needs 250 MB; 400 MB free.
+    stubEstimate(() => Promise.resolve({ quota: 1000 * MB, usage: 600 * MB }));
+    expect(await hasRoomFor(100 * MB)).toBe(true);
+  });
+
+  it('never blocks a tiny post below the 50 MB floor even on a tight estimate', async () => {
+    // 1 MB payload: 2.5× is only 2.5 MB, but the floor demands 50 MB free — and we have 60 MB.
+    stubEstimate(() => Promise.resolve({ quota: 1000 * MB, usage: 940 * MB }));
+    expect(await hasRoomFor(1 * MB)).toBe(true);
+  });
+
+  it('blocks a tiny post when free space is under the 50 MB floor', async () => {
+    stubEstimate(() => Promise.resolve({ quota: 1000 * MB, usage: 970 * MB })); // 30 MB free
+    expect(await hasRoomFor(1 * MB)).toBe(false);
+  });
+
+  it('does not block when the API is unavailable (returns true)', async () => {
+    stubEstimate(null); // navigator without .storage
+    expect(await hasRoomFor(500 * MB)).toBe(true);
+  });
+
+  it('does not block when estimate() throws', async () => {
+    stubEstimate(() => Promise.reject(new Error('nope')));
+    expect(await hasRoomFor(500 * MB)).toBe(true);
+  });
+
+  it('does not block when quota is missing/zero (unknown)', async () => {
+    stubEstimate(() => Promise.resolve({ quota: 0, usage: 0 }));
+    expect(await hasRoomFor(500 * MB)).toBe(true);
+  });
+});

--- a/src/services/storage-estimate.ts
+++ b/src/services/storage-estimate.ts
@@ -1,0 +1,42 @@
+/**
+ * Spec 1024 (US3) — a lightweight, best-effort on-device storage check.
+ *
+ * Before we cache a post's media into the `pendingPosts` outbox (which holds plaintext blobs until
+ * the upload confirms), we sanity-check there's headroom. We need MORE than the raw bytes: the
+ * outbox copy, the encode scratch, and the eventual encrypted media all coexist briefly — so we ask
+ * for `bytes × HEADROOM` and never less than a small floor (tiny posts shouldn't trip the guard on a
+ * nearly-full disk where the estimate is noisy).
+ *
+ * This is advisory only. `navigator.storage.estimate()` is heuristic, rounded, and absent on some
+ * browsers — when we can't get a reading we DON'T block (returning `true`), because a false "no room"
+ * that stops a real post is worse than letting the actual quota error surface and fail the upload.
+ */
+
+/** Reserve this multiple of the raw payload to cover the cached copy + encode scratch + sealed output. */
+const HEADROOM = 2.5;
+/** Never block a post smaller than this — small posts fit even when the estimate looks tight. */
+const FLOOR_BYTES = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Whether there's plausibly room to stage `bytes` of new media on the device.
+ * Returns `true` when storage can't be estimated (don't block on missing data).
+ */
+export async function hasRoomFor(bytes: number): Promise<boolean> {
+  if (bytes <= 0) return true;
+  const est = await readEstimate();
+  if (!est) return true; // unsupported / threw → don't block; let a real quota error surface instead
+  const { quota, usage } = est;
+  if (!quota) return true; // a 0/undefined quota is meaningless — treat as unknown
+  const free = quota - usage;
+  return free >= Math.max(bytes * HEADROOM, FLOOR_BYTES);
+}
+
+async function readEstimate(): Promise<{ quota: number; usage: number } | null> {
+  try {
+    if (typeof navigator === 'undefined' || !navigator.storage?.estimate) return null;
+    const { quota = 0, usage = 0 } = await navigator.storage.estimate();
+    return { quota, usage };
+  } catch {
+    return null;
+  }
+}

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -980,19 +980,33 @@ export function installTestHook(): void {
         body,
         audience: 'friends',
         lifetime: '72h',
-        items: withVoice
-          ? [{
-              localId: `v-${now}`,
-              blob: new Blob([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])], { type: 'audio/webm' }),
-              kind: 'voice',
-              name: 'voice.webm',
-              mime: 'audio/webm',
-              durationSec: 3,
-              progress: 0,
-            }]
-          : [],
+        // A photo (inline bytes) plus, optionally, a voice clip — so a test can confirm both survive
+        // the restart and come back staged in the composer.
+        items: [
+          {
+            localId: `img-${now}`,
+            bytes: Uint8Array.from(
+              atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='),
+              (c) => c.charCodeAt(0),
+            ).buffer,
+            kind: 'image',
+            name: 'photo.png',
+            mime: 'image/png',
+            progress: 0,
+          },
+          ...(withVoice
+            ? [{
+                localId: `v-${now}`,
+                bytes: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer,
+                kind: 'voice' as const,
+                name: 'voice.webm',
+                mime: 'audio/webm',
+                durationSec: 3,
+                progress: 0,
+              }]
+            : []),
+        ],
         status: 'interrupted',
-        droppedMedia: true,
         attempts: 0,
         createdLocally: now,
         updatedAt: now,

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -957,7 +957,7 @@ export function installTestHook(): void {
         lifetime: '72h',
         items: [],
         status: 'failed',
-        error: 'Upload failed — tap retry.',
+        error: 'Upload failed. Tap Retry to try again.',
         attempts: 1,
         createdLocally: now,
         updatedAt: now,

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -355,6 +355,9 @@ export function installTestHook(): void {
     setGroupAvatar: (chatId: string, dataUrl: string) => dbSetGroupAvatar(chatId, dataUrl),
     leaveGroup: (chatId: string) => dbLeaveGroup(chatId),
     sendChatMessage: (chatId: string, body: string) => dbSendMessage(chatId, body),
+    // Send with a per-message disappearing override (exercises the composer-timer plumbing).
+    sendChatMessageTtl: (chatId: string, body: string, ttlMs: number | null) =>
+      dbSendMessage(chatId, body, undefined, undefined, undefined, ttlMs),
     /** Send a group message that @mentions the given member ids (spec 1020). */
     sendWithMentions: (chatId: string, body: string, mentions: string[], everyone = false) =>
       dbSendMessage(chatId, body, undefined, mentions, everyone),
@@ -441,6 +444,7 @@ export function installTestHook(): void {
         reactions: m.reactions ?? [],
         replyTo: m.replyTo ?? null,
         albumId: m.albumId ?? null,
+        expiresAt: m.expiresAt ?? null, // disappearing messages: when this self-destructs
         deleted: !!m.deleted,
         editedAt: m.editedAt ?? null,
         location: m.location ?? null,

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -149,7 +149,7 @@ import { get, getAll, put, bulkPut } from '@/db/idb';
 import { initialsAvatar } from '@/db/avatars';
 import { uid } from '@/utils/uid';
 import { seedShowcase as runSeedShowcase } from '@/services/showcase-seed';
-import type { Chat, FriendRequest, Media, Message, Post } from '@/db/types';
+import type { Chat, FriendRequest, Media, Message, Post, OutboxPost } from '@/db/types';
 import {
   startDirectCall,
   startGroupCall,
@@ -943,6 +943,28 @@ export function installTestHook(): void {
       const p = await dbCreatePost({ body: opts.body, audience: opts.audience ?? 'friends', lifetime: opts.lifetime ?? '24h' });
       return p.id;
     },
+    /** Spec 1024 (US2): seed a FAILED pending post straight into the outbox so the Wall renders the
+     *  "Couldn't post" card with Retry/Cancel. Text-only (no cached blobs needed for the UI check). */
+    seedFailedPendingPost: async (body = 'Stuck post'): Promise<string> => {
+      const now = Date.now();
+      const id = `pp-${now}`;
+      await put<OutboxPost>('pendingPosts', {
+        id,
+        target: 'wall',
+        body,
+        audience: 'friends',
+        lifetime: '72h',
+        items: [],
+        status: 'failed',
+        error: 'Upload failed — tap retry.',
+        attempts: 1,
+        createdLocally: now,
+        updatedAt: now,
+      });
+      return id;
+    },
+    /** Count outbox records (any status) — lets a test assert a Cancel actually cleared one. */
+    pendingPostCount: async (): Promise<number> => (await getAll<OutboxPost>('pendingPosts')).length,
     /** Seed one own IMAGE post that has ONLY a poster tier and no full blob — i.e. a
      *  received post whose full media hasn't downloaded yet. The feed must still show the
      *  poster instantly (US1: no blank tile), which is what the thumbnail test asserts. */

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -129,6 +129,7 @@ import {
 } from '@/services/api';
 import { runInviteSync } from '@/services/invites';
 import { notifyBanners, showActionBanner } from '@/services/notify';
+import { recoverInterruptedPosts } from '@/services/pending-posts';
 import { recordCues, recordedCues } from '@/services/sound';
 import { syncContactEdges } from '@/services/directory';
 import { audioTrack, audioCurId, audioPlaying } from '@/composables/useAudioPlayer';
@@ -965,6 +966,39 @@ export function installTestHook(): void {
     },
     /** Count outbox records (any status) — lets a test assert a Cancel actually cleared one. */
     pendingPostCount: async (): Promise<number> => (await getAll<OutboxPost>('pendingPosts')).length,
+    /** Run (and await) cold-start recovery — lets a test order itself AFTER recovery so a freshly
+     *  seeded in-session failure isn't swept into a draft by the once-per-load recovery pass. */
+    recoverPending: () => recoverInterruptedPosts(),
+    /** Spec 1024 (US2): seed an INTERRUPTED draft (app closed mid-post) with a caption + a voice note,
+     *  so the Wall renders the "Post didn't finish" card and Finish restores it in the composer. */
+    seedInterruptedPost: async (body = 'Recovered draft', withVoice = true): Promise<string> => {
+      const now = Date.now();
+      const id = `pp-int-${now}`;
+      await put<OutboxPost>('pendingPosts', {
+        id,
+        target: 'wall',
+        body,
+        audience: 'friends',
+        lifetime: '72h',
+        items: withVoice
+          ? [{
+              localId: `v-${now}`,
+              blob: new Blob([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])], { type: 'audio/webm' }),
+              kind: 'voice',
+              name: 'voice.webm',
+              mime: 'audio/webm',
+              durationSec: 3,
+              progress: 0,
+            }]
+          : [],
+        status: 'interrupted',
+        droppedMedia: true,
+        attempts: 0,
+        createdLocally: now,
+        updatedAt: now,
+      });
+      return id;
+    },
     /** Seed one own IMAGE post that has ONLY a poster tier and no full blob — i.e. a
      *  received post whose full media hasn't downloaded yet. The feed must still show the
      *  poster instantly (US1: no blank tile), which is what the thumbnail test asserts. */

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -127,6 +127,15 @@ const UPLOAD_QUALITY: ChoiceOption[] = [
   { value: 'hd', label: 'HD (720p)' },
   { value: 'sd', label: 'SD', note: 'Smaller, fastest to send' },
 ];
+// Auto-download size cap (MB, as strings for the choice store; '0' = no limit).
+const SIZE_LIMIT: ChoiceOption[] = [
+  { value: '2', label: '2 MB' },
+  { value: '8', label: '8 MB' },
+  { value: '16', label: '16 MB' },
+  { value: '50', label: '50 MB' },
+  { value: '100', label: '100 MB' },
+  { value: '0', label: 'No limit' },
+];
 const AUTO_DOWNLOAD: ChoiceOption[] = [
   { value: 'never', label: 'Never' },
   { value: 'wifi', label: 'Wi-Fi' },
@@ -621,7 +630,7 @@ export const SETTINGS: Record<string, SettingNode> = {
         header: 'Media quality',
         items: [
           { type: 'link', id: 'media-upload-quality', title: 'Upload quality', icon: 'image' },
-          { type: 'link', id: 'media-download-quality', title: 'Auto-download quality', icon: 'download' },
+          { type: 'link', id: 'media-download-limit', title: 'Auto-download size limit', icon: 'download' },
         ],
       },
       {
@@ -652,14 +661,15 @@ export const SETTINGS: Record<string, SettingNode> = {
       },
     ],
   },
-  'media-download-quality': {
-    id: 'media-download-quality',
-    title: 'Auto-download quality',
+  'media-download-limit': {
+    id: 'media-download-limit',
+    title: 'Auto-download size limit',
     groups: [
       {
-        header: 'Quality',
-        items: [{ type: 'choice', key: 'storage.downloadQuality', default: 'hd', options: QUALITY }],
-        footer: 'Select the quality for photos and videos to be automatically downloaded in.',
+        header: 'Limit',
+        items: [{ type: 'choice', key: 'storage.autoDownloadLimit', default: '16', options: SIZE_LIMIT }],
+        footer:
+          'Attachments larger than this are left for you to download with a tap, even where auto-download is on. Voice messages always download.',
       },
     ],
   },

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -119,6 +119,14 @@ const QUALITY: ChoiceOption[] = [
   { value: 'standard', label: 'Standard quality', note: 'Faster to send, smaller file size' },
   { value: 'hd', label: 'HD quality', note: 'Slower to send, can be 6 times larger' },
 ];
+// Upload-quality tiers (the actual send tiers). A source below a tier is never upscaled — it just
+// sends at its own resolution — so a high setting is safe. Original keeps full fidelity.
+const UPLOAD_QUALITY: ChoiceOption[] = [
+  { value: 'original', label: 'Original', note: 'Full quality, largest file' },
+  { value: 'fhd', label: 'Full HD (1080p)' },
+  { value: 'hd', label: 'HD (720p)' },
+  { value: 'sd', label: 'SD', note: 'Smaller, fastest to send' },
+];
 const AUTO_DOWNLOAD: ChoiceOption[] = [
   { value: 'never', label: 'Never' },
   { value: 'wifi', label: 'Wi-Fi' },
@@ -634,9 +642,13 @@ export const SETTINGS: Record<string, SettingNode> = {
     title: 'Upload quality',
     groups: [
       {
-        header: 'Quality',
-        items: [{ type: 'choice', key: 'storage.uploadQuality', default: 'hd', options: QUALITY }],
-        footer: 'Select the quality for photos and videos to be sent at in chats.',
+        header: 'Photos',
+        items: [{ type: 'choice', key: 'storage.uploadQuality.photos', default: 'hd', options: UPLOAD_QUALITY }],
+      },
+      {
+        header: 'Videos',
+        items: [{ type: 'choice', key: 'storage.uploadQuality.videos', default: 'hd', options: UPLOAD_QUALITY }],
+        footer: 'Photos and videos each send at their own quality. A chat can override this in its info menu.',
       },
     ],
   },

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -630,12 +630,12 @@ export const SETTINGS: Record<string, SettingNode> = {
         header: 'Media quality',
         items: [
           { type: 'link', id: 'media-upload-quality', title: 'Upload quality', icon: 'image' },
-          { type: 'link', id: 'media-download-limit', title: 'Auto-download size limit', icon: 'download' },
         ],
       },
       {
         header: 'Media auto-download',
         items: [
+          { type: 'link', id: 'media-download-limit', title: 'Auto-download size limit', icon: 'download' },
           { type: 'link', id: 'storage-autodownload-photos', title: 'Photos', icon: 'image' },
           { type: 'link', id: 'storage-autodownload-audio', title: 'Audio', icon: 'music' },
           { type: 'link', id: 'storage-autodownload-video', title: 'Video', icon: 'video' },

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -24,6 +24,9 @@
      bleed through the text. Incoming = light grey, outgoing = soft green. */
   --app-bubble-in: #e7e8ec;
   --app-bubble-out: #d6f3cc;
+  /* Wall pending/unfinished post card — a warm amber so an unsent, uploading or failed post reads
+     as "not final yet" against the settled green posts. Opaque, like the bubbles, for legible text. */
+  --app-bubble-pending: #ffe6ad;
   /* Full-screen media viewer (spec 1014 FR-023): follows the app theme rather than a
      hardcoded black surface. Light defaults here; dark overrides below. The chrome (top/
      bottom bars) sits over the media, so the scrims + pill fills are theme-tinted for
@@ -51,6 +54,8 @@
   /* Opaque dark bubbles (WhatsApp-style): grey incoming, deep-green outgoing. */
   --app-bubble-in: #232d33;
   --app-bubble-out: #103a2c;
+  /* Deep amber pending card for dark mode (mirrors the light --app-bubble-pending). */
+  --app-bubble-pending: #43320c;
   /* Media viewer — immersive dark surface in dark mode (spec 1014 FR-023). */
   --viewer-surface: #000000;
   --viewer-text: #ffffff;

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -452,15 +452,19 @@
               <!-- Direction-aware foot: react button opposite the timestamp; sent →
                    time+tick right / react left, received → time left / react right. -->
               <div class="msg-foot" :class="m.outgoing ? 'out' : 'in'">
+                <!-- React button. On a disappearing message it becomes a melting face 🫠 that melts
+                     further as the message nears expiry (exact time-left is on the message info page);
+                     it still opens the reaction picker on tap, and stays visible past the react cap. -->
                 <button
-                  v-if="myEmojisFor(m).length < MAX_REACTIONS_PER_USER"
+                  v-if="myEmojisFor(m).length < MAX_REACTIONS_PER_USER || m.expiresAt"
                   type="button"
                   class="react-btn"
-                  aria-label="React"
+                  :aria-label="m.expiresAt ? `Disappearing message` : 'React'"
                   @click.stop="openQuickReact(m, $event)"
                   @pointerdown.prevent
                 >
-                  <ion-icon :icon="happyOutline" />
+                  <span v-if="m.expiresAt" class="ttl-melt" :style="{ '--frac': ttlFrac(m) }" :title="`Disappears in ${ttlLeft(m.expiresAt)}`" role="img">🫠</span>
+                  <ion-icon v-else :icon="happyOutline" />
                 </button>
                 <span class="time">
                   <span v-if="m.editedAt" class="edited">edited</span>
@@ -600,14 +604,15 @@
               </div>
               <div class="msg-foot" :class="item.messages[0].outgoing ? 'out' : 'in'">
                 <button
-                  v-if="myEmojisFor(item.messages[0]).length < MAX_REACTIONS_PER_USER"
+                  v-if="myEmojisFor(item.messages[0]).length < MAX_REACTIONS_PER_USER || item.messages[0].expiresAt"
                   type="button"
                   class="react-btn"
-                  aria-label="React"
+                  :aria-label="item.messages[0].expiresAt ? 'Disappearing message' : 'React'"
                   @click.stop="openQuickReact(item.messages[0], $event)"
                   @pointerdown.prevent
                 >
-                  <ion-icon :icon="happyOutline" />
+                  <span v-if="item.messages[0].expiresAt" class="ttl-melt" :style="{ '--frac': ttlFrac(item.messages[0]) }" :title="`Disappears in ${ttlLeft(item.messages[0].expiresAt!)}`" role="img">🫠</span>
+                  <ion-icon v-else :icon="happyOutline" />
                 </button>
                 <span class="time">
                   <!-- Count to the LEFT of the clock so the clock + tick stay put as it toggles. -->
@@ -2421,6 +2426,34 @@ function fmtTtl(ms: number): string {
   if (ms >= TTL_DAY) return `${Math.round(ms / TTL_DAY)}d`;
   if (ms >= HOUR) return `${Math.round(ms / HOUR)}h`;
   return `${Math.round(ms / MIN)}m`;
+}
+
+// A slowly-ticking clock so each disappearing message's "left" indicator stays current without a
+// per-second timer (windows are minutes-to-days). Reads drive template re-render every 30s.
+const nowMs = ref(Date.now());
+let ttlTick: ReturnType<typeof setInterval> | undefined;
+onMounted(() => {
+  ttlTick = setInterval(() => (nowMs.value = Date.now()), 30_000);
+});
+onUnmounted(() => clearInterval(ttlTick));
+
+// Compact "time left before this disappears" for a message's expiresAt (e.g. "1d", "3h", "5m", "9s").
+function ttlLeft(expiresAt: number): string {
+  const s = Math.max(0, Math.floor((expiresAt - nowMs.value) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+// Fraction of a disappearing message's life REMAINING (1 = just sent, 0 = about to vanish). Drives
+// how far the melting face has "melted". Base = the message timestamp the expiry was stamped from.
+function ttlFrac(m: { expiresAt?: number; timestamp: number }): number {
+  if (!m.expiresAt) return 1;
+  const total = m.expiresAt - m.timestamp;
+  if (total <= 0) return 0;
+  return Math.max(0, Math.min(1, (m.expiresAt - nowMs.value) / total));
 }
 const msgTtlShort = computed(() => (effectiveTtlMs.value ? fmtTtl(effectiveTtlMs.value) : ''));
 const msgTtlLabel = computed(() => {
@@ -5149,6 +5182,18 @@ function cancelRecording() {
   display: inline-flex;
   align-items: center;
   gap: 3px;
+}
+/* Disappearing message: the react button shows a melting face 🫠 that melts further (squishes, drips
+   down, blurs, fades) as the message nears expiry. --frac is the fraction of life REMAINING. */
+.ttl-melt {
+  font-size: 18px;
+  line-height: 1;
+  display: inline-block;
+  transform-origin: center bottom;
+  transform: translateY(calc((1 - var(--frac, 1)) * 3px)) scaleY(calc(0.6 + var(--frac, 1) * 0.4));
+  filter: blur(calc((1 - var(--frac, 1)) * 0.7px));
+  opacity: calc(0.45 + var(--frac, 1) * 0.55);
+  transition: transform 0.6s linear, opacity 0.6s linear, filter 0.6s linear;
 }
 /* Direction-aware bottom row (spec 1008): the react button sits opposite the
    timestamp — sent → time+tick right / react left; received → time left / react

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -3745,17 +3745,29 @@ async function onVideoNoteSend(blob: Blob, dur: number, poster?: string): Promis
 // source of this resolution can actually produce — no upscaling, no "4K" on a 720p clip
 // (spec 2007). `longEdge` is the largest source's longest pixel edge. When the source is
 // below the smallest tier it simply lists Original alone. Returns null on cancel.
-function pickQuality(longEdge?: number): Promise<Quality | null> {
+// This chat's default send quality: the per-chat override, else the global Upload-quality setting
+// (mapped onto the send tiers), else HD. Drives which option the Send-quality prompt pre-selects.
+async function resolvedSendQuality(): Promise<Quality> {
+  const perChat = chat.value?.sendQuality;
+  if (perChat) return perChat;
+  const global = await getSetting<string>('storage.uploadQuality', 'hd');
+  return global === 'standard' ? 'sd' : 'hd';
+}
+
+async function pickQuality(longEdge?: number): Promise<Quality | null> {
   const opts = availableQualities(longEdge);
   // Highest fidelity first (Original, then Full HD → SD), mirroring WhatsApp's ordering.
-  const tiers = opts.filter((q) => q !== 'original').reverse();
+  const ordered: Quality[] = ['original', ...opts.filter((q) => q !== 'original').reverse()];
+  // Float the chat's default to the top and mark it, so it's a one-tap send (spec: better default).
+  const def = await resolvedSendQuality();
+  if (ordered.includes(def)) ordered.sort((a, b) => (a === def ? -1 : b === def ? 1 : 0));
+  const label = (q: Quality): string => {
+    const base = q === 'original' ? 'Original quality' : q === 'sd' ? 'SD quality (smaller)' : `${qualityLabel(q)} quality`;
+    return q === def ? `${base} · Default` : base;
+  };
   return new Promise((resolve) => {
     const buttons: import('@ionic/vue').ActionSheetButton[] = [
-      { text: 'Original quality', handler: () => resolve('original') },
-      ...tiers.map((q) => ({
-        text: q === 'sd' ? 'SD quality (smaller)' : `${qualityLabel(q)} quality`,
-        handler: () => resolve(q),
-      })),
+      ...ordered.map((q) => ({ text: label(q), handler: () => resolve(q) })),
       { text: 'Cancel', role: 'cancel', handler: () => resolve(null) },
     ];
     void actionSheetController

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -947,33 +947,42 @@
       </ion-content>
     </ion-modal>
 
-    <!-- Per-item caption editor: a bottom sheet with a real ion-textarea so the field rides above the
-         keyboard (an alert input got pushed off-screen on iOS). -->
+    <!-- Per-item caption editor. A standard full ion-modal (header toolbar + ion-content) rather than
+         a partial sheet: ion-content handles the keyboard inset itself, so the field stays put instead
+         of being shoved off-screen the way the alert (and a breakpoint sheet) were on iOS. -->
     <ion-modal
       :is-open="captionSheet.open"
-      :initial-breakpoint="0.6"
-      :breakpoints="[0, 0.6]"
-      class="caption-sheet"
+      class="caption-modal"
       @did-dismiss="captionSheet.open = false"
       @did-present="focusCaptionInput"
     >
-      <ion-content>
-        <div class="caption-sheet-body">
-          <div class="caption-sheet-title">Caption</div>
-          <!-- Preview of exactly what's being captioned. For a video it's the generated poster —
-               the same frame that rides in the message — so it doubles as a quality check. -->
-          <div v-if="captionItem" class="caption-preview">
-            <img v-if="captionItem.kind === 'image' && captionItem.url" :src="captionItem.url" alt="Attachment preview" />
-            <template v-else-if="captionItem.kind === 'video'">
-              <img v-if="captionItem.poster" :src="captionItem.poster" alt="Video preview" />
-              <div v-else class="caption-preview-video"><ion-spinner name="crescent" /></div>
-              <ion-icon v-if="captionItem.poster" class="caption-preview-play" :icon="playCircle" />
-            </template>
-            <div v-else class="caption-preview-file">
-              <ion-icon :icon="documentOutline" />
-              <span>{{ captionItem.blob.name || 'File' }}</span>
-            </div>
+      <ion-header>
+        <ion-toolbar>
+          <ion-buttons slot="start">
+            <ion-button @click="captionSheet.open = false">Cancel</ion-button>
+          </ion-buttons>
+          <ion-title>Caption</ion-title>
+          <ion-buttons slot="end">
+            <ion-button strong @click="saveItemCaption">Save</ion-button>
+          </ion-buttons>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <!-- Preview of exactly what's being captioned. For a video it's the generated poster —
+             the same frame that rides in the message — so it doubles as a quality check. -->
+        <div v-if="captionItem" class="caption-preview">
+          <img v-if="captionItem.kind === 'image' && captionItem.url" :src="captionItem.url" alt="Attachment preview" />
+          <template v-else-if="captionItem.kind === 'video'">
+            <img v-if="captionItem.poster" :src="captionItem.poster" alt="Video preview" />
+            <div v-else class="caption-preview-video"><ion-spinner name="crescent" /></div>
+            <ion-icon v-if="captionItem.poster" class="caption-preview-play" :icon="playCircle" />
+          </template>
+          <div v-else class="caption-preview-file">
+            <ion-icon :icon="documentOutline" />
+            <span>{{ captionItem.blob.name || 'File' }}</span>
           </div>
+        </div>
+        <ion-item lines="none" class="caption-input-item">
           <ion-textarea
             ref="captionInputEl"
             :value="captionSheet.text"
@@ -983,14 +992,9 @@
             :rows="2"
             autocapitalize="sentences"
             autocorrect="on"
-            class="caption-sheet-input"
             @ion-input="onCaptionInput"
           />
-          <div class="caption-sheet-actions">
-            <ion-button fill="clear" color="medium" @click="captionSheet.open = false">Cancel</ion-button>
-            <ion-button @click="saveItemCaption">Save</ion-button>
-          </div>
-        </div>
+        </ion-item>
       </ion-content>
     </ion-modal>
 
@@ -4390,21 +4394,12 @@ function cancelRecording() {
   padding: 2px;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
 }
-/* Bottom-sheet caption editor. */
-.caption-sheet-body {
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.caption-sheet-title {
-  font-size: 17px;
-  font-weight: 600;
-}
 /* Preview of the item being captioned, above the input. */
 .caption-preview {
   position: relative;
-  align-self: center;
+  display: flex;
+  justify-content: center;
+  margin: 0 auto;
   max-width: 100%;
 }
 .caption-preview img {
@@ -4453,17 +4448,14 @@ function cancelRecording() {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.caption-sheet-input {
+.caption-input-item {
   --background: var(--app-surface);
   --padding-start: 12px;
   --padding-end: 12px;
+  --border-radius: 12px;
   border-radius: 12px;
+  margin-top: 16px;
   font-size: 16px;
-}
-.caption-sheet-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 6px;
 }
 /* Pen hint in the top-left corner: tap the thumbnail to add a caption (until one exists, then the
    filled badge above takes over at the bottom-left). */

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -771,7 +771,7 @@
               <!-- Top-left pen hints that tapping edits this item's caption (otherwise undiscoverable). -->
               <span v-else class="paste-cap-hint"><ion-icon :icon="createOutline" /></span>
             </button>
-            <button type="button" class="paste-x" aria-label="Remove attachment" @click="removePendingMedia(i)">
+            <button type="button" class="paste-x" aria-label="Remove attachment" @click="removePendingMedia(p.id)">
               <ion-icon :icon="closeOutline" />
             </button>
           </div>
@@ -1964,19 +1964,12 @@ function mediaLabelFor(media: PendingMedia[]): string | undefined {
 
 // ---- staged attachments in the draft: keep the photos/videos/files you added but didn't send ----
 // Their bytes are stored inline (ArrayBuffer), NOT as Blobs — an IDB Blob can read back broken on iOS
-// after a reload. Persisted on each attachment change (add / remove / caption), not per keystroke, so
-// a caption you type doesn't rewrite megabytes each time. Bytes are cached by item id to avoid
-// re-reading a (possibly large) clip when only a caption changed.
+// after a reload. The heavy bytes write is NOT done on every add/remove (serializing megabytes of
+// video into IndexedDB on each edit janked the composer, which made rapid removals misfire). Instead
+// it runs once when you LEAVE or background the chat — the only moments it needs to survive — while
+// the lightweight drafts record (mediaCount/label) is kept current per edit. Bytes are cached by
+// item id so the leave-time write doesn't re-read a (possibly large) clip.
 const draftMediaBytes = new Map<string, ArrayBuffer>();
-let draftMediaSaveTimer: ReturnType<typeof setTimeout> | undefined;
-
-function scheduleDraftMediaSave(): void {
-  clearTimeout(draftMediaSaveTimer);
-  draftMediaSaveTimer = setTimeout(() => {
-    void persistDraftMedia();
-    void persistDraft(); // keep the drafts record's mediaCount/label (and existence) in step
-  }, 300);
-}
 
 async function persistDraftMedia(): Promise<void> {
   const media = pendingMedia.value;
@@ -2006,7 +1999,6 @@ async function persistDraftMedia(): Promise<void> {
 // Sent → the draft is spent; drop the pending saves and the stored copies (text + attachments).
 function clearComposerDraft(): void {
   clearTimeout(draftSaveTimer);
-  clearTimeout(draftMediaSaveTimer);
   draftMediaBytes.clear();
   void clearDraft(chatId);
   void clearDraftMedia(chatId);
@@ -2517,7 +2509,7 @@ function saveItemCaption(): void {
   const next = pendingMedia.value[index];
   if (next) next.caption = text.trim() || undefined;
   captionSheet.value.open = false;
-  scheduleDraftMediaSave(); // persist the per-item caption into the draft
+  scheduleDraftSave(); // caption bytes are re-saved on leave; just touch the light drafts record now
 }
 // The Album/Individual choice only makes sense with 2+ image/video items.
 const albumChoiceVisible = computed(
@@ -2545,7 +2537,7 @@ function stageMedia(f: File, forceFile = false): 'audio' | 'staged' {
   const id = crypto.randomUUID();
   pendingMedia.value.push({ id, blob: f, kind, url });
   if (kind === 'video') void posterFromMaterialized(id, f);
-  scheduleDraftMediaSave(); // keep the staged attachment in the draft
+  scheduleDraftSave(); // update the light drafts record; the media bytes are saved on leave (below)
   return 'staged';
 }
 
@@ -2658,11 +2650,16 @@ function imageNameFromUrl(url: string, mime: string): string {
   return /\.[a-z0-9]+$/i.test(base) ? base : `${base}.${ext}`;
 }
 
-function removePendingMedia(i: number): void {
-  const [gone] = pendingMedia.value.splice(i, 1);
+// Remove by ID, not by v-for index: if the row re-renders slowly, repeated taps on one × would
+// otherwise reuse a stale index and delete whatever slid into that position (the reported "removes
+// the next ones too" bug). By id, a second tap on an already-removed item is simply a no-op.
+function removePendingMedia(id: string): void {
+  const idx = pendingMedia.value.findIndex((m) => m.id === id);
+  if (idx < 0) return;
+  const [gone] = pendingMedia.value.splice(idx, 1);
   if (gone?.url) URL.revokeObjectURL(gone.url);
   if (gone) draftMediaBytes.delete(gone.id);
-  scheduleDraftMediaSave(); // reflect the removal in the draft (clears it when the last one goes)
+  scheduleDraftSave(); // update the light drafts record now; heavy media bytes save on leave (below)
 }
 
 function clearPendingMedia(): void {
@@ -2925,9 +2922,10 @@ function onVisibilityChange(): void {
       scheduleShareHint();
     }
   } else {
-    // Backgrounded (incl. an iOS app close that starts here): flush the unsent message now, while we
-    // still can, so it survives a full termination.
+    // Backgrounded (incl. an iOS app close that starts here): flush the unsent message AND its staged
+    // attachments now, while we still can, so they survive a full termination.
     void persistDraft();
+    void persistDraftMedia();
     clearTimeout(shareHintTimer);
     dismissShareHintToast();
   }
@@ -2954,7 +2952,8 @@ function dismissShareHintToast(): void {
 onIonViewWillLeave(() => {
   viewActive.value = false;
   setActiveChat(null);
-  void persistDraft(); // navigating away within the app → save the unsent message
+  void persistDraft(); // navigating away within the app → save the unsent message …
+  void persistDraftMedia(); // … and its staged attachments (fires before unmount clears them)
   stopActivity(); // leaving the chat ends any outgoing activity indicator (spec 1009)
   clearTimeout(shareHintTimer);
   dismissShareHintToast(); // don't let the hint linger on other pages

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1013,6 +1013,7 @@ import {
   backfillThumbTiers,
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
+import { hasRoomFor } from '@/services/storage-estimate';
 import { groupProgress } from '@/services/message-status';
 import { getSelfUserId, getSelfUsername } from '@/services/auth';
 import MessageActions from '@/components/MessageActions.vue';
@@ -3521,11 +3522,18 @@ async function maxSourceLongEdge(
   return max || undefined;
 }
 
-function onPick(e: Event, mode: 'auto' | 'file') {
+async function onPick(e: Event, mode: 'auto' | 'file') {
   const input = e.target as HTMLInputElement;
   const files = Array.from(input.files ?? []);
   input.value = ''; // allow re-picking the same file
   if (!files.length) return;
+  // Spec 1024 (US3): staging caches the picked blobs on-device until send confirms. Bail up front
+  // if there's clearly no room, rather than failing partway through encode/upload.
+  const incoming = files.reduce((n, f) => n + f.size, 0);
+  if (!(await hasRoomFor(incoming))) {
+    void appToast({ message: 'Not enough storage on this device — free up space and try again.', duration: 2600 });
+    return;
+  }
   // Picked media now STAGES like a paste (spec 1023) so it can be captioned before
   // sending, and several photos/videos can go as an album or individually — see send().
   // Audio keeps its own title/artist review path.

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -917,6 +917,7 @@
               :aria-label="`Disappearing timer: ${msgTtlLabel}`"
               :color="effectiveTtlMs ? 'primary' : 'medium'"
               class="ttl-btn"
+              :class="{ 'has-badge': !!effectiveTtlMs }"
               @click="openMsgTtl"
             >
               <ion-icon slot="icon-only" :icon="timerOutline" />
@@ -5563,9 +5564,15 @@ function cancelRecording() {
 .ttl-btn {
   position: relative;
 }
+/* Shrink + lift the clock glyph so the duration badge has clear room underneath it (otherwise the
+   icon covers the text). Only when a badge is present. */
+.ttl-btn.has-badge ion-icon {
+  font-size: 20px;
+  transform: translateY(-4px);
+}
 .ttl-badge {
   position: absolute;
-  bottom: 1px;
+  bottom: 2px;
   left: 50%;
   transform: translateX(-50%);
   font-size: 9px;

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -345,8 +345,9 @@
                   </svg>
                   <ion-icon :icon="downloadOutline" />
                 </span>
-                <!-- Attachment size, so a large clip is obvious before you spend the data. -->
-                <span v-if="m.mediaSize" class="dl-size">{{ formatBytes(m.mediaSize) }}</span>
+                <!-- Attachment size (climbs live while downloading), so a large clip is obvious
+                     before you spend the data. -->
+                <span v-if="m.mediaSize" class="dl-size">{{ dlSizeLabel(m) }}</span>
               </div>
               <!-- Audio/file not downloaded yet: a chip with the name/size and a download button. -->
               <button
@@ -363,7 +364,7 @@
                   <ion-icon :icon="m.id in downloadProgress ? downloadOutline : (m.kind === 'audio' ? musicalNotesOutline : downloadOutline)" />
                 </span>
                 <span>{{ m.pendingMedia.name || (m.kind === 'audio' ? 'Audio' : 'File') }}</span>
-                <span v-if="m.mediaSize" class="chip-size">{{ formatBytes(m.mediaSize) }}</span>
+                <span v-if="m.mediaSize" class="chip-size">{{ dlSizeLabel(m) }}</span>
               </button>
 
               <!-- Media removed from THIS device to free space: a placeholder so the
@@ -1310,6 +1311,14 @@ async function downloadPendingMedia(id: string): Promise<void> {
   } finally {
     delete downloadProgress[id];
   }
+}
+// The size label on a not-yet-downloaded attachment: just the total when idle, or a live
+// "downloaded / total" counter (e.g. "45.2 MB / 127.8 MB") that climbs while it downloads.
+function dlSizeLabel(m: Message): string {
+  const total = m.mediaSize || 0;
+  if (!total) return '';
+  const p = downloadProgress[m.id];
+  return p === undefined ? formatBytes(total) : `${formatBytes(p * total)} / ${formatBytes(total)}`;
 }
 
 

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -960,6 +960,20 @@
       <ion-content>
         <div class="caption-sheet-body">
           <div class="caption-sheet-title">Caption</div>
+          <!-- Preview of exactly what's being captioned. For a video it's the generated poster —
+               the same frame that rides in the message — so it doubles as a quality check. -->
+          <div v-if="captionItem" class="caption-preview">
+            <img v-if="captionItem.kind === 'image' && captionItem.url" :src="captionItem.url" alt="Attachment preview" />
+            <template v-else-if="captionItem.kind === 'video'">
+              <img v-if="captionItem.poster" :src="captionItem.poster" alt="Video preview" />
+              <div v-else class="caption-preview-video"><ion-spinner name="crescent" /></div>
+              <ion-icon v-if="captionItem.poster" class="caption-preview-play" :icon="playCircle" />
+            </template>
+            <div v-else class="caption-preview-file">
+              <ion-icon :icon="documentOutline" />
+              <span>{{ captionItem.blob.name || 'File' }}</span>
+            </div>
+          </div>
           <ion-textarea
             ref="captionInputEl"
             :value="captionSheet.text"
@@ -2480,6 +2494,9 @@ const sendAsAlbum = ref(true);
 // off-screen the way the alert was on iOS.
 const captionSheet = ref<{ open: boolean; index: number; text: string }>({ open: false, index: -1, text: '' });
 const captionInputEl = ref<{ $el: HTMLIonTextareaElement } | null>(null);
+// The item being captioned — drives the preview shown above the input (a video's is the very poster
+// that gets embedded in the message, so it doubles as a quality check).
+const captionItem = computed(() => pendingMedia.value[captionSheet.value.index]);
 function editItemCaption(i: number): void {
   const item = pendingMedia.value[i];
   if (!item) return;
@@ -4383,6 +4400,58 @@ function cancelRecording() {
 .caption-sheet-title {
   font-size: 17px;
   font-weight: 600;
+}
+/* Preview of the item being captioned, above the input. */
+.caption-preview {
+  position: relative;
+  align-self: center;
+  max-width: 100%;
+}
+.caption-preview img {
+  display: block;
+  max-width: 100%;
+  max-height: 200px;
+  border-radius: 12px;
+  object-fit: contain;
+  background: #000;
+}
+.caption-preview-video {
+  width: 160px;
+  height: 120px;
+  border-radius: 12px;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+.caption-preview-play {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 40px;
+  color: #fff;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.6));
+  pointer-events: none;
+}
+.caption-preview-file {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: var(--app-surface);
+  max-width: 100%;
+}
+.caption-preview-file ion-icon {
+  font-size: 22px;
+  flex: none;
+}
+.caption-preview-file span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .caption-sheet-input {
   --background: var(--app-surface);

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -452,22 +452,22 @@
               <!-- Direction-aware foot: react button opposite the timestamp; sent →
                    time+tick right / react left, received → time left / react right. -->
               <div class="msg-foot" :class="m.outgoing ? 'out' : 'in'">
-                <!-- React button. On a disappearing message it becomes a melting face 🫠 that melts
-                     further as the message nears expiry (exact time-left is on the message info page);
-                     it still opens the reaction picker on tap, and stays visible past the react cap. -->
                 <button
-                  v-if="myEmojisFor(m).length < MAX_REACTIONS_PER_USER || m.expiresAt"
+                  v-if="myEmojisFor(m).length < MAX_REACTIONS_PER_USER"
                   type="button"
                   class="react-btn"
-                  :aria-label="m.expiresAt ? `Disappearing message` : 'React'"
+                  aria-label="React"
                   @click.stop="openQuickReact(m, $event)"
                   @pointerdown.prevent
                 >
-                  <span v-if="m.expiresAt" class="ttl-melt" :style="{ '--frac': ttlFrac(m) }" :title="`Disappears in ${ttlLeft(m.expiresAt)}`" role="img">🫠</span>
-                  <ion-icon v-else :icon="happyOutline" />
+                  <ion-icon :icon="happyOutline" />
                 </button>
                 <span class="time">
                   <span v-if="m.editedAt" class="edited">edited</span>
+                  <!-- Disappearing message: a small clock + time-left before it self-destructs. -->
+                  <span v-if="m.expiresAt" class="ttl-left" :title="`Disappears in ${ttlLeft(m.expiresAt)}`">
+                    <ion-icon :icon="timerOutline" />{{ ttlLeft(m.expiresAt) }}
+                  </span>
                   <!-- Group "X/N" sits to the LEFT of the clock so it grows/shrinks into the
                        footer's floating edge (like the "edited" tag) — the clock + tick stay a
                        stable right-anchored unit and never slide as the count appears/disappears. -->
@@ -604,17 +604,19 @@
               </div>
               <div class="msg-foot" :class="item.messages[0].outgoing ? 'out' : 'in'">
                 <button
-                  v-if="myEmojisFor(item.messages[0]).length < MAX_REACTIONS_PER_USER || item.messages[0].expiresAt"
+                  v-if="myEmojisFor(item.messages[0]).length < MAX_REACTIONS_PER_USER"
                   type="button"
                   class="react-btn"
-                  :aria-label="item.messages[0].expiresAt ? 'Disappearing message' : 'React'"
+                  aria-label="React"
                   @click.stop="openQuickReact(item.messages[0], $event)"
                   @pointerdown.prevent
                 >
-                  <span v-if="item.messages[0].expiresAt" class="ttl-melt" :style="{ '--frac': ttlFrac(item.messages[0]) }" :title="`Disappears in ${ttlLeft(item.messages[0].expiresAt!)}`" role="img">🫠</span>
-                  <ion-icon v-else :icon="happyOutline" />
+                  <ion-icon :icon="happyOutline" />
                 </button>
                 <span class="time">
+                  <span v-if="item.messages[0].expiresAt" class="ttl-left" :title="`Disappears in ${ttlLeft(item.messages[0].expiresAt!)}`">
+                    <ion-icon :icon="timerOutline" />{{ ttlLeft(item.messages[0].expiresAt!) }}
+                  </span>
                   <!-- Count to the LEFT of the clock so the clock + tick stay put as it toggles. -->
                   <span
                     v-if="item.messages[0].outgoing && item.messages[item.messages.length - 1].status !== 'failed' && item.messages[item.messages.length - 1].receipts && item.messages[item.messages.length - 1].receipts!.length > 1"
@@ -2446,14 +2448,6 @@ function ttlLeft(expiresAt: number): string {
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h`;
   return `${Math.floor(h / 24)}d`;
-}
-// Fraction of a disappearing message's life REMAINING (1 = just sent, 0 = about to vanish). Drives
-// how far the melting face has "melted". Base = the message timestamp the expiry was stamped from.
-function ttlFrac(m: { expiresAt?: number; timestamp: number }): number {
-  if (!m.expiresAt) return 1;
-  const total = m.expiresAt - m.timestamp;
-  if (total <= 0) return 0;
-  return Math.max(0, Math.min(1, (m.expiresAt - nowMs.value) / total));
 }
 const msgTtlShort = computed(() => (effectiveTtlMs.value ? fmtTtl(effectiveTtlMs.value) : ''));
 const msgTtlLabel = computed(() => {
@@ -5183,17 +5177,16 @@ function cancelRecording() {
   align-items: center;
   gap: 3px;
 }
-/* Disappearing message: the react button shows a melting face 🫠 that melts further (squishes, drips
-   down, blurs, fades) as the message nears expiry. --frac is the fraction of life REMAINING. */
-.ttl-melt {
-  font-size: 18px;
-  line-height: 1;
-  display: inline-block;
-  transform-origin: center bottom;
-  transform: translateY(calc((1 - var(--frac, 1)) * 3px)) scaleY(calc(0.6 + var(--frac, 1) * 0.4));
-  filter: blur(calc((1 - var(--frac, 1)) * 0.7px));
-  opacity: calc(0.45 + var(--frac, 1) * 0.55);
-  transition: transform 0.6s linear, opacity 0.6s linear, filter 0.6s linear;
+/* Disappearing message: a small clock + remaining time, tinted so it reads as an active countdown. */
+.ttl-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  color: var(--ion-color-primary);
+  font-variant-numeric: tabular-nums;
+}
+.ttl-left ion-icon {
+  font-size: 13px;
 }
 /* Direction-aware bottom row (spec 1008): the react button sits opposite the
    timestamp — sent → time+tick right / react left; received → time left / react

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -768,6 +768,8 @@
                 <span class="paste-file-name">{{ p.blob.name || 'File' }}</span>
               </div>
               <ion-icon v-if="p.caption" class="paste-cap-badge" :icon="chatbubbleEllipses" />
+              <!-- Top-left pen hints that tapping edits this item's caption (otherwise undiscoverable). -->
+              <span v-else class="paste-cap-hint"><ion-icon :icon="createOutline" /></span>
             </button>
             <button type="button" class="paste-x" aria-label="Remove attachment" @click="removePendingMedia(i)">
               <ion-icon :icon="closeOutline" />
@@ -945,6 +947,39 @@
       </ion-content>
     </ion-modal>
 
+    <!-- Per-item caption editor: a bottom sheet with a real ion-textarea so the field rides above the
+         keyboard (an alert input got pushed off-screen on iOS). -->
+    <ion-modal
+      :is-open="captionSheet.open"
+      :initial-breakpoint="0.6"
+      :breakpoints="[0, 0.6]"
+      class="caption-sheet"
+      @did-dismiss="captionSheet.open = false"
+      @did-present="focusCaptionInput"
+    >
+      <ion-content>
+        <div class="caption-sheet-body">
+          <div class="caption-sheet-title">Caption</div>
+          <ion-textarea
+            ref="captionInputEl"
+            :value="captionSheet.text"
+            placeholder="Add a caption…"
+            :maxlength="CAPTION_MAX"
+            :auto-grow="true"
+            :rows="2"
+            autocapitalize="sentences"
+            autocorrect="on"
+            class="caption-sheet-input"
+            @ion-input="onCaptionInput"
+          />
+          <div class="caption-sheet-actions">
+            <ion-button fill="clear" color="medium" @click="captionSheet.open = false">Cancel</ion-button>
+            <ion-button @click="saveItemCaption">Save</ion-button>
+          </div>
+        </div>
+      </ion-content>
+    </ion-modal>
+
     <!-- Full-screen album viewer -->
     <media-viewer
       :open="viewer.open"
@@ -1013,7 +1048,7 @@ import {
   micOutline, trashOutline, closeOutline, pause, banOutline, arrowRedoOutline, arrowUndoOutline, globeOutline,
   locationOutline, barChartOutline, personOutline, refreshOutline, downloadOutline,
   imageOutline, musicalNotesOutline, calendarOutline, checkmarkCircle, ellipseOutline,
-  chevronDownOutline, chatbubbleEllipses, albumsOutline, imagesOutline,
+  chevronDownOutline, chatbubbleEllipses, albumsOutline, imagesOutline, createOutline,
 } from 'ionicons/icons';
 import {
   getChat, getContact, listContacts, markChatRead, sendMediaMessage, sendMessage,
@@ -2439,36 +2474,29 @@ const pendingMedia = ref<PendingMedia[]>([]);
 // Multiple photos/videos: send as one album (default) or as separate messages.
 const sendAsAlbum = ref(true);
 
-// Caption a single staged item (tap its thumbnail). Per-item captions override the
-// shared caption typed in the composer for that one item (spec 1023). The shared caption
-// still applies to any item left without its own.
-async function editItemCaption(i: number): Promise<void> {
+// Caption a single staged item (tap its thumbnail). Per-item captions override the shared caption
+// typed in the composer for that one item (spec 1023). We use a bottom-sheet ion-modal with a real
+// ion-textarea (not an alert input) so the field rides ABOVE the keyboard instead of being shoved
+// off-screen the way the alert was on iOS.
+const captionSheet = ref<{ open: boolean; index: number; text: string }>({ open: false, index: -1, text: '' });
+const captionInputEl = ref<{ $el: HTMLIonTextareaElement } | null>(null);
+function editItemCaption(i: number): void {
   const item = pendingMedia.value[i];
   if (!item) return;
-  const alert = await alertController.create({
-    header: 'Caption',
-    inputs: [
-      {
-        name: 'caption',
-        type: 'textarea',
-        value: item.caption ?? '',
-        placeholder: 'Caption this item',
-        attributes: { maxlength: CAPTION_MAX, rows: 3 },
-      },
-    ],
-    buttons: [
-      { text: 'Cancel', role: 'cancel' },
-      {
-        text: 'Save',
-        handler: (d: { caption?: string }) => {
-          const next = pendingMedia.value[i];
-          if (next) next.caption = (d?.caption ?? '').slice(0, CAPTION_MAX).trim() || undefined;
-          scheduleDraftMediaSave(); // persist the per-item caption into the draft
-        },
-      },
-    ],
-  });
-  await alert.present();
+  captionSheet.value = { open: true, index: i, text: item.caption ?? '' };
+}
+function focusCaptionInput(): void {
+  void (captionInputEl.value?.$el as HTMLIonTextareaElement | undefined)?.setFocus?.();
+}
+function onCaptionInput(e: CustomEvent): void {
+  captionSheet.value.text = ((e.detail as { value?: string | null }).value ?? '').slice(0, CAPTION_MAX);
+}
+function saveItemCaption(): void {
+  const { index, text } = captionSheet.value;
+  const next = pendingMedia.value[index];
+  if (next) next.caption = text.trim() || undefined;
+  captionSheet.value.open = false;
+  scheduleDraftMediaSave(); // persist the per-item caption into the draft
 }
 // The Album/Individual choice only makes sense with 2+ image/video items.
 const albumChoiceVisible = computed(
@@ -2515,17 +2543,24 @@ async function posterFromMaterialized(id: string, f: File): Promise<void> {
 }
 
 // Generate a staged video's first-frame poster off-screen and drop it onto the (reactive) item.
-// Replace the array element (not mutate in place) so the tile repaints reliably; matched by id since
-// the row can shift if another item is removed while this resolves.
-async function ensureVideoPoster(id: string, blob: Blob): Promise<void> {
+// iOS frequently can't decode a frame right after a big multi-select (the reason the thumbnail only
+// used to appear after leaving + returning, once the page had settled). So on a null result we back
+// off and RETRY a few times, keeping the spinner up, instead of giving up to a black tile. The item
+// is updated by REPLACING it (not mutating in place) so the tile repaints reliably.
+async function ensureVideoPoster(id: string, blob: Blob, attempt = 0): Promise<void> {
   let poster: string | undefined;
   try {
     poster = await generateVideoPoster(blob);
   } catch {
-    /* no frame (codec/timeout) — the tile falls back to a plain black video box */
+    /* no frame yet */
   }
   const idx = pendingMedia.value.findIndex((m) => m.id === id);
-  if (idx < 0) return;
+  if (idx < 0) return; // item removed while we were decoding
+  if (!poster && attempt < 4) {
+    // Try again once the device has quieted down; leave the tile spinning meanwhile.
+    window.setTimeout(() => void ensureVideoPoster(id, blob, attempt + 1), 700 * (attempt + 1));
+    return;
+  }
   const cur = pendingMedia.value[idx];
   pendingMedia.value[idx] = { ...cur, poster: poster ?? cur.poster, ready: true };
 }
@@ -3751,7 +3786,13 @@ async function onPick(e: Event, mode: 'auto' | 'file') {
     if (stageMedia(f, mode === 'file') === 'audio') audioFiles.push(f);
   }
   if (overCap) {
-    void appToast({ message: `You can attach up to ${MAX_STAGED_MEDIA} items at once.`, duration: 2200 });
+    // A blocking alert (not a toast) so it's read and acknowledged — the extra picks were dropped.
+    const a = await alertController.create({
+      header: 'Up to 10 at once',
+      message: `You can attach up to ${MAX_STAGED_MEDIA} items to one message. The first ${MAX_STAGED_MEDIA} were added; the rest weren’t.`,
+      buttons: ['Got it'],
+    });
+    await a.present();
   }
   if (audioFiles.length) {
     // The pending reply (if any) rides the first audio only when nothing else was staged
@@ -4331,6 +4372,46 @@ function cancelRecording() {
   border-radius: 50%;
   padding: 2px;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+}
+/* Bottom-sheet caption editor. */
+.caption-sheet-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.caption-sheet-title {
+  font-size: 17px;
+  font-weight: 600;
+}
+.caption-sheet-input {
+  --background: var(--app-surface);
+  --padding-start: 12px;
+  --padding-end: 12px;
+  border-radius: 12px;
+  font-size: 16px;
+}
+.caption-sheet-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+/* Pen hint in the top-left corner: tap the thumbnail to add a caption (until one exists, then the
+   filled badge above takes over at the bottom-left). */
+.paste-cap-hint {
+  position: absolute;
+  left: 3px;
+  top: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 12px;
+  pointer-events: none;
 }
 /* Album vs Individual choice for a multi-photo/video send. */
 /* Column so the send-as choice sits on its OWN row under the thumbnails (ion-toolbar would otherwise

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1809,8 +1809,10 @@ function linkParts(body: string): Array<{ text: string; url?: string }> {
 }
 // A bubble whose main content is a single photo/video → render with a thin frame
 // (narrow padding) hugging the media, rather than the normal text padding.
+// A photo/video bubble uses the tight edge-to-edge media frame — whether it's downloaded (mediaId)
+// OR still pending (not-yet-downloaded), so the not-downloaded placeholder is framed identically.
 const mediaBubble = (m: Message) =>
-  !m.deleted && !!m.mediaId && (m.kind === 'image' || (m.kind === 'video' && !m.videoNote));
+  !m.deleted && (!!m.mediaId || !!m.pendingMedia) && (m.kind === 'image' || (m.kind === 'video' && !m.videoNote));
 
 // A media message whose blob was cleaned up locally to free space (not the same as
 // a sender-deleted message, nor a not-yet-downloaded one) → show a placeholder.

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1121,8 +1121,8 @@ import { segmentEmoji, emojiOnlyCount } from '@/utils/emoji';
 import { userColorBright } from '@/utils/user-color';
 import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
 import { jobProgress } from '@/services/media-jobs';
-import { generateVideoPoster, generateImageThumb, isAnimatedImage, readImageMeta, readVideoMeta } from '@/utils/media-meta';
-import { type Quality, availableQualities, qualityLabel, isPreservedImageMime } from '@/services/media-encode';
+import { generateVideoPoster, generateImageThumb, isAnimatedImage } from '@/utils/media-meta';
+import { type Quality } from '@/services/media-encode';
 import { openExternal } from '@/utils/external';
 import { selectEvictions } from '@/utils/lru';
 import { normalizeOutgoing } from '@/utils/text';
@@ -3630,22 +3630,11 @@ async function send() {
   // album carries the caption once (on the first item); individual messages each carry it.
   // Files are never part of an album.
   if (pendingMedia.value.length) {
-    // Ask the send quality once for the whole batch (photos/videos), as the chat composer
-    // has always done — quality is a per-chat choice (the HD-only rule is a Wall thing, not
-    // chats). GIF/WebP are sent untouched, so a batch with nothing compressible skips the
-    // no-op prompt. Cancelling keeps the staged media + the draft intact.
-    const compressible = pendingMedia.value.filter(
-      (it) => (it.kind === 'image' || it.kind === 'video') && !isPreservedImageMime(it.blob.type),
-    );
-    let quality: Quality = 'original';
-    if (compressible.length) {
-      const longEdge = await maxSourceLongEdge(
-        compressible.map((it) => ({ blob: it.blob, kind: it.kind as 'image' | 'video' })),
-      );
-      const picked = await pickQuality(longEdge);
-      if (picked === null) return; // cancelled
-      quality = picked;
-    }
+    // Quality is applied silently PER KIND from the resolved settings (photo vs video, per-chat
+    // override else the global Upload-quality) — no prompt. A source below the tier is never
+    // upscaled, so a high setting is safe; GIF/WebP images send untouched regardless.
+    const photoQ = await resolveSendQuality('image');
+    const videoQ = await resolveSendQuality('video');
     const items = pendingMedia.value.slice();
     pendingMedia.value = [];
     const caption = text;
@@ -3664,6 +3653,7 @@ async function send() {
       // A per-item caption (set by tapping the thumbnail) wins for that item; otherwise the
       // shared caption applies — once for an album (first item), or to each individual message.
       const cap = it.caption || (asAlbum ? (i === 0 ? caption : undefined) : caption);
+      const quality = it.kind === 'image' ? photoQ : it.kind === 'video' ? videoQ : 'original';
       await sendMediaMessage(
         chatId,
         it.kind,
@@ -3793,60 +3783,12 @@ async function onVideoNoteSend(blob: Blob, dur: number, poster?: string): Promis
 // source of this resolution can actually produce — no upscaling, no "4K" on a 720p clip
 // (spec 2007). `longEdge` is the largest source's longest pixel edge. When the source is
 // below the smallest tier it simply lists Original alone. Returns null on cancel.
-// This chat's default send quality: the per-chat override, else the global Upload-quality setting
-// (mapped onto the send tiers), else HD. Drives which option the Send-quality prompt pre-selects.
-async function resolvedSendQuality(): Promise<Quality> {
-  const perChat = chat.value?.sendQuality;
-  if (perChat) return perChat;
-  const global = await getSetting<string>('storage.uploadQuality', 'hd');
-  return global === 'standard' ? 'sd' : 'hd';
-}
-
-async function pickQuality(longEdge?: number): Promise<Quality | null> {
-  const opts = availableQualities(longEdge);
-  // Highest fidelity first (Original, then Full HD → SD), mirroring WhatsApp's ordering.
-  const ordered: Quality[] = ['original', ...opts.filter((q) => q !== 'original').reverse()];
-  // Float the chat's default to the top and mark it, so it's a one-tap send (spec: better default).
-  const def = await resolvedSendQuality();
-  if (ordered.includes(def)) ordered.sort((a, b) => (a === def ? -1 : b === def ? 1 : 0));
-  const label = (q: Quality): string => {
-    const base = q === 'original' ? 'Original quality' : q === 'sd' ? 'SD quality (smaller)' : `${qualityLabel(q)} quality`;
-    return q === def ? `${base} · Default` : base;
-  };
-  return new Promise((resolve) => {
-    const buttons: import('@ionic/vue').ActionSheetButton[] = [
-      ...ordered.map((q) => ({ text: label(q), handler: () => resolve(q) })),
-      { text: 'Cancel', role: 'cancel', handler: () => resolve(null) },
-    ];
-    void actionSheetController
-      .create({ header: 'Send quality', buttons })
-      .then((s) => {
-        // Tapping the backdrop also dismisses → treat as cancel.
-        s.onDidDismiss().then((d) => {
-          if (d.role === 'backdrop') resolve(null);
-        });
-        return s.present();
-      });
-  });
-}
-
-// The longest pixel edge across the chosen photos/videos (the largest source in the
-// batch), used to decide which quality tiers are worth offering. Best-effort + bounded
-// by the meta readers; an unreadable item contributes nothing.
-async function maxSourceLongEdge(
-  items: { blob: Blob; kind: 'image' | 'video' }[],
-): Promise<number | undefined> {
-  let max = 0;
-  for (const it of items) {
-    if (it.kind === 'image') {
-      const m = await readImageMeta(it.blob).catch(() => ({}) as { width?: number; height?: number });
-      if (m.width && m.height) max = Math.max(max, m.width, m.height);
-    } else {
-      const m = await readVideoMeta(it.blob).catch(() => ({}) as { width?: number; height?: number });
-      if (m.width && m.height) max = Math.max(max, m.width, m.height);
-    }
-  }
-  return max || undefined;
+// Resolve the send quality for a kind: the chat's per-kind override, else the global Upload-quality
+// setting for that kind (photos vs videos). Applied silently at send time — no prompt. A source
+// below the tier is never upscaled by the compressor, so a high setting is safe.
+async function resolveSendQuality(kind: 'image' | 'video'): Promise<Quality> {
+  if (kind === 'image') return chat.value?.sendQualityPhoto ?? (await getSetting<Quality>('storage.uploadQuality.photos', 'hd'));
+  return chat.value?.sendQualityVideo ?? (await getSetting<Quality>('storage.uploadQuality.videos', 'hd'));
 }
 
 async function onPick(e: Event, mode: 'auto' | 'file') {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -920,8 +920,11 @@
               :class="{ 'has-badge': !!effectiveTtlMs }"
               @click="openMsgTtl"
             >
-              <ion-icon slot="icon-only" :icon="timerOutline" />
-              <span v-if="effectiveTtlMs" class="ttl-badge">{{ msgTtlShort }}</span>
+              <!-- Icon + duration stacked vertically so the badge sits cleanly under the clock. -->
+              <span class="ttl-stack">
+                <ion-icon :icon="timerOutline" aria-hidden="true" />
+                <span v-if="effectiveTtlMs" class="ttl-badge">{{ msgTtlShort }}</span>
+              </span>
             </ion-button>
             <ion-button
               v-if="draft.trim() || pendingMedia.length"
@@ -5561,20 +5564,27 @@ function cancelRecording() {
   overflow-y: auto;
 }
 /* Disappearing-timer button: the duration badge tucks under the timer glyph. */
+/* Keep the button compact even without the icon-only slot (which we drop to stack icon + badge). */
 .ttl-btn {
-  position: relative;
+  --padding-start: 6px;
+  --padding-end: 6px;
 }
-/* Shrink + lift the clock glyph so the duration badge has clear room underneath it (otherwise the
-   icon covers the text). Only when a badge is present. */
-.ttl-btn.has-badge ion-icon {
-  font-size: 20px;
-  transform: translateY(-4px);
+.ttl-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  gap: 1px;
+}
+/* A hair smaller than a plain icon-only button so the icon + duration together fit the toolbar row. */
+.ttl-stack ion-icon {
+  font-size: 21px;
+}
+.ttl-btn.has-badge .ttl-stack ion-icon {
+  font-size: 19px;
 }
 .ttl-badge {
-  position: absolute;
-  bottom: 2px;
-  left: 50%;
-  transform: translateX(-50%);
   font-size: 9px;
   font-weight: 700;
   line-height: 1;

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -738,6 +738,7 @@
            out as the caption when Send is tapped. Picked AND pasted media land here
            (spec 1023), so library photos can be captioned just like a paste. -->
       <ion-toolbar v-if="pendingMedia.length" class="paste-bar">
+       <div class="paste-stack">
         <div class="paste-row">
           <div
             v-for="(p, i) in pendingMedia"
@@ -753,18 +754,14 @@
               @click="editItemCaption(i)"
             >
               <img v-if="p.kind === 'image' && p.url" :src="p.url" alt="Attachment" />
-              <template v-else-if="p.kind === 'video' && p.url">
-                <video
-                  :src="p.url"
-                  muted
-                  playsinline
-                  preload="metadata"
-                  @loadeddata="p.ready = true"
-                />
-                <!-- Large clips take a moment to decode a first frame; show a spinner over the black
-                     tile until then so it reads as "loading", not broken. -->
-                <ion-spinner v-if="!p.ready" name="crescent" class="paste-loading" />
-                <ion-icon v-else class="paste-play" :icon="playCircle" />
+              <template v-else-if="p.kind === 'video'">
+                <!-- iOS never paints a frame into a <video> until it's played, so we generate a
+                     first-frame poster off-screen (canvas) and show that. Spinner until it settles. -->
+                <img v-if="p.poster" :src="p.poster" alt="Attachment" />
+                <div v-else class="paste-vid">
+                  <ion-spinner v-if="!p.ready" name="crescent" class="paste-loading" />
+                </div>
+                <ion-icon class="paste-play" :icon="playCircle" />
               </template>
               <div v-else class="paste-file">
                 <ion-icon :icon="documentOutline" />
@@ -777,17 +774,26 @@
             </button>
           </div>
         </div>
-        <!-- 2+ photos/videos: send as one swipeable album (default) or separate messages. -->
+        <!-- 2+ photos/videos: send as one swipeable album (default) or separate messages. On its own
+             row (not squeezed beside the thumbnails) with a lead-in label so the choice is clear. -->
         <div v-if="albumChoiceVisible" class="send-mode">
+          <span class="send-mode-label">Send as</span>
           <ion-segment
             :value="sendAsAlbum ? 'album' : 'individual'"
             mode="ios"
             @ion-change="sendAsAlbum = ($event.detail.value as string) === 'album'"
           >
-            <ion-segment-button value="album"><ion-label>Album</ion-label></ion-segment-button>
-            <ion-segment-button value="individual"><ion-label>Individual</ion-label></ion-segment-button>
+            <ion-segment-button value="album">
+              <ion-icon :icon="albumsOutline" />
+              <ion-label>Album</ion-label>
+            </ion-segment-button>
+            <ion-segment-button value="individual">
+              <ion-icon :icon="imagesOutline" />
+              <ion-label>Separate</ion-label>
+            </ion-segment-button>
           </ion-segment>
         </div>
+       </div>
       </ion-toolbar>
       <!-- A still-pending (un-accepted) friend request: lock the composer until
            the other side accepts. -->
@@ -1007,7 +1013,7 @@ import {
   micOutline, trashOutline, closeOutline, pause, banOutline, arrowRedoOutline, arrowUndoOutline, globeOutline,
   locationOutline, barChartOutline, personOutline, refreshOutline, downloadOutline,
   imageOutline, musicalNotesOutline, calendarOutline, checkmarkCircle, ellipseOutline,
-  chevronDownOutline, chatbubbleEllipses,
+  chevronDownOutline, chatbubbleEllipses, albumsOutline, imagesOutline,
 } from 'ionicons/icons';
 import {
   getChat, getContact, listContacts, markChatRead, sendMediaMessage, sendMessage,
@@ -1850,6 +1856,7 @@ async function loadDraft(): Promise<void> {
       draftMediaBytes.set(id, it.bytes);
       const url = it.kind === 'image' || it.kind === 'video' ? URL.createObjectURL(file) : undefined;
       pendingMedia.value.push({ id, blob: file, kind: it.kind, url, caption: it.caption });
+      if (it.kind === 'video') void ensureVideoPoster(id, file); // rebuild the tile thumbnail
     }
   }
   if (d?.text) {
@@ -2422,7 +2429,8 @@ interface PendingMedia {
   kind: 'image' | 'video' | 'file';
   url?: string; // object URL for an image/video preview; files show a chip instead
   caption?: string; // optional per-item caption (overrides the shared one for this item)
-  ready?: boolean; // a video whose first frame has decoded (until then the tile shows a spinner)
+  poster?: string; // a video's first-frame thumbnail (data URL); a <video> tile paints black on iOS
+  ready?: boolean; // a video's poster generation has settled (succeeded or gave up) — stop the spinner
 }
 // Cap on staged attachments per message (photos + videos + files). The iOS library picker itself
 // can't be limited, so onPick trims the overflow to this.
@@ -2485,9 +2493,26 @@ function stageMedia(f: File, forceFile = false): 'audio' | 'staged' {
   if (k === 'audio') return 'audio';
   const kind: 'image' | 'video' | 'file' = k === 'image' || k === 'video' ? k : 'file';
   const url = kind === 'image' || kind === 'video' ? URL.createObjectURL(f) : undefined;
-  pendingMedia.value.push({ id: crypto.randomUUID(), blob: f, kind, url });
+  const id = crypto.randomUUID();
+  pendingMedia.value.push({ id, blob: f, kind, url });
+  if (kind === 'video') void ensureVideoPoster(id, f); // decode a first-frame thumbnail for the tile
   scheduleDraftMediaSave(); // keep the staged attachment in the draft
   return 'staged';
+}
+
+// Generate a staged video's first-frame poster off-screen and drop it onto the (reactive) item.
+// Matched by id since the row can shift if another item is removed while this resolves.
+async function ensureVideoPoster(id: string, blob: Blob): Promise<void> {
+  try {
+    const poster = await generateVideoPoster(blob);
+    const it = pendingMedia.value.find((m) => m.id === id);
+    if (it && poster) it.poster = poster;
+  } catch {
+    /* no frame (codec/timeout) — the tile falls back to a plain black video box */
+  } finally {
+    const it = pendingMedia.value.find((m) => m.id === id);
+    if (it) it.ready = true; // stop the spinner whether or not we got a frame
+  }
 }
 
 // Route a picked/pasted audio file into the title/artist review queue (its own flow).
@@ -4203,14 +4228,16 @@ function cancelRecording() {
   padding: 6px 6px 0 0;
 }
 .paste-thumb img,
-.paste-thumb video {
+.paste-thumb video,
+.paste-thumb .paste-vid {
   width: 64px;
   height: 64px;
   object-fit: cover;
   border-radius: 10px;
   display: block;
 }
-.paste-thumb video {
+/* Black box behind a staged video while its poster is being generated (or if it couldn't be). */
+.paste-thumb .paste-vid {
   background: #000;
 }
 /* Play glyph over a staged video's poster frame. */
@@ -4291,11 +4318,37 @@ function cancelRecording() {
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
 }
 /* Album vs Individual choice for a multi-photo/video send. */
+/* Column so the send-as choice sits on its OWN row under the thumbnails (ion-toolbar would otherwise
+   flex the two side by side and squeeze the segment). */
+.paste-stack {
+  display: flex;
+  flex-direction: column;
+}
 .send-mode {
-  padding: 2px 12px 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 12px 8px;
+}
+.send-mode-label {
+  font-size: 13px;
+  color: var(--app-text-muted);
+  flex: 0 0 auto;
 }
 .send-mode ion-segment {
-  max-width: 240px;
+  flex: 1 1 auto;
+  max-width: 320px;
+}
+.send-mode ion-segment-button {
+  min-height: 30px;
+}
+.send-mode ion-segment-button ion-icon {
+  font-size: 15px;
+  margin-right: 5px;
+}
+/* Icon + label on one line inside each segment button. */
+.send-mode ion-segment-button::part(native) {
+  flex-direction: row;
 }
 .paste-x {
   position: absolute;

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -156,7 +156,7 @@
             swipeId === m.id ? swipeDx : 0,
             selecting,
             isSelected(m.id),
-            downloadingMedia[m.id],
+            downloadProgress[m.id],
             groupRunStart(i),
             senderAvatar(m.senderId),
           ]"
@@ -338,9 +338,15 @@
                 <img v-if="m.posterData" class="bubble-image" :src="m.posterData" :alt="m.kind" />
                 <ion-skeleton-text v-else :animated="true" class="media-skel" />
                 <span class="dl-btn">
-                  <ion-spinner v-if="downloadingMedia[m.id]" name="crescent" />
-                  <ion-icon v-else :icon="downloadOutline" />
+                  <!-- Circular progress around the download glyph while fetching. -->
+                  <svg v-if="m.id in downloadProgress" class="dl-ring" viewBox="0 0 36 36" aria-hidden="true">
+                    <circle class="dl-ring-track" cx="18" cy="18" r="16" pathLength="100" />
+                    <circle class="dl-ring-fill" cx="18" cy="18" r="16" pathLength="100" :stroke-dasharray="`${(downloadProgress[m.id] || 0) * 100} 100`" />
+                  </svg>
+                  <ion-icon :icon="downloadOutline" />
                 </span>
+                <!-- Attachment size, so a large clip is obvious before you spend the data. -->
+                <span v-if="m.mediaSize" class="dl-size">{{ formatBytes(m.mediaSize) }}</span>
               </div>
               <!-- Audio/file not downloaded yet: a chip with the name/size and a download button. -->
               <button
@@ -349,8 +355,13 @@
                 class="file-chip pending-chip"
                 @click.stop="downloadPendingMedia(m.id)"
               >
-                <ion-spinner v-if="downloadingMedia[m.id]" name="crescent" />
-                <ion-icon v-else :icon="m.kind === 'audio' ? musicalNotesOutline : downloadOutline" />
+                <span class="chip-ico">
+                  <svg v-if="m.id in downloadProgress" class="dl-ring" viewBox="0 0 36 36" aria-hidden="true">
+                    <circle class="dl-ring-track" cx="18" cy="18" r="16" pathLength="100" />
+                    <circle class="dl-ring-fill" cx="18" cy="18" r="16" pathLength="100" :stroke-dasharray="`${(downloadProgress[m.id] || 0) * 100} 100`" />
+                  </svg>
+                  <ion-icon :icon="m.id in downloadProgress ? downloadOutline : (m.kind === 'audio' ? musicalNotesOutline : downloadOutline)" />
+                </span>
                 <span>{{ m.pendingMedia.name || (m.kind === 'audio' ? 'Audio' : 'File') }}</span>
                 <span v-if="m.mediaSize" class="chip-size">{{ formatBytes(m.mediaSize) }}</span>
               </button>
@@ -1286,16 +1297,18 @@ function closeSearch() {
 }
 
 // Fetch a deferred (not-yet-downloaded) video's full clip on tap.
-const downloadingMedia = reactive<Record<string, boolean>>({});
+// Per-message download progress (0..1) while a deferred attachment is being fetched; presence in the
+// map means "downloading now" and drives the circular progress ring on the download button.
+const downloadProgress = reactive<Record<string, number>>({});
 async function downloadPendingMedia(id: string): Promise<void> {
-  if (downloadingMedia[id]) return;
-  downloadingMedia[id] = true;
+  if (id in downloadProgress) return;
+  downloadProgress[id] = 0;
   try {
-    await downloadMessageMedia(id);
+    await downloadMessageMedia(id, (f) => (downloadProgress[id] = f));
   } catch {
     /* leave it pending so the user can tap again */
   } finally {
-    delete downloadingMedia[id];
+    delete downloadProgress[id];
   }
 }
 
@@ -5007,6 +5020,55 @@ function cancelRecording() {
 .dl-btn ion-spinner {
   width: 26px;
   height: 26px;
+}
+/* Circular download-progress ring around the download glyph (SVG, pathLength=100 so the fill
+   dasharray is a direct percentage). */
+.dl-ring {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg); /* start the fill at 12 o'clock */
+}
+.dl-ring-track {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.3);
+  stroke-width: 3;
+}
+.dl-ring-fill {
+  fill: none;
+  stroke: #fff;
+  stroke-width: 3;
+  stroke-linecap: round;
+  transition: stroke-dasharray 0.2s linear;
+}
+/* The attachment size badge on a not-yet-downloaded photo/video. */
+.dl-size {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+/* Icon + progress ring wrapper inside a pending audio/file chip. */
+.chip-ico {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex: none;
+}
+.chip-ico .dl-ring-track {
+  stroke: var(--app-border);
+}
+.chip-ico .dl-ring-fill {
+  stroke: var(--ion-color-primary);
 }
 /* Link preview card (privacy-safe: domain + icon, no remote fetch). */
 .link-card {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -156,7 +156,7 @@
             swipeId === m.id ? swipeDx : 0,
             selecting,
             isSelected(m.id),
-            downloadingVideo[m.id],
+            downloadingMedia[m.id],
             groupRunStart(i),
             senderAvatar(m.senderId),
           ]"
@@ -328,19 +328,32 @@
                 </a>
               </template>
 
-              <!-- Video not downloaded yet: the sent thumbnail + a download button
-                   (auto-download is off, or it's a manual fetch). -->
+              <!-- Photo/video not downloaded yet (auto-download off, over the size limit, or a manual
+                   fetch): the sent thumbnail + a download button. -->
               <div
-                v-if="m.kind === 'video' && !m.videoNote && !m.mediaId && m.pendingMedia"
+                v-if="((m.kind === 'video' && !m.videoNote) || m.kind === 'image') && !m.mediaId && m.pendingMedia"
                 class="video-poster pending"
-                @click.stop="downloadVideo(m.id)"
+                @click.stop="downloadPendingMedia(m.id)"
               >
-                <img v-if="m.posterData" class="bubble-image" :src="m.posterData" alt="video" />
+                <img v-if="m.posterData" class="bubble-image" :src="m.posterData" :alt="m.kind" />
                 <ion-skeleton-text v-else :animated="true" class="media-skel" />
                 <span class="dl-btn">
-                  <ion-spinner v-if="downloadingVideo[m.id]" name="crescent" />
+                  <ion-spinner v-if="downloadingMedia[m.id]" name="crescent" />
                   <ion-icon v-else :icon="downloadOutline" />
-                </span>              </div>
+                </span>
+              </div>
+              <!-- Audio/file not downloaded yet: a chip with the name/size and a download button. -->
+              <button
+                v-else-if="(m.kind === 'audio' || m.kind === 'file') && !m.mediaId && m.pendingMedia"
+                type="button"
+                class="file-chip pending-chip"
+                @click.stop="downloadPendingMedia(m.id)"
+              >
+                <ion-spinner v-if="downloadingMedia[m.id]" name="crescent" />
+                <ion-icon v-else :icon="m.kind === 'audio' ? musicalNotesOutline : downloadOutline" />
+                <span>{{ m.pendingMedia.name || (m.kind === 'audio' ? 'Audio' : 'File') }}</span>
+                <span v-if="m.mediaSize" class="chip-size">{{ formatBytes(m.mediaSize) }}</span>
+              </button>
 
               <!-- Media removed from THIS device to free space: a placeholder so the
                    chat still shows something was here (distinct from a sender-deleted
@@ -1127,6 +1140,7 @@ import { openExternal } from '@/utils/external';
 import { selectEvictions } from '@/utils/lru';
 import { normalizeOutgoing } from '@/utils/text';
 import { vEnterSend } from '@/directives/enter-send';
+import { formatBytes } from '@/utils/bytes';
 import { readAudioTags, readAudioDuration } from '@/utils/id3';
 import { get, put } from '@/db/idb';
 import type { Chat, Contact, Media, Message, MessageStatus, Reaction, ReplyRef, SharedContact, DraftMediaItem } from '@/db/types';
@@ -1261,16 +1275,16 @@ function closeSearch() {
 }
 
 // Fetch a deferred (not-yet-downloaded) video's full clip on tap.
-const downloadingVideo = reactive<Record<string, boolean>>({});
-async function downloadVideo(id: string): Promise<void> {
-  if (downloadingVideo[id]) return;
-  downloadingVideo[id] = true;
+const downloadingMedia = reactive<Record<string, boolean>>({});
+async function downloadPendingMedia(id: string): Promise<void> {
+  if (downloadingMedia[id]) return;
+  downloadingMedia[id] = true;
   try {
     await downloadMessageMedia(id);
   } catch {
     /* leave it pending so the user can tap again */
   } finally {
-    delete downloadingVideo[id];
+    delete downloadingMedia[id];
   }
 }
 
@@ -5510,6 +5524,28 @@ function cancelRecording() {
   font-size: 14px;
   color: inherit;
   text-decoration: none;
+}
+/* Not-yet-downloaded audio/file: a tappable chip with a download glyph and the size. */
+.pending-chip {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 2px 0;
+  max-width: 100%;
+}
+.pending-chip span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pending-chip .chip-size {
+  flex: none;
+  opacity: 0.7;
+  font-size: 12px;
+}
+.pending-chip ion-spinner {
+  width: 18px;
+  height: 18px;
 }
 .empty {
   text-align: center;

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1010,7 +1010,7 @@ import {
   sendLocation, sendPoll, sendContact, votePoll, messageSharedContact,
   unblockContact, detectTerminated, firstMessageOnOrAfter, countUnread,
   CAPTION_MAX, getSetting, listChatMediaAll, getMessage, listMessagesOlder,
-  backfillThumbTiers,
+  backfillThumbTiers, getDraft, saveDraft, clearDraft,
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
 import { hasRoomFor } from '@/services/storage-estimate';
@@ -1809,6 +1809,71 @@ watch(composerEl, (el) => {
   void ta?.getInputElement?.().then((native) => native?.setAttribute('dir', 'auto')).catch(() => {});
 });
 
+// ---- composer draft: keep your place across leaving the chat or closing the app ----
+// An unsent message (text + caret + any reply-in-progress) is restored when you re-open this chat,
+// saved as you type (debounced), flushed on leave / background, and cleared once you send.
+let draftSaveTimer: ReturnType<typeof setTimeout> | undefined;
+let draftLoaded = false;
+
+async function nativeComposer(): Promise<HTMLTextAreaElement | undefined> {
+  const ta = composerEl.value?.$el as
+    | (HTMLIonTextareaElement & { getInputElement?: () => Promise<HTMLTextAreaElement> })
+    | undefined;
+  return ta?.getInputElement?.().catch(() => undefined);
+}
+
+async function loadDraft(): Promise<void> {
+  if (draftLoaded) return; // once per mount; returning from a sub-page keeps the live draft as-is
+  draftLoaded = true;
+  const d = await getDraft(chatId);
+  if (!d || draft.value.trim()) return; // nothing saved, or the user already started typing
+  draft.value = d.text ?? '';
+  if (d.reply && !replyingTo.value) replyingTo.value = d.reply;
+  if (d.text) {
+    await nextTick();
+    const native = await nativeComposer();
+    if (native) {
+      const end = d.selEnd ?? d.text.length;
+      try {
+        native.setSelectionRange(d.selStart ?? end, end); // drop the caret back where it was
+      } catch {
+        /* selection unsupported on this element state — ignore */
+      }
+      native.focus();
+    }
+  }
+}
+
+function scheduleDraftSave(): void {
+  clearTimeout(draftSaveTimer);
+  draftSaveTimer = setTimeout(() => void persistDraft(), 400);
+}
+
+async function persistDraft(): Promise<void> {
+  clearTimeout(draftSaveTimer);
+  if (editingMsg.value) return; // an in-progress edit rewrites a sent message, it isn't a draft
+  const text = draft.value;
+  const reply = replyingTo.value ? { ...replyingTo.value } : undefined;
+  if (!text.trim() && !reply) {
+    await clearDraft(chatId);
+    return;
+  }
+  const native = await nativeComposer();
+  await saveDraft({
+    chatId,
+    text,
+    selStart: native?.selectionStart ?? undefined,
+    selEnd: native?.selectionEnd ?? undefined,
+    reply,
+  });
+}
+
+// Sent → the draft is spent; drop the pending save and the stored copy.
+function clearComposerDraft(): void {
+  clearTimeout(draftSaveTimer);
+  void clearDraft(chatId);
+}
+
 // A short text snapshot of a message for the quote (the media icon is rendered
 // separately from `replyTo.kind`, so these labels carry no emoji).
 function previewOf(m: Message): string {
@@ -2236,6 +2301,7 @@ function onComposerInput(e: CustomEvent): void {
   draft.value = (e.detail as { value?: string | null }).value ?? '';
   if (draft.value.trim()) startActivity('typing');
   else stopActivity('typing'); // cleared the draft → no longer typing
+  scheduleDraftSave(); // persist the unsent text so leaving/closing keeps your place
   updateMentionQuery(); // spec 1020: open/refresh the @-mention autocomplete
   const host = composerEl.value?.$el;
   if (host) requestAnimationFrame(() => { host.scrollTop = host.scrollHeight; });
@@ -2606,6 +2672,7 @@ watch(syncState, (s) => {
 onMounted(() => {
   void markChatRead(chatId);
   void resumePendingMediaJobs(); // restart any compressions interrupted by a reload
+  void loadDraft(); // restore an unsent message (text + caret + reply) if you left one here
   document.addEventListener('visibilitychange', onVisibilityChange);
   // Safety net: if the enter transition's didEnter never fires (e.g. opened
   // directly with no animation), still reveal the header rather than leave it
@@ -2617,6 +2684,7 @@ onMounted(() => {
   listReadyFallback = setTimeout(() => (listReady.value = true), 800);
 });
 onUnmounted(() => {
+  void persistDraft(); // leaving the chat → keep the unsent message for next time
   document.removeEventListener('visibilitychange', onVisibilityChange);
   clearTimeout(headerReadyFallback);
   clearTimeout(listReadyFallback);
@@ -2675,7 +2743,9 @@ function onVisibilityChange(): void {
       scheduleShareHint();
     }
   } else {
-    // Backgrounded: clear so a stale toast can't surface over the gate on return.
+    // Backgrounded (incl. an iOS app close that starts here): flush the unsent message now, while we
+    // still can, so it survives a full termination.
+    void persistDraft();
     clearTimeout(shareHintTimer);
     dismissShareHintToast();
   }
@@ -2702,6 +2772,7 @@ function dismissShareHintToast(): void {
 onIonViewWillLeave(() => {
   viewActive.value = false;
   setActiveChat(null);
+  void persistDraft(); // navigating away within the app → save the unsent message
   stopActivity(); // leaving the chat ends any outgoing activity indicator (spec 1009)
   clearTimeout(shareHintTimer);
   dismissShareHintToast(); // don't let the hint linger on other pages
@@ -3308,6 +3379,7 @@ async function send() {
     const target = editingMsg.value;
     editingMsg.value = null;
     draft.value = '';
+    clearComposerDraft();
     await editMessage(target.id, text);
     return;
   }
@@ -3337,6 +3409,7 @@ async function send() {
     pendingMedia.value = [];
     const caption = text;
     draft.value = '';
+    clearComposerDraft();
     // Plain copy, replyingTo.value is a reactive Proxy, which IndexedDB can't clone.
     const reply = replyingTo.value ? { ...replyingTo.value } : undefined;
     replyingTo.value = null;
@@ -3365,6 +3438,7 @@ async function send() {
   }
 
   draft.value = '';
+  clearComposerDraft();
   mentionQuery.value = null; // close the autocomplete
   // @mentions (spec 1020): resolve the body's @tokens to member ids + an honored @everyone.
   const { mentions, everyone } = resolveMentions(text);
@@ -3531,7 +3605,7 @@ async function onPick(e: Event, mode: 'auto' | 'file') {
   // if there's clearly no room, rather than failing partway through encode/upload.
   const incoming = files.reduce((n, f) => n + f.size, 0);
   if (!(await hasRoomFor(incoming))) {
-    void appToast({ message: 'Not enough storage on this device — free up space and try again.', duration: 2600 });
+    void appToast({ message: 'Not enough storage on this device. Free up space and try again.', duration: 2600 });
     return;
   }
   // Picked media now STAGES like a paste (spec 1023) so it can be captioned before

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1010,7 +1010,7 @@ import {
   sendLocation, sendPoll, sendContact, votePoll, messageSharedContact,
   unblockContact, detectTerminated, firstMessageOnOrAfter, countUnread,
   CAPTION_MAX, getSetting, listChatMediaAll, getMessage, listMessagesOlder,
-  backfillThumbTiers, getDraft, saveDraft, clearDraft,
+  backfillThumbTiers, getDraft, saveDraft, clearDraft, getDraftMedia, saveDraftMedia, clearDraftMedia,
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
 import { hasRoomFor } from '@/services/storage-estimate';
@@ -1050,7 +1050,7 @@ import { normalizeOutgoing } from '@/utils/text';
 import { vEnterSend } from '@/directives/enter-send';
 import { readAudioTags, readAudioDuration } from '@/utils/id3';
 import { get, put } from '@/db/idb';
-import type { Chat, Contact, Media, Message, MessageStatus, Reaction, ReplyRef, SharedContact } from '@/db/types';
+import type { Chat, Contact, Media, Message, MessageStatus, Reaction, ReplyRef, SharedContact, DraftMediaItem } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useChatHistory } from '@/composables/useChatHistory';
 import { LOOK_AHEAD_PX } from '@/utils/chat-window';
@@ -1825,11 +1825,25 @@ async function nativeComposer(): Promise<HTMLTextAreaElement | undefined> {
 async function loadDraft(): Promise<void> {
   if (draftLoaded) return; // once per mount; returning from a sub-page keeps the live draft as-is
   draftLoaded = true;
-  const d = await getDraft(chatId);
-  if (!d || draft.value.trim()) return; // nothing saved, or the user already started typing
-  draft.value = d.text ?? '';
-  if (d.reply && !replyingTo.value) replyingTo.value = d.reply;
-  if (d.text) {
+  const [d, dm] = await Promise.all([getDraft(chatId), getDraftMedia(chatId)]);
+  // Nothing saved, or the user already started composing before the (async) load resolved.
+  if ((!d && !dm) || draft.value.trim() || pendingMedia.value.length) return;
+  if (d) {
+    draft.value = d.text ?? '';
+    if (d.reply && !replyingTo.value) replyingTo.value = d.reply;
+  }
+  // Rebuild the staged attachments from their inline bytes as fresh in-memory files (always readable,
+  // unlike a Blob read back from IDB after a reload). Seed the bytes cache so the next save is free.
+  if (dm?.items.length) {
+    for (const it of dm.items) {
+      const file = new File([it.bytes], it.name || 'attachment', it.mime ? { type: it.mime } : undefined);
+      const id = crypto.randomUUID();
+      draftMediaBytes.set(id, it.bytes);
+      const url = it.kind === 'image' || it.kind === 'video' ? URL.createObjectURL(file) : undefined;
+      pendingMedia.value.push({ id, blob: file, kind: it.kind, url, caption: it.caption });
+    }
+  }
+  if (d?.text) {
     await nextTick();
     const native = await nativeComposer();
     if (native) {
@@ -1854,7 +1868,8 @@ async function persistDraft(): Promise<void> {
   if (editingMsg.value) return; // an in-progress edit rewrites a sent message, it isn't a draft
   const text = draft.value;
   const reply = replyingTo.value ? { ...replyingTo.value } : undefined;
-  if (!text.trim() && !reply) {
+  const media = pendingMedia.value;
+  if (!text.trim() && !reply && !media.length) {
     await clearDraft(chatId);
     return;
   }
@@ -1865,13 +1880,67 @@ async function persistDraft(): Promise<void> {
     selStart: native?.selectionStart ?? undefined,
     selEnd: native?.selectionEnd ?? undefined,
     reply,
+    mediaCount: media.length || undefined,
+    mediaLabel: mediaLabelFor(media),
   });
 }
 
-// Sent → the draft is spent; drop the pending save and the stored copy.
+// The Chats-list preview for a media-only draft (no typed text).
+function mediaLabelFor(media: PendingMedia[]): string | undefined {
+  if (!media.length) return undefined;
+  if (media.length > 1) return `${media.length} attachments`;
+  const k = media[0].kind;
+  return k === 'image' ? 'Photo' : k === 'video' ? 'Video' : 'File';
+}
+
+// ---- staged attachments in the draft: keep the photos/videos/files you added but didn't send ----
+// Their bytes are stored inline (ArrayBuffer), NOT as Blobs — an IDB Blob can read back broken on iOS
+// after a reload. Persisted on each attachment change (add / remove / caption), not per keystroke, so
+// a caption you type doesn't rewrite megabytes each time. Bytes are cached by item id to avoid
+// re-reading a (possibly large) clip when only a caption changed.
+const draftMediaBytes = new Map<string, ArrayBuffer>();
+let draftMediaSaveTimer: ReturnType<typeof setTimeout> | undefined;
+
+function scheduleDraftMediaSave(): void {
+  clearTimeout(draftMediaSaveTimer);
+  draftMediaSaveTimer = setTimeout(() => {
+    void persistDraftMedia();
+    void persistDraft(); // keep the drafts record's mediaCount/label (and existence) in step
+  }, 300);
+}
+
+async function persistDraftMedia(): Promise<void> {
+  const media = pendingMedia.value;
+  if (!media.length) {
+    await clearDraftMedia(chatId);
+    draftMediaBytes.clear();
+    return;
+  }
+  const items: DraftMediaItem[] = [];
+  for (const it of media) {
+    let bytes = draftMediaBytes.get(it.id);
+    if (!bytes) {
+      bytes = await it.blob.arrayBuffer();
+      draftMediaBytes.set(it.id, bytes);
+    }
+    items.push({
+      bytes,
+      kind: it.kind,
+      name: it.blob.name || 'attachment',
+      mime: it.blob.type || '',
+      caption: it.caption,
+    });
+  }
+  await saveDraftMedia(chatId, items);
+}
+
+// Sent → the draft is spent; drop the pending saves and the stored copies (text + attachments).
 function clearComposerDraft(): void {
   clearTimeout(draftSaveTimer);
+  clearTimeout(draftMediaSaveTimer);
+  draftMediaBytes.clear();
   void clearDraft(chatId);
+  void clearDraftMedia(chatId);
 }
 
 // A short text snapshot of a message for the quote (the media icon is rendered
@@ -2373,6 +2442,7 @@ async function editItemCaption(i: number): Promise<void> {
         handler: (d: { caption?: string }) => {
           const next = pendingMedia.value[i];
           if (next) next.caption = (d?.caption ?? '').slice(0, CAPTION_MAX).trim() || undefined;
+          scheduleDraftMediaSave(); // persist the per-item caption into the draft
         },
       },
     ],
@@ -2403,6 +2473,7 @@ function stageMedia(f: File, forceFile = false): 'audio' | 'staged' {
   const kind: 'image' | 'video' | 'file' = k === 'image' || k === 'video' ? k : 'file';
   const url = kind === 'image' || kind === 'video' ? URL.createObjectURL(f) : undefined;
   pendingMedia.value.push({ id: crypto.randomUUID(), blob: f, kind, url });
+  scheduleDraftMediaSave(); // keep the staged attachment in the draft
   return 'staged';
 }
 
@@ -2481,6 +2552,8 @@ function imageNameFromUrl(url: string, mime: string): string {
 function removePendingMedia(i: number): void {
   const [gone] = pendingMedia.value.splice(i, 1);
   if (gone?.url) URL.revokeObjectURL(gone.url);
+  if (gone) draftMediaBytes.delete(gone.id);
+  scheduleDraftMediaSave(); // reflect the removal in the draft (clears it when the last one goes)
 }
 
 function clearPendingMedia(): void {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -2495,24 +2495,39 @@ function stageMedia(f: File, forceFile = false): 'audio' | 'staged' {
   const url = kind === 'image' || kind === 'video' ? URL.createObjectURL(f) : undefined;
   const id = crypto.randomUUID();
   pendingMedia.value.push({ id, blob: f, kind, url });
-  if (kind === 'video') void ensureVideoPoster(id, f); // decode a first-frame thumbnail for the tile
+  if (kind === 'video') void posterFromMaterialized(id, f);
   scheduleDraftMediaSave(); // keep the staged attachment in the draft
   return 'staged';
 }
 
-// Generate a staged video's first-frame poster off-screen and drop it onto the (reactive) item.
-// Matched by id since the row can shift if another item is removed while this resolves.
-async function ensureVideoPoster(id: string, blob: Blob): Promise<void> {
+// Generating a poster straight from a freshly-picked iOS video File is unreliable — the <video>
+// element often can't decode a frame from it within the timeout, so the tile stayed black until you
+// left and came back (which rebuilds the clip from bytes). Reading the bytes into a fully in-memory
+// blob first makes it decode reliably. We cache those bytes for the draft so they aren't read twice.
+async function posterFromMaterialized(id: string, f: File): Promise<void> {
   try {
-    const poster = await generateVideoPoster(blob);
-    const it = pendingMedia.value.find((m) => m.id === id);
-    if (it && poster) it.poster = poster;
+    const buf = await f.arrayBuffer();
+    draftMediaBytes.set(id, buf);
+    await ensureVideoPoster(id, new Blob([buf], { type: f.type || 'video/mp4' }));
+  } catch {
+    await ensureVideoPoster(id, f); // fall back to the raw file
+  }
+}
+
+// Generate a staged video's first-frame poster off-screen and drop it onto the (reactive) item.
+// Replace the array element (not mutate in place) so the tile repaints reliably; matched by id since
+// the row can shift if another item is removed while this resolves.
+async function ensureVideoPoster(id: string, blob: Blob): Promise<void> {
+  let poster: string | undefined;
+  try {
+    poster = await generateVideoPoster(blob);
   } catch {
     /* no frame (codec/timeout) — the tile falls back to a plain black video box */
-  } finally {
-    const it = pendingMedia.value.find((m) => m.id === id);
-    if (it) it.ready = true; // stop the spinner whether or not we got a frame
   }
+  const idx = pendingMedia.value.findIndex((m) => m.id === id);
+  if (idx < 0) return;
+  const cur = pendingMedia.value[idx];
+  pendingMedia.value[idx] = { ...cur, poster: poster ?? cur.poster, ready: true };
 }
 
 // Route a picked/pasted audio file into the title/artist review queue (its own flow).

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -754,8 +754,17 @@
             >
               <img v-if="p.kind === 'image' && p.url" :src="p.url" alt="Attachment" />
               <template v-else-if="p.kind === 'video' && p.url">
-                <video :src="p.url" muted playsinline preload="metadata" />
-                <ion-icon class="paste-play" :icon="playCircle" />
+                <video
+                  :src="p.url"
+                  muted
+                  playsinline
+                  preload="metadata"
+                  @loadeddata="p.ready = true"
+                />
+                <!-- Large clips take a moment to decode a first frame; show a spinner over the black
+                     tile until then so it reads as "loading", not broken. -->
+                <ion-spinner v-if="!p.ready" name="crescent" class="paste-loading" />
+                <ion-icon v-else class="paste-play" :icon="playCircle" />
               </template>
               <div v-else class="paste-file">
                 <ion-icon :icon="documentOutline" />
@@ -2413,7 +2422,11 @@ interface PendingMedia {
   kind: 'image' | 'video' | 'file';
   url?: string; // object URL for an image/video preview; files show a chip instead
   caption?: string; // optional per-item caption (overrides the shared one for this item)
+  ready?: boolean; // a video whose first frame has decoded (until then the tile shows a spinner)
 }
+// Cap on staged attachments per message (photos + videos + files). The iOS library picker itself
+// can't be limited, so onPick trims the overflow to this.
+const MAX_STAGED_MEDIA = 10;
 const pendingMedia = ref<PendingMedia[]>([]);
 // Multiple photos/videos: send as one album (default) or as separate messages.
 const sendAsAlbum = ref(true);
@@ -3684,9 +3697,21 @@ async function onPick(e: Event, mode: 'auto' | 'file') {
   // Picked media now STAGES like a paste (spec 1023) so it can be captioned before
   // sending, and several photos/videos can go as an album or individually — see send().
   // Audio keeps its own title/artist review path.
+  // The iOS picker can't be capped (no `max` on a file input), so enforce the limit here: stage up to
+  // MAX_STAGED_MEDIA attachments and tell the user if the pick went over. Audio routes to its own
+  // queue and isn't counted against this.
   const audioFiles: File[] = [];
+  let overCap = false;
   for (const f of files) {
+    const isAudio = mediaKindOf(f, mode === 'file') === 'audio';
+    if (!isAudio && pendingMedia.value.length >= MAX_STAGED_MEDIA) {
+      overCap = true;
+      continue;
+    }
     if (stageMedia(f, mode === 'file') === 'audio') audioFiles.push(f);
+  }
+  if (overCap) {
+    void appToast({ message: `You can attach up to ${MAX_STAGED_MEDIA} items at once.`, duration: 2200 });
   }
   if (audioFiles.length) {
     // The pending reply (if any) rides the first audio only when nothing else was staged
@@ -4198,6 +4223,16 @@ function cancelRecording() {
   color: #fff;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6));
   pointer-events: none;
+}
+/* Spinner over a staged video whose first frame hasn't decoded yet (large clips take a moment). */
+.paste-loading {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 22px;
+  height: 22px;
+  color: #fff;
 }
 /* A staged non-media file shows a labelled chip instead of a thumbnail. */
 .paste-file {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -898,6 +898,17 @@
             @paste="onComposerPaste"
           />
           <ion-buttons slot="end">
+            <!-- Per-message disappearing timer (sticky until changed): green when messages you send
+                 will disappear (an override, or the chat's default), grey when they won't. -->
+            <ion-button
+              :aria-label="`Disappearing timer: ${msgTtlLabel}`"
+              :color="effectiveTtlMs ? 'primary' : 'medium'"
+              class="ttl-btn"
+              @click="openMsgTtl"
+            >
+              <ion-icon slot="icon-only" :icon="timerOutline" />
+              <span v-if="effectiveTtlMs" class="ttl-badge">{{ msgTtlShort }}</span>
+            </ion-button>
             <ion-button
               v-if="draft.trim() || pendingMedia.length"
               color="primary"
@@ -1066,7 +1077,7 @@ import {
   micOutline, trashOutline, closeOutline, pause, banOutline, arrowRedoOutline, arrowUndoOutline, globeOutline,
   locationOutline, barChartOutline, personOutline, refreshOutline, downloadOutline,
   imageOutline, musicalNotesOutline, calendarOutline, checkmarkCircle, ellipseOutline,
-  chevronDownOutline, chatbubbleEllipses, albumsOutline, imagesOutline, createOutline,
+  chevronDownOutline, chatbubbleEllipses, albumsOutline, imagesOutline, createOutline, timerOutline,
 } from 'ionicons/icons';
 import {
   getChat, getContact, listContacts, markChatRead, sendMediaMessage, sendMessage,
@@ -2379,6 +2390,43 @@ const search = ref('');
 const showSearch = ref(false);
 const draft = ref('');
 
+// ---- per-message disappearing timer (composer) ----
+// Sticky override applied to messages you send from now on, on top of the chat/group default:
+//   undefined = follow the chat default · null = off (don't disappear) · >0 = this many ms.
+// It stays until you change it (this session), and is passed as ttlOverrideMs on send.
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+const TTL_DAY = 24 * HOUR;
+const msgTtl = ref<number | null | undefined>(undefined);
+const effectiveTtlMs = computed(() => (msgTtl.value !== undefined ? msgTtl.value : chat.value?.defaultTtlMs ?? null));
+function fmtTtl(ms: number): string {
+  if (ms >= TTL_DAY) return `${Math.round(ms / TTL_DAY)}d`;
+  if (ms >= HOUR) return `${Math.round(ms / HOUR)}h`;
+  return `${Math.round(ms / MIN)}m`;
+}
+const msgTtlShort = computed(() => (effectiveTtlMs.value ? fmtTtl(effectiveTtlMs.value) : ''));
+const msgTtlLabel = computed(() => {
+  if (msgTtl.value === undefined) return effectiveTtlMs.value ? `chat default (${fmtTtl(effectiveTtlMs.value)})` : 'off (chat default)';
+  if (!msgTtl.value) return 'off';
+  return fmtTtl(msgTtl.value);
+});
+async function openMsgTtl(): Promise<void> {
+  const sheet = await actionSheetController.create({
+    header: 'Disappearing timer',
+    subHeader: 'Messages you send disappear after (until you change it):',
+    buttons: [
+      { text: 'Use chat default', handler: () => { msgTtl.value = undefined; } },
+      { text: 'Off', handler: () => { msgTtl.value = null; } },
+      { text: '5 minutes', handler: () => { msgTtl.value = 5 * MIN; } },
+      { text: '1 hour', handler: () => { msgTtl.value = HOUR; } },
+      { text: '24 hours', handler: () => { msgTtl.value = TTL_DAY; } },
+      { text: '7 days', handler: () => { msgTtl.value = 7 * TTL_DAY; } },
+      { text: 'Cancel', role: 'cancel' as const },
+    ],
+  });
+  await sheet.present();
+}
+
 // Keep the line you're typing visible. Once the composer hits its max height it
 // scrolls, but the scroll container is the ion-textarea HOST (its inner native
 // textarea grows to fit, so it never scrolls itself), and the browser only keeps
@@ -3622,7 +3670,7 @@ async function send() {
         it.blob,
         it.blob.name || (it.kind === 'file' ? 'file' : 'photo'),
         undefined,
-        { replyTo: i === 0 ? reply : undefined, caption: cap, albumId: inAlbum ? albumId : undefined, quality },
+        { replyTo: i === 0 ? reply : undefined, caption: cap, albumId: inAlbum ? albumId : undefined, quality, ttlOverrideMs: msgTtl.value },
       );
       if (it.url) URL.revokeObjectURL(it.url);
     }
@@ -3638,7 +3686,7 @@ async function send() {
   // Plain copy, replyingTo.value is a reactive Proxy, which IndexedDB can't clone.
   const reply = replyingTo.value ? { ...replyingTo.value } : undefined;
   replyingTo.value = null;
-  await sendMessage(chatId, text, reply, mentions, everyone);
+  await sendMessage(chatId, text, reply, mentions, everyone, msgTtl.value);
   await scrollToNewest();
 }
 
@@ -3738,7 +3786,7 @@ async function onVideoNoteSend(blob: Blob, dur: number, poster?: string): Promis
   // Plain copy, replyingTo.value is a reactive Proxy, which IndexedDB can't clone.
   const reply = replyingTo.value ? { ...replyingTo.value } : undefined;
   replyingTo.value = null;
-  await sendMediaMessage(chatId, 'video', blob, 'video-note', dur, { videoNote: true, replyTo: reply, poster });
+  await sendMediaMessage(chatId, 'video', blob, 'video-note', dur, { videoNote: true, replyTo: reply, poster, ttlOverrideMs: msgTtl.value });
 }
 
 // Ask the send quality for photos/videos (WhatsApp-style), offering ONLY the tiers a
@@ -3941,6 +3989,7 @@ async function onAudioReviewSend(meta: { title: string; artist: string }): Promi
     await sendMediaMessage(chatId, 'audio', cur.blob, cur.name, audioReview.value.durationSec, {
       audio: { title: meta.title, artist: meta.artist || undefined },
       replyTo: cur.reply,
+      ttlOverrideMs: msgTtl.value,
     });
     void scrollToNewest();
   }
@@ -4151,7 +4200,7 @@ async function stopAndSendRecording() {
   // Plain copy, replyingTo.value is a reactive Proxy, which IndexedDB can't clone.
   const reply = replyingTo.value ? { ...replyingTo.value } : undefined;
   replyingTo.value = null;
-  await sendMediaMessage(chatId, 'voice', blob, 'voice-message', durationSec, { replyTo: reply });
+  await sendMediaMessage(chatId, 'voice', blob, 'voice-message', durationSec, { replyTo: reply, ttlOverrideMs: msgTtl.value });
 }
 
 function cancelRecording() {
@@ -5531,5 +5580,20 @@ function cancelRecording() {
   --padding-bottom: 6px;
   max-height: 7.5rem;
   overflow-y: auto;
+}
+/* Disappearing-timer button: the duration badge tucks under the timer glyph. */
+.ttl-btn {
+  position: relative;
+}
+.ttl-badge {
+  position: absolute;
+  bottom: 1px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.3px;
+  pointer-events: none;
 }
 </style>

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1909,7 +1909,7 @@ async function loadDraft(): Promise<void> {
       draftMediaBytes.set(id, it.bytes);
       const url = it.kind === 'image' || it.kind === 'video' ? URL.createObjectURL(file) : undefined;
       pendingMedia.value.push({ id, blob: file, kind: it.kind, url, caption: it.caption });
-      if (it.kind === 'video') void ensureVideoPoster(id, file); // rebuild the tile thumbnail
+      if (it.kind === 'video') queueVideoPoster(id); // rebuild the tile thumbnail
     }
   }
   if (d?.text) {
@@ -2536,46 +2536,58 @@ function stageMedia(f: File, forceFile = false): 'audio' | 'staged' {
   const url = kind === 'image' || kind === 'video' ? URL.createObjectURL(f) : undefined;
   const id = crypto.randomUUID();
   pendingMedia.value.push({ id, blob: f, kind, url });
-  if (kind === 'video') void posterFromMaterialized(id, f);
+  if (kind === 'video') queueVideoPoster(id); // decode a first-frame thumbnail (serialized + retried)
   scheduleDraftSave(); // update the light drafts record; the media bytes are saved on leave (below)
   return 'staged';
 }
 
-// Generating a poster straight from a freshly-picked iOS video File is unreliable — the <video>
-// element often can't decode a frame from it within the timeout, so the tile stayed black until you
-// left and came back (which rebuilds the clip from bytes). Reading the bytes into a fully in-memory
-// blob first makes it decode reliably. We cache those bytes for the draft so they aren't read twice.
-async function posterFromMaterialized(id: string, f: File): Promise<void> {
+// Video poster generation is SERIALIZED through this queue. Decoding a frame right after a big
+// multi-select is flaky on iOS (why the tile stayed black until you left + came back, once the page
+// had settled); doing several at once made it worse. One at a time — with a breath between — mimics
+// the calm re-open that always works. Each item still retries a few times before giving up.
+const posterQueue: Array<() => Promise<void>> = [];
+let posterQueueRunning = false;
+function queueVideoPoster(id: string, attempt = 0): void {
+  posterQueue.push(() => attemptVideoPoster(id, attempt));
+  if (!posterQueueRunning) void runPosterQueue();
+}
+async function runPosterQueue(): Promise<void> {
+  posterQueueRunning = true;
   try {
-    const buf = await f.arrayBuffer();
-    draftMediaBytes.set(id, buf);
-    await ensureVideoPoster(id, new Blob([buf], { type: f.type || 'video/mp4' }));
-  } catch {
-    await ensureVideoPoster(id, f); // fall back to the raw file
+    while (posterQueue.length) {
+      const task = posterQueue.shift();
+      if (task) await task();
+      await new Promise((r) => window.setTimeout(r, 150)); // let the decoder settle between clips
+    }
+  } finally {
+    posterQueueRunning = false;
   }
 }
 
-// Generate a staged video's first-frame poster off-screen and drop it onto the (reactive) item.
-// iOS frequently can't decode a frame right after a big multi-select (the reason the thumbnail only
-// used to appear after leaving + returning, once the page had settled). So on a null result we back
-// off and RETRY a few times, keeping the spinner up, instead of giving up to a black tile. The item
-// is updated by REPLACING it (not mutating in place) so the tile repaints reliably.
-async function ensureVideoPoster(id: string, blob: Blob, attempt = 0): Promise<void> {
+// One decode attempt for a staged video's first-frame poster. On failure it RE-QUEUES itself (after a
+// backoff) rather than looping in place, so a stubborn clip doesn't hold up the others' turns — each
+// clip's later retries interleave with the rest. Gives up to a plain black tile after a few tries.
+// The item is updated by REPLACING it (not mutating in place) so the tile repaints reliably.
+async function attemptVideoPoster(id: string, attempt: number): Promise<void> {
+  const item = pendingMedia.value.find((m) => m.id === id);
+  if (!item || item.kind !== 'video') return; // removed while queued
   let poster: string | undefined;
   try {
-    poster = await generateVideoPoster(blob);
+    poster = await generateVideoPoster(item.blob);
   } catch {
     /* no frame yet */
   }
   const idx = pendingMedia.value.findIndex((m) => m.id === id);
   if (idx < 0) return; // item removed while we were decoding
-  if (!poster && attempt < 4) {
-    // Try again once the device has quieted down; leave the tile spinning meanwhile.
-    window.setTimeout(() => void ensureVideoPoster(id, blob, attempt + 1), 700 * (attempt + 1));
+  if (poster) {
+    pendingMedia.value[idx] = { ...pendingMedia.value[idx], poster, ready: true };
     return;
   }
-  const cur = pendingMedia.value[idx];
-  pendingMedia.value[idx] = { ...cur, poster: poster ?? cur.poster, ready: true };
+  if (attempt < 5) {
+    window.setTimeout(() => queueVideoPoster(id, attempt + 1), 600 * (attempt + 1)); // retry later
+    return;
+  }
+  pendingMedia.value[idx] = { ...pendingMedia.value[idx], ready: true }; // give up: black tile + play
 }
 
 // Route a picked/pasted audio file into the title/artist review queue (its own flow).
@@ -4316,11 +4328,12 @@ function cancelRecording() {
 .paste-thumb .paste-vid {
   background: #000;
 }
-/* Play glyph over a staged video's poster frame. */
+/* Play glyph over a staged video's poster frame. Dead-centered so it lands exactly where the
+   loading spinner was (no jump when the poster arrives). */
 .paste-play {
   position: absolute;
-  left: calc(50% - 3px);
-  top: calc(50% + 3px);
+  left: 50%;
+  top: 50%;
   transform: translate(-50%, -50%);
   font-size: 26px;
   color: #fff;

--- a/src/views/detail/ContactDetailPage.vue
+++ b/src/views/detail/ContactDetailPage.vue
@@ -97,10 +97,15 @@
             <ion-label>Disappearing messages</ion-label>
             <ion-note slot="end">{{ ttlLabel }}</ion-note>
           </ion-item>
-          <ion-item button :detail="false" @click="openQuality">
+          <ion-item button :detail="false" @click="openQuality('photo')">
             <ion-icon slot="start" :icon="imagesOutline" />
-            <ion-label>Media quality</ion-label>
-            <ion-note slot="end">{{ qualityLabel }}</ion-note>
+            <ion-label>Photo quality</ion-label>
+            <ion-note slot="end">{{ qualityLabel('photo') }}</ion-note>
+          </ion-item>
+          <ion-item button :detail="false" @click="openQuality('video')">
+            <ion-icon slot="start" :icon="videocamOutline" />
+            <ion-label>Video quality</ion-label>
+            <ion-note slot="end">{{ qualityLabel('video') }}</ion-note>
           </ion-item>
           <ion-item button :detail="false" lines="none" @click="openPresenceOverride">
             <ion-icon slot="start" :icon="eyeOutline" />
@@ -164,7 +169,7 @@ import {
   alertController, actionSheetController,
 } from '@ionic/vue';
 import {
-  chatbubbleOutline, searchOutline, banOutline, imagesOutline,
+  chatbubbleOutline, searchOutline, banOutline, imagesOutline, videocamOutline,
   notificationsOutline, notificationsOffOutline, starOutline, timerOutline, eyeOutline, documentTextOutline,
   createOutline, cameraOutline, refreshOutline, personOutline, trashOutline,
 } from 'ionicons/icons';
@@ -359,21 +364,21 @@ const QUALITY_ROWS = [
   { q: 'fhd' as const, text: 'Full HD' },
   { q: 'original' as const, text: 'Original' },
 ];
-const qualityLabel = computed(() => {
-  const q = chat.value?.sendQuality;
+// Per-chat send-quality override for a kind (photos vs videos). "Default" clears it back to the
+// global Upload-quality setting for that kind.
+function qualityLabel(kind: 'photo' | 'video'): string {
+  const q = kind === 'photo' ? chat.value?.sendQualityPhoto : chat.value?.sendQualityVideo;
   return q ? (QUALITY_ROWS.find((r) => r.q === q)?.text ?? q) : 'Default';
-});
-// Per-chat send-quality default (pre-selects the composer's Send-quality prompt). "Default" clears
-// it back to the global Upload-quality setting.
-async function openQuality(): Promise<void> {
+}
+async function openQuality(kind: 'photo' | 'video'): Promise<void> {
   const id = chat.value?.id;
   if (!id) return;
   const sheet = await actionSheetController.create({
-    header: 'Media quality',
-    subHeader: 'Default quality for photos and videos sent in this chat:',
+    header: kind === 'photo' ? 'Photo quality' : 'Video quality',
+    subHeader: `Quality for ${kind === 'photo' ? 'photos' : 'videos'} sent in this chat:`,
     buttons: [
-      ...QUALITY_ROWS.map((r) => ({ text: r.text, handler: () => void setChatSendQuality(id, r.q) })),
-      { text: 'Use global default', handler: () => void setChatSendQuality(id, null) },
+      ...QUALITY_ROWS.map((r) => ({ text: r.text, handler: () => void setChatSendQuality(id, kind, r.q) })),
+      { text: 'Use global default', handler: () => void setChatSendQuality(id, kind, null) },
       { text: 'Cancel', role: 'cancel' as const },
     ],
   });

--- a/src/views/detail/ContactDetailPage.vue
+++ b/src/views/detail/ContactDetailPage.vue
@@ -97,6 +97,11 @@
             <ion-label>Disappearing messages</ion-label>
             <ion-note slot="end">{{ ttlLabel }}</ion-note>
           </ion-item>
+          <ion-item button :detail="false" @click="openQuality">
+            <ion-icon slot="start" :icon="imagesOutline" />
+            <ion-label>Media quality</ion-label>
+            <ion-note slot="end">{{ qualityLabel }}</ion-note>
+          </ion-item>
           <ion-item button :detail="false" lines="none" @click="openPresenceOverride">
             <ion-icon slot="start" :icon="eyeOutline" />
             <ion-label class="ion-text-wrap">Online & last seen to this contact</ion-label>
@@ -165,7 +170,7 @@ import {
 } from 'ionicons/icons';
 import { computed, ref } from 'vue';
 import {
-  getContact, startDirectChat, blockContact, unblockContact, listChats, setChatMute, setChatTtl,
+  getContact, startDirectChat, blockContact, unblockContact, listChats, setChatMute, setChatTtl, setChatSendQuality,
   getPresenceOverrides, setPresenceOverride, setChatNotifyPrefs, type ChatNotifyContent,
   setContactLocalProfile, resetContactToRemote, adoptContactProfile, dismissContactProfile, downscaleAvatar,
   deleteContact,
@@ -342,6 +347,33 @@ async function openTtl(): Promise<void> {
       { text: '7 days', handler: () => void setChatTtl(id, 7 * DAY) },
       { text: '90 days', handler: () => void setChatTtl(id, 90 * DAY) },
       { text: 'Off', handler: () => void setChatTtl(id, null) },
+      { text: 'Cancel', role: 'cancel' as const },
+    ],
+  });
+  await sheet.present();
+}
+
+const QUALITY_ROWS = [
+  { q: 'sd' as const, text: 'SD (smaller)' },
+  { q: 'hd' as const, text: 'HD' },
+  { q: 'fhd' as const, text: 'Full HD' },
+  { q: 'original' as const, text: 'Original' },
+];
+const qualityLabel = computed(() => {
+  const q = chat.value?.sendQuality;
+  return q ? (QUALITY_ROWS.find((r) => r.q === q)?.text ?? q) : 'Default';
+});
+// Per-chat send-quality default (pre-selects the composer's Send-quality prompt). "Default" clears
+// it back to the global Upload-quality setting.
+async function openQuality(): Promise<void> {
+  const id = chat.value?.id;
+  if (!id) return;
+  const sheet = await actionSheetController.create({
+    header: 'Media quality',
+    subHeader: 'Default quality for photos and videos sent in this chat:',
+    buttons: [
+      ...QUALITY_ROWS.map((r) => ({ text: r.text, handler: () => void setChatSendQuality(id, r.q) })),
+      { text: 'Use global default', handler: () => void setChatSendQuality(id, null) },
       { text: 'Cancel', role: 'cancel' as const },
     ],
   });

--- a/src/views/detail/GroupInfoPage.vue
+++ b/src/views/detail/GroupInfoPage.vue
@@ -55,10 +55,15 @@
             <ion-label>Disappearing messages</ion-label>
             <ion-note slot="end">{{ ttlLabel }}</ion-note>
           </ion-item>
-          <ion-item button :detail="false" lines="none" @click="openQuality">
+          <ion-item button :detail="false" @click="openQuality('photo')">
             <ion-icon slot="start" :icon="imagesOutline" />
-            <ion-label>Media quality</ion-label>
-            <ion-note slot="end">{{ qualityLabel }}</ion-note>
+            <ion-label>Photo quality</ion-label>
+            <ion-note slot="end">{{ qualityLabel('photo') }}</ion-note>
+          </ion-item>
+          <ion-item button :detail="false" lines="none" @click="openQuality('video')">
+            <ion-icon slot="start" :icon="videocamOutline" />
+            <ion-label>Video quality</ion-label>
+            <ion-note slot="end">{{ qualityLabel('video') }}</ion-note>
           </ion-item>
         </ion-list>
 
@@ -159,7 +164,7 @@ import {
 import {
   personAddOutline, exitOutline, createOutline, cameraOutline, ellipsisHorizontal,
   imagesOutline, searchOutline, notificationsOutline, notificationsOffOutline, starOutline, timerOutline, atOutline,
-  chatbubbleOutline, documentTextOutline,
+  chatbubbleOutline, documentTextOutline, videocamOutline,
 } from 'ionicons/icons';
 import {
   getChat, listContacts, addMemberToGroup, removeMember, leaveGroup,
@@ -277,17 +282,17 @@ const QUALITY_ROWS = [
   { q: 'fhd' as const, text: 'Full HD' },
   { q: 'original' as const, text: 'Original' },
 ];
-const qualityLabel = computed(() => {
-  const q = chat.value?.sendQuality;
+function qualityLabel(kind: 'photo' | 'video'): string {
+  const q = kind === 'photo' ? chat.value?.sendQualityPhoto : chat.value?.sendQualityVideo;
   return q ? (QUALITY_ROWS.find((r) => r.q === q)?.text ?? q) : 'Default';
-});
-async function openQuality(): Promise<void> {
+}
+async function openQuality(kind: 'photo' | 'video'): Promise<void> {
   const sheet = await actionSheetController.create({
-    header: 'Media quality',
-    subHeader: 'Default quality for photos and videos sent in this group:',
+    header: kind === 'photo' ? 'Photo quality' : 'Video quality',
+    subHeader: `Quality for ${kind === 'photo' ? 'photos' : 'videos'} sent in this group:`,
     buttons: [
-      ...QUALITY_ROWS.map((r) => ({ text: r.text, handler: () => void setChatSendQuality(chatId, r.q) })),
-      { text: 'Use global default', handler: () => void setChatSendQuality(chatId, null) },
+      ...QUALITY_ROWS.map((r) => ({ text: r.text, handler: () => void setChatSendQuality(chatId, kind, r.q) })),
+      { text: 'Use global default', handler: () => void setChatSendQuality(chatId, kind, null) },
       { text: 'Cancel', role: 'cancel' as const },
     ],
   });

--- a/src/views/detail/GroupInfoPage.vue
+++ b/src/views/detail/GroupInfoPage.vue
@@ -50,10 +50,15 @@
             <ion-label>Notifications</ion-label>
             <ion-note slot="end">{{ muteLabel }}</ion-note>
           </ion-item>
-          <ion-item button :detail="false" lines="none" @click="openTtl">
+          <ion-item button :detail="false" @click="openTtl">
             <ion-icon slot="start" :icon="timerOutline" />
             <ion-label>Disappearing messages</ion-label>
             <ion-note slot="end">{{ ttlLabel }}</ion-note>
+          </ion-item>
+          <ion-item button :detail="false" lines="none" @click="openQuality">
+            <ion-icon slot="start" :icon="imagesOutline" />
+            <ion-label>Media quality</ion-label>
+            <ion-note slot="end">{{ qualityLabel }}</ion-note>
           </ion-item>
         </ion-list>
 
@@ -158,7 +163,7 @@ import {
 } from 'ionicons/icons';
 import {
   getChat, listContacts, addMemberToGroup, removeMember, leaveGroup,
-  renameGroup, setGroupAvatar, clearGroupAvatar, setChatMute, setChatTtl,
+  renameGroup, setGroupAvatar, clearGroupAvatar, setChatMute, setChatTtl, setChatSendQuality,
   setChatNotifyPrefs, type ChatNotifyContent,
 } from '@/db/queries';
 import type { Chat, Contact } from '@/db/types';
@@ -260,6 +265,29 @@ async function openTtl(): Promise<void> {
       { text: '7 days', handler: () => void setChatTtl(chatId, 7 * DAY) },
       { text: '90 days', handler: () => void setChatTtl(chatId, 90 * DAY) },
       { text: 'Off', handler: () => void setChatTtl(chatId, null) },
+      { text: 'Cancel', role: 'cancel' as const },
+    ],
+  });
+  await sheet.present();
+}
+
+const QUALITY_ROWS = [
+  { q: 'sd' as const, text: 'SD (smaller)' },
+  { q: 'hd' as const, text: 'HD' },
+  { q: 'fhd' as const, text: 'Full HD' },
+  { q: 'original' as const, text: 'Original' },
+];
+const qualityLabel = computed(() => {
+  const q = chat.value?.sendQuality;
+  return q ? (QUALITY_ROWS.find((r) => r.q === q)?.text ?? q) : 'Default';
+});
+async function openQuality(): Promise<void> {
+  const sheet = await actionSheetController.create({
+    header: 'Media quality',
+    subHeader: 'Default quality for photos and videos sent in this group:',
+    buttons: [
+      ...QUALITY_ROWS.map((r) => ({ text: r.text, handler: () => void setChatSendQuality(chatId, r.q) })),
+      { text: 'Use global default', handler: () => void setChatSendQuality(chatId, null) },
       { text: 'Cancel', role: 'cancel' as const },
     ],
   });

--- a/src/views/detail/MessageInfoPage.vue
+++ b/src/views/detail/MessageInfoPage.vue
@@ -27,6 +27,23 @@
         </ion-item>
       </ion-list>
 
+      <!-- Disappearing message: exact time left + when it self-destructs (the bubble shows a melting
+           face; the numbers live here). -->
+      <ion-list :inset="true" v-if="message?.expiresAt">
+        <ion-list-header>
+          <ion-icon :icon="timeOutline" />
+          <ion-label>Disappearing message</ion-label>
+        </ion-list-header>
+        <ion-item lines="inset">
+          <ion-label>Disappears in</ion-label>
+          <ion-note slot="end">{{ ttlLeftLabel }}</ion-note>
+        </ion-item>
+        <ion-item lines="none">
+          <ion-label>Disappears at</ion-label>
+          <ion-note slot="end">{{ formatTime(message.expiresAt) }}</ion-note>
+        </ion-item>
+      </ion-list>
+
       <!-- Media facts (quality · resolution · size · format · duration). Shown for
            media in BOTH directions — the metadata that used to sit on the bubble. -->
       <ion-list :inset="true" v-if="message && hasMediaMeta">
@@ -143,7 +160,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, onMounted, onUnmounted } from 'vue';
 import { useRoute } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
@@ -171,6 +188,27 @@ const message = useLiveQuery<Message | undefined>(
 );
 const chat = useLiveQuery<Chat | undefined>(() => getChat(chatId), ['chats'], undefined);
 const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+
+// Live countdown for a disappearing message (ticks each second while this page is open).
+const nowMs = ref(Date.now());
+let tick: ReturnType<typeof setInterval> | undefined;
+onMounted(() => (tick = setInterval(() => (nowMs.value = Date.now()), 1000)));
+onUnmounted(() => clearInterval(tick));
+const ttlLeftLabel = computed(() => {
+  const exp = message.value?.expiresAt;
+  if (!exp) return '';
+  let s = Math.max(0, Math.round((exp - nowMs.value) / 1000));
+  if (s <= 0) return 'any moment';
+  const d = Math.floor(s / 86400); s -= d * 86400;
+  const h = Math.floor(s / 3600); s -= h * 3600;
+  const m = Math.floor(s / 60); s -= m * 60;
+  const parts = [];
+  if (d) parts.push(`${d}d`);
+  if (h) parts.push(`${h}h`);
+  if (m) parts.push(`${m}m`);
+  if (!d && !h) parts.push(`${s}s`); // show seconds only when under an hour
+  return parts.join(' ');
+});
 
 // The on-device media record (for the MIME type → format label + preserved check).
 // Re-runs once the message resolves and we learn its mediaId.

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -26,16 +26,6 @@
         @ion-input="onInput"
       />
 
-      <!-- While sharing media: a real progress bar (encode % then upload %) so a video
-           post isn't just a frozen, unexplained wait. -->
-      <div v-if="sharing && mediaItems.length" class="share-progress">
-        <ion-progress-bar
-          :type="progress ? 'determinate' : 'indeterminate'"
-          :value="progress?.value ?? 0"
-        />
-        <span class="share-label">{{ progressLabel }}</span>
-      </div>
-
       <!-- Media staging (FR-019): photos, videos AND voice clips compose ONE post as a row of
            reorderable thumbnails (their order is the album order). Voice mixes in like any other
            item — record it and it joins the row; tap its ▶ to review it through the same player
@@ -139,12 +129,13 @@ import { computed, ref, onMounted, onUnmounted } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton, IonButton,
   IonContent, IonTextarea, IonList, IonListHeader, IonItem, IonSegment, IonSegmentButton,
-  IonLabel, IonIcon, IonProgressBar, IonSpinner, alertController,
+  IonLabel, IonIcon, IonSpinner, alertController,
 } from '@ionic/vue';
 import { useRouter } from 'vue-router';
 import { imageOutline, closeOutline, micOutline, playCircle } from 'ionicons/icons';
 import { vEnterSend } from '@/directives/enter-send';
-import { createPost, type PostLifetime } from '@/db/queries';
+import { enqueuePendingPost, type PostLifetime } from '@/db/queries';
+import { kickPendingPosts } from '@/services/pending-posts';
 import { generateVideoPoster } from '@/utils/media-meta';
 import { playAudio, stopIfPlaying } from '@/composables/useAudioPlayer';
 import { appToast } from '@/services/toast';
@@ -153,17 +144,7 @@ const router = useRouter();
 const body = ref('');
 const audience = ref<'friends' | 'close'>('friends');
 const lifetime = ref<PostLifetime>('72h');
-const sharing = ref(false);
-// Encode/upload progress while a post with media is being shared (drives the progress bar).
-const progress = ref<{ phase: 'encoding' | 'uploading'; index: number; total: number; value: number } | null>(null);
-let lastProgressTs = 0; // throttle progress re-renders so they don't starve the encoder
-const progressLabel = computed(() => {
-  const p = progress.value;
-  if (!p) return 'Sharing…';
-  const which = p.total > 1 ? ` ${p.index + 1}/${p.total}` : '';
-  const pct = Math.round((p.value ?? 0) * 100);
-  return p.phase === 'encoding' ? `Processing${which}… ${pct}%` : `Uploading${which}… ${pct}%`;
-});
+const sharing = ref(false); // true only during the brief enqueue, before the composer dismisses
 
 // Staged attachments. Several photos/videos compose an ALBUM post (spec 1022, FR-019); a
 // recorded voice clip is always on its own. Object URLs back the previews, revoked on
@@ -416,35 +397,25 @@ onUnmounted(() => {
 async function share(): Promise<void> {
   if (!canShare.value || sharing.value) return;
   sharing.value = true;
-  progress.value = mediaItems.value.length ? { phase: 'encoding', index: 0, total: mediaItems.value.length, value: 0 } : null;
   try {
-    await createPost({
+    // Spec 1024: cache the staged media into the outbox and DISMISS immediately — the upload
+    // worker finishes it in the background and the Wall shows a pending card with progress.
+    // HD-only on the Wall (spec 1022, FR-020): every post ships at HD.
+    await enqueuePendingPost({
+      target: 'wall',
       body: body.value,
       audience: audience.value,
       lifetime: lifetime.value,
-      // HD-only on the Wall (spec 1022, FR-020): no quality choice — every post ships at HD.
-      // One item → a single-media post; several photos/videos → an album (FR-019).
-      media: mediaItems.value.length
-        ? mediaItems.value.map((m) => ({
-            blob: m.blob,
-            kind: m.kind,
-            name: m.name,
-            durationSec: m.durationSec,
-            quality: 'hd' as const,
-          }))
-        : undefined,
-      onProgress: (p) => {
-        // Throttle: a per-frame bar update during video encoding starves the (main-thread)
-        // encoder on slower devices (the post would appear stuck). Update on a phase/item
-        // change, on completion, or at most ~8×/sec.
-        const t = performance.now();
-        const cur = progress.value;
-        if (!cur || cur.phase !== p.phase || cur.index !== p.index || p.value >= 1 || t - lastProgressTs > 120) {
-          lastProgressTs = t;
-          progress.value = p;
-        }
-      },
+      items: mediaItems.value.map((m) => ({
+        blob: m.blob,
+        kind: m.kind,
+        name: m.name,
+        mime: m.blob.type || (m.kind === 'voice' ? 'audio/webm' : m.kind === 'video' ? 'video/mp4' : 'image/jpeg'),
+        durationSec: m.durationSec,
+        poster: m.poster,
+      })),
     });
+    kickPendingPosts();
     router.back();
   } catch (err) {
     const a = await alertController.create({
@@ -455,7 +426,6 @@ async function share(): Promise<void> {
     await a.present();
   } finally {
     sharing.value = false;
-    progress.value = null;
   }
 }
 </script>
@@ -487,16 +457,6 @@ async function share(): Promise<void> {
 }
 .vpreview {
   width: 100%;
-}
-.share-progress {
-  margin: 10px 16px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.share-label {
-  font-size: 13px;
-  color: var(--app-text-muted, #8e8e93);
 }
 /* Album staging: a horizontal row of removable thumbnails + an "add more" tile. */
 .album-stage {

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -210,7 +210,7 @@ async function onFile(e: Event): Promise<void> {
   // pick up front if the device clearly can't stage them, so we fail loudly here instead of mid-upload.
   const incoming = files.reduce((n, f) => n + f.size, 0);
   if (!(await hasRoomFor(incoming))) {
-    void appToast('Not enough storage on this device — free up space and try again.');
+    void appToast('Not enough storage on this device. Free up space and try again.');
     return;
   }
   for (const f of files) {
@@ -546,7 +546,7 @@ async function share(): Promise<void> {
   align-items: center;
   /* Mic to the top, duration to the bottom — clears the center for the (larger) play glyph. */
   justify-content: space-between;
-  padding: 8px 0;
+  padding: 4px 0 9px;
   background: var(--ion-color-primary);
   color: #fff;
   font-size: 22px;

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -131,10 +131,10 @@ import {
   IonContent, IonTextarea, IonList, IonListHeader, IonItem, IonSegment, IonSegmentButton,
   IonLabel, IonIcon, IonSpinner, alertController,
 } from '@ionic/vue';
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 import { imageOutline, closeOutline, micOutline, playCircle } from 'ionicons/icons';
 import { vEnterSend } from '@/directives/enter-send';
-import { enqueuePendingPost, type PostLifetime } from '@/db/queries';
+import { enqueuePendingPost, getPendingPost, deletePendingPost, type PostLifetime } from '@/db/queries';
 import { kickPendingPosts } from '@/services/pending-posts';
 import { hasRoomFor } from '@/services/storage-estimate';
 import { generateVideoPoster } from '@/utils/media-meta';
@@ -142,10 +142,14 @@ import { playAudio, stopIfPlaying } from '@/composables/useAudioPlayer';
 import { appToast } from '@/services/toast';
 
 const router = useRouter();
+const route = useRoute();
 const body = ref('');
 const audience = ref<'friends' | 'close'>('friends');
 const lifetime = ref<PostLifetime>('72h');
 const sharing = ref(false); // true only during the brief enqueue, before the composer dismisses
+// Set when we're finishing a draft recovered after the app closed mid-post (?resume=<outbox id>):
+// the old record is removed once the post is re-shared so it doesn't linger on the Wall.
+const resumeId = ref<string | null>(null);
 
 // Staged attachments. Several photos/videos compose an ALBUM post (spec 1022, FR-019); a
 // recorded voice clip is always on its own. Object URLs back the previews, revoked on
@@ -322,7 +326,31 @@ onMounted(() => {
   document.addEventListener('touchmove', onDocTouchMove, { passive: false });
   document.addEventListener('touchend', onDocTouchEnd);
   document.addEventListener('touchcancel', onDocTouchEnd);
+  void loadResumeDraft();
 });
+
+// Spec 1024: if we arrived via "Finish" on a recovered draft, restore its caption + voice notes.
+// Library photos/videos can't be recovered after a full app close, so the user re-adds those.
+async function loadResumeDraft(): Promise<void> {
+  const id = typeof route.query.resume === 'string' ? route.query.resume : null;
+  if (!id) return;
+  const rec = await getPendingPost(id);
+  if (!rec || rec.status !== 'interrupted') return; // gone or no longer recoverable
+  resumeId.value = id;
+  body.value = rec.body ?? '';
+  if (rec.audience) audience.value = rec.audience;
+  if (rec.lifetime) lifetime.value = rec.lifetime;
+  for (const it of rec.items) {
+    if (it.kind !== 'voice') continue; // only in-app recordings survive; nothing else is kept here
+    mediaItems.value.push({
+      blob: it.blob,
+      kind: 'voice',
+      name: it.name,
+      durationSec: it.durationSec,
+      url: URL.createObjectURL(it.blob),
+    });
+  }
+}
 
 /* ---- voice post recording (mirrors the chat voice recorder, minus the live
    waveform/pause/preview — a post is a single take, kept simple) ---- */
@@ -423,6 +451,8 @@ async function share(): Promise<void> {
         poster: m.poster,
       })),
     });
+    // Finishing a recovered draft: clear the old interrupted record now that it's re-queued.
+    if (resumeId.value) await deletePendingPost(resumeId.value);
     kickPendingPosts();
     router.back();
   } catch (err) {

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -329,8 +329,8 @@ onMounted(() => {
   void loadResumeDraft();
 });
 
-// Spec 1024: if we arrived via "Finish" on a recovered draft, restore its caption + voice notes.
-// Library photos/videos can't be recovered after a full app close, so the user re-adds those.
+// Spec 1024: if we arrived via "Finish" on a recovered draft, restore the WHOLE post — caption,
+// audience, lifetime, and every attachment (photos, videos and voice) — so it's ready to post as-is.
 async function loadResumeDraft(): Promise<void> {
   const id = typeof route.query.resume === 'string' ? route.query.resume : null;
   if (!id) return;
@@ -341,19 +341,37 @@ async function loadResumeDraft(): Promise<void> {
   if (rec.audience) audience.value = rec.audience;
   if (rec.lifetime) lifetime.value = rec.lifetime;
   for (const it of rec.items) {
-    if (it.kind !== 'voice') continue; // only in-app recordings survive; nothing else is kept here
-    // Rebuild a FRESH in-memory Blob from the inline bytes. The stored Blob can read back broken on
-    // iOS after a reload (its bytes hang), which is what stalled the re-upload — the ArrayBuffer copy
-    // we stashed at enqueue is always readable. Fall back to the Blob if an older draft has no bytes.
-    const blob = it.bytes ? new Blob([it.bytes], { type: it.mime || 'audio/webm' }) : it.blob;
+    // Rebuild a FRESH in-memory Blob from the inline bytes. A Blob read back from IDB can hang on iOS
+    // after a reload; the ArrayBuffer we stashed at enqueue always reads back. Skip an older item that
+    // only has a (now-unreadable) legacy Blob and no bytes.
+    if (!it.bytes && !it.blob) continue;
+    const blob = it.bytes ? new Blob([it.bytes], { type: it.mime || defaultMime(it.kind) }) : (it.blob as Blob);
     mediaItems.value.push({
       blob,
-      kind: 'voice',
+      kind: it.kind,
       name: it.name,
       durationSec: it.durationSec,
       url: URL.createObjectURL(blob),
+      poster: it.poster, // a video's first-frame thumbnail rode along in the outbox record
+      posterTried: it.kind === 'video' ? !!it.poster : undefined,
     });
+    // A recovered video with no saved poster: regenerate one so its tile isn't a black box.
+    if (it.kind === 'video' && !it.poster) {
+      const staged = mediaItems.value[mediaItems.value.length - 1];
+      void generateVideoPoster(blob)
+        .then((poster) => {
+          if (poster) staged.poster = poster;
+        })
+        .catch(() => {})
+        .finally(() => {
+          staged.posterTried = true;
+        });
+    }
   }
+}
+
+function defaultMime(kind: 'image' | 'video' | 'voice'): string {
+  return kind === 'voice' ? 'audio/webm' : kind === 'video' ? 'video/mp4' : 'image/jpeg';
 }
 
 /* ---- voice post recording (mirrors the chat voice recorder, minus the live

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -544,8 +544,9 @@ async function share(): Promise<void> {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 4px;
+  /* Mic to the top, duration to the bottom — clears the center for the (larger) play glyph. */
+  justify-content: space-between;
+  padding: 8px 0;
   background: var(--ion-color-primary);
   color: #fff;
   font-size: 22px;
@@ -556,10 +557,14 @@ async function share(): Promise<void> {
 }
 .stage-voice .stage-play {
   position: absolute;
-  right: 4px;
-  bottom: 4px;
-  font-size: 18px;
-  opacity: 0.9;
+  left: 50%;
+  top: 50%;
+  right: auto;
+  bottom: auto;
+  transform: translate(-50%, -50%);
+  font-size: 32px;
+  opacity: 1;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.35));
 }
 .stage-spin {
   width: 24px;

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -342,12 +342,16 @@ async function loadResumeDraft(): Promise<void> {
   if (rec.lifetime) lifetime.value = rec.lifetime;
   for (const it of rec.items) {
     if (it.kind !== 'voice') continue; // only in-app recordings survive; nothing else is kept here
+    // Rebuild a FRESH in-memory Blob from the inline bytes. The stored Blob can read back broken on
+    // iOS after a reload (its bytes hang), which is what stalled the re-upload — the ArrayBuffer copy
+    // we stashed at enqueue is always readable. Fall back to the Blob if an older draft has no bytes.
+    const blob = it.bytes ? new Blob([it.bytes], { type: it.mime || 'audio/webm' }) : it.blob;
     mediaItems.value.push({
-      blob: it.blob,
+      blob,
       kind: 'voice',
       name: it.name,
       durationSec: it.durationSec,
-      url: URL.createObjectURL(it.blob),
+      url: URL.createObjectURL(blob),
     });
   }
 }

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -136,6 +136,7 @@ import { imageOutline, closeOutline, micOutline, playCircle } from 'ionicons/ico
 import { vEnterSend } from '@/directives/enter-send';
 import { enqueuePendingPost, type PostLifetime } from '@/db/queries';
 import { kickPendingPosts } from '@/services/pending-posts';
+import { hasRoomFor } from '@/services/storage-estimate';
 import { generateVideoPoster } from '@/utils/media-meta';
 import { playAudio, stopIfPlaying } from '@/composables/useAudioPlayer';
 import { appToast } from '@/services/toast';
@@ -191,14 +192,22 @@ function onLifetime(e: CustomEvent): void {
 function pickMedia(): void {
   fileInput.value?.click();
 }
-function onFile(e: Event): void {
+async function onFile(e: Event): Promise<void> {
   // Picking several photos/videos stages them all → one album on Send. Voice clips mix in as
   // their own items now, so we just APPEND — never clear what's already staged. Cap at MAX_MEDIA.
   const picked = Array.from((e.target as HTMLInputElement).files ?? []);
   const room = MAX_MEDIA - mediaItems.value.length;
   const files = picked.slice(0, Math.max(0, room));
+  if (fileInput.value) fileInput.value.value = '';
   if (picked.length > files.length) {
     void appToast(`You can share up to ${MAX_MEDIA} items in one post.`);
+  }
+  // Spec 1024 (US3): the outbox caches these blobs plaintext until the upload confirms. Refuse the
+  // pick up front if the device clearly can't stage them, so we fail loudly here instead of mid-upload.
+  const incoming = files.reduce((n, f) => n + f.size, 0);
+  if (!(await hasRoomFor(incoming))) {
+    void appToast('Not enough storage on this device — free up space and try again.');
+    return;
   }
   for (const f of files) {
     const url = URL.createObjectURL(f);
@@ -220,7 +229,6 @@ function onFile(e: Event): void {
         });
     }
   }
-  if (fileInput.value) fileInput.value.value = '';
 }
 function removeMedia(i: number): void {
   const [gone] = mediaItems.value.splice(i, 1);

--- a/src/views/detail/SettingDetailPage.vue
+++ b/src/views/detail/SettingDetailPage.vue
@@ -379,7 +379,8 @@ const AUTO_DOWNLOAD_DEFAULTS: Record<string, string> = {
   'storage.autoDownload.audio': 'wifi',
   'storage.autoDownload.video': 'wifi',
   'storage.autoDownload.documents': 'wifi',
-  'storage.uploadQuality': 'hd',
+  'storage.uploadQuality.photos': 'hd',
+  'storage.uploadQuality.videos': 'hd',
   'storage.downloadQuality': 'hd',
 };
 

--- a/src/views/detail/SettingDetailPage.vue
+++ b/src/views/detail/SettingDetailPage.vue
@@ -381,7 +381,7 @@ const AUTO_DOWNLOAD_DEFAULTS: Record<string, string> = {
   'storage.autoDownload.documents': 'wifi',
   'storage.uploadQuality.photos': 'hd',
   'storage.uploadQuality.videos': 'hd',
-  'storage.downloadQuality': 'hd',
+  'storage.autoDownloadLimit': '16',
 };
 
 const ACTIONS: Record<string, () => void | Promise<void>> = {

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -298,7 +298,11 @@ const hasLocked = computed(() => locked.value.length > 0);
 const drafts = useLiveQuery(() => listDrafts(), ['drafts'], [] as ChatDraft[]);
 const draftMap = computed(() => {
   const m = new Map<string, string>();
-  for (const d of drafts.value) if (d.text?.trim() || d.reply) m.set(d.chatId, d.text?.trim() ?? '');
+  for (const d of drafts.value) {
+    // A draft is text, a started reply, and/or staged attachments. The preview is the text if any,
+    // otherwise a label for the attachments (e.g. "Photo", "3 attachments").
+    if (d.text?.trim() || d.reply || d.mediaCount) m.set(d.chatId, d.text?.trim() || d.mediaLabel || '');
+  }
   return m;
 });
 const draftFor = (id: string): string | undefined => draftMap.value.get(id);

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -56,6 +56,7 @@
           v-for="chat in chats"
           :key="chat.id"
           :chat="chat"
+          :draft="draftFor(chat.id)"
           @open="open"
           @more="(c) => actions?.openMore(c)"
         />
@@ -181,14 +182,14 @@ import ChatFilterBar from '@/components/ChatFilterBar.vue';
 import ChatListsSheet from '@/components/ChatListsSheet.vue';
 import EditChatTabsModal from '@/components/EditChatTabsModal.vue';
 import NewListModal from '@/components/NewListModal.vue';
-import { listArchivedChats, listLockedChats, listContacts, startDirectChat, getSetting } from '@/db/queries';
+import { listArchivedChats, listLockedChats, listContacts, startDirectChat, getSetting, listDrafts } from '@/db/queries';
 import { useChatFilters } from '@/services/chat-filters';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useConnect } from '@/composables/useConnect';
 import { useHiddenChats } from '@/composables/useHiddenChats';
 import { hiddenPinLength } from '@/services/hidden-chats';
 import { isUnlocked } from '@/services/crypto/identity';
-import type { Chat, Contact } from '@/db/types';
+import type { Chat, Contact, ChatDraft } from '@/db/types';
 
 const router = useRouter();
 
@@ -291,6 +292,16 @@ const archivedCount = computed(() => archived.value.length);
 // Whether any chat is locked (entry shows; count hidden for privacy).
 const locked = useLiveQuery(() => listLockedChats(), ['chats', 'messages'], [] as Chat[]);
 const hasLocked = computed(() => locked.value.length > 0);
+
+// Unsent drafts → mark the chat row with a "Draft" preview (spec: keep-your-place). Keyed by chatId;
+// a row shows it instead of the last message until the draft is sent or cleared.
+const drafts = useLiveQuery(() => listDrafts(), ['drafts'], [] as ChatDraft[]);
+const draftMap = computed(() => {
+  const m = new Map<string, string>();
+  for (const d of drafts.value) if (d.text?.trim() || d.reply) m.set(d.chatId, d.text?.trim() ?? '');
+  return m;
+});
+const draftFor = (id: string): string | undefined => draftMap.value.get(id);
 
 function open(id: string) {
   router.push(`/chat/${id}`);

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -141,7 +141,7 @@
               </ion-label>
             </ion-item>
             <ion-item-options side="end">
-              <ion-item-option color="danger" @click="removeContact(person.id)">
+              <ion-item-option color="danger" @click="removeContact(person)">
                 <ion-icon slot="icon-only" :icon="trashOutline" />
               </ion-item-option>
             </ion-item-options>
@@ -235,12 +235,32 @@ async function onPullRefresh(e: RefresherCustomEvent): Promise<void> {
   }
 }
 const open = (id: string) => router.push(`/contact/${id}`);
-const removeContact = async (id: string): Promise<void> => {
-  try {
-    await deleteContact(id);
-  } catch {
-    void appToast({ message: 'Could not delete. Try again.', duration: 1500, color: 'danger' });
-  }
+// Deleting a contact is destructive (it also removes the conversation on this device and can't be
+// undone), so confirm first with a clear hint — matching the contact page's Delete flow — instead of
+// the swipe acting instantly.
+const removeContact = async (person: { id: string; name: string }): Promise<void> => {
+  const alert = await alertController.create({
+    header: `Delete ${person.name || 'this contact'}?`,
+    message:
+      'This removes them from your contacts and deletes this conversation on this device. It cannot be undone.',
+    buttons: [
+      { text: 'Cancel', role: 'cancel' },
+      {
+        text: 'Delete',
+        role: 'destructive',
+        handler: () => {
+          void (async () => {
+            try {
+              await deleteContact(person.id);
+            } catch {
+              void appToast({ message: 'Could not delete. Try again.', duration: 1500, color: 'danger' });
+            }
+          })();
+        },
+      },
+    ],
+  });
+  await alert.present();
 };
 
 // Shared add-contact flow (also used by the New-chat modal).

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -36,20 +36,42 @@
       </ion-header>
 
       <!-- Fresh device, nothing local yet AND the first server sync hasn't returned → show a
-           loader instead of the "No posts yet" empty state (which would flash misleadingly). -->
-      <div v-if="loaded && !wall.length && !synced" class="empty">
+           loader instead of the "No posts yet" empty state (which would flash misleadingly).
+           A pending (uploading) post counts as content, so the empty/loader states yield to it. -->
+      <div v-if="loaded && !wall.length && !synced && !pending.length" class="empty">
         <ion-spinner name="crescent" />
         <p>Loading your Wall…</p>
       </div>
-      <div v-else-if="loaded && !wall.length && synced" class="empty">
+      <div v-else-if="loaded && !wall.length && synced && !pending.length" class="empty">
         <ion-icon :icon="sparklesOutline" />
         <p>No posts yet. Share a moment with your friends.</p>
         <ion-button fill="solid" @click="compose">New post</ion-button>
       </div>
 
-      <div v-if="loaded && wall.length && !filteredWall.length" class="empty">
+      <div v-if="loaded && wall.length && !filteredWall.length && !pending.length" class="empty">
         <p>No posts match “{{ search }}”.</p>
       </div>
+
+      <!-- Spec 1024: posts still uploading. The composer dismissed immediately; the worker
+           finishes them in the background and each becomes a real post on confirmation. -->
+      <ion-item v-for="pp in pending" :key="pp.id" lines="none" class="postitem">
+        <div class="post pending-post">
+          <div class="phead">
+            <ion-avatar class="avatar"><div class="ph">{{ initial('You') }}</div></ion-avatar>
+            <div class="who">
+              <div class="name">You</div>
+              <div class="sub">{{ pp.status === 'failed' ? 'Couldn’t post — will retry' : 'Posting…' }}</div>
+            </div>
+            <ion-spinner v-if="pp.status === 'uploading'" name="crescent" class="pspin" />
+          </div>
+          <p v-if="pp.body" class="body"><EmojiText :text="pp.body" /></p>
+          <ion-progress-bar v-if="pp.status === 'uploading'" :value="pp.progress" class="pbar" />
+          <p class="pending-note">
+            {{ pp.count ? pp.count + (pp.count > 1 ? ' items' : ' item') : 'Text post' }} ·
+            {{ pp.status === 'failed' ? (pp.error || 'Failed') : Math.round(pp.progress * 100) + '%' }}
+          </p>
+        </div>
+      </ion-item>
 
       <!-- Each post is a sliding item: swipe LEFT to delete your own post (or hide
            someone else's), swipe RIGHT to mute/unmute their Wall notifications. -->
@@ -257,7 +279,7 @@
 import { computed, reactive, ref, watch } from 'vue';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent,
-  IonItem, IonAvatar, IonIcon, IonTextarea, IonSearchbar, IonSpinner,
+  IonItem, IonAvatar, IonIcon, IonTextarea, IonSearchbar, IonSpinner, IonProgressBar,
   IonRefresher, IonRefresherContent,
   actionSheetController, alertController,
   onIonViewWillEnter, onIonViewWillLeave,
@@ -278,6 +300,7 @@ import { suspendAutoplay } from '@/directives/autoplay-visible';
 import WallVideo from '@/components/WallVideo.vue';
 import VoicePlayer from '@/components/VoicePlayer.vue';
 import { useWall, type WallPost } from '@/composables/useWall';
+import { usePendingPosts } from '@/composables/usePendingPosts';
 import { useReactionPicker } from '@/composables/useReactionPicker';
 import {
   reactToPost, commentOnPost, deletePost, keepAlivePost, setPostAudience,
@@ -289,6 +312,7 @@ import { timeLeft, ago } from '@/utils/post-time';
 
 const router = useRouter();
 const { wall, now, loaded, synced } = useWall();
+const { pending } = usePendingPosts();
 
 // Pull-to-refresh: re-pull the feed (new posts stream in via the live query) and release the
 // control when the sync settles.
@@ -626,6 +650,27 @@ ion-item-sliding ion-item-option {
   align-items: center;
   gap: 10px;
   padding: 12px 14px 8px;
+}
+/* Spec 1024: pending (uploading) post card — the green card with a progress bar while the worker
+   finishes it; flips to a real post on confirmation. */
+.pending-post {
+  padding-bottom: 10px;
+}
+.pspin {
+  margin-left: auto;
+  width: 18px;
+  height: 18px;
+  color: var(--ion-color-primary);
+}
+.pbar {
+  margin: 6px 14px 4px;
+  border-radius: 3px;
+  --progress-background: var(--ion-color-primary);
+}
+.pending-note {
+  font-size: 12px;
+  color: var(--app-text-muted, #8e8e93);
+  margin: 2px 14px 0;
 }
 .avatar {
   width: 40px;

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -72,8 +72,7 @@
           <ion-progress-bar v-if="pp.status === 'uploading'" :value="pp.progress" class="pbar" />
           <p class="pending-note">
             <template v-if="pp.status === 'interrupted'">
-              The app closed before this finished.
-              {{ pp.droppedMedia ? 'Your caption and voice are saved. Re-add your photos or videos to post.' : 'Tap Finish to post it.' }}
+              The app closed before this finished. Everything you added is saved. Tap Finish to post it.
             </template>
             <template v-else>
               {{ pp.count ? pp.count + (pp.count > 1 ? ' items' : ' item') : 'Text post' }} ·

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -60,7 +60,7 @@
             <ion-avatar class="avatar"><div class="ph">{{ initial('You') }}</div></ion-avatar>
             <div class="who">
               <div class="name">You</div>
-              <div class="sub">{{ pp.status === 'failed' ? 'Couldn’t post — will retry' : 'Posting…' }}</div>
+              <div class="sub">{{ pp.status === 'failed' ? 'Couldn’t post' : 'Posting…' }}</div>
             </div>
             <ion-spinner v-if="pp.status === 'uploading'" name="crescent" class="pspin" />
           </div>
@@ -70,6 +70,11 @@
             {{ pp.count ? pp.count + (pp.count > 1 ? ' items' : ' item') : 'Text post' }} ·
             {{ pp.status === 'failed' ? (pp.error || 'Failed') : Math.round(pp.progress * 100) + '%' }}
           </p>
+          <!-- A failed upload keeps its cached blobs: the user can retry it or discard it. -->
+          <div v-if="pp.status === 'failed'" class="pending-actions">
+            <ion-button size="small" fill="solid" @click="retryPendingPost(pp.id)">Retry</ion-button>
+            <ion-button size="small" fill="clear" color="medium" @click="cancelPendingPost(pp.id)">Cancel</ion-button>
+          </div>
         </div>
       </ion-item>
 
@@ -301,6 +306,7 @@ import WallVideo from '@/components/WallVideo.vue';
 import VoicePlayer from '@/components/VoicePlayer.vue';
 import { useWall, type WallPost } from '@/composables/useWall';
 import { usePendingPosts } from '@/composables/usePendingPosts';
+import { retryPendingPost, cancelPendingPost } from '@/services/pending-posts';
 import { useReactionPicker } from '@/composables/useReactionPicker';
 import {
   reactToPost, commentOnPost, deletePost, keepAlivePost, setPostAudience,
@@ -671,6 +677,16 @@ ion-item-sliding ion-item-option {
   font-size: 12px;
   color: var(--app-text-muted, #8e8e93);
   margin: 2px 14px 0;
+}
+.pending-actions {
+  display: flex;
+  gap: 4px;
+  margin: 4px 8px 0;
+}
+.pending-actions ion-button {
+  --padding-start: 12px;
+  --padding-end: 12px;
+  margin: 0;
 }
 .avatar {
   width: 40px;

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -73,7 +73,7 @@
           <p class="pending-note">
             <template v-if="pp.status === 'interrupted'">
               The app closed before this finished.
-              {{ pp.droppedMedia ? 'Your caption & voice are saved — re-add your photos/videos to post.' : 'Tap Finish to post it.' }}
+              {{ pp.droppedMedia ? 'Your caption and voice are saved. Re-add your photos or videos to post.' : 'Tap Finish to post it.' }}
             </template>
             <template v-else>
               {{ pp.count ? pp.count + (pp.count > 1 ? ' items' : ' item') : 'Text post' }} ·
@@ -446,7 +446,7 @@ async function onReact(post: WallPost, emoji: string): Promise<void> {
     await appToast({
       message:
         res === 'limit-emojis'
-          ? `This post already has ${MAX_DISTINCT_REACTIONS} different reactions — tap one of those instead.`
+          ? `This post already has ${MAX_DISTINCT_REACTIONS} different reactions. Tap one of those instead.`
           : `You can add up to ${MAX_REACTIONS_PER_USER} reactions.`,
       duration: 1600,
     });
@@ -574,7 +574,7 @@ async function changeAudience(post: WallPost, audience: 'friends' | 'close'): Pr
                 duration: 1400,
               });
             } catch {
-              await appToast({ message: 'Couldn’t change who can see this — try again.', duration: 1800 });
+              await appToast({ message: 'Couldn’t change who can see this. Try again.', duration: 1800 });
             }
           })();
         },
@@ -590,7 +590,7 @@ async function extendPost(post: WallPost): Promise<void> {
     await keepAlivePost(post.id);
     await appToast({ message: 'Post kept for longer.', duration: 1400 });
   } catch {
-    await appToast({ message: 'Couldn’t extend that post — try again.', duration: 1800 });
+    await appToast({ message: 'Couldn’t extend that post. Try again.', duration: 1800 });
   }
 }
 
@@ -677,10 +677,13 @@ ion-item-sliding ion-item-option {
   gap: 10px;
   padding: 12px 14px 8px;
 }
-/* Spec 1024: pending (uploading) post card — the green card with a progress bar while the worker
-   finishes it; flips to a real post on confirmation. */
+/* Spec 1024: pending post card (uploading / failed / interrupted). A warm amber wash + a warning
+   accent down the left edge so an unfinished post is obviously NOT final, set apart from the
+   settled green posts. Flips to a normal green post once it confirms. */
 .pending-post {
   padding-bottom: 10px;
+  background: var(--app-bubble-pending, #ffe6ad);
+  box-shadow: inset 4px 0 0 var(--ion-color-warning, #ffc409), 0 1px 4px rgba(0, 0, 0, 0.1);
 }
 .pspin {
   margin-left: auto;

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -53,27 +53,42 @@
       </div>
 
       <!-- Spec 1024: posts still uploading. The composer dismissed immediately; the worker
-           finishes them in the background and each becomes a real post on confirmation. -->
+           finishes them in the background and each becomes a real post on confirmation.
+           An 'interrupted' post is a draft recovered after the app was closed mid-upload:
+           caption + voice notes were kept; the user re-adds media and finishes it. -->
       <ion-item v-for="pp in pending" :key="pp.id" lines="none" class="postitem">
         <div class="post pending-post">
           <div class="phead">
             <ion-avatar class="avatar"><div class="ph">{{ initial('You') }}</div></ion-avatar>
             <div class="who">
               <div class="name">You</div>
-              <div class="sub">{{ pp.status === 'failed' ? 'Couldn’t post' : 'Posting…' }}</div>
+              <div class="sub">
+                {{ pp.status === 'failed' ? 'Couldn’t post' : pp.status === 'interrupted' ? 'Post didn’t finish' : 'Posting…' }}
+              </div>
             </div>
             <ion-spinner v-if="pp.status === 'uploading'" name="crescent" class="pspin" />
           </div>
           <p v-if="pp.body" class="body"><EmojiText :text="pp.body" /></p>
           <ion-progress-bar v-if="pp.status === 'uploading'" :value="pp.progress" class="pbar" />
           <p class="pending-note">
-            {{ pp.count ? pp.count + (pp.count > 1 ? ' items' : ' item') : 'Text post' }} ·
-            {{ pp.status === 'failed' ? (pp.error || 'Failed') : Math.round(pp.progress * 100) + '%' }}
+            <template v-if="pp.status === 'interrupted'">
+              The app closed before this finished.
+              {{ pp.droppedMedia ? 'Your caption & voice are saved — re-add your photos/videos to post.' : 'Tap Finish to post it.' }}
+            </template>
+            <template v-else>
+              {{ pp.count ? pp.count + (pp.count > 1 ? ' items' : ' item') : 'Text post' }} ·
+              {{ pp.status === 'failed' ? (pp.error || 'Failed') : Math.round(pp.progress * 100) + '%' }}
+            </template>
           </p>
           <!-- A failed upload keeps its cached blobs: the user can retry it or discard it. -->
           <div v-if="pp.status === 'failed'" class="pending-actions">
             <ion-button size="small" fill="solid" @click="retryPendingPost(pp.id)">Retry</ion-button>
             <ion-button size="small" fill="clear" color="medium" @click="cancelPendingPost(pp.id)">Cancel</ion-button>
+          </div>
+          <!-- A recovered draft: reopen the composer (caption + voice restored) or discard it. -->
+          <div v-else-if="pp.status === 'interrupted'" class="pending-actions">
+            <ion-button size="small" fill="solid" @click="finishPendingPost(pp.id)">Finish</ion-button>
+            <ion-button size="small" fill="clear" color="medium" @click="cancelPendingPost(pp.id)">Discard</ion-button>
           </div>
         </div>
       </ion-item>
@@ -414,6 +429,11 @@ const filteredWall = computed(() => {
 
 function compose(): void {
   void router.push('/wall/compose');
+}
+// Reopen the composer on a recovered draft: its caption + voice notes are restored from the outbox
+// record; the user re-adds any photos/videos and shares. The record is cleared once it's re-sent.
+function finishPendingPost(id: string): void {
+  void router.push({ path: '/wall/compose', query: { resume: id } });
 }
 function initial(name: string): string {
   return (name.trim()[0] ?? '?').toUpperCase();


### PR DESCRIPTION
## Summary

Builds out **spec 1024 (resilient posting & on-device storage)** and a broad round of chat-media / composer polish validated on a real device.

### Resilient posting (Wall)
- Background posting: the composer closes immediately and the post finishes itself.
- Retry a failed post, and warn before the device runs out of space.
- Recover an interrupted post (app closed mid-post) as a draft instead of stalling forever; a recovered post keeps its photos, videos and voice clips, not just the caption.
- Clearer unfinished-post card and plainer wording.

### Drafts
- Keep an unsent chat message as a draft (text, cursor, reply) so you never lose your place; staged photos, videos and files are preserved too.
- Mark chats that have an unsent draft in the Chats list.

### Composer media & captions
- Cap picked attachments at 10 with a visible notice; reliable staged-video thumbnails that appear right away; centered play glyph.
- Media preview above a standard caption modal (keyboard can't hide it).
- Removing a staged attachment no longer deletes the following ones.

### Quality & disappearing timers
- Separate photo and video send quality, applied silently.
- Set a default media quality per chat; set a per-message disappearing timer from the composer.
- A green time-left indicator on disappearing messages; the exact "Disappears in / at" lives on the message info page.

### Auto-download & download UX
- Auto-download honors per-kind settings **and** a size limit (grouped under Media auto-download).
- Not-yet-downloaded photos/videos are framed identically to downloaded ones, with the attachment size shown.
- A circular progress ring + a live "downloaded / total" counter while fetching; on completion the download button swaps to the play button.
- **Server:** send `Content-Length` on blob download so progress is accurate.
- **Memory:** the streaming download assembles into one preallocated buffer and decrypts straight from bytes, so a large clip (100 MB+) completes on mobile instead of reverting to the download button.

## Testing
- `npm run build` (typecheck + build) green.
- `npx vitest run` — 416 unit tests pass.
- `cd server && go build/vet/test ./...` green (added a `Content-Length` assertion to the blob download test).
- Extensively exercised via the `drive/` harness on the live dev stack (progress counter, icon swap, framing parity, per-kind defer, disappearing indicator).

Zero-knowledge boundary intact throughout: the server only relays sealed ciphertext + a `Content-Length`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)