### PR TITLE
Hidden chats: keep quiet for real, ring with full identity, and allow one hidden + one visible chat per person

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1026-friends-only-and-settings-refinements/plan.md`
+`specs/1027-harden-hidden-chats/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,6 +48,7 @@ Specs are grouped by category band; status moves
 | [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
 | [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
 | [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
+| [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ Specs are grouped by category band; status moves
 | [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
 | [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
 | [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
-| [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🟡 in-progress |
+| [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ Specs are grouped by category band; status moves
 | [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
 | [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
 | [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
-| [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | ⚪ planned |
+| [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/hidden-coexist.mjs
+++ b/drive/scenarios/hidden-coexist.mjs
@@ -1,0 +1,41 @@
+// Spec 1027 — hide moves the chat and the hidden thread keeps receiving silently
+// (part 1, US1 / bug B1); coexistence journey lands in part 2 (US3).
+import { createAccount, pair, say, waitForMessage, chatWith, sweep, done } from '../driver.mjs';
+
+const ana = await createAccount({ name: 'Ana' });
+const ben = await createAccount({ name: 'Ben' });
+await pair(ana, ben);
+
+// Traffic both ways so the ratchet is established under the visible 1:1.
+await say(ben, ana.id, 'before hide');
+await waitForMessage(ana, ben.id, /before hide/);
+const anaChat = await chatWith(ana, ben.id);
+
+// Hide it on Ana's device.
+await ana.page.evaluate(() => window.__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+await ana.page.evaluate((p) => window.__ringTest.hiddenSetPin(p), '2468');
+await ana.page.evaluate((id) => window.__ringTest.hiddenAdd(id), anaChat);
+await ana.page.goto('/tabs/chats');
+await ana.page.waitForFunction(() => window.__ringTest?.isUnlocked?.() === true, null, { timeout: 30000 });
+
+// Ben keeps talking: the message must land in the HIDDEN thread — no visible
+// resurrection, no second conversation row (bug B1).
+await say(ben, ana.id, 'secret ping');
+let got = false;
+for (let t = 0; t < 15000 && !got; t += 300) {
+  got = await ana.page.evaluate((c) =>
+    window.__ringTest.messages(c).then((ms) => ms.some((m) => /secret ping/.test(m.body || ''))), anaChat);
+  if (!got) await new Promise((r) => setTimeout(r, 300));
+}
+const visible = await ana.page.evaluate(() => window.__ringTest.visibleChatIds());
+const withBen = await ana.page.evaluate((id) => window.__ringTest.chatsWith(id), ben.id);
+const badge = await ana.page.evaluate(() => window.__ringTest.unreadBadge());
+
+const pass = got && !visible.includes(anaChat) && withBen.length === 1 && badge > 0;
+console.log('[hidden-coexist:1] received=%s visibleLeak=%s threadsWithBen=%d badge=%d',
+  got, visible.includes(anaChat), withBen.length, badge);
+console.log(pass
+  ? '[PASS] hidden thread keeps receiving silently; no visible resurrection'
+  : '[FAIL] see above');
+await sweep([ana, ben]);
+await done();

--- a/drive/scenarios/hidden-coexist.mjs
+++ b/drive/scenarios/hidden-coexist.mjs
@@ -31,11 +31,52 @@ const visible = await ana.page.evaluate(() => window.__ringTest.visibleChatIds()
 const withBen = await ana.page.evaluate((id) => window.__ringTest.chatsWith(id), ben.id);
 const badge = await ana.page.evaluate(() => window.__ringTest.unreadBadge());
 
-const pass = got && !visible.includes(anaChat) && withBen.length === 1 && badge > 0;
+const pass1 = got && !visible.includes(anaChat) && withBen.length === 1 && badge > 0;
 console.log('[hidden-coexist:1] received=%s visibleLeak=%s threadsWithBen=%d badge=%d',
   got, visible.includes(anaChat), withBen.length, badge);
-console.log(pass
-  ? '[PASS] hidden thread keeps receiving silently; no visible resurrection'
+
+// ---- Part 2 (US3): fresh visible thread coexists; Hide/Unhide gated; ≥100-message isolation soak.
+const visibleChat = await ana.page.evaluate((id) => window.__ringTest.startChat(id), ben.id);
+const threads = await ana.page.evaluate((id) => window.__ringTest.chatsWith(id), ben.id);
+const hideVerdict = await ana.page.evaluate((id) => window.__ringTest.hiddenCanHide(id), visibleChat);
+const unhideVerdict = await ana.page.evaluate((id) => window.__ringTest.hiddenCanUnhide(id), anaChat);
+
+// Volume soak (SC-004): 100 messages alternate across the two threads from both
+// sides; not one may land in the wrong thread.
+const benChat = await chatWith(ben, ana.id); // Ben's plain 1:1 (his side of the hidden thread)
+for (let i = 0; i < 25; i++) {
+  await ana.page.evaluate(({ c, i }) => window.__ringTest.sendChatMessage(c, `open-a-${i}`), { c: visibleChat, i });
+  await ana.page.evaluate(({ c, i }) => window.__ringTest.sendChatMessage(c, `secret-a-${i}`), { c: anaChat, i });
+  await ben.page.evaluate(({ c, i }) => window.__ringTest.sendChatMessage(c, `open-b-${i}`), { c: visibleChat, i });
+  await ben.page.evaluate(({ c, i }) => window.__ringTest.sendChatMessage(c, `secret-b-${i}`), { c: benChat, i });
+}
+// Wait for full delivery on Ana's side (50 inbound: 25 open-b + 25 secret-b).
+let openBodies = [], secretBodies = [];
+for (let t = 0; t < 60000; t += 500) {
+  openBodies = (await ana.page.evaluate((c) => window.__ringTest.messages(c), visibleChat)).map((m) => m.body);
+  secretBodies = (await ana.page.evaluate((c) => window.__ringTest.messages(c), anaChat)).map((m) => m.body);
+  if (openBodies.filter((b) => /^open-b-/.test(b)).length >= 25 &&
+      secretBodies.filter((b) => /^secret-b-/.test(b)).length >= 25) break;
+  await new Promise((r) => setTimeout(r, 500));
+}
+const leaks =
+  openBodies.filter((b) => /^secret-/.test(b)).length +
+  secretBodies.filter((b) => /^open-/.test(b)).length;
+const delivered =
+  openBodies.filter((b) => /^open-b-/.test(b)).length +
+  secretBodies.filter((b) => /^secret-b-/.test(b)).length;
+
+const pass2 =
+  visibleChat !== anaChat &&
+  threads.length === 2 &&
+  hideVerdict.ok === false &&
+  unhideVerdict.ok === false &&
+  delivered === 50 &&
+  leaks === 0;
+console.log('[hidden-coexist:2] threads=%d hideBlocked=%s unhideBlocked=%s delivered=%d/50 leaks=%d',
+  threads.length, !hideVerdict.ok, !unhideVerdict.ok, delivered, leaks);
+console.log(pass1 && pass2
+  ? '[PASS] hidden thread silent + coexistence with zero cross-thread leaks over 100 messages'
   : '[FAIL] see above');
 await sweep([ana, ben]);
 await done();

--- a/drive/scenarios/hidden-flash.mjs
+++ b/drive/scenarios/hidden-flash.mjs
@@ -68,9 +68,11 @@ await bob.page.addInitScript(() => {
 // Reload onto the Chats tab so the list actually renders during the startup window.
 await bob.page.goto('/tabs/chats');
 
-// Hard-reload several times and analyze the captured startup window each time.
+// Hard-reload 20 times (spec 1027 SC-006 soak) and analyze the captured
+// startup window each time.
 let dataLeaks = 0, domLeaks = 0, emptyFlashes = 0;
-for (let i = 1; i <= 6; i++) {
+const ROUNDS = 20;
+for (let i = 1; i <= ROUNDS; i++) {
   await bob.page.reload();
   await bob.page.waitForFunction(() => Array.isArray(window.__flash) && window.__flash.length > 0, null, { timeout: 15_000 });
   await bob.page.waitForTimeout(2500); // let the sampler span the unlock transition
@@ -94,7 +96,7 @@ for (let i = 1; i <= 6; i++) {
   );
   if (firstDomNonEmpty) console.log(`           first rendered rows @${firstDomNonEmpty.ms}ms = ${JSON.stringify(firstDomNonEmpty.dom)}`);
 }
-console.log(`\n[summary] across 6 reloads: dataLeaks=${dataLeaks}  domVisualLeaks=${domLeaks}  emptyHintFlashes=${emptyFlashes}`);
+console.log(`\n[summary] across ${ROUNDS} reloads: dataLeaks=${dataLeaks}  domVisualLeaks=${domLeaks}  emptyHintFlashes=${emptyFlashes}`);
 console.log(dataLeaks === 0 && domLeaks === 0 && emptyFlashes === 0
   ? '[PASS] no hidden-chat leak and no empty-state flash during startup'
   : '[FAIL] something flashed at startup');

--- a/drive/scenarios/hidden-kickout.mjs
+++ b/drive/scenarios/hidden-kickout.mjs
@@ -1,0 +1,51 @@
+// Spec 1027 US2/FR-009 — grace expiry while INSIDE an open hidden chat kicks
+// out to the Chats list at once (bug B5). Uses the real grace machinery
+// (useHiddenChats' visibilitychange handler) by overriding visibilityState,
+// with grace set to 'immediately' so any away-time relocks.
+import { createAccount, pair, say, waitForMessage, chatWith, sweep, done } from '../driver.mjs';
+
+const mia = await createAccount({ name: 'Mia' });
+const leo = await createAccount({ name: 'Leo' });
+await pair(mia, leo);
+await say(leo, mia.id, 'psst');
+await waitForMessage(mia, leo.id, /psst/);
+const chat = await chatWith(mia, leo.id);
+
+await mia.page.evaluate(() => window.__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+await mia.page.evaluate(() => window.__ringTest.setGlobalSetting('privacy.hiddenChatsGrace', 'immediately'));
+await mia.page.evaluate((p) => window.__ringTest.hiddenSetPin(p), '1357');
+await mia.page.evaluate((id) => window.__ringTest.hiddenAdd(id), chat);
+
+// Land on Chats (mounts the grace watcher), reveal, open the hidden chat.
+await mia.page.goto('/tabs/chats');
+await mia.page.waitForFunction(() => window.__ringTest?.isUnlocked?.() === true, null, { timeout: 30000 });
+await mia.page.evaluate((p) => window.__ringTest.hiddenReveal(p), '1357');
+await mia.page.evaluate((id) => window.__ringTest.navigate(`/chat/${id}`), chat);
+await mia.page.waitForFunction((id) => window.location.pathname === `/chat/${id}`, chat, { timeout: 10000 });
+
+// Simulate app-switch away and back: visibilityState hidden → visible. With
+// grace 'immediately' the return relocks, and the relock must kick us out.
+await mia.page.evaluate(() => {
+  Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+});
+await mia.page.waitForTimeout(300);
+await mia.page.evaluate(() => {
+  Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+});
+
+let kicked = false;
+for (let t = 0; t < 10000 && !kicked; t += 200) {
+  kicked = await mia.page.evaluate(() => window.location.pathname === '/tabs/chats');
+  if (!kicked) await new Promise((r) => setTimeout(r, 200));
+}
+const relocked = !(await mia.page.evaluate((id) =>
+  window.__ringTest.visibleChatIds().then((ids) => ids.includes(id)), chat));
+
+console.log('[hidden-kickout] kickedOut=%s relocked=%s', kicked, relocked);
+console.log(kicked && relocked
+  ? '[PASS] grace expiry inside the hidden chat kicked out and relocked'
+  : '[FAIL] see above');
+await sweep([mia, leo]);
+await done();

--- a/drive/scenarios/hidden-reset-relay.mjs
+++ b/drive/scenarios/hidden-reset-relay.mjs
@@ -1,0 +1,43 @@
+// Spec 1027 US5 (FR-018, bug B3) — after a hidden-chats reset, a live inbound
+// message must NOT re-materialize the wiped conversation; deliberately starting
+// a new chat lifts the block and everything works again.
+import { createAccount, pair, say, waitForMessage, chatWith, sweep, done } from '../driver.mjs';
+
+const kim = await createAccount({ name: 'Kim' });
+const raj = await createAccount({ name: 'Raj' });
+await pair(kim, raj);
+await say(raj, kim.id, 'pre-reset');
+await waitForMessage(kim, raj.id, /pre-reset/);
+const chat = await chatWith(kim, raj.id);
+
+await kim.page.evaluate(() => window.__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+await kim.page.evaluate((p) => window.__ringTest.hiddenSetPin(p), '9753');
+await kim.page.evaluate((id) => window.__ringTest.hiddenAdd(id), chat);
+const res = await kim.page.evaluate(() => window.__ringTest.hiddenReset());
+
+// Raj keeps talking over the live relay — nothing may come back.
+await say(raj, kim.id, 'anyone home?');
+await new Promise((r) => setTimeout(r, 5000));
+const after = await kim.page.evaluate((id) => window.__ringTest.chatsWith(id), raj.id);
+const visible = await kim.page.evaluate(() => window.__ringTest.visibleChatIds());
+
+// Kim re-engages: block lifts, conversation restarts cleanly.
+const fresh = await kim.page.evaluate((id) => window.__ringTest.startChat(id), raj.id);
+await kim.page.evaluate(({ c }) => window.__ringTest.sendChatMessage(c, 'fresh start'), { c: fresh });
+await waitForMessage(raj, kim.id, /fresh start/);
+await say(raj, kim.id, 'got it');
+let back = false;
+for (let t = 0; t < 15000 && !back; t += 300) {
+  back = await kim.page.evaluate((c) =>
+    window.__ringTest.messages(c).then((ms) => ms.some((m) => /got it/.test(m.body || ''))), fresh);
+  if (!back) await new Promise((r) => setTimeout(r, 300));
+}
+
+const pass = res.wiped.includes(chat) && after.length === 0 && visible.length === 0 && back;
+console.log('[hidden-reset-relay] wiped=%s rematerialized=%d visibleLeak=%d reengaged=%s',
+  res.wiped.includes(chat), after.length, visible.length, back);
+console.log(pass
+  ? '[PASS] reset holds against the live relay; explicit re-engagement lifts it'
+  : '[FAIL] see above');
+await sweep([kim, raj]);
+await done();

--- a/e2e/hidden-call.spec.ts
+++ b/e2e/hidden-call.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair, startCall, accept, hangup, waitCallState, remoteTracks } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1027 US4 — the "knock-knock call" (FR-013/FR-014): a live incoming call
+// from a hidden-chat peer rings with FULL caller identity and is answerable
+// (calls are never suppressed by hiding; supersedes 1019 FR-019's generic
+// pre-answer identity), while the call leaves no Calls-tab entry naming the
+// hidden peer as long as the chats are relocked.
+
+const ev = (p: any, fn: (...a: any[]) => any, ...args: any[]): Promise<any> =>
+  p.page.evaluate(fn, ...args);
+
+test('a call from a hidden-chat peer rings with full identity and stays out of relocked history', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const a = await createAccount(await browser.newContext(), 'KNOCK001');
+  const b = await createAccount(await browser.newContext(), 'KNOCK002');
+  await pair(a, b);
+
+  // A hides the 1:1 with B. Give B a distinctive saved name so the identity
+  // assert can't accidentally pass on a placeholder.
+  await ev(a, (id: string) => (window as any).__ringTest.setContactName(id, 'Besnik Knock'), b.id);
+  await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  const chat = await ev(a, (id: string) => (window as any).__ringTest.chatWith(id), b.id);
+  await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '8642');
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), chat);
+
+  // Knock knock: B calls A. The ring shows B's real name and avatar (FR-013).
+  await startCall(b, a.id, 'audio');
+  await waitCallState(a, ['incoming'], 40_000);
+  const meta = await ev(a, () => (window as any).__ringTest.callMeta());
+  expect(meta.name).toBe('Besnik Knock');
+  expect(meta.name).not.toMatch(/private caller/i);
+  expect(meta.avatar).toBeTruthy();
+  expect(meta.avatar).not.toBe('');
+
+  // ...and it is answerable like any call: accept → media flows both ways.
+  await accept(a);
+  await waitCallState(a, ['connected'], 40_000);
+  await waitCallState(b, ['connected'], 40_000);
+  await expect.poll(() => remoteTracks(a), { timeout: 30_000 }).toBeGreaterThan(0);
+  await expect.poll(() => remoteTracks(b), { timeout: 30_000 }).toBeGreaterThan(0);
+  await hangup(a);
+  await waitCallState(b, ['idle', 'ended'], 30_000);
+
+  // FR-014: while relocked, the Calls tab shows no row naming the hidden peer,
+  // and the missed/unseen badge can't betray them either (this call wasn't
+  // missed, so the row exclusion is the observable).
+  const history = await ev(a, () => (window as any).__ringTest.callHistoryContactIds());
+  expect(history).not.toContain(b.id);
+  // B (nothing hidden there) logs the call normally — hiding is one-sided.
+  await expect
+    .poll(() => ev(b, () => (window as any).__ringTest.callHistoryContactIds()), { timeout: 15_000 })
+    .toContain(a.id);
+});

--- a/e2e/hidden-coexist.spec.ts
+++ b/e2e/hidden-coexist.spec.ts
@@ -62,3 +62,62 @@ test('hiding the only 1:1 keeps it receiving silently — no visible resurrectio
   await ev(a, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'reply from hiding'), aChat);
   await expect.poll(() => bodies(b, bChat), { timeout: 20_000 }).toContain('reply from hiding');
 });
+
+test('one hidden + one visible chat per person: coexistence, isolation, and blocked Hide/Unhide (US3)', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const a = await createAccount(await browser.newContext(), 'COEXIST3');
+  const b = await createAccount(await browser.newContext(), 'COEXIST4');
+  await pair(a, b);
+
+  // Establish + hide the 1:1.
+  await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  const hiddenChat = await ev(a, (id: string) => (window as any).__ringTest.chatWith(id), b.id);
+  const bChat = await ev(b, (id: string) => (window as any).__ringTest.startChat(id), a.id);
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'seed'), bChat);
+  await expect.poll(() => bodies(a, hiddenChat), { timeout: 20_000 }).toContain('seed');
+  await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '1234');
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), hiddenChat);
+  await expect.poll(() => visibleIds(a)).not.toContain(hiddenChat);
+
+  // FR-004: starting a NEW conversation with the same person creates a fresh
+  // VISIBLE thread — a pair conversation (distinct channel), no PIN involved —
+  // while the hidden thread stays hidden.
+  const visibleChat = await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  expect(visibleChat).not.toBe(hiddenChat);
+  await expect.poll(() => visibleIds(a)).toContain(visibleChat);
+  expect(await visibleIds(a)).not.toContain(hiddenChat);
+  const threads = await chatsWith(a, b.id);
+  expect(threads).toHaveLength(2);
+  expect(threads.find((t) => t.id === visibleChat)?.isGroup).toBe(true); // pair conversation
+
+  // FR-005 isolation, both directions. B sees the pair conversation appear (a
+  // normal new conversation from their side) and replies in each thread.
+  await ev(a, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'open hello'), visibleChat);
+  await expect.poll(() => bodies(b, visibleChat), { timeout: 20_000 }).toContain('open hello'); // group ids are shared
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'open reply'), visibleChat);
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'secret reply'), bChat);
+  await expect.poll(() => bodies(a, visibleChat), { timeout: 20_000 }).toContain('open reply');
+  await expect.poll(() => bodies(a, hiddenChat), { timeout: 20_000 }).toContain('secret reply');
+  // Zero cross-contamination.
+  expect(await bodies(a, visibleChat)).not.toContain('secret reply');
+  expect(await bodies(a, hiddenChat)).not.toContain('open reply');
+  expect(await bodies(a, hiddenChat)).not.toContain('open hello');
+
+  // INV-1: hiding the visible thread is blocked while the hidden one exists.
+  const hideVerdict = await ev(a, (id: string) => (window as any).__ringTest.hiddenCanHide(id), visibleChat);
+  expect(hideVerdict.ok).toBe(false);
+  expect(hideVerdict.reason).toMatch(/already have a hidden chat/i);
+
+  // INV-2: unhiding is blocked while the visible thread exists.
+  const unhideVerdict = await ev(a, (id: string) => (window as any).__ringTest.hiddenCanUnhide(id), hiddenChat);
+  expect(unhideVerdict.ok).toBe(false);
+  expect(unhideVerdict.reason).toMatch(/already have a chat/i);
+
+  // Delete the visible thread → unhide becomes possible and works.
+  await ev(a, (id: string) => (window as any).__ringTest.deleteChat(id), visibleChat);
+  await expect
+    .poll(async () => (await ev(a, (id: string) => (window as any).__ringTest.hiddenCanUnhide(id), hiddenChat)).ok)
+    .toBe(true);
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenRemove(id), hiddenChat);
+  await expect.poll(() => visibleIds(a)).toContain(hiddenChat);
+});

--- a/e2e/hidden-coexist.spec.ts
+++ b/e2e/hidden-coexist.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1027 — hide MOVES the conversation and the hidden thread keeps receiving
+// silently (US1, bug B1 regression), and one hidden + one visible chat coexist
+// per person with Hide/Unhide gated by the pair invariant (US3).
+
+const ev = (p: any, fn: (...a: any[]) => any, ...args: any[]): Promise<any> =>
+  p.page.evaluate(fn, ...args);
+const visibleIds = (p: any): Promise<string[]> =>
+  p.page.evaluate(() => (window as any).__ringTest.visibleChatIds());
+const chatsWith = (p: any, peerId: string): Promise<{ id: string; isGroup: boolean }[]> =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatsWith(id), peerId);
+const bodies = async (p: any, chatId: string): Promise<string[]> =>
+  (await p.page.evaluate((id: string) => (window as any).__ringTest.messages(id), chatId)).map(
+    (m: any) => m.body,
+  );
+
+test('hiding the only 1:1 keeps it receiving silently — no visible resurrection (US1 / bug B1)', async ({ browser }) => {
+  test.setTimeout(120_000);
+  const a = await createAccount(await browser.newContext(), 'COEXIST1');
+  const b = await createAccount(await browser.newContext(), 'COEXIST2');
+  await pair(a, b);
+
+  // Baseline: a visible 1:1 with traffic in both directions (so the ratchet is
+  // fully established under this chat id before we hide it).
+  await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  const aChat = await ev(a, (id: string) => (window as any).__ringTest.chatWith(id), b.id);
+  const bChat = await ev(b, (id: string) => (window as any).__ringTest.startChat(id), a.id);
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'before hide'), bChat);
+  await expect.poll(() => bodies(a, aChat), { timeout: 20_000 }).toContain('before hide');
+
+  // Hide it. It leaves the visible list; the person has NO visible presence.
+  await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '2468');
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), aChat);
+  await expect.poll(() => visibleIds(a)).not.toContain(aChat);
+
+  // THE B1 REGRESSION: B keeps talking. The message must land in the HIDDEN
+  // thread — not resurrect a visible chat, not mint a second 1:1, not re-key.
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'secret ping'), bChat);
+  await expect.poll(() => bodies(a, aChat), { timeout: 20_000 }).toContain('secret ping');
+  expect(await visibleIds(a)).not.toContain(aChat);
+  // Still exactly ONE conversation with B on A's device, and nothing visible.
+  const withB = await chatsWith(a, b.id);
+  expect(withB).toHaveLength(1);
+  expect(withB[0].id).toBe(aChat);
+  expect(
+    await ev(a, (id: string) => (window as any).__ringTest.visibleChatWith(id), b.id),
+  ).toBe('');
+
+  // The badge still counts it (default mode 'always').
+  await expect.poll(() => ev(a, () => (window as any).__ringTest.unreadBadge())).toBeGreaterThan(0);
+
+  // Reveal shows the full history inside the one hidden thread.
+  expect(await ev(a, (p: string) => (window as any).__ringTest.hiddenReveal(p), '2468')).toBe(true);
+  await expect.poll(() => visibleIds(a)).toContain(aChat);
+  expect(await bodies(a, aChat)).toEqual(expect.arrayContaining(['before hide', 'secret ping']));
+
+  // And the ratchet did not fork: A can still reply over the same session and B
+  // receives it in their one chat.
+  await ev(a, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'reply from hiding'), aChat);
+  await expect.poll(() => bodies(b, bChat), { timeout: 20_000 }).toContain('reply from hiding');
+});

--- a/e2e/hidden-privacy.spec.ts
+++ b/e2e/hidden-privacy.spec.ts
@@ -78,3 +78,38 @@ test('a wrong PIN in the search bar reveals nothing and gives no signal (FR-008)
   await expect.poll(() => visibleIds(a), { timeout: 15_000 }).toContain(chat);
   await expect(search).toHaveValue('');
 });
+
+test('the badge honors always/never/revealed for hidden chats without suppressing visible ones (US4 / FR-015)', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const a = await createAccount(await browser.newContext(), 'PRIVAC05');
+  const b = await createAccount(await browser.newContext(), 'PRIVAC06');
+  const c = await createAccount(await browser.newContext(), 'PRIVAC07');
+  await pair(a, b);
+  await pair(a, c);
+  const badge = (): Promise<number> => ev(a, () => (window as any).__ringTest.unreadBadge());
+
+  // One unread in the (soon hidden) chat with B, one unread in the visible chat with C.
+  const hiddenChat = await hiddenOneToOne(a, b, '1234');
+  const bChat = await ev(b, (id: string) => (window as any).__ringTest.startChat(id), a.id);
+  const cChat = await ev(c, (id: string) => (window as any).__ringTest.startChat(id), a.id);
+  await ev(b, (id: string) => (window as any).__ringTest.sendChatMessage(id, 'hidden unread'), bChat);
+  await ev(c, (id: string) => (window as any).__ringTest.sendChatMessage(id, 'visible unread'), cChat);
+  await expect.poll(badge, { timeout: 20_000 }).toBe(2); // default 'always': both count
+
+  // 'never': the hidden unread vanishes from the badge, the visible one stays.
+  await ev(a, () => (window as any).__ringTest.setGlobalSetting('privacy.hiddenChatsBadge', 'never'));
+  await expect.poll(badge, { timeout: 10_000 }).toBe(1);
+  // Another hidden-chat message never bumps it in 'never'.
+  await ev(b, (id: string) => (window as any).__ringTest.sendChatMessage(id, 'still hidden'), bChat);
+  await a.page.waitForTimeout(2000);
+  expect(await badge()).toBe(1);
+
+  // 'revealed': counts hidden unreads only during an active reveal session.
+  await ev(a, () => (window as any).__ringTest.setGlobalSetting('privacy.hiddenChatsBadge', 'revealed'));
+  expect(await badge()).toBe(1); // relocked → excluded
+  expect(await ev(a, (p: string) => (window as any).__ringTest.hiddenReveal(p), '1234')).toBe(true);
+  await expect.poll(badge, { timeout: 10_000 }).toBe(3); // revealed → 2 hidden + 1 visible
+  await ev(a, () => (window as any).__ringTest.hiddenRelock());
+  await expect.poll(badge, { timeout: 10_000 }).toBe(1); // relock → excluded again
+  void hiddenChat;
+});

--- a/e2e/hidden-privacy.spec.ts
+++ b/e2e/hidden-privacy.spec.ts
@@ -113,3 +113,58 @@ test('the badge honors always/never/revealed for hidden chats without suppressin
   await expect.poll(badge, { timeout: 10_000 }).toBe(1); // relock → excluded again
   void hiddenChat;
 });
+
+test('cold open never flashes a hidden chat and the badge is right from the first frame (US6 / FR-017, SC-006)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const a = await createAccount(await browser.newContext(), 'PRIVAC08');
+  const b = await createAccount(await browser.newContext(), 'PRIVAC09');
+  const c = await createAccount(await browser.newContext(), 'PRIVAC10');
+  await pair(a, b);
+  await pair(a, c);
+
+  // Hidden chat with B (1 unread) + visible chat with C (1 unread), badge mode
+  // 'never' → the correct badge is 1; a hidden-inclusive computation would say 2
+  // and a collateral fail-closed would say 0. Both are detectable.
+  const hiddenChat = await hiddenOneToOne(a, b, '1234');
+  const bChat = await ev(b, (id: string) => (window as any).__ringTest.startChat(id), a.id);
+  const cChat = await ev(c, (id: string) => (window as any).__ringTest.startChat(id), a.id);
+  await ev(a, () => (window as any).__ringTest.setGlobalSetting('privacy.hiddenChatsBadge', 'never'));
+  await ev(b, (id: string) => (window as any).__ringTest.sendChatMessage(id, 'hidden unread'), bChat);
+  await ev(c, (id: string) => (window as any).__ringTest.sendChatMessage(id, 'visible unread'), cChat);
+  const visibleChat = await ev(a, (id: string) => (window as any).__ringTest.chatWith(id), c.id);
+  await expect
+    .poll(() => ev(a, () => (window as any).__ringTest.unreadBadge()), { timeout: 20_000 })
+    .toBe(1); // seeds badge.lastCount with the filtered total
+
+  // SC-006 loop: five cold starts, polling from the earliest possible moment.
+  for (let round = 0; round < 5; round++) {
+    await a.page.reload();
+    const snapshots: Array<{ ids: string[]; badge: number }> = [];
+    const deadline = Date.now() + 20_000;
+    let settled = false;
+    while (Date.now() < deadline) {
+      try {
+        const snap = await ev(a, async () => ({
+          ids: await (window as any).__ringTest.visibleChatIds(),
+          badge: await (window as any).__ringTest.unreadBadge(),
+        }));
+        snapshots.push(snap);
+        if (snap.ids.length > 0) {
+          settled = true;
+          break;
+        }
+      } catch {
+        /* hook not ready yet — keep polling; nothing painted before it either */
+      }
+      await a.page.waitForTimeout(100);
+    }
+    expect(settled, `round ${round}: list settled`).toBe(true);
+    for (const s of snapshots) {
+      expect(s.ids, `round ${round}: hidden chat never in the list`).not.toContain(hiddenChat);
+      expect(s.badge, `round ${round}: badge never counts the hidden unread`).toBeLessThanOrEqual(1);
+    }
+    const last = snapshots[snapshots.length - 1];
+    expect(last.ids).toContain(visibleChat); // visible chats correct once painted
+    expect(last.badge).toBe(1); // ...and the badge (lastCount fallback → real value)
+  }
+});

--- a/e2e/hidden-privacy.spec.ts
+++ b/e2e/hidden-privacy.spec.ts
@@ -52,6 +52,33 @@ test('relock kicks an open hidden chat out, and the door guard blocks deep links
   await expect.poll(() => path(a), { timeout: 15_000 }).toBe('/tabs/chats');
 });
 
+test('relock kick-out and the door guard also cover a hidden PAIR CONVERSATION at /group/:id (FR-009)', async ({ browser }) => {
+  test.setTimeout(120_000);
+  const a = await createAccount(await browser.newContext(), 'PRIVAC11');
+  const b = await createAccount(await browser.newContext(), 'PRIVAC12');
+  await pair(a, b);
+
+  // A pair conversation (spec 1027 coexistence) is group-modeled, so it lives at
+  // /group/:id — where the member list is the hidden person's identity. Create
+  // one via the hidden-start path and hide it.
+  await ev(a, () => (window as any).__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+  await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '1234');
+  const pairId = await ev(a, (id: string) => (window as any).__ringTest.hiddenStartChat(id), b.id);
+
+  // Reveal, open the pair conversation's INFO page (/group/:id).
+  expect(await ev(a, (p: string) => (window as any).__ringTest.hiddenReveal(p), '1234')).toBe(true);
+  await ev(a, (id: string) => (window as any).__ringTest.navigate(`/group/${id}`), pairId);
+  await expect.poll(() => path(a)).toBe(`/group/${pairId}`);
+
+  // Relock while on the hidden group-info page → kicked out at once.
+  await ev(a, () => (window as any).__ringTest.hiddenRelock());
+  await expect.poll(() => path(a), { timeout: 10_000 }).toBe('/tabs/chats');
+
+  // Door guard: navigating straight to the hidden /group/:id while relocked bounces.
+  await ev(a, (id: string) => (window as any).__ringTest.navigate(`/group/${id}`), pairId);
+  await expect.poll(() => path(a), { timeout: 10_000 }).toBe('/tabs/chats');
+});
+
 test('a wrong PIN in the search bar reveals nothing and gives no signal (FR-008)', async ({ browser }) => {
   test.setTimeout(120_000);
   const a = await createAccount(await browser.newContext(), 'PRIVAC03');

--- a/e2e/hidden-privacy.spec.ts
+++ b/e2e/hidden-privacy.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1027 — the relock kick-out and door guard (US2 / FR-009, bug B5), the
+// no-oracle reveal gesture (FR-008), plus badge + cold-open sections (US4/US6)
+// added by their phases.
+
+const ev = (p: any, fn: (...a: any[]) => any, ...args: any[]): Promise<any> =>
+  p.page.evaluate(fn, ...args);
+const visibleIds = (p: any): Promise<string[]> =>
+  p.page.evaluate(() => (window as any).__ringTest.visibleChatIds());
+const path = (p: any): Promise<string> => p.page.evaluate(() => window.location.pathname);
+
+async function hiddenOneToOne(a: any, b: any, pin: string): Promise<string> {
+  await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  const chat = await ev(a, (id: string) => (window as any).__ringTest.chatWith(id), b.id);
+  await ev(a, () => (window as any).__ringTest.setGlobalSetting('privacy.hiddenChatsEnabled', true));
+  await ev(a, (p: string) => (window as any).__ringTest.hiddenSetPin(p), pin);
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), chat);
+  return chat;
+}
+
+test('relock kicks an open hidden chat out, and the door guard blocks deep links (US2 / FR-009)', async ({ browser }) => {
+  test.setTimeout(120_000);
+  const a = await createAccount(await browser.newContext(), 'PRIVAC01');
+  const b = await createAccount(await browser.newContext(), 'PRIVAC02');
+  await pair(a, b);
+  const chat = await hiddenOneToOne(a, b, '1234');
+
+  // Revealed → the hidden chat can be opened like any other (SPA navigation —
+  // reveal state is memory-only, a full load would relock by design).
+  expect(await ev(a, (p: string) => (window as any).__ringTest.hiddenReveal(p), '1234')).toBe(true);
+  await ev(a, (id: string) => (window as any).__ringTest.navigate(`/chat/${id}`), chat);
+  await expect.poll(() => path(a)).toBe(`/chat/${chat}`);
+
+  // Relock while INSIDE the chat → kicked out to the Chats list immediately.
+  await ev(a, () => (window as any).__ringTest.hiddenRelock());
+  await expect.poll(() => path(a), { timeout: 10_000 }).toBe('/tabs/chats');
+
+  // Door guard: SPA-navigating straight to the hidden chat while relocked bounces.
+  await ev(a, (id: string) => (window as any).__ringTest.navigate(`/chat/${id}`), chat);
+  await expect.poll(() => path(a), { timeout: 10_000 }).toBe('/tabs/chats');
+
+  // ...including its sub-pages (media grid carries the same :id param).
+  await ev(a, (id: string) => (window as any).__ringTest.navigate(`/chat/${id}/media`), chat);
+  await expect.poll(() => path(a), { timeout: 10_000 }).toBe('/tabs/chats');
+
+  // And a full-load deep link (fresh context = relocked by design) bounces too.
+  await a.page.goto(`/chat/${chat}`);
+  await a.page.waitForFunction(() => (window as any).__ringTest?.isUnlocked() === true, null, { timeout: 30_000 });
+  await expect.poll(() => path(a), { timeout: 15_000 }).toBe('/tabs/chats');
+});
+
+test('a wrong PIN in the search bar reveals nothing and gives no signal (FR-008)', async ({ browser }) => {
+  test.setTimeout(120_000);
+  const a = await createAccount(await browser.newContext(), 'PRIVAC03');
+  const b = await createAccount(await browser.newContext(), 'PRIVAC04');
+  await pair(a, b);
+  const chat = await hiddenOneToOne(a, b, '1234');
+
+  await a.page.goto('/tabs/chats');
+  await a.page.waitForFunction(() => (window as any).__ringTest?.isUnlocked() === true, null, { timeout: 30_000 });
+  const search = a.page.locator('ion-searchbar input').first();
+  await expect(search).toBeVisible({ timeout: 15_000 });
+  await expect.poll(() => visibleIds(a), { timeout: 15_000 }).not.toContain(chat);
+
+  // Wrong PIN of the right length: nothing reveals, and the input is NOT
+  // cleared — clearing only on success would be an oracle in itself, and
+  // clearing on failure would eat an unlucky search query.
+  await search.fill('9999');
+  await a.page.waitForTimeout(1500); // give a (wrong) reveal time to happen
+  expect(await visibleIds(a)).not.toContain(chat);
+  await expect(search).toHaveValue('9999');
+
+  // The correct PIN reveals and clears the box (the one intended signal).
+  await search.fill('1234');
+  await expect.poll(() => visibleIds(a), { timeout: 15_000 }).toContain(chat);
+  await expect(search).toHaveValue('');
+});

--- a/e2e/hidden-reset.spec.ts
+++ b/e2e/hidden-reset.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1027 US5 (FR-018, bug B3): a hidden-chats reset must hold against the
+// LIVE relay path too. The 1019 reset only tombstoned the chat id, but a new
+// inbound message simply minted a fresh chat id and re-materialized the
+// conversation as a visible chat. Now the reset records a peer-keyed localOnly
+// block: inbound 1:1 content from that person is acked and dropped without a
+// trace until the user deliberately starts a new chat with them.
+
+const ev = (p: any, fn: (...a: any[]) => any, ...args: any[]): Promise<any> =>
+  p.page.evaluate(fn, ...args);
+const visibleIds = (p: any): Promise<string[]> =>
+  p.page.evaluate(() => (window as any).__ringTest.visibleChatIds());
+const chatsWith = (p: any, peerId: string): Promise<{ id: string }[]> =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatsWith(id), peerId);
+
+test('reset wipes the hidden chat and a live inbound message cannot re-materialize it (FR-018)', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const a = await createAccount(await browser.newContext(), 'RESET001');
+  const b = await createAccount(await browser.newContext(), 'RESET002');
+  await pair(a, b);
+
+  // Hidden 1:1 with traffic (a real ratchet to destroy).
+  await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  const chat = await ev(a, (id: string) => (window as any).__ringTest.chatWith(id), b.id);
+  const bChat = await ev(b, (id: string) => (window as any).__ringTest.startChat(id), a.id);
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'pre-reset'), bChat);
+  await expect
+    .poll(async () => (await ev(a, (c: string) => (window as any).__ringTest.messages(c), chat)).length, { timeout: 20_000 })
+    .toBeGreaterThan(0);
+  await ev(a, (pin: string) => (window as any).__ringTest.hiddenSetPin(pin), '1234');
+  await ev(a, (id: string) => (window as any).__ringTest.hiddenAdd(id), chat);
+
+  // Destructive reset.
+  const res = await ev(a, () => (window as any).__ringTest.hiddenReset());
+  expect(res.wiped).toContain(chat);
+  expect(await chatsWith(a, b.id)).toHaveLength(0);
+
+  // THE B3 REGRESSION: B keeps sending over the live relay. Nothing may
+  // re-materialize — no chat row (hidden or visible), nothing identifying B.
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'are you there?'), bChat);
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'hello??'), bChat);
+  await a.page.waitForTimeout(5000); // give the relay + client time to (not) act
+  expect(await chatsWith(a, b.id)).toHaveLength(0);
+  expect(await visibleIds(a)).toHaveLength(0);
+
+  // Deliberate re-engagement lifts the block: A starts a new chat with B and
+  // the conversation works again (fresh session both ways).
+  const fresh = await ev(a, (id: string) => (window as any).__ringTest.startChat(id), b.id);
+  expect(fresh).not.toBe('');
+  expect(fresh).not.toBe(chat);
+  await ev(a, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'starting over'), fresh);
+  await expect
+    .poll(async () => (await ev(b, (c: string) => (window as any).__ringTest.messages(c), bChat)).map((m: any) => m.body), { timeout: 20_000 })
+    .toContain('starting over');
+  await ev(b, (c: string) => (window as any).__ringTest.sendChatMessage(c, 'welcome back'), bChat);
+  await expect
+    .poll(async () => (await ev(a, (c: string) => (window as any).__ringTest.messages(c), fresh)).map((m: any) => m.body), { timeout: 20_000 })
+    .toContain('welcome back');
+});

--- a/specs/1027-harden-hidden-chats/checklists/requirements.md
+++ b/specs/1027-harden-hidden-chats/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Harden Hidden Chats + One-Hidden-One-Visible Per Person
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec deliberately names a few concrete artifacts (`src/db/queries.ts` NUL
+  byte, `startHiddenChat`) because this is a fix/harden spec over an existing
+  implementation and those anchors are the subject of the work, not new design.
+  They live in FRs about cleanup/reuse, not in the user-facing success criteria.
+- The one genuinely open design point — which crypto channel each of the two
+  coexisting threads uses — is intentionally deferred to `/speckit-plan` (called out
+  in FR-005 and Assumptions) rather than guessed here.
+- Items marked incomplete require spec updates before `/speckit-clarify` or
+  `/speckit-plan`.

--- a/specs/1027-harden-hidden-chats/checklists/zero-knowledge.md
+++ b/specs/1027-harden-hidden-chats/checklists/zero-knowledge.md
@@ -1,0 +1,69 @@
+# Zero-Knowledge & Crypto Discipline Checklist: Harden Hidden Chats
+
+**Purpose**: Constitution Principle I/IV gate — validate that the 1027 requirements
+themselves are complete, unambiguous, and internally consistent on every
+zero-knowledge and crypto-discipline dimension before `/speckit-implement`.
+This checks the WRITING, not the implementation.
+**Created**: 2026-07-02
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [data-model.md](../data-model.md)
+**Depth**: formal gate (required for Principle I/IV specs) · **Audience**: pre-implement reviewer
+
+## Wire Silence (nothing new crosses to the server)
+
+- [ ] CHK001 - Does the ZK Impact section explicitly enumerate every user action added/changed by this feature (hide, unhide, reveal, relock, blocked-hide, fresh-visible-chat, reset) and state its wire effect? [Completeness, Spec §Zero-Knowledge Impact]
+- [ ] CHK002 - Is the pair-conversation creation path (the one flow that DOES emit wire traffic — a group create card) identified as pre-existing traffic with no new fields, and is its observer (the peer, not the server) named? [Clarity, Spec §ZK "Coexisting conversations"; research R3]
+- [ ] CHK003 - Are requirements explicit that hiding itself is wire-silent (no message, no card, no sync write) so the moment of hiding is unobservable to both server and peer? [Completeness, research R3 "Hide stays a move"]
+- [ ] CHK004 - Is the spurious-rekey elimination (B1) framed as a requirement — hiding must not change observable wire behavior (no rekey bursts correlated with the hide action)? [Coverage, research R2-B1 / plan D2]
+- [ ] CHK005 - Does the spec state what the server can still see (unchanged relay metadata) so "no new signal" is falsifiable rather than aspirational? [Measurability, Spec §ZK "What crosses the wire"]
+
+## Device-Local State Never Syncs
+
+- [ ] CHK006 - Are ALL new device-local artifacts (`hiddenPeer:` tombstones, `badge.lastCount`) explicitly required to be excluded from own-data sync, with a test obligation named for each? [Completeness, Spec FR-019; tasks T027/T030]
+- [ ] CHK007 - Is the existing exclusion of `privacy.hiddenChats` / `privacy.hiddenPin` restated as a preserved invariant (not silently assumed) in the 1027 requirements? [Consistency, Spec FR-019; data-model §Hidden set]
+- [ ] CHK008 - Are the `localOnly` tombstone semantics (honored by ingest, never uploaded, never propagated to the user's other devices) specified for the new `hiddenPeer:` rows, matching the 1019 chat-id rows? [Consistency, data-model §Peer block; research R4]
+- [ ] CHK009 - Is the requirement that reveal state is memory-only (never persisted, cold start always locked) stated with its observable consequence (SW must treat `revealed` as never-revealed)? [Clarity, Spec FR-009; data-model §Badge preference]
+
+## No PIN Oracle
+
+- [ ] CHK010 - Is "no oracle" defined across ALL observable channels (visual, audible, timing, state change) rather than just "no error message"? [Clarity, Spec FR-008, SC-007]
+- [ ] CHK011 - Is the timing-parity claim grounded in a stated mechanism (Argon2id runs identically on both outcomes) rather than left as an untestable assertion? [Measurability, tasks T011; SC-007]
+- [ ] CHK012 - Are PIN storage requirements explicit that no recoverable form and no fast-compare path exist (verification = decrypt success only)? [Completeness, Spec FR-010]
+- [ ] CHK013 - Is the auto-verify-at-length behavior's dependency on a stored PIN length acknowledged, with the cleartext-length trade-off addressed (sealed per T044) or explicitly accepted in writing? [Gap→resolved, tasks T044; analyze H1]
+- [ ] CHK014 - Are repeated-wrong-PIN requirements defined (no lockout signal, no state change) so brute-force behavior is specified rather than incidental? [Edge Case, Spec §Edge Cases "Wrong PIN entered repeatedly"]
+
+## Fail-Closed Surfaces (without collateral suppression)
+
+- [ ] CHK015 - Is every surface that consults hidden state enumerated (chat list, search, pickers, call history, missed-call badge, unread badge, notifications, route access) so "everywhere" in FR-017 is a checkable list? [Completeness, Spec FR-002/FR-017; research R1 choke points]
+- [ ] CHK016 - Is "fail closed" paired with an explicit non-collateral requirement (visible chats and their counts stay correct during the unknown-set window) and a defined fallback source (`badge.lastCount`)? [Clarity, Spec FR-015/FR-017; plan D4]
+- [ ] CHK017 - Is the inbound-frame fail-closed behavior specified (re-queue when the hidden set is unknown, never resolve against an unknown set) including why the window cannot normally occur? [Coverage, plan D2; data-model §Inbound routing]
+- [ ] CHK018 - Are the SW's constraints stated as requirements (cannot know reveal state, may be unable to decrypt the hidden set → fail closed for the hidden contribution only, unclassifiable frames uncounted)? [Completeness, data-model §Badge computation; contracts sw-inbox]
+- [ ] CHK019 - Is the cold-open no-flash requirement measurable (poll from first paint, N restarts, zero occurrences) rather than "never flashes"? [Measurability, Spec SC-006; tasks T036]
+
+## Crypto Discipline (Principle IV — reuse only)
+
+- [ ] CHK020 - Do the requirements state that NO new primitive, key-exchange, ratchet, or ciphertext shape is introduced — channel *selection* only between the two existing channels? [Completeness, plan §Technical Context / Constitution Check IV]
+- [ ] CHK021 - Is the one-plain-1:1-per-peer constraint (INV-3) documented with its crypto rationale (the ratchet session is keyed by chat id, so a second plain 1:1 would fork/steal the session)? [Clarity, data-model §INV-3; research R1/R3]
+- [ ] CHK022 - Is the two-stage routing rule unambiguous about what is knowable pre-decrypt (peer only) vs post-decrypt (groupId), so no requirement implicitly depends on reading sealed data early? [Consistency, data-model §Inbound routing stages; plan D2]
+- [ ] CHK023 - Is `messaging.ts` untouchability stated as a requirement with the dependency direction (`queries.ts → messaging.ts`, no cycle) preserved? [Consistency, plan §Constitution Check IV; constitution §IV]
+- [ ] CHK024 - Are the reset-ordering requirements (block first, delete second, clear set/PIN last) carried over from 1019 FR-024 and extended to the new peer blocks, so no interruption window can flip a hidden chat visible? [Coverage, data-model §state machine "Reset"; tasks T030/T033]
+- [ ] CHK025 - Are adversarial test obligations named for the changed inbound path (forged/replayed frames from blocked peers, group frames riding the 1:1 session, unsolicited-content trace removal vs hidden chats)? [Coverage, tasks T005/T008/T031; constitution §IV]
+
+## Notification & Call Surface Consistency
+
+- [ ] CHK026 - Is the platform constraint that forces the push-path banner documented as a requirement premise (silent pushes → subscription revocation), so the carve-out is justified rather than a soft exception? [Traceability, Spec §Clarifications Q1 / FR-012]
+- [ ] CHK027 - Is "byte-identical to the previews-off generic" specified precisely (title, body, url, coalescing tag) so indistinguishability is testable? [Measurability, Spec FR-012; contracts sw-inbox]
+- [ ] CHK028 - Do the knock-knock requirements (FR-013 full identity) and the call-history requirements (FR-014 no relocked entry) avoid contradiction by separating live-ring from at-rest history, and is the 1019 FR-019 supersession explicit? [Conflict→resolved, Spec FR-013/FR-014/FR-016]
+- [ ] CHK029 - Are all three delivery paths (foreground, backgrounded-connected, push-woken) covered by exactly one specified outcome each, with no path left to inference? [Coverage, data-model §Notification decision]
+
+## Ambiguities & Assumptions Surfaced
+
+- [ ] CHK030 - Is the peer-visible side effect of coexistence (a new conversation appears on the peer's device when the fresh visible chat is created) stated as accepted, so it cannot later be read as a leak/regression? [Assumption, research R3; Spec §ZK]
+- [ ] CHK031 - Is the legacy broken state (hidden + visible plain 1:1 from pre-1027 B1) addressed with defined behavior (tolerated read-only, convergence path) rather than undefined? [Edge Case, data-model §Legacy tolerance]
+- [ ] CHK032 - Is the group-frame session-carrier case specified (a group message from a peer whose only 1:1 is hidden must not resurrect a visible 1:1 row)? [Edge Case, research R2-B1 corollary; tasks T005]
+
+## Notes
+
+- Check each item against the written artifacts only; an item fails if the cited
+  text is missing, vague, or contradicted elsewhere — not if the code differs.
+- Items CHK013 and CHK028 encode analyze findings H1 and FR-016's reconciliation;
+  if either regresses during implementation, re-run `/speckit-analyze`.

--- a/specs/1027-harden-hidden-chats/checklists/zero-knowledge.md
+++ b/specs/1027-harden-hidden-chats/checklists/zero-knowledge.md
@@ -10,56 +10,56 @@ This checks the WRITING, not the implementation.
 
 ## Wire Silence (nothing new crosses to the server)
 
-- [ ] CHK001 - Does the ZK Impact section explicitly enumerate every user action added/changed by this feature (hide, unhide, reveal, relock, blocked-hide, fresh-visible-chat, reset) and state its wire effect? [Completeness, Spec §Zero-Knowledge Impact]
-- [ ] CHK002 - Is the pair-conversation creation path (the one flow that DOES emit wire traffic — a group create card) identified as pre-existing traffic with no new fields, and is its observer (the peer, not the server) named? [Clarity, Spec §ZK "Coexisting conversations"; research R3]
-- [ ] CHK003 - Are requirements explicit that hiding itself is wire-silent (no message, no card, no sync write) so the moment of hiding is unobservable to both server and peer? [Completeness, research R3 "Hide stays a move"]
-- [ ] CHK004 - Is the spurious-rekey elimination (B1) framed as a requirement — hiding must not change observable wire behavior (no rekey bursts correlated with the hide action)? [Coverage, research R2-B1 / plan D2]
-- [ ] CHK005 - Does the spec state what the server can still see (unchanged relay metadata) so "no new signal" is falsifiable rather than aspirational? [Measurability, Spec §ZK "What crosses the wire"]
+- [x] CHK001 - Does the ZK Impact section explicitly enumerate every user action added/changed by this feature (hide, unhide, reveal, relock, blocked-hide, fresh-visible-chat, reset) and state its wire effect? [Completeness, Spec §Zero-Knowledge Impact]
+- [x] CHK002 - Is the pair-conversation creation path (the one flow that DOES emit wire traffic — a group create card) identified as pre-existing traffic with no new fields, and is its observer (the peer, not the server) named? [Clarity, Spec §ZK "Coexisting conversations"; research R3]
+- [x] CHK003 - Are requirements explicit that hiding itself is wire-silent (no message, no card, no sync write) so the moment of hiding is unobservable to both server and peer? [Completeness, research R3 "Hide stays a move"]
+- [x] CHK004 - Is the spurious-rekey elimination (B1) framed as a requirement — hiding must not change observable wire behavior (no rekey bursts correlated with the hide action)? [Coverage, research R2-B1 / plan D2]
+- [x] CHK005 - Does the spec state what the server can still see (unchanged relay metadata) so "no new signal" is falsifiable rather than aspirational? [Measurability, Spec §ZK "What crosses the wire"]
 
 ## Device-Local State Never Syncs
 
-- [ ] CHK006 - Are ALL new device-local artifacts (`hiddenPeer:` tombstones, `badge.lastCount`) explicitly required to be excluded from own-data sync, with a test obligation named for each? [Completeness, Spec FR-019; tasks T027/T030]
-- [ ] CHK007 - Is the existing exclusion of `privacy.hiddenChats` / `privacy.hiddenPin` restated as a preserved invariant (not silently assumed) in the 1027 requirements? [Consistency, Spec FR-019; data-model §Hidden set]
-- [ ] CHK008 - Are the `localOnly` tombstone semantics (honored by ingest, never uploaded, never propagated to the user's other devices) specified for the new `hiddenPeer:` rows, matching the 1019 chat-id rows? [Consistency, data-model §Peer block; research R4]
-- [ ] CHK009 - Is the requirement that reveal state is memory-only (never persisted, cold start always locked) stated with its observable consequence (SW must treat `revealed` as never-revealed)? [Clarity, Spec FR-009; data-model §Badge preference]
+- [x] CHK006 - Are ALL new device-local artifacts (`hiddenPeer:` tombstones, `badge.lastCount`) explicitly required to be excluded from own-data sync, with a test obligation named for each? [Completeness, Spec FR-019; tasks T027/T030]
+- [x] CHK007 - Is the existing exclusion of `privacy.hiddenChats` / `privacy.hiddenPin` restated as a preserved invariant (not silently assumed) in the 1027 requirements? [Consistency, Spec FR-019; data-model §Hidden set]
+- [x] CHK008 - Are the `localOnly` tombstone semantics (honored by ingest, never uploaded, never propagated to the user's other devices) specified for the new `hiddenPeer:` rows, matching the 1019 chat-id rows? [Consistency, data-model §Peer block; research R4]
+- [x] CHK009 - Is the requirement that reveal state is memory-only (never persisted, cold start always locked) stated with its observable consequence (SW must treat `revealed` as never-revealed)? [Clarity, Spec FR-009; data-model §Badge preference]
 
 ## No PIN Oracle
 
-- [ ] CHK010 - Is "no oracle" defined across ALL observable channels (visual, audible, timing, state change) rather than just "no error message"? [Clarity, Spec FR-008, SC-007]
-- [ ] CHK011 - Is the timing-parity claim grounded in a stated mechanism (Argon2id runs identically on both outcomes) rather than left as an untestable assertion? [Measurability, tasks T011; SC-007]
-- [ ] CHK012 - Are PIN storage requirements explicit that no recoverable form and no fast-compare path exist (verification = decrypt success only)? [Completeness, Spec FR-010]
-- [ ] CHK013 - Is the auto-verify-at-length behavior's dependency on a stored PIN length acknowledged, with the cleartext-length trade-off addressed (sealed per T044) or explicitly accepted in writing? [Gap→resolved, tasks T044; analyze H1]
-- [ ] CHK014 - Are repeated-wrong-PIN requirements defined (no lockout signal, no state change) so brute-force behavior is specified rather than incidental? [Edge Case, Spec §Edge Cases "Wrong PIN entered repeatedly"]
+- [x] CHK010 - Is "no oracle" defined across ALL observable channels (visual, audible, timing, state change) rather than just "no error message"? [Clarity, Spec FR-008, SC-007]
+- [x] CHK011 - Is the timing-parity claim grounded in a stated mechanism (Argon2id runs identically on both outcomes) rather than left as an untestable assertion? [Measurability, tasks T011; SC-007]
+- [x] CHK012 - Are PIN storage requirements explicit that no recoverable form and no fast-compare path exist (verification = decrypt success only)? [Completeness, Spec FR-010]
+- [x] CHK013 - Is the auto-verify-at-length behavior's dependency on a stored PIN length acknowledged, with the cleartext-length trade-off addressed (sealed per T044) or explicitly accepted in writing? [Gap→resolved, tasks T044; analyze H1]
+- [x] CHK014 - Are repeated-wrong-PIN requirements defined (no lockout signal, no state change) so brute-force behavior is specified rather than incidental? [Edge Case, Spec §Edge Cases "Wrong PIN entered repeatedly"]
 
 ## Fail-Closed Surfaces (without collateral suppression)
 
-- [ ] CHK015 - Is every surface that consults hidden state enumerated (chat list, search, pickers, call history, missed-call badge, unread badge, notifications, route access) so "everywhere" in FR-017 is a checkable list? [Completeness, Spec FR-002/FR-017; research R1 choke points]
-- [ ] CHK016 - Is "fail closed" paired with an explicit non-collateral requirement (visible chats and their counts stay correct during the unknown-set window) and a defined fallback source (`badge.lastCount`)? [Clarity, Spec FR-015/FR-017; plan D4]
-- [ ] CHK017 - Is the inbound-frame fail-closed behavior specified (re-queue when the hidden set is unknown, never resolve against an unknown set) including why the window cannot normally occur? [Coverage, plan D2; data-model §Inbound routing]
-- [ ] CHK018 - Are the SW's constraints stated as requirements (cannot know reveal state, may be unable to decrypt the hidden set → fail closed for the hidden contribution only, unclassifiable frames uncounted)? [Completeness, data-model §Badge computation; contracts sw-inbox]
-- [ ] CHK019 - Is the cold-open no-flash requirement measurable (poll from first paint, N restarts, zero occurrences) rather than "never flashes"? [Measurability, Spec SC-006; tasks T036]
+- [x] CHK015 - Is every surface that consults hidden state enumerated (chat list, search, pickers, call history, missed-call badge, unread badge, notifications, route access) so "everywhere" in FR-017 is a checkable list? [Completeness, Spec FR-002/FR-017; research R1 choke points]
+- [x] CHK016 - Is "fail closed" paired with an explicit non-collateral requirement (visible chats and their counts stay correct during the unknown-set window) and a defined fallback source (`badge.lastCount`)? [Clarity, Spec FR-015/FR-017; plan D4]
+- [x] CHK017 - Is the inbound-frame fail-closed behavior specified (re-queue when the hidden set is unknown, never resolve against an unknown set) including why the window cannot normally occur? [Coverage, plan D2; data-model §Inbound routing]
+- [x] CHK018 - Are the SW's constraints stated as requirements (cannot know reveal state, may be unable to decrypt the hidden set → fail closed for the hidden contribution only, unclassifiable frames uncounted)? [Completeness, data-model §Badge computation; contracts sw-inbox]
+- [x] CHK019 - Is the cold-open no-flash requirement measurable (poll from first paint, N restarts, zero occurrences) rather than "never flashes"? [Measurability, Spec SC-006; tasks T036]
 
 ## Crypto Discipline (Principle IV — reuse only)
 
-- [ ] CHK020 - Do the requirements state that NO new primitive, key-exchange, ratchet, or ciphertext shape is introduced — channel *selection* only between the two existing channels? [Completeness, plan §Technical Context / Constitution Check IV]
-- [ ] CHK021 - Is the one-plain-1:1-per-peer constraint (INV-3) documented with its crypto rationale (the ratchet session is keyed by chat id, so a second plain 1:1 would fork/steal the session)? [Clarity, data-model §INV-3; research R1/R3]
-- [ ] CHK022 - Is the two-stage routing rule unambiguous about what is knowable pre-decrypt (peer only) vs post-decrypt (groupId), so no requirement implicitly depends on reading sealed data early? [Consistency, data-model §Inbound routing stages; plan D2]
-- [ ] CHK023 - Is `messaging.ts` untouchability stated as a requirement with the dependency direction (`queries.ts → messaging.ts`, no cycle) preserved? [Consistency, plan §Constitution Check IV; constitution §IV]
-- [ ] CHK024 - Are the reset-ordering requirements (block first, delete second, clear set/PIN last) carried over from 1019 FR-024 and extended to the new peer blocks, so no interruption window can flip a hidden chat visible? [Coverage, data-model §state machine "Reset"; tasks T030/T033]
-- [ ] CHK025 - Are adversarial test obligations named for the changed inbound path (forged/replayed frames from blocked peers, group frames riding the 1:1 session, unsolicited-content trace removal vs hidden chats)? [Coverage, tasks T005/T008/T031; constitution §IV]
+- [x] CHK020 - Do the requirements state that NO new primitive, key-exchange, ratchet, or ciphertext shape is introduced — channel *selection* only between the two existing channels? [Completeness, plan §Technical Context / Constitution Check IV]
+- [x] CHK021 - Is the one-plain-1:1-per-peer constraint (INV-3) documented with its crypto rationale (the ratchet session is keyed by chat id, so a second plain 1:1 would fork/steal the session)? [Clarity, data-model §INV-3; research R1/R3]
+- [x] CHK022 - Is the two-stage routing rule unambiguous about what is knowable pre-decrypt (peer only) vs post-decrypt (groupId), so no requirement implicitly depends on reading sealed data early? [Consistency, data-model §Inbound routing stages; plan D2]
+- [x] CHK023 - Is `messaging.ts` untouchability stated as a requirement with the dependency direction (`queries.ts → messaging.ts`, no cycle) preserved? [Consistency, plan §Constitution Check IV; constitution §IV]
+- [x] CHK024 - Are the reset-ordering requirements (block first, delete second, clear set/PIN last) carried over from 1019 FR-024 and extended to the new peer blocks, so no interruption window can flip a hidden chat visible? [Coverage, data-model §state machine "Reset"; tasks T030/T033]
+- [x] CHK025 - Are adversarial test obligations named for the changed inbound path (forged/replayed frames from blocked peers, group frames riding the 1:1 session, unsolicited-content trace removal vs hidden chats)? [Coverage, tasks T005/T008/T031; constitution §IV]
 
 ## Notification & Call Surface Consistency
 
-- [ ] CHK026 - Is the platform constraint that forces the push-path banner documented as a requirement premise (silent pushes → subscription revocation), so the carve-out is justified rather than a soft exception? [Traceability, Spec §Clarifications Q1 / FR-012]
-- [ ] CHK027 - Is "byte-identical to the previews-off generic" specified precisely (title, body, url, coalescing tag) so indistinguishability is testable? [Measurability, Spec FR-012; contracts sw-inbox]
-- [ ] CHK028 - Do the knock-knock requirements (FR-013 full identity) and the call-history requirements (FR-014 no relocked entry) avoid contradiction by separating live-ring from at-rest history, and is the 1019 FR-019 supersession explicit? [Conflict→resolved, Spec FR-013/FR-014/FR-016]
-- [ ] CHK029 - Are all three delivery paths (foreground, backgrounded-connected, push-woken) covered by exactly one specified outcome each, with no path left to inference? [Coverage, data-model §Notification decision]
+- [x] CHK026 - Is the platform constraint that forces the push-path banner documented as a requirement premise (silent pushes → subscription revocation), so the carve-out is justified rather than a soft exception? [Traceability, Spec §Clarifications Q1 / FR-012]
+- [x] CHK027 - Is "byte-identical to the previews-off generic" specified precisely (title, body, url, coalescing tag) so indistinguishability is testable? [Measurability, Spec FR-012; contracts sw-inbox]
+- [x] CHK028 - Do the knock-knock requirements (FR-013 full identity) and the call-history requirements (FR-014 no relocked entry) avoid contradiction by separating live-ring from at-rest history, and is the 1019 FR-019 supersession explicit? [Conflict→resolved, Spec FR-013/FR-014/FR-016]
+- [x] CHK029 - Are all three delivery paths (foreground, backgrounded-connected, push-woken) covered by exactly one specified outcome each, with no path left to inference? [Coverage, data-model §Notification decision]
 
 ## Ambiguities & Assumptions Surfaced
 
-- [ ] CHK030 - Is the peer-visible side effect of coexistence (a new conversation appears on the peer's device when the fresh visible chat is created) stated as accepted, so it cannot later be read as a leak/regression? [Assumption, research R3; Spec §ZK]
-- [ ] CHK031 - Is the legacy broken state (hidden + visible plain 1:1 from pre-1027 B1) addressed with defined behavior (tolerated read-only, convergence path) rather than undefined? [Edge Case, data-model §Legacy tolerance]
-- [ ] CHK032 - Is the group-frame session-carrier case specified (a group message from a peer whose only 1:1 is hidden must not resurrect a visible 1:1 row)? [Edge Case, research R2-B1 corollary; tasks T005]
+- [x] CHK030 - Is the peer-visible side effect of coexistence (a new conversation appears on the peer's device when the fresh visible chat is created) stated as accepted, so it cannot later be read as a leak/regression? [Assumption, research R3; Spec §ZK]
+- [x] CHK031 - Is the legacy broken state (hidden + visible plain 1:1 from pre-1027 B1) addressed with defined behavior (tolerated read-only, convergence path) rather than undefined? [Edge Case, data-model §Legacy tolerance]
+- [x] CHK032 - Is the group-frame session-carrier case specified (a group message from a peer whose only 1:1 is hidden must not resurrect a visible 1:1 row)? [Edge Case, research R2-B1 corollary; tasks T005]
 
 ## Notes
 

--- a/specs/1027-harden-hidden-chats/contracts/internal-api.md
+++ b/specs/1027-harden-hidden-chats/contracts/internal-api.md
@@ -1,0 +1,111 @@
+# Internal Module Contracts: 1027 Harden Hidden Chats
+
+**No HTTP/wire API changes.** The server is untouched; these are the client
+module contracts that tasks and tests are written against.
+
+## NEW `src/services/hidden-pair.ts` (pure leaf — no idb, no imports beyond types)
+
+```ts
+/** Plain 1:1s and pair conversations with this peer (multi-member groups never count). */
+export function chatsWithPeer(chats: Chat[], peerId: string): Chat[]
+
+/** Per-person one-hidden rule (INV-1). */
+export function canHide(
+  chats: Chat[], hidden: ReadonlySet<string>, chatId: string,
+): { ok: true } | { ok: false; reason: string }
+
+/** Per-person one-visible rule (INV-2). */
+export function canUnhide(
+  chats: Chat[], hidden: ReadonlySet<string>, chatId: string,
+): { ok: true } | { ok: false; reason: string }
+
+/** Rule R stage 1 (pre-decrypt session resolution, steps S1–S2) as a pure
+ *  function; null → caller consults the peer block / creates. Never returns a
+ *  pair conversation (those carry no 1:1 session; group content routes by
+ *  groupId post-decrypt). */
+export function resolveInboundDirectChat(
+  chats: Chat[], hidden: ReadonlySet<string>, peerId: string,
+): Chat | null
+```
+
+Contract notes:
+- Deterministic, synchronous, no side effects — unit-tested exhaustively
+  including the legacy INV-3-violating state (hidden + visible plain 1:1).
+- `reason` strings are the user-facing copy (UI voice rules apply: warm, plain,
+  "you", no em-dashes/semicolons).
+
+## CHANGED `src/db/queries.ts`
+
+```ts
+/** Existing signature, new behavior: if a hidden chat with this peer exists,
+ *  creates/returns the VISIBLE PAIR CONVERSATION (group-modeled) instead of a
+ *  second plain 1:1; also lifts any 'hiddenPeer:' block (explicit re-engagement). */
+export async function startDirectChat(contact: Contact): Promise<string>
+
+/** Existing function, new resolution: rule R replaces the internal
+ *  startDirectChat call; step 4 acks+drops on a 'hiddenPeer:' tombstone with no
+ *  rekey and no writes. */
+async function receiveIncomingInner(from, remoteId, ciphertext): Promise<void>
+
+/** Existing signature; new: persists 'badge.lastCount' on success and returns it
+ *  (never 0-collateral) when the hidden set is unknown in never/revealed modes. */
+export async function countUnread(): Promise<number>
+```
+
+## CHANGED `src/services/hidden-chats-reset.ts`
+
+```ts
+/** Additionally records localOnly 'hiddenPeer:<peer>' tombstones for each hidden
+ *  plain-1:1 peer BEFORE deleting data (same FR-024 ordering). */
+export async function resetHiddenChats(): Promise<{ wiped: string[] }>
+```
+
+## CHANGED `src/services/hidden-state.ts`
+
+```ts
+/** NEW: register a callback fired on every transition to revealed=false and on
+ *  clearHiddenState — the router uses it to leave an open hidden conversation. */
+export function registerRelockHook(fn: () => void): void
+```
+
+(Leaf discipline preserved: the router imports the leaf, never the reverse.)
+
+## CHANGED `src/router/index.ts`
+
+- Registers the relock hook: active route is a hidden conversation →
+  `router.replace('/tabs/chats')`.
+- `beforeEach`: navigation to a hidden conversation while not revealed →
+  redirect `/tabs/chats` (deep links, notification taps, back-stack).
+
+## CHANGED `src/services/notify.ts`
+
+- The hidden-chat branch's backgrounded-but-connected generic
+  `notifyLocal('Ring','New message',…)` bridge is removed; that path is silent
+  (badge only). Foreground claim behavior unchanged.
+
+## CHANGED `src/services/sw-inbox.ts`
+
+```ts
+/** Existing signature; new: applies privacy.hiddenChatsBadge ('revealed' ≡
+ *  'never' in the SW), excludes hidden chats via readHiddenSet(), falls back to
+ *  'badge.lastCount' when the set is locked, and never counts a pending frame it
+ *  cannot classify as non-hidden. */
+export async function unreadCount(): Promise<number>
+```
+
+- `noteForPayload` hidden branch: unchanged behavior, now pinned by tests —
+  byte-identical to the previews-off generic (`Ring` / `New message` /
+  `/tabs/chats`) and evaluated before mention/mute/content branches.
+
+## CHANGED `src/components/ChatActionsSheet.vue`
+
+- Hide/Unhide entries consult `canHide`/`canUnhide`; a blocked action renders
+  disabled with the reason as its note text (stock Ionic action sheet only).
+
+## UNCHANGED (contract pinned by tests)
+
+- `hidden-chats.ts` public API (set + PIN + verifier semantics).
+- `hidden-calls.ts` (`hiddenCallKeys`) and the call-history exclusion.
+- The incoming-call overlay: full caller identity for hidden peers (knock-knock)
+  — asserted by a new e2e, no code change.
+- `messaging.ts` — not modified at all.

--- a/specs/1027-harden-hidden-chats/data-model.md
+++ b/specs/1027-harden-hidden-chats/data-model.md
@@ -1,0 +1,168 @@
+# Data Model: Harden Hidden Chats + One-Hidden-One-Visible Per Person
+
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-02
+
+No new IndexedDB object stores and no `DB_VERSION` bump. All new data rides
+existing stores (`settings`, `tombstones`). This file defines the entities,
+their keys, the per-person invariant, and the hide/reveal state machine.
+
+## Entities
+
+### Conversation (existing `chats` store — unchanged shape)
+
+Two channel shapes participate in the per-person model:
+
+| Shape | Discriminator | Crypto channel | Inbound routing key |
+|---|---|---|---|
+| **Plain 1:1** | `!isGroup && participantIds.length === 1` | per-peer Double Ratchet; session stored under this chat's id (`sessions[chatId]`, `smeta:<chatId>`) | sender (`from`) — resolved by rule R |
+| **Pair conversation** | `isGroup && participantIds.length === 1` | sender keys (group mechanism) | `payload.groupId` (exact id) |
+| Multi-member group | `isGroup && participantIds.length > 1` | sender keys | `payload.groupId` |
+
+*Hidden* is **not** a chat field — membership in the sealed hidden set is the
+only marker (unchanged from 1019). Multi-member groups are outside the
+per-person rule and hide/unhide individually.
+
+### Hidden set (existing, unchanged)
+
+`settings['privacy.hiddenChats']` — `EncWrapper` (AEAD-sealed `string[]` under
+the master key, AAD = key name). Device-local; excluded from own-data sync.
+
+### Hidden PIN verifier (existing, unchanged)
+
+`settings['privacy.hiddenPin']` — `{ salt, env, length }`, Argon2id-derived key,
+decrypt-succeeds verification, no recoverable PIN, no fast path.
+
+### Reveal session (existing, unchanged storage; new relock hook)
+
+Memory-only (`hidden-state.ts`): `revealed` flag + grace timer in
+`useHiddenChats.ts`. **New**: a registered navigation hook fires on every
+transition to `revealed=false` (grace expiry, manual relock, keystore auto-lock,
+`clearHiddenState`) so an on-screen hidden conversation is left immediately.
+
+### Peer block (new rows in existing `tombstones` store)
+
+```
+Tombstone {
+  id:        'hiddenPeer:<peerUserId>'   // store-qualified key, existing scheme
+  store:     'hiddenPeer'                // logical namespace, not an idb store
+  recordId:  <peerUserId>
+  deletedAt: Number.MAX_SAFE_INTEGER     // permanent until explicitly lifted
+  localOnly: true                        // never uploaded, never synced
+}
+```
+
+Written by `resetHiddenChats` for each hidden **plain-1:1** peer (pair/group
+threads keep chat-id tombstones — their ids are stable and shared, so id-keyed
+blocking works). Consulted by rule R step 4 in `receiveIncomingInner` (ack +
+drop, no rekey, no contact/chat creation). Lifted by `clearTombstone` when the
+user explicitly starts a new chat with that person (`startDirectChat`).
+
+### Badge cache (new `settings` key)
+
+`settings['badge.lastCount']` — plain integer, the last successfully computed
+(already preference-filtered) unread total. Device-local: added to the own-sync
+exclusion list beside the hidden keys. Read as the fallback when the hidden set
+is not yet decryptable in modes `never`/`revealed` (page `countUnread`, SW
+`unreadCount`). Leaks nothing: it equals the number the OS badge already
+displays.
+
+### Badge preference (existing, unchanged values)
+
+`settings['privacy.hiddenChatsBadge']`: `'always'` (default) | `'never'` |
+`'revealed'`. New semantics detail: in the SW, `'revealed'` behaves as
+`'never'` (reveal is page-memory-only and must never be assumed from the SW).
+
+## The per-person invariant
+
+For a peer `P`, over the set `chatsWithPeer(P)` = plain 1:1s with `P` + pair
+conversations with `P`:
+
+- **INV-1**: at most one member of `chatsWithPeer(P)` is hidden.
+- **INV-2**: at most one member of `chatsWithPeer(P)` is visible.
+- **INV-3**: at most one plain 1:1 with `P` exists (channel uniqueness — the
+  ratchet session for `P` lives under exactly one chat id).
+
+Enforcement points (all through pure `hidden-pair.ts` predicates):
+
+| Action | Guard | Blocked outcome |
+|---|---|---|
+| Hide chat | `canHide`: no other hidden member of `chatsWithPeer(P)` | Action disabled, reason: already a hidden chat with this person |
+| Unhide chat | `canUnhide`: no visible member of `chatsWithPeer(P)` | Action disabled, reason: already a visible chat with this person (delete it first) |
+| Start chat (user) | `startDirectChat`: existing visible member → return it; hidden plain 1:1 exists → create **pair conversation**; else create plain 1:1 | never a second visible, never a second plain 1:1 |
+| Inbound frame | rule R (below) | never creates a row when a hidden thread exists |
+
+Legacy tolerance: pre-1027 devices may hold a hidden **and** a visible plain 1:1
+for the same peer (bug B1's residue), violating INV-3. Tolerated read-only: rule
+R prefers the visible one (where the live session is), `canHide`/`canUnhide`
+still hold INV-1/INV-2, and deleting either chat converges the state. No
+migration pass.
+
+## Inbound routing (rule R)
+
+For an inbound frame from peer `P` (runs only unlocked; frames queue while
+locked — existing gate). Rule R has two stages, because `payload.groupId` lives
+INSIDE the sealed payload and is only known after decryption:
+
+**Stage 1 — session resolution (PRE-decrypt).** Every frame from `P` rides the
+per-peer 1:1 ratchet regardless of what it carries, so the session chat is
+resolved without looking at the payload:
+
+```
+S1. visible plain 1:1 with P?   → that chat (open the packet under its id)
+S2. hidden plain 1:1 with P?    → that chat (silent: no row created, no unhide)
+S3. tombstone 'hiddenPeer:P'?   → ack + drop (no rekey request, no contact/chat
+                                   creation, no notification — no trace)
+S4. else                        → create fresh visible plain 1:1 (existing path)
+```
+
+**Stage 2 — content routing (POST-decrypt).** With the payload open:
+
+```
+C1. payload.groupId?            → conversation payload.groupId (existing behavior;
+                                   ensureGroupChat consults group-id tombstones —
+                                   the stage-1 chat only carried the session)
+C2. else (plain 1:1 content)    → the stage-1 chat (hidden thread stays silent:
+                                   notifications per FR-012, badge per FR-015)
+```
+
+Fail-closed rule: if the hidden set is not `isHiddenKnown()` at stage-1 time
+(cannot normally happen — unlocked implies decryptable), the frame is re-queued,
+never resolved against an unknown set.
+
+Stage 1 is what eliminates bug B1's spurious `requestRekey`: the packet is
+always opened under the chat id that actually holds the ratchet.
+
+## Hide / reveal state machine (per device)
+
+States: `Setup` (no PIN) → `Locked` (PIN exists, not revealed) ⇄ `Revealed`.
+
+| From | Event | Guard | To | Effects |
+|---|---|---|---|---|
+| Setup | Hide chat | PIN created via `ensureHiddenPin`; `canHide` | Locked | chat id added to sealed set; leaves all visible surfaces |
+| Locked | Correct PIN typed in search | length match + verifier decrypt | Revealed | lists re-query; hidden chats marked + sorted to top; search box cleared |
+| Locked | Wrong PIN | — | Locked | no output, no signal (no oracle) |
+| Revealed | Grace expiry / manual relock / keystore auto-lock / app close | — | Locked | lists re-query; **kick-out hook** leaves any open hidden conversation |
+| Revealed | Hide chat | `canHide` | Revealed | new id sealed into set |
+| Revealed | Unhide chat | `canUnhide` | Revealed | id removed from set; chat rejoins normal list |
+| any | Reset hidden chats | user confirm | Setup | tombstones (chat ids + `hiddenPeer:` peers) → wipe messages/sessions/senderkeys/chats → clear set + PIN + memory (order preserved from 1019 FR-024) |
+
+## Notification decision (per delivery path — FR-012)
+
+| Path | Hidden + relocked outcome |
+|---|---|
+| Foreground page | Fully silent; claims the banner so a co-arriving push can't double-fire; badge updates |
+| Backgrounded, WS-connected, not push-woken | Fully silent (generic bridge **removed** — B6); badge updates |
+| Push-woken SW | Generic note byte-identical to previews-off: title `Ring`, body `New message`, url `/tabs/chats`, internal coalescing tag; badge per preference |
+| Incoming call (any path) | Full identity ring — never suppressed (knock-knock, FR-013) |
+
+## Badge computation (FR-015)
+
+```
+mode = privacy.hiddenChatsBadge
+if mode == 'always':      total = Σ unread(all chats)            # no hidden dependency
+else:
+  if hidden set known:    total = Σ unread(chats not hidden)     # + hidden if revealed & mode=='revealed' (page only)
+  else:                   total = settings['badge.lastCount']    # last good, never 0-collateral
+persist settings['badge.lastCount'] = total on every successful computation
+SW: 'revealed' ≡ 'never'; pending frames not classifiable as non-hidden are NOT counted
+```

--- a/specs/1027-harden-hidden-chats/plan.md
+++ b/specs/1027-harden-hidden-chats/plan.md
@@ -1,0 +1,231 @@
+# Implementation Plan: Harden Hidden Chats + One-Hidden-One-Visible Per Person
+
+**Branch**: `feat/1027-harden-hidden-chats` | **Date**: 2026-07-02 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1027-harden-hidden-chats/spec.md`
+
+## Summary
+
+Fix and harden the shipped Hidden Chats feature (spec 1019). The central defect:
+inbound routing (`receiveIncomingInner` → `startDirectChat`) refuses hidden chats,
+so hiding your only 1:1 with a peer makes their next message resurrect a *visible*
+chat, land content in it, fire spurious re-keys, and orphan the hidden thread.
+The fix is a peer-aware inbound routing rule plus a per-person invariant: at most
+one hidden and one visible chat per person, where two coexisting threads are
+always two distinct crypto channels (the plain 1:1 Double Ratchet thread and a
+group-modeled "pair conversation" using the existing sender-key mechanism —
+`startHiddenChat`'s channel, finally wired into real UI via `startDirectChat`).
+Also fixed: peer-keyed reset block on the live relay path, badge correctness
+without collateral suppression (page + SW), relock kick-out + route guard,
+fully-silent non-push notification paths, and the raw NUL byte in `queries.ts`.
+Everything client-side; zero server changes. All design decisions and their
+rationale: [research.md](./research.md).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (ES modules, `@/` → `src/`), Vue 3 `<script setup>` + Ionic 8; no server changes (Go untouched)
+
+**Primary Dependencies**: libsodium-wrappers-sumo (existing X3DH / Double Ratchet / sender keys — reused, never modified), Vue Router, existing `idb` wrapper
+
+**Storage**: IndexedDB via `src/db/idb.ts` — existing stores only (`chats`, `messages`, `sessions`, `senderkeys`, `settings`, `tombstones`); **no new object store, no `DB_VERSION` bump** (new data = new `settings` keys + new `tombstones` rows in existing stores)
+
+**Testing**: vitest (unit; fake idb), Playwright `e2e/` (hermetic stack, real WebRTC), `drive/` scenarios (live dev stack) — Playwright is the primary behavioral gate per FR-022
+
+**Target Platform**: installable PWA (iOS Safari 16.4+, Android Chrome, desktop); service-worker web push constraints are load-bearing (see FR-012)
+
+**Project Type**: web app (client-only change within the existing monorepo)
+
+**Performance Goals**: no regression to chat-list query time (`listChats` stays a single pass); badge computation stays O(chats)
+
+**Constraints**: zero-knowledge boundary (no new wire data), fail-closed hidden filtering without collateral suppression, no PIN oracle, reveal state memory-only
+
+**Scale/Scope**: ~10 client files touched + tests; the crypto core (`src/services/crypto/`) is NOT modified — only channel *selection* changes
+
+## Constitution Check
+
+*GATE: evaluated against constitution v1.2.0 — re-checked after Phase 1 design: PASS.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Zero-Knowledge Boundary | ✅ | No new client→server request/field/payload. Pair conversations are ordinary opaque conversations the server already relays. Spec has the mandatory ZK Impact section. |
+| II. Spec-Driven Development | ✅ | Spec 1027 (ad-hoc band), pipeline followed: specify → clarify (3 Qs) → plan (this) → tasks → analyze → taskstoissues → implement. |
+| III. Test-Driven Development | ✅ | tasks.md will order failing tests first; B1/B3/B4 get regression tests before fixes; e2e extended for every changed user-facing behavior. |
+| IV. Crypto Discipline | ✅ | No new primitives or schemes — channel *selection* between the two existing channels (per-peer ratchet, sender-key groups). `messaging.ts` untouched and stays crypto-only; `queries.ts → messaging.ts` direction preserved. `/speckit-checklist` REQUIRED (Principle I/IV spec) and will be run before implement. Security review requested on the PR. |
+| V. Offline-First Data Integrity | ✅ | No store/schema change; writes stay on `idb.ts` + change bus; `useLiveQuery` reactivity via existing `touch()` pattern. |
+| VI. Stateless Server & Migrations | ✅ | Server untouched. |
+| VII. Quality Gates | ✅ | `npm run build`, vitest + floors, `go build/vet/test` (unchanged but run), e2e for changed behavior. Release-note-style commit subjects. |
+| VIII. Traceable Delivery | ✅ | `make roadmap` run; taskstoissues will open issues; PR lists `Closes #N`. |
+| IX. Privacy & Data Minimization | ✅ | Strictly reduces what the device shows; nothing new collected. |
+| X. Accessibility & i18n | ✅ | Blocked Hide/Unhide reasons are plain copy on stock components; no new text surface with direction risk. |
+| XI. Ionic-First UI | ✅ | Disabled action-sheet buttons + caption text; no custom widgets. |
+
+No violations → Complexity Tracking not needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1027-harden-hidden-chats/
+├── plan.md              # This file
+├── research.md          # Phase 0 — audit + design decisions R1-R10
+├── data-model.md        # Phase 1 — entities, keys, state machine
+├── quickstart.md        # Phase 1 — implementation slices
+├── contracts/
+│   └── internal-api.md  # Phase 1 — module contracts (no HTTP API changes)
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── services/
+│   ├── hidden-pair.ts             # NEW — pure per-person invariant + routing rule (R8)
+│   ├── hidden-pair.test.ts        # NEW
+│   ├── hidden-chats.ts            # unchanged API; doc comments updated
+│   ├── hidden-chats-start.ts      # absorbed: pair-conversation creation reused by startDirectChat
+│   ├── hidden-chats-reset.ts      # + peer-keyed localOnly blocks (R4)
+│   ├── hidden-state.ts            # + registered relock navigation hook (R6)
+│   ├── notify.ts                  # remove backgrounded generic bridge (B6/R7)
+│   └── sw-inbox.ts                # unreadCount honors badge pref + hidden set (B4/R5)
+├── db/
+│   ├── queries.ts                 # rule-R inbound resolver; startDirectChat pair path;
+│   │                              #   countUnread badge cache; NUL → \u0000 (B1/B3/B4)
+│   ├── hidden-calls.ts            # unchanged (verified by tests)
+│   └── tombstones.ts              # unchanged (reused: hiddenPeer:<id> localOnly rows)
+├── composables/
+│   └── useHiddenChats.ts          # relock triggers kick-out hook
+├── components/
+│   └── ChatActionsSheet.vue       # canHide/canUnhide gating + blocked reasons
+├── router/
+│   └── index.ts                   # hidden-chat route guard (R6)
+└── views/tabs/ChatsPage.vue       # unchanged reveal gesture (covered by tests)
+
+e2e/
+└── hidden-chats.spec.ts (+ new: hidden-coexist.spec.ts, hidden-privacy.spec.ts,
+                             hidden-call.spec.ts, hidden-reset.spec.ts)
+
+drive/scenarios/
+└── (+ hidden-coexist.mjs, hidden-reset-relay.mjs, hidden-kickout.mjs; existing six kept)
+```
+
+**Structure Decision**: single-project client change inside the existing monorepo
+layout; the one new module (`hidden-pair.ts`) is a pure leaf so the invariant is
+unit-testable without IndexedDB and importable from both `queries.ts` and UI
+without cycles (same pattern as `hidden-state.ts`).
+
+## Design (Phase 1 summary — details in data-model.md / contracts/)
+
+### D1. Channels and roles (R3)
+
+Per peer there is at most one **plain 1:1** channel (ratchet session keyed by that
+chat's id) and at most one **pair conversation** (group-modeled, `isGroup: true`,
+`participantIds: [peer]`, sender keys, routed by `groupId`). *Hidden* and
+*visible* are roles laid over whichever channel each thread happens to be.
+
+- **Hide** = `addHidden(chatId)` after `canHide` passes. No migration, no wire
+  traffic, nothing the peer or server can observe.
+- **Fresh visible chat** when a hidden chat with that peer exists =
+  `startDirectChat` creates a **pair conversation** (reusing
+  `createGroup('', [peer])` exactly as `startHiddenChat` does today) instead of a
+  second plain 1:1. The peer sees a new conversation appear — inherent to
+  coexistence and accepted in the spec.
+- **Unhide** = `removeHidden(chatId)` after `canUnhide` passes (no visible chat
+  with the same peer).
+
+### D2. Inbound routing rule R (fixes B1)
+
+`receiveIncomingInner` replaces its blind `startDirectChat` call with a
+two-stage resolver (`payload.groupId` is inside the sealed payload, so a frame's
+group membership is only known post-decrypt):
+
+- **Stage 1 — session resolution (pre-decrypt)**; every frame rides the per-peer
+  1:1 ratchet: visible plain 1:1 with the peer if it exists; else hidden plain
+  1:1 (never creates a row, never un-hides); else if `hiddenPeer:<peer>` block
+  exists → ack + drop, no rekey, no trace; else create a fresh visible 1:1
+  (genuinely new peer — unchanged).
+- **Stage 2 — content routing (post-decrypt)**: `payload.groupId` → that
+  conversation (unchanged); otherwise the stage-1 chat (silent per FR-012 when
+  hidden).
+
+Because frames are queued while locked (`isUnlockedNow()` gate already in place),
+the resolver always runs with the master key available, so the hidden set is
+decryptable — no new fail-open window. If `ensureHiddenLoaded()` still cannot
+produce a known set, the frame is re-queued (fail closed) rather than resolved
+against an unknown set.
+
+### D3. Reset block (fixes B3) — R4
+
+`resetHiddenChats` additionally writes `hiddenPeer:<peerId>` localOnly tombstones
+for each hidden plain-1:1 peer and keeps id tombstones for pair/group threads;
+`ensureGroupChat`/`handleGroupCard` consult group-id tombstones. `startDirectChat`
+lifts the peer block (`clearTombstone`) on explicit user re-engagement.
+
+### D4. Badge (fixes B4) — R5
+
+- Page `countUnread`: persist last successful result to `badge.lastCount`
+  (device-local, added to the own-sync exclusion list next to the hidden keys);
+  return it — not 0 — when the set is unknown in `never`/`revealed` modes.
+- SW `unreadCount`: apply `privacy.hiddenChatsBadge`; `revealed` behaves as
+  `never` in the SW (reveal is page-memory-only); unclassifiable frames are not
+  counted (privacy over accuracy); fall back to `badge.lastCount` when locked.
+
+### D5. Relock kick-out + guard (fixes B5) — R6
+
+Router registers a hook with `hidden-state` (leaf stays import-light): on
+`setRevealed(false)`/`clearHiddenState`, if the active route is a hidden
+conversation → `router.replace('/tabs/chats')`. Plus a `beforeEach` guard:
+`/chat/:id` where id is hidden and not revealed → redirect. Covers grace expiry,
+keystore auto-lock, manual relock, deep links, and back-stack restoration.
+
+### D6. Notification paths (fixes B6) — R7
+
+Remove the `notify.ts` backgrounded-but-connected generic bridge; assert the SW
+generic note is byte-identical to the previews-off generic; pin branch ordering
+(hidden before mention/mute/content) with a regression test. Calls: no changes —
+add the e2e asserting full-identity ring (knock-knock) and relocked call-history
+exclusion.
+
+### D7. Cleanups
+
+NUL byte → `\u0000` escape (same runtime string — SHA-256 input unchanged, so
+contact-card dedup hashes stay stable). Biometric dangling references per R9.
+1019's unreachable `hidden-chats-start.ts` path becomes genuinely used (D1) —
+its "test-harness-only" status resolves itself.
+
+## Zero-Knowledge & Crypto Review Notes (Principle I/IV gate)
+
+- Nothing new crosses the wire; no new ciphertext shape; no new key material
+  except none at all — both channels already exist.
+- The peer block and badge cache are device-local; `badge.lastCount` is a single
+  integer equal to what the OS badge already displays.
+- `messaging.ts` is untouched; `queries.ts → messaging.ts` stays one-directional.
+- `/speckit-checklist` will be generated for this spec (required: touches
+  Principle I & IV) and a security review requested on the PR (constitution IV).
+
+## Testing strategy (FR-022/FR-023 — Playwright-first)
+
+Red → Green ordering enforced in tasks.md:
+
+1. **Failing regression tests first** for B1 (hide → inbound lands hidden,
+   silently, no resurrect/rekey), B3 (reset → live inbound leaves no trace), B4
+   (badge modes incl. cold-open correctness), B5 (kick-out + guard), B6 (silent
+   non-push background).
+2. **Unit (vitest)**: `hidden-pair` predicates + rule R as pure functions; SW
+   `unreadCount` modes; reset peer-block; notify-policy ordering; NUL-escape hash
+   stability.
+3. **e2e (Playwright, hermetic)**: coexistence journey (hide → message lands
+   hidden → fresh visible pair chat → cross-thread isolation ≥ both directions →
+   Hide blocked with reason → delete visible → unhide), knock-knock 2-person call
+   with full identity while messages stay generic/silent, badge across all three
+   modes, reset + relay re-materialization block, cold-open no-flash with correct
+   visible badge, relock kick-out.
+4. **drive scenarios (live stack)**: `hidden-coexist.mjs`, `hidden-reset-relay.mjs`,
+   `hidden-kickout.mjs` + keep the existing six green.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally empty.

--- a/specs/1027-harden-hidden-chats/quickstart.md
+++ b/specs/1027-harden-hidden-chats/quickstart.md
@@ -1,0 +1,106 @@
+# Quickstart: 1027 Harden Hidden Chats — implementation slices
+
+**Plan**: [plan.md](./plan.md) | Ordered so each slice is independently landable
+and tests come first inside every slice (Red → Green).
+
+## Slice 0 — Hygiene (tiny, unblocks tooling)
+
+Replace the raw NUL byte in `src/db/queries.ts` L3703 with the `\u0000` escape
+(same runtime string → SHA-256 contact-card hashes unchanged; add a unit test
+pinning the hash of a known input before flipping). After this, `grep`/`rg` treat
+the file as text again.
+
+## Slice 1 — The invariant core (`hidden-pair.ts`)
+
+1. Write `src/services/hidden-pair.test.ts` first: `chatsWithPeer`, `canHide`,
+   `canUnhide`, `resolveInboundDirectChat` across: no chats, only visible, only
+   hidden, both (pair combinations), multi-member groups excluded, the legacy
+   hidden+visible plain-1:1 state.
+2. Implement the pure module. No idb imports.
+
+## Slice 2 — Inbound routing rule R (fixes B1) — the heart
+
+1. Failing vitest: fake-idb harness where the sole 1:1 is hidden; an inbound
+   frame must land in the hidden chat, create no new row, and request no rekey.
+2. Failing e2e (`e2e/hidden-coexist.spec.ts`): A hides the chat with B; B sends;
+   A's chat list stays empty, reveal shows the message in the hidden thread.
+3. Implement: `receiveIncomingInner` uses `resolveInboundDirectChat` (+ peer
+   block check + fail-closed requeue) instead of blind `startDirectChat`.
+4. `startDirectChat`: hidden plain 1:1 exists → create the visible **pair
+   conversation** (reuse the `createGroup('', [peer])` path from
+   `hidden-chats-start.ts`); also `clearTombstone('hiddenPeer:…')`.
+5. e2e continues: A starts a new chat with B from Contacts → fresh visible
+   thread; both threads exchange messages with zero cross-contamination; Hide on
+   the visible thread is blocked with the reason; delete visible → Unhide works.
+
+## Slice 3 — Hide/Unhide gating in the UI (fixes B2)
+
+1. Failing e2e: Hide blocked when hidden exists; Unhide blocked when visible
+   exists (reason copy asserted).
+2. `ChatActionsSheet.vue` consults `canHide`/`canUnhide` (disabled + reason).
+
+## Slice 4 — Reset block on the relay path (fixes B3)
+
+1. Failing e2e (`e2e/hidden-reset.spec.ts`): hide → reset → B sends live → no
+   chat appears, no notification, no rekey; A explicitly starts a chat with B →
+   works (block lifted).
+2. `resetHiddenChats` writes `hiddenPeer:` localOnly tombstones (before deletes);
+   rule R step 4 acks + drops; `ensureGroupChat`/`handleGroupCard` consult
+   group-id tombstones.
+
+## Slice 5 — Badge correctness (fixes B4)
+
+1. Failing vitest: `countUnread` across all three modes × (set known / unknown),
+   asserting visible counts survive the unknown window; SW `unreadCount` same
+   matrix + unclassifiable pending frames not counted; `'revealed'` ≡ `'never'`
+   in the SW.
+2. Implement `badge.lastCount` (page persist + both fallbacks + own-sync
+   exclusion).
+3. e2e: badge assertions folded into `hidden-privacy.spec.ts` (modes `always` /
+   `never`), cold-open badge correct from first frame.
+
+## Slice 6 — Relock kick-out + route guard (fixes B5)
+
+1. Failing e2e: reveal → open hidden chat → force relock (test hook / grace
+   `immediately` + background-foreground) → app is on `/tabs/chats`; deep-link
+   `/chat/<hiddenId>` while relocked → redirected.
+2. `registerRelockHook` in `hidden-state.ts`; router registers the hook + the
+   `beforeEach` guard.
+
+## Slice 7 — Notification silence + SW generic pinning (fixes B6, pins FR-012)
+
+1. Failing vitest: notify path backgrounded-but-connected hidden message →
+   no local notification; SW `noteForPayload` hidden note byte-equals the
+   previews-off generic and precedes mention/mute/content branches.
+2. Remove the `notify.ts` L389 bridge.
+3. drive scenario `hidden-notify.mjs` updated for the new silent expectation.
+
+## Slice 8 — Knock-knock call e2e (pins FR-013/FR-014)
+
+New `e2e/hidden-call.spec.ts` (2-person call per CI constraints): B calls A whose
+chat with B is hidden → incoming overlay shows B's name/avatar, answerable; after
+hangup, Calls tab shows no entry for B while relocked; reveal shows it.
+
+## Slice 9 — Cold-open no-flash (pins FR-017)
+
+e2e: seed hidden chats, cold-start, assert no hidden row ever paints (poll from
+first frame) while visible chats + badge are correct immediately (regression net
+over the existing `hidden-flash.mjs` drive scenario).
+
+## Slice 10 — Cleanups + docs
+
+Biometric dangling references neutralized (R9); doc comments updated
+(`hidden-chats.ts`, 1019 cross-reference note); `make roadmap`; drive scenarios
+`hidden-coexist.mjs`, `hidden-reset-relay.mjs`, `hidden-kickout.mjs`.
+
+## Gates before PR
+
+```sh
+npm run build            # vue-tsc + vite
+npx vitest run           # unit + coverage floors
+npm run test:e2e         # Playwright (needs make db-up)
+cd server && go build ./... && go vet ./... && go test ./...   # untouched but verified
+```
+
+`/speckit-checklist` (crypto/ZK — required) must be generated and satisfied;
+security review requested on the PR (constitution IV).

--- a/specs/1027-harden-hidden-chats/research.md
+++ b/specs/1027-harden-hidden-chats/research.md
@@ -1,0 +1,264 @@
+# Phase 0 Research: Harden Hidden Chats + One-Hidden-One-Visible Per Person
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-07-02
+
+This feature is a fix/harden pass over a shipped implementation, so "research"
+here is primarily a precise audit of the current mechanics (file:line anchored)
+plus the one open design decision the spec deferred: which crypto channel backs
+each of the two coexisting threads and how inbound routing picks the right one.
+
+## R1. How the pieces work today (audit summary)
+
+- **Hidden set + PIN** (`src/services/hidden-chats.ts`): the hidden conversation
+  ids live in `privacy.hiddenChats`, AEAD-sealed under the master key; the reveal
+  PIN is a separate Argon2id-derived verifier (`privacy.hiddenPin`, decrypt-succeeds
+  only, no oracle). Both are device-local settings excluded from own-data sync.
+  This layer is sound — 1027 keeps it unchanged.
+- **In-memory leaf** (`src/services/hidden-state.ts`): cached id set + `loaded`
+  flag + memory-only `revealed` flag; fails closed by keeping the last-known set
+  on decrypt failure and only marking `loaded` on success. Sound; kept.
+- **Choke points** (`src/db/queries.ts`): `listChats` (L59), `listCallGroups`,
+  `listCallsForTotals`, `archiveAllChats`, `countUnread` (L3794),
+  `countMissedUnseen`, `startDirectChat` (L4059). All consult
+  `ensureHiddenLoaded()` + `isRevealed()` and fail closed via `isHiddenKnown()`.
+- **Ratchet sessions are keyed by chat id** (`src/services/messaging.ts` L83-97:
+  `loadSession(chatId)` / `smeta:${chatId}`). The 1:1 Double Ratchet session for a
+  peer lives under the id of the 1:1 chat row. This single fact drives the whole
+  coexistence design (R2).
+- **Inbound routing** (`src/db/queries.ts` `receiveIncomingInner` L4391): every
+  inbound 1:1 frame resolves its chat via `startDirectChat(contact)` (L4429)
+  *before* decrypting — and `startDirectChat` **refuses hidden chats** (the #544
+  loophole fix) and creates a fresh visible chat when the only match is hidden.
+- **Notifications**: page path `src/services/notify.ts` L373-391 (foreground:
+  silent + claims the banner; backgrounded-but-connected: bridges a generic local
+  notification); SW path `src/services/sw-inbox.ts` `noteForPayload` L207-216
+  (generic "Ring / New message" note, before mute/mention/content branches).
+- **Badges**: page `countUnread` honors `privacy.hiddenChatsBadge` but fails
+  closed to **0 for the whole total** when the set is unknown (L3806). SW
+  `unreadCount()` (sw-inbox L522) counts **all** chats unconditionally — it never
+  applies the badge preference or the hidden set.
+- **Reset** (`src/services/hidden-chats-reset.ts`): tombstones (localOnly,
+  `deletedAt = MAX_SAFE_INTEGER`) then deletes messages/sessions/senderkeys/chats,
+  then clears set+PIN. Tombstones are honored only by the own-data sync ingest
+  (`services/sync.ts`, `services/ownsync.ts`) — **not** by `receiveIncomingInner`.
+- **Calls**: `hiddenCallKeys` (`src/db/hidden-calls.ts`) excludes hidden peers
+  from call history + missed-call badge. There is **no** pre-answer caller-identity
+  suppression anywhere — the incoming-call overlay always shows full identity.
+- **The NUL byte** (`src/db/queries.ts` L3703, offset 158588): an *intentional*
+  hash-domain separator written as a raw byte inside a template literal
+  (`` `${card.name}<NUL>${card.avatar}` `` feeding SHA-256). Functionally fine;
+  it just makes grep treat the file as binary. Fix: the `\u0000` escape.
+
+## R2. The confirmed core bugs (with mechanism)
+
+### B1 — Hiding your only 1:1 breaks the thread and resurrects a visible chat
+`receiveIncomingInner` L4429 calls `startDirectChat` for **every** inbound frame
+from a peer. Once the sole 1:1 with that peer is hidden:
+1. `startDirectChat` skips the hidden chat → creates a fresh **visible** chat `V`.
+2. `openPacket(V, …)` finds **no session** under `V` (the ratchet lives under the
+   hidden chat's id) → throws → `requestRekey(V, from)` fires (spurious wire
+   traffic; also observable behavior change caused by hiding).
+3. The peer re-keys; the new session establishes under `V`; their message lands
+   **visibly** in `V`.
+4. The hidden thread is permanently orphaned (its session is now stale) and never
+   receives anything again.
+
+This violates the privacy contract three ways (visible resurrection, visible
+content, dead hidden thread) and matches the user-reported "buggy" behavior.
+Corollary: even a **group** message from that peer (which rides the 1:1 session)
+resurrects an empty visible 1:1 row.
+
+### B2 — No per-person invariant
+Nothing prevents hiding a second chat with the same person or unhiding into two
+visible chats. `toggleHidden` (`ChatActionsSheet.vue` L102) is a bare
+`addHidden`/`removeHidden`.
+
+### B3 — Reset re-materialization
+The reset tombstone is keyed by the **old chat id**, but a post-reset inbound
+message creates a chat with a **new id** (via B1's path) — so even consulting
+tombstones in the relay path would not block it. The block must be **peer-keyed**
+for 1:1s (and id-keyed for groups, where ids are stable and shared).
+
+### B4 — Collateral badge suppression + SW badge ignores the preference
+Page: `countUnread` returns 0 for the whole app while the set is unknown (modes
+`never`/`revealed`). SW: `unreadCount()` never filters at all, so mode `never`
+still bumps the badge for hidden-chat pushes — leaking against an explicit choice.
+
+### B5 — No relock kick-out
+`relockHidden()` flips state and refreshes lists, but an open
+`/chat/<hiddenId>` page stays on screen. Nothing navigates away, and no route
+guard blocks direct navigation to a hidden chat while relocked.
+
+### B6 — Backgrounded-but-connected generic banner
+`notify.ts` L389 bridges a generic local notification on the non-push background
+path. Per the clarified FR-012, every path the platform doesn't force must be
+fully silent — this bridge must go.
+
+## R3. Decision — coexistence channels and inbound routing
+
+**Decision**: Two coexisting threads with one person are always **two distinct
+channels**: at most one *plain 1:1* (the per-peer Double Ratchet channel, session
+keyed by its chat id) and at most one *pair conversation* (a group-modeled
+conversation with exactly that one participant, sender-key crypto, routed by
+`groupId` — the existing `startHiddenChat`/`createGroup` mechanism). Hidden vs
+visible are **roles**; channel type is whatever each thread happens to be.
+
+- **Hide stays a move**: `addHidden(existingChatId)` — no migration, no wire
+  traffic, no signal to the peer, history and ratchet intact. (B1 is fixed by
+  routing, not by changing what "hide" does.)
+- **Inbound routing rule R** (replaces the blind `startDirectChat` call in
+  `receiveIncomingInner`) — two stages, since `payload.groupId` is sealed and
+  only known post-decrypt:
+  - *Stage 1 — session resolution (pre-decrypt)*: the **visible** plain 1:1 with
+    the peer if one exists; else the **hidden** plain 1:1 (never creates
+    anything visible); else, if a hidden-reset **peer block** exists (R4) →
+    ack + drop, no trace; else create a fresh visible 1:1 (today's behavior for
+    genuinely new peers).
+  - *Stage 2 — content routing (post-decrypt)*: `payload.groupId` present →
+    that conversation id (unchanged today); else the stage-1 chat.
+  Stage 1 always opens the packet under the id that actually holds the session —
+  no more spurious re-keys.
+- **Fresh visible chat** (`startDirectChat`, user-initiated only): if a hidden
+  plain 1:1 with the peer exists → create a **visible pair conversation**
+  (group-modeled) instead of a second plain 1:1. If the hidden thread is itself a
+  pair conversation (legacy 1019 shape, or re-hidden later) and no plain 1:1
+  exists → create a plain 1:1 (normal path). Either way at most one channel of
+  each type exists, so routing stays unambiguous.
+
+**Why this is the only coherent shape**: the peer has their own thread(s) and
+decides where their messages go. Splitting one peer channel across two local
+threads is arbitrary and leaks: if a fresh *plain* 1:1 were created next to a
+hidden plain 1:1, rule R would steer the peer's replies-to-the-secret-conversation
+into the **visible** thread — a catastrophic content leak. Coexistence inherently
+requires two wire channels, which means the peer necessarily sees two
+conversations once the user starts the fresh visible one. That is accepted and
+stated in the spec's ZK section (to the server both are opaque; to the peer a new
+conversation appearing is a normal event).
+
+**Alternatives considered**:
+- *Migrate history into a group-modeled hidden thread at hide time*: sends a group
+  create card at the moment of hiding — leaks the hide action to the peer; also
+  heavyweight (history move, session teardown). Rejected.
+- *Tag messages with a hidden-channel marker inside the sealed payload*: requires
+  peer-side understanding, doesn't survive the peer replying from their single
+  thread, adds protocol surface. Rejected.
+- *One thread only (hide = pure visibility flag, no coexistence)*: contradicts the
+  explicitly requested one-hidden-one-visible model. Rejected.
+
+## R4. Decision — peer-keyed reset block
+
+**Decision**: `resetHiddenChats` additionally records a localOnly tombstone per
+hidden **1:1 peer** under a dedicated key (`hiddenPeer:<peerId>`, reusing the
+existing `tombstones` store and `recordTombstone(…, localOnly=true)`), alongside
+today's chat-id tombstones (which keep blocking own-data re-download) and group-id
+tombstones (ids are stable for groups, so id-keyed works there — `ensureGroupChat`
+and `handleGroupCard` must consult them). Rule R step 4 consults the peer block:
+inbound 1:1 content from a blocked peer is **acked and dropped** with no rekey
+request, no contact/chat creation, no notification (mirror of the friends-only
+"leave no trace" path already in `receiveIncomingInner`). An explicit user action
+(`startDirectChat` from the contact) lifts the block via `clearTombstone` —
+deliberate re-engagement, same pattern as contact re-add.
+
+**Alternative considered**: dropping frames only until the next app restart —
+rejected; FR-018 requires the block to hold indefinitely until deliberate user
+action.
+
+## R5. Decision — badge correctness without collateral suppression
+
+**Decision**: cache the last successfully computed badge number.
+- Page: `countUnread` persists its result to a device-local plain setting
+  (`badge.lastCount`) on every successful computation. When mode is
+  `never`/`revealed` and the hidden set is unknown (locked at cold open), return
+  the cached number instead of 0. The cached value is already hidden-filtered (it
+  was computed under the preference) and is exactly what the OS badge showed a
+  moment ago — it leaks nothing new and keeps visible-chat badges correct.
+- SW: `unreadCount()` applies the same preference: read
+  `privacy.hiddenChatsBadge`; for `never` (and `revealed`, which in the SW is
+  always "not revealed" — reveal is page-memory-only) exclude chats in
+  `readHiddenSet()` from the stored-unread sum, and do not count **pending
+  frames** attributable to hidden chats. If the hidden set cannot be decrypted
+  (locked), fail closed *for the hidden contribution only*: fall back to
+  `badge.lastCount` for the stored part and count only pending frames that are
+  provably not hidden (an unclassifiable frame is not counted — privacy beats
+  accuracy on the badge, matching the user's explicit `never` choice).
+- Mode `always` (default) is unchanged: count everything, no fail-closed needed.
+
+**Alternative considered**: a cleartext list of hidden ids for the badge path —
+rejected outright (leaks hidden ids at rest, defeating the sealed set).
+
+## R6. Decision — relock kick-out and navigation guard
+
+**Decision**: two layers.
+1. `setRevealed(false)`/`clearHiddenState` gains a registered navigation hook
+   (injected from the router module to keep `hidden-state.ts` a leaf): when a
+   reveal session ends and the current route is `/chat/:id` (or a detail page of)
+   a hidden conversation, `router.replace('/tabs/chats')` immediately.
+2. A router guard on chat detail routes: navigating to a hidden conversation while
+   not revealed redirects to `/tabs/chats` (defense in depth against deep links,
+   stale notification taps, and back-stack restoration).
+
+## R7. Decision — notification paths (clarified FR-012)
+
+- **SW path**: keep the existing generic note (sw-inbox L211-216) — verify it is
+  byte-identical to the previews-off generic (title `Ring`, body `New message`,
+  url `/tabs/chats`) and keeps the internal coalescing tag. It already runs before
+  mention/mute/content branches (hidden wins) — add a regression test pinning the
+  ordering and the byte-identity.
+- **Page path**: foreground stays fully silent + claims the banner (unchanged).
+  The backgrounded-but-connected generic bridge (`notify.ts` L389) is **removed**
+  — that path becomes badge-only (B6). If a co-arriving push wakes the SW anyway,
+  the SW's generic note covers the platform requirement.
+- **Calls**: no change to the live ring (full identity — knock-knock). The 1019
+  FR-019 "pre-answer no-preview" idea was never built; nothing to remove. 1027
+  documents full-identity as intended and adds an e2e asserting it.
+
+## R8. Decision — enforcement predicate and state machine
+
+**Decision**: a small pure module (`src/services/hidden-pair.ts`, unit-testable
+without IndexedDB) defines:
+- `chatsWithPeer(chats, peerId)`: plain 1:1s (`!isGroup && participantIds ===
+  [peerId]`) plus pair conversations (`isGroup && participantIds === [peerId]`).
+  Multi-member groups never count.
+- `canHide(chats, hidden, chatId)` → `{ ok } | { ok:false, reason }`: false when
+  another chat with the same peer is already hidden (per-person one-hidden rule);
+  groups (multi-member) are always hideable individually.
+- `canUnhide(chats, hidden, chatId)` → false when a visible chat with the same
+  peer exists (per-person one-visible rule).
+- `resolveInboundDirectChat(chats, hidden, peerId)` → rule R steps 2-3 as a pure
+  function (the impure wrapper in `queries.ts` adds tombstone check + creation).
+`ChatActionsSheet` consumes `canHide`/`canUnhide` to disable the action with the
+reason as a caption (stock Ionic, Principle XI). Legacy broken states (e.g. a
+hidden **and** a visible plain 1:1 for the same peer, produced by B1 before the
+fix) are tolerated read-only: rule R routes to the visible one (where the live
+session is), unhide stays blocked until the user deletes one — no data loss, no
+migration pass needed; covered by a drive scenario.
+
+## R9. Decision — biometric leftovers (1019 US6)
+
+**Decision**: stays deferred. Remove the dangling references so the codebase is
+consistent: the `privacy.hiddenChatsBiometric` mentions in
+`hidden-chats.zk.test.ts` and `specs/1019-…/contracts/internal-api.md` /
+`quickstart.md` remain historical spec artifacts (not code); the only *code*
+reference is the zk test asserting the key never syncs — keep that assertion (it
+is future-proofing, not dead code) but drop any test/contract text implying the
+feature exists. No settings toggle is added.
+
+## R10. Testing approach (FR-022/FR-023)
+
+- **e2e (`e2e/`)**: extend `hidden-chats.spec.ts` + new specs for: hide-moves +
+  inbound-lands-hidden-silently (B1 regression), coexistence via fresh visible
+  pair chat with cross-thread isolation, Hide/Unhide blocking with reasons,
+  knock-knock call full identity (2-person call, per e2e CI constraints), badge
+  modes, reset + live-inbound re-materialization block (B3 regression), relock
+  kick-out + route guard, cold-open no-flash with correct visible badge (B4
+  regression). Real multi-context WebRTC is already proven in this suite.
+- **drive (`drive/scenarios/`)**: keep/extend the six existing hidden-chat
+  scenarios and add: `hidden-coexist.mjs` (full user journey), `hidden-reset-relay.mjs`
+  (reset then live message), `hidden-kickout.mjs` (grace expiry inside the chat).
+- **vitest**: new `hidden-pair.test.ts` (pure predicate/state machine),
+  routing-rule unit tests against the fake idb, badge-cache tests, SW
+  `unreadCount` preference tests, tombstone peer-block tests; keep + extend the
+  existing hidden suites.
+
+All decisions above resolve the spec's deferred design point; no NEEDS
+CLARIFICATION remain.

--- a/specs/1027-harden-hidden-chats/spec.md
+++ b/specs/1027-harden-hidden-chats/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1027-harden-hidden-chats/spec.md
+++ b/specs/1027-harden-hidden-chats/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1027-harden-hidden-chats/spec.md
+++ b/specs/1027-harden-hidden-chats/spec.md
@@ -1,0 +1,503 @@
+# Feature Specification: Harden Hidden Chats + One-Hidden-One-Visible Per Person
+
+**Feature Branch**: `feat/1027-harden-hidden-chats`
+
+**Created**: 2026-07-02
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Investigate the current hidden-chat implementation — it is buggy. Find the bugs and fix them and make the implementation robust and secure so when a chat is hidden, by default nothing except the knock-knock call and the badge update is shown on the device. We also want to be able to have a hidden chat with one person and a separate non-hidden chat with the same person; if a hidden chat with that person already exists, the second chat can no longer be set to hidden. At most one hidden and one non-hidden chat with the same person. Use Playwright as much as possible and test all the behaviours."
+
+## Overview
+
+Ring already ships a **Hidden Chats** privacy layer (spec 1019): a user can take a
+conversation out of the visible chat list and tuck it behind a dedicated PIN,
+revealed only by typing the PIN into the search bar. It is a purely local,
+on-device visibility layer on top of Ring's end-to-end encryption — the server is
+never told a chat is hidden and learns nothing new.
+
+The shipped implementation is **buggy and incomplete**. This feature is an
+investigate → fix → harden pass over the existing behaviour, plus one deliberate
+model change:
+
+1. **A tight privacy contract.** When a chat is hidden, *nothing* about it appears
+   on the device by default — no chat-list row, no message notification content, no
+   preview, no sender identity, no search hit, no call-history entry — with exactly
+   two intentional exceptions: the **knock-knock call** (a live incoming call still
+   rings with full identity, because you must be able to answer) and the **badge /
+   unread count** (subject to the user's badge preference). One platform-forced
+   carve-out: a push-woken delivery must show *some* notification or the platform
+   revokes push for the whole app, so that path shows a banner byte-identical to
+   the global previews-off generic — indistinguishable from ordinary
+   previews-off activity (FR-012).
+
+2. **One hidden and one visible chat per person.** A person may have at most two
+   conversations with you: exactly one hidden and exactly one visible. "Hide chat"
+   *moves* the current conversation into the hidden set; once hidden, if it was the
+   only chat with that person, nothing remains visible for them until you reveal
+   with the PIN. A fresh visible chat is (re)created only when you next start a
+   conversation with that person. If a hidden chat with that person already exists,
+   the visible one **cannot** be hidden — the Hide action is blocked with a clear
+   reason.
+
+3. **Robustness and security.** Every surface that consults hidden state fails
+   closed (hidden chats never flash into view before the hidden set decrypts) but
+   without collaterally suppressing unrelated visible data. Wrong PIN reveals
+   nothing and gives no oracle. The hidden set, the lock state, and the PIN never
+   leave the device and never enter any sync payload.
+
+This spec supersedes the visibility model in 1019: where 1019 said the visible
+chat is "never removed or altered" when a hidden chat exists, 1027 makes hiding a
+**move** — the hidden chat and a later, separately-started visible chat coexist,
+but hiding the last visible chat leaves nothing visible for that person.
+
+## Clarifications
+
+### Session 2026-07-02
+
+- Q: When a message arrives for a hidden chat while the app is in the background,
+  what should the device show? → A: Split by delivery path, dictated by web-push
+  platform rules (a push-woken service worker MUST show a user-visible
+  notification or the browser eventually revokes the push subscription, killing
+  notifications for ALL chats; a badge update alone does not count). Push-woken
+  deliveries show a generic notification **byte-identical** to the one used when
+  message previews are off globally ("Ring / New message" → Chats tab), so an
+  observer cannot distinguish hidden-chat activity from a previews-off visible
+  chat. Every path the platform does not force — foreground, or backgrounded but
+  WebSocket-connected without a push wake — is fully silent, badge only. Bursts
+  coalesce into a single generic banner with no count.
+- Q: What happens when the user tries to unhide a hidden chat while a visible chat
+  with that same person already exists? → A: Unhide is blocked with a clear
+  user-facing reason; the user must first delete the visible chat. The one-visible
+  invariant is never broken and histories are never merged.
+- Q: If the reveal grace window expires (or relock triggers) while the user is
+  inside an open hidden chat? → A: Kick out immediately — relock navigates away
+  from the open hidden chat to the Chats list at once; nothing hidden stays on
+  screen past the grace window.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Hide a chat and it disappears (Priority: P1)
+
+A user long-presses a conversation and taps **Hide chat**. If no hidden PIN exists
+yet, they are asked to create one. The conversation immediately leaves the chat
+list, search, pickers, and call history. If that was the only chat with that
+person, the person is now entirely absent from every visible surface. The hidden
+conversation keeps receiving messages silently in the background.
+
+**Why this priority**: This is the core promise of the feature and the thing that
+is buggy today. Without a correct, complete hide, nothing else matters.
+
+**Independent Test**: With two accounts, hide the 1:1 with a peer, confirm it is
+gone from Chats / search / Calls, send a message from the peer, and confirm the
+device shows no chat-list row and no notification content — only the badge.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visible 1:1 chat and no hidden PIN yet, **When** the user taps Hide
+   chat, **Then** they are prompted to create a PIN and, on success, the chat
+   leaves every visible surface (Chats, search, contact/group pickers, Calls tab).
+2. **Given** a hidden chat that is the only chat with a peer, **When** the peer
+   sends a message, **Then** no chat-list row appears, nothing revealing is shown
+   (silent, or the generic previews-off banner only if push-woken — see FR-012),
+   and the badge/unread count updates (per preference).
+3. **Given** a hidden chat, **When** the app is fully closed and reopened, **Then**
+   the chat stays hidden with no flash of it appearing during load.
+
+---
+
+### User Story 2 - Reveal with the PIN, then relock (Priority: P1)
+
+A user types their hidden PIN into the Chats search bar. Hidden chats appear
+(visually marked as revealed) and sort to the top. They stay revealed through a
+short grace window across quick app-switches, then relock — and any full app close
+relocks immediately, leaving no trace.
+
+**Why this priority**: Hiding is only useful if the owner can reliably get back in,
+and relock is the other half of the privacy guarantee.
+
+**Independent Test**: Hide a chat, type the PIN in the search bar, confirm it
+appears; background and foreground within the grace window and confirm it is still
+revealed; exceed the grace window (or fully close) and confirm it relocks.
+
+**Acceptance Scenarios**:
+
+1. **Given** hidden chats exist, **When** the user types the correct PIN into the
+   search bar, **Then** hidden chats become visible, marked as revealed, and sorted
+   to the top, and the search box clears.
+2. **Given** a wrong PIN is typed, **When** it is entered, **Then** nothing is
+   revealed and there is no visible, audible, or timing difference that confirms the
+   PIN was wrong (no oracle).
+3. **Given** chats are revealed, **When** the grace window elapses or the app is
+   fully closed, **Then** the chats relock and disappear again — and if a hidden
+   chat is open on screen at that moment, the app navigates away from it to the
+   Chats list immediately.
+
+---
+
+### User Story 3 - One hidden and one visible chat with the same person (Priority: P1)
+
+A user has a normal visible chat with a friend. They hide it — it moves into the
+hidden set and disappears. Later they start a fresh conversation with the same
+friend; a new visible chat appears. Now they have exactly one hidden and one
+visible chat with that friend, each with its own history, routed independently. If
+they try to hide the second (visible) chat while the hidden one still exists, the
+Hide action is unavailable and explains why.
+
+**Why this priority**: This is the new model the user explicitly asked for and the
+main behavioural change of this spec.
+
+**Independent Test**: Hide the 1:1 with a peer, start a new chat with the same
+peer, confirm both exist (one hidden, one visible) with separate histories, then
+confirm the Hide action on the visible chat is blocked while the hidden one exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a hidden chat with a peer already exists, **When** the user starts a
+   new conversation with that same peer, **Then** a fresh visible chat is created
+   and both coexist, each receiving only its own messages.
+2. **Given** a hidden chat with a peer already exists, **When** the user opens the
+   actions for the visible chat with that peer, **Then** Hide chat is blocked /
+   disabled with a clear reason ("You already have a hidden chat with this person").
+3. **Given** a person with whom the user has no hidden chat, **When** the user hides
+   their only chat, **Then** nothing remains visible for that person until reveal,
+   and a later new conversation with them succeeds as a fresh visible chat.
+4. **Given** both a hidden and a visible chat with the same peer, **When** either
+   side sends a message in one of them, **Then** it lands only in that thread and
+   never leaks into or duplicates the other.
+
+---
+
+### User Story 4 - Only the knock-knock call and badge surface (Priority: P1)
+
+While a chat is hidden, the device stays silent about it except for two things: a
+live incoming **call** from that peer rings normally with full caller identity
+(name + avatar) so the user can answer, and the **badge/unread count** updates
+according to the user's badge preference. Message notifications show nothing
+revealing, the lock screen shows no sender, and there is no call-history entry that
+names the hidden peer.
+
+**Why this priority**: This is the precise privacy contract the user specified and
+the behaviour most likely to leak if it regresses.
+
+**Independent Test**: With a hidden chat, place a call from the peer and confirm the
+incoming-call screen shows their real name/avatar; send a message from the peer and
+confirm the notification is generic/silent with no sender or preview; confirm the
+badge updates and that the ended call leaves no history entry naming the peer.
+
+**Acceptance Scenarios**:
+
+1. **Given** a hidden chat, **When** the peer places a call, **Then** the incoming
+   call rings with full caller identity and can be answered normally.
+2. **Given** a hidden chat and the app was woken by a push, **When** the peer
+   sends a message, **Then** the notification shown is byte-identical to the
+   generic previews-off notification ("Ring / New message" → Chats tab) — no
+   sender, avatar, content, or preview — regardless of preview or mention
+   settings, and bursts coalesce into one such banner.
+3. **Given** a hidden chat and the app is in the foreground (or backgrounded but
+   still connected without a push wake), **When** the peer sends a message,
+   **Then** nothing is shown at all — no banner, no sound — and only the badge
+   updates per preference.
+4. **Given** a hidden chat, **When** a call with that peer ends, **Then** no
+   call-history entry that reveals the hidden peer is shown while relocked.
+5. **Given** the badge preference is `always`, `never`, or `revealed`, **When** a
+   hidden chat has unread messages, **Then** the badge reflects that preference and,
+   for `never`/`revealed`, hidden unreads are excluded **without** suppressing the
+   count of unrelated visible chats.
+
+---
+
+### User Story 5 - Reset wipes hidden state and cannot be re-materialized (Priority: P2)
+
+From Settings, a user resets hidden chats. All hidden-chat local state — the hidden
+set, the PIN, and the hidden conversations' local data — is destroyed, and the
+wiped conversations cannot silently reappear, including from a live inbound message
+that arrives right after the reset.
+
+**Why this priority**: A reset that leaves a way for a hidden chat to re-appear
+breaks the plausible-deniability promise; it is a real bug in the current code.
+
+**Independent Test**: Hide a chat, reset hidden chats, then send a message from the
+peer and confirm no chat (hidden or visible) re-materializes from that inbound
+message and no notification reveals the peer.
+
+**Acceptance Scenarios**:
+
+1. **Given** hidden chats and a PIN exist, **When** the user confirms reset, **Then**
+   the hidden set, PIN, and hidden conversations' local data are all destroyed.
+2. **Given** a chat was just reset, **When** a new message for that conversation
+   arrives over the live relay, **Then** it does not re-create the conversation as a
+   visible chat and reveals nothing about the peer.
+
+---
+
+### User Story 6 - Robust, no-flash, no-collateral behaviour (Priority: P2)
+
+Hidden state is consulted correctly on every surface. During the brief window
+before the hidden set decrypts at cold start, hidden chats never flash into view,
+yet the app never over-suppresses: visible chats, their unread counts, and their
+notifications all behave normally throughout.
+
+**Why this priority**: The fail-closed logic exists today but over-reaches in at
+least one place (whole-badge suppression), and a stray NUL byte in a core data file
+signals latent fragility.
+
+**Independent Test**: Cold-start the app with hidden chats present and confirm no
+hidden row ever paints; simultaneously confirm visible chats and their badges are
+correct from the first frame.
+
+**Acceptance Scenarios**:
+
+1. **Given** hidden chats exist, **When** the app cold-starts, **Then** no hidden
+   chat is ever briefly visible in the list, search, or badge.
+2. **Given** the hidden set has not yet decrypted, **When** the chat list and badge
+   render, **Then** visible chats and their unread counts are shown correctly (no
+   collateral blanking of the whole list or badge).
+
+---
+
+### Edge Cases
+
+- **Hiding when a hidden chat already exists for the peer**: blocked with a clear
+  reason; never produces two hidden chats with the same person.
+- **Starting a new chat when only a hidden chat exists**: resolves to a fresh
+  visible conversation, never silently reopens or reveals the hidden one, and never
+  requires the PIN to create the visible one.
+- **Inbound message for a hidden 1:1**: lands in the existing hidden conversation
+  (silently), and never spawns a duplicate visible chat for that peer.
+- **Inbound message after reset**: does not re-materialize the wiped conversation.
+- **Reveal expiring mid-interaction**: relocking while a revealed hidden chat is
+  open on screen navigates away to the Chats list immediately; nothing hidden stays
+  visible past the grace window.
+- **Unhide when a visible chat exists**: blocked with a clear reason; the user must
+  delete the visible chat first. Histories are never merged.
+- **Silent-push subscription safety**: hidden-chat handling never swallows a
+  push-woken delivery without showing a notification, so the platform never revokes
+  the push subscription.
+- **Group chat hidden**: the same hide/reveal/relock and notification rules apply to
+  a hidden group; the one-hidden-one-visible rule is defined per person for 1:1s and
+  per conversation for groups.
+- **Badge preference `never`/`revealed` during the pre-decrypt window**: the visible
+  unread total is still correct; only hidden unreads are withheld.
+- **Wrong PIN entered repeatedly**: no lockout signal, no oracle, no state change.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Hiding and the per-person model**
+
+- **FR-001**: The system MUST provide a user-reachable "Hide chat" action on a
+  conversation (available only when the Hidden Chats feature is enabled).
+- **FR-002**: Hiding a chat MUST move that conversation into the hidden set so it is
+  removed from every visible surface (chat list, search, pickers, Calls/call
+  history) and, if it was the only chat with that person, leave nothing visible for
+  that person until reveal.
+- **FR-003**: The system MUST allow at most one hidden and one visible chat per
+  person (per 1:1 peer). It MUST block the Hide action on a visible chat when a
+  hidden chat with that same person already exists, with a clear user-facing reason.
+- **FR-004**: The system MUST let a user start a fresh visible conversation with a
+  person for whom only a hidden chat exists, creating a new, independent visible
+  chat without revealing or reopening the hidden one and without requiring the PIN.
+- **FR-005**: Coexisting hidden and visible chats with the same person MUST route
+  messages independently: a message sent or received in one thread MUST appear only
+  in that thread and never leak into or duplicate the other. (The plan MUST define
+  the channel mechanism, given Ring keeps one Double Ratchet session per peer; the
+  existing distinct-conversation channel — a group-modeled conversation created via
+  `startHiddenChat`/`createGroup`, currently only reachable from the test harness —
+  is the expected basis, and MUST be wired into a real, user-reachable flow.)
+- **FR-006**: The system MUST provide an "Unhide chat" action that returns a hidden
+  conversation to visible. If a visible chat with the same person already exists,
+  unhide MUST be blocked with a clear user-facing reason (the user must first delete
+  the visible chat); histories are never merged and the one-visible-per-person
+  invariant is never broken.
+
+**Reveal, relock, PIN**
+
+- **FR-007**: The system MUST reveal hidden chats only when the correct dedicated
+  hidden PIN is entered via the Chats search bar, and MUST visually mark revealed
+  chats and sort them to the top while revealed.
+- **FR-008**: A wrong PIN MUST reveal nothing and MUST NOT produce any visible,
+  audible, or timing signal that distinguishes wrong from right (no oracle).
+- **FR-009**: Revealed state MUST persist only in memory, survive a short
+  configurable grace window across quick app-switches, and relock after the grace
+  window, when the keystore auto-locks, or on any full app close. Relock MUST take
+  effect immediately everywhere: if a hidden chat is open on screen when relock
+  triggers, the app MUST navigate away from it to the Chats list at once.
+- **FR-010**: The hidden PIN MUST be verified without any recoverable copy of the
+  PIN and without a fast comparison path (verification is decrypt-succeeds only).
+- **FR-011**: The system MUST support creating and changing the hidden PIN, and a
+  destructive reset (see FR-018).
+
+**Notifications, calls, badge (the privacy contract)**
+
+- **FR-012**: While a chat is hidden and relocked, message notifications MUST reveal
+  no sender name, avatar, content, or preview, overriding preview, mention, and mute
+  settings — split by delivery path:
+  - **Push-woken (service-worker) deliveries** MUST show a generic notification
+    byte-identical to the global previews-off notification ("Ring / New message" →
+    Chats tab), because silently swallowing a push risks the platform revoking the
+    push subscription for all chats; bursts MUST coalesce into a single generic
+    banner with no count.
+  - **Every path the platform does not force** — app in the foreground, or
+    backgrounded but still connected without a push wake — MUST be fully silent
+    (no banner, no sound); only the badge updates per preference.
+- **FR-013**: A live incoming call from a hidden-chat peer MUST ring with full
+  caller identity (name + avatar) and be answerable normally (the "knock-knock
+  call"). Calls are never suppressed by hiding.
+- **FR-014**: While relocked, call history MUST NOT show any entry that reveals a
+  hidden peer or hidden conversation.
+- **FR-015**: The badge / unread count MUST honour the user's hidden-badge
+  preference (`always` counts hidden unreads, `never` excludes them, `revealed`
+  counts them only while revealed) and MUST NOT, under any preference or timing,
+  suppress the unread count of unrelated visible chats.
+- **FR-016**: Any pre-answer or notification surface that today attempts a partial
+  "no-preview" treatment for hidden-chat *calls* MUST be reconciled with FR-013
+  (calls show full identity); dead or contradictory half-built call-preview
+  suppression MUST be removed.
+
+**Robustness, security, zero-knowledge**
+
+- **FR-017**: Every surface that consults hidden state (list, search, notifications,
+  call history, badge) MUST fail closed so hidden chats never flash into view before
+  the hidden set decrypts, while never collaterally hiding unrelated visible data.
+- **FR-018**: Resetting hidden chats MUST destroy the hidden set, the PIN, and the
+  hidden conversations' local data, and MUST prevent a wiped conversation from
+  re-materializing — including from a live inbound message arriving over the relay
+  immediately after reset (the tombstone/re-sync block MUST cover the live
+  message-relay path, not only the own-data sync path).
+- **FR-019**: The hidden set, hidden lock state, and PIN MUST never leave the device
+  and MUST never appear in any client→server request or sync payload; the server
+  MUST gain no signal that hiding is enabled, that a chat is hidden, or that a PIN
+  exists.
+- **FR-020**: The stray NUL byte in the core data-layer file (`src/db/queries.ts`)
+  MUST be removed and the file kept as clean UTF-8 text.
+- **FR-021**: The hide / reveal / relock / unhide / reset transitions and the
+  per-person one-hidden-one-visible invariant MUST be implemented as a deterministic,
+  unit-tested state machine.
+
+**Testing**
+
+- **FR-022**: All behaviours in this spec MUST be covered by Playwright — both
+  `e2e/` tests and `drive/` scenarios — including: hide-moves-and-vanishes; reveal
+  via search PIN; relock after grace and across restart; coexistence of one hidden +
+  one visible with the same person; Hide blocked when a hidden chat already exists;
+  incoming call from a hidden peer rings with full identity while messages stay
+  suppressed; notification suppression (generic/silent); badge across
+  `always`/`never`/`revealed`; reset wipes and blocks re-materialization from a live
+  inbound message; and no cold-open flash of hidden chats.
+- **FR-023**: Existing vitest unit tests for hidden chats MUST stay green and be
+  extended to cover the new per-person invariant and the fixed bugs.
+
+### Key Entities *(include if feature involves data)*
+
+- **Hidden set**: The device-local, at-rest-sealed set of conversation ids that are
+  hidden. Never synced; readable while the app is unlocked so hidden chats can be
+  excluded by default.
+- **Hidden PIN**: A dedicated PIN (separate from the app passcode) whose only role is
+  gating reveal; stored as a verifier that cannot be reversed to the PIN and has no
+  fast-compare path.
+- **Reveal session**: In-memory-only state that hidden chats are currently revealed,
+  with a grace timer; destroyed on relock, keystore auto-lock, or full app close.
+- **Conversation (chat)**: A 1:1 or group thread with its own id and history. Per
+  person there may be at most one hidden and one visible conversation; the two
+  coexisting threads are distinct channels routed independently.
+- **Tombstone**: A local-only marker that a conversation was reset/wiped, consulted
+  on both the own-data sync path and the live message-relay path to block
+  re-materialization.
+- **Badge preference**: The user's choice (`always` / `never` / `revealed`) for how
+  hidden unreads contribute to the app badge and unread totals.
+
+## Zero-Knowledge Impact *(mandatory — Constitution Principle I)*
+
+- **What crosses the wire**: Nothing new. Hiding, unhiding, revealing, relocking,
+  the per-person limit (including a blocked hide/unhide), and reset add no new
+  client→server request, field, or payload. Messages for hidden
+  chats continue to flow as the same sealed envelopes as any other chat; the server
+  cannot distinguish a hidden chat from a visible one.
+- **What is encrypted / protected**: The hidden PIN is never stored in recoverable
+  form; the hidden set and lock state are protected at rest on the device
+  (consistent with Ring's PIN-derived at-rest wrapping), so the hidden designation
+  cannot be read off the device without the PIN.
+- **Coexisting conversations**: A second, distinct conversation between the same two
+  people is — to the server — just another opaque conversation it already relays.
+  Group membership is encrypted and invisible to the server, so it cannot tell that
+  two conversations share participants, nor which (if any) is hidden.
+- **Calls**: The knock-knock call rides the existing call signalling/relay unchanged;
+  showing full caller identity is a purely local rendering choice and adds no server
+  signal. Hiding a call from history is a local-only concern.
+- **Notifications**: The push path already carries no plaintext to the server; the
+  generic/silent rule is enforced entirely on the client when rendering, so the
+  guarantee does not depend on the server.
+- **Reset**: Wiping local hidden state and tombstoning conversations is entirely
+  on-device; the server is not told anything was reset.
+- **Why this is safe**: This remains a client-only visibility layer over content that
+  is already end-to-end encrypted. It never introduces a new thing for the server to
+  know.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: While relocked, a hidden chat appears in **zero** user-facing surfaces
+  (Chats, search, pickers, Calls/call history, badge per preference), verified across
+  all of them — including missed calls.
+- **SC-002**: 100% of hidden-chat message deliveries follow the FR-012 split: fully
+  silent (badge only) on non-push paths, and on push-woken paths a notification
+  byte-identical to the global previews-off generic — no sender, avatar, content, or
+  preview — including offline-queued and burst cases (bursts coalesce to one banner).
+- **SC-003**: 100% of incoming calls from a hidden-chat peer ring with full caller
+  identity and are answerable, verified in an automated call test.
+- **SC-004**: A person can have exactly one hidden and one visible chat; attempting a
+  second hidden chat with the same person is blocked 100% of the time, and the two
+  coexisting threads never cross-contaminate messages (0 leaks across ≥100 test
+  messages).
+- **SC-005**: After a reset, a wiped conversation re-materializes in **0** cases,
+  including when a live inbound message arrives immediately after reset.
+- **SC-006**: Across ≥20 cold starts with hidden chats present, a hidden chat flashes
+  into view in **0** of them, while the visible chat list and badge are correct from
+  the first frame in 100% of them.
+- **SC-007**: A wrong PIN yields no distinguishable outcome (visual, audible, or
+  timing) in 100% of attempts.
+- **SC-008**: All new and existing hidden-chat unit tests and the Playwright e2e +
+  drive scenarios listed in FR-022 pass in CI.
+
+## Assumptions
+
+- **Coexistence channel**: True simultaneous hidden + visible chats with the same
+  person are realized with two distinct crypto channels — the per-peer 1:1 Double
+  Ratchet channel and a separate group-modeled conversation — because a single peer
+  has exactly one 1:1 ratchet channel. The plan will decide which of the two threads
+  uses which channel and how the "fresh visible chat" is created; the existing
+  `startHiddenChat`/group mechanism is assumed available and correct as the basis.
+- **Fresh visible chat is user-initiated**: When only a hidden chat exists for a
+  person, a new visible chat is created only by an explicit user action (starting a
+  conversation), not automatically from an inbound message (which stays in the hidden
+  thread).
+- **Badge default**: The default badge preference remains `always` (hidden unreads
+  counted), matching current behaviour.
+- **Grace window default**: Unchanged from the shipped default (short grace, e.g. one
+  minute), configurable in settings.
+- **Reuse of existing primitives**: Hiding continues to use the existing device-local
+  sealed hidden set + dedicated-PIN verifier + in-memory reveal session, and the
+  existing search-bar reveal gesture — this spec fixes and extends them rather than
+  replacing them.
+- **Scope of "person"**: The per-person one-hidden-one-visible rule is defined for
+  1:1 conversations keyed by peer identity; group conversations are hidden/revealed
+  individually.
+
+## Out of Scope
+
+- **Biometric unlock**: Optional biometric reveal (1019 US6, never implemented) stays
+  deferred. This spec does not add it; it MUST also remove or neutralize dangling
+  references to an unimplemented biometric path so the codebase and tests are
+  consistent.
+- Syncing hidden state across a user's own devices.
+- A separate encrypted media "vault" distinct from hidden chats.
+- Server-side awareness or enforcement of hiding.
+- Disappearing-messages behaviour specific to hidden chats.

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -166,12 +166,12 @@ visible chats and badge correct from the first frame.
 
 ### Tests (write first, must FAIL where behavior changes)
 
-- [ ] T036 (#629) [P] [US6] Failing/pinning Playwright e2e in `e2e/hidden-privacy.spec.ts` (cold-open section): seed hidden + visible chats, then LOOP ≥5 context restarts polling from first paint — hidden row never appears, visible rows and unread badge correct immediately (uses `badge.lastCount` from T027); extend `drive/scenarios/hidden-flash.mjs` to a ≥20-restart soak for the full SC-006 sample
-- [ ] T037 (#630) [P] [US6] Pinning vitest in `src/db/hidden-calls.test.ts` (extend): `countMissedUnseen` and call-history exclusion stay fail-closed without collateral loss once the set loads
+- [x] T036 (#629) [P] [US6] Failing/pinning Playwright e2e in `e2e/hidden-privacy.spec.ts` (cold-open section): seed hidden + visible chats, then LOOP ≥5 context restarts polling from first paint — hidden row never appears, visible rows and unread badge correct immediately (uses `badge.lastCount` from T027); extend `drive/scenarios/hidden-flash.mjs` to a ≥20-restart soak for the full SC-006 sample
+- [x] T037 (#630) [P] [US6] Pinning vitest in `src/db/hidden-calls.test.ts` (extend): `countMissedUnseen` and call-history exclusion stay fail-closed without collateral loss once the set loads
 
 ### Implementation
 
-- [ ] T038 (#631) [US6] Verify/adjust the `listChats` fail-closed nudge path (`src/db/queries.ts:59`, `src/services/hidden-state.ts`) so the T036 first-frame guarantee holds; fix anything T036 exposes
+- [x] T038 (#631) [US6] Verify/adjust the `listChats` fail-closed nudge path (`src/db/queries.ts:59`, `src/services/hidden-state.ts`) so the T036 first-frame guarantee holds; fix anything T036 exposes
 
 **Checkpoint**: all six bugs (B1–B6) fixed with regression coverage.
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -92,14 +92,14 @@ visible thread is blocked; delete visible → Unhide works.
 
 ### Tests (write first, must FAIL)
 
-- [ ] T015 (#608) [P] [US3] Failing vitest for `startDirectChat` in `src/db/queries.start-direct.test.ts`: hidden plain 1:1 exists → creates a visible pair conversation (isGroup, single participant) and lifts any `hiddenPeer:` block; visible exists → returns it (never a second visible); hidden pair conversation + no plain 1:1 → creates a plain 1:1
-- [ ] T016 (#609) [P] [US3] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 2): A starts a new chat with B from Contacts → fresh visible thread appears while hidden stays hidden; A↔B exchange messages in BOTH threads (B replies in each) and each message lands only in its own thread; Hide on the visible thread is blocked with the reason; Unhide on the hidden thread is blocked while the visible exists; delete visible → Unhide succeeds
+- [x] T015 (#608) [P] [US3] Failing vitest for `startDirectChat` in `src/db/queries.start-direct.test.ts`: hidden plain 1:1 exists → creates a visible pair conversation (isGroup, single participant) and lifts any `hiddenPeer:` block; visible exists → returns it (never a second visible); hidden pair conversation + no plain 1:1 → creates a plain 1:1
+- [x] T016 (#609) [P] [US3] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 2): A starts a new chat with B from Contacts → fresh visible thread appears while hidden stays hidden; A↔B exchange messages in BOTH threads (B replies in each) and each message lands only in its own thread; Hide on the visible thread is blocked with the reason; Unhide on the hidden thread is blocked while the visible exists; delete visible → Unhide succeeds
 
 ### Implementation
 
-- [ ] T017 (#610) [US3] Extend `startDirectChat` in `src/db/queries.ts:4059` per contract: hidden-chat-with-peer branch creates the visible pair conversation (reuse the `createGroup('', [peer])` mechanism from `src/services/hidden-chats-start.ts`) and calls `clearTombstone('hiddenPeer:<peer>')`
-- [ ] T018 (#611) [US3] Gate Hide/Unhide in `src/components/ChatActionsSheet.vue` via `canHide`/`canUnhide` — blocked entry renders disabled with the reason text (stock Ionic only, Principle XI)
-- [ ] T019 (#612) [P] [US3] Extend `drive/scenarios/hidden-coexist.mjs` (part 2: coexistence + blocked Hide/Unhide journey), including an SC-004 volume loop — ≥100 messages split across both threads with zero cross-thread leaks asserted
+- [x] T017 (#610) [US3] Extend `startDirectChat` in `src/db/queries.ts:4059` per contract: hidden-chat-with-peer branch creates the visible pair conversation (reuse the `createGroup('', [peer])` mechanism from `src/services/hidden-chats-start.ts`) and calls `clearTombstone('hiddenPeer:<peer>')`
+- [x] T018 (#611) [US3] Gate Hide/Unhide in `src/components/ChatActionsSheet.vue` via `canHide`/`canUnhide` — blocked entry renders disabled with the reason text (stock Ionic only, Principle XI)
+- [x] T019 (#612) [P] [US3] Extend `drive/scenarios/hidden-coexist.mjs` (part 2: coexistence + blocked Hide/Unhide journey), including an SC-004 volume loop — ≥100 messages split across both threads with zero cross-thread leaks asserted
 
 **Checkpoint**: the per-person model is fully user-reachable and enforced.
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -28,8 +28,8 @@ design ids (R1–R10, D1–D7, INV-1..3, rule R) refer to research.md / plan.md 
 
 **Purpose**: The pure per-person predicate/routing module every story consumes (R8, INV-1..3).
 
-- [ ] T003 (#596) Write failing unit tests for the pure invariant module in `src/services/hidden-pair.test.ts`: `chatsWithPeer` (plain 1:1s + pair conversations counted, multi-member groups excluded), `canHide` (INV-1), `canUnhide` (INV-2), `resolveInboundDirectChat` (rule R steps 2–3; never returns a pair conversation), including the legacy hidden+visible plain-1:1 state (INV-3 violation tolerated read-only)
-- [ ] T004 (#597) Implement `src/services/hidden-pair.ts` as a pure leaf (no idb imports; user-facing `reason` copy follows the UI voice rules) until T003 is green
+- [x] T003 (#596) Write failing unit tests for the pure invariant module in `src/services/hidden-pair.test.ts`: `chatsWithPeer` (plain 1:1s + pair conversations counted, multi-member groups excluded), `canHide` (INV-1), `canUnhide` (INV-2), `resolveInboundDirectChat` (rule R steps 2–3; never returns a pair conversation), including the legacy hidden+visible plain-1:1 state (INV-3 violation tolerated read-only)
+- [x] T004 (#597) Implement `src/services/hidden-pair.ts` as a pure leaf (no idb imports; user-facing `reason` copy follows the UI voice rules) until T003 is green
 
 **Checkpoint**: invariant semantics locked in by unit tests — story phases can begin.
 
@@ -45,14 +45,14 @@ calls stay empty of B, no rekey traffic, reveal shows the message in the hidden 
 
 ### Tests (write first, must FAIL)
 
-- [ ] T005 (#598) [P] [US1] Failing vitest for inbound routing in `src/db/queries.receive.hidden.test.ts` (fake idb): sole 1:1 hidden → inbound frame lands in the hidden chat, creates no new chat row, requests no rekey; group frame from the same peer resurrects nothing; unknown hidden set → frame re-queued (fail closed)
-- [ ] T006 (#599) [P] [US1] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 1): A hides the chat with B (PIN created on first hide), chat leaves list/search, B sends a message, A's chat list stays empty, badge updates, reveal shows the message inside the hidden thread
+- [x] T005 (#598) [P] [US1] Failing vitest for inbound routing in `src/db/queries.receive.hidden.test.ts` (fake idb): sole 1:1 hidden → inbound frame lands in the hidden chat, creates no new chat row, requests no rekey; group frame from the same peer resurrects nothing; unknown hidden set → frame re-queued (fail closed)
+- [x] T006 (#599) [P] [US1] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 1): A hides the chat with B (PIN created on first hide), chat leaves list/search, B sends a message, A's chat list stays empty, badge updates, reveal shows the message inside the hidden thread
 
 ### Implementation
 
-- [ ] T007 (#600) [US1] Replace the blind `startDirectChat` call in `receiveIncomingInner` (`src/db/queries.ts:4429`) with rule R resolution via `resolveInboundDirectChat` + peer-block check + fail-closed requeue (D2); pre-decrypt session id now always matches the thread that holds the ratchet
-- [ ] T008 (#601) [US1] Update the `hadDirectChatBefore` / unsolicited-content cleanup path in `receiveIncomingInner` so a hidden chat is never deleted or exposed by the friends-only trace-removal branch (`src/db/queries.ts:4414`, `:4518`)
-- [ ] T009 (#602) [P] [US1] Drive scenario `drive/scenarios/hidden-coexist.mjs` (part 1: hide → inbound lands hidden silently) against the live dev stack
+- [x] T007 (#600) [US1] Replace the blind `startDirectChat` call in `receiveIncomingInner` (`src/db/queries.ts:4429`) with rule R resolution via `resolveInboundDirectChat` + peer-block check + fail-closed requeue (D2); pre-decrypt session id now always matches the thread that holds the ratchet
+- [x] T008 (#601) [US1] Update the `hadDirectChatBefore` / unsolicited-content cleanup path in `receiveIncomingInner` so a hidden chat is never deleted or exposed by the friends-only trace-removal branch (`src/db/queries.ts:4414`, `:4518`)
+- [x] T009 (#602) [P] [US1] Drive scenario `drive/scenarios/hidden-coexist.mjs` (part 1: hide → inbound lands hidden silently) against the live dev stack
 
 **Checkpoint**: hiding your only chat with a person is safe — MVP fix shipped.
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -179,12 +179,12 @@ visible chats and badge correct from the first frame.
 
 ## Phase 9: Polish & Cross-Cutting
 
-- [ ] T039 (#632) [P] Neutralize dangling biometric references per R9 (keep the never-syncs assertion in `src/services/hidden-chats.zk.test.ts`, drop text implying the feature exists); confirm no `revealWithBiometric`/settings toggle is referenced anywhere in `src/`
-- [ ] T040 (#633) [P] Update doc comments: `src/services/hidden-chats.ts` header (per-person model + 1027 cross-reference), `src/services/hidden-chats-start.ts` (no longer test-only), `src/db/queries.ts` rule-R comment block
-- [ ] T041 (#634) Run all six existing hidden drive scenarios (`hidden-chats-1019.mjs`, `hidden-notify.mjs`, `hidden-badge.mjs`, `hidden-marker.mjs`, `hidden-pin-pad.mjs`, `hidden-flash.mjs`) against the dev stack and fix regressions — this run also re-verifies FR-007's reveal marker + sort-to-top behavior (unchanged in 1027)
+- [x] T039 (#632) [P] Neutralize dangling biometric references per R9 (keep the never-syncs assertion in `src/services/hidden-chats.zk.test.ts`, drop text implying the feature exists); confirm no `revealWithBiometric`/settings toggle is referenced anywhere in `src/`
+- [x] T040 (#633) [P] Update doc comments: `src/services/hidden-chats.ts` header (per-person model + 1027 cross-reference), `src/services/hidden-chats-start.ts` (no longer test-only), `src/db/queries.ts` rule-R comment block
+- [x] T041 (#634) Run all six existing hidden drive scenarios (`hidden-chats-1019.mjs`, `hidden-notify.mjs`, `hidden-badge.mjs`, `hidden-marker.mjs`, `hidden-pin-pad.mjs`, `hidden-flash.mjs`) against the dev stack and fix regressions — this run also re-verifies FR-007's reveal marker + sort-to-top behavior (unchanged in 1027)
 - [ ] T042 (#635) Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build ./... && go vet ./... && go test ./...`
 - [ ] T043 (#636) Bump spec `**Status**:` to `in-progress` → run `make roadmap` (start of implement); bump to `in-review` + re-run at PR time
-- [ ] T044 (#637) [P] Hardening: seal `HiddenPinRec.length` in `src/services/hidden-chats.ts` under the master key instead of cleartext (auto-verify-at-length reads it only while unlocked, so availability is unchanged); migrate existing records in place on first read (reseal + rewrite) and extend `src/services/hidden-chats.test.ts` for both fresh and migrated shapes
+- [x] T044 (#637) [P] Hardening: seal `HiddenPinRec.length` in `src/services/hidden-chats.ts` under the master key instead of cleartext (auto-verify-at-length reads it only while unlocked, so availability is unchanged); migrate existing records in place on first read (reseal + rewrite) and extend `src/services/hidden-chats.test.ts` for both fresh and migrated shapes
 
 ---
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -19,8 +19,8 @@ design ids (R1–R10, D1–D7, INV-1..3, rule R) refer to research.md / plan.md 
 
 **Purpose**: Make `queries.ts` greppable again before everything else touches it (quickstart Slice 0).
 
-- [ ] T001 Add a vitest pinning the contact-card hash for a known name/avatar input (the `${card.name}\u0000${card.avatar}` SHA-256 path) in `src/db/contact-card-hash.test.ts` — must PASS against current code before the byte flip
-- [ ] T002 Replace the raw NUL byte at `src/db/queries.ts:3703` with the `\u0000` escape; confirm T001 still passes and `rg` now treats the file as text (FR-020)
+- [ ] T001 (#594) Add a vitest pinning the contact-card hash for a known name/avatar input (the `${card.name}\u0000${card.avatar}` SHA-256 path) in `src/db/contact-card-hash.test.ts` — must PASS against current code before the byte flip
+- [ ] T002 (#595) Replace the raw NUL byte at `src/db/queries.ts:3703` with the `\u0000` escape; confirm T001 still passes and `rg` now treats the file as text (FR-020)
 
 ---
 
@@ -28,8 +28,8 @@ design ids (R1–R10, D1–D7, INV-1..3, rule R) refer to research.md / plan.md 
 
 **Purpose**: The pure per-person predicate/routing module every story consumes (R8, INV-1..3).
 
-- [ ] T003 Write failing unit tests for the pure invariant module in `src/services/hidden-pair.test.ts`: `chatsWithPeer` (plain 1:1s + pair conversations counted, multi-member groups excluded), `canHide` (INV-1), `canUnhide` (INV-2), `resolveInboundDirectChat` (rule R steps 2–3; never returns a pair conversation), including the legacy hidden+visible plain-1:1 state (INV-3 violation tolerated read-only)
-- [ ] T004 Implement `src/services/hidden-pair.ts` as a pure leaf (no idb imports; user-facing `reason` copy follows the UI voice rules) until T003 is green
+- [ ] T003 (#596) Write failing unit tests for the pure invariant module in `src/services/hidden-pair.test.ts`: `chatsWithPeer` (plain 1:1s + pair conversations counted, multi-member groups excluded), `canHide` (INV-1), `canUnhide` (INV-2), `resolveInboundDirectChat` (rule R steps 2–3; never returns a pair conversation), including the legacy hidden+visible plain-1:1 state (INV-3 violation tolerated read-only)
+- [ ] T004 (#597) Implement `src/services/hidden-pair.ts` as a pure leaf (no idb imports; user-facing `reason` copy follows the UI voice rules) until T003 is green
 
 **Checkpoint**: invariant semantics locked in by unit tests — story phases can begin.
 
@@ -45,14 +45,14 @@ calls stay empty of B, no rekey traffic, reveal shows the message in the hidden 
 
 ### Tests (write first, must FAIL)
 
-- [ ] T005 [P] [US1] Failing vitest for inbound routing in `src/db/queries.receive.hidden.test.ts` (fake idb): sole 1:1 hidden → inbound frame lands in the hidden chat, creates no new chat row, requests no rekey; group frame from the same peer resurrects nothing; unknown hidden set → frame re-queued (fail closed)
-- [ ] T006 [P] [US1] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 1): A hides the chat with B (PIN created on first hide), chat leaves list/search, B sends a message, A's chat list stays empty, badge updates, reveal shows the message inside the hidden thread
+- [ ] T005 (#598) [P] [US1] Failing vitest for inbound routing in `src/db/queries.receive.hidden.test.ts` (fake idb): sole 1:1 hidden → inbound frame lands in the hidden chat, creates no new chat row, requests no rekey; group frame from the same peer resurrects nothing; unknown hidden set → frame re-queued (fail closed)
+- [ ] T006 (#599) [P] [US1] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 1): A hides the chat with B (PIN created on first hide), chat leaves list/search, B sends a message, A's chat list stays empty, badge updates, reveal shows the message inside the hidden thread
 
 ### Implementation
 
-- [ ] T007 [US1] Replace the blind `startDirectChat` call in `receiveIncomingInner` (`src/db/queries.ts:4429`) with rule R resolution via `resolveInboundDirectChat` + peer-block check + fail-closed requeue (D2); pre-decrypt session id now always matches the thread that holds the ratchet
-- [ ] T008 [US1] Update the `hadDirectChatBefore` / unsolicited-content cleanup path in `receiveIncomingInner` so a hidden chat is never deleted or exposed by the friends-only trace-removal branch (`src/db/queries.ts:4414`, `:4518`)
-- [ ] T009 [P] [US1] Drive scenario `drive/scenarios/hidden-coexist.mjs` (part 1: hide → inbound lands hidden silently) against the live dev stack
+- [ ] T007 (#600) [US1] Replace the blind `startDirectChat` call in `receiveIncomingInner` (`src/db/queries.ts:4429`) with rule R resolution via `resolveInboundDirectChat` + peer-block check + fail-closed requeue (D2); pre-decrypt session id now always matches the thread that holds the ratchet
+- [ ] T008 (#601) [US1] Update the `hadDirectChatBefore` / unsolicited-content cleanup path in `receiveIncomingInner` so a hidden chat is never deleted or exposed by the friends-only trace-removal branch (`src/db/queries.ts:4414`, `:4518`)
+- [ ] T009 (#602) [P] [US1] Drive scenario `drive/scenarios/hidden-coexist.mjs` (part 1: hide → inbound lands hidden silently) against the live dev stack
 
 **Checkpoint**: hiding your only chat with a person is safe — MVP fix shipped.
 
@@ -68,14 +68,14 @@ everywhere immediately — open hidden chat is kicked out; deep links blocked (f
 
 ### Tests (write first, must FAIL)
 
-- [ ] T010 [P] [US2] Failing vitest for the relock hook in `src/services/hidden-state.test.ts`: `registerRelockHook` fires on `setRevealed(false)` and `clearHiddenState`, not on `setRevealed(true)`
-- [ ] T011 [P] [US2] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (relock section): reveal → open hidden chat → trigger relock (grace `immediately` + background/foreground via test hook) → route is `/tabs/chats`; direct navigation to `/chat/<hiddenId>` while relocked redirects; wrong PIN in search bar reveals nothing and clears nothing (no oracle, FR-008 — behavioral assertion only; timing parity is architectural, Argon2id runs identically on both outcomes per SC-007)
+- [ ] T010 (#603) [P] [US2] Failing vitest for the relock hook in `src/services/hidden-state.test.ts`: `registerRelockHook` fires on `setRevealed(false)` and `clearHiddenState`, not on `setRevealed(true)`
+- [ ] T011 (#604) [P] [US2] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (relock section): reveal → open hidden chat → trigger relock (grace `immediately` + background/foreground via test hook) → route is `/tabs/chats`; direct navigation to `/chat/<hiddenId>` while relocked redirects; wrong PIN in search bar reveals nothing and clears nothing (no oracle, FR-008 — behavioral assertion only; timing parity is architectural, Argon2id runs identically on both outcomes per SC-007)
 
 ### Implementation
 
-- [ ] T012 [US2] Add `registerRelockHook(fn)` to `src/services/hidden-state.ts` (leaf discipline: router imports the leaf, never the reverse) and invoke it from `setRevealed(false)` / `clearHiddenState`
-- [ ] T013 [US2] Register the hook + `beforeEach` guard in `src/router/index.ts`: active route is a hidden conversation on relock → `router.replace('/tabs/chats')`; navigation to a hidden conversation while not revealed → redirect (D5)
-- [ ] T014 [P] [US2] Drive scenario `drive/scenarios/hidden-kickout.mjs`: grace expiry while inside the open hidden chat kicks out to the Chats list
+- [ ] T012 (#605) [US2] Add `registerRelockHook(fn)` to `src/services/hidden-state.ts` (leaf discipline: router imports the leaf, never the reverse) and invoke it from `setRevealed(false)` / `clearHiddenState`
+- [ ] T013 (#606) [US2] Register the hook + `beforeEach` guard in `src/router/index.ts`: active route is a hidden conversation on relock → `router.replace('/tabs/chats')`; navigation to a hidden conversation while not revealed → redirect (D5)
+- [ ] T014 (#607) [P] [US2] Drive scenario `drive/scenarios/hidden-kickout.mjs`: grace expiry while inside the open hidden chat kicks out to the Chats list
 
 **Checkpoint**: relock is airtight across grace expiry, auto-lock, deep links, back stack.
 
@@ -92,14 +92,14 @@ visible thread is blocked; delete visible → Unhide works.
 
 ### Tests (write first, must FAIL)
 
-- [ ] T015 [P] [US3] Failing vitest for `startDirectChat` in `src/db/queries.start-direct.test.ts`: hidden plain 1:1 exists → creates a visible pair conversation (isGroup, single participant) and lifts any `hiddenPeer:` block; visible exists → returns it (never a second visible); hidden pair conversation + no plain 1:1 → creates a plain 1:1
-- [ ] T016 [P] [US3] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 2): A starts a new chat with B from Contacts → fresh visible thread appears while hidden stays hidden; A↔B exchange messages in BOTH threads (B replies in each) and each message lands only in its own thread; Hide on the visible thread is blocked with the reason; Unhide on the hidden thread is blocked while the visible exists; delete visible → Unhide succeeds
+- [ ] T015 (#608) [P] [US3] Failing vitest for `startDirectChat` in `src/db/queries.start-direct.test.ts`: hidden plain 1:1 exists → creates a visible pair conversation (isGroup, single participant) and lifts any `hiddenPeer:` block; visible exists → returns it (never a second visible); hidden pair conversation + no plain 1:1 → creates a plain 1:1
+- [ ] T016 (#609) [P] [US3] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 2): A starts a new chat with B from Contacts → fresh visible thread appears while hidden stays hidden; A↔B exchange messages in BOTH threads (B replies in each) and each message lands only in its own thread; Hide on the visible thread is blocked with the reason; Unhide on the hidden thread is blocked while the visible exists; delete visible → Unhide succeeds
 
 ### Implementation
 
-- [ ] T017 [US3] Extend `startDirectChat` in `src/db/queries.ts:4059` per contract: hidden-chat-with-peer branch creates the visible pair conversation (reuse the `createGroup('', [peer])` mechanism from `src/services/hidden-chats-start.ts`) and calls `clearTombstone('hiddenPeer:<peer>')`
-- [ ] T018 [US3] Gate Hide/Unhide in `src/components/ChatActionsSheet.vue` via `canHide`/`canUnhide` — blocked entry renders disabled with the reason text (stock Ionic only, Principle XI)
-- [ ] T019 [P] [US3] Extend `drive/scenarios/hidden-coexist.mjs` (part 2: coexistence + blocked Hide/Unhide journey), including an SC-004 volume loop — ≥100 messages split across both threads with zero cross-thread leaks asserted
+- [ ] T017 (#610) [US3] Extend `startDirectChat` in `src/db/queries.ts:4059` per contract: hidden-chat-with-peer branch creates the visible pair conversation (reuse the `createGroup('', [peer])` mechanism from `src/services/hidden-chats-start.ts`) and calls `clearTombstone('hiddenPeer:<peer>')`
+- [ ] T018 (#611) [US3] Gate Hide/Unhide in `src/components/ChatActionsSheet.vue` via `canHide`/`canUnhide` — blocked entry renders disabled with the reason text (stock Ionic only, Principle XI)
+- [ ] T019 (#612) [P] [US3] Extend `drive/scenarios/hidden-coexist.mjs` (part 2: coexistence + blocked Hide/Unhide journey), including an SC-004 volume loop — ≥100 messages split across both threads with zero cross-thread leaks asserted
 
 **Checkpoint**: the per-person model is fully user-reachable and enforced.
 
@@ -116,19 +116,19 @@ silent/generic per path; badge across always/never/revealed; call history clean 
 
 ### Tests (write first, must FAIL)
 
-- [ ] T020 [P] [US4] Failing vitest in `src/services/notify.hidden.test.ts`: backgrounded-but-connected hidden-chat message produces NO local notification (B6); foreground stays silent and claims the banner
-- [ ] T021 [P] [US4] Failing/pinning vitest in `src/services/sw-inbox.hidden.test.ts` (extend): the hidden generic note byte-equals the previews-off generic (`Ring` / `New message` / `/tabs/chats`) and is decided before mention/mute/content branches; burst frames coalesce under the internal tag
-- [ ] T022 [P] [US4] Failing vitest in `src/services/sw-inbox.badge.test.ts`: SW `unreadCount()` across `always`/`never`/`revealed` × (hidden set readable / locked): `revealed` ≡ `never` in the SW, hidden chats excluded, locked → falls back to `badge.lastCount`, unclassifiable pending frames not counted
-- [ ] T023 [P] [US4] Failing vitest in `src/db/queries.badge.test.ts`: page `countUnread()` persists `badge.lastCount` on success and returns it (not 0) when the set is unknown in `never`/`revealed` modes; visible-chat counts never suppressed (B4)
-- [ ] T024 [P] [US4] Failing Playwright e2e in `e2e/hidden-call.spec.ts` (2-person call per CI constraints): B calls A whose chat with B is hidden → incoming overlay shows B's name and avatar and the call is answerable (knock-knock, FR-013); after hangup the Calls tab shows no entry for B while relocked, and reveal shows it (FR-014)
-- [ ] T025 [P] [US4] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (badge/notify section): hidden-chat message produces no visible notification UI while badge reflects ALL THREE modes — `always`, `never`, and `revealed` (hidden unreads counted only during an active reveal, excluded again after relock)
+- [ ] T020 (#613) [P] [US4] Failing vitest in `src/services/notify.hidden.test.ts`: backgrounded-but-connected hidden-chat message produces NO local notification (B6); foreground stays silent and claims the banner
+- [ ] T021 (#614) [P] [US4] Failing/pinning vitest in `src/services/sw-inbox.hidden.test.ts` (extend): the hidden generic note byte-equals the previews-off generic (`Ring` / `New message` / `/tabs/chats`) and is decided before mention/mute/content branches; burst frames coalesce under the internal tag
+- [ ] T022 (#615) [P] [US4] Failing vitest in `src/services/sw-inbox.badge.test.ts`: SW `unreadCount()` across `always`/`never`/`revealed` × (hidden set readable / locked): `revealed` ≡ `never` in the SW, hidden chats excluded, locked → falls back to `badge.lastCount`, unclassifiable pending frames not counted
+- [ ] T023 (#616) [P] [US4] Failing vitest in `src/db/queries.badge.test.ts`: page `countUnread()` persists `badge.lastCount` on success and returns it (not 0) when the set is unknown in `never`/`revealed` modes; visible-chat counts never suppressed (B4)
+- [ ] T024 (#617) [P] [US4] Failing Playwright e2e in `e2e/hidden-call.spec.ts` (2-person call per CI constraints): B calls A whose chat with B is hidden → incoming overlay shows B's name and avatar and the call is answerable (knock-knock, FR-013); after hangup the Calls tab shows no entry for B while relocked, and reveal shows it (FR-014)
+- [ ] T025 (#618) [P] [US4] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (badge/notify section): hidden-chat message produces no visible notification UI while badge reflects ALL THREE modes — `always`, `never`, and `revealed` (hidden unreads counted only during an active reveal, excluded again after relock)
 
 ### Implementation
 
-- [ ] T026 [US4] Remove the backgrounded-but-connected generic bridge from the hidden branch of `notifyIncoming` in `src/services/notify.ts:389` (path becomes badge-only; D6)
-- [ ] T027 [US4] Implement the badge cache in `src/db/queries.ts` `countUnread` (persist + fallback `badge.lastCount`) and add the key to the own-sync exclusion list next to the hidden keys (R5, D4)
-- [ ] T028 [US4] Apply the badge preference in `src/services/sw-inbox.ts` `unreadCount()` per contract (readHiddenSet exclusion, `revealed` ≡ `never`, `badge.lastCount` fallback, unclassifiable pending frames uncounted)
-- [ ] T029 [P] [US4] Update `drive/scenarios/hidden-notify.mjs` for the new fully-silent non-push expectation and `drive/scenarios/hidden-badge.mjs` for the cache-backed modes
+- [ ] T026 (#619) [US4] Remove the backgrounded-but-connected generic bridge from the hidden branch of `notifyIncoming` in `src/services/notify.ts:389` (path becomes badge-only; D6)
+- [ ] T027 (#620) [US4] Implement the badge cache in `src/db/queries.ts` `countUnread` (persist + fallback `badge.lastCount`) and add the key to the own-sync exclusion list next to the hidden keys (R5, D4)
+- [ ] T028 (#621) [US4] Apply the badge preference in `src/services/sw-inbox.ts` `unreadCount()` per contract (readHiddenSet exclusion, `revealed` ≡ `never`, `badge.lastCount` fallback, unclassifiable pending frames uncounted)
+- [ ] T029 (#622) [P] [US4] Update `drive/scenarios/hidden-notify.mjs` for the new fully-silent non-push expectation and `drive/scenarios/hidden-badge.mjs` for the cache-backed modes
 
 **Checkpoint**: the privacy contract (knock-knock + badge only) holds on every delivery path.
 
@@ -143,15 +143,15 @@ rekey; A explicitly starts a chat with B → works again.
 
 ### Tests (write first, must FAIL)
 
-- [ ] T030 [P] [US5] Failing vitest in `src/services/hidden-chats-reset.test.ts` (extend): reset records `hiddenPeer:<peer>` localOnly tombstones for hidden plain-1:1 peers BEFORE deleting data (FR-024 ordering) and keeps id tombstones for pair/group threads; extend `src/services/hidden-chats.zk.test.ts` so BOTH the `hiddenPeer:` blocks AND `badge.lastCount` are asserted to never enter a sync payload (FR-019)
-- [ ] T031 [P] [US5] Failing vitest in `src/db/queries.receive.hidden.test.ts` (extend): inbound 1:1 frame from a `hiddenPeer:`-blocked peer is acked + dropped — no rekey request, no contact/chat/message writes, no notification; group-card re-creation for a tombstoned group id is dropped
-- [ ] T032 [P] [US5] Failing Playwright e2e in `e2e/hidden-reset.spec.ts`: hide → reset from Settings → B sends a live message → no chat (hidden or visible) appears and nothing identifies B; A starts a new chat with B from Contacts → conversation works (block lifted)
+- [ ] T030 (#623) [P] [US5] Failing vitest in `src/services/hidden-chats-reset.test.ts` (extend): reset records `hiddenPeer:<peer>` localOnly tombstones for hidden plain-1:1 peers BEFORE deleting data (FR-024 ordering) and keeps id tombstones for pair/group threads; extend `src/services/hidden-chats.zk.test.ts` so BOTH the `hiddenPeer:` blocks AND `badge.lastCount` are asserted to never enter a sync payload (FR-019)
+- [ ] T031 (#624) [P] [US5] Failing vitest in `src/db/queries.receive.hidden.test.ts` (extend): inbound 1:1 frame from a `hiddenPeer:`-blocked peer is acked + dropped — no rekey request, no contact/chat/message writes, no notification; group-card re-creation for a tombstoned group id is dropped
+- [ ] T032 (#625) [P] [US5] Failing Playwright e2e in `e2e/hidden-reset.spec.ts`: hide → reset from Settings → B sends a live message → no chat (hidden or visible) appears and nothing identifies B; A starts a new chat with B from Contacts → conversation works (block lifted)
 
 ### Implementation
 
-- [ ] T033 [US5] Write `hiddenPeer:` localOnly tombstones in `src/services/hidden-chats-reset.ts` (step 1, before deletes)
-- [ ] T034 [US5] Consume the peer block in rule R step 4 in `src/db/queries.ts` `receiveIncomingInner` (ack + drop, no trace) and consult group-id tombstones in `ensureGroupChat`/`handleGroupCard`
-- [ ] T035 [P] [US5] Drive scenario `drive/scenarios/hidden-reset-relay.mjs`: reset then live inbound message leaves no trace
+- [ ] T033 (#626) [US5] Write `hiddenPeer:` localOnly tombstones in `src/services/hidden-chats-reset.ts` (step 1, before deletes)
+- [ ] T034 (#627) [US5] Consume the peer block in rule R step 4 in `src/db/queries.ts` `receiveIncomingInner` (ack + drop, no trace) and consult group-id tombstones in `ensureGroupChat`/`handleGroupCard`
+- [ ] T035 (#628) [P] [US5] Drive scenario `drive/scenarios/hidden-reset-relay.mjs`: reset then live inbound message leaves no trace
 
 **Checkpoint**: FR-018 satisfied end-to-end, including the relay path.
 
@@ -166,12 +166,12 @@ visible chats and badge correct from the first frame.
 
 ### Tests (write first, must FAIL where behavior changes)
 
-- [ ] T036 [P] [US6] Failing/pinning Playwright e2e in `e2e/hidden-privacy.spec.ts` (cold-open section): seed hidden + visible chats, then LOOP ≥5 context restarts polling from first paint — hidden row never appears, visible rows and unread badge correct immediately (uses `badge.lastCount` from T027); extend `drive/scenarios/hidden-flash.mjs` to a ≥20-restart soak for the full SC-006 sample
-- [ ] T037 [P] [US6] Pinning vitest in `src/db/hidden-calls.test.ts` (extend): `countMissedUnseen` and call-history exclusion stay fail-closed without collateral loss once the set loads
+- [ ] T036 (#629) [P] [US6] Failing/pinning Playwright e2e in `e2e/hidden-privacy.spec.ts` (cold-open section): seed hidden + visible chats, then LOOP ≥5 context restarts polling from first paint — hidden row never appears, visible rows and unread badge correct immediately (uses `badge.lastCount` from T027); extend `drive/scenarios/hidden-flash.mjs` to a ≥20-restart soak for the full SC-006 sample
+- [ ] T037 (#630) [P] [US6] Pinning vitest in `src/db/hidden-calls.test.ts` (extend): `countMissedUnseen` and call-history exclusion stay fail-closed without collateral loss once the set loads
 
 ### Implementation
 
-- [ ] T038 [US6] Verify/adjust the `listChats` fail-closed nudge path (`src/db/queries.ts:59`, `src/services/hidden-state.ts`) so the T036 first-frame guarantee holds; fix anything T036 exposes
+- [ ] T038 (#631) [US6] Verify/adjust the `listChats` fail-closed nudge path (`src/db/queries.ts:59`, `src/services/hidden-state.ts`) so the T036 first-frame guarantee holds; fix anything T036 exposes
 
 **Checkpoint**: all six bugs (B1–B6) fixed with regression coverage.
 
@@ -179,12 +179,12 @@ visible chats and badge correct from the first frame.
 
 ## Phase 9: Polish & Cross-Cutting
 
-- [ ] T039 [P] Neutralize dangling biometric references per R9 (keep the never-syncs assertion in `src/services/hidden-chats.zk.test.ts`, drop text implying the feature exists); confirm no `revealWithBiometric`/settings toggle is referenced anywhere in `src/`
-- [ ] T040 [P] Update doc comments: `src/services/hidden-chats.ts` header (per-person model + 1027 cross-reference), `src/services/hidden-chats-start.ts` (no longer test-only), `src/db/queries.ts` rule-R comment block
-- [ ] T041 Run all six existing hidden drive scenarios (`hidden-chats-1019.mjs`, `hidden-notify.mjs`, `hidden-badge.mjs`, `hidden-marker.mjs`, `hidden-pin-pad.mjs`, `hidden-flash.mjs`) against the dev stack and fix regressions — this run also re-verifies FR-007's reveal marker + sort-to-top behavior (unchanged in 1027)
-- [ ] T042 Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build ./... && go vet ./... && go test ./...`
-- [ ] T043 Bump spec `**Status**:` to `in-progress` → run `make roadmap` (start of implement); bump to `in-review` + re-run at PR time
-- [ ] T044 [P] Hardening: seal `HiddenPinRec.length` in `src/services/hidden-chats.ts` under the master key instead of cleartext (auto-verify-at-length reads it only while unlocked, so availability is unchanged); migrate existing records in place on first read (reseal + rewrite) and extend `src/services/hidden-chats.test.ts` for both fresh and migrated shapes
+- [ ] T039 (#632) [P] Neutralize dangling biometric references per R9 (keep the never-syncs assertion in `src/services/hidden-chats.zk.test.ts`, drop text implying the feature exists); confirm no `revealWithBiometric`/settings toggle is referenced anywhere in `src/`
+- [ ] T040 (#633) [P] Update doc comments: `src/services/hidden-chats.ts` header (per-person model + 1027 cross-reference), `src/services/hidden-chats-start.ts` (no longer test-only), `src/db/queries.ts` rule-R comment block
+- [ ] T041 (#634) Run all six existing hidden drive scenarios (`hidden-chats-1019.mjs`, `hidden-notify.mjs`, `hidden-badge.mjs`, `hidden-marker.mjs`, `hidden-pin-pad.mjs`, `hidden-flash.mjs`) against the dev stack and fix regressions — this run also re-verifies FR-007's reveal marker + sort-to-top behavior (unchanged in 1027)
+- [ ] T042 (#635) Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build ./... && go vet ./... && go test ./...`
+- [ ] T043 (#636) Bump spec `**Status**:` to `in-progress` → run `make roadmap` (start of implement); bump to `in-review` + re-run at PR time
+- [ ] T044 (#637) [P] Hardening: seal `HiddenPinRec.length` in `src/services/hidden-chats.ts` under the master key instead of cleartext (auto-verify-at-length reads it only while unlocked, so availability is unchanged); migrate existing records in place on first read (reseal + rewrite) and extend `src/services/hidden-chats.test.ts` for both fresh and migrated shapes
 
 ---
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -68,14 +68,14 @@ everywhere immediately — open hidden chat is kicked out; deep links blocked (f
 
 ### Tests (write first, must FAIL)
 
-- [ ] T010 (#603) [P] [US2] Failing vitest for the relock hook in `src/services/hidden-state.test.ts`: `registerRelockHook` fires on `setRevealed(false)` and `clearHiddenState`, not on `setRevealed(true)`
-- [ ] T011 (#604) [P] [US2] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (relock section): reveal → open hidden chat → trigger relock (grace `immediately` + background/foreground via test hook) → route is `/tabs/chats`; direct navigation to `/chat/<hiddenId>` while relocked redirects; wrong PIN in search bar reveals nothing and clears nothing (no oracle, FR-008 — behavioral assertion only; timing parity is architectural, Argon2id runs identically on both outcomes per SC-007)
+- [x] T010 (#603) [P] [US2] Failing vitest for the relock hook in `src/services/hidden-state.test.ts`: `registerRelockHook` fires on `setRevealed(false)` and `clearHiddenState`, not on `setRevealed(true)`
+- [x] T011 (#604) [P] [US2] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (relock section): reveal → open hidden chat → trigger relock (grace `immediately` + background/foreground via test hook) → route is `/tabs/chats`; direct navigation to `/chat/<hiddenId>` while relocked redirects; wrong PIN in search bar reveals nothing and clears nothing (no oracle, FR-008 — behavioral assertion only; timing parity is architectural, Argon2id runs identically on both outcomes per SC-007)
 
 ### Implementation
 
-- [ ] T012 (#605) [US2] Add `registerRelockHook(fn)` to `src/services/hidden-state.ts` (leaf discipline: router imports the leaf, never the reverse) and invoke it from `setRevealed(false)` / `clearHiddenState`
-- [ ] T013 (#606) [US2] Register the hook + `beforeEach` guard in `src/router/index.ts`: active route is a hidden conversation on relock → `router.replace('/tabs/chats')`; navigation to a hidden conversation while not revealed → redirect (D5)
-- [ ] T014 (#607) [P] [US2] Drive scenario `drive/scenarios/hidden-kickout.mjs`: grace expiry while inside the open hidden chat kicks out to the Chats list
+- [x] T012 (#605) [US2] Add `registerRelockHook(fn)` to `src/services/hidden-state.ts` (leaf discipline: router imports the leaf, never the reverse) and invoke it from `setRevealed(false)` / `clearHiddenState`
+- [x] T013 (#606) [US2] Register the hook + `beforeEach` guard in `src/router/index.ts`: active route is a hidden conversation on relock → `router.replace('/tabs/chats')`; navigation to a hidden conversation while not revealed → redirect (D5)
+- [x] T014 (#607) [P] [US2] Drive scenario `drive/scenarios/hidden-kickout.mjs`: grace expiry while inside the open hidden chat kicks out to the Chats list
 
 **Checkpoint**: relock is airtight across grace expiry, auto-lock, deep links, back stack.
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -1,0 +1,215 @@
+# Tasks: Harden Hidden Chats + One-Hidden-One-Visible Per Person
+
+**Input**: Design documents from `/specs/1027-harden-hidden-chats/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/internal-api.md, quickstart.md
+
+**Tests**: REQUIRED — constitution Principle III (TDD) and spec FR-022/FR-023 mandate
+tests first. Every story orders its failing tests before the implementation that
+satisfies them (Red → Green). Bug fixes B1–B6 each begin with a failing regression test.
+
+**Organization**: Grouped by user story (US1–US6 from spec.md). Bug ids (B1–B6) and
+design ids (R1–R10, D1–D7, INV-1..3, rule R) refer to research.md / plan.md / data-model.md.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup & Hygiene
+
+**Purpose**: Make `queries.ts` greppable again before everything else touches it (quickstart Slice 0).
+
+- [ ] T001 Add a vitest pinning the contact-card hash for a known name/avatar input (the `${card.name}\u0000${card.avatar}` SHA-256 path) in `src/db/contact-card-hash.test.ts` — must PASS against current code before the byte flip
+- [ ] T002 Replace the raw NUL byte at `src/db/queries.ts:3703` with the `\u0000` escape; confirm T001 still passes and `rg` now treats the file as text (FR-020)
+
+---
+
+## Phase 2: Foundational — the invariant core (blocks US1/US3/US5)
+
+**Purpose**: The pure per-person predicate/routing module every story consumes (R8, INV-1..3).
+
+- [ ] T003 Write failing unit tests for the pure invariant module in `src/services/hidden-pair.test.ts`: `chatsWithPeer` (plain 1:1s + pair conversations counted, multi-member groups excluded), `canHide` (INV-1), `canUnhide` (INV-2), `resolveInboundDirectChat` (rule R steps 2–3; never returns a pair conversation), including the legacy hidden+visible plain-1:1 state (INV-3 violation tolerated read-only)
+- [ ] T004 Implement `src/services/hidden-pair.ts` as a pure leaf (no idb imports; user-facing `reason` copy follows the UI voice rules) until T003 is green
+
+**Checkpoint**: invariant semantics locked in by unit tests — story phases can begin.
+
+---
+
+## Phase 3: User Story 1 — Hide a chat and it disappears (P1) 🎯 MVP
+
+**Goal**: Hiding moves the chat out of every surface AND the hidden thread keeps
+receiving silently — no visible resurrection, no spurious re-keys (fixes B1 via rule R).
+
+**Independent Test**: Two accounts; A hides the 1:1 with B; B sends; A's list/search/
+calls stay empty of B, no rekey traffic, reveal shows the message in the hidden thread.
+
+### Tests (write first, must FAIL)
+
+- [ ] T005 [P] [US1] Failing vitest for inbound routing in `src/db/queries.receive.hidden.test.ts` (fake idb): sole 1:1 hidden → inbound frame lands in the hidden chat, creates no new chat row, requests no rekey; group frame from the same peer resurrects nothing; unknown hidden set → frame re-queued (fail closed)
+- [ ] T006 [P] [US1] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 1): A hides the chat with B (PIN created on first hide), chat leaves list/search, B sends a message, A's chat list stays empty, badge updates, reveal shows the message inside the hidden thread
+
+### Implementation
+
+- [ ] T007 [US1] Replace the blind `startDirectChat` call in `receiveIncomingInner` (`src/db/queries.ts:4429`) with rule R resolution via `resolveInboundDirectChat` + peer-block check + fail-closed requeue (D2); pre-decrypt session id now always matches the thread that holds the ratchet
+- [ ] T008 [US1] Update the `hadDirectChatBefore` / unsolicited-content cleanup path in `receiveIncomingInner` so a hidden chat is never deleted or exposed by the friends-only trace-removal branch (`src/db/queries.ts:4414`, `:4518`)
+- [ ] T009 [P] [US1] Drive scenario `drive/scenarios/hidden-coexist.mjs` (part 1: hide → inbound lands hidden silently) against the live dev stack
+
+**Checkpoint**: hiding your only chat with a person is safe — MVP fix shipped.
+
+---
+
+## Phase 4: User Story 2 — Reveal with the PIN, then relock (P1)
+
+**Goal**: Reveal via search-bar PIN works as shipped; relock now takes effect
+everywhere immediately — open hidden chat is kicked out; deep links blocked (fixes B5).
+
+**Independent Test**: Reveal, open a hidden chat, force relock → app lands on
+/tabs/chats; navigating to /chat/<hiddenId> while relocked redirects.
+
+### Tests (write first, must FAIL)
+
+- [ ] T010 [P] [US2] Failing vitest for the relock hook in `src/services/hidden-state.test.ts`: `registerRelockHook` fires on `setRevealed(false)` and `clearHiddenState`, not on `setRevealed(true)`
+- [ ] T011 [P] [US2] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (relock section): reveal → open hidden chat → trigger relock (grace `immediately` + background/foreground via test hook) → route is `/tabs/chats`; direct navigation to `/chat/<hiddenId>` while relocked redirects; wrong PIN in search bar reveals nothing and clears nothing (no oracle, FR-008 — behavioral assertion only; timing parity is architectural, Argon2id runs identically on both outcomes per SC-007)
+
+### Implementation
+
+- [ ] T012 [US2] Add `registerRelockHook(fn)` to `src/services/hidden-state.ts` (leaf discipline: router imports the leaf, never the reverse) and invoke it from `setRevealed(false)` / `clearHiddenState`
+- [ ] T013 [US2] Register the hook + `beforeEach` guard in `src/router/index.ts`: active route is a hidden conversation on relock → `router.replace('/tabs/chats')`; navigation to a hidden conversation while not revealed → redirect (D5)
+- [ ] T014 [P] [US2] Drive scenario `drive/scenarios/hidden-kickout.mjs`: grace expiry while inside the open hidden chat kicks out to the Chats list
+
+**Checkpoint**: relock is airtight across grace expiry, auto-lock, deep links, back stack.
+
+---
+
+## Phase 5: User Story 3 — One hidden and one visible chat per person (P1)
+
+**Goal**: Fresh visible chat coexists with the hidden one as a distinct channel
+(pair conversation); Hide/Unhide blocked per INV-1/INV-2 with clear reasons (fixes B2, D1).
+
+**Independent Test**: With a hidden 1:1 with B, start a new chat with B → fresh
+visible thread; both exchange messages with zero cross-contamination; Hide on the
+visible thread is blocked; delete visible → Unhide works.
+
+### Tests (write first, must FAIL)
+
+- [ ] T015 [P] [US3] Failing vitest for `startDirectChat` in `src/db/queries.start-direct.test.ts`: hidden plain 1:1 exists → creates a visible pair conversation (isGroup, single participant) and lifts any `hiddenPeer:` block; visible exists → returns it (never a second visible); hidden pair conversation + no plain 1:1 → creates a plain 1:1
+- [ ] T016 [P] [US3] Failing Playwright e2e in `e2e/hidden-coexist.spec.ts` (part 2): A starts a new chat with B from Contacts → fresh visible thread appears while hidden stays hidden; A↔B exchange messages in BOTH threads (B replies in each) and each message lands only in its own thread; Hide on the visible thread is blocked with the reason; Unhide on the hidden thread is blocked while the visible exists; delete visible → Unhide succeeds
+
+### Implementation
+
+- [ ] T017 [US3] Extend `startDirectChat` in `src/db/queries.ts:4059` per contract: hidden-chat-with-peer branch creates the visible pair conversation (reuse the `createGroup('', [peer])` mechanism from `src/services/hidden-chats-start.ts`) and calls `clearTombstone('hiddenPeer:<peer>')`
+- [ ] T018 [US3] Gate Hide/Unhide in `src/components/ChatActionsSheet.vue` via `canHide`/`canUnhide` — blocked entry renders disabled with the reason text (stock Ionic only, Principle XI)
+- [ ] T019 [P] [US3] Extend `drive/scenarios/hidden-coexist.mjs` (part 2: coexistence + blocked Hide/Unhide journey), including an SC-004 volume loop — ≥100 messages split across both threads with zero cross-thread leaks asserted
+
+**Checkpoint**: the per-person model is fully user-reachable and enforced.
+
+---
+
+## Phase 6: User Story 4 — Only the knock-knock call and badge surface (P1)
+
+**Goal**: Calls ring with full identity; message paths are silent (non-push) or the
+byte-identical previews-off generic (push-woken); badge honors the preference on every
+path without collateral suppression (fixes B4, B6; pins FR-012/FR-013/FR-014/FR-015).
+
+**Independent Test**: B calls A (hidden chat) → full-identity ring; B messages A →
+silent/generic per path; badge across always/never/revealed; call history clean while relocked.
+
+### Tests (write first, must FAIL)
+
+- [ ] T020 [P] [US4] Failing vitest in `src/services/notify.hidden.test.ts`: backgrounded-but-connected hidden-chat message produces NO local notification (B6); foreground stays silent and claims the banner
+- [ ] T021 [P] [US4] Failing/pinning vitest in `src/services/sw-inbox.hidden.test.ts` (extend): the hidden generic note byte-equals the previews-off generic (`Ring` / `New message` / `/tabs/chats`) and is decided before mention/mute/content branches; burst frames coalesce under the internal tag
+- [ ] T022 [P] [US4] Failing vitest in `src/services/sw-inbox.badge.test.ts`: SW `unreadCount()` across `always`/`never`/`revealed` × (hidden set readable / locked): `revealed` ≡ `never` in the SW, hidden chats excluded, locked → falls back to `badge.lastCount`, unclassifiable pending frames not counted
+- [ ] T023 [P] [US4] Failing vitest in `src/db/queries.badge.test.ts`: page `countUnread()` persists `badge.lastCount` on success and returns it (not 0) when the set is unknown in `never`/`revealed` modes; visible-chat counts never suppressed (B4)
+- [ ] T024 [P] [US4] Failing Playwright e2e in `e2e/hidden-call.spec.ts` (2-person call per CI constraints): B calls A whose chat with B is hidden → incoming overlay shows B's name and avatar and the call is answerable (knock-knock, FR-013); after hangup the Calls tab shows no entry for B while relocked, and reveal shows it (FR-014)
+- [ ] T025 [P] [US4] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (badge/notify section): hidden-chat message produces no visible notification UI while badge reflects ALL THREE modes — `always`, `never`, and `revealed` (hidden unreads counted only during an active reveal, excluded again after relock)
+
+### Implementation
+
+- [ ] T026 [US4] Remove the backgrounded-but-connected generic bridge from the hidden branch of `notifyIncoming` in `src/services/notify.ts:389` (path becomes badge-only; D6)
+- [ ] T027 [US4] Implement the badge cache in `src/db/queries.ts` `countUnread` (persist + fallback `badge.lastCount`) and add the key to the own-sync exclusion list next to the hidden keys (R5, D4)
+- [ ] T028 [US4] Apply the badge preference in `src/services/sw-inbox.ts` `unreadCount()` per contract (readHiddenSet exclusion, `revealed` ≡ `never`, `badge.lastCount` fallback, unclassifiable pending frames uncounted)
+- [ ] T029 [P] [US4] Update `drive/scenarios/hidden-notify.mjs` for the new fully-silent non-push expectation and `drive/scenarios/hidden-badge.mjs` for the cache-backed modes
+
+**Checkpoint**: the privacy contract (knock-knock + badge only) holds on every delivery path.
+
+---
+
+## Phase 7: User Story 5 — Reset wipes and cannot re-materialize (P2)
+
+**Goal**: Reset blocks the live relay path too — peer-keyed (fixes B3, D3, FR-018).
+
+**Independent Test**: Hide → reset → B sends live → nothing appears anywhere, no
+rekey; A explicitly starts a chat with B → works again.
+
+### Tests (write first, must FAIL)
+
+- [ ] T030 [P] [US5] Failing vitest in `src/services/hidden-chats-reset.test.ts` (extend): reset records `hiddenPeer:<peer>` localOnly tombstones for hidden plain-1:1 peers BEFORE deleting data (FR-024 ordering) and keeps id tombstones for pair/group threads; extend `src/services/hidden-chats.zk.test.ts` so BOTH the `hiddenPeer:` blocks AND `badge.lastCount` are asserted to never enter a sync payload (FR-019)
+- [ ] T031 [P] [US5] Failing vitest in `src/db/queries.receive.hidden.test.ts` (extend): inbound 1:1 frame from a `hiddenPeer:`-blocked peer is acked + dropped — no rekey request, no contact/chat/message writes, no notification; group-card re-creation for a tombstoned group id is dropped
+- [ ] T032 [P] [US5] Failing Playwright e2e in `e2e/hidden-reset.spec.ts`: hide → reset from Settings → B sends a live message → no chat (hidden or visible) appears and nothing identifies B; A starts a new chat with B from Contacts → conversation works (block lifted)
+
+### Implementation
+
+- [ ] T033 [US5] Write `hiddenPeer:` localOnly tombstones in `src/services/hidden-chats-reset.ts` (step 1, before deletes)
+- [ ] T034 [US5] Consume the peer block in rule R step 4 in `src/db/queries.ts` `receiveIncomingInner` (ack + drop, no trace) and consult group-id tombstones in `ensureGroupChat`/`handleGroupCard`
+- [ ] T035 [P] [US5] Drive scenario `drive/scenarios/hidden-reset-relay.mjs`: reset then live inbound message leaves no trace
+
+**Checkpoint**: FR-018 satisfied end-to-end, including the relay path.
+
+---
+
+## Phase 8: User Story 6 — Robust, no-flash, no-collateral (P2)
+
+**Goal**: Cold-open never flashes hidden chats AND never blanks visible data (pins FR-017; closes the loop on B4's collateral side).
+
+**Independent Test**: Cold-start with hidden chats present: no hidden row ever paints;
+visible chats and badge correct from the first frame.
+
+### Tests (write first, must FAIL where behavior changes)
+
+- [ ] T036 [P] [US6] Failing/pinning Playwright e2e in `e2e/hidden-privacy.spec.ts` (cold-open section): seed hidden + visible chats, then LOOP ≥5 context restarts polling from first paint — hidden row never appears, visible rows and unread badge correct immediately (uses `badge.lastCount` from T027); extend `drive/scenarios/hidden-flash.mjs` to a ≥20-restart soak for the full SC-006 sample
+- [ ] T037 [P] [US6] Pinning vitest in `src/db/hidden-calls.test.ts` (extend): `countMissedUnseen` and call-history exclusion stay fail-closed without collateral loss once the set loads
+
+### Implementation
+
+- [ ] T038 [US6] Verify/adjust the `listChats` fail-closed nudge path (`src/db/queries.ts:59`, `src/services/hidden-state.ts`) so the T036 first-frame guarantee holds; fix anything T036 exposes
+
+**Checkpoint**: all six bugs (B1–B6) fixed with regression coverage.
+
+---
+
+## Phase 9: Polish & Cross-Cutting
+
+- [ ] T039 [P] Neutralize dangling biometric references per R9 (keep the never-syncs assertion in `src/services/hidden-chats.zk.test.ts`, drop text implying the feature exists); confirm no `revealWithBiometric`/settings toggle is referenced anywhere in `src/`
+- [ ] T040 [P] Update doc comments: `src/services/hidden-chats.ts` header (per-person model + 1027 cross-reference), `src/services/hidden-chats-start.ts` (no longer test-only), `src/db/queries.ts` rule-R comment block
+- [ ] T041 Run all six existing hidden drive scenarios (`hidden-chats-1019.mjs`, `hidden-notify.mjs`, `hidden-badge.mjs`, `hidden-marker.mjs`, `hidden-pin-pad.mjs`, `hidden-flash.mjs`) against the dev stack and fix regressions — this run also re-verifies FR-007's reveal marker + sort-to-top behavior (unchanged in 1027)
+- [ ] T042 Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build ./... && go vet ./... && go test ./...`
+- [ ] T043 Bump spec `**Status**:` to `in-progress` → run `make roadmap` (start of implement); bump to `in-review` + re-run at PR time
+- [ ] T044 [P] Hardening: seal `HiddenPinRec.length` in `src/services/hidden-chats.ts` under the master key instead of cleartext (auto-verify-at-length reads it only while unlocked, so availability is unchanged); migrate existing records in place on first read (reseal + rewrite) and extend `src/services/hidden-chats.test.ts` for both fresh and migrated shapes
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1 (Setup)** → **Phase 2 (Foundational)** → story phases.
+- **US1 (Phase 3)** requires T004; **US3 (Phase 5)** requires US1's rule R (T007) — sequential.
+- **US2 (Phase 4)** is independent of US1/US3 — can run in parallel with Phase 3/5.
+- **US4 (Phase 6)** is independent of US1/US3 except T036's badge dependency on T027 (within-phase order handles it).
+- **US5 (Phase 7)** requires rule R (T007) for step-4 consumption.
+- **US6 (Phase 8)** T036 depends on T027 (badge cache).
+- **Polish (Phase 9)** last; T042 gates the PR.
+
+### Parallel opportunities
+
+- T005+T006, T010+T011, T015+T016, T020–T025, T030–T032, T036+T037 (test batches per story).
+- US2 (relock) can be built in parallel with US1/US3 by a second contributor.
+- Drive-scenario tasks (T009, T014, T019, T029, T035) parallel to their story's e2e.
+
+---
+
+## Implementation Strategy
+
+**MVP = Phase 1–3 (US1)**: the B1 routing fix alone repairs the reported breakage
+(hiding a chat no longer resurrects/leaks). Validate independently, then layer
+US2 (relock hardening), US3 (coexistence), US4 (notification/badge contract),
+US5 (reset), US6 (no-flash), polishing last. Each checkpoint is independently
+testable and landable; nothing outside `src/` + tests is touched (server untouched).

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -143,15 +143,15 @@ rekey; A explicitly starts a chat with B → works again.
 
 ### Tests (write first, must FAIL)
 
-- [ ] T030 (#623) [P] [US5] Failing vitest in `src/services/hidden-chats-reset.test.ts` (extend): reset records `hiddenPeer:<peer>` localOnly tombstones for hidden plain-1:1 peers BEFORE deleting data (FR-024 ordering) and keeps id tombstones for pair/group threads; extend `src/services/hidden-chats.zk.test.ts` so BOTH the `hiddenPeer:` blocks AND `badge.lastCount` are asserted to never enter a sync payload (FR-019)
-- [ ] T031 (#624) [P] [US5] Failing vitest in `src/db/queries.receive.hidden.test.ts` (extend): inbound 1:1 frame from a `hiddenPeer:`-blocked peer is acked + dropped — no rekey request, no contact/chat/message writes, no notification; group-card re-creation for a tombstoned group id is dropped
-- [ ] T032 (#625) [P] [US5] Failing Playwright e2e in `e2e/hidden-reset.spec.ts`: hide → reset from Settings → B sends a live message → no chat (hidden or visible) appears and nothing identifies B; A starts a new chat with B from Contacts → conversation works (block lifted)
+- [x] T030 (#623) [P] [US5] Failing vitest in `src/services/hidden-chats-reset.test.ts` (extend): reset records `hiddenPeer:<peer>` localOnly tombstones for hidden plain-1:1 peers BEFORE deleting data (FR-024 ordering) and keeps id tombstones for pair/group threads; extend `src/services/hidden-chats.zk.test.ts` so BOTH the `hiddenPeer:` blocks AND `badge.lastCount` are asserted to never enter a sync payload (FR-019)
+- [x] T031 (#624) [P] [US5] Failing vitest in `src/db/queries.receive.hidden.test.ts` (extend): inbound 1:1 frame from a `hiddenPeer:`-blocked peer is acked + dropped — no rekey request, no contact/chat/message writes, no notification; group-card re-creation for a tombstoned group id is dropped
+- [x] T032 (#625) [P] [US5] Failing Playwright e2e in `e2e/hidden-reset.spec.ts`: hide → reset from Settings → B sends a live message → no chat (hidden or visible) appears and nothing identifies B; A starts a new chat with B from Contacts → conversation works (block lifted)
 
 ### Implementation
 
-- [ ] T033 (#626) [US5] Write `hiddenPeer:` localOnly tombstones in `src/services/hidden-chats-reset.ts` (step 1, before deletes)
-- [ ] T034 (#627) [US5] Consume the peer block in rule R step 4 in `src/db/queries.ts` `receiveIncomingInner` (ack + drop, no trace) and consult group-id tombstones in `ensureGroupChat`/`handleGroupCard`
-- [ ] T035 (#628) [P] [US5] Drive scenario `drive/scenarios/hidden-reset-relay.mjs`: reset then live inbound message leaves no trace
+- [x] T033 (#626) [US5] Write `hiddenPeer:` localOnly tombstones in `src/services/hidden-chats-reset.ts` (step 1, before deletes)
+- [x] T034 (#627) [US5] Consume the peer block in rule R step 4 in `src/db/queries.ts` `receiveIncomingInner` (ack + drop, no trace) and consult group-id tombstones in `ensureGroupChat`/`handleGroupCard`
+- [x] T035 (#628) [P] [US5] Drive scenario `drive/scenarios/hidden-reset-relay.mjs`: reset then live inbound message leaves no trace
 
 **Checkpoint**: FR-018 satisfied end-to-end, including the relay path.
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -19,8 +19,8 @@ design ids (R1–R10, D1–D7, INV-1..3, rule R) refer to research.md / plan.md 
 
 **Purpose**: Make `queries.ts` greppable again before everything else touches it (quickstart Slice 0).
 
-- [ ] T001 (#594) Add a vitest pinning the contact-card hash for a known name/avatar input (the `${card.name}\u0000${card.avatar}` SHA-256 path) in `src/db/contact-card-hash.test.ts` — must PASS against current code before the byte flip
-- [ ] T002 (#595) Replace the raw NUL byte at `src/db/queries.ts:3703` with the `\u0000` escape; confirm T001 still passes and `rg` now treats the file as text (FR-020)
+- [x] T001 (#594) Add a vitest pinning the contact-card hash for a known name/avatar input (the `${card.name}\u0000${card.avatar}` SHA-256 path) in `src/db/contact-card-hash.test.ts` — must PASS against current code before the byte flip
+- [x] T002 (#595) Replace the raw NUL byte at `src/db/queries.ts:3703` with the `\u0000` escape; confirm T001 still passes and `rg` now treats the file as text (FR-020)
 
 ---
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -116,19 +116,19 @@ silent/generic per path; badge across always/never/revealed; call history clean 
 
 ### Tests (write first, must FAIL)
 
-- [ ] T020 (#613) [P] [US4] Failing vitest in `src/services/notify.hidden.test.ts`: backgrounded-but-connected hidden-chat message produces NO local notification (B6); foreground stays silent and claims the banner
-- [ ] T021 (#614) [P] [US4] Failing/pinning vitest in `src/services/sw-inbox.hidden.test.ts` (extend): the hidden generic note byte-equals the previews-off generic (`Ring` / `New message` / `/tabs/chats`) and is decided before mention/mute/content branches; burst frames coalesce under the internal tag
-- [ ] T022 (#615) [P] [US4] Failing vitest in `src/services/sw-inbox.badge.test.ts`: SW `unreadCount()` across `always`/`never`/`revealed` × (hidden set readable / locked): `revealed` ≡ `never` in the SW, hidden chats excluded, locked → falls back to `badge.lastCount`, unclassifiable pending frames not counted
-- [ ] T023 (#616) [P] [US4] Failing vitest in `src/db/queries.badge.test.ts`: page `countUnread()` persists `badge.lastCount` on success and returns it (not 0) when the set is unknown in `never`/`revealed` modes; visible-chat counts never suppressed (B4)
-- [ ] T024 (#617) [P] [US4] Failing Playwright e2e in `e2e/hidden-call.spec.ts` (2-person call per CI constraints): B calls A whose chat with B is hidden → incoming overlay shows B's name and avatar and the call is answerable (knock-knock, FR-013); after hangup the Calls tab shows no entry for B while relocked, and reveal shows it (FR-014)
-- [ ] T025 (#618) [P] [US4] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (badge/notify section): hidden-chat message produces no visible notification UI while badge reflects ALL THREE modes — `always`, `never`, and `revealed` (hidden unreads counted only during an active reveal, excluded again after relock)
+- [x] T020 (#613) [P] [US4] Failing vitest in `src/services/notify.hidden.test.ts`: backgrounded-but-connected hidden-chat message produces NO local notification (B6); foreground stays silent and claims the banner
+- [x] T021 (#614) [P] [US4] Failing/pinning vitest in `src/services/sw-inbox.hidden.test.ts` (extend): the hidden generic note byte-equals the previews-off generic (`Ring` / `New message` / `/tabs/chats`) and is decided before mention/mute/content branches; burst frames coalesce under the internal tag
+- [x] T022 (#615) [P] [US4] Failing vitest in `src/services/sw-inbox.badge.test.ts`: SW `unreadCount()` across `always`/`never`/`revealed` × (hidden set readable / locked): `revealed` ≡ `never` in the SW, hidden chats excluded, locked → falls back to `badge.lastCount`, unclassifiable pending frames not counted
+- [x] T023 (#616) [P] [US4] Failing vitest in `src/db/queries.badge.test.ts`: page `countUnread()` persists `badge.lastCount` on success and returns it (not 0) when the set is unknown in `never`/`revealed` modes; visible-chat counts never suppressed (B4)
+- [x] T024 (#617) [P] [US4] Failing Playwright e2e in `e2e/hidden-call.spec.ts` (2-person call per CI constraints): B calls A whose chat with B is hidden → incoming overlay shows B's name and avatar and the call is answerable (knock-knock, FR-013); after hangup the Calls tab shows no entry for B while relocked, and reveal shows it (FR-014)
+- [x] T025 (#618) [P] [US4] Failing Playwright e2e in `e2e/hidden-privacy.spec.ts` (badge/notify section): hidden-chat message produces no visible notification UI while badge reflects ALL THREE modes — `always`, `never`, and `revealed` (hidden unreads counted only during an active reveal, excluded again after relock)
 
 ### Implementation
 
-- [ ] T026 (#619) [US4] Remove the backgrounded-but-connected generic bridge from the hidden branch of `notifyIncoming` in `src/services/notify.ts:389` (path becomes badge-only; D6)
-- [ ] T027 (#620) [US4] Implement the badge cache in `src/db/queries.ts` `countUnread` (persist + fallback `badge.lastCount`) and add the key to the own-sync exclusion list next to the hidden keys (R5, D4)
-- [ ] T028 (#621) [US4] Apply the badge preference in `src/services/sw-inbox.ts` `unreadCount()` per contract (readHiddenSet exclusion, `revealed` ≡ `never`, `badge.lastCount` fallback, unclassifiable pending frames uncounted)
-- [ ] T029 (#622) [P] [US4] Update `drive/scenarios/hidden-notify.mjs` for the new fully-silent non-push expectation and `drive/scenarios/hidden-badge.mjs` for the cache-backed modes
+- [x] T026 (#619) [US4] Remove the backgrounded-but-connected generic bridge from the hidden branch of `notifyIncoming` in `src/services/notify.ts:389` (path becomes badge-only; D6)
+- [x] T027 (#620) [US4] Implement the badge cache in `src/db/queries.ts` `countUnread` (persist + fallback `badge.lastCount`) and add the key to the own-sync exclusion list next to the hidden keys (R5, D4)
+- [x] T028 (#621) [US4] Apply the badge preference in `src/services/sw-inbox.ts` `unreadCount()` per contract (readHiddenSet exclusion, `revealed` ≡ `never`, `badge.lastCount` fallback, unclassifiable pending frames uncounted)
+- [x] T029 (#622) [P] [US4] Update `drive/scenarios/hidden-notify.mjs` for the new fully-silent non-push expectation and `drive/scenarios/hidden-badge.mjs` for the cache-backed modes
 
 **Checkpoint**: the privacy contract (knock-knock + badge only) holds on every delivery path.
 

--- a/specs/1027-harden-hidden-chats/tasks.md
+++ b/specs/1027-harden-hidden-chats/tasks.md
@@ -182,8 +182,8 @@ visible chats and badge correct from the first frame.
 - [x] T039 (#632) [P] Neutralize dangling biometric references per R9 (keep the never-syncs assertion in `src/services/hidden-chats.zk.test.ts`, drop text implying the feature exists); confirm no `revealWithBiometric`/settings toggle is referenced anywhere in `src/`
 - [x] T040 (#633) [P] Update doc comments: `src/services/hidden-chats.ts` header (per-person model + 1027 cross-reference), `src/services/hidden-chats-start.ts` (no longer test-only), `src/db/queries.ts` rule-R comment block
 - [x] T041 (#634) Run all six existing hidden drive scenarios (`hidden-chats-1019.mjs`, `hidden-notify.mjs`, `hidden-badge.mjs`, `hidden-marker.mjs`, `hidden-pin-pad.mjs`, `hidden-flash.mjs`) against the dev stack and fix regressions — this run also re-verifies FR-007's reveal marker + sort-to-top behavior (unchanged in 1027)
-- [ ] T042 (#635) Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build ./... && go vet ./... && go test ./...`
-- [ ] T043 (#636) Bump spec `**Status**:` to `in-progress` → run `make roadmap` (start of implement); bump to `in-review` + re-run at PR time
+- [x] T042 (#635) Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build ./... && go vet ./... && go test ./...`
+- [x] T043 (#636) Bump spec `**Status**:` to `in-progress` → run `make roadmap` (start of implement); bump to `in-review` + re-run at PR time
 - [x] T044 (#637) [P] Hardening: seal `HiddenPinRec.length` in `src/services/hidden-chats.ts` under the master key instead of cleartext (auto-verify-at-length reads it only while unlocked, so availability is unchanged); migrate existing records in place on first read (reseal + rewrite) and extend `src/services/hidden-chats.test.ts` for both fresh and migrated shapes
 
 ---

--- a/src/components/ChatActionsSheet.vue
+++ b/src/components/ChatActionsSheet.vue
@@ -30,9 +30,19 @@
           <ion-icon slot="start" :icon="chat.locked ? lockOpenOutline : lockClosedOutline" />
           <ion-label>{{ chat.locked ? 'Unlock chat' : 'Lock chat' }}</ion-label>
         </ion-item>
-        <ion-item v-if="hiddenEnabled || hidden" button :detail="false" @click="toggleHidden">
+        <ion-item
+          v-if="hiddenEnabled || hidden"
+          button
+          :detail="false"
+          :disabled="!pairVerdict.ok"
+          @click="toggleHidden"
+        >
           <ion-icon slot="start" :icon="hidden ? eyeOutline : eyeOffOutline" />
-          <ion-label>{{ hidden ? 'Unhide chat' : 'Hide chat' }}</ion-label>
+          <ion-label>
+            {{ hidden ? 'Unhide chat' : 'Hide chat' }}
+            <!-- The per-person rule (spec 1027 INV-1/INV-2): say WHY it's blocked. -->
+            <p v-if="!pairVerdict.ok" class="pair-reason">{{ pairVerdict.reason }}</p>
+          </ion-label>
         </ion-item>
         <ion-item button :detail="false" @click="toggleFavorite">
           <ion-icon slot="start" :icon="chat.favorite ? heart : heartOutline" />
@@ -77,7 +87,9 @@ import {
 import { lockConfigured } from '@/services/chat-lock';
 import { addHidden, removeHidden } from '@/services/hidden-chats';
 import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
-import { isHiddenId } from '@/services/hidden-state';
+import { isHiddenId, hiddenIdsSync } from '@/services/hidden-state';
+import { canHide, canUnhide } from '@/services/hidden-pair';
+import { getAll } from '@/db/idb';
 import type { Chat } from '@/db/types';
 
 const props = defineProps<{ chat: Chat | null; isOpen: boolean }>();
@@ -92,10 +104,20 @@ const muted = computed(() => !!props.chat?.mutedUntil && props.chat.mutedUntil >
 // (reachable while revealed). `hidden` reflects the local hidden set.
 const hidden = computed(() => (props.chat ? isHiddenId(props.chat.id) : false));
 const hiddenEnabled = ref(false);
+// Per-person one-hidden/one-visible rule (spec 1027, INV-1/INV-2): the action is
+// disabled — with the reason as its caption — when hiding would make a second
+// hidden chat with the same person, or unhiding a second visible one.
+const pairVerdict = ref<{ ok: true } | { ok: false; reason: string }>({ ok: true });
 watch(
-  () => props.isOpen,
-  async (open) => {
-    if (open) hiddenEnabled.value = await getSetting<boolean>('privacy.hiddenChatsEnabled', false);
+  () => [props.isOpen, props.chat?.id] as const,
+  async ([open]) => {
+    if (!open) return;
+    hiddenEnabled.value = await getSetting<boolean>('privacy.hiddenChatsEnabled', false);
+    const c = props.chat;
+    if (!c) return;
+    const chats = await getAll<Chat>('chats');
+    const set = hiddenIdsSync();
+    pairVerdict.value = isHiddenId(c.id) ? canUnhide(chats, set, c.id) : canHide(chats, set, c.id);
   },
 );
 
@@ -103,10 +125,12 @@ async function toggleHidden(): Promise<void> {
   const c = props.chat;
   if (!c) return;
   if (isHiddenId(c.id)) {
+    if (!canUnhide(await getAll<Chat>('chats'), hiddenIdsSync(), c.id).ok) return; // INV-2
     await removeHidden(c.id); // permanent unhide → returns to the normal list
     emit('dismiss');
     return;
   }
+  if (!canHide(await getAll<Chat>('chats'), hiddenIdsSync(), c.id).ok) return; // INV-1
   if (!(await ensureHiddenPin())) {
     emit('dismiss'); // user cancelled PIN creation
     return;
@@ -253,5 +277,13 @@ async function confirmRemove(): Promise<void> {
 .actions ion-icon {
   font-size: 22px;
   color: var(--ion-text-color);
+}
+/* Why Hide/Unhide is blocked (spec 1027 per-person rule) — quiet caption under
+   the disabled label, using the stock muted token. */
+.pair-reason {
+  font-size: 12px;
+  color: var(--ion-color-medium);
+  margin: 2px 0 0;
+  white-space: normal;
 }
 </style>

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -18,7 +18,7 @@ import {
   getContact,
   getChat,
   addContactWithId,
-  startDirectChat,
+  sessionChatIdForPeer,
   createCall,
   finishCall,
   markCallMissed,
@@ -1242,7 +1242,7 @@ export async function startDirectCall(contactId: string, kind: CallKind): Promis
   }
   const contact = await getContact(contactId);
   if (!contact) return;
-  const chatId = await startDirectChat(contact);
+  const chatId = await sessionChatIdForPeer(contact); // may be a hidden 1:1 (knock-knock, spec 1027)
   const callId = uid();
 
   callMeta.value = {
@@ -1646,7 +1646,7 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
     contact = await getContact(from);
   }
   if (!contact) return;
-  const chatId = await startDirectChat(contact);
+  const chatId = await sessionChatIdForPeer(contact); // may be a hidden 1:1 (knock-knock, spec 1027)
 
   // Per-chat call mute (spec 1015 FR-022a): a muted or web-push-off chat silences
   // its incoming calls too. The caller/chat is resolvable here (the app is live), so
@@ -2055,7 +2055,7 @@ async function presentSecondDirect(
     contact = await getContact(from);
   }
   if (!contact) return busy();
-  const chatId = await startDirectChat(contact);
+  const chatId = await sessionChatIdForPeer(contact); // may be a hidden 1:1 (knock-knock, spec 1027)
   const offerChat = await getChat(chatId);
   if ((offerChat?.mutedUntil && offerChat.mutedUntil > Date.now()) || offerChat?.notifyWebPush === false) return;
   const signal = await openSealedSignal(chatId, frame.ciphertext);

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -27,13 +27,10 @@ import {
   sendMessage,
   getSetting,
 } from '@/db/queries';
-import { groupAvatar, initialsAvatar } from '@/db/avatars';
-import { isHidden } from '@/services/hidden-chats';
+import { groupAvatar } from '@/db/avatars';
 
 // Pre-answer identity for a call whose conversation is hidden (spec 1019, FR-019):
 // the incoming surface must reveal nothing identifying. A neutral name + avatar.
-const HIDDEN_CALL_NAME = 'Private caller';
-const hiddenCallAvatar = (): string => initialsAvatar('•');
 import { getSelfUserId } from '@/services/auth';
 import { isUnlockedNow, isUnlocked } from '@/services/crypto/identity';
 import { getTurnConfig, warmTurnConfig, rtcConfig } from '@/services/call/turn';
@@ -1466,7 +1463,6 @@ async function handleGroupInvite(frame: Extract<CallFrame, { t: 'call-group-invi
   // A real group chat lends its name/avatar; an ad-hoc room has none, so derive a title
   // from the people involved (server stays blind to it).
   const chat = await getChat(roomId);
-  const hiddenRoom = await isHidden(roomId); // FR-019: hidden group → generic pre-answer identity
   callMeta.value = {
     callId: roomId,
     isGroup: true,
@@ -1477,8 +1473,11 @@ async function handleGroupInvite(frame: Extract<CallFrame, { t: 'call-group-invi
     // roster once we join.
     roster: [...new Set([frame.from, ...(frame.members ?? [])])],
     invited: participants,
-    name: hiddenRoom ? HIDDEN_CALL_NAME : chat?.name || (await deriveGroupCallTitle(participants)),
-    avatar: hiddenRoom ? hiddenCallAvatar() : chat?.avatar || groupAvatar(roomId),
+    // Spec 1027 knock-knock (FR-013, supersedes 1019 FR-019): a live incoming
+    // call ALWAYS rings with full identity — you must be able to decide and
+    // answer. Hiding governs at-rest surfaces (list, history), never the ring.
+    name: chat?.name || (await deriveGroupCallTitle(participants)),
+    avatar: chat?.avatar || groupAvatar(roomId),
   };
   setState('incoming');
   presentIncoming(); // full-screen if the app is being opened for this call; else the banner
@@ -1666,7 +1665,6 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
   }
 
   const kind: CallKind = signal.kind ?? 'audio';
-  const hiddenCall = await isHidden(chatId); // FR-019: no identity on the pre-answer surface
   callMeta.value = {
     callId: frame.callId,
     isGroup: false,
@@ -1675,8 +1673,10 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
     peerUserId: from,
     chatId,
     roster: [from],
-    name: hiddenCall ? HIDDEN_CALL_NAME : contact.name,
-    avatar: hiddenCall ? hiddenCallAvatar() : contact.avatar,
+    // Spec 1027 knock-knock (FR-013, supersedes 1019 FR-019): full caller
+    // identity on the ring, always — hiding never suppresses a live call.
+    name: contact.name,
+    avatar: contact.avatar,
   };
   pendingOffer = { sdp: signal.sdp, sdpType: signal.sdpType ?? 'offer' };
   await createCall({ callId: frame.callId, contactId: from, direction: 'incoming', video: kind === 'video' });

--- a/src/db/badge-count.test.ts
+++ b/src/db/badge-count.test.ts
@@ -1,0 +1,44 @@
+// Unit tests for the badge total computation (spec 1027 T023, fixes bug B4).
+// The old page code failed closed to 0 for the WHOLE app while the hidden set
+// was still locked in modes never/revealed — blanking legitimate visible-chat
+// badges. The pure helper makes the fallback explicit: an unknown set falls
+// back to the last successfully computed (already preference-filtered) count,
+// never to zero, and never counts what it cannot classify.
+import { describe, it, expect } from 'vitest';
+import { computeUnreadTotal } from './badge-count';
+
+const chats = [
+  { id: 'v1', unread: 2 },
+  { id: 'v2', unread: 0 },
+  { id: 'h1', unread: 5 },
+];
+const hidden = new Set(['h1']);
+
+describe('computeUnreadTotal', () => {
+  it("mode 'always' counts everything and needs no hidden knowledge", () => {
+    expect(computeUnreadTotal(chats, 'always', null, false, null)).toEqual({ total: 7, fresh: true });
+    expect(computeUnreadTotal(chats, 'always', hidden, false, null)).toEqual({ total: 7, fresh: true });
+  });
+
+  it("mode 'never' excludes hidden unreads when the set is known", () => {
+    expect(computeUnreadTotal(chats, 'never', hidden, false, null)).toEqual({ total: 2, fresh: true });
+  });
+
+  it("mode 'revealed' counts hidden unreads only during an active reveal", () => {
+    expect(computeUnreadTotal(chats, 'revealed', hidden, true, null)).toEqual({ total: 7, fresh: true });
+    expect(computeUnreadTotal(chats, 'revealed', hidden, false, null)).toEqual({ total: 2, fresh: true });
+  });
+
+  it('an unknown set falls back to the last good count — never a collateral zero (B4)', () => {
+    expect(computeUnreadTotal(chats, 'never', null, false, 2)).toEqual({ total: 2, fresh: false });
+    expect(computeUnreadTotal(chats, 'revealed', null, false, 4)).toEqual({ total: 4, fresh: false });
+  });
+
+  it('an unknown set with no cached count yields 0 without claiming freshness', () => {
+    expect(computeUnreadTotal(chats, 'never', null, false, null)).toEqual({ total: 0, fresh: false });
+  });
+
+  it('empty chat list is 0 and fresh', () => {
+    expect(computeUnreadTotal([], 'never', hidden, false, 9)).toEqual({ total: 0, fresh: true });
+  });
+});

--- a/src/db/badge-count.ts
+++ b/src/db/badge-count.ts
@@ -1,0 +1,45 @@
+/**
+ * Badge total computation (spec 1027, fixes bug B4).
+ *
+ * How hidden chats affect the unread badge is user-chosen
+ * (`privacy.hiddenChatsBadge`):
+ *   'always'   (default) — hidden chats count, so you always know something is
+ *              waiting (the badge can hint a hidden chat exists; the user opted in).
+ *   'revealed' — hidden chats count only during an active reveal session.
+ *   'never'    — hidden chats never contribute, so the badge can't betray one.
+ *
+ * The subtlety is the cold-open window in the non-'always' modes: before the
+ * hidden set decrypts we cannot classify ANY chat, and the old code returned 0
+ * for the whole app — suppressing legitimate visible-chat badges. The fix:
+ * `hidden === null` (unknown) falls back to `lastCount`, the most recent
+ * successfully computed and ALREADY preference-filtered total (persisted as the
+ * device-local `badge.lastCount`; it equals what the OS badge showed a moment
+ * ago, so it reveals nothing new). `fresh` tells the caller whether the result
+ * came from a real computation (persist it) or the fallback (don't).
+ *
+ * Pure and dependency-free so both the page (`queries.countUnread`) and any
+ * future SW use share one tested semantic.
+ */
+
+export type HiddenBadgeMode = 'always' | 'never' | 'revealed';
+
+export function computeUnreadTotal(
+  chats: ReadonlyArray<{ id: string; unread?: number }>,
+  mode: HiddenBadgeMode,
+  hidden: ReadonlySet<string> | null, // null = set not yet decryptable (unknown)
+  revealed: boolean,
+  lastCount: number | null,
+): { total: number; fresh: boolean } {
+  if (mode === 'always') {
+    return { total: chats.reduce((n, c) => n + (c.unread || 0), 0), fresh: true };
+  }
+  if (!hidden) return { total: lastCount ?? 0, fresh: false };
+  const countHidden = mode === 'revealed' && revealed;
+  return {
+    total: chats.reduce(
+      (n, c) => n + (!countHidden && hidden.has(c.id) ? 0 : c.unread || 0),
+      0,
+    ),
+    fresh: true,
+  };
+}

--- a/src/db/contact-card-hash.test.ts
+++ b/src/db/contact-card-hash.test.ts
@@ -1,0 +1,41 @@
+// Guards the contact-card signature input across the NUL-byte cleanup (spec 1027
+// FR-020 / T001-T002). `cardSignature` in queries.ts hashes
+// `${card.name}\u0000${card.avatar}` — the separator used to be a RAW 0x00 byte
+// embedded in the source, which made grep treat the whole file as binary. The fix
+// rewrites it as the `\u0000` escape, which MUST produce the identical runtime
+// string (and therefore identical SHA-256 signatures — a changed signature would
+// make every stored profile-reshare hint fire once for no reason).
+//
+// queries.ts itself can't load under node vitest (it transitively imports .vue
+// components), so this pins the two halves separately:
+//   1. escape ≡ raw byte (the language-level equivalence the cleanup relies on)
+//   2. the source file contains the escape and NO raw NUL byte (stays clean text)
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+const QUERIES = path.resolve(__dirname, 'queries.ts');
+
+function sig(name: string, avatar: string, sep: string): string {
+  const data = new TextEncoder().encode(`${name}${sep}${avatar}`);
+  return createHash('sha256').update(data).digest('hex');
+}
+
+describe('contact-card signature separator (FR-020)', () => {
+  it('the \\u0000 escape is byte-identical to the raw NUL separator', () => {
+    const name = 'Alice';
+    const avatar = 'data:image/png;base64,AAA';
+    const escaped = sig(name, avatar, '\u0000');
+    const raw = sig(name, avatar, String.fromCharCode(0));
+    expect(escaped).toBe(raw);
+    // Pin the digest itself so any future separator change is a loud failure.
+    expect(escaped).toBe('1fe9d4a8ec6475b32bc20a4b07f59de450e3cbb16ce608cecadd2a024ea7c03a');
+  });
+
+  it('queries.ts contains the escape and no raw NUL byte', () => {
+    const bytes = readFileSync(QUERIES);
+    expect(bytes.includes(0)).toBe(false); // grep must see the file as text
+    expect(bytes.toString('utf8')).toContain('${card.name}\\u0000${card.avatar}');
+  });
+});

--- a/src/db/hidden-calls.test.ts
+++ b/src/db/hidden-calls.test.ts
@@ -34,4 +34,35 @@ describe('hiddenCallKeys', () => {
     expect(keys.has('peerA')).toBe(false);
     expect([...keys].sort()).toEqual(['c2', 'peerB']);
   });
+
+  // ---- spec 1027 (FR-014) — the coexistence model's call keys ----
+
+  it('a hidden PAIR conversation with no visible chat excludes the peer too', () => {
+    // The person's only thread is the hidden pair conversation: a 1:1 call row
+    // (contactId = peer) would reveal them — exclude it.
+    const chats = [chat({ id: 'p1', isGroup: true, participantIds: ['peerA'] })];
+    const keys = hiddenCallKeys(chats, new Set(['p1']));
+    expect(keys.has('peerA')).toBe(true);
+    expect(keys.has('p1')).toBe(true);
+  });
+
+  it('a visible chat with the same person keeps their calls in history (no collateral)', () => {
+    // Coexistence steady state: hidden 1:1 + visible pair conversation. Calls
+    // with the person belong to the OPEN relationship — hiding them would leak
+    // the opposite way (a visible contact with mysteriously missing calls).
+    const chats = [
+      chat({ id: 'h1', isGroup: false, participantIds: ['peerA'] }),
+      chat({ id: 'v1', isGroup: true, participantIds: ['peerA'] }),
+    ];
+    const keys = hiddenCallKeys(chats, new Set(['h1']));
+    expect(keys.has('peerA')).toBe(false); // visible relationship exists → calls show
+    expect(keys.has('h1')).toBe(true); // the hidden thread's own id stays excluded
+  });
+
+  it('a hidden multi-member group never excludes its members from 1:1 call history', () => {
+    const chats = [chat({ id: 'g1', isGroup: true, participantIds: ['m1', 'm2'] })];
+    const keys = hiddenCallKeys(chats, new Set(['g1']));
+    expect(keys.has('m1')).toBe(false);
+    expect(keys.has('m2')).toBe(false);
+  });
 });

--- a/src/db/hidden-calls.ts
+++ b/src/db/hidden-calls.ts
@@ -1,10 +1,18 @@
 /**
- * Pure helper (spec 1019, FR-019): map the hidden-chat set to the call
- * `contactId`s that must be excluded from the Calls tab and the missed badge.
+ * Pure helper (spec 1019 FR-019, extended by spec 1027 FR-014): map the
+ * hidden-chat set to the call `contactId`s that must be excluded from the
+ * Calls tab and the missed badge.
  *
- * A `Call` stores `contactId = peer userId` for a 1:1 and `= room/group id` for a
- * group, while the hidden set holds chat ids — so a hidden group's calls key on
- * its group/chat id, and a hidden 1:1's calls key on the peer id.
+ * A `Call` stores `contactId = peer userId` for a 1:1 and `= room/group id` for
+ * a group, while the hidden set holds chat ids — so a hidden group's calls key
+ * on its group/chat id, and calls with a hidden PERSON key on the peer id.
+ *
+ * The per-person rule (1027): a peer's 1:1 calls are excluded when their
+ * hidden thread — plain 1:1 OR pair conversation — is their ONLY chat. When a
+ * visible chat with the same person coexists, their calls belong to that open
+ * relationship and stay in history (hiding them would leak the other way: a
+ * visible contact with mysteriously missing calls). Multi-member groups only
+ * ever exclude their own room id, never their members.
  *
  * Extracted from `queries.ts` so it can be unit-tested without importing the
  * (heavy, DOM-dependent) data layer.
@@ -15,8 +23,17 @@ export function hiddenCallKeys(chats: Chat[], hidden: Set<string>): Set<string> 
   const out = new Set<string>();
   for (const c of chats) {
     if (!hidden.has(c.id)) continue;
-    out.add(c.id); // group calls key on the group/chat id
-    if (!c.isGroup && c.participantIds[0]) out.add(c.participantIds[0]); // 1:1 calls key on the peer id
+    out.add(c.id); // group/room calls key on the group/chat id
+    const peer = c.participantIds.length === 1 ? c.participantIds[0] : null;
+    if (!peer) continue; // multi-member group → members' own calls untouched
+    const visibleWithPeer = chats.some(
+      (o) =>
+        o.id !== c.id &&
+        !hidden.has(o.id) &&
+        o.participantIds.length === 1 &&
+        o.participantIds[0] === peer,
+    );
+    if (!visibleWithPeer) out.add(peer); // 1:1 calls key on the peer id
   }
   return out;
 }

--- a/src/db/inbound-route.test.ts
+++ b/src/db/inbound-route.test.ts
@@ -1,0 +1,125 @@
+// Unit tests for rule R stage 1 — the pre-decrypt inbound session resolution
+// (spec 1027 T005/T031, fixes bug B1). The full receive pipeline lives in
+// queries.ts (untestable under node vitest — it drags in .vue components), so
+// the DECISION layer is extracted here and the queries.ts wiring is covered by
+// the Playwright e2e (hidden-coexist.spec.ts / hidden-reset.spec.ts).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Chat } from '@/db/types';
+
+const h = vi.hoisted(() => ({
+  rows: new Map<string, Map<string, unknown>>(), // store -> id -> row
+}));
+function store(name: string): Map<string, unknown> {
+  let s = h.rows.get(name);
+  if (!s) {
+    s = new Map();
+    h.rows.set(name, s);
+  }
+  return s;
+}
+
+vi.mock('@/db/idb', () => ({
+  get: async (s: string, id: string) => store(s).get(id),
+  getAll: async (s: string) => [...store(s).values()],
+  getByIndex: async () => [],
+  put: async (s: string, row: { id?: string; key?: string }) => {
+    store(s).set((row.id ?? row.key) as string, row);
+  },
+  remove: async (s: string, id: string) => {
+    store(s).delete(id);
+  },
+  touch: () => {},
+}));
+
+import { routeInboundFrom } from './inbound-route';
+import { recordHiddenPeerBlock, clearHiddenPeerBlock } from './tombstones';
+import {
+  registerHiddenLoader,
+  setHiddenIdsCache,
+  clearHiddenState,
+} from '@/services/hidden-state';
+
+const P = 'peer-1';
+let seq = 0;
+function putChat(over: Partial<Chat>): Chat {
+  seq += 1;
+  const c: Chat = {
+    id: over.id ?? `c${seq}`,
+    name: 'x',
+    avatar: '',
+    isGroup: false,
+    participantIds: [P],
+    lastMessage: '',
+    lastMessageTime: 0,
+    unread: 0,
+    updatedAt: 0,
+    ...over,
+  };
+  store('chats').set(c.id, c);
+  return c;
+}
+
+beforeEach(() => {
+  h.rows.clear();
+  clearHiddenState();
+  // Deterministic loader: the cache is driven directly via setHiddenIdsCache.
+  registerHiddenLoader(async () => new Set<string>());
+});
+
+describe('routeInboundFrom (rule R stage 1)', () => {
+  it('resolves to the visible plain 1:1 when one exists', async () => {
+    putChat({ id: 'v' });
+    setHiddenIdsCache([]);
+    expect(await routeInboundFrom(P)).toEqual({ kind: 'chat', chatId: 'v' });
+  });
+
+  it('resolves to the hidden plain 1:1 when it is the only one (bug B1 core)', async () => {
+    putChat({ id: 'hid' });
+    setHiddenIdsCache(['hid']);
+    expect(await routeInboundFrom(P)).toEqual({ kind: 'chat', chatId: 'hid' });
+  });
+
+  it('prefers the visible 1:1 over the hidden one (legacy B1 residue state)', async () => {
+    putChat({ id: 'hid' });
+    putChat({ id: 'v' });
+    setHiddenIdsCache(['hid']);
+    expect(await routeInboundFrom(P)).toEqual({ kind: 'chat', chatId: 'v' });
+  });
+
+  it('ignores pair conversations (group-modeled threads route by groupId)', async () => {
+    putChat({ id: 'pair', isGroup: true });
+    setHiddenIdsCache([]);
+    expect(await routeInboundFrom(P)).toEqual({ kind: 'create' });
+  });
+
+  it('returns blocked for a hiddenPeer-reset peer, and create after the block lifts', async () => {
+    setHiddenIdsCache([]);
+    await recordHiddenPeerBlock(P);
+    expect(await routeInboundFrom(P)).toEqual({ kind: 'blocked' });
+    await clearHiddenPeerBlock(P);
+    expect(await routeInboundFrom(P)).toEqual({ kind: 'create' });
+  });
+
+  it('an existing chat wins over a stale peer block (block only guards creation)', async () => {
+    // A block can only coexist with a chat if the user re-engaged; never drop
+    // frames for a conversation that exists again.
+    putChat({ id: 'v' });
+    setHiddenIdsCache([]);
+    await recordHiddenPeerBlock(P);
+    expect(await routeInboundFrom(P)).toEqual({ kind: 'chat', chatId: 'v' });
+  });
+
+  it('defers (fail closed) while the hidden set is unknown', async () => {
+    putChat({ id: 'hid' });
+    clearHiddenState();
+    registerHiddenLoader(async () => {
+      throw new Error('keystore locked');
+    });
+    expect(await routeInboundFrom(P)).toEqual({ kind: 'defer' });
+  });
+
+  it('creates for a genuinely new peer', async () => {
+    setHiddenIdsCache([]);
+    expect(await routeInboundFrom('someone-new')).toEqual({ kind: 'create' });
+  });
+});

--- a/src/db/inbound-route.ts
+++ b/src/db/inbound-route.ts
@@ -1,0 +1,49 @@
+/**
+ * Rule R stage 1 — pre-decrypt inbound session resolution (spec 1027, fixes B1).
+ *
+ * Every inbound frame from a peer rides the per-peer 1:1 Double Ratchet, whose
+ * session is stored under the plain 1:1 chat's id (`sessions[chatId]`). The old
+ * code resolved that chat with `startDirectChat`, which REFUSES hidden chats —
+ * so hiding your only 1:1 made the peer's next frame mint a fresh VISIBLE chat
+ * with no session (spurious re-key, visible content, orphaned hidden thread).
+ *
+ * This resolver replaces that call. It is deliberately a thin leaf over idb +
+ * hidden-state + tombstones (no queries.ts import) so the decision table is
+ * unit-testable; `receiveIncomingInner` acts on the returned kind:
+ *
+ *   chat    → open the packet under chatId (visible 1:1 first, else hidden 1:1)
+ *   blocked → hiddenPeer reset block (FR-018): ack + drop, no rekey, no trace
+ *   defer   → hidden set not yet decryptable: re-queue, never resolve blind
+ *   create  → genuinely new peer: create the fresh visible 1:1 (existing path)
+ *
+ * `payload.groupId` (rule R stage 2) is NOT consulted here — it lives inside
+ * the sealed payload and only routes CONTENT after the packet is opened.
+ */
+import { getAll } from './idb';
+import { hasHiddenPeerBlock } from './tombstones';
+import { ensureHiddenLoaded, isHiddenKnown } from '@/services/hidden-state';
+import { resolveInboundDirectChat } from '@/services/hidden-pair';
+import type { Chat } from './types';
+
+export type InboundRoute =
+  | { kind: 'chat'; chatId: string }
+  | { kind: 'blocked' }
+  | { kind: 'defer' }
+  | { kind: 'create' };
+
+export async function routeInboundFrom(peerId: string): Promise<InboundRoute> {
+  const hidden = await ensureHiddenLoaded();
+  // Fail closed: an unknown set must never be read as "nothing hidden" — a
+  // hidden 1:1 would fall through to `create` and resurrect a visible chat.
+  // Unreachable in practice (frames queue while locked, and unlocked implies
+  // the set decrypts), but the guard costs nothing and the invariant is load-
+  // bearing.
+  if (!isHiddenKnown()) return { kind: 'defer' };
+  const chats = await getAll<Chat>('chats');
+  const chat = resolveInboundDirectChat(chats, hidden, peerId);
+  if (chat) return { kind: 'chat', chatId: chat.id };
+  // No conversation with this peer. A reset block only guards re-CREATION: if a
+  // chat exists again the user has already re-engaged, so frames route above.
+  if (await hasHiddenPeerBlock(peerId)) return { kind: 'blocked' };
+  return { kind: 'create' };
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3700,7 +3700,7 @@ async function handleContactCard(from: string, chatId: string, card: ContactCard
 /* ---- profile re-share hint ---- */
 
 async function cardSignature(card: ContactCard): Promise<string> {
-  const data = new TextEncoder().encode(`${card.name} ${card.avatar}`);
+  const data = new TextEncoder().encode(`${card.name}\u0000${card.avatar}`);
   const digest = await crypto.subtle.digest('SHA-256', data);
   return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -5,7 +5,7 @@
  */
 import { bulkPut, clearStore, get, getAll, getByIndex, put, remove } from './idb';
 import { enqueue, removeOutboxByFrameId } from './outbox';
-import { recordTombstone, clearHiddenPeerBlock } from './tombstones';
+import { recordTombstone, isTombstoned, clearTombstone, clearHiddenPeerBlock } from './tombstones';
 import { callLogPreview } from './calllog';
 import { uid } from '@/utils/uid';
 import { capitalizeFirst } from '@/utils/text';
@@ -1275,6 +1275,10 @@ export async function acceptGroupInvite(groupId: string): Promise<void> {
   if (!r) return;
   const self = getSelfUserId() ?? '';
   const ts = now();
+  // Accepting an invite is the deliberate re-engagement that lifts a
+  // hidden-chats-reset block on this conversation id (spec 1027 FR-018 —
+  // mirrors startDirectChat lifting the 1:1 peer block).
+  await clearTombstone('chats', groupId);
   const roster = r.roster ?? [];
   for (const m of roster) {
     if (!m.id || m.id === self) continue;
@@ -4338,6 +4342,11 @@ async function handleGroupCard(from: string, card: GroupCard): Promise<void> {
   }
 
   const participantIds = card.members.map((m) => m.id).filter((id) => id !== self);
+  // A create/update card must not silently re-materialize a conversation wiped
+  // by a hidden-chats reset (spec 1027 FR-018; the reset tombstone is PERMANENT
+  // so it wins over any card timestamp). A fresh INVITE still reaches the user —
+  // accepting it is the deliberate re-engagement that ends the block.
+  if (!existing && (await isTombstoned('chats', card.groupId, card.at || now()))) return;
   // Empty card.name → auto-derive a display name from the other members.
   const autoName = !card.name;
   const displayName = card.name || autoDisplayName(card.members, self);
@@ -4375,6 +4384,11 @@ async function handleGroupCard(from: string, card: GroupCard): Promise<void> {
 /** Ensure a group chat exists locally (placeholder if a message beats its card). */
 async function ensureGroupChat(groupId: string, from: string): Promise<void> {
   if (await getChat(groupId)) return;
+  // A wiped hidden group/pair conversation must not be re-materialized by a
+  // bare group message (spec 1027 FR-018): the reset's PERMANENT localOnly
+  // tombstone outlasts any timestamp. Ordinary old deletions don't block —
+  // their tombstones predate a genuinely new message.
+  if (await isTombstoned('chats', groupId, now())) return;
   const self = getSelfUserId() ?? '';
   await put<Chat>('chats', {
     id: groupId,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -30,6 +30,8 @@ import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview, shouldBuildLinkPreview } from '@/services/link-preview';
 import { ensureHiddenLoaded, isRevealed, isHiddenKnown } from '@/services/hidden-state';
 import { hiddenCallKeys } from '@/db/hidden-calls';
+import { routeInboundFrom } from '@/db/inbound-route';
+import { resolveInboundDirectChat } from '@/services/hidden-pair';
 import type {
   MessagePayload, ContactCard, GroupCard, GroupMember, ReactionSignal, PollVoteSignal, MediaRef,
   EditSignal, EraseSignal, LinkPreviewSignal,
@@ -3156,7 +3158,9 @@ export async function acceptRequest(id: string): Promise<void> {
     await dropRequest(id);
     return;
   }
-  const chatId = await startDirectChat(contact);
+  // Session carrier, not user intent: accepting must ride the existing ratchet
+  // (which may live under a HIDDEN 1:1) and must not mint a pair conversation.
+  const chatId = await sessionChatIdForPeer(contact);
   await setChatPending(chatId, false);
   await markContactConnected(id);
   const card = await ownCard('accept');
@@ -3633,7 +3637,9 @@ export async function requestFriend(peerUserId: string): Promise<void> {
   const contact = await getContact(peerUserId);
   if (!contact) return;
   await markContactConnected(peerUserId);
-  const chatId = await startDirectChat(contact); // visible (connected → not pending)
+  // Session carrier (rides a hidden 1:1's ratchet when one exists) — the chat
+  // row this creates for a brand-new friend is visible, same as before.
+  const chatId = await sessionChatIdForPeer(contact);
   const card = await ownCard('profile');
   await sendCard(await getChat(chatId), card);
   await setCardShared(chatId);
@@ -4083,6 +4089,38 @@ export async function startDirectChat(contact: Contact): Promise<string> {
     }
     return placeholder.id;
   }
+  return createDirectChatRow(contact);
+}
+
+/**
+ * The 1:1 RATCHET SESSION CARRIER for a peer (spec 1027). Sessions are keyed by
+ * the plain 1:1 chat's id, so everything that seals/opens pairwise traffic —
+ * call signalling, contact cards, friend-request/accept flows — must resolve to
+ * the chat that actually holds the session: the visible plain 1:1, else the
+ * HIDDEN plain 1:1 (hiding must never fork the ratchet or resurrect a visible
+ * row — bug B1 applied to calls too), else a fresh plain 1:1 for a genuinely
+ * new peer. Never a pair conversation (group-modeled threads carry no 1:1
+ * session). Unlike startDirectChat this is NOT a user-intent entry: it never
+ * lifts a hidden-reset block and never creates a pair conversation.
+ *
+ * An unknown hidden set only degrades the visible-vs-hidden PREFERENCE (both
+ * are the same session container), so no fail-closed gate is needed here — no
+ * visibility decision is being made.
+ */
+export async function sessionChatIdForPeer(contact: Contact): Promise<string> {
+  const hidden = await ensureHiddenLoaded();
+  const chats = await getAll<Chat>('chats');
+  const existing = resolveInboundDirectChat(chats, hidden, contact.id);
+  if (existing) return existing.id;
+  return createDirectChatRow(contact);
+}
+
+/** Create the plain 1:1 chat row for a contact (the session-carrying channel —
+ *  exactly one per peer, INV-3). Split from startDirectChat so the inbound path
+ *  (receiveIncomingInner) can create the row for a genuinely new peer WITHOUT
+ *  startDirectChat's user-initiated semantics (reset-block lifting, and the
+ *  pair-conversation branch used when a hidden 1:1 already exists). */
+async function createDirectChatRow(contact: Contact): Promise<string> {
   const ts = now();
   const id = uid();
   const ttl = await defaultTimerMs();
@@ -4401,6 +4439,29 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     return;
   }
 
+  // Rule R stage 1 (spec 1027, fixes B1): resolve the SESSION chat for this peer
+  // before touching anything. The old code used startDirectChat here, which
+  // refuses hidden chats — so hiding your only 1:1 made the next inbound frame
+  // mint a fresh VISIBLE chat with no session (spurious re-key, visible content,
+  // orphaned hidden thread). The resolver prefers the visible plain 1:1, falls
+  // back to the HIDDEN plain 1:1 (content lands there silently), honors the
+  // hidden-reset peer block, and fails closed while the hidden set is unknown.
+  const route = await routeInboundFrom(from);
+  if (route.kind === 'blocked') {
+    // Hidden-chat reset block (FR-018): the user destroyed this conversation and
+    // its re-download must leave no trace — ack so the relay drops its copy, but
+    // create no contact/chat/session, send no re-key request, show nothing. The
+    // block lifts only when the user deliberately starts a new chat with them.
+    if (remoteId) await markInboundSeen(remoteId);
+    return;
+  }
+  if (route.kind === 'defer') {
+    // Hidden set not decryptable yet (fail closed) — park the frame with the
+    // locked-keystore queue; it drains once the set is known.
+    await queuePendingIncoming(from, remoteId, ciphertext);
+    return;
+  }
+
   // Friends-only messaging: only people you've connected with can put message CONTENT in
   // your inbox. We can't drop here, though: connection CARDS (friend request, invite
   // auto-connect, accept) and other control payloads must always be processed, because
@@ -4408,12 +4469,11 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
   // by shared membership. So we open first, apply any card/control payload below, and gate
   // only actual 1:1 content. Capture whether we knew this peer (and had a chat with them)
   // BEFORE creating the provisional contact/chat needed to open the packet, so unsolicited
-  // content can be dropped again without leaving a trace.
+  // content can be dropped again without leaving a trace. (A hidden chat always counts as
+  // "had a chat before" — the trace-removal below must never delete it.)
   const hadContactBefore = !!(await getContact(from));
   const knewSenderBefore = hadContactBefore || (await isPeerConnected(from));
-  const hadDirectChatBefore = (await getAll<Chat>('chats')).some(
-    (c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === from,
-  );
+  const hadDirectChatBefore = route.kind === 'chat';
 
   let contact = await getContact(from);
   if (!contact) {
@@ -4426,7 +4486,12 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     void hydrateContactFromDirectory(from);
   }
   if (!contact) return;
-  const chatId = await startDirectChat(contact);
+  // The session carrier: the resolved 1:1 (visible or hidden), or a fresh plain
+  // 1:1 for a genuinely new peer. Deliberately NOT startDirectChat — that is the
+  // user-initiated entry which (a) lifts reset blocks and (b) creates a pair
+  // conversation when a hidden 1:1 exists; an inbound frame must do neither
+  // (the pair conversation carries no 1:1 session).
+  const chatId = route.kind === 'chat' ? route.chatId : await createDirectChatRow(contact);
 
   let payload;
   try {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -5,7 +5,7 @@
  */
 import { bulkPut, clearStore, get, getAll, getByIndex, put, remove } from './idb';
 import { enqueue, removeOutboxByFrameId } from './outbox';
-import { recordTombstone } from './tombstones';
+import { recordTombstone, clearHiddenPeerBlock } from './tombstones';
 import { callLogPreview } from './calllog';
 import { uid } from '@/utils/uid';
 import { capitalizeFirst } from '@/utils/text';
@@ -31,7 +31,7 @@ import { firstLink, buildLinkPreview, shouldBuildLinkPreview } from '@/services/
 import { ensureHiddenLoaded, isRevealed, isHiddenKnown } from '@/services/hidden-state';
 import { hiddenCallKeys } from '@/db/hidden-calls';
 import { routeInboundFrom } from '@/db/inbound-route';
-import { resolveInboundDirectChat } from '@/services/hidden-pair';
+import { resolveInboundDirectChat, planStartDirectChat } from '@/services/hidden-pair';
 import type {
   MessagePayload, ContactCard, GroupCard, GroupMember, ReactionSignal, PollVoteSignal, MediaRef,
   EditSignal, EraseSignal, LinkPreviewSignal,
@@ -4063,31 +4063,34 @@ async function defaultTimerMs(): Promise<number | null> {
 }
 
 export async function startDirectChat(contact: Contact): Promise<string> {
+  // The USER-INTENT entry ("start a conversation with this person"), distinct
+  // from sessionChatIdForPeer (the crypto-container resolver). Spec 1027:
+  //   - never resolves to a hidden chat (the 1019/#544 rule — a PIN-locked
+  //     conversation must not open without the PIN);
+  //   - when the person's only thread is a HIDDEN plain 1:1, the fresh visible
+  //     chat is a PAIR CONVERSATION (group-modeled, its own sender-key channel)
+  //     because the hidden thread owns the peer's one 1:1 ratchet (INV-3) — a
+  //     second plain 1:1 would steer the peer's replies-to-the-hidden-thread
+  //     into the visible one;
+  //   - as a deliberate re-engagement it lifts any hidden-reset peer block
+  //     (FR-018) — inbound frames never do.
+  await clearHiddenPeerBlock(contact.id);
   const chats = await getAll<Chat>('chats');
-  // NEVER resolve to a hidden chat (spec 1019): starting a chat from the contact must
-  // not open a PIN-locked hidden conversation — that would reveal it without the PIN.
-  // A hidden chat coexists with a normal one; this path only ever uses/creates the
-  // normal (non-hidden) chat, creating a fresh one when the sole match is hidden.
   const hiddenSet = await ensureHiddenLoaded();
-  const matches = chats.filter(
-    (c) =>
-      !c.isGroup &&
-      c.participantIds.length === 1 &&
-      c.participantIds[0] === contact.id &&
-      !hiddenSet.has(c.id),
-  );
-  // Prefer a real (visible) chat over an unaccepted-request placeholder.
-  const visible = matches.find((c) => !c.pending);
-  if (visible) return visible.id;
-  const placeholder = matches[0];
-  if (placeholder) {
+  const plan = planStartDirectChat(chats, hiddenSet, contact.id);
+  if (plan.action === 'open') {
+    const chat = chats.find((c) => c.id === plan.chatId);
     // Opening a chat with an already-accepted friend → make it visible.
-    if (placeholder.pending && (await isPeerConnected(contact.id))) {
-      placeholder.pending = false;
-      placeholder.updatedAt = now();
-      await put('chats', placeholder);
+    if (chat?.pending && (await isPeerConnected(contact.id))) {
+      chat.pending = false;
+      chat.updatedAt = now();
+      await put('chats', chat);
     }
-    return placeholder.id;
+    return plan.chatId;
+  }
+  if (plan.action === 'createPair') {
+    // Same mechanism as startHiddenChat (spec 1019 US2), on the visible side.
+    return createGroup('', [contact.id]);
   }
   return createDirectChatRow(contact);
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -32,6 +32,7 @@ import { ensureHiddenLoaded, isRevealed, isHiddenKnown } from '@/services/hidden
 import { hiddenCallKeys } from '@/db/hidden-calls';
 import { routeInboundFrom } from '@/db/inbound-route';
 import { resolveInboundDirectChat, planStartDirectChat } from '@/services/hidden-pair';
+import { computeUnreadTotal, type HiddenBadgeMode } from '@/db/badge-count';
 import type {
   MessagePayload, ContactCard, GroupCard, GroupMember, ReactionSignal, PollVoteSignal, MediaRef,
   EditSignal, EraseSignal, LinkPreviewSignal,
@@ -3798,20 +3799,25 @@ export async function resolveAlert(id: string): Promise<void> {
 /* ---- badge counts ---- */
 
 export async function countUnread(): Promise<number> {
-  // How hidden chats (spec 1019) affect the unread badge is user-chosen
-  // (privacy.hiddenChatsBadge):
-  //   'always'   (default) — hidden chats count, so you always know something is
-  //               waiting (the badge can hint a hidden chat exists; the user opted in).
-  //   'revealed' — hidden chats count only during an active reveal session.
-  //   'never'    — hidden chats never contribute, so the badge can't betray one.
-  const mode = await getSetting<string>('privacy.hiddenChatsBadge', 'always');
+  // Preference semantics + the fail-closed-without-collateral rule live in the
+  // pure `computeUnreadTotal` (spec 1027, fixes B4): in modes never/revealed an
+  // UNKNOWN hidden set (locked at cold open) no longer zeroes the whole badge —
+  // it falls back to `badge.lastCount`, the last successfully computed and
+  // already preference-filtered total (device-local, never synced; it equals
+  // what the OS badge showed a moment ago, so it leaks nothing).
+  const mode = (await getSetting<string>('privacy.hiddenChatsBadge', 'always')) as HiddenBadgeMode;
   const chats = await getAll<Chat>('chats');
-  if (mode === 'always') return chats.reduce((n, c) => n + (c.unread || 0), 0);
-  // 'never' / 'revealed' need the hidden set to know what to exclude.
-  const hidden = await ensureHiddenLoaded();
-  if (!isHiddenKnown()) return 0; // unknown set (locked at open) → fail closed
-  const countHidden = mode === 'revealed' && isRevealed();
-  return chats.reduce((n, c) => n + (!countHidden && hidden.has(c.id) ? 0 : c.unread || 0), 0);
+  let hidden: ReadonlySet<string> | null = null;
+  if (mode !== 'always') {
+    const set = await ensureHiddenLoaded();
+    hidden = isHiddenKnown() ? set : null;
+  }
+  const last = await getSetting<number | null>('badge.lastCount', null);
+  const { total, fresh } = computeUnreadTotal(chats, mode, hidden, isRevealed(), last);
+  // Persist only real computations (the fallback would just rewrite itself),
+  // and only on change (this runs on every badge refresh).
+  if (fresh && total !== last) await setSetting('badge.lastCount', total);
+  return total;
 }
 
 export async function countMissedUnseen(): Promise<number> {

--- a/src/db/tombstones.ts
+++ b/src/db/tombstones.ts
@@ -69,3 +69,39 @@ export async function clearTombstone(store: StoreName, recordId: string): Promis
 export async function listTombstones(): Promise<Tombstone[]> {
   return (await getAll<Tombstone>('tombstones')).filter((t) => !t.localOnly);
 }
+
+/* ---- hidden-chat reset peer blocks (spec 1027, FR-018) ----
+ *
+ * A Hidden Chats reset wipes the hidden conversations, but a 1:1 chat id is
+ * local-random — the peer's NEXT live message would simply mint a new chat id,
+ * sailing past any chat-id tombstone and re-materializing the conversation as a
+ * visible chat. So the relay-path block is keyed by the PEER, not the chat:
+ * rows in the same tombstones store under the logical namespace 'hiddenPeer'
+ * (not an idb store — just the key prefix). Always localOnly: the block must
+ * never sync, exactly like the reset itself. It is lifted only by an explicit
+ * user re-engagement (startDirectChat), mirroring how a deleted contact's
+ * tombstone is lifted by a deliberate re-add. */
+
+const PEER_NS = 'hiddenPeer';
+
+/** Permanently block inbound 1:1 content from this peer on THIS device. */
+export async function recordHiddenPeerBlock(peerId: string): Promise<void> {
+  const t: Tombstone = {
+    id: key(PEER_NS, peerId),
+    store: PEER_NS,
+    recordId: peerId,
+    deletedAt: Number.MAX_SAFE_INTEGER, // permanent until explicitly lifted
+    localOnly: true,
+  };
+  await put<Tombstone>('tombstones', t);
+}
+
+/** Is inbound 1:1 content from this peer blocked by a hidden-chat reset? */
+export async function hasHiddenPeerBlock(peerId: string): Promise<boolean> {
+  return !!(await get<Tombstone>('tombstones', key(PEER_NS, peerId)));
+}
+
+/** Lift the block — the user deliberately started a new chat with this peer. */
+export async function clearHiddenPeerBlock(peerId: string): Promise<void> {
+  await remove('tombstones', key(PEER_NS, peerId));
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -210,10 +210,21 @@ router.beforeEach((to) => {
   return true;
 });
 
+// A route whose `:id` is a conversation id that could be hidden. BOTH the 1:1
+// chat detail (`/chat/:id` + its info/media/starred sub-pages) AND the group
+// detail (`/group/:id`) carry the conversation id as `:id` — and a hidden PAIR
+// CONVERSATION (spec 1027 coexistence: a group-modeled 1:1) routes to
+// `/group/:id`, where the member list IS the hidden person's identity. Guarding
+// only `/chat/` would leave that surface (and hidden multi-member groups) open.
+function hiddenChatRouteId(path: string, id: unknown): string | null {
+  return (path.startsWith('/chat/') || path.startsWith('/group/')) && typeof id === 'string'
+    ? id
+    : null;
+}
+
 // Hidden chats (spec 1027, FR-009): the reveal PIN is the ONLY door. Navigating
 // to a hidden conversation while relocked — a deep link, a stale notification
-// tap, back-stack restoration — bounces to the Chats list. Covers /chat/:id and
-// its sub-pages (info/media/starred), which all carry the chat id as :id.
+// tap, back-stack restoration — bounces to the Chats list.
 //
 // Cold-start hole: at the first navigation the hidden set may not have
 // decrypted yet, so `isHiddenId` can only say "not known to be hidden" and the
@@ -222,8 +233,8 @@ router.beforeEach((to) => {
 // the set decrypts, `setHiddenIdsCache` fires the relock hook below, which
 // re-runs this check against the now-known set and ejects if needed.
 router.beforeEach((to) => {
-  const id = to.params.id;
-  if (to.path.startsWith('/chat/') && typeof id === 'string') {
+  const id = hiddenChatRouteId(to.path, to.params.id);
+  if (id !== null) {
     if (!isHiddenKnown()) void ensureHiddenLoaded();
     if (isHiddenId(id) && !isRevealed()) return '/tabs/chats';
   }
@@ -246,8 +257,8 @@ watch(isUnlocked, (v) => {
 registerRelockHook(() => {
   if (isRevealed()) return;
   const cur = router.currentRoute.value;
-  const id = cur.params.id;
-  if (cur.path.startsWith('/chat/') && typeof id === 'string' && isHiddenId(id)) {
+  const id = hiddenChatRouteId(cur.path, cur.params.id);
+  if (id !== null && isHiddenId(id)) {
     void router.replace('/tabs/chats');
   }
 });

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,15 @@
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import type { RouteRecordRaw } from 'vue-router';
+import { watch } from 'vue';
 import { isAuthenticated } from '@/services/auth';
+import { isUnlocked } from '@/services/crypto/identity';
+import {
+  ensureHiddenLoaded,
+  isHiddenId,
+  isHiddenKnown,
+  isRevealed,
+  registerRelockHook,
+} from '@/services/hidden-state';
 // The four bottom-tab pages are eager-loaded (static imports), NOT lazy
 // `() => import()` chunks. They are the app's core surface, reached within
 // seconds of launch and already SW-precached; lazy-splitting them only bought a
@@ -199,6 +208,48 @@ router.beforeEach((to) => {
     return '/auth';
   }
   return true;
+});
+
+// Hidden chats (spec 1027, FR-009): the reveal PIN is the ONLY door. Navigating
+// to a hidden conversation while relocked — a deep link, a stale notification
+// tap, back-stack restoration — bounces to the Chats list. Covers /chat/:id and
+// its sub-pages (info/media/starred), which all carry the chat id as :id.
+//
+// Cold-start hole: at the first navigation the hidden set may not have
+// decrypted yet, so `isHiddenId` can only say "not known to be hidden" and the
+// guard fails open. We don't bounce blind (that would break notification taps
+// into ordinary chats), we CLOSE the hole instead: kick the load here and once
+// the set decrypts, `setHiddenIdsCache` fires the relock hook below, which
+// re-runs this check against the now-known set and ejects if needed.
+router.beforeEach((to) => {
+  const id = to.params.id;
+  if (to.path.startsWith('/chat/') && typeof id === 'string') {
+    if (!isHiddenKnown()) void ensureHiddenLoaded();
+    if (isHiddenId(id) && !isRevealed()) return '/tabs/chats';
+  }
+  return true;
+});
+
+// The load above no-ops while the keystore is locked (fail-closed, stays
+// unknown); retry the moment it unlocks so the recheck can run even on a page
+// that never queries the chat list (a cold-loaded chat detail).
+watch(isUnlocked, (v) => {
+  if (v && !isHiddenKnown()) void ensureHiddenLoaded();
+});
+
+// ...and when a reveal session ENDS (grace expiry, manual relock, keystore
+// auto-lock, wipe) — or the hidden set becomes KNOWN after a cold start that
+// deep-linked straight into a hidden chat — leave it at once (the "kick out").
+// The `!isRevealed()` check keeps set mutations during an active reveal (e.g.
+// hiding another chat while browsing) from ejecting the user. The hook lives in
+// the hidden-state leaf so the state module never imports the router.
+registerRelockHook(() => {
+  if (isRevealed()) return;
+  const cur = router.currentRoute.value;
+  const id = cur.params.id;
+  if (cur.path.startsWith('/chat/') && typeof id === 'string' && isHiddenId(id)) {
+    void router.replace('/tabs/chats');
+  }
 });
 
 // Tabs are terminal (WhatsApp-style): the iOS PWA back-swipe walks the browser

--- a/src/services/call/signalling.ts
+++ b/src/services/call/signalling.ts
@@ -5,18 +5,21 @@
  * outbox, since real-time signalling that can't be delivered now is useless.
  */
 import { sealForChat, openPacket, clearSession } from '@/services/messaging';
-import { getContact, startDirectChat } from '@/db/queries';
+import { getContact, sessionChatIdForPeer } from '@/db/queries';
 import type { CallSignal, QosReport } from '@/services/crypto/message';
 import { sendLive } from '@/composables/useSync';
 import type { CallAnswerFrame, CallIceFrame, CallOfferFrame, CallKind } from '@/services/transport';
 
 export type { CallSignal };
 
-/** Resolve the 1:1 ratchet chat id for a peer (creating the chat if needed). */
+/** Resolve the 1:1 ratchet chat id for a peer (creating the chat if needed).
+ *  Uses the session-carrier resolver, NOT startDirectChat: the session may live
+ *  under a HIDDEN 1:1 (spec 1027 knock-knock — calls ride it without
+ *  resurrecting a visible chat or forking the ratchet). */
 export async function chatIdForPeer(peerUserId: string): Promise<string | null> {
   const contact = await getContact(peerUserId);
   if (!contact) return null;
-  return startDirectChat(contact);
+  return sessionChatIdForPeer(contact);
 }
 
 // An ad-hoc group call meshes between EVERY pair of participants, but the initiator's
@@ -34,7 +37,7 @@ const CALL_SESSION_PREFIX = 'callsess:';
  *  established 1:1 session, or an ephemeral call-scoped one for a non-contact co-member. */
 export async function meshSessionChatId(peerUserId: string): Promise<string> {
   const contact = await getContact(peerUserId);
-  if (contact) return startDirectChat(contact);
+  if (contact) return sessionChatIdForPeer(contact); // may be a hidden 1:1 — see chatIdForPeer
   return CALL_SESSION_PREFIX + peerUserId;
 }
 

--- a/src/services/hidden-chats-reset.test.ts
+++ b/src/services/hidden-chats-reset.test.ts
@@ -8,20 +8,35 @@ const h = vi.hoisted(() => ({
   hidden: new Set<string>(['chatHid', 'grpHid']),
   removed: [] as Array<[string, string]>,
   tombstones: [] as Array<{ store: string; recordId: string; deletedAt: number; localOnly: boolean }>,
+  peerBlocks: [] as string[],
+  seq: [] as string[], // interleaved op log for FR-024 ordering asserts
   cleared: false,
   stateCleared: false,
 }));
 
 vi.mock('@/db/idb', () => ({
+  // chatHid is a plain 1:1 with peer-9; grpHid is a group-modeled thread.
+  get: async (_store: string, id: string) =>
+    id === 'chatHid'
+      ? { id, isGroup: false, participantIds: ['peer-9'] }
+      : id === 'grpHid'
+        ? { id, isGroup: true, participantIds: ['peer-9'] }
+        : undefined,
   getByIndex: async (_store: string, _idx: string, chatId: string) =>
     chatId === 'chatHid' ? [{ id: 'm1' }, { id: 'm2' }] : [],
   remove: async (store: string, id: string) => {
     h.removed.push([store, id]);
+    h.seq.push(`remove:${store}:${id}`);
   },
 }));
 vi.mock('@/db/tombstones', () => ({
   recordTombstone: async (store: string, recordId: string, deletedAt: number, localOnly = false) => {
     h.tombstones.push({ store, recordId, deletedAt, localOnly });
+    h.seq.push(`tombstone:${recordId}`);
+  },
+  recordHiddenPeerBlock: async (peerId: string) => {
+    h.peerBlocks.push(peerId);
+    h.seq.push(`block:${peerId}`);
   },
 }));
 vi.mock('@/services/hidden-chats', () => ({
@@ -41,6 +56,8 @@ import { resetHiddenChats } from './hidden-chats-reset';
 beforeEach(() => {
   h.removed.length = 0;
   h.tombstones.length = 0;
+  h.peerBlocks.length = 0;
+  h.seq.length = 0;
   h.cleared = false;
   h.stateCleared = false;
   h.hidden = new Set(['chatHid', 'grpHid']);
@@ -83,5 +100,27 @@ describe('resetHiddenChats', () => {
     for (const id of order) {
       expect(h.tombstones.find((t) => t.recordId === id)).toBeTruthy();
     }
+  });
+
+  // ---- spec 1027 FR-018 (bug B3): the live-relay peer block ----
+
+  it('records a peer block for each hidden PLAIN 1:1 — groups keep id-keyed blocking', async () => {
+    await resetHiddenChats();
+    // chatHid is the plain 1:1 with peer-9 → blocked by peer. grpHid is a
+    // group-modeled thread → its stable id tombstone is the block; a peer block
+    // for it would wrongly gag the person everywhere.
+    expect(h.peerBlocks).toEqual(['peer-9']);
+  });
+
+  it('records every block (chat-id AND peer) BEFORE any data is deleted (FR-024 ordering)', async () => {
+    // If the wipe is interrupted mid-way, the blocks must already hold — a
+    // half-wiped conversation may never flip visible or re-download.
+    await resetHiddenChats();
+    const firstRemoval = h.seq.findIndex((s) => s.startsWith('remove:'));
+    const lastBlock = Math.max(
+      ...h.seq.map((s, i) => (s.startsWith('block:') || s.startsWith('tombstone:') ? i : -1)),
+    );
+    expect(firstRemoval).toBeGreaterThan(-1);
+    expect(lastBlock).toBeLessThan(firstRemoval);
   });
 });

--- a/src/services/hidden-chats-reset.ts
+++ b/src/services/hidden-chats-reset.ts
@@ -10,11 +10,11 @@
  * LAST. So if the wipe is interrupted, the conversations are still hidden (in the
  * set) and still blocked from re-sync — they can never flip to visible mid-reset.
  */
-import { getByIndex, remove } from '@/db/idb';
-import { recordTombstone } from '@/db/tombstones';
+import { get, getByIndex, remove } from '@/db/idb';
+import { recordTombstone, recordHiddenPeerBlock } from '@/db/tombstones';
 import { getHiddenSet, clearHiddenStorage } from '@/services/hidden-chats';
 import { clearHiddenState } from '@/services/hidden-state';
-import type { Message } from '@/db/types';
+import type { Chat, Message } from '@/db/types';
 
 // A far-future cover so the block is permanent on this device — even if the
 // server later holds a newer `updatedAt` for the conversation, the ingest check
@@ -24,9 +24,19 @@ const PERMANENT = Number.MAX_SAFE_INTEGER;
 export async function resetHiddenChats(): Promise<{ wiped: string[] }> {
   const ids = [...(await getHiddenSet())];
 
-  // 1) Block re-sync FIRST (local-only tombstone, never uploaded).
+  // 1) Block re-sync FIRST (local-only tombstone, never uploaded). Two kinds
+  //    (spec 1027 FR-018): the chat-id tombstone blocks the own-data sync path,
+  //    and — for plain 1:1s — a PEER-keyed block covers the live relay path,
+  //    because a new inbound message would otherwise just mint a fresh chat id
+  //    and sail past any id-keyed tombstone (bug B3). Group/pair threads keep
+  //    id-keyed blocking (their ids are stable and shared), consulted by the
+  //    group-card / group-message ingest.
   for (const id of ids) {
     await recordTombstone('chats', id, PERMANENT, true);
+    const chat = await get<Chat>('chats', id);
+    if (chat && !chat.isGroup && chat.participantIds.length === 1) {
+      await recordHiddenPeerBlock(chat.participantIds[0]);
+    }
   }
   // 2) Delete local data for each hidden conversation.
   for (const id of ids) {

--- a/src/services/hidden-chats-start.ts
+++ b/src/services/hidden-chats-start.ts
@@ -4,6 +4,11 @@
  * Split out from `hidden-chats.ts` because it depends on `queries.ts`
  * (`createGroup`), which the service worker must not pull in. UI/test callers
  * import from here; the SW imports only the queries-free `hidden-chats.ts`.
+ *
+ * Spec 1027 note: the same distinct-channel mechanism (a pair conversation via
+ * `createGroup('', [peer])`) is now also the USER-REACHABLE coexistence path —
+ * `startDirectChat` creates the visible pair conversation when a hidden plain
+ * 1:1 exists. This helper remains the hidden-side variant (create + hide).
  */
 import { createGroup } from '@/db/queries';
 import { addHidden } from '@/services/hidden-chats';

--- a/src/services/hidden-chats.test.ts
+++ b/src/services/hidden-chats.test.ts
@@ -148,6 +148,26 @@ describe('separate dedicated PIN', () => {
     expect(await hiddenPinLength()).toBe(6);
   }, PIN_TIMEOUT);
 
+  it('stores the PIN length sealed, not in cleartext (spec 1027 T044)', async () => {
+    await enableHiddenPin('123456');
+    const raw = JSON.stringify(h.settings.get('privacy.hiddenPin'));
+    expect(raw).not.toContain('"length"'); // no legacy cleartext field
+    expect(raw).not.toContain(':6'); // the digit count itself never appears bare
+    expect(await hiddenPinLength()).toBe(6); // ...but reads fine while unlocked
+  }, PIN_TIMEOUT);
+
+  it('migrates a legacy cleartext-length record in place on first read', async () => {
+    // Simulate a pre-1027 record: real verifier + cleartext `length`.
+    await enableHiddenPin('98765');
+    const rec = h.settings.get('privacy.hiddenPin') as { salt: string; env: unknown; len?: unknown };
+    h.settings.set('privacy.hiddenPin', { salt: rec.salt, env: rec.env, length: 5 });
+    expect(await hiddenPinLength()).toBe(5); // read works...
+    const migrated = JSON.stringify(h.settings.get('privacy.hiddenPin'));
+    expect(migrated).not.toContain('"length"'); // ...and the plaintext is gone
+    expect(await hiddenPinLength()).toBe(5); // sealed copy round-trips
+    expect(await verifyHiddenPin('98765')).toBe(true); // verifier untouched
+  }, PIN_TIMEOUT);
+
   it('change requires the old PIN and rotates the verifier', async () => {
     await enableHiddenPin('1111');
     await expect(changeHiddenPin('0000', '2222')).rejects.toThrow();

--- a/src/services/hidden-chats.ts
+++ b/src/services/hidden-chats.ts
@@ -105,10 +105,21 @@ export async function getHiddenSet(): Promise<Set<string>> {
  * already shows a generic, content-free notification in that case.
  */
 export async function readHiddenSet(): Promise<Set<string>> {
+  return (await readHiddenSetOrNull()) ?? new Set();
+}
+
+/**
+ * Like readHiddenSet, but distinguishes "no chats hidden" (a set) from "can't
+ * know — keystore locked" (null). The SW badge needs the difference (spec 1027
+ * B4): under badge mode 'never'/'revealed' an unreadable set must fall back to
+ * the last preference-filtered count, not be mistaken for "nothing hidden"
+ * (which would count hidden unreads against the user's explicit choice).
+ */
+export async function readHiddenSetOrNull(): Promise<Set<string> | null> {
   try {
     return await loadSet();
   } catch {
-    return new Set();
+    return null;
   }
 }
 

--- a/src/services/hidden-chats.ts
+++ b/src/services/hidden-chats.ts
@@ -1,10 +1,16 @@
 /**
- * Hidden Chats — the local, zero-knowledge privacy layer (spec 1019).
+ * Hidden Chats — the local, zero-knowledge privacy layer (spec 1019, hardened
+ * and given its per-person model by spec 1027).
  *
  * A hidden chat is an ordinary conversation whose id is recorded in a per-device
  * "hidden set". That set, and a separate dedicated reveal PIN, live ONLY on this
  * device and never cross the wire (the server already can't read conversation
  * content; hiding adds no new signal — see spec §Zero-Knowledge Impact).
+ *
+ * Per person there is at most ONE hidden and ONE visible chat (`hidden-pair.ts`
+ * enforces it), inbound frames route to the hidden thread instead of minting a
+ * visible one (`inbound-route.ts`), and a destructive reset blocks the live
+ * relay path too (`hidden-chats-reset.ts` + the hiddenPeer tombstones).
  *
  * Storage (both device-local `settings` keys, deliberately excluded from
  * own-data sync so hiding stays per-device):
@@ -64,7 +70,18 @@ interface EncWrapper {
 interface HiddenPinRec {
   salt: string; // b64url Argon2id salt (clear)
   env: Envelope; // PIN_MARKER sealed under the PIN-derived key
-  length: number; // digit count, for auto-verify-at-length
+  // Digit count for auto-verify-at-length, SEALED under the master key (spec
+  // 1027 T044): stored in the clear it told anyone reading IndexedDB how many
+  // digits to brute-force. The search-bar gesture only needs it while the app
+  // is unlocked, so master-key sealing costs no availability.
+  len?: Envelope;
+  length?: number; // legacy cleartext count (pre-1027) — migrated on first read
+}
+
+const LEN_AAD = 'privacy.hiddenPin.len';
+
+function sealLen(n: number): Envelope {
+  return sealJson(getMasterKey(), n, 'master', utf8ToBytes(LEN_AAD));
 }
 
 /* ---- hidden set: master-key-sealed, device-local ---- */
@@ -153,7 +170,11 @@ export async function enableHiddenPin(pin: string): Promise<void> {
   const salt = randomBytes(ARGON_SALT_BYTES);
   const key = argon2id(pin, salt);
   const env = sealJson(key, PIN_MARKER, 'pin');
-  await writeSetting<HiddenPinRec>(PIN_KEY, { salt: bytesToB64url(salt), env, length: pin.length });
+  await writeSetting<HiddenPinRec>(PIN_KEY, {
+    salt: bytesToB64url(salt),
+    env,
+    len: sealLen(pin.length),
+  });
 }
 
 /** Verify a reveal-PIN attempt. Returns false (no oracle) on any failure. */
@@ -177,7 +198,26 @@ export async function changeHiddenPin(oldPin: string, newPin: string): Promise<v
 
 export async function hiddenPinLength(): Promise<number | null> {
   const rec = await readSetting<HiddenPinRec | undefined>(PIN_KEY, undefined);
-  return rec ? rec.length : null;
+  if (!rec) return null;
+  if (rec.len) {
+    try {
+      return openJson<number>(getMasterKey(), rec.len, utf8ToBytes(LEN_AAD));
+    } catch {
+      return null; // locked → the reveal gesture simply stays un-armed
+    }
+  }
+  // Legacy pre-1027 record with a CLEARTEXT length: migrate in place (reseal +
+  // drop the plaintext) on first read while unlocked.
+  if (typeof rec.length === 'number') {
+    const n = rec.length;
+    try {
+      await writeSetting<HiddenPinRec>(PIN_KEY, { salt: rec.salt, env: rec.env, len: sealLen(n) });
+    } catch {
+      /* locked → keep the legacy shape; the next unlocked read migrates it */
+    }
+    return n;
+  }
+  return null;
 }
 
 /** Erase the hidden set + PIN material from storage and the in-memory cache.

--- a/src/services/hidden-chats.zk.test.ts
+++ b/src/services/hidden-chats.zk.test.ts
@@ -10,13 +10,16 @@ import { dirname, resolve } from 'node:path';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const ownsync = readFileSync(resolve(root, 'src/services/ownsync.ts'), 'utf8');
+const ownsyncKeys = readFileSync(resolve(root, 'src/services/ownsync-keys.ts'), 'utf8');
 
-// The hidden-chats storage keys (mirrors hidden-chats.ts SET_KEY/PIN_KEY + prefs).
-const HIDDEN_KEYS = ['privacy.hiddenChats', 'privacy.hiddenPin', 'privacy.hiddenChatsEnabled', 'privacy.hiddenChatsGrace', 'privacy.hiddenChatsBiometric'];
+// The hidden-chats storage keys (mirrors hidden-chats.ts SET_KEY/PIN_KEY + prefs),
+// plus the spec-1027 device-local badge cache (already preference-filtered, but a
+// per-device number that must never ride the snapshot to other devices).
+const HIDDEN_KEYS = ['privacy.hiddenChats', 'privacy.hiddenPin', 'privacy.hiddenChatsEnabled', 'privacy.hiddenChatsGrace', 'privacy.hiddenChatsBiometric', 'badge.lastCount'];
 
 describe('zero-knowledge: hidden state never syncs', () => {
   it('no hidden-chats key appears in the synced-pref allowlist', () => {
-    const block = ownsync.match(/SYNCED_PREF_KEYS[^\]]*\]/s)?.[0] ?? '';
+    const block = ownsyncKeys.match(/SYNCED_PREF_KEYS[^\]]*\]/s)?.[0] ?? '';
     expect(block).not.toEqual('');
     for (const k of HIDDEN_KEYS) expect(block).not.toContain(k);
   });
@@ -31,5 +34,12 @@ describe('zero-knowledge: hidden state never syncs', () => {
     const tombstones = readFileSync(resolve(root, 'src/db/tombstones.ts'), 'utf8');
     // listTombstones must filter out localOnly markers before uploading.
     expect(tombstones).toMatch(/listTombstones[\s\S]*filter[\s\S]*!t\.localOnly/);
+  });
+
+  it('hidden-reset peer blocks are localOnly by construction (spec 1027 FR-018/FR-019)', () => {
+    const tombstones = readFileSync(resolve(root, 'src/db/tombstones.ts'), 'utf8');
+    // recordHiddenPeerBlock hard-codes localOnly: true — combined with the
+    // listTombstones filter above, a hiddenPeer: block can never be uploaded.
+    expect(tombstones).toMatch(/recordHiddenPeerBlock[\s\S]{0,400}localOnly:\s*true/);
   });
 });

--- a/src/services/hidden-chats.zk.test.ts
+++ b/src/services/hidden-chats.zk.test.ts
@@ -15,6 +15,9 @@ const ownsyncKeys = readFileSync(resolve(root, 'src/services/ownsync-keys.ts'), 
 // The hidden-chats storage keys (mirrors hidden-chats.ts SET_KEY/PIN_KEY + prefs),
 // plus the spec-1027 device-local badge cache (already preference-filtered, but a
 // per-device number that must never ride the snapshot to other devices).
+// NOTE: privacy.hiddenChatsBiometric is FUTURE-PROOFING ONLY — biometric reveal
+// (1019 US6) was never implemented and stays deferred (spec 1027 Out of Scope);
+// the assertion simply guarantees that if it ever lands, it can't sync either.
 const HIDDEN_KEYS = ['privacy.hiddenChats', 'privacy.hiddenPin', 'privacy.hiddenChatsEnabled', 'privacy.hiddenChatsGrace', 'privacy.hiddenChatsBiometric', 'badge.lastCount'];
 
 describe('zero-knowledge: hidden state never syncs', () => {

--- a/src/services/hidden-pair.test.ts
+++ b/src/services/hidden-pair.test.ts
@@ -10,6 +10,7 @@ import {
   chatsWithPeer,
   canHide,
   canUnhide,
+  planStartDirectChat,
   resolveInboundDirectChat,
 } from './hidden-pair';
 
@@ -106,6 +107,48 @@ describe('canUnhide (INV-2: at most one visible chat per person)', () => {
 
   it('always allows unhiding a multi-member group', () => {
     expect(canUnhide([bigGroup('g'), oneToOne('a')], hidden('g'), 'g')).toEqual({ ok: true });
+  });
+});
+
+describe('planStartDirectChat (user-initiated "start a conversation")', () => {
+  it('opens the existing visible plain 1:1', () => {
+    const chats = [oneToOne('v')];
+    expect(planStartDirectChat(chats, hidden(), P)).toEqual({ action: 'open', chatId: 'v' });
+  });
+
+  it('opens the existing visible pair conversation (the coexistence steady state)', () => {
+    const chats = [oneToOne('h'), pairConv('p')];
+    expect(planStartDirectChat(chats, hidden('h'), P)).toEqual({ action: 'open', chatId: 'p' });
+  });
+
+  it('creates a pair conversation when the only chat is a hidden plain 1:1 (FR-004)', () => {
+    const chats = [oneToOne('h')];
+    expect(planStartDirectChat(chats, hidden('h'), P)).toEqual({ action: 'createPair' });
+  });
+
+  it('creates a plain 1:1 when the hidden thread is a pair conversation and no 1:1 exists', () => {
+    const chats = [pairConv('hp')];
+    expect(planStartDirectChat(chats, hidden('hp'), P)).toEqual({ action: 'createOneToOne' });
+  });
+
+  it('creates a plain 1:1 for a brand-new peer', () => {
+    expect(planStartDirectChat([], hidden(), P)).toEqual({ action: 'createOneToOne' });
+  });
+
+  it('never resolves to a hidden chat (the #544 loophole stays closed)', () => {
+    const chats = [oneToOne('h'), pairConv('hp')];
+    const plan = planStartDirectChat(chats, hidden('h', 'hp'), P);
+    // Both threads hidden (legacy INV-1 breach): nothing visible may open.
+    expect(plan.action).not.toBe('open');
+  });
+
+  it('prefers the non-pending plain 1:1, then the pair conversation, then a pending placeholder', () => {
+    const chats = [oneToOne('pend', { pending: true }), pairConv('p'), oneToOne('v')];
+    expect(planStartDirectChat(chats, hidden(), P)).toEqual({ action: 'open', chatId: 'v' });
+    expect(planStartDirectChat([oneToOne('pend', { pending: true }), pairConv('p')], hidden(), P))
+      .toEqual({ action: 'open', chatId: 'p' });
+    expect(planStartDirectChat([oneToOne('pend', { pending: true })], hidden(), P))
+      .toEqual({ action: 'open', chatId: 'pend' });
   });
 });
 

--- a/src/services/hidden-pair.test.ts
+++ b/src/services/hidden-pair.test.ts
@@ -1,0 +1,145 @@
+// Unit tests for the per-person hidden/visible invariant core (spec 1027, R8).
+// Pure module — no idb, no mocks needed. Encodes INV-1 (at most one hidden chat
+// per person), INV-2 (at most one visible), and rule R stage 1 (pre-decrypt
+// session resolution), including the legacy INV-3-violating state (a hidden AND
+// a visible plain 1:1 with the same peer, residue of bug B1) which is tolerated
+// read-only.
+import { describe, it, expect } from 'vitest';
+import type { Chat } from '@/db/types';
+import {
+  chatsWithPeer,
+  canHide,
+  canUnhide,
+  resolveInboundDirectChat,
+} from './hidden-pair';
+
+let seq = 0;
+function chat(over: Partial<Chat>): Chat {
+  seq += 1;
+  return {
+    id: over.id ?? `c${seq}`,
+    name: 'x',
+    avatar: '',
+    isGroup: false,
+    participantIds: [],
+    lastMessage: '',
+    lastMessageTime: 0,
+    unread: 0,
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+const P = 'peer-1';
+const oneToOne = (id: string, extra: Partial<Chat> = {}) =>
+  chat({ id, isGroup: false, participantIds: [P], ...extra });
+const pairConv = (id: string) => chat({ id, isGroup: true, participantIds: [P] });
+const bigGroup = (id: string) => chat({ id, isGroup: true, participantIds: [P, 'peer-2'] });
+const hidden = (...ids: string[]) => new Set(ids);
+
+describe('chatsWithPeer', () => {
+  it('counts plain 1:1s and pair conversations, never multi-member groups', () => {
+    const chats = [oneToOne('a'), pairConv('b'), bigGroup('g'), chat({ id: 'other', participantIds: ['peer-2'] })];
+    expect(chatsWithPeer(chats, P).map((c) => c.id)).toEqual(['a', 'b']);
+  });
+
+  it('is empty for an unknown peer', () => {
+    expect(chatsWithPeer([oneToOne('a')], 'nobody')).toEqual([]);
+  });
+});
+
+describe('canHide (INV-1: at most one hidden chat per person)', () => {
+  it('allows hiding the only chat with a person', () => {
+    expect(canHide([oneToOne('a')], hidden(), 'a')).toEqual({ ok: true });
+  });
+
+  it('blocks hiding when another chat with the same person is already hidden', () => {
+    const r = canHide([oneToOne('a'), pairConv('b')], hidden('a'), 'b');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/already have a hidden chat/i);
+  });
+
+  it('blocks the legacy state too: hiding the visible plain 1:1 next to a hidden one', () => {
+    // Pre-1027 bug B1 could leave a hidden AND a visible plain 1:1 for one peer.
+    const r = canHide([oneToOne('a'), oneToOne('b')], hidden('a'), 'b');
+    expect(r.ok).toBe(false);
+  });
+
+  it('is idempotent for an already-hidden chat (its own id does not block it)', () => {
+    expect(canHide([oneToOne('a')], hidden('a'), 'a')).toEqual({ ok: true });
+  });
+
+  it('always allows hiding a multi-member group, even with a hidden 1:1 sharing a member', () => {
+    expect(canHide([oneToOne('a'), bigGroup('g')], hidden('a'), 'g')).toEqual({ ok: true });
+  });
+
+  it('allows hiding for an unknown chat id (nothing to compare against)', () => {
+    expect(canHide([], hidden(), 'ghost')).toEqual({ ok: true });
+  });
+});
+
+describe('canUnhide (INV-2: at most one visible chat per person)', () => {
+  it('allows unhiding when nothing visible exists for that person', () => {
+    expect(canUnhide([oneToOne('a')], hidden('a'), 'a')).toEqual({ ok: true });
+  });
+
+  it('blocks unhiding while a visible chat with the same person exists', () => {
+    const r = canUnhide([oneToOne('a'), pairConv('b')], hidden('a'), 'a');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/already have a chat/i);
+  });
+
+  it('blocks the legacy state: unhiding next to a visible plain 1:1', () => {
+    expect(canUnhide([oneToOne('a'), oneToOne('b')], hidden('a'), 'a').ok).toBe(false);
+  });
+
+  it('a pending placeholder still blocks (it becomes visible on accept)', () => {
+    const r = canUnhide([oneToOne('a'), oneToOne('b', { pending: true })], hidden('a'), 'a');
+    expect(r.ok).toBe(false);
+  });
+
+  it('another HIDDEN chat with the same person does not block unhiding', () => {
+    // Only visible chats enforce INV-2 (a second hidden one is an INV-1 legacy
+    // state; unhiding one of them is the way OUT of it).
+    expect(canUnhide([oneToOne('a'), pairConv('b')], hidden('a', 'b'), 'a')).toEqual({ ok: true });
+  });
+
+  it('always allows unhiding a multi-member group', () => {
+    expect(canUnhide([bigGroup('g'), oneToOne('a')], hidden('g'), 'g')).toEqual({ ok: true });
+  });
+});
+
+describe('resolveInboundDirectChat (rule R stage 1, pre-decrypt)', () => {
+  it('prefers the visible plain 1:1', () => {
+    const chats = [oneToOne('v'), pairConv('p')];
+    expect(resolveInboundDirectChat(chats, hidden(), P)?.id).toBe('v');
+  });
+
+  it('falls back to the hidden plain 1:1 when no visible one exists', () => {
+    const chats = [oneToOne('h'), pairConv('p')];
+    expect(resolveInboundDirectChat(chats, hidden('h'), P)?.id).toBe('h');
+  });
+
+  it('never returns a pair conversation (those route by groupId post-decrypt)', () => {
+    expect(resolveInboundDirectChat([pairConv('p')], hidden(), P)).toBeNull();
+  });
+
+  it('returns null when nothing matches (caller consults the peer block / creates)', () => {
+    expect(resolveInboundDirectChat([bigGroup('g')], hidden(), P)).toBeNull();
+  });
+
+  it('legacy state routes to the VISIBLE plain 1:1 (where the live session is)', () => {
+    const chats = [oneToOne('h'), oneToOne('v')];
+    expect(resolveInboundDirectChat(chats, hidden('h'), P)?.id).toBe('v');
+  });
+
+  it('prefers a non-pending visible 1:1 over a pending placeholder', () => {
+    const chats = [oneToOne('pend', { pending: true }), oneToOne('real')];
+    expect(resolveInboundDirectChat(chats, hidden(), P)?.id).toBe('real');
+  });
+
+  it('uses the pending placeholder when it is the only visible 1:1', () => {
+    const chats = [oneToOne('pend', { pending: true }), oneToOne('h')];
+    expect(resolveInboundDirectChat(chats, hidden('h'), P)?.id).toBe('pend');
+  });
+});

--- a/src/services/hidden-pair.ts
+++ b/src/services/hidden-pair.ts
@@ -69,6 +69,37 @@ export function canUnhide(chats: Chat[], hidden: ReadonlySet<string>, chatId: st
   return { ok: true };
 }
 
+export type StartDirectPlan =
+  | { action: 'open'; chatId: string }
+  | { action: 'createPair' }
+  | { action: 'createOneToOne' };
+
+/**
+ * The user-initiated "start a conversation with this person" decision (spec
+ * 1027 FR-004, wired by `startDirectChat`). Never resolves to a hidden chat —
+ * starting a chat from a contact must not open a PIN-locked conversation (the
+ * #544 loophole). Preference among the VISIBLE chats with the peer: the real
+ * plain 1:1, then a pair conversation, then a pending request placeholder.
+ * When nothing visible exists the channel of the NEW thread is forced by
+ * INV-3: a hidden plain 1:1 already owns the peer's ratchet → create a pair
+ * conversation (the distinct group-modeled channel); otherwise a plain 1:1.
+ */
+export function planStartDirectChat(
+  chats: Chat[],
+  hidden: ReadonlySet<string>,
+  peerId: string,
+): StartDirectPlan {
+  const withPeer = chatsWithPeer(chats, peerId);
+  const visible = withPeer.filter((c) => !hidden.has(c.id));
+  const open =
+    visible.find((c) => !c.isGroup && !c.pending) ??
+    visible.find((c) => c.isGroup) ??
+    visible[0];
+  if (open) return { action: 'open', chatId: open.id };
+  const hiddenPlain = withPeer.some((c) => !c.isGroup && hidden.has(c.id));
+  return hiddenPlain ? { action: 'createPair' } : { action: 'createOneToOne' };
+}
+
 /**
  * Rule R stage 1 — pre-decrypt session resolution for an inbound frame from
  * `peerId` (spec 1027 D2). Every frame from a peer rides the per-peer 1:1

--- a/src/services/hidden-pair.ts
+++ b/src/services/hidden-pair.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-person hidden/visible invariant core (spec 1027, research R8).
+ *
+ * Ring's crypto forces the shape of coexistence: the 1:1 Double Ratchet session
+ * for a peer is keyed by the plain 1:1 chat's id, so there can only ever be ONE
+ * plain 1:1 per peer (INV-3) — a second thread with the same person must be a
+ * "pair conversation" (a group-modeled chat with exactly that one participant,
+ * sender-key crypto, routed by groupId). On top of that channel reality, spec
+ * 1027 defines the per-person rule: at most one HIDDEN chat (INV-1) and at most
+ * one VISIBLE chat (INV-2) per person. Hidden/visible are roles; channel type is
+ * whatever each thread happens to be.
+ *
+ * This module is a pure leaf (no idb, no service imports) so the invariant is
+ * unit-testable without IndexedDB and usable from both the data layer
+ * (`queries.ts`) and the UI (`ChatActionsSheet`) without cycles — the same
+ * pattern as `hidden-state.ts`.
+ */
+import type { Chat } from '@/db/types';
+
+/** All conversations that count as "a chat with this person" for the per-person
+ *  rule: plain 1:1s and pair conversations. Multi-member groups never count —
+ *  they hide/unhide individually and are unconstrained by the pair invariant. */
+export function chatsWithPeer(chats: Chat[], peerId: string): Chat[] {
+  return chats.filter((c) => c.participantIds.length === 1 && c.participantIds[0] === peerId);
+}
+
+export type PairVerdict = { ok: true } | { ok: false; reason: string };
+
+/** True for the threads the per-person rule constrains (single-participant). */
+function isPairScoped(c: Chat): boolean {
+  return c.participantIds.length === 1;
+}
+
+/**
+ * INV-1 gate for the Hide action: hiding is blocked when ANOTHER chat with the
+ * same person is already hidden. Multi-member groups always pass. Re-hiding an
+ * already-hidden chat passes (idempotent — its own id never blocks it).
+ */
+export function canHide(chats: Chat[], hidden: ReadonlySet<string>, chatId: string): PairVerdict {
+  const chat = chats.find((c) => c.id === chatId);
+  if (!chat || !isPairScoped(chat)) return { ok: true };
+  const peer = chat.participantIds[0];
+  const otherHidden = chatsWithPeer(chats, peer).some((c) => c.id !== chatId && hidden.has(c.id));
+  if (otherHidden) {
+    return { ok: false, reason: 'You already have a hidden chat with this person' };
+  }
+  return { ok: true };
+}
+
+/**
+ * INV-2 gate for the Unhide action: unhiding is blocked while a VISIBLE chat
+ * with the same person exists (delete it first — histories are never merged).
+ * A pending request placeholder counts as a blocker too: it turns visible the
+ * moment the request is accepted, which would break INV-2 after the fact.
+ * Another hidden chat does not block — unhiding is the way out of the legacy
+ * two-hidden state.
+ */
+export function canUnhide(chats: Chat[], hidden: ReadonlySet<string>, chatId: string): PairVerdict {
+  const chat = chats.find((c) => c.id === chatId);
+  if (!chat || !isPairScoped(chat)) return { ok: true };
+  const peer = chat.participantIds[0];
+  const visibleExists = chatsWithPeer(chats, peer).some((c) => c.id !== chatId && !hidden.has(c.id));
+  if (visibleExists) {
+    return {
+      ok: false,
+      reason: 'You already have a chat with this person. Delete it first to unhide this one',
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Rule R stage 1 — pre-decrypt session resolution for an inbound frame from
+ * `peerId` (spec 1027 D2). Every frame from a peer rides the per-peer 1:1
+ * ratchet, whose session is stored under the plain 1:1 chat's id, so this picks
+ * that chat WITHOUT reading the (still sealed) payload:
+ *
+ *   1. the visible plain 1:1 (non-pending preferred, pending placeholder next);
+ *   2. else the hidden plain 1:1 — content lands there silently;
+ *   3. else null — the caller consults the `hiddenPeer:` reset block and only
+ *      then creates a fresh visible 1:1.
+ *
+ * Never returns a pair conversation: those carry no 1:1 session, and their
+ * content routes by `payload.groupId` post-decrypt (rule R stage 2). In the
+ * legacy B1 state (hidden AND visible plain 1:1) the visible one wins — that is
+ * where the live session ended up.
+ */
+export function resolveInboundDirectChat(
+  chats: Chat[],
+  hidden: ReadonlySet<string>,
+  peerId: string,
+): Chat | null {
+  const ones = chats.filter(
+    (c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === peerId,
+  );
+  const visible = ones.filter((c) => !hidden.has(c.id));
+  return visible.find((c) => !c.pending) ?? visible[0] ?? ones.find((c) => hidden.has(c.id)) ?? null;
+}

--- a/src/services/hidden-state.test.ts
+++ b/src/services/hidden-state.test.ts
@@ -1,0 +1,77 @@
+// Unit tests for the hidden-state relock hook (spec 1027 T010, fixes bug B5).
+// The hook is how the router learns a reveal session ended, so an OPEN hidden
+// conversation can be left immediately (FR-009 "kick out"). It must fire on
+// every transition INTO the locked state — grace expiry / manual relock
+// (setRevealed(false)) and keystore lock / wipe (clearHiddenState) — and never
+// on reveal.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/db/idb', () => ({ touch: () => {} }));
+
+import {
+  registerRelockHook,
+  registerHiddenLoader,
+  ensureHiddenLoaded,
+  setRevealed,
+  setHiddenIdsCache,
+  clearHiddenState,
+  isRevealed,
+} from './hidden-state';
+
+let fired: number;
+
+beforeEach(() => {
+  fired = 0;
+  clearHiddenState();
+  registerRelockHook(() => {
+    fired += 1;
+  });
+  fired = 0; // ignore any firing caused by the reset itself
+});
+
+describe('registerRelockHook', () => {
+  it('fires when an active reveal session ends', () => {
+    setRevealed(true);
+    expect(fired).toBe(0);
+    setRevealed(false);
+    expect(fired).toBe(1);
+    expect(isRevealed()).toBe(false);
+  });
+
+  it('does not fire on reveal or on a redundant relock', () => {
+    setRevealed(true);
+    expect(fired).toBe(0);
+    setRevealed(false);
+    setRevealed(false); // no state change → no second firing
+    expect(fired).toBe(1);
+  });
+
+  it('fires on clearHiddenState (keystore lock / wipe), even mid-reveal', () => {
+    setRevealed(true);
+    clearHiddenState();
+    expect(fired).toBe(1);
+    expect(isRevealed()).toBe(false);
+  });
+
+  it('fires on clearHiddenState even when not revealed (deep-link defense)', () => {
+    clearHiddenState();
+    expect(fired).toBe(1);
+  });
+
+  it('fires when the hidden set becomes known or mutates (cold-start deep-link recheck)', () => {
+    // The router's door guard fails open before the set decrypts; this firing
+    // is what re-runs the check once it is known. The router callback itself
+    // ignores active reveal sessions (checked there via isRevealed).
+    setHiddenIdsCache(['c1']);
+    expect(fired).toBe(1);
+    setHiddenIdsCache(['c1', 'c2']); // every mutation rechecks
+    expect(fired).toBe(2);
+  });
+
+  it('fires after a successful LAZY load too (the actual cold-start path)', async () => {
+    registerHiddenLoader(async () => new Set(['c1']));
+    await ensureHiddenLoaded();
+    await new Promise<void>((r) => queueMicrotask(r)); // load defers to a microtask
+    expect(fired).toBe(1);
+  });
+});

--- a/src/services/hidden-state.test.ts
+++ b/src/services/hidden-state.test.ts
@@ -16,6 +16,7 @@ import {
   setHiddenIdsCache,
   clearHiddenState,
   isRevealed,
+  isHiddenId,
 } from './hidden-state';
 
 let fired: number;
@@ -51,6 +52,25 @@ describe('registerRelockHook', () => {
     clearHiddenState();
     expect(fired).toBe(1);
     expect(isRevealed()).toBe(false);
+  });
+
+  it('clearHiddenState fires the hook while ids are STILL known and revealed is already false', () => {
+    // Regression (spec 1027 security review): clearing ids before firing the
+    // hook made the router kick-out no-op on the keystore-lock/wipe path —
+    // isHiddenId(currentRouteId) was always false. The hook must be able to
+    // both see the hidden ids AND observe revealed===false at fire time.
+    setHiddenIdsCache(['open-hidden']);
+    setRevealed(true);
+    let idKnownAtFire: boolean | null = null;
+    let revealedAtFire: boolean | null = null;
+    registerRelockHook(() => {
+      idKnownAtFire = isHiddenId('open-hidden');
+      revealedAtFire = isRevealed();
+    });
+    clearHiddenState();
+    expect(idKnownAtFire).toBe(true); // ids still populated when the hook ran
+    expect(revealedAtFire).toBe(false); // ...and no longer revealed (hook won't early-return)
+    expect(isHiddenId('open-hidden')).toBe(false); // cleared afterwards
   });
 
   it('fires on clearHiddenState even when not revealed (deep-link defense)', () => {

--- a/src/services/hidden-state.ts
+++ b/src/services/hidden-state.ts
@@ -141,9 +141,14 @@ export function setRevealed(v: boolean): void {
  *  relock: even without an active reveal session an open hidden chat (e.g. a
  *  stale deep link) must be left when the keystore locks. */
 export function clearHiddenState(): void {
+  // Order matters: the relock hook decides the kick-out by testing whether the
+  // CURRENT route's id is hidden, so it must run while `ids` still holds the
+  // set AND `revealed` is already false (the hook early-returns while revealed).
+  // Clearing `ids` first would make `isHiddenId` always false → the kick-out
+  // would silently no-op on the keystore-lock/wipe path (spec 1027 FR-009).
+  revealed = false;
+  relockHook?.();
   ids = new Set();
   loaded = false;
-  revealed = false;
   refreshLists();
-  relockHook?.();
 }

--- a/src/services/hidden-state.ts
+++ b/src/services/hidden-state.ts
@@ -59,8 +59,14 @@ export async function ensureHiddenLoaded(): Promise<Set<string>> {
     // the first load attempt fails closed (unloaded). Once it finally succeeds,
     // nudge the lists to re-query with the now-known set so any chat that was
     // briefly shown gets excluded. Deferred to a microtask to avoid re-entering
-    // the in-flight query.
-    queueMicrotask(refreshLists);
+    // the in-flight query. The relock hook runs too: a cold start can deep-link
+    // INSIDE a hidden chat before the set decrypts (the router's door guard
+    // fails open on an unknown set), and this is the moment the router can
+    // finally see it and kick out (spec 1027 FR-009).
+    queueMicrotask(() => {
+      refreshLists();
+      relockHook?.();
+    });
   } catch {
     // Locked / corrupt: do NOT mark loaded (so we retry once unlocked) and keep
     // the last-known set rather than an empty one. This fails closed — a
@@ -96,6 +102,12 @@ export function setHiddenIdsCache(next: Iterable<string>): void {
   ids = new Set(next);
   loaded = true;
   refreshLists();
+  // The router's door guard fails open at cold start (the set is unknown when
+  // the first navigation resolves), so a deep link can land INSIDE a hidden
+  // chat before the set decrypts. Re-run the kick-out check the moment the set
+  // is known (and after every mutation — hiding a chat from inside it must
+  // close it too). The registered callback ignores active reveal sessions.
+  relockHook?.();
 }
 
 /** Is a reveal session currently active? */
@@ -103,18 +115,35 @@ export function isRevealed(): boolean {
   return revealed;
 }
 
+// Fired on every transition INTO the locked state (spec 1027, FR-009). The
+// router registers a callback that leaves an open hidden conversation
+// immediately — grace expiry, manual relock, keystore auto-lock, or a wipe must
+// never leave hidden content on screen. Registered from the router module (this
+// leaf imports nothing heavy, and the router importing the leaf keeps the
+// dependency direction clean).
+let relockHook: (() => void) | null = null;
+
+/** Register the relock callback (router kick-out). Replaces any previous one. */
+export function registerRelockHook(fn: () => void): void {
+  relockHook = fn;
+}
+
 /** Flip the reveal session. Refreshes the lists when it actually changes. */
 export function setRevealed(v: boolean): void {
   if (revealed !== v) {
     revealed = v;
     refreshLists();
+    if (!v) relockHook?.();
   }
 }
 
-/** Drop all in-memory state (on lock / wipe / reset). */
+/** Drop all in-memory state (on lock / wipe / reset). Always counts as a
+ *  relock: even without an active reveal session an open hidden chat (e.g. a
+ *  stale deep link) must be left when the keystore locks. */
 export function clearHiddenState(): void {
   ids = new Set();
   loaded = false;
   revealed = false;
   refreshLists();
+  relockHook?.();
 }

--- a/src/services/notify.hidden.test.ts
+++ b/src/services/notify.hidden.test.ts
@@ -1,0 +1,73 @@
+// Unit tests for the PAGE-side hidden-chat notification paths (spec 1027
+// T020/T026, fixes bug B6). Clarified FR-012: every delivery path the platform
+// does not force must be FULLY silent for a hidden chat — the old code bridged
+// a generic local notification on the backgrounded-but-connected (non-push)
+// path. Only the push-woken SW path may show the generic banner.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  notifyLocal: vi.fn(),
+  tones: vi.fn(),
+  settings: new Map<string, unknown>(),
+}));
+
+vi.mock('@ionic/vue', () => ({ alertController: { create: vi.fn() } }));
+vi.mock('@/router', () => ({ default: { push: vi.fn(), currentRoute: { value: { path: '/' } } } }));
+vi.mock('@/db/queries', () => ({
+  getSetting: async (key: string, fallback: unknown) => h.settings.get(key) ?? fallback,
+  isChatMuted: async () => false,
+  getChat: async () => undefined,
+}));
+vi.mock('@/db/idb', () => ({ subscribe: () => () => {}, touch: () => {} }));
+vi.mock('@/services/push', () => ({ notifyLocal: h.notifyLocal }));
+vi.mock('@/services/notify-prefs', () => ({
+  inAppGloballyEnabled: async () => true,
+  getChatNotifyPrefs: async () => null,
+}));
+vi.mock('@/services/crypto/identity', () => ({
+  isUnlockedNow: () => true,
+  isUnlocked: { value: true },
+}));
+vi.mock('@/services/sound', () => ({ playTone: h.tones }));
+
+import { notifyIncoming } from './notify';
+import {
+  registerHiddenLoader,
+  setHiddenIdsCache,
+  clearHiddenState,
+} from './hidden-state';
+
+beforeEach(() => {
+  h.notifyLocal.mockClear();
+  h.tones.mockClear();
+  h.settings.clear();
+  clearHiddenState();
+  registerHiddenLoader(async () => new Set<string>());
+  setHiddenIdsCache(['hidden-1']);
+});
+
+const msg = (over: Record<string, unknown> = {}) =>
+  ({ kind: 'message', chatId: 'hidden-1', title: 'Peer', body: 'secret', ...over }) as never;
+
+describe('notifyIncoming — hidden chats (FR-012 non-push paths are silent)', () => {
+  it('backgrounded-but-connected (no push wake): NO local notification, no sound (B6)', async () => {
+    // node env has no `document`, so appVisible() is false = backgrounded.
+    const presented = await notifyIncoming(msg({ pushWoken: false }));
+    expect(presented).toBe(false);
+    expect(h.notifyLocal).not.toHaveBeenCalled();
+    expect(h.tones).not.toHaveBeenCalled();
+  });
+
+  it('push-woken drain: nothing from the page either (the SW owns the generic)', async () => {
+    const presented = await notifyIncoming(msg({ pushWoken: true }));
+    expect(presented).toBe(false);
+    expect(h.notifyLocal).not.toHaveBeenCalled();
+  });
+
+  it('a NON-hidden chat on the same path still notifies (no over-suppression)', async () => {
+    const presented = await notifyIncoming(msg({ chatId: 'visible-1' }));
+    // Backgrounded + connected for a normal chat → the page bridges its local
+    // notification exactly as before this spec.
+    expect(presented || h.notifyLocal.mock.calls.length > 0).toBe(true);
+  });
+});

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -371,9 +371,9 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
   // (Requests / system notices have no chat and always-surface semantics — handled
   // below the predicate, unchanged.)
   if (n.kind === 'message') {
-    // Hidden chats (spec 1019): a LOCKED hidden chat must leave no foreground trace —
-    // never a banner, sound, or a name/content notification. (When revealed, the user
-    // is actively in hidden mode → fall through to the normal policy.)
+    // Hidden chats (spec 1019, tightened by 1027 FR-012): a LOCKED hidden chat
+    // must leave no trace on ANY path the platform doesn't force. (When
+    // revealed, the user is actively in hidden mode → normal policy.)
     if (n.chatId && !isRevealed() && (await ensureHiddenLoaded()).has(n.chatId)) {
       if (appVisible()) {
         // Foreground: stay completely silent (no banner, no sound). Claim it so a
@@ -382,11 +382,10 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
         notifyBannerPresented();
         return true;
       }
-      // Backgrounded but connected via WS (no push woke us): the OS push didn't cover
-      // this, so bridge a GENERIC, content-free notification — NEVER the sender name or
-      // message text — mirroring the SW's hidden-chat handling. A push-woken drain
-      // leaves the (already-generic) OS notification to the SW.
-      if (!n.pushWoken) void notifyLocal('Ring', 'New message', '/tabs/chats', undefined);
+      // Backgrounded: fully silent — badge only. The old generic local-
+      // notification bridge is gone (spec 1027 B6): the page never shows
+      // anything for a hidden chat; only a PUSH-woken delivery may surface the
+      // generic banner, and that one belongs to the SW (platform contract).
       return false;
     }
     const p = await ensurePrefs();

--- a/src/services/sw-inbox.badge.test.ts
+++ b/src/services/sw-inbox.badge.test.ts
@@ -1,0 +1,71 @@
+// Unit tests for the SW badge total (spec 1027 T022/T028, fixes bug B4's SW
+// half): `unreadCount()` used to sum ALL chats unconditionally, so a push for a
+// hidden chat bumped the badge even when the user chose badge = 'never' —
+// leaking hidden activity against an explicit preference. The SW never knows
+// the page's reveal session (memory-only), so 'revealed' behaves as 'never'
+// here, and a locked (unreadable) hidden set falls back to `badge.lastCount`
+// instead of guessing.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  settings: new Map<string, unknown>(),
+  chats: [] as Array<{ id: string; unread: number }>,
+  hidden: null as Set<string> | null, // what readHiddenSetOrNull yields
+}));
+
+vi.mock('@/db/idb', () => ({
+  get: async (_s: string, key: string) =>
+    h.settings.has(key) ? { key, value: h.settings.get(key) } : undefined,
+  getAll: async (s: string) => (s === 'chats' ? h.chats : []),
+  getByIndex: async () => [],
+  put: async (_s: string, row: { key: string; value: unknown }) => {
+    h.settings.set(row.key, row.value);
+  },
+  remove: async () => {},
+  touch: () => {},
+}));
+
+vi.mock('@/services/hidden-chats', () => ({
+  readHiddenSet: async () => h.hidden ?? new Set<string>(),
+  readHiddenSetOrNull: async () => h.hidden,
+}));
+
+import { unreadCount } from './sw-inbox';
+
+beforeEach(() => {
+  h.settings.clear();
+  h.chats = [
+    { id: 'v1', unread: 2 },
+    { id: 'h1', unread: 5 },
+  ];
+  h.hidden = new Set(['h1']);
+});
+
+describe('SW unreadCount honors privacy.hiddenChatsBadge', () => {
+  it("default ('always') counts everything — unchanged behavior", async () => {
+    expect(await unreadCount()).toBe(7);
+  });
+
+  it("'never' excludes hidden chats", async () => {
+    h.settings.set('privacy.hiddenChatsBadge', 'never');
+    expect(await unreadCount()).toBe(2);
+  });
+
+  it("'revealed' behaves as 'never' in the SW (reveal is page-memory-only)", async () => {
+    h.settings.set('privacy.hiddenChatsBadge', 'revealed');
+    expect(await unreadCount()).toBe(2);
+  });
+
+  it('a locked hidden set falls back to badge.lastCount — no guess, no collateral zero', async () => {
+    h.settings.set('privacy.hiddenChatsBadge', 'never');
+    h.settings.set('badge.lastCount', 2);
+    h.hidden = null; // keystore locked → set unreadable
+    expect(await unreadCount()).toBe(2);
+  });
+
+  it('a locked hidden set with no cached count yields 0 (fail closed)', async () => {
+    h.settings.set('privacy.hiddenChatsBadge', 'never');
+    h.hidden = null;
+    expect(await unreadCount()).toBe(0);
+  });
+});

--- a/src/services/sw-inbox.hidden.test.ts
+++ b/src/services/sw-inbox.hidden.test.ts
@@ -38,4 +38,53 @@ describe('noteForPayload — hidden chats', () => {
     const { note } = noteForPayload(frame, payload, [chat], contacts, true, true);
     expect(note!.title).toBe('Peer One');
   });
+
+  // ---- spec 1027 FR-012 pins ----
+
+  it('the hidden note is byte-identical (visible fields) to the previews-off generic', () => {
+    // A hidden chat's banner must be indistinguishable from ordinary
+    // previews-off traffic — crowd anonymity, since the platform forces SOME
+    // notification on a push wake. Same title, same body; the tap target is the
+    // Chats tab (a previews-off note may still deep-link, which reveals nothing
+    // on the lock screen — only title/body render there).
+    const hiddenNote = noteForPayload(
+      frame, payload, [oneToOne('chat-h')], contacts, true, true, new Set(['chat-h']),
+    ).note!;
+    const previewsOff = noteForPayload(
+      frame, payload, [oneToOne('chat-v')], contacts, true, /* showPreview */ false, new Set(),
+    ).note!;
+    expect(hiddenNote.title).toBe(previewsOff.title);
+    expect(hiddenNote.body).toBe(previewsOff.body);
+    expect(hiddenNote.url).toBe('/tabs/chats');
+    expect(hiddenNote.tag).toBe('ring:chat-h'); // internal per-chat tag → bursts coalesce
+  });
+
+  it('hidden is decided BEFORE the @mention escalation (a mention never unmasks)', () => {
+    const group: Chat = {
+      id: 'grp-1', name: 'Group', isGroup: true, participantIds: ['peer-1'], createdBy: 'peer-1',
+    } as unknown as Chat;
+    const mentionPayload = { text: 'psst @me', groupId: 'grp-1', mentions: ['me'] } as any;
+    const { note } = noteForPayload(
+      frame, mentionPayload, [group], contacts, true, true, new Set(['grp-1']), 'me',
+    );
+    expect(note!.title).toBe('Ring');
+    expect(note!.body).toBe('New message');
+    expect(JSON.stringify(note)).not.toContain('mention');
+  });
+
+  it('hidden is decided BEFORE per-chat mute/content silencers (never silently dropped)', () => {
+    const chat = {
+      ...oneToOne('chat-m'),
+      mutedUntil: Date.now() + 60_000,
+      notifyContent: 'none',
+    } as Chat;
+    const { note, silenced } = noteForPayload(
+      frame, payload, [chat], contacts, true, true, new Set(['chat-m']),
+    );
+    // A hidden chat's push must still yield the generic note (platform contract),
+    // not the silenced/no-notification outcome mute would otherwise pick.
+    expect(silenced).toBeFalsy();
+    expect(note!.title).toBe('Ring');
+    expect(note!.body).toBe('New message');
+  });
 });

--- a/src/services/sw-inbox.test.ts
+++ b/src/services/sw-inbox.test.ts
@@ -20,7 +20,7 @@ function decision(r: PreviewResult, timedOut = false): 'notes' | 'generic' | 'no
   return 'generic';
 }
 
-const base: PreviewResult = { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: false };
+const base: PreviewResult = { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: false };
 const note = { ids: ['m1'], title: 'Alice', body: 'hi', url: '/', tag: 'chat-1' };
 
 describe('spec 2016 — generic placeholder gating (isNothingNew)', () => {

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -19,7 +19,7 @@
  */
 import { attemptDeviceUnlock } from './crypto/identity';
 import { previewPacket } from './messaging';
-import { readHiddenSet } from './hidden-chats';
+import { readHiddenSet, readHiddenSetOrNull } from './hidden-chats';
 import { readSessionToken, readSessionUserId } from './session';
 import { get, getAll, put } from '@/db/idb';
 import { notifyPreview } from '@/utils/notify-preview';
@@ -61,6 +61,12 @@ export interface SwNote {
 export interface PreviewResult {
   notes: SwNote[];
   pending: number;
+  // The pending count the app-icon BADGE may use (spec 1027, B4): equal to
+  // `pending` under badge mode 'always'; under 'never'/'revealed' only frames
+  // that decrypted AND resolved to a provably NON-hidden chat. A frame we can't
+  // classify (undecryptable, already-shown, unknown chat) is never counted —
+  // privacy beats accuracy on the badge when the user opted hidden chats out.
+  badgePending: number;
   // suppressed: there was something to alert on but the user's global "Show
   // notifications" toggle withheld it → caller skips the generic placeholder AND
   // doesn't badge (nothing to count for the user).
@@ -369,7 +375,7 @@ export async function previewPending(): Promise<PreviewResult> {
     console.warn('[sw-inbox] no session token → generic');
     // Couldn't even authenticate to fetch the queue → uncertain; a real message likely woke us, so
     // honor the placeholder (newUnshown) rather than silently dropping a possible message.
-    return { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: true };
+    return { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: true };
   }
 
   // Kick the device unlock NOW, IN PARALLEL with the fetch below (spec 2010
@@ -401,21 +407,26 @@ export async function previewPending(): Promise<PreviewResult> {
     }
     if (!res.ok) {
       console.warn('[sw-inbox] /relay/pending not ok', res.status);
-      return { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: true, reason: `relay-${res.status}` };
+      return { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: true, reason: `relay-${res.status}` };
     }
     frames = ((await res.json()) as { frames?: MsgFrame[] }).frames ?? [];
   } catch (e) {
     console.warn('[sw-inbox] /relay/pending fetch failed', e);
-    return { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: true, reason: 'relay-error' };
+    return { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: true, reason: 'relay-error' };
   }
   // No pending frames: the message was already drained (page / a prior straggler) or this push carried
   // no queued message (a settings / own-data sync wake). Nothing genuinely new → no placeholder (2016).
-  if (!frames.length) return { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: false, reason: 'no-frames' };
+  if (!frames.length) return { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: false, reason: 'no-frames' };
 
   // Queued message frames = the undelivered backlog → the app-icon badge. Known
   // from the fetch alone, so the badge is right even if we can't decrypt.
   const pending = frames.filter((f) => f.t === 'msg' && !!f.id).length;
   console.info('[sw-inbox] fetched frames', { total: frames.length, pending });
+
+  // Badge mode (spec 1027, B4): under 'never'/'revealed' only frames we can
+  // POSITIVELY attribute to a non-hidden chat may bump the badge.
+  const badgeMode = await setting<string>('privacy.hiddenChatsBadge', 'always');
+  const badgeAll = badgeMode === 'always';
 
   const showMessages = await setting<boolean>('notifications.message.show', true);
 
@@ -431,7 +442,9 @@ export async function previewPending(): Promise<PreviewResult> {
     // Locked but there ARE pending msg frames we couldn't decrypt → a genuinely-new message warrants
     // the placeholder (newUnshown). If only non-msg frames are queued (pending === 0) there's nothing
     // new to announce here.
-    return { notes: [], pending, suppressed: !showMessages, silenced: false, newUnshown: pending > 0, reason: 'locked' };
+    // Locked → nothing is classifiable, so a non-'always' badge adds nothing
+    // here (unreadCount's badge.lastCount fallback still covers the stored part).
+    return { notes: [], pending, badgePending: badgeAll ? pending : 0, suppressed: !showMessages, silenced: false, newUnshown: pending > 0, reason: 'locked' };
   }
 
   const showPreview = await setting<boolean>('notifications.showPreview', true);
@@ -445,6 +458,7 @@ export async function previewPending(): Promise<PreviewResult> {
   const seen = new Set(shown);
 
   const raw: SwNote[] = [];
+  let badgeable = 0; // frames provably in a NON-hidden chat (badge modes never/revealed)
   let withheldMessage = false;
   let silencedMessage = false; // a message intentionally silenced by per-chat prefs
   let decryptFailed = 0; // frames we couldn't decrypt (cold start / session not reachable)
@@ -459,6 +473,14 @@ export async function previewPending(): Promise<PreviewResult> {
       continue; // can't decrypt this one (session not reachable yet) → leave it for the page
     }
     seen.add(f.id);
+    // Classify for the badge (spec 1027): the frame counts only when its chat
+    // resolves AND is provably not hidden. Same resolution noteForPayload uses.
+    if (!badgeAll) {
+      const bChat = payload.groupId
+        ? chats.find((c) => c.id === payload.groupId)
+        : chats.find((c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === f.from);
+      if (bChat && !hidden.has(bChat.id)) badgeable += 1;
+    }
     const { note, wasMessage, silenced } = noteForPayload(f, payload, chats, contacts, showMessages, showPreview, hidden, selfId ?? '');
     if (note) raw.push(note);
     else if (silenced) silencedMessage = true;
@@ -488,7 +510,7 @@ export async function previewPending(): Promise<PreviewResult> {
   // When every fetched frame was already shown (all-seen), decryptFailed === 0 and notes is empty →
   // newUnshown is false → the caller shows NO new placeholder (kills the burst extra-generic).
   const newUnshown = decryptFailed > 0;
-  return { notes, pending, suppressed, silenced, newUnshown, reason };
+  return { notes, pending, badgePending: badgeAll ? pending : badgeable, suppressed, silenced, newUnshown, reason };
 }
 
 /**
@@ -518,10 +540,21 @@ export async function markShown(ids: string[]): Promise<void> {
 
 /** Best-effort unread total from the on-device chats. The SW can't persist the new
  *  message (read-only preview), so the push handler adds the count of fresh
- *  notifications on top for the app-icon badge. */
+ *  notifications on top for the app-icon badge.
+ *
+ *  Honors `privacy.hiddenChatsBadge` (spec 1027, B4): 'never' excludes hidden
+ *  chats; 'revealed' behaves as 'never' here because the reveal session is
+ *  page-memory-only and the SW must never assume it. When the hidden set can't
+ *  be decrypted (locked), fall back to `badge.lastCount` — the page's last
+ *  successfully computed, already preference-filtered total — rather than
+ *  guessing in either direction. */
 export async function unreadCount(): Promise<number> {
   const chats = await getAll<Chat>('chats');
-  return chats.reduce((n, c) => n + (c.unread || 0), 0);
+  const mode = await setting<string>('privacy.hiddenChatsBadge', 'always');
+  if (mode === 'always') return chats.reduce((n, c) => n + (c.unread || 0), 0);
+  const hidden = await readHiddenSetOrNull();
+  if (!hidden) return (await setting<number | null>('badge.lastCount', null)) ?? 0;
+  return chats.reduce((n, c) => n + (hidden.has(c.id) ? 0 : c.unread || 0), 0);
 }
 
 /* ---- friend-request (connection) lifecycle notifications (spec 1015 US2) ---- */

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -386,6 +386,14 @@ export function installTestHook(): void {
       const all = await getAll<{ id: string; isGroup: boolean; participantIds: string[] }>('chats');
       return all.find((c) => !c.isGroup && c.participantIds[0] === peerId)?.id ?? '';
     },
+    /** ALL conversation ids with a peer — plain 1:1s AND pair conversations —
+     *  for the spec-1027 per-person invariant asserts (no duplicate threads). */
+    chatsWith: async (peerId: string): Promise<{ id: string; isGroup: boolean }[]> => {
+      const all = await getAll<{ id: string; isGroup: boolean; participantIds: string[] }>('chats');
+      return all
+        .filter((c) => c.participantIds.length === 1 && c.participantIds[0] === peerId)
+        .map((c) => ({ id: c.id, isGroup: c.isGroup }));
+    },
     /** The VISIBLE (non-pending) 1:1 chat id for a peer, or '' if hidden/none. */
     visibleChatWith: async (peerId: string): Promise<string> =>
       (await listChats()).find((c) => !c.isGroup && c.participantIds[0] === peerId)?.id ?? '',

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -104,6 +104,7 @@ import {
   setCloseFriend as dbSetCloseFriend,
   listCloseFriends as dbListCloseFriends,
   listFriends as dbListFriends,
+  listCallGroups as dbListCallGroups,
   countUnread as dbCountUnread,
   setContactLocalProfile as dbSetContactLocalProfile,
   resetContactToRemote as dbResetContactToRemote,
@@ -415,6 +416,10 @@ export function installTestHook(): void {
       canHide(await getAll<Chat>('chats'), hiddenIdsSync(), chatId),
     hiddenCanUnhide: async (chatId: string) =>
       canUnhide(await getAll<Chat>('chats'), hiddenIdsSync(), chatId),
+    /** The Calls-tab rows' contact ids (what listCallGroups shows) — for the
+     *  spec-1027 knock-knock asserts: hidden peers never appear while relocked. */
+    callHistoryContactIds: async (): Promise<string[]> =>
+      (await dbListCallGroups()).map((g) => g.contactId),
     /** Reveal (verify PIN → start session). Returns whether the PIN was correct. */
     hiddenReveal: (pin: string) => hcReveal(pin),
     /** End the reveal session. */

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -117,6 +117,8 @@ import {
 } from '@/services/hidden-chats';
 import { startHiddenChat as hcStartChat } from '@/services/hidden-chats-start';
 import { resetHiddenChats as hcReset } from '@/services/hidden-chats-reset';
+import { canHide, canUnhide } from '@/services/hidden-pair';
+import { hiddenIdsSync } from '@/services/hidden-state';
 import { revealWithPin as hcReveal, relockHidden as hcRelock } from '@/composables/useHiddenChats';
 import { downloadBlob } from '@/services/media-transfer';
 import {
@@ -408,6 +410,11 @@ export function installTestHook(): void {
     hiddenIds: async (): Promise<string[]> => [...(await hcGetSet())],
     /** Start a distinct hidden chat with a contact; returns the new chat id. */
     hiddenStartChat: (contactId: string) => hcStartChat(contactId),
+    /** The per-person pair-invariant verdicts the actions sheet uses (spec 1027). */
+    hiddenCanHide: async (chatId: string) =>
+      canHide(await getAll<Chat>('chats'), hiddenIdsSync(), chatId),
+    hiddenCanUnhide: async (chatId: string) =>
+      canUnhide(await getAll<Chat>('chats'), hiddenIdsSync(), chatId),
     /** Reveal (verify PIN → start session). Returns whether the PIN was correct. */
     hiddenReveal: (pin: string) => hcReveal(pin),
     /** End the reveal session. */

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -412,7 +412,7 @@ async function showMessageNotification(): Promise<void> {
   // later wakes find everything shown and re-assert silently. Delivery receipts are unaffected.
   await serializeNotify(async () => {
   const preview = previewPending(); // started once; awaited twice (race, then settle)
-  let result: Awaited<ReturnType<typeof previewPending>> = { notes: [], pending: 0, suppressed: false, silenced: false, newUnshown: false };
+  let result: Awaited<ReturnType<typeof previewPending>> = { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: false };
   let timedOut = false; // spec 2014: distinguish a slow cold start from a fetched-but-undecryptable result
   try {
     result = await Promise.race([
@@ -475,7 +475,7 @@ async function showMessageNotification(): Promise<void> {
   // we actually learned from the fetch. When the fetch failed/timed out, pending is
   // 0 and we badge from the stored unread alone rather than inventing a "+1" that
   // teaches a wrong count. A suppressed (notifications-off) push adds nothing.
-  await updateAppBadge(result.suppressed ? 0 : pending);
+  await updateAppBadge(result.suppressed ? 0 : result.badgePending);
   }); // end the initial serialized section (release the lock before the straggler sleeps)
 
   // Catch stragglers from a rapid burst (see STRAGGLER_WINDOW_MS): re-fetch the
@@ -499,7 +499,7 @@ async function showMessageNotification(): Promise<void> {
         await closeByTag(GENERIC_TAG);
         await showNotes(more.notes);
         await markShown(allIds(more.notes));
-        await updateAppBadge(more.suppressed ? 0 : more.pending);
+        await updateAppBadge(more.suppressed ? 0 : more.badgePending);
       }
       return false;
     });


### PR DESCRIPTION
## Spec 1027 — Harden Hidden Chats + one hidden and one visible chat per person

Fixes the six audited defects in the Hidden Chats layer (spec 1019) and delivers the per-person coexistence model. Full pipeline artifacts in `specs/1027-harden-hidden-chats/` (spec, clarifications, plan, research R1-R10, data-model, contracts, quickstart, zero-knowledge checklist — all gates evaluated).

### The privacy contract
When a chat is hidden, nothing shows on the device except the **knock-knock call** (live calls always ring with full caller identity — the half-built "Private caller" masking is removed per FR-013/FR-016) and the **badge** (per the always/never/revealed preference). The only platform-forced carve-out: a push-woken delivery shows a banner byte-identical to the previews-off generic.

### Bugs fixed
- **B1** Hiding your only 1:1 no longer resurrects a visible chat on the peer's next message (or call): inbound frames and call signalling now resolve their ratchet session via rule R (visible 1:1 → hidden 1:1 → reset block → create) instead of `startDirectChat`. The e2e was proven **red against the bug**, green with the fix.
- **B2** Per-person invariant (at most one hidden + one visible chat per person) enforced in the actions sheet with clear reasons; a fresh visible chat with someone whose 1:1 is hidden is a distinct pair conversation (existing sender-key channel — no new crypto).
- **B3** A hidden-chats reset now holds against the **live relay**: peer-keyed, never-synced blocks ack + drop inbound content tracelessly until the user deliberately re-engages.
- **B4** The badge respects the hidden-badge preference everywhere — including the service worker — and a locked-at-boot hidden set falls back to the last good count instead of blanking the whole badge.
- **B5** Relock kicks an open hidden chat back to the Chats list immediately; deep links to hidden chats bounce, including the cold-start window (the guard re-checks the moment the set decrypts).
- **B6** Non-push delivery paths are fully silent for hidden chats (the backgrounded generic bridge is removed).

Plus: the PIN digit count is now sealed at rest (was cleartext), call-history keys follow the coexistence model, and the raw NUL byte in `queries.ts` is an escape (hash pinned by test).

### Zero-knowledge / crypto
No new wire data, no new ciphertext shape, no crypto changes — channel *selection* only between the two existing channels. `messaging.ts` untouched. New device-local state (`hiddenPeer:` blocks, `badge.lastCount`, sealed PIN length) is pinned by the zk never-syncs tests. **Security review requested** (constitution Principle IV).

### Testing
- `npm run build`, `go build/vet/test`: green
- vitest: **514 passed** (60+ new: pair invariant, inbound routing, badge matrix, SW generic pinning, reset ordering, sealed-length migration)
- Playwright e2e: **159/159** including 4 new specs (`hidden-coexist`, `hidden-privacy`, `hidden-call` with real WebRTC, `hidden-reset`)
- Drive scenarios: 9/9 against the live dev stack, incl. a 20-restart no-flash soak (0 leaks, data + DOM) and a 100-message cross-thread isolation soak (0 leaks)

Closes #594
Closes #595
Closes #596
Closes #597
Closes #598
Closes #599
Closes #600
Closes #601
Closes #602
Closes #603
Closes #604
Closes #605
Closes #606
Closes #607
Closes #608
Closes #609
Closes #610
Closes #611
Closes #612
Closes #613
Closes #614
Closes #615
Closes #616
Closes #617
Closes #618
Closes #619
Closes #620
Closes #621
Closes #622
Closes #623
Closes #624
Closes #625
Closes #626
Closes #627
Closes #628
Closes #629
Closes #630
Closes #631
Closes #632
Closes #633
Closes #634
Closes #635
Closes #636
Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbEauS9eXGW7W3c4AATXcF
