### PR TITLE
docs(roadmap): mark 1024 (resilient posting & storage) in-review

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ Specs are grouped by category band; status moves
 | [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | 🔵 in-review |
 | [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | 🔵 in-review |
 | [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🟡 in-progress |
-| [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | ⚪ planned |
+| [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1024-resilient-posting-and-storage/spec.md
+++ b/specs/1024-resilient-posting-and-storage/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-30
 
-**Status**: planned
+**Status**: in-review
 
 **Input**: User description: "When sharing media to the Wall (and selecting media in chat), make
 posting resilient: tapping Share should dismiss the composer immediately and show a pending


### PR DESCRIPTION
Spec 1024 was implemented and merged to `develop` in #564 but its status was still `planned`. Move it to `in-review` (matching the other develop-merged features) and regenerate `ROADMAP.md`.

Kept at `in-review`, not `shipped`, since it isn't released to production yet.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)