### PR TITLE
feat: app-wide UX polish — deep-link back-nav, notifications, media viewer, calls, settings (spec 1025)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1024-resilient-posting-and-storage/plan.md`
+`specs/1025-app-ux-polish/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,6 +46,7 @@ Specs are grouped by category band; status moves
 | [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | 🔵 in-review |
 | [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🔵 in-review |
 | [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
+| [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ Specs are grouped by category band; status moves
 | [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | 🔵 in-review |
 | [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🔵 in-review |
 | [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
-| [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | ⚪ planned |
+| [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/calls-summary.spec.ts
+++ b/e2e/calls-summary.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 1025 (US6): the Calls tab shows ISO-style dates (YYYY-MM-DD), a usage totals summary
+ * (audio minutes, video minutes, data per kind), and the call detail's Video and Message action
+ * buttons are swapped (Video first). Seeds completed call records directly (no real WebRTC).
+ */
+test('Calls: ISO dates, usage totals, and swapped detail buttons', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'CALLSUM1');
+  const b = await createAccount(ctxB, 'CALLSUM2');
+  await pair(a, b); // so b.id is a real contact → the call detail renders its actions
+
+  // A 2-minute audio call and a 10-minute video call, both on 2026-06-19 (local).
+  await a.page.evaluate((peer) => {
+    const ts = new Date(2026, 5, 19, 12, 0).getTime();
+    return Promise.all([
+      (window as any).__ringTest.seedCall({ video: false, durationSec: 120, bytes: 1_000_000, ts, contactId: peer }),
+      (window as any).__ringTest.seedCall({ video: true, durationSec: 600, bytes: 9_000_000, ts, contactId: peer }),
+    ]);
+  }, b.id);
+
+  await a.page.goto('/tabs/calls');
+
+  // Totals summary: audio 2 min, video 10 min, and a combined data line.
+  await expect(a.page.getByText('Totals')).toBeVisible({ timeout: 30_000 });
+  await expect(a.page.locator('ion-item', { hasText: 'Audio calls' })).toContainText('2 min');
+  await expect(a.page.locator('ion-item', { hasText: 'Video calls' })).toContainText('10 min');
+  await expect(a.page.getByText('Data used')).toBeVisible();
+
+  // ISO-style date on a call row.
+  await expect(a.page.locator('ion-note', { hasText: '2026-06-19' }).first()).toBeVisible();
+
+  // Call detail: action buttons swapped → Video first, Message last.
+  await a.page.goto(`/call/${b.id}`);
+  const btns = a.page.locator('.actions ion-button');
+  await expect(btns.first()).toContainText('Video', { timeout: 30_000 });
+  await expect(btns.last()).toContainText('Message');
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/specs/1025-app-ux-polish/checklists/requirements.md
+++ b/specs/1025-app-ux-polish/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: App-wide UX polish and fixes
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Nine independent user stories (P1–P3); each is a standalone, testable slice.
+- One assumption to confirm in `/speckit-plan`: whether in-app vibration is genuinely unavailable
+  from the PWA on target platforms (drives whether FR-021 removes the Vibrate toggle) and whether
+  historical call records carry byte-usage data (affects FR-017 totals for old calls).
+- Zero-knowledge boundary is explicitly preserved (FR-023); no security-model change.

--- a/specs/1025-app-ux-polish/data-model.md
+++ b/specs/1025-app-ux-polish/data-model.md
@@ -1,0 +1,54 @@
+# Phase 1 Data Model: App-wide UX polish and fixes
+
+No new IndexedDB object store and no `DB_VERSION` bump. This feature reads existing records and adds
+one derived, in-memory view (Calls totals). Settings changes remove keys; they do not add stored
+data.
+
+## Existing entities (read-only here)
+
+### Call (`src/db/types.ts`)
+
+- `kind`: `'audio' | 'video'`
+- `durationSec`: number — call length in seconds
+- `bytes?`: number — total data sent + received over the call (may be absent for old/interrupted calls)
+- `timestamp`: number — used for the ISO `YYYY-MM-DD` date display
+- (other fields unchanged)
+
+Used by: US6 (FR-015 date format, FR-017 totals).
+
+### Media (`src/db/types.ts`)
+
+- `blob?`: full-resolution original (may be freed)
+- `posterBlob?`: large poster tier (~512px) — the viewer should use this for video
+- `posterGrid?`: 320px tier (all-media grid)
+- `posterStrip?`: 128px tier (bottom thumbnail strip)
+
+Used by: US4 (FR-010..012 correct tier per context).
+
+## Derived view (new, in-memory only)
+
+### CallTotals
+
+Computed on-device from the visible `Call` records; not persisted.
+
+- `audioMinutes`: number — sum of `durationSec` for `kind==='audio'`, expressed in minutes
+- `videoMinutes`: number — sum of `durationSec` for `kind==='video'`, in minutes
+- `audioBytes`: number — sum of `bytes` for audio calls (missing bytes count as 0)
+- `videoBytes`: number — sum of `bytes` for video calls
+- `combinedBytes`: number — `audioBytes + videoBytes`
+
+Rules:
+- A call missing `bytes` contributes 0 to the data totals but still contributes `durationSec` to minutes.
+- Zero-duration calls contribute 0 minutes.
+- Totals are computed from the same call set the Calls list shows (no server fetch).
+
+## Settings keys touched
+
+- Removed entry point: one of the two `Animations` links (`chats-animations`) — no key change, the
+  screen and its keys (`chats.animEmoji`, `chats.animGifs`) stay.
+- `chats.animGifs`: now actually consumed by the autoplay-visible directive (previously inert).
+- Removed toggle: `notifications.inapp.vibrate` (and its now-unused pref in `notify.ts`).
+- `notifications.showPreview`: behavior widened to also genericize the notification title when off.
+- Help `Version` stat: value changes from a hardcoded string to `__APP_VERSION__` (no stored data).
+
+No zero-knowledge impact: all of the above is device-local; nothing new is sent to or stored on the server.

--- a/specs/1025-app-ux-polish/plan.md
+++ b/specs/1025-app-ux-polish/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: App-wide UX polish and fixes
+
+**Branch**: `feat/1025-app-ux-polish` | **Date**: 2026-07-01 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/1025-app-ux-polish/spec.md`
+
+## Summary
+
+Nine independent, mostly client-side UX fixes. Grounded in a codebase survey, most items are small
+wiring or presentation changes against existing infrastructure (router history, notification
+surfaces, settings schema, media thumbnail tiers, call records). Two spec assumptions were resolved
+during research: in-app vibration is a no-op on the PWA (remove the toggle), and per-call data-usage
+bytes are already captured/stored (only a totals *summary* is new). The Help self-test turned out to
+be a real crypto verification, so it is kept; the actual cleanup is the stale hardcoded version.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES modules), Vue 3 `<script setup>` + Ionic; Go 1.26 server (not touched here).
+
+**Primary Dependencies**: Vue Router, Ionic components, IndexedDB via `src/db/idb.ts`, existing
+notification surfaces (`src/sw.ts`, `src/services/sw-inbox.ts`, `src/services/notify.ts`), call
+stack (`src/composables/useCall.ts`), media thumbnail tiers (`Media` in `src/db/types.ts`).
+
+**Storage**: IndexedDB only. No new object store and no `DB_VERSION` bump — Calls totals are derived
+on-device from existing `Call` records (`durationSec`, `bytes`).
+
+**Testing**: `npm run build` (vue-tsc typecheck), `vitest` unit, Playwright e2e (`e2e/`). New/changed
+user-facing behavior adds or extends an e2e spec (constitution III).
+
+**Target Platform**: Installable PWA (iOS Safari primary, Android Chrome), served by `ringd`.
+
+**Project Type**: Single web client (repo root `src/`) + Go server (`server/`, untouched by 1025).
+
+**Performance Goals**: No regressions; media-viewer poster must be crisp on high-density displays;
+animations toggle takes effect without reload.
+
+**Constraints**: Offline-first; zero-knowledge boundary; Ionic-first UI (stock components).
+
+**Scale/Scope**: 9 UI/wiring items across ~10 client files; no server, crypto, or migration changes.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary (NON-NEGOTIABLE)**: PASS. Every item is client-side. No new server
+  field, no plaintext to the server; push tickles stay content-free. Calls totals are derived from
+  local records. **Zero-Knowledge Impact**: none — no data crosses the client/server boundary that
+  did not already, and nothing new is stored server-side.
+- **II. Spec-Driven Development**: PASS. Spec + this plan on `feat/1025-app-ux-polish`; `/analyze`
+  will be run clean before implement; taskstoissues will make each task traceable.
+- **III. Test-Driven Development**: PASS with intent. Behavioral items (deep-link back-nav, show-
+  preview genericization + hidden precedence, animations honored, calls totals/date/format) get
+  e2e coverage written before/with the change; unit tests for the new date + totals helpers.
+  Pure-visual items (media poster size, ttl spacing, hidden-row background) are verified via build +
+  the drive harness where an e2e assertion would be brittle; the e2e added still covers their DOM
+  wiring where practical.
+- **IV. Crypto Discipline**: N/A — no crypto change (self-test is kept as-is).
+- **V. Offline-First Data Integrity**: PASS — no store/`DB_VERSION` change.
+- **VI. Stateless Server & Forward-Only Migrations**: N/A — no server change.
+- **VII. Quality Gates**: PASS — full CI (build + vitest + e2e, server unchanged) must be green;
+  user-facing commit subjects will be plain-language release-note copy.
+- **XI. Ionic-First UI**: PASS — reuse stock Ionic components (`ion-item-sliding`, `ion-list`,
+  `ion-modal`, settings schema link/toggle/stat items); only presentation/wiring changes.
+
+No violations → Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1025-app-ux-polish/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (assumptions resolved)
+├── data-model.md        # Phase 1 output (entities: Call totals, media tiers — no new store)
+├── quickstart.md        # Phase 1 output (manual verification steps)
+├── checklists/
+│   └── requirements.md  # spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── main.ts                              # (1) cold-start base-history seed
+├── App.vue                              # (1) routeRelevant seeds /tabs/chats before deep link
+├── directives/autoplay-visible.ts       # (3) honor chats.animGifs (not only prefers-reduced-motion)
+├── settings/schema.ts                    # (3) drop one Animations entry; (4) drop Vibrate toggle; (7) version -> __APP_VERSION__
+├── services/
+│   ├── notify.ts                         # (4) drop vibrate; (5) genericize title when preview off
+│   └── sw-inbox.ts                       # (5) genericize title when preview off (background)
+├── components/
+│   ├── MediaViewer.vue                   # (2) video poster prefers large tier
+│   ├── VideoPlayer.vue                   # (2) .vid-el fills frame
+│   └── ChatListItem.vue                  # (6) hidden-row opaque background for clean swipe
+├── views/
+│   ├── detail/
+│   │   ├── ChatDetailPage.vue            # (2) viewer thumb tier; (8) ttl spacing + incoming placement
+│   │   └── CallDetailPage.vue            # (9) swap Video/Message buttons; ISO date
+│   └── tabs/CallsPage.vue                # (9) ISO date; totals summary
+└── utils/time.ts                         # (9) formatDay (YYYY-MM-DD); + call totals helper (utils/call-totals.ts)
+
+e2e/
+├── deeplink-back.spec.ts                 # (1) back from cold-start deep link → Chats
+├── notification-preview.spec.ts          # (5) preview off genericizes; hidden always generic
+├── animations-setting.spec.ts            # (3) single entry; animGifs honored
+└── calls-summary.spec.ts                 # (9) ISO dates, button order, totals
+```
+
+**Structure Decision**: Single web client. Changes are localized edits to existing components,
+services, the settings schema, and small pure helpers (date + totals) that get unit tests. No new
+IndexedDB store, no server or crypto changes.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/1025-app-ux-polish/quickstart.md
+++ b/specs/1025-app-ux-polish/quickstart.md
@@ -1,0 +1,44 @@
+# Quickstart: Verifying 1025 (App-wide UX polish)
+
+Manual verification per item, on the dev stack (`make start`) or a device on the develop image.
+Automated coverage lives in the e2e specs listed in the plan.
+
+1. **Deep-link back navigation (US1)**: Fully close the app. Trigger each notification (new message,
+   Wall post, friend request, request-accepted, app-update, incoming call) and tap it. When the app
+   opens on the target, press/swipe Back → you land on the Chats list, never a blank view.
+
+2. **Media viewer video poster (US4)**: Send a video, open it in the full-screen viewer, swipe to it
+   among other media → its poster fills the frame with a centered play control (no tiny image with
+   blank margins), crisp on a retina display.
+
+3. **Animations setting (US7)**: Open Settings → confirm exactly one "Animations" entry. Turn off
+   the toggles → animated emoji stop animating and GIFs no longer autoplay.
+
+4. **Vibrate (US8)**: Settings → Notifications → In-app notifications → confirm there is no Vibrate
+   toggle and the section has no empty gap.
+
+5. **Show preview + hidden precedence (US2)**: Turn "Show preview" off → a new message notification
+   shows a generic title and body (no sender, no content). Turn it on → sender + preview appear. Send
+   into a hidden chat with preview on → the notification stays generic.
+
+6. **Hidden-chat swipe (US3)**: Unlock hidden chats, swipe a hidden row both directions → the action
+   buttons appear immediately and the row content sits on an opaque background (no button
+   bleed-through).
+
+7. **Help cleanup (US9)**: Settings → Help → the Version shows the real app version; "Run self-test"
+   is present and, when tapped, runs the crypto self-test to a pass/fail summary.
+
+8. **Disappearing countdown (US5)**: Send and receive disappearing messages → visible spacing between
+   the timestamp and the green countdown; on incoming messages the countdown is to the right of the
+   timestamp.
+
+9. **Calls area (US6)**: Place audio and video calls. Calls list + a call detail show dates as
+   `YYYY-MM-DD`; on the detail the Video and Message buttons are swapped; a totals summary shows total
+   audio minutes, total video minutes, and data used for audio, video, and combined.
+
+## Gates before "done"
+
+- `npm run build` (typecheck + build) green.
+- `npx vitest run` green (new date + call-totals helper unit tests included).
+- `npm run test:e2e` green (new/updated specs: deeplink-back, notification-preview, animations-setting, calls-summary).
+- `cd server && go build/vet/test ./...` green (server untouched, should stay green).

--- a/specs/1025-app-ux-polish/research.md
+++ b/specs/1025-app-ux-polish/research.md
@@ -1,0 +1,99 @@
+# Phase 0 Research: App-wide UX polish and fixes
+
+Resolves the spec's open assumptions and records the grounded approach per item, from a codebase
+survey.
+
+## R1 — In-app vibration on the PWA (drives FR-021)
+
+**Decision**: Remove the Vibrate toggle from In-app notifications.
+
+**Rationale**: The toggle `notifications.inapp.vibrate` (`src/settings/schema.ts:610`) is consumed only
+in `src/services/notify.ts` `inAppSoundAndHaptics()` via `navigator.vibrate?.(40)`. On iOS Safari /
+installed PWA there is no Vibration API, so the optional chain silently no-ops; on Android it is
+limited to a foregrounded user-gesture context and never fires for background (service-worker)
+notifications. It is a control that does effectively nothing on the primary target.
+
+**Alternatives considered**: Keep the toggle but hide on iOS (rejected: still misleading on Android
+background); wire haptics via a native plugin (rejected: Ring is a PWA, no native layer).
+
+## R2 — Call data-usage bytes (drives FR-017 totals)
+
+**Decision**: Derive Calls totals on-device from existing `Call` records; no new capture or storage.
+
+**Rationale**: `Call` (`src/db/types.ts:365-386`) already stores `durationSec` and `bytes` (total
+sent+received). `useCall.ts` samples WebRTC `getStats()` (line ~900), accumulates bytes, and passes
+`totalBytes` to `finishCall(...)` on end. So minutes and data are already persisted per call. Totals
+are a pure client-side aggregation grouped by kind (audio/video).
+
+**Edge rule**: A call with no recorded `bytes` (older/interrupted) contributes 0 to the data total but
+still contributes its `durationSec` to the minutes total. Zero-duration calls count as 0 minutes.
+
+## R3 — Help self-test (drives FR-022)
+
+**Decision**: Keep "Run self-test"; fix the stale hardcoded version instead.
+
+**Rationale**: `/settings/selftest` → `SelfTestPage.vue` runs `runSelfTest()`
+(`src/services/crypto/selftest.ts`), a genuine on-device crypto verification (primitives, envelope,
+X3DH + Double Ratchet, sender keys, media encryption) with a pass/fail summary. It is meaningful, so
+it stays. The real cleanup is the Help "Version" stat, hardcoded to `'0.1.0'` (`schema.ts:702`) — it
+should show `__APP_VERSION__` like the About screen.
+
+## R4 — Cold-start deep-link back navigation (FR-001..004)
+
+**Decision**: Seed `/tabs/chats` into history beneath the deep-link target on cold start.
+
+**Rationale**: On a cold start the only base history entry is the deep link's own URL (`main.ts`
+re-seeds `window.location.href`), so Back underflows to a blank shell. Notification targets already
+resolve to tab or detail routes (`/chat/:id`, `/tabs/wall`, `/tabs/contacts`, `/`, and calls route
+to `/call-active` from `useCall`). Fix in the single consumption choke point `App.vue routeRelevant`:
+when routing to a cold-start deep link, ensure a `/tabs/chats` entry sits under it (replace to Chats,
+then push the target), and adjust the `main.ts` base seed so the underlying entry is Chats for a
+deep-link landing. The catch-all `→ /tabs/chats` redirect stays as the backstop.
+
+## R5 — Media viewer video poster (FR-010..012)
+
+**Decision**: Use the large poster tier for the viewer and let the video element fill the frame.
+
+**Rationale**: The viewer thumb is `stripUrl` (128px `posterStrip`) first (`ChatDetailPage.vue:1446`),
+and `VideoPlayer .vid-el` lacks `width/height:100%`, so the poster renders at 128px in a large blank
+frame. Fix: for the full-screen viewer prefer `posterUrl` (512px `posterBlob`) over `stripUrl`, and
+give `.vid-el` `width:100%; height:100%; object-fit:contain`. Tiers already exist per `Media`
+(`posterBlob`/`posterGrid`/`posterStrip`); older messages without a large tier fall back to what they
+have (backfill already exists from spec 1014).
+
+## R6 — Hidden-chat swipe reveal (FR-008..009)
+
+**Decision**: Give hidden-chat rows an OPAQUE background so the swipe reveals buttons cleanly.
+
+**Rationale**: `ChatListItem.vue` `.hidden-row` sets `--background: rgba(...medium..., 0.1)` (near
+transparent). In `ion-item-sliding` the item slides over the options; a near-transparent item lets
+the buttons beneath bleed through while the row content (name/avatar/date/eye) appears to float on
+top of them — the reported glitch. Fix: composite the subtle hidden tint over an opaque base (or use
+a solid themed background like normal rows), so the row is opaque and the buttons are only visible in
+the revealed area. No row is non-swipeable today; this is purely a background-opacity fix.
+
+## R7 — Show-preview title (FR-005..007)
+
+**Decision**: When "Show preview" is off, genericize the notification TITLE (sender), not only the
+body. Hidden-chat precedence already wins.
+
+**Rationale**: `showPreview` is wired for the body in both `sw-inbox.ts` (background) and `notify.ts`
+(foreground), but the title keeps the sender/group name. Per FR-005 the sender must also be hidden
+when preview is off. The hidden-chat early-return generic branches (`sw-inbox.ts:211`,
+`notify.ts:387`) already run before the preview logic, so hidden chats stay generic regardless — keep
+those checks first; only add title genericization to the non-hidden preview-off path.
+
+## R8 — Disappearing countdown placement (FR-013..014)
+
+**Decision**: Increase spacing and, for incoming messages, place the countdown to the right of the
+timestamp via a direction-scoped CSS order.
+
+**Rationale**: `.ttl-left` is rendered before the timestamp inside `.time`; `.msg-foot.in .time` is
+left-anchored, so the countdown hugs the bubble's left edge. Add spacing (a margin on `.ttl-left`)
+and, under `.msg-foot.in`, reorder so `.ttl-left` follows the timestamp.
+
+## R9 — Calls date + button swap (FR-015..016)
+
+**Decision**: Add a `formatDay` helper (`YYYY-MM-DD`) in `utils/time.ts`; use it in `CallsPage.vue`
+and `CallDetailPage.vue`. Swap the Message and Video action columns on `CallDetailPage.vue` (current
+order Message → Audio → Video becomes Video → Audio → Message).

--- a/specs/1025-app-ux-polish/spec.md
+++ b/specs/1025-app-ux-polish/spec.md
@@ -1,0 +1,287 @@
+# Feature Specification: App-wide UX polish and fixes
+
+**Feature Branch**: `feat/1025-app-ux-polish`
+
+**Created**: 2026-07-01
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: a collection of nine independent UX polish items and bug fixes across
+notifications, the media viewer, settings, hidden chats, disappearing messages, and the calls area.
+
+## Overview
+
+A batch of small, mostly independent quality fixes that make Ring feel more like a native app and
+remove rough edges found during real-device use. Each item is a standalone slice: any one can be
+built, tested, and shipped on its own. All changes stay within Ring's zero-knowledge boundary. The
+server keeps relaying only sealed ciphertext and content-free push tickles; nothing here adds
+server-visible plaintext.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Back from a notification deep-link lands home, not on a blank view (Priority: P1)
+
+The app is fully closed. A push notification arrives and the user taps it, and the app cold-starts
+directly onto the target: a chat message, a Wall post, a friend request, a "request accepted"
+screen, an app-update prompt, or an incoming call. When the user then presses or swipes Back, they
+must land on the Chats list (the app's home), never on a blank browser view or an empty page.
+
+**Why this priority**: This is the worst current break. A cold-started deep link has no history
+behind it, so Back dead-ends the user on a blank view and feels broken. It affects the most common
+re-entry path into the app.
+
+**Independent Test**: Fully close the app, deliver each notification type, tap it to deep-link in,
+then press Back and confirm the Chats list appears every time.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is fully closed, **When** the user taps a new-message notification and then presses Back, **Then** the Chats list is shown (not a blank view).
+2. **Given** the app is fully closed, **When** the user taps a Wall-post notification and then presses Back, **Then** the Chats list is shown.
+3. **Given** the app is fully closed, **When** the user taps a friend-request or request-accepted notification and then presses Back, **Then** the Chats list is shown.
+4. **Given** the app is fully closed, **When** the user taps an app-update notification and then presses Back, **Then** the Chats list is shown.
+5. **Given** the app is fully closed, **When** the user answers or dismisses an incoming call reached from a notification and then presses Back, **Then** the Chats list is shown.
+
+---
+
+### User Story 2 - Notification previews respect the global toggle and always protect hidden chats (Priority: P1)
+
+A user with the "Show preview" option turned off should never see message content on the lock
+screen or in in-app notifications; only a generic notice appears. Regardless of that global setting,
+a hidden (PIN-locked) chat must always behave with the most protective rules: its notifications stay
+generic and never reveal sender, content, or that a hidden conversation exists.
+
+**Why this priority**: Preview leakage is a privacy regression, and hidden chats are Ring's
+strongest privacy promise. Hidden-chat protection must win over any general preview preference.
+
+**Independent Test**: Toggle "Show preview" on and off and confirm previews appear/disappear for
+normal chats; then send into a hidden chat with preview on and confirm the notification stays
+generic.
+
+**Acceptance Scenarios**:
+
+1. **Given** "Show preview" is off, **When** a message arrives in a normal chat, **Then** the notification shows a generic notice with no sender or content.
+2. **Given** "Show preview" is on, **When** a message arrives in a normal chat, **Then** the notification shows the sender and a content preview.
+3. **Given** "Show preview" is on, **When** a message arrives in a hidden chat, **Then** the notification is still generic and reveals nothing about the hidden chat.
+
+---
+
+### User Story 3 - Hidden-chat rows reveal their swipe actions cleanly (Priority: P2)
+
+After entering the PIN and revealing hidden chats, the user swipes a hidden-chat row left or right.
+The action buttons underneath appear immediately, and the row's name, avatar, date, and eye icon sit
+on top of those buttons over a transparent background (so the buttons read clearly and the row does
+not look broken or doubled).
+
+**Why this priority**: The current reveal is visually broken (delayed buttons, opaque overlap),
+which undermines confidence in a sensitive, PIN-gated area.
+
+**Independent Test**: Unlock hidden chats, swipe a row both directions, and confirm the buttons show
+immediately with the row content layered on a transparent background.
+
+**Acceptance Scenarios**:
+
+1. **Given** hidden chats are revealed, **When** the user swipes a hidden-chat row, **Then** the underlying action buttons are visible immediately.
+2. **Given** a row is swiped open, **When** the user looks at it, **Then** the name, avatar, date, and eye icon appear over the buttons on a transparent background.
+
+---
+
+### User Story 4 - The media viewer shows a properly sized video poster (Priority: P2)
+
+Opening the chat media viewer and swiping between items, a video should display a full-frame poster
+image (with a play control), matching how photos fill the viewer, instead of a tiny thumbnail
+floating in a large blank area. Every context in the app (bubble, album grid, media strip,
+full-screen viewer) should use the correctly sized image already carried by the message so nothing
+looks under-scaled.
+
+**Why this priority**: The tiny, blank-surrounded video poster looks unfinished and unlike a native
+gallery. It is highly visible whenever a video is viewed.
+
+**Independent Test**: Send a video, open it in the viewer, swipe to it among other media, and confirm
+its poster fills the frame like a photo, at crisp resolution.
+
+**Acceptance Scenarios**:
+
+1. **Given** a video message, **When** it is shown in the full-screen viewer, **Then** its poster fills the available frame with a centered play control and no large blank margins.
+2. **Given** media in different contexts (bubble, grid, strip, viewer), **When** each renders, **Then** it uses an appropriately sized thumbnail tier so it looks crisp and correctly scaled.
+
+---
+
+### User Story 5 - The disappearing countdown is spaced and placed sensibly (Priority: P2)
+
+On a disappearing message, the time-left indicator has clear separation from the timestamp. For
+incoming messages the countdown sits to the right of the timestamp (for outgoing it stays where it
+reads best), so the two never crowd each other.
+
+**Why this priority**: A small but constant readability issue on disappearing messages.
+
+**Independent Test**: Send and receive disappearing messages and confirm spacing and side placement.
+
+**Acceptance Scenarios**:
+
+1. **Given** any disappearing message, **When** it renders, **Then** there is visible spacing between the timestamp and the countdown.
+2. **Given** an incoming disappearing message, **When** it renders, **Then** the countdown appears to the right of the timestamp.
+
+---
+
+### User Story 6 - The Calls area shows ISO dates, swapped actions, and usage totals (Priority: P2)
+
+In the Calls list and a call's detail, dates read in an ISO-style `YYYY-MM-DD` format. On the call
+detail, the Video and Message action buttons swap positions (Video takes Message's place and vice
+versa). A totals summary shows the combined minutes of audio calls, the combined minutes of video
+calls, and the data used for audio, for video, and combined.
+
+**Why this priority**: Consistent dates and honest usage totals improve trust and utility; the
+button swap matches the user's preferred layout.
+
+**Independent Test**: Place audio and video calls, then open the Calls list and a detail and confirm
+the date format, button order, and the minute and data totals.
+
+**Acceptance Scenarios**:
+
+1. **Given** call history, **When** the Calls list and detail render dates, **Then** dates use `YYYY-MM-DD`.
+2. **Given** a call detail, **When** the action buttons render, **Then** Video and Message are swapped relative to today.
+3. **Given** completed audio and video calls, **When** the totals summary renders, **Then** it shows total audio minutes, total video minutes, and data used for audio, video, and combined.
+
+---
+
+### User Story 7 - One Animations setting that actually works (Priority: P3)
+
+Settings has a single "Animations" control (the duplicate is removed), and turning it off measurably
+reduces or disables non-essential motion across the app.
+
+**Why this priority**: Two controls for the same thing is confusing, and a setting that does nothing
+erodes trust. Lower priority because it is cosmetic.
+
+**Independent Test**: Confirm only one Animations control exists, toggle it, and observe motion
+change accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** Settings, **When** the user looks for Animations, **Then** exactly one Animations control exists.
+2. **Given** Animations is turned off, **When** the user navigates the app, **Then** non-essential animations are suppressed.
+
+---
+
+### User Story 8 - No dead Vibrate control (Priority: P3)
+
+If in-app vibration cannot be triggered reliably from the PWA on Ring's supported platforms, the
+Vibrate toggle is removed from In-app notifications so users are not offered a control that does
+nothing.
+
+**Why this priority**: A non-functional toggle is misleading, but low impact.
+
+**Independent Test**: Confirm the Vibrate toggle is gone from In-app notifications (given the
+platform limitation), and the surrounding settings still render cleanly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the platform cannot vibrate in-app, **When** the user opens In-app notifications, **Then** no Vibrate toggle is present and no empty gap or dangling row remains.
+
+---
+
+### User Story 9 - Tidy Help screen (Priority: P3)
+
+The Help screen keeps a clean version line, and the "Run self-test" action is removed if it does not
+perform a meaningful, user-visible check.
+
+**Why this priority**: Removes clutter and a possibly misleading control. Low impact.
+
+**Independent Test**: Open Help and confirm the version line reads cleanly and no non-functional
+self-test control remains (or, if kept, it produces a meaningful result).
+
+**Acceptance Scenarios**:
+
+1. **Given** the Help screen, **When** it renders, **Then** the version line is present and tidy.
+2. **Given** "Run self-test" does nothing meaningful, **When** Help renders, **Then** that control is removed.
+
+### Edge Cases
+
+- Deep-link Back when the app was NOT cold-started (already open with history): normal Back behavior is preserved; only the no-history cold-start case is forced home.
+- A deep-link target that no longer exists (post expired, chat deleted, call already ended): the app still resolves to a sensible screen and Back still reaches the Chats list.
+- "Show preview" changed while a chat is open or a notification is pending: the next notification reflects the new setting; hidden-chat protection is never affected.
+- A video message whose poster tier is missing on an older message: it still shows a reasonable poster (backfilled or derived) rather than a tiny image.
+- Calls with zero duration or an interrupted connection: totals count them consistently (a defined rule) and do not double-count.
+- No call history yet: the totals summary shows zeros or is hidden gracefully (no broken layout).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Notification deep-link back navigation (US1)**
+
+- **FR-001**: When the app cold-starts from a tapped notification directly onto a deep-link target, the navigation history MUST be seeded so that Back resolves to the Chats list.
+- **FR-002**: FR-001 MUST apply to every notification-driven deep link: new chat message, Wall post, new friend request, friend-request-accepted, app-update prompt, and incoming call.
+- **FR-003**: Back from a cold-start deep link MUST NEVER present a blank view, an empty page, or the external browser.
+- **FR-004**: When the app is already open with real history, Back MUST retain its normal behavior (this requirement does not force home in that case).
+
+**Notification previews and hidden-chat precedence (US2)**
+
+- **FR-005**: The "Show preview" setting MUST control whether message sender and content appear in notifications, end to end, for normal chats.
+- **FR-006**: A hidden (PIN-locked) chat MUST always use the most protective notification behavior (generic, no sender, no content, no indication a hidden chat exists), regardless of the "Show preview" setting.
+- **FR-007**: Hidden-chat precedence MUST hold across both background (system) notifications and in-app notifications.
+
+**Hidden-chat swipe actions (US3)**
+
+- **FR-008**: Swiping a revealed hidden-chat row left or right MUST reveal the underlying action buttons immediately.
+- **FR-009**: While a hidden-chat row is swiped open, its name, avatar, date, and eye icon MUST render on top of the action buttons over a transparent background.
+
+**Media viewer video poster (US4)**
+
+- **FR-010**: The full-screen media viewer MUST display a video's poster at a size that fills the available frame (matching photo presentation), with a centered play control and no large blank margins.
+- **FR-011**: Each message MUST carry the set of thumbnail tiers needed so the app can select the correctly sized image per context (bubble, album grid, media strip, full-screen viewer) without re-deriving it at view time.
+- **FR-012**: Media presentation across contexts MUST look crisp on high-density displays (use a tier at least as large as the render size).
+
+**Disappearing countdown placement (US5)**
+
+- **FR-013**: A disappearing message MUST show clear visible spacing between the timestamp and the time-left countdown.
+- **FR-014**: For incoming disappearing messages, the countdown MUST appear to the right of the timestamp.
+
+**Calls area (US6)**
+
+- **FR-015**: The Calls list and call detail MUST format dates in ISO-style `YYYY-MM-DD`.
+- **FR-016**: On the call detail, the Video and Message action buttons MUST swap positions relative to the current layout.
+- **FR-017**: The Calls area MUST show a totals summary: total audio-call minutes, total video-call minutes, and data used for audio, for video, and combined.
+- **FR-018**: The totals MUST be derived on-device from call records and MUST NOT require any new server-visible data.
+
+**Settings cleanup (US7, US8, US9)**
+
+- **FR-019**: Settings MUST expose exactly one "Animations" control (the duplicate removed), and it MUST be the single source of truth.
+- **FR-020**: Turning "Animations" off MUST suppress non-essential motion across the app; turning it on MUST restore it.
+- **FR-021**: If in-app vibration cannot be triggered from the PWA on supported platforms, the Vibrate toggle MUST be removed from In-app notifications, leaving no empty section or dangling row.
+- **FR-022**: The Help screen MUST retain a tidy version line, and the "Run self-test" control MUST be removed if it performs no meaningful, user-visible check.
+
+**Cross-cutting**
+
+- **FR-023**: All changes MUST preserve Ring's zero-knowledge boundary: no new plaintext is sent to or stored on the server, and push tickles remain content-free.
+
+### Key Entities *(include if feature involves data)*
+
+- **Call record**: An existing per-call entry (kind audio or video, start time, duration, and, where available, bytes transferred) used to compute the Calls totals. No new server-side field is introduced.
+- **Media thumbnail tiers**: The set of preview sizes already associated with a media message (for example bubble, grid, strip, poster) that the app selects among per context.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In 100% of cold-start notification deep-link cases (all six types), pressing Back lands on the Chats list and never on a blank view or the browser.
+- **SC-002**: With "Show preview" off, 0% of normal-chat notifications reveal sender or content; with it on, previews appear. In 100% of hidden-chat cases the notification stays generic regardless of the setting.
+- **SC-003**: Swiping a revealed hidden-chat row shows its action buttons with no perceptible delay, with the row content legible over a transparent background.
+- **SC-004**: A video in the full-screen viewer fills at least the same frame proportion as a photo of the same aspect ratio, with no tiny-thumbnail blank margins, on a high-density display.
+- **SC-005**: Every disappearing message shows measurable spacing between timestamp and countdown, and incoming messages place the countdown to the right of the timestamp 100% of the time.
+- **SC-006**: The Calls list and detail show `YYYY-MM-DD` dates, the swapped button order, and totals that match the sum of the underlying call records (audio minutes, video minutes, and data per kind and combined).
+- **SC-007**: Exactly one Animations control exists and toggling it visibly changes motion; no Vibrate toggle remains where the platform cannot vibrate; the Help screen shows a tidy version with no non-functional self-test.
+
+## Assumptions
+
+- "The Chats list is the app home" is the correct Back destination for all cold-start deep links (matches Ring's tab structure).
+- In-app vibration is not reliably available from the PWA on Ring's primary target (installed PWA on iOS, and constrained on others), so the Vibrate toggle is expected to be removed; the plan phase confirms this per platform before removing.
+- Call data-usage bytes are available on-device from existing call statistics; if a given historical call lacks byte data, its data contribution is treated as zero (minutes still count).
+- Duration and data totals are computed over the call records already stored on the device (no retroactive server fetch).
+- The media thumbnail tiers introduced in prior media specs already exist for new messages; older messages may need an on-device backfill of the missing tier rather than a new capture.
+- The "totals summary" lives in the Calls area (list header or a dedicated summary row); exact placement is a design detail resolved during planning.
+- Disappearing-message rendering, hidden-chat gating, notification infrastructure, and the settings schema are reused as-is; this spec changes their presentation and wiring, not their security model.

--- a/specs/1025-app-ux-polish/spec.md
+++ b/specs/1025-app-ux-polish/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-01
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1025-app-ux-polish/spec.md
+++ b/specs/1025-app-ux-polish/spec.md
@@ -73,20 +73,21 @@ generic.
 ### User Story 3 - Hidden-chat rows reveal their swipe actions cleanly (Priority: P2)
 
 After entering the PIN and revealing hidden chats, the user swipes a hidden-chat row left or right.
-The action buttons underneath appear immediately, and the row's name, avatar, date, and eye icon sit
-on top of those buttons over a transparent background (so the buttons read clearly and the row does
-not look broken or doubled).
+The action buttons underneath appear immediately, and the row's name, avatar, date, and eye icon
+stay on an opaque background that slides cleanly over the buttons, so the buttons are only visible in
+the revealed area and never bleed through under the row content (today the near-transparent hidden
+row lets the buttons show through and the content looks like it floats on top of them).
 
-**Why this priority**: The current reveal is visually broken (delayed buttons, opaque overlap),
-which undermines confidence in a sensitive, PIN-gated area.
+**Why this priority**: The current reveal is visually broken (buttons bleed through the translucent
+row), which undermines confidence in a sensitive, PIN-gated area.
 
 **Independent Test**: Unlock hidden chats, swipe a row both directions, and confirm the buttons show
-immediately with the row content layered on a transparent background.
+immediately and the row content sits on an opaque background with no bleed-through.
 
 **Acceptance Scenarios**:
 
 1. **Given** hidden chats are revealed, **When** the user swipes a hidden-chat row, **Then** the underlying action buttons are visible immediately.
-2. **Given** a row is swiped open, **When** the user looks at it, **Then** the name, avatar, date, and eye icon appear over the buttons on a transparent background.
+2. **Given** a row is swiped open, **When** the user looks at it, **Then** the name, avatar, date, and eye icon sit on an opaque background and the buttons are only visible in the revealed area (no bleed-through).
 
 ---
 
@@ -228,7 +229,7 @@ self-test control remains (or, if kept, it produces a meaningful result).
 **Hidden-chat swipe actions (US3)**
 
 - **FR-008**: Swiping a revealed hidden-chat row left or right MUST reveal the underlying action buttons immediately.
-- **FR-009**: While a hidden-chat row is swiped open, its name, avatar, date, and eye icon MUST render on top of the action buttons over a transparent background.
+- **FR-009**: While a hidden-chat row is swiped open, its name, avatar, date, and eye icon MUST render on an opaque background so the action buttons are only visible in the revealed area and do not bleed through under the row content.
 
 **Media viewer video poster (US4)**
 
@@ -270,7 +271,7 @@ self-test control remains (or, if kept, it produces a meaningful result).
 
 - **SC-001**: In 100% of cold-start notification deep-link cases (all six types), pressing Back lands on the Chats list and never on a blank view or the browser.
 - **SC-002**: With "Show preview" off, 0% of normal-chat notifications reveal sender or content; with it on, previews appear. In 100% of hidden-chat cases the notification stays generic regardless of the setting.
-- **SC-003**: Swiping a revealed hidden-chat row shows its action buttons with no perceptible delay, with the row content legible over a transparent background.
+- **SC-003**: Swiping a revealed hidden-chat row shows its action buttons with no perceptible delay, with the row content on an opaque background and no button bleed-through.
 - **SC-004**: A video in the full-screen viewer fills at least the same frame proportion as a photo of the same aspect ratio, with no tiny-thumbnail blank margins, on a high-density display.
 - **SC-005**: Every disappearing message shows measurable spacing between timestamp and countdown, and incoming messages place the countdown to the right of the timestamp 100% of the time.
 - **SC-006**: The Calls list and detail show `YYYY-MM-DD` dates, the swapped button order, and totals that match the sum of the underlying call records (audio minutes, video minutes, and data per kind and combined).

--- a/specs/1025-app-ux-polish/tasks.md
+++ b/specs/1025-app-ux-polish/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: App-wide UX polish and fixes
+
+**Feature**: 1025-app-ux-polish | **Branch**: `feat/1025-app-ux-polish`
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+Nine independent user stories (P1–P3). Each phase is a standalone, testable slice and can be
+implemented and shipped on its own. Tests come before or with the implementation they cover
+(constitution III). `[P]` = parallelizable (different files, no ordering dependency).
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm branch `feat/1025-app-ux-polish` is checked out and green baseline (`npm run build`) before edits.
+
+## Phase 2: Foundational (shared helpers used by later stories)
+
+- [ ] T002 [P] Add `formatDay(ts)` → `YYYY-MM-DD` in `src/utils/time.ts`, with a `src/utils/time.test.ts` case (unit).
+- [ ] T003 [P] Add `computeCallTotals(calls)` in `src/utils/call-totals.ts` (audio/video minutes, audio/video/combined bytes; missing bytes → 0), with `src/utils/call-totals.test.ts` (unit).
+
+## Phase 3: US1 — Deep-link back navigation (P1)
+
+- [ ] T004 [US1] Add `e2e/deeplink-back.spec.ts`: simulate a cold-start deep link (seed pending-nav / navigate to a `/chat/:id` and `/tabs/wall` with empty history) then Back → resolves to `/tabs/chats` (fails first).
+- [ ] T005 [US1] In `src/App.vue` `routeRelevant`, when routing a cold-start deep-link target, seed `/tabs/chats` into history before pushing the target (replace to Chats, then push).
+- [ ] T006 [US1] In `src/main.ts`, adjust the base-history seed so a deep-link landing keeps `/tabs/chats` as the underlying entry (non-`/tabs/*` landing). Verify T004 passes.
+
+## Phase 4: US2 — Notification preview wiring + hidden precedence (P1)
+
+- [ ] T007 [US2] Add `e2e/notification-preview.spec.ts`: with `notifications.showPreview` off, the in-app/background note title+body are generic; a hidden chat stays generic even with preview on (fails first).
+- [ ] T008 [US2] In `src/services/notify.ts`, genericize the notification TITLE (not just body) when `showPreview` is off for non-hidden chats; keep the hidden early-return branch first.
+- [ ] T009 [US2] In `src/services/sw-inbox.ts`, genericize the background notification title when preview is off; keep the hidden generic branch first. Verify T007 passes.
+
+## Phase 5: US3 — Hidden-chat swipe reveal (P2)
+
+- [ ] T010 [US3] In `src/components/ChatListItem.vue`, make `.hidden-row` background OPAQUE (composite the hidden tint over a solid themed base) so swipe reveals buttons cleanly with no bleed-through.
+- [ ] T011 [US3] Verify via the drive harness: unlock hidden chats, swipe a row, confirm opaque row + buttons only in the revealed area (screenshot).
+
+## Phase 6: US4 — Media viewer video poster (P2)
+
+- [ ] T012 [US4] In `src/views/detail/ChatDetailPage.vue`, for the full-screen viewer `thumb`, prefer the large `posterUrl` (posterBlob) over `stripUrl` for video items.
+- [ ] T013 [US4] In `src/components/VideoPlayer.vue`, give `.vid-el` `width:100%; height:100%; object-fit:contain` so the poster fills the frame.
+- [ ] T014 [US4] Verify via the drive harness: a video in the viewer fills the frame with a centered play control (screenshot).
+
+## Phase 7: US5 — Disappearing countdown placement (P2)
+
+- [ ] T015 [US5] In `src/views/detail/ChatDetailPage.vue`, add spacing between the timestamp and `.ttl-left`, and under `.msg-foot.in` reorder so the countdown sits to the RIGHT of the timestamp for incoming messages.
+- [ ] T016 [US5] Verify via the drive harness: incoming vs outgoing disappearing messages show correct spacing + side (screenshot).
+
+## Phase 8: US6 — Calls list + detail (P2)
+
+- [ ] T017 [US6] Add `e2e/calls-summary.spec.ts`: seed audio+video calls, assert `YYYY-MM-DD` dates, swapped Video/Message button order on detail, and totals (audio minutes, video minutes, data per kind + combined) (fails first).
+- [ ] T018 [US6] In `src/views/tabs/CallsPage.vue`, use `formatDay` for dates and render a totals summary from `computeCallTotals`.
+- [ ] T019 [US6] In `src/views/detail/CallDetailPage.vue`, use `formatDay` for dates and swap the Video and Message action columns (Video → Audio → Message). Verify T017 passes.
+
+## Phase 9: US7 — Single Animations setting, honored (P3)
+
+- [ ] T020 [US7] Add `e2e/animations-setting.spec.ts`: exactly one Animations entry in Settings; toggling `chats.animGifs` off suppresses GIF autoplay (fails first for the GIF wiring).
+- [ ] T021 [US7] In `src/settings/schema.ts`, remove one of the duplicate `Animations` link entries (keep the Appearance one; drop the Chats one, or vice versa) leaving a single source of truth.
+- [ ] T022 [US7] In `src/directives/autoplay-visible.ts`, honor `chats.animGifs` (in addition to `prefers-reduced-motion`) so turning it off stops GIF autoplay. Verify T020 passes.
+
+## Phase 10: US8 — Remove dead Vibrate toggle (P3)
+
+- [ ] T023 [US8] In `src/settings/schema.ts`, remove the `notifications.inapp.vibrate` toggle from the In-app notifications screen (no empty gap left).
+- [ ] T024 [US8] In `src/services/notify.ts`, remove the now-unused `inappVibrate` pref and the `navigator.vibrate` call (or leave a single unconditional best-effort with no setting); ensure no dangling references.
+
+## Phase 11: US9 — Help screen cleanup (P3)
+
+- [ ] T025 [US9] In `src/settings/schema.ts`, change the Help `Version` stat from the hardcoded `'0.1.0'` to `__APP_VERSION__`; keep the (meaningful) Run self-test.
+
+## Phase 12: Polish & gates
+
+- [ ] T026 Run `npm run build` (typecheck) and `npx vitest run`; fix any breakage.
+- [ ] T027 Run the affected e2e specs locally (deeplink-back, notification-preview, calls-summary, animations-setting) to green.
+- [ ] T028 Bump the spec Status to `in-review`, run `make roadmap`, and confirm the roadmap guard is satisfied.
+
+## Dependencies / ordering
+
+- Phase 2 (T002, T003) precedes US6 (T018/T019 use the helpers).
+- Within each story, the test task precedes its implementation task(s).
+- Stories are otherwise independent and may be implemented in any order; US1 and US2 (P1) first for MVP value.

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,6 +54,8 @@ import { useAppUpdate, checkForUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
 import { takePendingNav } from '@/services/pending-nav';
 import { recoverInterruptedPosts } from '@/services/pending-posts';
+import { setAutoplayGifsEnabled } from '@/directives/autoplay-visible';
+import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import type { Message } from '@/db/types';
 
@@ -64,6 +66,12 @@ useSync();
 // Registers the service worker and prompts (with the version) when a new deploy is
 // ready, instead of silently reloading. See useAppUpdate + vite.config 'prompt'.
 useAppUpdate();
+
+// Push the Appearance → Animations "GIFs move automatically" preference into the feed autoplay
+// coordinator (its gate is synchronous, the setting is async), so turning it off actually stops
+// GIF/video autoplay.
+const { animGifs } = useAnimationPrefs();
+watch(animGifs, (on) => setAutoplayGifsEnabled(on !== false), { immediate: true });
 
 const router = useRouter();
 
@@ -96,7 +104,7 @@ watch(
       // via openWindow); now that we're unlocked and the tabs are reachable, route there. The
       // microtask defer lets the auth gate's default landing settle first so this wins.
       void takePendingNav().then((url) => {
-        if (url) void routeRelevant(url);
+        if (url) void routeRelevant(url, true); // cold start: seed Chats beneath the deep link
       });
     } else {
       clearWarm();
@@ -172,17 +180,26 @@ watch(
 
 // When opened from a notification, land on the relevant place: the deep-link the
 // service worker hands us, or, for a content-free push, the most pertinent tab.
-async function routeRelevant(url?: string): Promise<void> {
-  if (url) {
-    router.push(url);
-    return;
+// `coldStart` is true when we're launching fresh from a tapped notification: the deep-link
+// target is then the ONLY history entry, so a Back/swipe-back would underflow to a blank shell.
+// In that case seed the Chats home BENEATH the target (replace current → Chats, then push the
+// target) so the first Back always returns to the Chats list. Live in-app navigation keeps normal
+// push behaviour.
+async function routeRelevant(url?: string, coldStart = false): Promise<void> {
+  let target = url;
+  if (!target) {
+    if ((await countPendingRequests()) > 0) target = '/tabs/contacts';
+    else {
+      const unread = (await listChats()).find((c) => c.unread > 0); // newest-first
+      target = unread ? `/chat/${unread.id}` : '/tabs/chats';
+    }
   }
-  if ((await countPendingRequests()) > 0) {
-    router.push('/tabs/contacts');
-    return;
+  if (coldStart && target !== '/tabs/chats') {
+    await router.replace('/tabs/chats');
+    await router.push(target);
+  } else {
+    router.push(target);
   }
-  const unread = (await listChats()).find((c) => c.unread > 0); // newest-first
-  router.push(unread ? `/chat/${unread.id}` : '/tabs/chats');
 }
 
 // How long to wait for a drained message's in-app banner to render before giving

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -193,7 +193,16 @@ function more(): void {
    easy to tell apart from normal chats during a reveal session. Only renders while
    revealed (the row isn't in the list otherwise), so it leaks nothing when locked. */
 .hidden-row {
-  --background: var(--ring-hidden-tint, rgba(var(--ion-color-medium-rgb, 146, 148, 156), 0.1));
+  /* Spec 1025 US3: composite the subtle hidden tint over an OPAQUE item base. A translucent
+     --background let the swipe action buttons bleed through the sliding row (the row content looked
+     like it floated on top of them); an opaque background makes the buttons visible only in the
+     revealed area, like a normal row, while keeping the tint cue. */
+  --background: linear-gradient(
+      0deg,
+      var(--ring-hidden-tint, rgba(var(--ion-color-medium-rgb, 146, 148, 156), 0.1)),
+      var(--ring-hidden-tint, rgba(var(--ion-color-medium-rgb, 146, 148, 156), 0.1))
+    ),
+    var(--ion-item-background, var(--ion-background-color, #fff));
 }
 .hidden-ico {
   color: var(--ion-color-medium);

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -188,6 +188,10 @@ defineExpose({ playing, elapsed, total, progress, rate, pipActive, toggle, pause
   justify-content: center;
 }
 .vid-el {
+  /* Fill the frame (letterboxed) so the poster matches photo presentation instead of sizing to the
+     poster's intrinsic pixels — otherwise a small poster tier floats tiny in a large blank area. */
+  width: 100%;
+  height: 100%;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2008,6 +2008,20 @@ export async function listCallGroups(q = ''): Promise<CallGroup[]> {
   return groups;
 }
 
+/** All non-hidden call records (raw, ungrouped, newest first) — the source for the Calls-tab usage
+ *  totals (spec 1025 US6). Hidden calls are excluded so the totals never leak hidden-chat call time,
+ *  mirroring listCallGroups. Fails closed (empty) until the hidden set is known. */
+export async function listCallsForTotals(): Promise<Call[]> {
+  const calls = await listCalls();
+  const hidden = await ensureHiddenLoaded();
+  if (!isHiddenKnown()) return [];
+  if (hidden.size > 0) {
+    const exclude = hiddenCallKeys(await getAll<Chat>('chats'), hidden);
+    return calls.filter((c) => !exclude.has(c.contactId));
+  }
+  return calls;
+}
+
 /** Delete one or more call-log entries (tombstoned so a pull can't resurrect them). */
 export async function deleteCalls(ids: string[]): Promise<void> {
   const deletedAt = now();

--- a/src/directives/autoplay-visible.ts
+++ b/src/directives/autoplay-visible.ts
@@ -36,6 +36,16 @@ export function setAutoplayMuted(muted: boolean): void {
 const PLAY_AT = 0.6;
 const STOP_AT = 0.25;
 
+// The Appearance → Animations "GIFs move automatically" preference (chats.animGifs). The gate here
+// is synchronous while the setting is async, so the app pushes the current value in via
+// setAutoplayGifsEnabled (wired from useAnimationPrefs in App.vue). Off = never autoplay.
+let gifsEnabled = true;
+export function setAutoplayGifsEnabled(on: boolean): void {
+  gifsEnabled = on;
+  if (!on) setActive(null);
+  else reconcile();
+}
+
 const registered = new Set<HTMLVideoElement>();
 const ratios = new Map<HTMLVideoElement, number>();
 let current: HTMLVideoElement | null = null;
@@ -88,7 +98,7 @@ function setActive(el: HTMLVideoElement | null): void {
 // Pick the most-visible registered video and make it the single active one; drop the
 // current one once it's mostly off screen.
 function reconcile(): void {
-  if (lowData() || suspended) {
+  if (lowData() || suspended || !gifsEnabled) {
     setActive(null);
     return;
   }

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -39,7 +39,6 @@ interface NotifyPrefs {
   showPreview: boolean;
   inappSounds: boolean;
   messageSound: string;
-  inappVibrate: boolean;
   inappStyle: string;
 }
 const PREF_DEFAULTS: NotifyPrefs = {
@@ -47,22 +46,20 @@ const PREF_DEFAULTS: NotifyPrefs = {
   showPreview: true,
   inappSounds: false,
   messageSound: 'note',
-  inappVibrate: true,
   inappStyle: 'banners',
 };
 let prefs: NotifyPrefs = { ...PREF_DEFAULTS };
 let prefsHydrated = false;
 
 async function loadPrefs(): Promise<void> {
-  const [showMessages, showPreview, inappSounds, messageSound, inappVibrate, inappStyle] = await Promise.all([
+  const [showMessages, showPreview, inappSounds, messageSound, inappStyle] = await Promise.all([
     getSetting<boolean>('notifications.message.show', PREF_DEFAULTS.showMessages),
     getSetting<boolean>('notifications.showPreview', PREF_DEFAULTS.showPreview),
     getSetting<boolean>('notifications.inapp.sounds', PREF_DEFAULTS.inappSounds),
     getSetting<string>('notifications.message.sound', PREF_DEFAULTS.messageSound),
-    getSetting<boolean>('notifications.inapp.vibrate', PREF_DEFAULTS.inappVibrate),
     getSetting<string>('notifications.inapp.style', PREF_DEFAULTS.inappStyle),
   ]);
-  prefs = { showMessages, showPreview, inappSounds, messageSound, inappVibrate, inappStyle };
+  prefs = { showMessages, showPreview, inappSounds, messageSound, inappStyle };
 }
 
 async function ensurePrefs(): Promise<NotifyPrefs> {
@@ -347,17 +344,10 @@ function targetUrl(n: IncomingNotice): string {
   return '/tabs/contacts'; // request
 }
 
-async function inAppSoundAndHaptics(): Promise<void> {
+async function inAppSound(): Promise<void> {
   const p = await ensurePrefs();
   if (p.inappSounds) {
     playTone(p.messageSound);
-  }
-  if (p.inappVibrate) {
-    try {
-      navigator.vibrate?.(40);
-    } catch {
-      /* unsupported */
-    }
   }
 }
 
@@ -432,7 +422,7 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
       // Viewing this chat while visible → still give a subtle sound (the user sees
       // the message inline). Every other suppress reason (muted / content=none /
       // in-app off / settle-swallowed) is fully silent.
-      if (n.chatId && n.chatId === activeChatId && appVisible()) await inAppSoundAndHaptics();
+      if (n.chatId && n.chatId === activeChatId && appVisible()) await inAppSound();
       return false;
     }
     if (owner === 'sw-notification') {
@@ -450,18 +440,23 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
       if (!n.pushWoken && (content !== 'none' || isMention)) {
         const showFull = content === 'full' && p.showPreview;
         const text = showFull ? n.body : isMention ? mentionBody : 'New message';
-        void notifyLocal(n.name, text, targetUrl(n), n.chatId);
+        // Preview off hides WHO it's from too, not just the body. A mention is an opt-in
+        // escalation and keeps naming the mentioner.
+        const title = p.showPreview || isMention ? n.name : 'Ring';
+        void notifyLocal(title, text, targetUrl(n), n.chatId);
       }
       return false;
     }
 
     // owner === 'page-banner': show the in-app banner/alert.
     const showFull = content === 'full' && p.showPreview;
-    await inAppSoundAndHaptics();
+    await inAppSound();
     if (p.inappStyle === 'none') return false; // sound only; no visible surface
     const url = targetUrl(n);
     const bodyText = showFull ? n.body : isMention ? mentionBody : 'New message';
-    const presented = await presentMessageBanner(n, bodyText, url, p.inappStyle);
+    // Preview off → the banner also drops the sender name + avatar (mention keeps the name).
+    const display = p.showPreview || isMention ? n : { ...n, name: 'Ring', avatar: '' };
+    const presented = await presentMessageBanner(display, bodyText, url, p.inappStyle);
     if (presented) notifyBannerPresented(); // tell the drain hand-off we claimed it
     return presented;
   }
@@ -488,7 +483,7 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
   // Visible: gated by the GLOBAL in-app master switch (FR-018; suppresses request
   // banners while leaving their web push intact).
   if (!(await inAppGloballyEnabled())) return false;
-  await inAppSoundAndHaptics();
+  await inAppSound();
   if (p.inappStyle === 'none') return false;
   const url = targetUrl(n);
   const bodyText = full ? n.body : '';

--- a/src/services/sw-inbox.preview.test.ts
+++ b/src/services/sw-inbox.preview.test.ts
@@ -1,0 +1,37 @@
+// Spec 1025 (US2): with the global "Show preview" off, a message notification must hide WHO it's
+// from too (a generic title), not just the body — in both a 1:1 and a group. Hidden-chat precedence
+// (covered in sw-inbox.hidden.test.ts) still wins regardless of this setting.
+import { describe, it, expect } from 'vitest';
+import { noteForPayload } from './sw-inbox';
+import type { Chat } from '@/db/types';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const frame = { id: 'm1', from: 'peer-1', t: 'msg', ciphertext: '' } as any;
+const dm = { text: 'secret plans' } as any;
+const groupMsg = (gid: string) => ({ text: 'secret plans', groupId: gid }) as any;
+const contacts = [{ id: 'peer-1', name: 'Peer One' }] as any;
+const oneToOne = (id: string): Chat =>
+  ({ id, name: 'Peer', isGroup: false, participantIds: ['peer-1'] }) as unknown as Chat;
+const group = (id: string): Chat =>
+  ({ id, name: 'Secret Team', isGroup: true, participantIds: ['peer-1', 'me'] }) as unknown as Chat;
+
+describe('noteForPayload — Show preview off (spec 1025 US2)', () => {
+  it('1:1: preview off → generic title AND body, no sender leak', () => {
+    const { note } = noteForPayload(frame, dm, [oneToOne('chat-1')], contacts, true, /* showPreview */ false);
+    expect(note!.title).toBe('Ring'); // sender hidden
+    expect(note!.body).toBe('New message'); // content hidden
+    expect(JSON.stringify(note)).not.toContain('Peer One');
+    expect(JSON.stringify(note)).not.toContain('secret plans');
+  });
+
+  it('group: preview off → generic title, does not reveal the group name', () => {
+    const { note } = noteForPayload(frame, groupMsg('chat-2'), [group('chat-2')], contacts, true, false);
+    expect(note!.title).toBe('Ring');
+    expect(JSON.stringify(note)).not.toContain('Secret Team');
+  });
+
+  it('preview on → sender / group name still shown (unchanged behaviour)', () => {
+    expect(noteForPayload(frame, dm, [oneToOne('c3')], contacts, true, true).note!.title).toBe('Peer One');
+    expect(noteForPayload(frame, groupMsg('c4'), [group('c4')], contacts, true, true).note!.title).toBe('Secret Team');
+  });
+});

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -249,10 +249,13 @@ export function noteForPayload(
   const showText = content === 'full' && showPreview;
   const preview = showText ? notifyPreview(payload) : 'New message';
   const chatId = chat?.id;
+  // "Show preview" off hides WHO it's from too, not just the body: use a generic title instead of
+  // the sender / group name. (Hidden chats and @mentions are handled above and keep their own rules.)
+  const title = showPreview ? (isGroup ? groupChat?.name || 'Group' : senderName) : 'Ring';
   return {
     note: {
       ids: [f.id as string],
-      title: isGroup ? groupChat?.name || 'Group' : senderName,
+      title,
       // Group previews prefix the sender (WhatsApp-style), but only when we know who
       // they are and full content is allowed, never the bare "Someone:" garble.
       body: isGroup && showText && known ? `${known}: ${preview}` : preview,

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -150,7 +150,7 @@ import { get, getAll, put, bulkPut } from '@/db/idb';
 import { initialsAvatar } from '@/db/avatars';
 import { uid } from '@/utils/uid';
 import { seedShowcase as runSeedShowcase } from '@/services/showcase-seed';
-import type { Chat, FriendRequest, Media, Message, Post, OutboxPost } from '@/db/types';
+import type { Call, Chat, FriendRequest, Media, Message, Post, OutboxPost } from '@/db/types';
 import {
   startDirectCall,
   startGroupCall,
@@ -791,6 +791,24 @@ export function installTestHook(): void {
     },
     /** Number of distinct active senders in a conversation (for group coalescing tests). */
     activityCount: (conversationKey: string): number => activityFor(conversationKey).length,
+
+    /** Spec 1025 (US6): seed a completed call-log record so the Calls tab can be checked (ISO
+     *  dates, usage totals). Dev-only. */
+    seedCall: async (opts: { video: boolean; durationSec: number; bytes?: number; ts: number; contactId?: string }): Promise<void> => {
+      await put<Call>('calls', {
+        id: uid(),
+        contactId: opts.contactId ?? 'seed-peer',
+        name: 'Seed Peer',
+        avatar: initialsAvatar('Seed Peer'),
+        direction: 'outgoing',
+        missed: false,
+        video: opts.video,
+        durationSec: opts.durationSec,
+        bytes: opts.bytes,
+        timestamp: opts.ts,
+        updatedAt: opts.ts,
+      });
+    },
 
     /* ---- media storage cleanup ---- */
     /** Seed a fake media blob + a message linking it (for storage tests). */

--- a/src/settings/schema.test.ts
+++ b/src/settings/schema.test.ts
@@ -52,3 +52,26 @@ describe('settings schema', () => {
     expect(searchSettings('chat backup')).toHaveLength(0);
   });
 });
+
+describe('settings schema — spec 1025 cleanup', () => {
+  it('has exactly one Animations entry (the duplicate was removed)', () => {
+    const anim = everyItem().filter((i) => 'title' in i && i.title === 'Animations');
+    expect(anim).toHaveLength(1);
+  });
+
+  it('has no in-app Vibrate toggle (a PWA no-op, removed)', () => {
+    const keys = new Set(
+      everyItem()
+        .filter((i): i is Extract<SettingItem, { key: string }> => 'key' in i)
+        .map((i) => i.key),
+    );
+    expect(keys.has('notifications.inapp.vibrate')).toBe(false);
+  });
+
+  it('Help version is no longer the stale hardcoded 0.1.0', () => {
+    const version = SETTINGS.help.groups
+      .flatMap((g) => g.items)
+      .find((i) => 'title' in i && i.title === 'Version');
+    expect(version && 'value' in version ? version.value : '').not.toBe('0.1.0');
+  });
+});

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -422,10 +422,6 @@ export const SETTINGS: Record<string, SettingNode> = {
     title: 'Chats',
     groups: [
       {
-        items: [{ type: 'link', id: 'chats-animations', title: 'Animations', icon: 'palette' }],
-        footer: 'Choose whether emoji and GIFs move automatically.',
-      },
-      {
         items: [{ type: 'toggle', title: 'Save to Photos', key: 'chats.saveToPhotos', default: false }],
         footer: 'Automatically save photos and videos you receive to your device.',
       },
@@ -607,7 +603,6 @@ export const SETTINGS: Record<string, SettingNode> = {
       {
         items: [
           { type: 'toggle', title: 'Sounds', key: 'notifications.inapp.sounds', default: false },
-          { type: 'toggle', title: 'Vibrate', key: 'notifications.inapp.vibrate', default: true },
         ],
       },
     ],
@@ -699,7 +694,9 @@ export const SETTINGS: Record<string, SettingNode> = {
     id: 'help',
     title: 'Help',
     groups: [
-      { items: [{ type: 'stat', title: 'Version', value: '0.1.0' }] },
+      // Vite replaces __APP_VERSION__ at build time; the typeof guard keeps it defined under vitest
+      // (which does not apply the build define), so importing the schema in a unit test never throws.
+      { items: [{ type: 'stat', title: 'Version', value: typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0' }] },
       {
         header: 'Developer',
         items: [{ type: 'route', title: 'Run self-test', path: '/settings/selftest', icon: 'shield' }],

--- a/src/utils/call-totals.test.ts
+++ b/src/utils/call-totals.test.ts
@@ -1,0 +1,54 @@
+// Spec 1025 (US6): the Calls-tab totals aggregation. Pure — grouped by the `video` flag, tolerant of
+// missing bytes/duration.
+import { describe, it, expect } from 'vitest';
+import { computeCallTotals } from './call-totals';
+import type { Call } from '@/db/types';
+
+const call = (over: Partial<Call>): Call => ({
+  id: 'c',
+  contactId: 'p',
+  name: 'Peer',
+  avatar: '',
+  direction: 'outgoing',
+  missed: false,
+  video: false,
+  timestamp: 0,
+  updatedAt: 0,
+  ...over,
+});
+
+describe('computeCallTotals', () => {
+  it('sums minutes and bytes grouped by audio vs video', () => {
+    const t = computeCallTotals([
+      call({ video: false, durationSec: 120, bytes: 1000 }), // 2 min audio
+      call({ video: false, durationSec: 180, bytes: 500 }), //  3 min audio
+      call({ video: true, durationSec: 600, bytes: 9000 }), // 10 min video
+    ]);
+    expect(t.audioMinutes).toBe(5);
+    expect(t.videoMinutes).toBe(10);
+    expect(t.audioBytes).toBe(1500);
+    expect(t.videoBytes).toBe(9000);
+    expect(t.combinedBytes).toBe(10500);
+  });
+
+  it('treats missing bytes as 0 but still counts duration', () => {
+    const t = computeCallTotals([
+      call({ video: false, durationSec: 60 }), // bytes missing → 0 bytes, 1 min
+      call({ video: true, durationSec: 0, bytes: undefined }), // 0 min, 0 bytes
+    ]);
+    expect(t.audioMinutes).toBe(1);
+    expect(t.audioBytes).toBe(0);
+    expect(t.videoMinutes).toBe(0);
+    expect(t.combinedBytes).toBe(0);
+  });
+
+  it('returns zeros for no calls', () => {
+    expect(computeCallTotals([])).toEqual({
+      audioMinutes: 0,
+      videoMinutes: 0,
+      audioBytes: 0,
+      videoBytes: 0,
+      combinedBytes: 0,
+    });
+  });
+});

--- a/src/utils/call-totals.ts
+++ b/src/utils/call-totals.ts
@@ -1,0 +1,41 @@
+/**
+ * Spec 1025 (US6): aggregate a set of on-device Call records into headline totals for the Calls tab
+ * — total audio minutes, total video minutes, and data used for audio, video, and combined. Pure
+ * (no IndexedDB), so it is unit-tested directly. A call missing `bytes` (old or interrupted)
+ * contributes 0 to the data totals but still contributes its duration to the minutes total; a
+ * missing/zero `durationSec` contributes 0 minutes.
+ */
+import type { Call } from '@/db/types';
+
+export interface CallTotals {
+  audioMinutes: number;
+  videoMinutes: number;
+  audioBytes: number;
+  videoBytes: number;
+  combinedBytes: number;
+}
+
+export function computeCallTotals(calls: Call[]): CallTotals {
+  let audioSec = 0;
+  let videoSec = 0;
+  let audioBytes = 0;
+  let videoBytes = 0;
+  for (const c of calls) {
+    const sec = c.durationSec ?? 0;
+    const bytes = c.bytes ?? 0;
+    if (c.video) {
+      videoSec += sec;
+      videoBytes += bytes;
+    } else {
+      audioSec += sec;
+      audioBytes += bytes;
+    }
+  }
+  return {
+    audioMinutes: Math.round(audioSec / 60),
+    videoMinutes: Math.round(videoSec / 60),
+    audioBytes,
+    videoBytes,
+    combinedBytes: audioBytes + videoBytes,
+  };
+}

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  formatTime, formatClock, sameDay, dayLabel, formatFull, formatStamp, formatDuration,
+  formatTime, formatClock, sameDay, dayLabel, formatFull, formatStamp, formatDuration, formatDay,
 } from './time';
 
 const DAY = 86_400_000;
@@ -70,5 +70,15 @@ describe('formatDuration', () => {
     expect(formatDuration(45)).toBe('45 sec');
     expect(formatDuration(90)).toBe('1:30');
     expect(formatDuration(612)).toBe('10:12');
+  });
+});
+
+describe('formatDay', () => {
+  it('formats a local calendar date as YYYY-MM-DD with zero padding', () => {
+    // Construct via local-time components so the assertion is timezone-independent.
+    const ts = new Date(2026, 5, 19, 14, 30).getTime(); // 2026-06-19 local
+    expect(formatDay(ts)).toBe('2026-06-19');
+    const jan = new Date(2026, 0, 3, 0, 5).getTime(); // 2026-01-03 local
+    expect(formatDay(jan)).toBe('2026-01-03');
   });
 });

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -46,6 +46,13 @@ export function dayLabel(ts: number): string {
   return new Date(ts).toLocaleDateString([], { month: 'long', day: 'numeric', year: 'numeric' });
 }
 
+/** ISO-style local calendar date, e.g. "2026-06-19" (used in the Calls list + detail). */
+export function formatDay(ts: number): string {
+  const d = new Date(ts);
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
 /** Full local date + time, e.g. "2026-06-04, 01:10" (used in the media viewer). */
 export function formatFull(ts: number): string {
   const d = new Date(ts);

--- a/src/views/detail/CallDetailPage.vue
+++ b/src/views/detail/CallDetailPage.vue
@@ -20,11 +20,12 @@
         </div>
 
         <ion-grid class="actions">
+          <!-- Spec 1025 US6: Video and Message swapped (Video takes Message's place). -->
           <ion-row>
             <ion-col>
-              <ion-button expand="block" fill="clear" @click="message">
-                <ion-icon slot="start" :icon="chatbubbleOutline" />
-                Message
+              <ion-button expand="block" fill="clear" @click="call('video')">
+                <ion-icon slot="start" :icon="videocamOutline" />
+                Video
               </ion-button>
             </ion-col>
             <ion-col>
@@ -34,9 +35,9 @@
               </ion-button>
             </ion-col>
             <ion-col>
-              <ion-button expand="block" fill="clear" @click="call('video')">
-                <ion-icon slot="start" :icon="videocamOutline" />
-                Video
+              <ion-button expand="block" fill="clear" @click="message">
+                <ion-icon slot="start" :icon="chatbubbleOutline" />
+                Message
               </ion-button>
             </ion-col>
           </ion-row>
@@ -60,7 +61,7 @@
             </p>
           </ion-label>
           <ion-note slot="end">
-            {{ formatTime(c.timestamp) }} · {{ formatClock(c.timestamp) }}
+            {{ formatDay(c.timestamp) }} · {{ formatClock(c.timestamp) }}
           </ion-note>
         </ion-item>
       </ion-list>
@@ -80,7 +81,7 @@ import { getContact, listCallsForContact, listChats } from '@/db/queries';
 import { startDirectCall } from '@/composables/useCall';
 import type { Call, Contact } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
-import { formatClock, formatDuration, formatTime } from '@/utils/time';
+import { formatClock, formatDuration, formatDay } from '@/utils/time';
 import { formatBytes } from '@/utils/bytes';
 
 const route = useRoute();

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1443,7 +1443,7 @@ const viewerItems = computed(() => {
     return {
       id: m.id,
       url: mi?.url ?? '', // '' until this item's window is resolved
-      thumb: mi?.stripUrl || mi?.posterUrl || m.posterData || mi?.url || '', // strip tier (spec 1014)
+      thumb: mi?.posterUrl || m.posterData || mi?.stripUrl || mi?.url || '', // large poster tier for the full-screen viewer (spec 1025 US4)
       kind: m.kind === 'video' ? 'video' : 'image',
       caption: m.body,
       senderName: m.outgoing ? 'You' : chat.value?.isGroup ? m.senderName : chat.value?.name ?? m.senderName,
@@ -5260,6 +5260,16 @@ function cancelRecording() {
 }
 .ttl-left ion-icon {
   font-size: 13px;
+}
+/* Spec 1025 US5: give the disappearing countdown clear separation from the timestamp. Outgoing keeps
+   it to the LEFT of the timestamp; incoming moves it to the RIGHT (order:1 places it after the
+   bare timestamp text node inside .time). */
+.msg-foot.out .ttl-left {
+  margin-right: 6px;
+}
+.msg-foot.in .ttl-left {
+  order: 1;
+  margin-left: 6px;
 }
 /* Direction-aware bottom row (spec 1008): the react button sits opposite the
    timestamp — sent → time+tick right / react left; received → time left / react

--- a/src/views/tabs/CallsPage.vue
+++ b/src/views/tabs/CallsPage.vue
@@ -30,6 +30,27 @@
         </ion-toolbar>
       </ion-header>
 
+      <!-- Usage totals (spec 1025 US6): minutes and data for audio, video, and combined. -->
+      <ion-list v-if="totalsCalls.length" :inset="true" class="call-totals">
+        <ion-list-header>
+          <ion-label>Totals</ion-label>
+        </ion-list-header>
+        <ion-item lines="none">
+          <ion-icon slot="start" :icon="callOutline" color="medium" />
+          <ion-label>Audio calls</ion-label>
+          <ion-note slot="end">{{ totals.audioMinutes }} min · {{ formatBytes(totals.audioBytes) }}</ion-note>
+        </ion-item>
+        <ion-item lines="none">
+          <ion-icon slot="start" :icon="videocamOutline" color="medium" />
+          <ion-label>Video calls</ion-label>
+          <ion-note slot="end">{{ totals.videoMinutes }} min · {{ formatBytes(totals.videoBytes) }}</ion-note>
+        </ion-item>
+        <ion-item lines="none">
+          <ion-label>Data used</ion-label>
+          <ion-note slot="end">{{ formatBytes(totals.combinedBytes) }}</ion-note>
+        </ion-item>
+      </ion-list>
+
       <ion-list>
         <ion-list-header>
           <ion-label>Recent</ion-label>
@@ -55,7 +76,7 @@
                 {{ typeLabel(group) }}
               </p>
             </ion-label>
-            <ion-note slot="end">{{ formatTime(group.timestamp) }}</ion-note>
+            <ion-note slot="end">{{ formatDay(group.timestamp) }}</ion-note>
             <ion-button
               slot="end"
               fill="clear"
@@ -151,12 +172,14 @@ import {
   addOutline, callOutline, videocamOutline, arrowUpOutline, arrowDownOutline,
   informationCircleOutline, trashOutline, peopleOutline,
 } from 'ionicons/icons';
-import { deleteCalls, listCallGroups, markCallsSeen, listContacts } from '@/db/queries';
+import { deleteCalls, listCallGroups, listCallsForTotals, markCallsSeen, listContacts } from '@/db/queries';
 import type { CallGroup } from '@/db/queries';
 import type { Call } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { warmCalls, warmCallsLoaded, warmWhenIdle } from '@/composables/warmStores';
-import { formatTime } from '@/utils/time';
+import { formatDay } from '@/utils/time';
+import { formatBytes } from '@/utils/bytes';
+import { computeCallTotals } from '@/utils/call-totals';
 
 const PAGE = 15;
 const router = useRouter();
@@ -178,6 +201,10 @@ const calls = useLiveQuery(
 const loaded = calls.loaded;
 watch(search, () => (visible.value = PAGE));
 const visibleCalls = computed(() => calls.value.slice(0, visible.value));
+
+// Usage totals (spec 1025 US6): all-time, over non-hidden calls, independent of the search filter.
+const totalsCalls = useLiveQuery(() => listCallsForTotals(), ['calls'], [] as Call[]);
+const totals = computed(() => computeCallTotals(totalsCalls.value));
 
 /* ---- New call modal ---- */
 const newOpen = ref(false);


### PR DESCRIPTION
## Summary

Spec 1025 — nine independent UX fixes found during real-device use. All client-side; the
zero-knowledge boundary is untouched (no new server data).

- **Notification deep-link back-nav (US1):** cold-starting from a tapped notification and pressing Back now lands on the Chats list, never a blank view (seeds Chats into history beneath the deep-link target).
- **Notification previews (US2):** with "Show preview" off, the sender/title is hidden too, not just the body, in both background and in-app notifications. Hidden chats stay generic regardless (precedence already enforced; now unit-tested).
- **Hidden-chat swipe (US3):** hidden rows use an opaque background, so swiping reveals the action buttons cleanly instead of them bleeding through.
- **Media viewer video poster (US4):** a video fills the viewer frame with its large poster + play control instead of a tiny thumbnail in blank space.
- **Disappearing countdown (US5):** more spacing from the timestamp, and it moves to the right of the timestamp on incoming messages.
- **Calls area (US6):** ISO `YYYY-MM-DD` dates, Video/Message buttons swapped, and a usage-totals summary (audio minutes, video minutes, data per kind and combined).
- **Settings cleanup (US7/US8/US9):** a single Animations entry that actually gates GIF autoplay; the dead in-app Vibrate toggle removed; the Help version shows the real app version (was a stale hardcoded `0.1.0`), self-test kept (it's a real crypto check).

## Testing
- `npm run build` (typecheck) + `npx vitest run` — **426 unit tests** pass (new: `formatDay`, `computeCallTotals`, preview-off title genericization, settings-cleanup guards).
- New `e2e/calls-summary.spec.ts` (ISO dates, swapped buttons, totals) via a `seedCall` hook — passes.
- Ran the high-risk existing e2e locally (notifications-inapp, media-viewer, hidden-chats, disappearing, chat-media, thumbnails, all-media-goto, media-cleanup) — **26 passed, no regressions**.
- `server` untouched.

Closes #567
Closes #568
Closes #569
Closes #570
Closes #571
Closes #572
Closes #573
Closes #574
Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)