### PR TITLE
feat: friends-only messaging with privacy, settings and help refinements (spec 1026)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1025-app-ux-polish/plan.md`
+`specs/1026-friends-only-and-settings-refinements/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,7 @@ Specs are grouped by category band; status moves
 | [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🔵 in-review |
 | [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
 | [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
+| [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/friends-only.spec.ts
+++ b/e2e/friends-only.spec.ts
@@ -11,19 +11,18 @@ const bodies = async (p: any, id: string): Promise<string[]> => {
 };
 
 /**
- * "Block unknown account messages" (privacy.blockUnknown): a message from someone
- * who is neither a contact nor an accepted connection is dropped while the toggle is
- * on. C is connected to A only server-side (a one-way link, as a group co-member
- * would be) but is NOT in A's contacts/connected ledger — i.e. "unknown" to A.
+ * Messaging is friends-only by design: a message from someone who is neither a contact
+ * nor an accepted connection is dropped. C is connected to A only server-side (a one-way
+ * link, as a group co-member would be) but is NOT in A's contacts/connected ledger — i.e.
+ * "unknown" to A — so A drops C's message until A connects with them. (Call signalling
+ * rides a separate path, so this never blocks adding a non-contact to a call.)
  */
-test('block unknown: drops a stranger’s message until the toggle is off', async ({ browser }) => {
+test('friends-only: drops a stranger’s message until A connects with them', async ({ browser }) => {
   test.setTimeout(60_000);
   const ctxA = await browser.newContext();
   const ctxC = await browser.newContext();
   const a = await createAccount(ctxA, 'BLKUNK1');
   const c = await createAccount(ctxC, 'BLKUNK2');
-
-  await ev(a, () => (window as any).__ringTest.setSetting('privacy.blockUnknown', true), null);
 
   // C reaches A server-side (link makes the bundle fetchable both ways) but A never
   // adds C, so C is "unknown" to A.
@@ -31,18 +30,18 @@ test('block unknown: drops a stranger’s message until the toggle is off', asyn
   await ev(c, (aid) => (window as any).__ringTest.importDirectoryUser(aid), a.id);
   const cChat = (await ev(c, (aid) => (window as any).__ringTest.startChat(aid), a.id)) as string;
   expect(cChat).toBeTruthy();
-  await ev(c, (id) => (window as any).__ringTest.sendChatMessage(id, 'blocked-msg'), cChat);
+  await ev(c, (id) => (window as any).__ringTest.sendChatMessage(id, 'stranger-msg'), cChat);
 
   // Give it time to (not) arrive, then assert A never stored it.
   await a.page.waitForTimeout(3000);
-  expect(await bodies(a, c.id)).not.toContain('blocked-msg');
+  expect(await bodies(a, c.id)).not.toContain('stranger-msg');
 
-  // Turn the block off; a new message now lands.
-  await ev(a, () => (window as any).__ringTest.setSetting('privacy.blockUnknown', false), null);
-  await ev(c, (id) => (window as any).__ringTest.sendChatMessage(id, 'allowed-msg'), cChat);
-  await expect.poll(() => bodies(a, c.id), { timeout: 30_000 }).toContain('allowed-msg');
+  // A connects with C (adds them). A new message from C now lands.
+  await ev(a, (cid) => (window as any).__ringTest.requestFriend(cid), c.id);
+  await ev(c, (id) => (window as any).__ringTest.sendChatMessage(id, 'friend-msg'), cChat);
+  await expect.poll(() => bodies(a, c.id), { timeout: 30_000 }).toContain('friend-msg');
   // The previously-blocked message stays gone (it was dropped, not just deferred).
-  expect(await bodies(a, c.id)).not.toContain('blocked-msg');
+  expect(await bodies(a, c.id)).not.toContain('stranger-msg');
 
   await ctxA.close();
   await ctxC.close();

--- a/specs/1026-friends-only-and-settings-refinements/checklists/requirements.md
+++ b/specs/1026-friends-only-and-settings-refinements/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Friends-only messaging with privacy, settings and help refinements
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Retroactive spec: the implementation already exists on this branch. Requirements were derived from
+  the shipped behavior, so acceptance scenarios map directly to existing/added tests.
+- The one genuine risk area (US1 must not break call setup for non-mutual contacts) is called out
+  explicitly in FR-004 / SC-002 and covered by the calling architecture (separate inbound path).
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`. All items
+  pass.

--- a/specs/1026-friends-only-and-settings-refinements/data-model.md
+++ b/specs/1026-friends-only-and-settings-refinements/data-model.md
@@ -1,0 +1,40 @@
+# Phase 1 Data Model: Friends-only messaging & settings refinements
+
+No new or altered IndexedDB object stores. No `DB_VERSION` bump. No server tables or migrations.
+
+The friends-only gate reads two **pre-existing** data structures; it introduces no fields:
+
+## Connection ledger (existing)
+
+- **Store/shape**: `settings` entry keyed `connectedPeers` → `Record<peerUserId, boolean>`.
+- **Meaning**: a peer present (and `true`) is an accepted connection whose direct messages are
+  delivered.
+- **Writers (existing)**: `markContactConnected` (on invite auto-connect, accepting a request,
+  `requestFriend`, and after a message from an already-passing sender).
+- **Reader (this feature)**: `isPeerConnected(from)` in `handleIncoming` — one half of the gate.
+
+## Contacts (existing)
+
+- **Store**: `contacts` object store (`Contact` records).
+- **Reader (this feature)**: `getContact(from)` in `handleIncoming` — the other half of the gate.
+- The gate is `deliver ⟺ getContact(from) !== undefined || isPeerConnected(from)`.
+
+## Settings keys (existing; changed membership only)
+
+- **Removed**: `privacy.blockUnknown` — deleted from the schema tree and from the `ownsync.ts`
+  synced-key allowlist. Any previously-stored value becomes inert.
+- **Relocated (unchanged value/semantics)**: `privacy.disableLinkPreviews` — moved from the removed
+  Advanced node onto the Privacy page; still synced; still gates sender-side link-preview generation.
+- **Added (content only, no persisted state)**: `help-*` schema nodes are static content; they store
+  nothing.
+
+## State transitions
+
+Inbound 1:1 message → `handleIncoming`:
+
+```
+unknown sender (not contact, not connected)  ──drop (ack; discarded)──▶  never stored
+known/connected sender                       ──deliver──▶  stored; sender marked connected
+```
+
+No other lifecycle changes.

--- a/specs/1026-friends-only-and-settings-refinements/plan.md
+++ b/specs/1026-friends-only-and-settings-refinements/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Friends-only messaging with privacy, settings and help refinements
+
+**Branch**: `feat/1026-friends-only-and-settings-refinements` | **Date**: 2026-07-02 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/1026-friends-only-and-settings-refinements/spec.md`
+
+## Summary
+
+Make direct (1:1) messaging friends-only by default and retire the redundant "Block unknown account
+messages" toggle, then clear several adjacent rough edges: a simpler Privacy screen, real in-app Help
+guides, a confirmation before resetting auto-download, an emoji that never renders as a broken image,
+and roomier settings captions. The approach is entirely client-side and additive to existing modules
+— no server, protocol, storage, or data-model changes. The single real risk (breaking call setup
+between participants who are not mutual contacts) is structurally avoided because call signalling
+travels a separate inbound path from direct messages.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES modules), Vue 3 `<script setup>` + Ionic; no Go/server changes.
+
+**Primary Dependencies**: Ionic components, existing IndexedDB layer (`src/db/idb.ts`), the
+declarative settings tree (`src/settings/schema.ts`), the message pipeline (`src/db/queries.ts` →
+`src/services/messaging.ts`), the call stack (`src/composables/useCall.ts`,
+`src/services/call/signalling.ts`), own-data sync (`src/services/ownsync.ts`).
+
+**Storage**: IndexedDB (no schema/`DB_VERSION` change; no new object store). The connection ledger
+(`connectedPeers`) and contacts store already exist.
+
+**Testing**: `npm run build` (vue-tsc typecheck), `npm run test:unit` (vitest), `npm run test:e2e`
+(Playwright, drives via `window.__ringTest`).
+
+**Target Platform**: Installable PWA (iOS/Android/desktop browsers).
+
+**Project Type**: Client-only change to the existing Vue 3 + Ionic PWA.
+
+**Performance Goals**: No new hot paths; the gate is one extra IndexedDB lookup per inbound 1:1
+message (contact/ledger reads already happen immediately after).
+
+**Constraints**: Offline-first; zero-knowledge boundary intact; Ionic-first UI (Principle XI);
+settings changes are data edits to `schema.ts`, not new components.
+
+**Scale/Scope**: 6 independent slices; ~5 client files touched + 1 e2e spec reworked + new how-to
+content nodes; no migrations.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0 and again after Phase 1.*
+
+- **I. Zero-Knowledge Boundary (NON-NEGOTIABLE)**: PASS. No plaintext crosses the boundary; no new
+  server-visible metadata; no new server capability. See the spec's Zero-Knowledge Impact section.
+- **II. Spec-Driven Development**: PASS. This spec is being created and taken through the full pipeline
+  (specify → clarify → plan → tasks → analyze → taskstoissues → implement). Branch/commits/issues will
+  be traceable to spec 1026.
+- **III. Test-Driven Development**: PARTIAL → addressed in tasks. Changed store logic (the
+  friends-only gate in `queries.ts`) and changed user-facing behavior require coverage: the e2e spec
+  is reworked (`e2e/friends-only.spec.ts`), and unit coverage for the emoji fallback and link-preview
+  gating is added/verified in `tasks.md`. (Retroactive note: implementation preceded some tests; the
+  tasks list backfills them so the suite proves every user story.)
+- **IV. Crypto Discipline**: PASS (N/A). No crypto primitives or ratchet logic change; the gate acts
+  on an already-decrypted inbound payload. No new sealed formats are introduced.
+- **V. Offline-First Data Integrity**: PASS. No object store added/altered; no `DB_VERSION` bump.
+- **VI. Stateless Server & Forward-Only Migrations**: PASS. No server or migration changes.
+- **VII. Quality Gates Are the Definition of Done**: PASS (planned). Typecheck + unit + e2e green
+  before done; user-facing commit subjects written as plain-language release notes.
+- **VIII. Traceable, Auto-Closing Delivery**: PASS (planned). One issue per task; the feature→develop
+  PR will list `Closes #N` for each.
+- **IX. Privacy & Data Minimization**: PASS. Net privacy improvement (unsolicited DMs blocked by
+  default); a settings key is removed from sync (less synced data).
+- **X. Accessibility & i18n**: PASS. Help content and settings rows use stock Ionic list items with
+  wrapping text; bidi rendering unchanged.
+- **XI. Ionic-First UI**: PASS. Help how-tos and the moved toggle are data edits to `schema.ts`
+  rendered by the existing `SettingDetailPage.vue`; the only CSS is a scoped padding variable.
+
+**Result**: No unjustified gate violations. Proceed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1026-friends-only-and-settings-refinements/
+├── spec.md              # Feature spec (with Clarifications + Zero-Knowledge Impact)
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Spec-quality checklist
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root) — files touched
+
+```text
+src/db/queries.ts                       # US1: unconditional friends-only gate in handleIncoming
+src/settings/schema.ts                  # US2/US3/US4: remove Advanced+blockUnknown, move
+                                        #   link-preview, add help-* how-to nodes, add confirm to
+                                        #   reset-autodownload
+src/services/ownsync.ts                 # US2: drop privacy.blockUnknown from synced key allowlist
+src/components/Emoji.vue                 # US5: native-glyph fallback when no image asset / no FE0F
+src/views/detail/SettingDetailPage.vue  # US6: scoped --inner-padding-bottom for captions/notes
+e2e/friends-only.spec.ts                # US1: reworked from e2e/block-unknown.spec.ts
+```
+
+No changes under `server/`.
+
+## Complexity Tracking
+
+No constitution gate violations requiring justification. The change deliberately avoids new
+components (settings-as-data), new stores, and any server surface, keeping complexity flat.
+
+## Phase 0 / Phase 1 outputs
+
+- `research.md` — the key design questions and how the implementation answers them (chiefly: why the
+  friends-only gate cannot break calls).
+- `data-model.md` — the (pre-existing) entities the gate reads; confirms no new/changed stores.
+- `quickstart.md` — how to manually verify each user story.

--- a/specs/1026-friends-only-and-settings-refinements/quickstart.md
+++ b/specs/1026-friends-only-and-settings-refinements/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: verifying spec 1026
+
+Prereqs: `make start` (dev stack) for manual UI checks; `npm run test:unit` and
+`npm run test:e2e` for automated coverage.
+
+## US1 — Friends-only messaging
+
+Automated: `npm run test:e2e -- friends-only` — a stranger's DM is dropped until the recipient
+connects, then a new message lands (and the dropped one stays gone).
+
+Manual (via `drive/` or two dev accounts):
+1. Create accounts A and B; do NOT connect them.
+2. From B, start a chat with A and send a message → A never sees it.
+3. From A, add/connect B (Contacts → add, or accept a request) → a new message from B now appears.
+4. Calls unaffected: start a group call from A including a non-contact of the other participant →
+   all legs connect.
+
+## US2 — Simpler Privacy screen
+
+1. Settings → Privacy → confirm there is no "Advanced" row and no "Block unknown account messages".
+2. Confirm "Disable link previews" is directly on the Privacy page.
+3. Turn it on, share a URL in a chat → no rich preview is generated.
+
+## US3 — Help guides
+
+1. Settings → Help → confirm the how-to topics are listed (privacy, getting started, adding people,
+   chats & groups, disappearing messages, hidden chats & app lock, calls, recovery key).
+2. Open any topic → readable guidance shows.
+3. Confirm no version line on Help; version still on Settings → About.
+4. Confirm "Run self-test" is still present under Developer.
+
+## US4 — Confirm auto-download reset
+
+1. Settings → Storage and data → tap "Reset auto-download settings".
+2. A confirmation prompt appears; Cancel leaves settings unchanged; Confirm restores defaults.
+
+## US5 — Emoji fallback
+
+1. React to a message with an emoji that has no bundled asset (a very new emoji).
+2. Confirm the native glyph shows — never a persistent broken-image "?" box.
+
+Automated (unit): `Emoji.vue` — on image error with no variation selector, it renders the native
+glyph (no stuck broken image).
+
+## US6 — Caption spacing
+
+1. Open a settings screen with a multi-line group caption (e.g. Privacy → Seen receipts caption).
+2. Confirm visible spacing between the last line and the card's bottom edge.
+
+## Full gate before "done"
+
+```sh
+npm run build        # typecheck
+npm run test:unit    # vitest
+npm run test:e2e     # Playwright (needs make db-up)
+```

--- a/specs/1026-friends-only-and-settings-refinements/research.md
+++ b/specs/1026-friends-only-and-settings-refinements/research.md
@@ -1,0 +1,72 @@
+# Phase 0 Research: Friends-only messaging & settings refinements
+
+## R1 — Will a friends-only message gate break group calls between non-mutual contacts?
+
+**Decision**: No. Place the gate on the direct-message receive path only; leave call signalling
+untouched. This is safe because the two are already separate inbound paths.
+
+**Rationale**:
+- Inbound WebSocket frames are dispatched by type in `src/services/sync.ts::handleIncomingFrame`:
+  `'msg'` → `receiveIncoming` → `handleIncoming` (the gated path); `call-offer/answer/ice/...` →
+  `useCall.handleCallFrame` (a separate path).
+- Group calls mesh between every pair of participants. Two co-invitees who are not each other's
+  contacts have no 1:1 ratchet, so `src/services/call/signalling.ts::meshSessionChatId` bootstraps an
+  **ephemeral, call-scoped** Double-Ratchet session (`callsess:` prefix) with no contact row and no
+  chat-list entry, torn down when the call ends. The server permits the prekey fetch only for the
+  shared call room.
+- Therefore call setup never flows through `handleIncoming`, and a message gate there cannot drop it.
+
+**Alternatives considered**:
+- Gate at a shared choke point below both paths → rejected: would drop call signalling for
+  non-contacts and break the documented mesh behavior.
+- Server-side enforcement → impossible under the zero-knowledge boundary (the server can't read who
+  is whose contact) and rejected on principle.
+
+**Evidence**: `sync.ts:123` (`'msg'`), `sync.ts:133-155` (`call-*` → `handleCallFrame`),
+`signalling.ts:22-45` (ephemeral `callsess:` sessions), `queries.ts` `handleIncoming` gate.
+
+## R2 — Is the removed "Block unknown" toggle truly redundant?
+
+**Decision**: Yes. Making its behavior the unconditional default removes the toggle without losing a
+capability.
+
+**Rationale**: The toggle only ever wrapped exactly the check we now always run
+(`!getContact(from) && !isPeerConnected(from) → drop`). With friends-only as the default, the toggle
+would be a permanent no-op if left in place.
+
+**Alternatives considered**: Keep the toggle defaulted-on → rejected as confusing dead UI.
+
+## R3 — Is "Disable link previews" actually wired before we promote it?
+
+**Decision**: Yes — it is safe to surface on the Privacy page.
+
+**Rationale**: `src/db/queries.ts` gates preview generation on
+`getSetting('privacy.disableLinkPreviews')` before calling `attachLinkPreview` (the sender's device
+builds previews; when the setting is on, none are built). Confirmed wired end-to-end.
+
+## R4 — How should Help how-tos be built given Ionic-First (Principle XI)?
+
+**Decision**: Author each guide as a schema node of static `note` items in
+`src/settings/schema.ts`, linked from the Help node and rendered by the existing
+`SettingDetailPage.vue`. No new component.
+
+**Rationale**: The settings tree is the sanctioned way to add screens (data edit, not code). `note`
+items already render as wrapped paragraphs; `link` items already navigate to nodes by id, and the
+flat settings search index picks up the new topics for free.
+
+**Alternatives considered**: A bespoke Help/article Vue component → rejected under Principle XI (would
+be new non-Ionic UI for content the schema renders natively).
+
+## R5 — Root cause of the broken-image "?" emoji
+
+**Decision**: In `Emoji.vue`, only take the "retry without the FE0F variation selector" step when the
+emoji actually contains an FE0F; otherwise skip straight to the native glyph.
+
+**Rationale**: For an emoji with no FE0F, dropping FE0F yields an identical image URL, so the browser
+never refetches, the second `error` never fires, the attempt counter sticks below the native-fallback
+threshold, and the broken-image placeholder stays forever. Guarding the retry on the presence of a
+variation selector guarantees the native-glyph fallback is always reached.
+
+## Open questions
+
+None. All Technical Context items are resolved; the retroactive implementation confirms each decision.

--- a/specs/1026-friends-only-and-settings-refinements/spec.md
+++ b/specs/1026-friends-only-and-settings-refinements/spec.md
@@ -1,0 +1,269 @@
+# Feature Specification: Friends-only messaging with privacy, settings and help refinements
+
+**Feature Branch**: `feat/1026-friends-only-and-settings-refinements`
+
+**Created**: 2026-07-02
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: a batch of privacy, settings, help, and rendering refinements found
+during real-device use — headlined by making direct messaging friends-only, plus a simpler Privacy
+screen, real in-app Help guides, a confirmation before resetting auto-download, a reliable emoji
+fallback, and roomier settings captions.
+
+## Overview
+
+Ring previously ran an "open in-network inbox": because the network is invitation-only, any member
+could message any other member, and a stranger's first message was accepted and auto-added. Feedback
+from real use showed people expect direct messages to come only from those they've chosen to connect
+with. This batch makes **direct messaging friends-only by default** and folds the old, redundant
+"Block unknown account messages" toggle into that default. Alongside the messaging change, it clears
+several rough edges surfaced in the same pass: a simpler Privacy screen, a genuinely useful Help
+section, a guard on a destructive-feeling reset, an emoji that always renders, and captions that
+don't crowd their card edge.
+
+Each item is an independent slice: any one can be built, tested, and shipped on its own. All changes
+stay within Ring's zero-knowledge boundary — the server keeps relaying only sealed ciphertext and
+content-free tickles, and there are **no server changes**. The friends-only gate is enforced entirely
+on the recipient's device.
+
+## Clarifications
+
+### Session 2026-07-02
+
+Resolved from the shipped implementation (retroactive spec):
+
+- Q: Does the friends-only gate apply to group messages too, or only 1:1 direct messages? → A: Only 1:1 direct messages. Group messaging is governed by group membership and is unaffected; the gate lives on the direct-message receive path only.
+- Q: What happens to users who had "Block unknown account messages" turned on/off before this change? → A: The setting and its key are removed. Because friends-only is now the always-on default, users who had it ON keep identical behavior; users who had it OFF now get friends-only (the intended change). No migration step is required.
+- Q: When an unknown sender's message is dropped, is it deferred or discarded? → A: Discarded — it is acknowledged to the relay so it is not redelivered (see FR-002); it does not reappear if the recipient later connects.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Direct messages come only from people you've connected with (Priority: P1)
+
+A member of the network who is not in the user's contacts and has not been accepted as a connection
+tries to send the user a direct message. The user never sees it — the message is dropped on their
+device on arrival, not merely hidden. To reach the user, that person must first connect through the
+existing request/invite flow; once the user has connected with them, their messages are delivered
+normally. Crucially, this must **not** interfere with calls: the user can add someone who is not a
+mutual contact to a (group) call and the call still connects for everyone.
+
+**Why this priority**: This is the headline behavior change and a privacy expectation. It also
+carries the sharpest risk of collateral damage (breaking call setup between non-mutual-contact
+participants), so it must be both correct and provably scoped to messaging only.
+
+**Independent Test**: With two accounts where the recipient has never connected with the sender, send
+a direct message and confirm it never appears for the recipient; then connect and confirm a new
+message arrives. Separately, start a group call including a non-contact participant and confirm the
+call connects.
+
+**Acceptance Scenarios**:
+
+1. **Given** the sender is neither a contact nor an accepted connection of the recipient, **When** the sender sends a direct message, **Then** the recipient never sees or stores it.
+2. **Given** a message was dropped because the sender was unknown, **When** time passes and the connection state is unchanged, **Then** the message stays gone (it was dropped, not deferred for later delivery).
+3. **Given** the recipient then connects with the sender, **When** the sender sends a new message, **Then** the recipient receives it.
+4. **Given** a sender who is an accepted connection, **When** they send a message, **Then** it is delivered even if their contact card has not arrived yet.
+5. **Given** the user invites someone into a group call who is not their contact (and not a contact of the other participants), **When** the call is placed, **Then** all legs connect and media flows.
+6. **Given** any user, **When** someone wants to reach them for the first time, **Then** a connection request still reaches them (requests travel outside the direct-message path).
+
+---
+
+### User Story 2 - A simpler Privacy screen (Priority: P2)
+
+The user opens Privacy settings. There is no separate "Advanced" sub-page to dig into. The redundant
+"Block unknown account messages" control is gone (its protection is now always on). The one control
+that lived there and still has meaning — turning off link previews — sits directly on the Privacy
+page where it's easy to find.
+
+**Why this priority**: The Advanced page existed almost entirely to house a toggle that is now the
+default; leaving it would present a confusing no-op. Surfacing the remaining, working control removes
+a dead end.
+
+**Independent Test**: Open Privacy and confirm there is no "Advanced" entry, no "Block unknown"
+toggle, and a working "Disable link previews" control is directly present. Toggle it on and confirm
+shared links no longer produce a rich preview.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Privacy screen, **When** the user views it, **Then** no "Advanced" entry and no "Block unknown account messages" toggle are shown.
+2. **Given** the Privacy screen, **When** the user looks for the link-preview control, **Then** "Disable link previews" is present directly on the page.
+3. **Given** "Disable link previews" is on, **When** the user shares a URL, **Then** no rich link preview is generated for it.
+4. **Given** the removed toggle, **When** settings sync across the user's devices, **Then** the obsolete key is not part of the synced set.
+
+---
+
+### User Story 3 - Help that actually helps (Priority: P2)
+
+The user opens Help and finds short, plain-language guides that explain how Ring works: how chats
+stay private, how to get started, how to add people, how chats and groups work, disappearing
+messages, hidden chats and app lock, calls, and the recovery key. The app version is not repeated
+here (it lives on About), and the developer self-test is still available.
+
+**Why this priority**: The old Help screen showed only a (visually broken) duplicate of the version
+plus a developer button — it did not help anyone. Real guidance is valuable as Ring approaches wider
+use.
+
+**Independent Test**: Open Help and confirm it lists the how-to topics, opening each shows readable
+guidance, the version is not shown, and the self-test is still reachable.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Help screen, **When** the user views it, **Then** it lists how-to guides covering privacy/encryption, getting started, adding people, chats and groups, disappearing messages, hidden chats and app lock, calls, and the recovery key.
+2. **Given** a how-to topic, **When** the user opens it, **Then** readable, plain-language guidance is shown.
+3. **Given** the Help screen, **When** the user looks for the app version, **Then** it is not shown on Help (it appears on About).
+4. **Given** the Help screen, **When** a developer wants to validate the build, **Then** the on-device self-test is still reachable.
+
+---
+
+### User Story 4 - Confirm before resetting auto-download (Priority: P3)
+
+In Storage and data settings, the user taps "Reset auto-download settings". Instead of instantly
+wiping their choices, the app asks them to confirm; only on confirmation are the defaults restored.
+
+**Why this priority**: It's a one-tap action that silently discards a set of preferences. A
+confirmation prevents accidental loss with minimal friction.
+
+**Independent Test**: Tap "Reset auto-download settings" and confirm a confirmation prompt appears;
+cancel and verify nothing changed; confirm and verify defaults are restored.
+
+**Acceptance Scenarios**:
+
+1. **Given** custom auto-download choices, **When** the user taps "Reset auto-download settings", **Then** a confirmation prompt appears before anything changes.
+2. **Given** the confirmation prompt, **When** the user cancels, **Then** their auto-download choices are unchanged.
+3. **Given** the confirmation prompt, **When** the user confirms, **Then** the auto-download settings return to their defaults.
+
+---
+
+### User Story 5 - Emoji always render (Priority: P3)
+
+An emoji that has no bundled image asset (for example a very new emoji) shows the device's own emoji
+glyph instead of a broken-image placeholder. This is most visible on message reactions, where the
+placeholder previously appeared as a "?" box.
+
+**Why this priority**: A broken-image "?" in place of an emoji looks like a bug and undermines trust,
+even though it's cosmetic.
+
+**Independent Test**: React with (or send) an emoji that has no image asset and confirm the native
+glyph is shown, never a persistent broken-image placeholder.
+
+**Acceptance Scenarios**:
+
+1. **Given** an emoji with no available image asset, **When** it is displayed, **Then** the device's native emoji glyph is shown.
+2. **Given** such an emoji, **When** it is displayed, **Then** a broken-image placeholder is never left on screen.
+
+---
+
+### User Story 6 - Settings captions get room to breathe and stay readable (Priority: P3)
+
+On settings screens, the explanatory caption beneath a group and the standalone note paragraphs have
+a little space below the text so they no longer sit flush against the rounded bottom edge of their
+card, and they use a text colour with enough contrast to read comfortably on both the light and dark
+themes.
+
+**Why this priority**: Purely visual polish, but text crowding the border reads as unfinished, and the
+dim default description colour was genuinely hard to read.
+
+**Independent Test**: View a settings screen whose group has a multi-line caption and confirm there is
+visible spacing between the last line and the card's bottom edge, and that the caption is easy to read
+in both light and dark mode.
+
+**Acceptance Scenarios**:
+
+1. **Given** a settings group with a multi-line caption, **When** it is displayed, **Then** there is visible spacing between the last line of the caption and the bottom edge of the card.
+2. **Given** the light or the dark theme, **When** a caption or help paragraph is displayed, **Then** its text is comfortably readable (clearly higher contrast than the previous dim default).
+
+---
+
+### Edge Cases
+
+- A person who shares a group with the user but is not a contact and not connected: their **direct**
+  message is dropped (they must connect first); the group conversation is unaffected.
+- A sender who is an accepted connection but whose contact row has not been created yet (e.g. invite
+  auto-connect before the profile card lands): their message is delivered and the contact row is
+  created on receipt.
+- A message dropped as "unknown" is acknowledged so the relay stops holding it — it does not silently
+  reappear after a later, unrelated connection.
+- An emoji without a variation selector and no image asset: still resolves to the native glyph rather
+  than looping on an identical failed image request.
+- Turning off link previews mid-session: URLs shared afterward produce no preview.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Friends-only messaging (US1)**
+
+- **FR-001**: The system MUST drop an inbound direct (1:1) message whose sender is neither an existing contact nor an accepted connection, so the recipient never sees or stores it.
+- **FR-002**: A message dropped under FR-001 MUST be acknowledged to the relay so it is not redelivered later (dropped, not deferred).
+- **FR-003**: After the recipient connects with a previously-unknown sender (adds them, accepts their request, or auto-connects via invite), subsequent messages from that sender MUST be delivered.
+- **FR-004**: The friends-only gate MUST apply only to the direct-message path and MUST NOT affect call signalling; a user MUST be able to join or add a non-contact participant to a call and exchange call setup with them.
+- **FR-005**: First-contact connection requests (friend requests and invites) MUST continue to reach recipients, as they travel over a channel separate from the gated direct-message path.
+
+**Simplified Privacy settings (US2)**
+
+- **FR-006**: The Privacy settings MUST NOT present an "Advanced" sub-page.
+- **FR-007**: The "Block unknown account messages" toggle MUST be removed; its former behavior is now the always-on default (see FR-001).
+- **FR-008**: "Disable link previews" MUST be presented as a control directly on the Privacy page.
+- **FR-009**: When "Disable link previews" is enabled, the sender's device MUST NOT generate a link preview for shared URLs.
+- **FR-010**: The obsolete "Block unknown" setting key MUST NOT be included in cross-device settings sync.
+
+**Help guides (US3)**
+
+- **FR-011**: The Help screen MUST present plain-language how-to guides covering, at minimum: how chats stay private (encryption), getting started, adding people, chats and groups, disappearing messages, hidden chats and app lock, calls, and the recovery key.
+- **FR-012**: The Help screen MUST NOT display the app version (it is shown on the About screen).
+- **FR-013**: The on-device developer self-test MUST remain reachable from Help.
+
+**Confirm auto-download reset (US4)**
+
+- **FR-014**: Resetting auto-download settings MUST require explicit user confirmation before the defaults are applied; cancelling MUST leave settings unchanged.
+
+**Reliable emoji rendering (US5)**
+
+- **FR-015**: An emoji with no available image asset MUST fall back to the device's native glyph and MUST NOT leave a persistent broken-image placeholder on screen.
+
+**Settings caption spacing and readability (US6)**
+
+- **FR-016**: Multi-line group captions and standalone note paragraphs on settings screens MUST have visible spacing below the text so they do not sit flush against the card's bottom edge.
+- **FR-017**: Setting captions and help paragraphs MUST use a text colour with enough contrast to read comfortably on both the light and dark themes.
+- **FR-018**: User-facing copy across these screens (Help guides, settings captions, confirmations) MUST read in Ring's plain, warm voice and MUST NOT use em-dashes or semicolons. The About screen header reads "Made with love for privacy" (the footer already credits the maker).
+
+### Key Entities
+
+- **Connection ledger**: the per-device record of which peers the user has accepted a connection with; it, together with the contacts list, determines whether an inbound direct message is delivered or dropped.
+- **Settings tree**: the declarative hierarchy that renders the Privacy and Help screens; the changes here are edits to this tree (removed Advanced node, moved link-preview control, added Help how-to nodes).
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: 100% of direct messages from senders the recipient has not connected with are kept off the recipient's device.
+- **SC-002**: A user can add a non-contact to a group call and the call connects for all participants, even though those participants cannot send each other direct messages.
+- **SC-003**: The Privacy screen shows no "Advanced" entry, and the link-preview control is reachable in a single step from the Privacy screen.
+- **SC-004**: Help offers at least 8 how-to topics, and the app version appears in exactly one place in Settings (About).
+- **SC-005**: Resetting auto-download never changes any setting without an intervening confirmation step.
+- **SC-006**: No emoji is ever left showing a broken-image placeholder.
+- **SC-007**: Setting captions and help paragraphs are readable on both themes and contain no em-dashes or semicolons.
+
+## Zero-Knowledge Impact
+
+- **What plaintext, if any, is involved and where is it encrypted?** No new plaintext crosses the
+  client/server boundary. Messages, link previews, and call setup remain end-to-end encrypted exactly
+  as before. The friends-only decision is made on the recipient's already-decrypted inbound message,
+  entirely on-device.
+- **What new metadata (if any) does the server see?** None. The relay continues to forward opaque
+  sealed frames and content-free tickles; it cannot tell an accepted message from a dropped one (the
+  recipient still acks the frame either way, so queue behavior is unchanged from the server's view).
+- **Does the server gain any new capability?** No. There are no server, protocol, or API changes; the
+  gate cannot be and is not enforced server-side.
+- **Settings sync**: the removed `privacy.blockUnknown` key simply leaves the client-encrypted
+  own-data snapshot; that snapshot is sealed under the master key as before, so nothing new is exposed.
+
+## Assumptions
+
+- "Connected" means the peer is in the user's contacts or in the accepted-connection ledger; both invite auto-connect and accepting a friend request establish this.
+- The change is client-side only; the zero-knowledge server cannot and does not enforce the gate, and no server or protocol change is introduced.
+- "Native glyph" refers to the emoji rendering the user's own platform provides; devices without a glyph for a brand-new emoji will show their own platform placeholder, which is outside Ring's control.
+- Existing conversations with people the user has already messaged are unaffected, because those peers are already recorded as connected.

--- a/specs/1026-friends-only-and-settings-refinements/tasks.md
+++ b/specs/1026-friends-only-and-settings-refinements/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Friends-only messaging with privacy, settings and help refinements
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Branch**: `feat/1026-friends-only-and-settings-refinements`
+
+Retroactive spec: the implementation already exists on this branch. Tasks marked `[X]` are the
+already-landed change for that slice; tasks left `[ ]` are the test backfill / verification needed so
+every user story is proven green before the spec is "done" (Constitution III). No server tasks.
+
+Vitest runs in a **node** environment (no DOM / `@vue/test-utils`), so component-level tests are done
+by extracting pure decision helpers and testing those.
+
+## GitHub issues (spec-1026 label)
+
+Task → issue mapping (repo `zuptalo/ring`). The feature→`develop` PR MUST list every one as
+`Closes #N`.
+
+| Task | Issue | Task | Issue |
+|------|-------|------|-------|
+| T001 | #592 | T009 | #588 |
+| T002 | #583 | T010 | #589 |
+| T003 | #584 | T011 | #579 |
+| T004 | #577 | T012 | #590 |
+| T005 | #585 | T013 | #591 |
+| T006 | #586 | T014 | #581 |
+| T007 | #578 | T015 | #582 |
+| T008 | #587 | T016 | #580 |
+
+PR closing line:
+`Closes #577, #578, #579, #580, #581, #582, #583, #584, #585, #586, #587, #588, #589, #590, #591, #592`
+
+## Phase 1: Setup
+
+- [X] T001 Create spec 1026 and pipeline artifacts (spec.md, clarify, plan.md, research.md, data-model.md, quickstart.md, checklists/requirements.md) under `specs/1026-friends-only-and-settings-refinements/`
+
+## Phase 2: Foundational
+
+_None — no shared prerequisites; each user story is an independent slice._
+
+## Phase 3: User Story 1 — Direct messages come only from people you've connected with (P1) 🎯 MVP
+
+**Goal**: Drop inbound 1:1 messages from non-connected senders on-device; keep calls unaffected.
+**Independent test**: `npm run test:e2e -- friends-only` (stranger DM dropped until connected).
+
+- [X] T002 [US1] Make the friends-only gate unconditional in `handleIncoming` (`src/db/queries.ts`): drop when the sender is neither `getContact(from)` nor `isPeerConnected(from)`; remove the old "open in-network inbox" auto-add path and update the stale comment.
+- [X] T003 [US1] Rework the e2e spec from `e2e/block-unknown.spec.ts` → `e2e/friends-only.spec.ts`: assert a stranger's DM is dropped by default, is delivered after the recipient connects (`requestFriend`), and the dropped one stays gone.
+- [X] T004 [US1] Verify the gate cannot break calls: confirm `call-*` frames route via `src/services/sync.ts` → `useCall.handleCallFrame` and use `src/services/call/signalling.ts::meshSessionChatId` (ephemeral `callsess:` session for non-contacts). Confirm existing group-call e2e still passes with a non-contact participant; record the finding in `research.md` (done) and quickstart.
+
+## Phase 4: User Story 2 — A simpler Privacy screen (P2)
+
+**Goal**: Remove the Advanced sub-page + redundant toggle; surface "Disable link previews" on Privacy.
+**Independent test**: Privacy shows no Advanced / no Block-unknown; link-preview control present and it suppresses previews.
+
+- [X] T005 [US2] In `src/settings/schema.ts`: delete the `privacy-advanced` node and its link; move the `privacy.disableLinkPreviews` toggle (with its footer) directly onto the `privacy` page.
+- [X] T006 [US2] Remove `privacy.blockUnknown` from the synced-key allowlist in `src/services/ownsync.ts`.
+- [X] T007 [US2] Cover FR-009 (link previews suppressed when the setting is on): add a vitest unit test for `firstLink` URL detection in `src/services/link-preview.test.ts`, and assert the gating decision (`firstLink(body) && !disableLinkPreviews`) — extract a tiny pure predicate if needed so it is testable in the node env. Document any part left to the quickstart/manual check.
+
+## Phase 5: User Story 3 — Help that actually helps (P2)
+
+**Goal**: Replace the near-empty Help screen with plain-language how-to guides; drop the duplicated version; keep the self-test.
+**Independent test**: Help lists ≥8 how-to topics, each opens to readable text, no version shown, self-test reachable.
+
+- [X] T008 [US3] In `src/settings/schema.ts`: rewrite the `help` node (remove the version stat, add a "How Ring works" group linking `help-*` how-to nodes, keep the Developer → self-test route) and add the `help-privacy`, `help-getting-started`, `help-contacts`, `help-chats`, `help-disappearing`, `help-hidden`, `help-calls`, `help-recovery` content nodes as `note` paragraphs.
+
+## Phase 6: User Story 4 — Confirm before resetting auto-download (P3)
+
+**Goal**: Require confirmation before restoring auto-download defaults.
+**Independent test**: Reset prompts; cancel = no change; confirm = defaults restored.
+
+- [X] T009 [US4] Add a `confirm` string to the `reset-autodownload` action in `src/settings/schema.ts` (the existing `runAction` confirm flow presents Cancel/Confirm).
+
+## Phase 7: User Story 5 — Emoji always render (P3)
+
+**Goal**: No persistent broken-image placeholder; fall back to the native glyph.
+**Independent test**: An emoji with no asset renders the native glyph.
+
+- [X] T010 [US5] Fix `src/components/Emoji.vue`: only advance to the FE0F-less retry when a variation selector is present; otherwise jump straight to the native-glyph fallback.
+- [X] T011 [US5] Extract the fallback decision into a pure helper in `src/utils/emoji.ts` (e.g. `nextEmojiAttempt(emoji, attempt)` / `emojiUsesImage(...)`), use it from `Emoji.vue`, and add a vitest unit test in `src/utils/emoji.test.ts` covering: no-FE0F asset failure → native glyph (never stuck), and FE0F present → retry then native.
+
+## Phase 8: User Story 6 — Settings captions get room to breathe (P3)
+
+**Goal**: Multi-line captions/notes don't sit flush against the card's bottom edge.
+**Independent test**: Visible spacing under a multi-line caption.
+
+- [X] T012 [US6] Add a scoped style in `src/views/detail/SettingDetailPage.vue` giving `.group-footer` and `.group-note` a `--inner-padding-bottom`; tag the footer/note `ion-item`s with those classes.
+
+## Phase 9: Polish & Cross-Cutting
+
+- [X] T016 Add `src/settings/schema.test.ts` (node/vitest — the schema is a pure data tree) asserting the settings-structure FRs: `settingNode('privacy-advanced')` is undefined and no `privacy.blockUnknown` key exists anywhere in the tree (FR-006/FR-007); the `privacy` node exposes `privacy.disableLinkPreviews` directly (FR-008); the `help` node links ≥8 `help-*` nodes that all resolve and shows no version stat, and the self-test route is still present (FR-011/FR-012/FR-013); the `reset-autodownload` action carries a `confirm` string (FR-014); and assert `SYNCED_PREF_KEYS` in `src/services/ownsync.ts` does not include `privacy.blockUnknown` (FR-010).
+- [X] T013 Point the CLAUDE.md current-plan reference (SPECKIT markers) at `specs/1026-friends-only-and-settings-refinements/plan.md`.
+- [X] T014 Regenerate `ROADMAP.md` via `make roadmap`; confirm the 1026 row and its `in-review` status; ensure the CI "Roadmap up to date" guard would pass.
+- [X] T015 Run the full gate and confirm green: `npm run build` (typecheck), `npm run test:unit` (445 pass), and `npm run test:e2e -- friends-only` (1 pass).
+- [X] T017 [US6] Readable description colour (FR-017): add `--app-text-secondary` to `src/theme/variables.css` (light + dark) and apply it to `.group-note p` / `.group-footer ion-note` in `src/views/detail/SettingDetailPage.vue`.
+- [X] T018 Copy-voice pass (FR-018): rewrite Help guides in Ring's plain voice, strip em-dashes and semicolons from Help and settings captions, fix copy that referenced removed features, and simplify the About header (`src/settings/schema.ts`, `src/views/detail/AboutPage.vue`).
+
+## Dependencies & ordering
+
+- T001 precedes everything (pipeline scaffolding).
+- Within each user story, the `[X]` implementation task precedes its `[ ]` test/verify task.
+- User stories US1–US6 are independent and can be delivered/tested in any order (MVP = US1 alone).
+- Polish (T013–T015) runs after the story tasks.
+
+## Parallel execution opportunities
+
+- The test-backfill tasks touch different files and can run in parallel: `T007` (link-preview),
+  `T011` (emoji helper), `T004` (call-path verification).
+- The `[X]` implementation tasks already landed together but were independent edits across
+  `queries.ts`, `schema.ts`, `ownsync.ts`, `Emoji.vue`, and `SettingDetailPage.vue`.
+
+## Implementation strategy
+
+MVP is **User Story 1** (friends-only messaging) — the headline behavior and the only slice with real
+risk (must not break calls). The remaining stories are independent polish and can ship alongside or
+separately. Remaining open work before "done": T004, T007, T011, T016, T014, T015 (test backfill,
+settings-schema test, roadmap regen, and the full green gate).

--- a/src/components/Emoji.vue
+++ b/src/components/Emoji.vue
@@ -15,42 +15,36 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
+import { emojiCodepoints, nextEmojiAttempt, EMOJI_ATTEMPT_NATIVE } from '@/utils/emoji';
 
 /**
  * Renders an emoji using the Noto emoji set, served from our own server's cached
  * proxy (/v1/emoji/...), never a third-party CDN, so emoji use and the user's IP
  * don't leak. If the emoji has no Noto asset (or the server can't reach it), it
  * falls back to the platform's native glyph. Animation respects the
- * Appearance, Animations, Emoji preference.
+ * Appearance, Animations, Emoji preference. The attempt/fallback logic lives as pure
+ * helpers in @/utils/emoji so it can be unit-tested without a DOM.
  */
 const props = withDefaults(defineProps<{ emoji: string; animated?: boolean }>(), { animated: true });
 
 const { animEmoji } = useAnimationPrefs();
 
 // 0 = full codepoint sequence, 1 = retry without the FE0F variation selector,
-// 2 = give up and render the native glyph (Noto has no asset for it).
+// EMOJI_ATTEMPT_NATIVE = give up and render the native glyph (Noto has no asset for it).
 const attempt = ref(0);
-const nativeFallback = computed(() => attempt.value >= 2);
+const nativeFallback = computed(() => attempt.value >= EMOJI_ATTEMPT_NATIVE);
 // When emoji animation is off, render the static native glyph instead of the
 // (looping) Noto WebP.
 const useImage = computed(() => animEmoji.value && !nativeFallback.value);
 
-function codepoints(dropVariationSelector: boolean): string {
-  return [...props.emoji]
-    .map((c) => c.codePointAt(0) ?? 0)
-    .filter((cp) => !(dropVariationSelector && cp === 0xfe0f))
-    .map((cp) => cp.toString(16))
-    .join('_');
-}
-
 const src = computed(() => {
-  const cp = codepoints(attempt.value === 1);
+  const cp = emojiCodepoints(props.emoji, attempt.value === 1);
   // Self-hosted: proxied + cached by our own server (never a third-party CDN).
   return `/v1/emoji/${cp}/512.webp`;
 });
 
 const onError = (): void => {
-  attempt.value += 1;
+  attempt.value = nextEmojiAttempt(props.emoji, attempt.value);
 };
 watch(
   () => props.emoji,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -27,7 +27,7 @@ import { setCompressProgress, setUploadProgress, resetJobProgress, clearJobProgr
 import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deriveTiers, blobToDataUrl } from '@/utils/media-meta';
 import { THUMB_TIERS } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
-import { firstLink, buildLinkPreview } from '@/services/link-preview';
+import { firstLink, buildLinkPreview, shouldBuildLinkPreview } from '@/services/link-preview';
 import { ensureHiddenLoaded, isRevealed, isHiddenKnown } from '@/services/hidden-state';
 import { hiddenCallKeys } from '@/db/hidden-calls';
 import type {
@@ -383,9 +383,10 @@ export async function sendMessage(
   // Link preview: build it in the background (a relay round-trip + downscale) and
   // patch it in once ready, so the text isn't held up. Best-effort and gated by
   // the privacy toggle. Fire-and-forget — never awaited, never blocks the send.
-  const link = firstLink(body);
-  if (link && !(await getSetting<boolean>('privacy.disableLinkPreviews', false))) {
-    void attachLinkPreview(message.id, link);
+  const previewsDisabled = await getSetting<boolean>('privacy.disableLinkPreviews', false);
+  if (shouldBuildLinkPreview(body, previewsDisabled)) {
+    const link = firstLink(body);
+    if (link) void attachLinkPreview(message.id, link);
   }
 }
 
@@ -4400,33 +4401,32 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     return;
   }
 
-  // "Block unknown account messages" (privacy.blockUnknown): when on, drop a message
-  // from someone who is neither already a contact nor an accepted connection — a
-  // stranger must connect with you first. Connection REQUESTS travel over a separate
-  // server channel (not this E2EE message path), so this never stops someone from
-  // reaching out to connect; it only blocks unsolicited message content.
-  if (await getSetting<boolean>('privacy.blockUnknown', false)) {
-    if (!(await getContact(from)) && !(await isPeerConnected(from))) return;
-  }
+  // Friends-only messaging: only people you've connected with can put message CONTENT in
+  // your inbox. We can't drop here, though: connection CARDS (friend request, invite
+  // auto-connect, accept) and other control payloads must always be processed, because
+  // that is how people connect, and a group message rides a 1:1 session but is authorised
+  // by shared membership. So we open first, apply any card/control payload below, and gate
+  // only actual 1:1 content. Capture whether we knew this peer (and had a chat with them)
+  // BEFORE creating the provisional contact/chat needed to open the packet, so unsolicited
+  // content can be dropped again without leaving a trace.
+  const hadContactBefore = !!(await getContact(from));
+  const knewSenderBefore = hadContactBefore || (await isPeerConnected(from));
+  const hadDirectChatBefore = (await getAll<Chat>('chats')).some(
+    (c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === from,
+  );
 
   let contact = await getContact(from);
   if (!contact) {
+    // Provisionally create the contact so we have a chat + session to open the packet. If
+    // this turns out to be unsolicited 1:1 content it is removed again below; a card or a
+    // group message keeps it. Pull their real name/photo/@username from the directory
+    // (fire-and-forget; falls back to the next connect-time refresh).
     await addContactWithId(from, '');
     contact = await getContact(from);
-    // New inbound peer → pull their real name/photo/@username from the directory
-    // (fire-and-forget; falls back to the next connect-time refresh).
     void hydrateContactFromDirectory(from);
   }
   if (!contact) return;
-  // Open in-network inbox: the network is invite-only but internally everyone is
-  // discoverable, so any member can message any member; there is no longer a
-  // friend-request gate. A first message is shown immediately. We record the
-  // sender as connected so their chat stays visible (and a stale legacy
-  // 'request' card from an old client can't re-hide it).
-  if (!(await isPeerConnected(from))) await markContactConnected(from);
   const chatId = await startDirectChat(contact);
-  const ch = await getChat(chatId);
-  if (ch?.pending) await setChatPending(chatId, false);
 
   let payload;
   try {
@@ -4510,6 +4510,28 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
 
   // A group message arrives over a 1:1 session but belongs to the group chat.
   const isGroupMsg = !!payload.groupId;
+
+  // Friends-only gate, applied only to 1:1 CONTENT (cards/controls were handled above; a
+  // group message is authorised by shared membership). Content from someone we haven't
+  // connected with is unsolicited: ack it so the relay stops holding it, then remove the
+  // provisional contact/chat/session we created only to open it, so it leaves no trace.
+  if (!isGroupMsg && !knewSenderBefore && !(await isPeerConnected(from))) {
+    if (remoteId) await markInboundSeen(remoteId);
+    if (!hadDirectChatBefore) {
+      await remove('sessions', chatId);
+      await remove('chats', chatId);
+    }
+    if (!hadContactBefore) await remove('contacts', from);
+    return;
+  }
+  // Accepted 1:1 content from a known peer: keep them connected and un-pend the chat so it
+  // stays visible (and a stale legacy 'request' card from an old client can't re-hide it).
+  if (!isGroupMsg) {
+    if (!(await isPeerConnected(from))) await markContactConnected(from);
+    const ch = await getChat(chatId);
+    if (ch?.pending) await setChatPending(chatId, false);
+  }
+
   const targetChatId = payload.groupId ?? chatId;
   if (payload.groupId) await ensureGroupChat(payload.groupId, from);
 

--- a/src/services/link-preview.test.ts
+++ b/src/services/link-preview.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { firstLink, linkDomain, shouldBuildLinkPreview } from './link-preview';
+
+describe('firstLink', () => {
+  it('finds the first http(s) URL in a body', () => {
+    expect(firstLink('see https://example.com/x for more')).toBe('https://example.com/x');
+    expect(firstLink('http://a.test and https://b.test')).toBe('http://a.test');
+  });
+
+  it('returns undefined when there is no URL', () => {
+    expect(firstLink('just some text')).toBeUndefined();
+    expect(firstLink('not a link: example.com')).toBeUndefined(); // no scheme
+  });
+});
+
+describe('linkDomain', () => {
+  it('strips a leading www.', () => {
+    expect(linkDomain('https://www.example.com/path')).toBe('example.com');
+    expect(linkDomain('https://sub.example.com')).toBe('sub.example.com');
+  });
+});
+
+describe('shouldBuildLinkPreview (spec 1026 US2 / FR-009)', () => {
+  it('builds a preview for a link when previews are enabled', () => {
+    expect(shouldBuildLinkPreview('look https://example.com', false)).toBe(true);
+  });
+
+  it('does NOT build a preview when "Disable link previews" is on', () => {
+    expect(shouldBuildLinkPreview('look https://example.com', true)).toBe(false);
+  });
+
+  it('does NOT build a preview when the body has no link', () => {
+    expect(shouldBuildLinkPreview('no link here', false)).toBe(false);
+  });
+});

--- a/src/services/link-preview.ts
+++ b/src/services/link-preview.ts
@@ -25,6 +25,15 @@ export function firstLink(body: string): string | undefined {
   return body.match(LINK_RE)?.[0];
 }
 
+/**
+ * Whether a just-sent text should get a link preview: it contains a link AND the user has
+ * not turned previews off (privacy.disableLinkPreviews). Pure so the gate is unit-testable
+ * without the message pipeline; `queries.ts` passes the resolved setting value.
+ */
+export function shouldBuildLinkPreview(body: string, previewsDisabled: boolean): boolean {
+  return !previewsDisabled && firstLink(body) !== undefined;
+}
+
 // Bounds that keep a preview from bloating the E2EE ratchet packet. The card
 // renders up to ~260px CSS-wide, so 640px (≈2x) stays sharp on retina displays
 // without letting the inline image grow unbounded.

--- a/src/services/ownsync-keys.ts
+++ b/src/services/ownsync-keys.ts
@@ -1,0 +1,20 @@
+/**
+ * The user-preference settings backed up by encrypted own-data sync (see `ownsync.ts`).
+ *
+ * Kept in its own dependency-free module so the allowlist can be imported and asserted in
+ * unit tests without pulling in the full sync engine (which transitively imports UI/SFC code).
+ *
+ * App-lock and device-local/storage settings are intentionally excluded (they're per-device or
+ * security-sensitive). The whole snapshot is sealed under the master key before it leaves the
+ * device — the server enforces nothing here.
+ */
+export const SYNCED_PREF_KEYS: string[] = [
+  'privacy.lastSeen', 'privacy.online', 'privacy.profilePhoto', 'privacy.about',
+  'privacy.groups', 'privacy.messageTimer',
+  'privacy.disableLinkPreviews',
+  'notifications.message.show', 'notifications.message.reactions', 'notifications.message.sound',
+  'notifications.group.show', 'notifications.group.reactions', 'notifications.group.sound',
+  'notifications.wall.show', 'notifications.showPreview', 'notifications.badge',
+  'notifications.inapp.enabled', 'notifications.inapp.style', 'notifications.inapp.sounds', 'notifications.inapp.vibrate',
+  'chats.animEmoji', 'chats.animGifs', 'chats.tabFilters', 'chats.saveToPhotos', 'chats.keepArchived',
+];

--- a/src/services/ownsync.test.ts
+++ b/src/services/ownsync.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { SYNCED_PREF_KEYS } from './ownsync-keys';
+
+describe('own-data sync key allowlist (spec 1026 US2 / FR-010)', () => {
+  it('does not sync the removed privacy.blockUnknown key', () => {
+    expect(SYNCED_PREF_KEYS).not.toContain('privacy.blockUnknown');
+  });
+
+  it('still syncs the relocated privacy.disableLinkPreviews key', () => {
+    expect(SYNCED_PREF_KEYS).toContain('privacy.disableLinkPreviews');
+  });
+});

--- a/src/services/ownsync.ts
+++ b/src/services/ownsync.ts
@@ -11,6 +11,7 @@
  * while unlocked), so it runs after the passcode gate.
  */
 import { get, getAll, put, remove, type StoreName } from '@/db/idb';
+import { SYNCED_PREF_KEYS } from './ownsync-keys';
 import { recordTombstone, isTombstoned, listTombstones } from '@/db/tombstones';
 import { isUnlockedNow, getMasterKey, getRecoveryWrapForUpload } from '@/services/crypto/identity';
 import { sealJson, openJson, type Envelope } from '@/services/crypto/envelope';
@@ -34,16 +35,8 @@ const PAGE = 500;
 // excluded (they're per-device or security-sensitive). Server enforces nothing
 // here, the whole snapshot is sealed under the master key.
 const PROFILE_STORE = 'profile';
-const SYNCED_PREF_KEYS: string[] = [
-  'privacy.lastSeen', 'privacy.online', 'privacy.profilePhoto', 'privacy.about',
-  'privacy.groups', 'privacy.messageTimer',
-  'privacy.blockUnknown', 'privacy.disableLinkPreviews',
-  'notifications.message.show', 'notifications.message.reactions', 'notifications.message.sound',
-  'notifications.group.show', 'notifications.group.reactions', 'notifications.group.sound',
-  'notifications.wall.show', 'notifications.showPreview', 'notifications.badge',
-  'notifications.inapp.enabled', 'notifications.inapp.style', 'notifications.inapp.sounds', 'notifications.inapp.vibrate',
-  'chats.animEmoji', 'chats.animGifs', 'chats.tabFilters', 'chats.saveToPhotos', 'chats.keepArchived',
-];
+// SYNCED_PREF_KEYS lives in the dependency-free ./ownsync-keys module (imported at the top) so the
+// allowlist can be unit-tested without pulling in this sync engine's UI-touching dependencies.
 
 interface ProfileSnapshot {
   v: 1;

--- a/src/settings/schema.test.ts
+++ b/src/settings/schema.test.ts
@@ -68,10 +68,50 @@ describe('settings schema — spec 1025 cleanup', () => {
     expect(keys.has('notifications.inapp.vibrate')).toBe(false);
   });
 
-  it('Help version is no longer the stale hardcoded 0.1.0', () => {
-    const version = SETTINGS.help.groups
+});
+
+describe('settings schema — spec 1026 (friends-only & refinements)', () => {
+  it('US2: no "Advanced" sub-page and nothing links to it (FR-006)', () => {
+    expect(settingNode('privacy-advanced')).toBeUndefined();
+    expect(everyItem().some((i) => i.type === 'link' && i.id === 'privacy-advanced')).toBe(false);
+  });
+
+  it('US2: no "Block unknown account messages" control anywhere (FR-007)', () => {
+    const hasBlockUnknown = everyItem().some((i) => 'key' in i && i.key === 'privacy.blockUnknown');
+    expect(hasBlockUnknown).toBe(false);
+  });
+
+  it('US2: "Disable link previews" sits directly on the Privacy page (FR-008)', () => {
+    const items = SETTINGS.privacy.groups.flatMap((g) => g.items);
+    const toggle = items.find((i) => 'key' in i && i.key === 'privacy.disableLinkPreviews');
+    expect(toggle?.type).toBe('toggle');
+  });
+
+  it('US3: Help links ≥8 how-to topics that all resolve (FR-011)', () => {
+    const links = SETTINGS.help.groups
       .flatMap((g) => g.items)
-      .find((i) => 'title' in i && i.title === 'Version');
-    expect(version && 'value' in version ? version.value : '').not.toBe('0.1.0');
+      .filter((i): i is Extract<SettingItem, { type: 'link' }> => i.type === 'link' && i.id.startsWith('help-'));
+    expect(links.length).toBeGreaterThanOrEqual(8);
+    for (const l of links) expect(settingNode(l.id), `missing node ${l.id}`).toBeDefined();
+  });
+
+  it('US3: Help no longer shows the app version (FR-012)', () => {
+    const hasStat = SETTINGS.help.groups.flatMap((g) => g.items).some((i) => i.type === 'stat');
+    expect(hasStat).toBe(false);
+  });
+
+  it('US3: the developer self-test is still reachable from Help (FR-013)', () => {
+    const hasSelfTest = SETTINGS.help.groups
+      .flatMap((g) => g.items)
+      .some((i) => i.type === 'route' && i.path === '/settings/selftest');
+    expect(hasSelfTest).toBe(true);
+  });
+
+  it('US4: resetting auto-download requires confirmation (FR-014)', () => {
+    const reset = everyItem().find(
+      (i): i is Extract<SettingItem, { type: 'action' }> =>
+        i.type === 'action' && i.action === 'reset-autodownload',
+    );
+    expect(reset?.confirm && reset.confirm.length > 0).toBe(true);
   });
 });

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -281,9 +281,9 @@ export const SETTINGS: Record<string, SettingNode> = {
         ],
       },
       {
-        items: [
-          { type: 'link', id: 'privacy-advanced', title: 'Advanced', icon: 'shield' },
-        ],
+        items: [{ type: 'toggle', title: 'Disable link previews', key: 'privacy.disableLinkPreviews', default: false }],
+        footer:
+          'When this is on, Ring stops making previews for the links you share, so those sites cannot get a peek at your IP address.',
       },
     ],
   },
@@ -294,7 +294,7 @@ export const SETTINGS: Record<string, SettingNode> = {
       {
         items: [{ type: 'toggle', title: 'Enable hidden chats', key: 'privacy.hiddenChatsEnabled', default: false }],
         footer:
-          'Hide chats behind a separate PIN. A hidden chat is removed from your chat list, search, calls, and notification previews until you type the PIN into the chat search bar. Hiding stays on this device only — it never leaves your phone.',
+          'Hide chats behind a separate PIN. A hidden chat is removed from your chat list, search, calls, and notification previews until you type the PIN into the chat search bar. Hiding stays on this device only, and it never leaves your phone.',
       },
       {
         items: [{ type: 'action', title: 'Set or change PIN', action: 'hidden-set-pin', icon: 'key' }],
@@ -318,7 +318,7 @@ export const SETTINGS: Record<string, SettingNode> = {
             action: 'hidden-reset',
             danger: true,
             confirm:
-              'This permanently deletes every hidden chat on this device and cannot be undone — they will not come back from the server. Continue?',
+              'This permanently deletes every hidden chat on this device and cannot be undone. They will not come back from the server. Continue?',
           },
         ],
         footer: 'Forgot your PIN? Resetting permanently deletes the hidden chats on this device so they can never be exposed.',
@@ -395,27 +395,10 @@ export const SETTINGS: Record<string, SettingNode> = {
         header: 'Require passcode after being away for',
         items: [{ type: 'choice', key: 'privacy.appLock.timeout', default: '1m', options: APP_LOCK_TIMEOUT }],
         footer:
-          'When a passcode is set and Ring has been in the background longer than this, it asks for your passcode again on return. “Never” skips that on-return prompt — but fully closing and reopening Ring still asks for your passcode.',
+          'When a passcode is set and Ring has been in the background longer than this, it asks for your passcode again on return. “Never” skips that prompt on return, but fully closing and reopening Ring still asks for your passcode.',
       },
     ],
   },
-  'privacy-advanced': {
-    id: 'privacy-advanced',
-    title: 'Advanced',
-    groups: [
-      {
-        items: [{ type: 'toggle', title: 'Block unknown account messages', key: 'privacy.blockUnknown', default: false }],
-        footer:
-          'Block messages from people who aren’t in your contacts. They’ll need to send you a contact request first.',
-      },
-      {
-        items: [{ type: 'toggle', title: 'Disable link previews', key: 'privacy.disableLinkPreviews', default: false }],
-        footer:
-          'To help protect your IP address from being inferred by third-party websites, previews for the links you share in chats will no longer be generated.',
-      },
-    ],
-  },
-
   /* ===== CHATS ===== */
   chats: {
     id: 'chats',
@@ -533,7 +516,7 @@ export const SETTINGS: Record<string, SettingNode> = {
         items: [
           { type: 'toggle', title: 'In-call sounds', key: 'notifications.callSounds', default: true },
         ],
-        footer: 'Subtle cues during a call — connecting, reconnecting, mute/unmute, camera on/off, and a quiet tone for a message that arrives while you’re on a call.',
+        footer: 'Subtle cues during a call, like connecting, reconnecting, mute and unmute, camera on and off, and a quiet tone for a message that arrives while you’re on a call.',
       },
       {
         header: 'Home screen notifications',
@@ -582,7 +565,7 @@ export const SETTINGS: Record<string, SettingNode> = {
     groups: [
       {
         items: [{ type: 'toggle', title: 'In-app notifications', key: 'notifications.inapp.enabled', default: true }],
-        footer: 'Master switch for banners that appear while Ring is open. When off, no in-app banner is shown for any chat — system (lock-screen) notifications and the app badge are unaffected.',
+        footer: 'Master switch for banners that appear while Ring is open. When off, no in-app banner is shown for any chat. System (lock-screen) notifications and the app badge are unaffected.',
       },
       {
         header: 'Alert style',
@@ -635,7 +618,7 @@ export const SETTINGS: Record<string, SettingNode> = {
           { type: 'link', id: 'storage-autodownload-audio', title: 'Audio', icon: 'music' },
           { type: 'link', id: 'storage-autodownload-video', title: 'Video', icon: 'video' },
           { type: 'link', id: 'storage-autodownload-documents', title: 'Documents', icon: 'document' },
-          { type: 'action', title: 'Reset auto-download settings', action: 'reset-autodownload' },
+          { type: 'action', title: 'Reset auto-download settings', action: 'reset-autodownload', confirm: 'This puts every download choice back to the way it started.' },
         ],
         footer: 'Voice messages are always automatically downloaded.',
       },
@@ -690,17 +673,182 @@ export const SETTINGS: Record<string, SettingNode> = {
   },
 
   /* ===== HELP ===== */
+  // A small set of plain-language how-tos, each its own schema node rendered as
+  // static `note` paragraphs. The version lives on the About page (which styles it
+  // properly), so Help no longer duplicates it. The Developer group keeps the
+  // on-device self-test.
   help: {
     id: 'help',
     title: 'Help',
     groups: [
-      // Vite replaces __APP_VERSION__ at build time; the typeof guard keeps it defined under vitest
-      // (which does not apply the build define), so importing the schema in a unit test never throws.
-      { items: [{ type: 'stat', title: 'Version', value: typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0' }] },
+      {
+        header: 'How Ring works',
+        items: [
+          { type: 'link', id: 'help-privacy', title: 'How Ring keeps chats private', icon: 'lock' },
+          { type: 'link', id: 'help-getting-started', title: 'Getting started', icon: 'person' },
+          { type: 'link', id: 'help-contacts', title: 'Adding people', icon: 'people' },
+          { type: 'link', id: 'help-chats', title: 'Chats and groups', icon: 'chat' },
+          { type: 'link', id: 'help-disappearing', title: 'Disappearing messages', icon: 'time' },
+          { type: 'link', id: 'help-hidden', title: 'Hidden chats and app lock', icon: 'eyeOff' },
+          { type: 'link', id: 'help-calls', title: 'Voice and video calls', icon: 'call' },
+          { type: 'link', id: 'help-recovery', title: 'Your recovery key', icon: 'key' },
+        ],
+      },
       {
         header: 'Developer',
         items: [{ type: 'route', title: 'Run self-test', path: '/settings/selftest', icon: 'shield' }],
-        footer: 'Runs the on-device encryption & sync checks in this browser.',
+        footer: 'Runs the encryption and sync checks right here in your browser.',
+      },
+    ],
+  },
+  'help-privacy': {
+    id: 'help-privacy',
+    title: 'How Ring keeps chats private',
+    groups: [
+      {
+        items: [
+          { type: 'note', text: 'Ring is end-to-end encrypted. Your messages, calls and keys are scrambled on your device, and only the person you are talking to can open them.' },
+          { type: 'note', text: 'The server just passes sealed data along. It never sees your messages, media, contacts or profile, so nobody in the middle can read your stuff.' },
+          { type: 'note', text: 'There is no phone number and no ads, and you only get in by invitation.' },
+        ],
+      },
+      {
+        header: 'What you control',
+        items: [
+          { type: 'note', text: 'Head into Privacy to choose who sees your last seen, online status, profile photo and about. You can pick everyone, just your contacts, or nobody.' },
+          { type: 'note', text: 'Seen receipts and typing indicators go both ways. Turn them off and you stop sharing them, and you stop seeing other people’s too.' },
+          { type: 'note', text: 'You can also switch off link previews so the sites you link to cannot get a peek at your IP address.' },
+        ],
+      },
+    ],
+  },
+  'help-getting-started': {
+    id: 'help-getting-started',
+    title: 'Getting started',
+    groups: [
+      {
+        header: 'Joining',
+        items: [
+          { type: 'note', text: 'Ring is invite only. On the welcome screen tap Have Invitation Code and type in the code a friend gave you.' },
+          { type: 'note', text: 'Pick a username you like. It stays with you and cannot be changed later, so go with something you are happy with.' },
+          { type: 'note', text: 'You will see a recovery key once. Save it somewhere safe before you carry on, because it is your only way back in if you lose this device.' },
+          { type: 'note', text: 'Then set your name and photo, and if you want, allow notifications so you hear about new messages and calls.' },
+        ],
+      },
+      {
+        header: 'Already have an account?',
+        items: [
+          { type: 'note', text: 'On a new device, tap Have Recovery Key on the welcome screen and enter the key you saved to bring your account back.' },
+        ],
+      },
+    ],
+  },
+  'help-contacts': {
+    id: 'help-contacts',
+    title: 'Adding people',
+    groups: [
+      {
+        items: [
+          { type: 'note', text: 'In the Contacts tab, tap the plus button. From there you can invite someone, scan a friend’s QR code, show your own, or browse the directory.' },
+          { type: 'note', text: 'Invite someone by giving the invite a nickname so you remember who it is for, then share the link and code. When they join with it, the two of you connect on your own, no accepting needed.' },
+          { type: 'note', text: 'To use a QR code, tap Show my QR code for someone to scan, or Scan a friend’s QR to add them. Your username and full ID are right there to copy too.' },
+          { type: 'note', text: 'Sent invites show up under Invited with a countdown, and you can extend or cancel them from the three dots menu.' },
+        ],
+      },
+      {
+        header: 'Requests and blocking',
+        items: [
+          { type: 'note', text: 'Only people you have connected with can message you, so add someone before you start chatting. Friend requests show up with Accept or Decline, you can swipe a contact to delete them, and anyone you block sits at the bottom of the list.' },
+        ],
+      },
+    ],
+  },
+  'help-chats': {
+    id: 'help-chats',
+    title: 'Chats and groups',
+    groups: [
+      {
+        header: 'Direct chats',
+        items: [
+          { type: 'note', text: 'In the Chats tab, tap the compose button at the top and pick a contact to start a direct chat. Tapping a friend in Contacts opens the same chat.' },
+        ],
+      },
+      {
+        header: 'Groups',
+        items: [
+          { type: 'note', text: 'Start a group from the compose menu or the plus menu in Contacts. Give it a name if you like, tap the people to add, then hit Create.' },
+          { type: 'note', text: 'Open Group info any time to change the name or photo, add more people, see who is in it, remove someone, or leave.' },
+        ],
+      },
+      {
+        header: 'Reactions and replies',
+        items: [
+          { type: 'note', text: 'Tap the reaction button on a message for quick emoji, or press and hold a message for reply, forward, edit and more.' },
+        ],
+      },
+    ],
+  },
+  'help-disappearing': {
+    id: 'help-disappearing',
+    title: 'Disappearing messages',
+    groups: [
+      {
+        items: [
+          { type: 'note', text: 'Disappearing messages delete themselves for everyone after a set time, and they show a little clock with how long is left.' },
+          { type: 'note', text: 'For a whole chat, open the chat or group info and set Disappearing messages. Pick 24 hours, 7 days, 90 days, or off, and it covers new messages from everyone there.' },
+          { type: 'note', text: 'For just your next message, tap the clock in the composer. It turns green when what you send will disappear.' },
+          { type: 'note', text: 'To start new chats this way by default, set a timer under Privacy, in Default message timer. It only touches new direct chats, not the ones you already have.' },
+        ],
+      },
+    ],
+  },
+  'help-hidden': {
+    id: 'help-hidden',
+    title: 'Hidden chats and app lock',
+    groups: [
+      {
+        header: 'Hidden chats',
+        items: [
+          { type: 'note', text: 'A hidden chat drops out of your chat list, search, calls and notification previews, and you open it with its own PIN.' },
+          { type: 'note', text: 'Turn it on under Privacy, in Hidden chats, and set a PIN. Then swipe a conversation, tap More, and hide it. There is no button for making a brand new hidden chat on purpose.' },
+          { type: 'note', text: 'To bring them back, type your hidden chats PIN into the search bar at the top of Chats. Hiding stays on this device and never leaves your phone.' },
+          { type: 'note', text: 'Forgot the PIN? Reset PIN and delete hidden chats is your only way out, and it wipes those chats on this device for good.' },
+        ],
+      },
+      {
+        header: 'App lock',
+        items: [
+          { type: 'note', text: 'Turn on App lock under Privacy to ask for a passcode every time you open Ring. You can set how long Ring waits before it asks again.' },
+          { type: 'note', text: 'With app lock on, notifications in the background only say New message instead of showing a preview.' },
+        ],
+      },
+    ],
+  },
+  'help-calls': {
+    id: 'help-calls',
+    title: 'Voice and video calls',
+    groups: [
+      {
+        items: [
+          { type: 'note', text: 'Start a call from a chat with the video or phone button at the top. Tapping a call in your history dials the same kind again.' },
+          { type: 'note', text: 'While you are on a call you can mute, turn the camera on or off, switch where the sound comes out, and hang up. You can move an audio call up to video too, and the other side gets asked first.' },
+          { type: 'note', text: 'Group calls ring everyone, up to 8 people on audio and 4 on video.' },
+          { type: 'note', text: 'Calls are end-to-end encrypted. The sound and video go straight between devices, and no server ever sees or hears them.' },
+        ],
+      },
+    ],
+  },
+  'help-recovery': {
+    id: 'help-recovery',
+    title: 'Your recovery key',
+    groups: [
+      {
+        items: [
+          { type: 'note', text: 'Your recovery key is a one time code you get when you sign up. It is the only way to bring your account back on a new device.' },
+          { type: 'note', text: 'Nobody can get it back for you, not even Ring, so keep it somewhere safe and private.' },
+          { type: 'note', text: 'To restore, tap Have Recovery Key on the welcome screen and type in the code.' },
+          { type: 'note', text: 'You can make a new one under Account, in Recovery key, then Generate new recovery key. The old one stops working right away, so do this if you think it might have leaked.' },
+        ],
       },
     ],
   },

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -17,6 +17,9 @@
 :root {
   --app-text: #000000;
   --app-text-muted: rgba(0, 0, 0, 0.55);
+  /* Secondary/explanatory text (setting captions, help paragraphs). Stronger than
+     --app-text-muted so descriptions stay comfortably readable on both themes. */
+  --app-text-secondary: rgba(0, 0, 0, 0.72);
   --app-surface: rgba(0, 0, 0, 0.04);
   --app-border: rgba(0, 0, 0, 0.1);
   --app-otp-border: rgba(0, 0, 0, 0.22);
@@ -48,6 +51,7 @@
 :root.ion-palette-dark {
   --app-text: #ffffff;
   --app-text-muted: rgba(255, 255, 255, 0.6);
+  --app-text-secondary: rgba(255, 255, 255, 0.78);
   --app-surface: rgba(255, 255, 255, 0.05);
   --app-border: rgba(255, 255, 255, 0.12);
   --app-otp-border: rgba(255, 255, 255, 0.25);

--- a/src/utils/emoji.test.ts
+++ b/src/utils/emoji.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { segmentEmoji, emojiOnlyCount } from './emoji';
+import {
+  segmentEmoji,
+  emojiOnlyCount,
+  hasVariationSelector,
+  emojiCodepoints,
+  nextEmojiAttempt,
+  EMOJI_ATTEMPT_NATIVE,
+} from './emoji';
 
 describe('segmentEmoji', () => {
   it('splits text and emoji into alternating runs', () => {
@@ -35,5 +42,44 @@ describe('emojiOnlyCount', () => {
   it('returns 0 for empty/whitespace-only input', () => {
     expect(emojiOnlyCount('   ')).toBe(0);
     expect(emojiOnlyCount('')).toBe(0);
+  });
+});
+
+describe('emoji image fallback (spec 1026 US5)', () => {
+  // 😀 U+1F600 has no variation selector; ❤️ = U+2764 U+FE0F does.
+  const noSelector = '😀';
+  const withSelector = '❤️';
+
+  it('detects the FE0F variation selector', () => {
+    expect(hasVariationSelector(withSelector)).toBe(true);
+    expect(hasVariationSelector(noSelector)).toBe(false);
+  });
+
+  it('builds underscore-joined codepoints, optionally dropping FE0F', () => {
+    expect(emojiCodepoints(noSelector)).toBe('1f600');
+    expect(emojiCodepoints(withSelector)).toBe('2764_fe0f');
+    expect(emojiCodepoints(withSelector, true)).toBe('2764');
+  });
+
+  it('falls straight to the native glyph for an emoji with no FE0F to retry', () => {
+    // The bug: dropping a non-existent FE0F yields the same URL, so the retry would never
+    // re-fire an error and the broken image would stick. We must jump to native immediately.
+    expect(nextEmojiAttempt(noSelector, 0)).toBe(EMOJI_ATTEMPT_NATIVE);
+  });
+
+  it('retries without FE0F first, then goes native, for an emoji that has one', () => {
+    expect(nextEmojiAttempt(withSelector, 0)).toBe(1);
+    expect(nextEmojiAttempt(withSelector, 1)).toBe(EMOJI_ATTEMPT_NATIVE);
+  });
+
+  it('never gets stuck below the native threshold on repeated errors', () => {
+    // Simulate the browser firing error → onError → error … from attempt 0.
+    let attempt = 0;
+    for (let i = 0; i < 5; i++) attempt = nextEmojiAttempt(noSelector, attempt);
+    expect(attempt).toBe(EMOJI_ATTEMPT_NATIVE);
+
+    attempt = 0;
+    for (let i = 0; i < 5; i++) attempt = nextEmojiAttempt(withSelector, attempt);
+    expect(attempt).toBe(EMOJI_ATTEMPT_NATIVE);
   });
 });

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -53,3 +53,37 @@ export function emojiOnlyCount(body: string): number {
   }
   return count;
 }
+
+/* ---- Noto image fallback (used by Emoji.vue) ----
+ * The Noto emoji set is served from our own cached proxy at /v1/emoji/<codepoints>/512.webp.
+ * When an emoji has no asset there, the renderer must fall back to the platform's native glyph
+ * instead of sitting on a broken image. The attempt sequence is:
+ *   0 = full codepoint sequence, 1 = retry without the FE0F variation selector, 2 = native glyph.
+ * These helpers are pure so the fallback logic is unit-testable without a DOM. */
+
+/** Whether an emoji string carries a U+FE0F variation selector. */
+export function hasVariationSelector(emoji: string): boolean {
+  return [...emoji].some((c) => c.codePointAt(0) === 0xfe0f);
+}
+
+/** Underscore-joined hex codepoints for the asset path; optionally drop the FE0F selector. */
+export function emojiCodepoints(emoji: string, dropVariationSelector = false): string {
+  return [...emoji]
+    .map((c) => c.codePointAt(0) ?? 0)
+    .filter((cp) => !(dropVariationSelector && cp === 0xfe0f))
+    .map((cp) => cp.toString(16))
+    .join('_');
+}
+
+/** Attempt index at which we give up on an image and render the native glyph. */
+export const EMOJI_ATTEMPT_NATIVE = 2;
+
+/**
+ * The next attempt after an image-load error. The FE0F-less retry (attempt 1) only helps when
+ * there IS an FE0F to drop; otherwise it would produce an identical URL, the browser would not
+ * refetch, no further error would fire, and the broken image would stick forever — so in that
+ * case skip straight to the native glyph.
+ */
+export function nextEmojiAttempt(emoji: string, attempt: number): number {
+  return attempt === 0 && hasVariationSelector(emoji) ? 1 : EMOJI_ATTEMPT_NATIVE;
+}

--- a/src/views/detail/AboutPage.vue
+++ b/src/views/detail/AboutPage.vue
@@ -26,7 +26,7 @@
         <ion-list :inset="true">
           <ion-item lines="none">
             <ion-label class="ion-text-wrap maker">
-              <h2>Made by Zuptalo, with love for privacy 🔒</h2>
+              <h2>Made with love for privacy 🔒</h2>
               <p>
                 I built Ring because I wanted a messenger that doesn't watch you. No
                 phone number, no ads, nobody in the middle reading your stuff. Your

--- a/src/views/detail/SettingDetailPage.vue
+++ b/src/views/detail/SettingDetailPage.vue
@@ -125,12 +125,12 @@
             </ion-item>
 
             <!-- static note -->
-            <ion-item v-else-if="item.type === 'note'" lines="none">
+            <ion-item v-else-if="item.type === 'note'" lines="none" class="group-note">
               <ion-label class="ion-text-wrap"><p>{{ item.text }}</p></ion-label>
             </ion-item>
           </template>
 
-          <ion-item v-if="group.footer" lines="none">
+          <ion-item v-if="group.footer" lines="none" class="group-footer">
             <ion-note class="ion-text-wrap">{{ group.footer }}</ion-note>
           </ion-item>
         </ion-list>
@@ -144,6 +144,24 @@
     </ion-content>
   </ion-page>
 </template>
+
+<style scoped>
+/* Footer captions and static note paragraphs are multi-line and, as the last row of an
+   inset card, otherwise sit flush against its rounded bottom edge. Give the text a little
+   breathing room below so it doesn't crowd the border. */
+.group-footer,
+.group-note {
+  --inner-padding-bottom: 10px;
+}
+
+/* Description text (help paragraphs + group captions) defaults to Ionic's dim step colour,
+   which is hard to read on both themes. Use the app's secondary token so it stays legible
+   while still reading as secondary to the setting titles. */
+.group-note p,
+.group-footer ion-note {
+  color: var(--app-text-secondary);
+}
+</style>
 
 <script lang="ts">
 // Module-scoped scroll cache. This single component renders every settings


### PR DESCRIPTION
Implements spec **1026** — a batch of privacy, settings, help and rendering refinements.

## What changed
- **Friends-only messaging (US1):** direct messages from someone you haven't connected with are dropped on your device; a stranger must connect first. Replaces the old "block unknown" toggle (now the default). Calls are unaffected — call signalling rides a separate path with ephemeral call-scoped sessions for non-contacts.
- **Simpler Privacy (US2):** removed the Advanced sub-page, moved "Disable link previews" onto Privacy, dropped `privacy.blockUnknown` from settings sync.
- **In-app Help guides (US3):** plain-language how-tos; version now only on About; self-test kept.
- **Confirm before resetting auto-download (US4).**
- **Emoji fallback (US5):** an emoji with no asset renders the native glyph instead of a broken-image "?".
- **Readable, roomier captions + copy voice (US6):** more contrast on both themes, no em-dashes/semicolons, warmer wording; About header simplified.

## Tests
- `npm run build` ✓, `npm run test:unit` ✓ (445), `npm run test:e2e -- friends-only` ✓
- New unit coverage: emoji fallback, link-preview gate, settings-schema invariants, sync-key allowlist.

## Spec
`specs/1026-friends-only-and-settings-refinements/` (full pipeline: specify → clarify → plan → tasks → analyze → taskstoissues).

Closes #577, #578, #579, #580, #581, #582, #583, #584, #585, #586, #587, #588, #589, #590, #591, #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)