### PR TITLE
feat(about): finish spec 1021 — share a support link + per-option descriptions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,7 +44,7 @@ Specs are grouped by category band; status moves
 | [1018](specs/1018-media-sharing-and/spec.md) | Media Sharing & Viewer Improvements | 🔵 in-review |
 | [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | 🔵 in-review |
 | [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | 🔵 in-review |
-| [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🟡 in-progress |
+| [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🔵 in-review |
 | [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)

--- a/e2e/support-contributions.spec.ts
+++ b/e2e/support-contributions.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { createAccount } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Support Ring (spec 1021): the About screen lists the funding options with a one-line
+ * description each (FR-002), and offers to SHARE the canonical support URL — the repository,
+ * where FUNDING.yml surfaces every option (FR-010, US3). No payment data or tracking is
+ * involved; the links only open on tap.
+ */
+test('Support: About lists funding options and shares the canonical support URL', async ({ browser }) => {
+  const ctx = await browser.newContext();
+  const a = await createAccount(ctx, 'SUPPORT1');
+
+  await a.page.goto('/settings/about');
+
+  // Each option shows its name + a plain-language one-liner (FR-002).
+  await expect(a.page.getByText('Ko-fi', { exact: true })).toBeVisible({ timeout: 30_000 });
+  await expect(a.page.getByText('One-off or monthly, no fees taken.')).toBeVisible();
+  await expect(a.page.getByText('Liberapay', { exact: true })).toBeVisible();
+  await expect(a.page.getByText('Recurring donations, open-source friendly.')).toBeVisible();
+  await expect(a.page.getByText('GitHub Sponsors', { exact: true })).toBeVisible();
+
+  // Stub Web Share to capture what gets shared, then tap Share (FR-010): it must be the
+  // canonical support URL (the repo).
+  await a.page.evaluate(() => {
+    (window as any).__shared = null;
+    (navigator as any).share = (d: any) => {
+      (window as any).__shared = d;
+      return Promise.resolve();
+    };
+  });
+  await a.page.getByText('Share a link to support Ring').click();
+  const shared = await a.page.evaluate(() => (window as any).__shared);
+  expect(shared?.url).toBe('https://github.com/zuptalo/ring');
+
+  await ctx.close();
+});

--- a/specs/1021-support-contributions/spec.md
+++ b/specs/1021-support-contributions/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-27
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/views/detail/AboutPage.vue
+++ b/src/views/detail/AboutPage.vue
@@ -53,18 +53,33 @@
           </ion-item>
           <ion-item button :detail="false" lines="none" @click="openExternal('https://ko-fi.com/zuptalo')">
             <ion-icon slot="start" :icon="cafeOutline" color="primary" />
-            <ion-label color="primary">Ko-fi</ion-label>
+            <ion-label class="ion-text-wrap">
+              <span class="opt-name">Ko-fi</span>
+              <p class="opt-desc">One-off or monthly, no fees taken.</p>
+            </ion-label>
             <ion-icon slot="end" :icon="openOutline" color="medium" />
           </ion-item>
           <ion-item button :detail="false" lines="none" @click="openExternal('https://liberapay.com/zuptalo')">
             <ion-icon slot="start" :icon="heartOutline" color="primary" />
-            <ion-label color="primary">Liberapay</ion-label>
+            <ion-label class="ion-text-wrap">
+              <span class="opt-name">Liberapay</span>
+              <p class="opt-desc">Recurring donations, open-source friendly.</p>
+            </ion-label>
             <ion-icon slot="end" :icon="openOutline" color="medium" />
           </ion-item>
           <ion-item button :detail="false" lines="none" @click="openExternal('https://github.com/sponsors/zuptalo')">
             <ion-icon slot="start" :icon="logoGithub" color="primary" />
-            <ion-label color="primary">GitHub Sponsors</ion-label>
+            <ion-label class="ion-text-wrap">
+              <span class="opt-name">GitHub Sponsors</span>
+              <p class="opt-desc">Sponsor from your GitHub account.</p>
+            </ion-label>
             <ion-icon slot="end" :icon="openOutline" color="medium" />
+          </ion-item>
+          <!-- Share the canonical support link (Web Share, clipboard fallback) so someone can
+               contribute without installing the app. -->
+          <ion-item button :detail="false" lines="none" @click="shareSupport">
+            <ion-icon slot="start" :icon="shareSocialOutline" color="primary" />
+            <ion-label color="primary">Share a link to support Ring</ion-label>
           </ion-item>
         </ion-list>
 
@@ -77,19 +92,55 @@
 <script setup lang="ts">
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
-  IonContent, IonList, IonItem, IonLabel, IonIcon,
+  IonContent, IonList, IonItem, IonLabel, IonIcon, toastController,
 } from '@ionic/vue';
-import { cafeOutline, heartOutline, logoGithub, openOutline } from 'ionicons/icons';
+import { cafeOutline, heartOutline, logoGithub, openOutline, shareSocialOutline } from 'ionicons/icons';
 import { openExternal } from '@/utils/external';
 
 const appVersion = __APP_VERSION__;
 // Donation links open in the system browser on tap (openExternal); nothing from any
 // platform loads until then, so opening this page never reaches out on its own.
+
+// The canonical "support Ring" link: the repository, where the FUNDING.yml Sponsor button
+// surfaces every funding option — so a friend can contribute without installing the app.
+const SUPPORT_URL = 'https://github.com/zuptalo/ring';
+async function shareSupport(): Promise<void> {
+  if (navigator.share) {
+    try {
+      await navigator.share({
+        title: 'Support Ring',
+        text: 'Support Ring, a private end-to-end-encrypted messenger.',
+        url: SUPPORT_URL,
+      });
+    } catch {
+      /* user cancelled the share sheet */
+    }
+    return;
+  }
+  // No Web Share on this device: copy the link so it can still be shared.
+  try {
+    await navigator.clipboard?.writeText(SUPPORT_URL);
+    const toast = await toastController.create({ message: 'Support link copied', duration: 1500 });
+    await toast.present();
+  } catch {
+    /* clipboard unavailable */
+  }
+}
 </script>
 
 <style scoped>
 .about {
   padding-bottom: max(env(safe-area-inset-bottom, 0px), 24px);
+}
+/* Funding option: primary-coloured platform name + a muted one-line description. */
+.opt-name {
+  color: var(--ion-color-primary);
+  font-weight: 500;
+}
+.opt-desc {
+  color: var(--app-text-muted);
+  font-size: 13px;
+  margin-top: 2px;
 }
 .brand {
   text-align: center;


### PR DESCRIPTION
## Summary

Finishes **spec 1021 (Support the project)**. On checking, both prioritized user stories were already shipped (in-app funding options in **Settings → About**, and `.github/FUNDING.yml`), but two requirements were unmet after the earlier Support→About consolidation:

- **FR-010 / US3 — share the canonical support link:** added a **"Share a link to support Ring"** action using the Web Share API with a clipboard fallback. It shares the repo URL (`github.com/zuptalo/ring`), where FUNDING.yml surfaces every funding option — so a friend can contribute without installing the app.
- **FR-002 — per-option description:** each funding option (Ko-fi, Liberapay, GitHub Sponsors) now shows a one-line plain-language description.

Zero-knowledge / privacy invariants intact: links only, no payment data, no tracking, no third-party scripts (FR-004/005/012).

Marks 1021 **in-review** and regenerates `ROADMAP.md`.

## Testing
- New `e2e/support-contributions.spec.ts`: asserts the options + descriptions render and that tapping Share hands the **canonical support URL** to the share sheet (stubbed) — the spec's Independent Test for US3. Passes locally.
- `npm run build` + `vue-tsc` green; verified on the live About screen via the drive harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)