### PR TITLE
Add people to a group call + tap phone/email in messages & posts (+ hidden-badge fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1027-harden-hidden-chats/plan.md`
+`specs/1028-robust-audio-and/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@ Specs are grouped by category band; status moves
 | [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
 | [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
 | [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🔵 in-review |
-| [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | ⚪ planned |
+| [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ Specs are grouped by category band; status moves
 | [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
 | [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🔵 in-review |
 | [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🟡 in-progress |
-| [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | ⚪ planned |
+| [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,6 +50,7 @@ Specs are grouped by category band; status moves
 | [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
 | [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🔵 in-review |
 | [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🟡 in-progress |
+| [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,7 @@ Specs are grouped by category band; status moves
 | [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
 | [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
 | [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🔵 in-review |
+| [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/call-add-cap.spec.ts
+++ b/e2e/call-add-cap.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startGroup, hangup, waitRemotes, remoteStreamCount, roster, callState,
+} from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1028, US3 — the PRE-EMPTIVE CLIENT cap gate on the add path. We shrink the
+// CLIENT caps on the adder's device (setCallCaps, the client analogue of the
+// server's call-config override) so a full call needs only 3 contexts. At the cap,
+// Add people is blocked BEFORE anyone is rung and the existing call is undisturbed;
+// the server's JoinIfRoom refusal (covered by call-caps.spec.ts) stays the backstop.
+
+const remaining = (c: any): Promise<number> =>
+  c.page.evaluate(() => (window as any).__ringTest.callRemainingSlots());
+const invited = (c: any): Promise<string[]> =>
+  c.page.evaluate(() => (window as any).__ringTest.callInvited());
+const addPeople = (c: any, ids: string[]): Promise<void> =>
+  c.page.evaluate((x: string[]) => (window as any).__ringTest.addPeople(x), ids);
+
+test('adding past the cap is blocked before ringing; the call is undisturbed (US3)', async ({ browser }) => {
+  test.setTimeout(120_000);
+  const ctx = await Promise.all([0, 1, 2, 3].map(() => browser.newContext()));
+  const [a, b, c, d] = await Promise.all([
+    createAccount(ctx[0], 'ADDCAP1'),
+    createAccount(ctx[1], 'ADDCAP2'),
+    createAccount(ctx[2], 'ADDCAP3'),
+    createAccount(ctx[3], 'ADDCAP4'),
+  ]);
+  await pair(a, b); await pair(a, c); await pair(a, d);
+
+  // Shrink A's client audio cap to 3 so a 3-person call is "full" for the gate.
+  await a.page.evaluate(() => (window as any).__ringTest.setCallCaps(undefined, 3));
+
+  // Fill the 3-seat audio call with A, B, C.
+  const room = 'e2e-add-cap';
+  await startGroup(a, room, 'audio');
+  await startGroup(b, room, 'audio');
+  await startGroup(c, room, 'audio');
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+
+  // At the cap: no free slots, and attempting to add D rings nobody.
+  expect(await remaining(a)).toBe(0);
+  await addPeople(a, [d.id]);
+  await a.page.waitForTimeout(1500);
+  expect(await invited(a)).not.toContain(d.id); // D was never rung
+  expect(await callState(d)).toBe('idle'); // D's device never rang
+
+  // The existing call is undisturbed.
+  expect(await callState(a)).toBe('connected');
+  expect(await remoteStreamCount(a)).toBe(2);
+  expect((await roster(a)).sort()).toEqual([a.id, b.id, c.id].sort());
+
+  // One seat frees up → adding is allowed again.
+  await hangup(c);
+  await a.page.waitForFunction(() => (window as any).__ringTest.callRemainingSlots() >= 1, null, { timeout: 15_000 });
+  expect(await remaining(a)).toBeGreaterThanOrEqual(1);
+
+  for (const p of [a, b, d]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});

--- a/e2e/call-add-merge.spec.ts
+++ b/e2e/call-add-merge.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startGroup, hangup, waitRemotes, remoteStreamCount, roster,
+} from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1028, US2 — add people to an ongoing GROUP call (the MVP add path; no 1:1
+// promotion yet). An existing participant rings a NEW person into the room; on
+// accept they mesh with EVERYONE already in the call, not just the inviter. AUDIO
+// mesh only (headless CI can't run a 3+ person video mesh — see call-quality.spec).
+
+const addPeople = (c: any, ids: string[]): Promise<void> =>
+  c.page.evaluate((x: string[]) => (window as any).__ringTest.addPeople(x), ids);
+const acceptCall = (c: any): Promise<void> =>
+  c.page.evaluate(() => (window as any).__ringTest.accept());
+const waitIncoming = (c: any): Promise<void> =>
+  c.page.waitForFunction(() => (window as any).__ringTest.callState() === 'incoming', null, { timeout: 30_000 });
+
+test('add a new person to an ongoing group audio call — they mesh with everyone (US2)', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const ctx = await Promise.all([0, 1, 2, 3].map(() => browser.newContext()));
+  const [a, b, c, d] = await Promise.all([
+    createAccount(ctx[0], 'ADD01'),
+    createAccount(ctx[1], 'ADD02'),
+    createAccount(ctx[2], 'ADD03'),
+    createAccount(ctx[3], 'ADD04'),
+  ]);
+  // Full pairing so every leg has a ratchet (the same-room key gate would also
+  // cover it, but explicit pairs keep the mesh deterministic under CI load).
+  await pair(a, b); await pair(a, c); await pair(a, d);
+  await pair(b, c); await pair(b, d); await pair(c, d);
+
+  // A, B, C are in a 3-way group audio call.
+  const room = 'e2e-add-people';
+  await startGroup(a, room, 'audio');
+  await startGroup(b, room, 'audio');
+  await startGroup(c, room, 'audio');
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+
+  // A adds D. D rings, accepts, and joins the mesh.
+  await addPeople(a, [d.id]);
+  await waitIncoming(d);
+  await acceptCall(d);
+
+  // Everyone — including the non-initiators B and C — ends up meshed with all 3 others.
+  for (const p of [a, b, c, d]) await waitRemotes(p, 3);
+  expect(await remoteStreamCount(b)).toBeGreaterThanOrEqual(3); // B (not the adder) sees D
+  expect((await roster(b))).toContain(d.id); // B knows about the newly-added D
+  const rd = await roster(d);
+  for (const id of [a.id, b.id, c.id]) expect(rd).toContain(id); // D is meshed with all three
+
+  for (const p of [a, b, c, d]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});

--- a/e2e/tap-entities.spec.ts
+++ b/e2e/tap-entities.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1029 — a phone number and an email in a received message render as tappable
+// entities; tapping opens the OS-handoff action sheet; Copy places the value on the
+// clipboard (native tel:/sms:/mailto: launch itself isn't invocable headless, so we
+// assert the rendered hrefs + the action menu + the copy confirmation).
+
+test('phone + email in a message render tappable with the right actions (US1/US2)', async ({ browser }) => {
+  test.setTimeout(90_000);
+  const a = await createAccount(await browser.newContext(), 'ENT01');
+  // B reads/writes the clipboard to verify Copy (headless needs the grant).
+  const ctxB = await browser.newContext({ permissions: ['clipboard-read', 'clipboard-write'] });
+  const b = await createAccount(ctxB, 'ENT02');
+  await pair(a, b);
+
+  // A sends B a message containing a phone number and an email.
+  const body = 'reach me on +1 415 555 0134 or hi@example.com anytime';
+  const aChat = await a.page.evaluate((peer) => (window as any).__ringTest.startChat(peer), b.id);
+  await a.page.evaluate(([c, t]) => (window as any).__ringTest.sendChatMessage(c, t), [aChat, body] as const);
+
+  // B opens the chat and waits for the message to arrive + render.
+  const bChat = await b.page.evaluate((peer) => (window as any).__ringTest.chatWith(peer), a.id);
+  await b.page.goto(`/chat/${bChat}`);
+  await b.page.waitForFunction(() => (window as any).__ringTest?.isUnlocked() === true, null, { timeout: 30_000 });
+
+  const phone = b.page.locator('a.msg-link[href^="tel:"]');
+  const email = b.page.locator('a.msg-link[href^="mailto:"]');
+  await expect(phone).toBeVisible({ timeout: 20_000 });
+  await expect(email).toBeVisible();
+  // Normalized hand-off targets.
+  await expect(phone).toHaveAttribute('href', 'tel:+14155550134');
+  await expect(email).toHaveAttribute('href', 'mailto:hi@example.com');
+  // The visible text is the number/address as written.
+  await expect(phone).toHaveText('+1 415 555 0134');
+  await expect(email).toHaveText('hi@example.com');
+
+  // Tapping the phone opens the action sheet with Call / Message / Copy.
+  await phone.click();
+  const sheet = b.page.locator('ion-action-sheet');
+  await expect(sheet).toBeVisible({ timeout: 10_000 });
+  for (const label of ['Call', 'Message', 'Copy']) {
+    await expect(sheet.locator('.action-sheet-button', { hasText: label })).toBeVisible();
+  }
+
+  // Copy places the raw number on the clipboard.
+  await sheet.locator('.action-sheet-button', { hasText: 'Copy' }).click();
+  await expect
+    .poll(() => b.page.evaluate(() => navigator.clipboard.readText()), { timeout: 8_000 })
+    .toBe('+1 415 555 0134');
+  await expect(b.page.locator('ion-action-sheet')).toHaveCount(0); // dismissed before the next tap
+
+  // The email offers Email / Copy (no Call/Message).
+  await email.click();
+  const emailSheet = b.page.locator('ion-action-sheet');
+  await expect(emailSheet).toBeVisible({ timeout: 10_000 });
+  await expect(emailSheet.locator('.action-sheet-button', { hasText: 'Email' })).toBeVisible();
+  await expect(emailSheet.locator('.action-sheet-button', { hasText: 'Call' })).toHaveCount(0);
+});

--- a/specs/1028-robust-audio-and/checklists/requirements.md
+++ b/specs/1028-robust-audio-and/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Robust Calls + Add-to-Call
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Two design points are intentionally deferred to `/speckit-clarify`, not guessed
+  here: (1) the exact experience for the *existing* peer when a 1:1 is promoted to a
+  group (seamless auto-follow vs. a lightweight "you're now in a group call" cue),
+  and (2) whether "Add to call" appears for a second *group invite* or only for a
+  1:1/second direct caller. Both are called out in Edge Cases / Assumptions.
+- The spec references the existing caps and mesh only as fixed constraints to reuse,
+  not as new design — those are audited facts, kept out of Success Criteria.

--- a/specs/1028-robust-audio-and/checklists/zero-knowledge.md
+++ b/specs/1028-robust-audio-and/checklists/zero-knowledge.md
@@ -1,0 +1,60 @@
+# Zero-Knowledge & Crypto Discipline Checklist: Robust Calls + Add-to-Call
+
+**Purpose**: Constitution Principle I/IV gate — validate that the 1028 requirements
+themselves are complete, unambiguous, and internally consistent on every
+zero-knowledge, crypto-discipline, and mesh-only dimension before
+`/speckit-implement`. This tests the WRITING, not the implementation.
+**Created**: 2026-07-02
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [data-model.md](../data-model.md)
+**Depth**: formal gate (required for Principle I/IV specs) · **Audience**: pre-implement reviewer
+
+## Wire Silence — no new server capability
+
+- [x] CHK001 - Does the ZK Impact section state that growing a call adds NO new client→server request, frame type, or field, enumerating which existing frames are reused (call-join / call-ring / call-roster / call-offer-answer-ice)? [Completeness, Spec §Zero-Knowledge Impact / FR-017]
+- [x] CHK002 - Is the `joinroom` signal specified as carried INSIDE the existing `call-ice` frame (the hold/resume pattern), so no new transport frame is introduced? [Clarity, data-model §New sealed signal; contracts §transport.ts]
+- [x] CHK003 - Is the `joinroom` payload's content bound explicitly to `{roomId, kind}` only, with a stated requirement that it carries no name, contact id (beyond an opaque room id), or other plaintext? [Completeness, tasks T005; FR-017]
+- [x] CHK004 - Does the spec state what the server DOES see (room membership + numeric cap) and assert it is identical to today's group calls — i.e. "no new signal", falsifiably? [Measurability, Spec §ZK "What metadata is unavoidably visible"]
+- [x] CHK005 - Is promoting a 1:1 to a room described as adding only a room identifier the server already handles for group calls (no new server-visible content)? [Clarity, Spec §ZK]
+
+## Crypto Discipline — reuse only (Principle IV)
+
+- [x] CHK006 - Do the requirements state that NO new primitive, key exchange, or ratchet scheme is introduced — `joinroom` reuses `sealForChat`/`openPacket` over the existing per-pair Double Ratchet? [Completeness, plan §Crypto Discipline / FR-017]
+- [x] CHK007 - Is it specified that `messaging.ts` and the crypto core are untouched, and that per-pair SDP/ICE stays sealed over each pair's session (no plaintext signalling)? [Consistency, plan §Constitution Check IV; contracts §UNCHANGED]
+- [x] CHK008 - Is the mesh-only invariant (no SFU / no server media) stated as a hard constraint, with the SFU-comment cleanup (FR-016) explicitly a no-behaviour-change tidy rather than a code path being reintroduced? [Clarity, Spec §Overview / FR-016]
+- [x] CHK009 - Are adversarial considerations named for the new signal — a forged/replayed `joinroom` can only come from an authenticated pair session, and a bogus roomId can't pull a device into a room it can't decrypt legs for? [Coverage, Gap — confirm the spec/plan addresses joinroom trust]
+
+## Key fetch & membership
+
+- [x] CHK010 - Is the requirement that added/unconnected participants fetch keys ONLY via the existing same-room key gate (SharesCallRoom), for the call's duration, stated — with no new key-fetch permission? [Completeness, Spec §ZK "Key fetch"; research R1]
+- [x] CHK011 - Is it clear that a person becomes reachable for pairwise key fetch only once they are a room member (not merely invited/ringing), matching today's group-call gate? [Clarity, research R1; data-model §joinroom]
+
+## Caps stay authoritative server-side
+
+- [x] CHK012 - Do the requirements keep the numeric caps (4 video / 8 audio) enforced AUTHORITATIVELY on the server (`JoinIfRoom`), with the new client gate described as pre-emptive UX only — not the security boundary? [Consistency, Spec §FR-009/FR-010; research R1]
+- [x] CHK013 - Is "invited counts against capacity" specified so two concurrent adds cannot both pass the client gate and overshoot the cap (with the server as the final backstop)? [Edge Case, data-model §Capacity]
+- [x] CHK014 - For the group-invite merge (US6), is the cap evaluated over the COMBINED distinct headcount, and is the blocked-when-over-cap outcome specified? [Completeness, Spec §FR-003a / SC-009]
+
+## No server changes (verifiable)
+
+- [x] CHK015 - Is "no `server/` diff" an explicit, checkable obligation (a task confirms `go build/vet/test` green AND an empty server diff), with an escalation rule if a server change turns out necessary? [Measurability, tasks T030; plan §ZK notes]
+
+## Consent & privacy of participants
+
+- [x] CHK016 - Is consent-to-be-added specified for every add path (merge + add-people + group-invite merge all RING the added party; no silent pull-in)? [Completeness, Spec §FR-015]
+- [x] CHK017 - Is the existing peer's auto-follow on 1:1→group promotion specified as NOT weakening their security posture (they were already in an authenticated call with the promoter; the new member is authenticated via their own ring)? [Consistency, Spec §Clarifications / FR-002]
+- [x] CHK018 - Is it stated that no new user data is collected or persisted (calls remain ephemeral; call-history logging unchanged)? [Completeness, plan §Storage; Constitution IX]
+
+## Reuse-not-fork consistency
+
+- [x] CHK019 - Are hold/swap/drop + the single-held-slot rule stated as untouched by merge/add (merge acts only on the active call), so the crypto/state invariants of specs 0005/2009 are preserved? [Consistency, Spec §FR-005 / US4]
+- [x] CHK020 - Is kind reconciliation specified to reuse the EXISTING consent-gated video-upgrade flow (no new upgrade mechanism, so no new crypto surface)? [Clarity, Spec §FR-005a; research R5]
+
+## Notes
+
+- Every item tests the written artifacts; an item fails if the cited requirement is
+  missing, vague, or contradicted — not if code differs.
+- CHK009 is the one genuine gap to confirm during planning-to-implement: the spec
+  should state (in ZK Impact or an edge case) that a `joinroom` is only trusted from an
+  authenticated pair session and that a spurious roomId is inert (a device can only
+  participate in legs it can decrypt). If not already covered, add a one-line ZK note
+  before implementing.

--- a/specs/1028-robust-audio-and/contracts/internal-api.md
+++ b/specs/1028-robust-audio-and/contracts/internal-api.md
@@ -1,0 +1,92 @@
+# Internal Module Contracts: 1028 Robust Calls + Add-to-Call
+
+**No HTTP/wire API change intended.** The server is untouched (a task verifies this).
+The only new *wire* element is a sealed `CallSignal` variant carried inside the
+existing `call-ice` frame — opaque to the server. These are the client module
+contracts tasks and tests are written against.
+
+## NEW `src/services/call/capacity.ts` (pure leaf — no WebRTC, no imports beyond types)
+
+```ts
+import { VIDEO_MAX, AUDIO_MAX, type CallKind } from './types';
+
+export function capOf(kind: CallKind): number; // video→4, audio→8
+
+/** Distinct heads currently occupying slots: roster ∪ invited ∪ self. */
+export function headcount(roster: string[], invited: string[], selfId: string): number;
+
+export function remainingSlots(
+  kind: CallKind, roster: string[], invited: string[], selfId: string,
+): number;
+
+/** Pre-emptive add gate (FR-010/FR-011). Reason copy is kind-specific and user-facing. */
+export function canAdd(
+  kind: CallKind, roster: string[], invited: string[], selfId: string, n: number,
+): { ok: true } | { ok: false; reason: string };
+```
+
+Deterministic, synchronous, exhaustively unit-tested (incl. invited-counts-against-cap,
+combined headcount for US6, and the 5th-video / 9th-audio boundaries).
+
+## CHANGED `src/services/call/signalling.ts`
+
+```ts
+/** Promote/merge control: tell a peer to join a mesh room, sealed inside a call-ice
+ *  frame (the sendHoldResume pattern — no new server frame). */
+export function sendJoinRoom(
+  chatId: string, peerUserId: string, callId: string, roomId: string, kind: CallKind,
+): Promise<boolean>;
+```
+
+- Plus: correct the misleading "SFU" doc comments (no behaviour change).
+
+## CHANGED `src/composables/useCall.ts`
+
+```ts
+/** Promote the ACTIVE 1:1 into a mesh room (idempotent if already a room). Reuses the
+ *  live capture; sends joinroom to the existing peer; tears down the 1:1 PC on leg
+ *  connect. Resolves once the room is live locally. */
+async function ensureActiveIsRoom(): Promise<void>;
+
+/** Ring ids into the ACTIVE room after cap-gating + dedup (adds to meta.invited). */
+async function inviteToRoom(ids: string[]): Promise<void>;
+
+/** US2 — user picked contacts to add to the current call. */
+export async function addPeople(ids: string[]): Promise<void>;
+
+/** US1 — accept the current incoming DIRECT caller INTO the active call (merge). */
+export async function mergeIncoming(): Promise<void>;
+
+/** US6 — merge the current incoming GROUP INVITE into the active call. */
+export async function mergeGroupInvite(): Promise<void>;
+
+/** Remaining capacity for the active call, for gating the picker/actions in the UI. */
+export function callRemainingSlots(): number;
+```
+
+- `handleCallFrame` / `handleMeshSignal` / the `call-ice` dispatch gains a `joinroom`
+  case: auto-join the room, reuse the stream, show the cue.
+- The join cue: transient "{name} joined the call" via the existing toast/cue infra.
+- SFU comment cleanup (`~L1346`, `~L1526`).
+
+## CHANGED `src/services/transport.ts`
+
+- Extend the `CallSignal` union with `{ type: 'joinroom', roomId, kind }` (sealed
+  payload only; no new transport *frame* type — it rides `call-ice`).
+
+## CHANGED UI
+
+- `src/components/IncomingCallOverlay.vue`: an **Add to call** action shown when you're
+  already in a call — for a direct caller (→ `mergeIncoming`) and a group invite (→
+  `mergeGroupInvite`), alongside the existing Hold/Decline.
+- `src/views/detail/CallActivePage.vue`: an **Add people** button opening the existing
+  contact picker, gated by `callRemainingSlots()`; confirm → `addPeople(ids)`.
+
+## UNCHANGED (contract pinned by the suite staying green)
+
+- `server/` — no diff (verified).
+- `mesh.ts` public surface (`start`/`onRoster`/`buildLeg`/hold/resume) — the add path
+  drives it via the server roster only.
+- Hold/swap/drop (`acceptAndHold`/`swapCalls`/`heldSlot`) — untouched by merge/add.
+- The consent-gated upgrade (`requestVideoUpgrade`) — reused as-is for kind reconciliation.
+- The crypto core / `messaging.ts` — not modified.

--- a/specs/1028-robust-audio-and/data-model.md
+++ b/specs/1028-robust-audio-and/data-model.md
@@ -1,0 +1,100 @@
+# Data Model: Robust Calls + Add-to-Call
+
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-02
+
+Calls are ephemeral (no IndexedDB change). This defines the in-memory entities the
+new flows touch, the capacity rule, the new sealed signal, and the promotion state
+machine.
+
+## Entities (existing, reused)
+
+### CallMeta (`src/services/call/types.ts`, unchanged shape)
+- `isGroup`, `kind` (`'audio'|'video'`), `roomId?`, `roster: string[]` (in the room),
+  `invited?: string[]` (rung, not yet joined), `peerUserId?`/`chatId?` (1:1).
+- A **1:1** has `isGroup:false`, no `roomId`, a bare `RTCPeerConnection`.
+- A **group** has `isGroup:true`, a `roomId`, a `MeshSession`.
+- **Promotion** turns the former into the latter in place (same `CallMeta` object gains
+  `roomId`, `isGroup:true`, and `roster` grows).
+
+### MeshSession (`src/services/call/mesh.ts`, reused)
+- Owns per-pair legs; `start(existing?)` reuses a captured stream; `onRoster` →
+  `applyRoster` (serialized, set-based) opens/closes legs. No shape change; the add path
+  drives it purely by growing the server roster.
+
+### HeldSlot (spec 0005, unchanged)
+- At most one held call. **Never** touched by merge/add (which act on the active call).
+
+## Capacity (new — pure)
+
+```
+capOf(kind)                         = kind === 'video' ? VIDEO_MAX(4) : AUDIO_MAX(8)
+headcount(roster, invited, self)    = |distinct(roster ∪ invited ∪ {self})|
+remainingSlots(kind, roster, invited) = max(0, capOf(kind) − headcount(...))
+canAdd(kind, roster, invited, n)    = n ≤ remainingSlots(...)  → {ok}
+                                      else {ok:false, reason:"<kind>-specific copy"}
+```
+
+- **Invited counts against capacity** (a ringing placeholder holds a slot) so two
+  concurrent adds can't both squeak past the cap.
+- **US6 (group-invite merge)** evaluates `canAdd` over the **combined distinct** headcount
+  of both rooms' rosters+invited.
+- Server `JoinIfRoom(roomId, userId, capOf(kind))` remains the authoritative backstop.
+
+## New sealed signal: `joinroom`
+
+A new `CallSignal` variant, carried **inside an existing `call-ice` frame** (the
+hold/resume/qos pattern — no new server frame, opaque to the server):
+
+```
+CallSignal { type: 'joinroom', roomId: string, kind: CallKind }
+```
+
+- **Sender**: the promoter (to the existing 1:1 peer) and, for merge-incoming, to the
+  incoming caller.
+- **Receiver action**: join the mesh room (`MeshSession(roomId, kind).start(sharedStream)`,
+  `call-join` with no members), tear down the prior 1:1 PC once the mesh leg connects,
+  and show the "{name} joined the call" cue.
+- Sealed over the pair's Double Ratchet (`sealForChat`/`openPacket`); the server relays
+  ciphertext and learns only that a room is forming (already true for group calls).
+
+## Promotion state machine (per device)
+
+```
+Active call kinds:  ONE_TO_ONE ──promote──▶ ROOM (mesh)
+```
+
+| From | Event | Guard | To | Effects |
+|---|---|---|---|---|
+| ONE_TO_ONE | `ensureActiveIsRoom()` (add/merge initiated) | active is 1:1 | ROOM | mint roomId; MeshSession.start(existingStream); send `joinroom` to peer; tear down 1:1 PC on leg-connect |
+| ONE_TO_ONE | receive `joinroom` from peer | — | ROOM | auto-join room (reuse stream); tear down 1:1 PC on leg-connect; show cue |
+| ROOM | `inviteToRoom(ids)` | `canAdd` passes | ROOM | dedup vs roster∪invited; add to invited; `call-ring` each |
+| ROOM | roster member appears (post-promotion) | — | ROOM | `applyRoster` builds the leg; show cue for a genuinely new member |
+| ROOM | invitee declines / times out | — | ROOM | remove from invited; drop ringing tile |
+| any | promotion times out (peer never joins) | — | leave half-formed room cleanly | no stuck state |
+
+Invariants:
+- **INV-1**: at most one active call + one held call (unchanged); merge/add touch only
+  the active one.
+- **INV-2**: `headcount ≤ capOf(kind)` at all times, gated pre-emptively on the client and
+  backstopped by the server.
+- **INV-3**: exactly one capture (mic/cam) per device for the session; every promotion/add
+  reuses the existing stream (`MeshSession.start(existing)`).
+- **INV-4**: a member present in both a room roster and an incoming set resolves to a
+  single participant / one leg (set semantics in `applyRoster` + `inviteToRoom` dedup).
+
+## Kind reconciliation (merge)
+
+```
+after merge join:
+  wantVideo = active.kind==='video' OR mergedParty.kind==='video'
+  if wantVideo AND headcount ≤ VIDEO_MAX:  run existing consent-gated requestVideoUpgrade
+  else:                                    stay audio; merged party audio-only
+```
+
+## Compose map (new client functions → primitives)
+
+| User action | Composition |
+|---|---|
+| Add people (US2) | `ensureActiveIsRoom()` → `inviteToRoom(pickedIds)` |
+| Merge incoming direct caller (US1) | `ensureActiveIsRoom()` → send `joinroom` to caller → kind reconcile |
+| Merge incoming group invite (US6) | `canAdd(combined)` → `ensureActiveIsRoom()` → `inviteToRoom(inviteRoster − present)` → `call-leave` invite room |

--- a/specs/1028-robust-audio-and/plan.md
+++ b/specs/1028-robust-audio-and/plan.md
@@ -1,0 +1,183 @@
+# Implementation Plan: Robust Calls + Add-to-Call (Merge Incoming, Add People)
+
+**Branch**: `feat/1028-robust-audio-and` | **Date**: 2026-07-02 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1028-robust-audio-and/spec.md`
+
+## Summary
+
+Grow a live call two ways — **merge** an incoming caller (or group invite) into your
+current call, and **add** new people to an ongoing call — within the existing 4-video /
+8-audio caps. The design reuses proven mesh machinery and adds **no new server
+capability**: promotion of a 1:1 to a group is a **sealed `joinroom` control signal**
+(the `sendHoldResume` pattern) plus a fresh mesh room both sides join via the existing
+`call-join`/roster/late-leg path; adding people rings them via the existing in-room
+`call-ring`. Both funnel through one pure **capacity gate** and one **`inviteToRoom`**
+primitive. Kind reconciliation reuses the existing consent-gated video upgrade; the
+existing peer auto-follows with a "{name} joined the call" cue. Plus a robustness pass
+over the add/roster/leg lifecycle and cleanup of dead "SFU" comments. Design rationale
+and code anchors: [research.md](./research.md).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (Vue 3 `<script setup>`, Ionic 8); **no server
+changes intended** (Go untouched — verified by a task)
+
+**Primary Dependencies**: native WebRTC (mesh, DTLS-SRTP), the existing
+`src/services/call/` engine (`mesh.ts`, `signalling.ts`, `useCall.ts`), sealed
+signalling over each pair's Double Ratchet (`messaging.ts` via `signalling.ts`)
+
+**Storage**: none new (calls are ephemeral; call-history logging unchanged)
+
+**Testing**: vitest (pure capacity/decision helpers), Playwright `e2e/` (audio meshes
++ 2-person proxies), `drive/` scenarios (video path / real-device)
+
+**Target Platform**: PWA (iOS Safari / Android Chrome / desktop); WebRTC mesh
+
+**Project Type**: web app (client-only change)
+
+**Performance Goals**: merge completes < 10s to three-way media (SC-001); no second
+capture / no camera re-prompt (SC-006); no regression to first-connect speed (spec 2008)
+
+**Constraints**: mesh only (no SFU); zero-knowledge (no new server-visible data); caps
+4 video / 8 audio unchanged; single held slot unchanged; CI cannot run 3-person video
+mesh headless
+
+**Scale/Scope**: ~6 client files touched + a new pure `capacity.ts` + tests; the crypto
+core and the server are NOT modified
+
+## Constitution Check
+
+*GATE: constitution v1.2.0 — re-checked after Phase 1 design: PASS.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Zero-Knowledge Boundary | ✅ | No new server-visible data. `joinroom` is an opaque sealed `CallSignal` inside an existing `call-ice` frame; promotion/add reuse existing group-call signalling + the same-room key gate. Mandatory ZK Impact section present. |
+| II. Spec-Driven Development | ✅ | Spec 1028 (ad-hoc), pipeline followed: specify → clarify (3 Qs) → plan → tasks → analyze → taskstoissues → implement. |
+| III. Test-Driven Development | ✅ | tasks.md orders failing tests first; pure capacity/decision helpers unit-first; new user-facing behaviour gets e2e. Not a `2001+` bug spec, so no single regression-test mandate, but robustness fixes get targeted tests. |
+| IV. Crypto Discipline | ✅ | No new primitives/schemes. `joinroom` reuses `sealForChat`/`openPacket` exactly like hold/resume; per-pair ratchet unchanged; `messaging.ts` untouched. The one new sealed `CallSignal.type` carries only `{roomId, kind}` (opaque to the server). `/speckit-checklist` REQUIRED (Principle I/IV) before implement; security review on the PR. |
+| V. Offline-First Data Integrity | ✅ | No IndexedDB store/schema change; calls are ephemeral. |
+| VI. Stateless Server & Migrations | ✅ | Server untouched (a task verifies `go build/vet/test` stays green with no `server/` diff). |
+| VII. Quality Gates | ✅ | `npm run build`, vitest, `go build/vet/test`, e2e for changed behaviour. Release-note-style commit subjects. |
+| VIII. Traceable Delivery | ✅ | `make roadmap`; taskstoissues; PR lists `Closes #N`. |
+| IX. Privacy & Data Minimization | ✅ | No new data collected; room membership is the same signal group calls already expose. |
+| X. Accessibility & i18n | ✅ | Add-people picker + "Add to call" action on stock Ionic; cue is plain copy; no direction-risk text. |
+| XI. Ionic-First UI | ✅ | Add-people uses the existing contact-picker pattern; "Add to call" is a button on the existing incoming overlay; the join cue is `ion-toast`/existing cue infra — no bespoke widgets. |
+
+No violations → Complexity Tracking omitted. **One standing risk (not a violation):**
+promoting a live 1:1 to a mesh mid-call is inherently the most fragile change; mitigated
+by reusing the proven late-join path (R2) rather than migrating a live PC, and by the
+robustness tests (US5).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1028-robust-audio-and/
+├── plan.md              # This file
+├── research.md          # Phase 0 — audit + decisions R1-R10
+├── data-model.md        # Phase 1 — call/room/roster entities + promotion state machine
+├── quickstart.md        # Phase 1 — implementation slices
+├── contracts/
+│   └── internal-api.md  # Phase 1 — new client fns + the joinroom signal (no HTTP change)
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/services/call/
+├── capacity.ts            # NEW — pure cap gate (capOf/remainingSlots/canAdd)
+├── capacity.test.ts       # NEW
+├── types.ts               # (unchanged caps; maybe a Capacity type)
+├── mesh.ts                # start(existing) reuse already exists; verify roster dedup on add
+└── signalling.ts          # NEW: sendJoinRoom (sealed CallSignal 'joinroom'); comment fixes
+
+src/composables/
+└── useCall.ts             # ensureActiveIsRoom (promotion), inviteToRoom, mergeIncoming,
+                           #   addPeople, joinroom dispatch, join cue; SFU comment cleanup
+
+src/components/
+├── IncomingCallOverlay.vue  # "Add to call" action (direct caller + group invite)
+└── (contact picker reuse for Add people)
+
+src/views/detail/
+└── CallActivePage.vue     # "Add people" button + picker entry; roster/tiles already reactive
+
+e2e/  (+ call-add-merge.spec.ts, call-add-cap.spec.ts; extend call-waiting.spec.ts)
+drive/scenarios/  (+ promote-1to1-video.mjs; extend group-call-4.mjs)
+```
+
+**Structure Decision**: client-only; the one new module (`capacity.ts`) is a pure leaf
+so the cap math is unit-tested without WebRTC. All new call orchestration lives in the
+existing `useCall.ts` / `signalling.ts` / `mesh.ts` so it composes with the proven
+hold/swap/roster code rather than forking it.
+
+## Design (Phase 1 summary — details in data-model.md / contracts/)
+
+### D1. Promotion (1:1 → mesh) — the `joinroom` signal (R2)
+`ensureActiveIsRoom()`: if the active call is a 1:1, mint a `roomId`, build a
+`MeshSession(roomId, kind).start(existingStream)`, send a sealed `CallSignal
+{type:'joinroom', roomId, kind}` to the peer over the existing `call-ice` channel, and
+tear the 1:1 PC down once the mesh leg connects. The peer's `handleMeshSignal`/`call-ice`
+dispatch gains a `joinroom` case: auto-join the room (reuse stream), show the cue. Result:
+a mesh room reusing the proven late-join legs. Idempotent when already a room.
+
+### D2. Add-people (US2) + merge (US1/US6) via `inviteToRoom` (R3)
+`inviteToRoom(ids)`: dedup vs `roster ∪ invited`, cap-gate (D3), add to `meta.invited`,
+`call-ring` each. Composed:
+- **addPeople(pickedIds)** = `ensureActiveIsRoom()` → `inviteToRoom`.
+- **mergeIncoming()** (direct caller) = `ensureActiveIsRoom()` → send `joinroom` to the
+  incoming caller (they join instead of a 1:1 answer); reuse their capture.
+- **mergeGroupInvite()** (US6) = cap-check combined distinct headcount →
+  `ensureActiveIsRoom()` → `inviteToRoom(inviteRoster − present)` → `call-leave` the
+  incoming invite room.
+
+### D3. Capacity gate (R4) — `capacity.ts`
+Pure `capOf`/`remainingSlots`/`canAdd`. The picker disables past `remainingSlots`;
+merge/add call `canAdd` before ringing; server `JoinIfRoom` is the backstop. US6 uses the
+combined distinct headcount.
+
+### D4. Kind reconciliation (R5)
+After a merge join: if wanted AND combined ≤ `VIDEO_MAX`, run the existing
+`requestVideoUpgrade` (consent-gated); else audio-only. No new mechanism.
+
+### D5. Cue (R6) + robustness (R7)
+Transient "{name} joined the call" toast on `joinroom` / new post-promotion roster member.
+Robustness: reuse `rosterChain` serialization + set-based `applyRoster`; `inviteToRoom`
+dedups; add-in-flight guard before a swap; a promotion timeout that leaves a half-formed
+room cleanly rather than stalling.
+
+### D6. Cleanups (R9)
+Fix the misleading "SFU" comments in `useCall.ts`; remove any dead SFU remnants (no
+behaviour change).
+
+## Zero-Knowledge & Crypto Review Notes (Principle I/IV gate)
+- No new server frame or field; `joinroom` is an opaque sealed `CallSignal` (server
+  relays ciphertext, same as hold/resume/qos). Room membership + the numeric cap are the
+  only server-visible signals — identical to today's group calls.
+- `messaging.ts` and the crypto core are untouched; `joinroom` uses the existing
+  `sealForChat`/`openPacket`.
+- A task verifies **no `server/` diff** is required; if one is, it is escalated before
+  adding any server capability.
+- `/speckit-checklist` (Principle I/IV) generated before implement; PR security review.
+
+## Testing strategy (SC-001…009; CI-constrained)
+Red → Green ordering in tasks.md: pure `capacity.ts` tests first; then per-slice failing
+e2e before the orchestration lands.
+1. **Unit**: `capacity.ts` (cap math, kind, combined headcount); a pure merge/roster
+   decision helper where extractable.
+2. **e2e (audio + 2-person proxies)**: merge incoming → 3-way audio (SC-001/002);
+   add-people meshes a non-initiator (SC-002); cap gate blocks 5th video / 9th audio
+   (SC-003); merge leaves a held call intact (SC-004); group-invite merge fits vs blocked
+   (SC-009); existing-peer cue (SC-008).
+3. **drive (video / real-device)**: promote-1:1-to-3-way video; extend `group-call-4`.
+4. Keep ALL existing call e2e/unit green (SC-007).
+
+## Complexity Tracking
+No constitution violations — table intentionally empty. The mesh-promotion risk is
+tracked in the Constitution Check note and mitigated by design (reuse late-join, not PC
+migration) + the US5 robustness tests.

--- a/specs/1028-robust-audio-and/quickstart.md
+++ b/specs/1028-robust-audio-and/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: 1028 Robust Calls + Add-to-Call — implementation slices
+
+**Plan**: [plan.md](./plan.md) | Ordered so each slice is independently landable and
+tests come first inside every slice (Red → Green). Riskiest change (promotion) is
+isolated in Slice 3 behind the proven late-join path.
+
+## Slice 0 — Capacity gate (pure, no WebRTC)
+
+1. `src/services/call/capacity.test.ts` first: `capOf`, `headcount` (distinct roster ∪
+   invited ∪ self), `remainingSlots`, `canAdd` — incl. invited-counts-against-cap, the
+   5th-video / 9th-audio boundaries, and the US6 combined headcount.
+2. Implement `src/services/call/capacity.ts`. Wire `callRemainingSlots()` in useCall to it.
+
+## Slice 1 — Add people to an EXISTING group call (US2, no promotion yet)
+
+1. Failing e2e (`e2e/call-add-merge.spec.ts` part 1, AUDIO 3→4): A+B+C in a group
+   audio call; A adds D; D rings, accepts, meshes with A, B, AND C (assert from B).
+2. `inviteToRoom(ids)` in useCall (dedup + `canAdd` + add to invited + `call-ring`).
+3. `Add people` button + contact picker in `CallActivePage.vue`, gated by
+   `callRemainingSlots()`.
+4. drive: extend `group-call-4.mjs` to add a 4th mid-call.
+
+## Slice 2 — Pre-emptive cap gate (US3)
+
+1. Failing e2e (`e2e/call-add-cap.spec.ts`): fill an audio call to 8 → Add people
+   disabled/blocked with reason; a video call to 4 → blocked; just-below allowed.
+2. Enforce `canAdd` in the picker (disable over-cap) + the action; server `call-full`
+   remains the backstop (assert the local call is undisturbed on any refusal).
+
+## Slice 3 — Promotion 1:1 → mesh (the risky core) + `joinroom`
+
+1. Failing unit: `joinroom` seal/open round-trip; the `call-ice` dispatch routes a
+   `joinroom` signal to the room-join handler.
+2. Failing e2e (`call-add-merge.spec.ts` part 2, AUDIO): A+B in a 1:1; A promotes →
+   both land in a mesh room reusing capture; assert B auto-followed (no ring) and got
+   the join cue.
+3. Implement `sendJoinRoom` (signalling), the `joinroom` dispatch case, and
+   `ensureActiveIsRoom()` (mint room, MeshSession.start(existingStream), send joinroom,
+   tear down 1:1 PC on leg connect). Add the promotion timeout / clean half-formed-room
+   fallback.
+
+## Slice 4 — Merge an incoming DIRECT caller (US1)
+
+1. Failing e2e (AUDIO 1:1 + 1): A+B in a call; C calls A; A taps **Add to call** →
+   `ensureActiveIsRoom()` then send `joinroom` to C; assert A, B, C all meshed, A's
+   capture reused (SC-006), and if C declines the call is unaffected (FR-004).
+2. `Add to call` action in `IncomingCallOverlay.vue` (direct caller) → `mergeIncoming`.
+3. Kind reconciliation (D4): C video-calls an audio A+B ≤4 → consent-gated upgrade
+   runs; >4 → C audio-only (unit-test the decision; e2e the ≤4 upgrade path on 2-person
+   proxy where feasible).
+
+## Slice 5 — Merge coexists with hold/swap (US4)
+
+1. Failing e2e (extend `call-waiting.spec.ts`): A active with X, holding Y; C calls; A
+   merges C into X; assert Y still held + paused; swap to Y works; single-held-slot
+   invariant holds.
+2. Add-in-flight guard so an add completes/cancels cleanly before a swap parks the call
+   (FR-014).
+
+## Slice 6 — Merge an incoming GROUP INVITE (US6)
+
+1. Failing e2e (AUDIO): A+B in a call; C invites A to a group with D; A **Add to call**
+   → fold C+D into A+B within cap; assert one combined call, dedup of any shared member;
+   and a separate case where the combined headcount exceeds the cap → blocked with reason
+   (SC-009).
+2. `mergeGroupInvite()`: `canAdd(combined)` → `ensureActiveIsRoom()` →
+   `inviteToRoom(inviteRoster − present)` → `call-leave` the invite room. `Add to call`
+   on a group invite in `IncomingCallOverlay.vue`.
+
+## Slice 7 — Robustness pass (US5)
+
+1. Failing e2e/drive: concurrent join+leave on an audio mesh; simultaneous add of the
+   same person (dedup); invitee reload mid-ring (reuse spec 2012) then accept → no
+   duplicate, no stuck ringing tile.
+2. Fix anything the churn tests expose in `applyRoster`/`inviteToRoom`/cue.
+
+## Slice 8 — Cleanups + video validation
+
+1. Fix the misleading "SFU" comments in `useCall.ts` (`~L1346`, `~L1526`); grep + remove
+   any dead SFU remnants (no behaviour change; suite stays green).
+2. drive `promote-1to1-video.mjs`: promote a 1:1 to a 3-way VIDEO call on the live stack
+   (real-device/interactive validation — NOT headless CI).
+3. Verify **no `server/` diff**: `cd server && go build ./... && go vet ./... && go test
+   ./...` green with the server untouched.
+
+## Gates before PR
+
+```sh
+npm run build            # vue-tsc + vite
+npx vitest run           # unit + coverage floors
+npm run test:e2e         # Playwright (needs make db-up) — audio meshes + 2-person proxies
+cd server && go build ./... && go vet ./... && go test ./...   # untouched, verified
+```
+
+`/speckit-checklist` (crypto/ZK — required for the `joinroom` signal) generated + satisfied;
+security review requested on the PR. 3-person **video** mesh validated via drive/real device,
+never headless CI.

--- a/specs/1028-robust-audio-and/research.md
+++ b/specs/1028-robust-audio-and/research.md
@@ -1,0 +1,171 @@
+# Phase 0 Research: Robust Calls + Add-to-Call
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-07-02
+
+This feature extends live WebRTC **mesh** calling — the most fragile part of the
+app. The research goal is a design that reuses proven machinery (mesh join,
+serialized roster, late-joiner legs, consent-gated upgrade, invite recovery) and
+adds **no new server capability**, so the risk is contained to well-scoped client
+seams. Every decision below is anchored to the current code.
+
+## R1. Current mechanics (audit, file:line)
+
+- **Caps already exist**: `VIDEO_MAX=4`, `AUDIO_MAX=8` (`src/services/call/types.ts:10-11`);
+  server mirror + authoritative enforcement `registry.go` `JoinIfRoom` (over-cap join
+  refused, `call-full` to joiner only; an already-present user is always re-admitted).
+  Audio→video upgrade already blocked above `VIDEO_MAX`.
+- **1:1 calls are a bare `RTCPeerConnection`**, not a `MeshSession` (`useCall.ts`
+  `handleOffer`/`acceptCall`/`startDirectCall`). **Group calls are a `MeshSession`**
+  (`src/services/call/mesh.ts`) keyed by a `roomId`.
+- **Mesh join / roster / late-join**: `MeshSession.start` sends `call-join`
+  (`mesh.ts:207`); the server rings the initiator's `members` and `broadcastRoster`s;
+  each client's `onRoster` → `applyRoster` (`mesh.ts:225`) opens a leg to each new peer
+  (`buildLeg`) and closes departed legs — **serialized through `rosterChain`** so
+  bursts never interleave. A late joiner already meshes with everyone (e2e-tested).
+- **Ringing a new id into a room**: server `call-ring` handler requires the sender be
+  `InRoom` and rings an arbitrary `To`, broadcasting `ringing` room-wide
+  (`hub.go:1581`). The client already **inserts an unknown id into `meta.invited`** on
+  a `call-member` `ringing` broadcast (`useCall.ts:2995-2999`). Today only
+  `recallMember` (`useCall.ts:1506`, re-ring an original invitee) and `cancelInvite`
+  use this — never for a brand-new id.
+- **Hold/swap (spec 0005)**: `acceptAndHold`/`parkActiveAsHeld`/`swapCalls`; single
+  `heldSlot`; hold rides a **sealed `CallSignal` inside an existing `call-ice` frame**
+  (`sendHoldResume`, `signalling.ts:88`) — the proven pattern for a new control signal
+  with **no new server frame**. Second-incoming uses the single `incomingSecond` slot.
+- **Consent-gated video upgrade**: `requestVideoUpgrade`/`acceptUpgrade`/`rejectUpgrade`
+  (`useCall.ts:2569-2593`), `call-upgrade-*` frames relayed by the server.
+- **Shared capture on the second call**: `MeshSession.start(existing)` reuses an
+  already-captured stream instead of a second `getUserMedia` (`mesh.ts:188-201`) —
+  exactly what a merge needs (one capture per device).
+
+## R2. Decision — promotion architecture (1:1 → mesh), the crux
+
+**Decision**: Promotion is a **sealed control signal + a fresh mesh room**, not an
+in-place migration of the existing 1:1 `RTCPeerConnection`.
+
+Flow to promote a 1:1 with peer P to a group and add new caller/contact N:
+1. Promoter mints `roomId = uid()`, constructs `MeshSession(roomId, kind, cb,
+   members=[])` and `start(existingStream)` — **reusing the current capture** (no
+   second gUM), sending `call-join` (no members → a plain join, the promoter is first
+   into the room).
+2. Promoter sends a **sealed `CallSignal { type: 'joinroom', roomId, kind }`** to P
+   over their existing 1:1 `call-ice` channel (the `sendHoldResume` pattern). P's
+   device auto-joins the room (`MeshSession(roomId).start(existingStream)`, `call-join`
+   no members), tears its old 1:1 PC down once its mesh leg connects, and shows the
+   "{name} joined the call" cue (FR-002 / SC-008).
+3. The server `broadcastRoster`s as each joins; `applyRoster` builds the P↔promoter
+   leg **fresh inside the room** (reuses the proven late-join path — no PC migration).
+4. Bringing in N differs by source:
+   - **Add-people (US2)**: N is rung via `call-ring` (`inviteToRoom`), joins normally.
+   - **Merge-incoming (US1)**: N is the caller who just rang us on a 1:1. Instead of a
+     1:1 answer we reply with the same sealed `joinroom` signal (over N's incoming
+     1:1 `call-ice`/answer channel); N joins the room; their original 1:1 offer is
+     superseded.
+
+**Why not migrate the existing PC into a mesh leg**: reusing an established
+`RTCPeerConnection` as a room leg means rewriting its signalling identity and racing
+renegotiation — far more fragile. Rebuilding the pair leg inside the room reuses the
+exact code a late joiner already exercises (proven, e2e-covered). The one-time cost is
+a brief renegotiation of the existing pair, which is acceptable.
+
+**No server change**: `joinroom` is an opaque sealed `CallSignal` (like hold/resume);
+`call-join`/`call-ring`/`broadcastRoster`/`JoinIfRoom` already exist. The server sees
+a group room forming — a shape it already handles.
+
+**Alternatives considered**: (a) server-side "promote 1:1 to room" frame — rejected,
+adds server capability for no gain; (b) migrate the live PC — rejected, fragile.
+
+## R3. Decision — one shared primitive for both new capabilities
+
+**Decision**: Both merge and add-people compose two primitives:
+- `ensureActiveIsRoom()` — if the active call is a 1:1, run R2's promotion (idempotent
+  once it's already a room).
+- `inviteToRoom(ids: string[])` — cap-gate, add each to `meta.invited`, `call-ring`
+  each into the room; the roster/leg machinery meshes them on accept.
+
+Then:
+- **US2 add-people** = `ensureActiveIsRoom()` → `inviteToRoom(pickedIds)`.
+- **US1 merge-incoming direct caller** = `ensureActiveIsRoom()` → send `joinroom` to
+  the incoming caller (they join instead of a 1:1 answer).
+- **US6 merge group invite** = `ensureActiveIsRoom()` → `inviteToRoom(inviteRoster
+  minus already-present)`, then decline the incoming invite room (`call-leave`),
+  subject to the combined-headcount cap.
+
+This keeps the new surface tiny and funnels every add through the same cap gate and
+the same mesh join.
+
+## R4. Decision — pre-emptive cap gate (pure, tested)
+
+**Decision**: a pure helper `src/services/call/capacity.ts`:
+- `capOf(kind)` → `VIDEO_MAX | AUDIO_MAX`.
+- `remainingSlots(kind, roster, invited)` → cap − |distinct(roster ∪ invited ∪ self)|.
+- `canAdd(kind, roster, invited, n)` → `{ ok } | { ok:false, reason }` (kind-specific
+  copy).
+The add-people picker disables selections past `remainingSlots`; merge/add actions call
+`canAdd` before ringing (FR-010/FR-011). The server `JoinIfRoom` stays the backstop.
+For US6, `canAdd` is evaluated over the **combined distinct** headcount of both rosters.
+
+## R5. Decision — kind reconciliation on merge (reuse the upgrade flow)
+
+**Decision**: no new mechanism. After a merge completes the join:
+- If the merged party (or the active call) wants video AND the combined headcount ≤
+  `VIDEO_MAX`, run the **existing consent-gated `requestVideoUpgrade`** so each
+  participant opts in — exactly today's flow (`useCall.ts:2569`).
+- If the combined headcount > `VIDEO_MAX`, no upgrade: the merged party joins
+  audio-only and the call stays audio (reuses the existing above-cap upgrade block).
+A video call absorbing an audio participant keeps video; that participant may enable
+their camera under the same consent flow. (Clarification 2.)
+
+## R6. Decision — the existing-peer cue (US1 / SC-008)
+
+**Decision**: on receiving `joinroom` (P's promotion) and on a new roster member
+appearing after promotion, show a transient "{name} joined the call" toast via the
+existing cue/toast infra — no consent prompt (Clarification 1). Reuses the goodbye-wave
+sibling pattern (roster diffs already drive tile add/remove animations).
+
+## R7. Decision — robustness pass (FR-013/014, US5)
+
+**Decision**: lean on existing serialization + set semantics; fix the identified gaps:
+- **Cap race** (audit fragility #3): today a mid-call add would only fail server-side
+  with `call-full`; the R4 pre-emptive gate closes it.
+- **Concurrent join/leave & simultaneous same-person add**: `rosterChain` serializes
+  roster application; `applyRoster` is set-based (idempotent — a duplicate add resolves
+  to one leg). `inviteToRoom` dedups against `roster ∪ invited`.
+- **Invitee reload mid-ring**: reuses spec 2012 invite-recovery unchanged (the added
+  invite is an ordinary ring).
+- **Add-then-swap** (FR-014): merge/add act only on the ACTIVE call; `heldSlot` is
+  untouched. Add a guard so an add in flight completes (or is cancelled cleanly) before
+  a swap parks the call — no half-open leg.
+- **Promotion interrupted** (promoter or P drops mid-promote): if P never joins the
+  room, the promoter's room still forms (P simply appears offline/ringing); define a
+  timeout that falls back to leaving the half-formed room rather than a stuck state.
+
+## R8. Decision — no server changes (verify in implementation)
+
+**Decision**: target **zero** server changes. `call-join`, `call-ring` (in-room sender
+rings arbitrary To), `broadcastRoster`, `JoinIfRoom` (cap backstop), and opaque sealed
+`call-ice` relay already cover promotion + invite. A task explicitly **verifies** no
+`server/` change is needed (and that `go test ./...` stays green untouched); if a gap
+is found, it is raised before adding any server capability (constitution I/VI).
+
+## R9. Decision — SFU comment cleanup (FR-016)
+
+**Decision**: correct the misleading "SFU" comments (`useCall.ts:~1346`, `~1526`) to
+say "mesh session"; grep the tree for dead SFU identifiers and remove any unreachable
+remnants. No behaviour change; covered by the existing suite staying green.
+
+## R10. Decision — testing under the CI constraint
+
+**Decision**:
+- **Unit (vitest)**: the pure `capacity.ts` helpers; a pure roster/merge decision
+  module (`ensureActiveIsRoom`/`inviteToRoom` planning as pure functions where feasible).
+- **e2e (Playwright)**: on **audio** meshes (3–4 people) + 2-person proxies — merge an
+  incoming caller into a 1:1 → 3-way audio; add-a-person to an ongoing audio call and
+  assert a non-initiator also meshes; the pre-emptive cap gate blocks the 5th video /
+  9th audio; merge leaves a held call intact; group-invite merge fits vs. blocked.
+- **drive scenarios**: the **video** path (`group-call-4.mjs` extended) + a promote-1:1
+  →video-3-way scenario for real-device/interactive validation.
+- **Never** a 3-person video mesh in headless CI (documented flaky —
+  `e2e/call-quality.spec.ts:44-51`).
+
+All NEEDS CLARIFICATION resolved (the three clarify answers are folded into R2/R5/R3).

--- a/specs/1028-robust-audio-and/spec.md
+++ b/specs/1028-robust-audio-and/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1028-robust-audio-and/spec.md
+++ b/specs/1028-robust-audio-and/spec.md
@@ -1,0 +1,447 @@
+# Feature Specification: Robust Calls + Add-to-Call (Merge Incoming, Add People)
+
+**Feature Branch**: `feat/1028-robust-audio-and`
+
+**Created**: 2026-07-02
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Evaluate and robusten the audio/video calls and the scenarios around them. Today we can put a call on hold and answer another while keeping them waiting and swap between them; I also want the option to accept an incoming caller and ADD them to the existing call, and while in a call to add a 3rd or 4th (or more) person to the ongoing call. The 4-person limit is for video calls and the 8-person limit for audio calls. Use Playwright as much as possible and test the behaviours."
+
+## Overview
+
+Ring's calling is a peer-to-peer WebRTC **mesh**: a 1:1 is a single encrypted
+connection, a group call is one connection per pair of people, and the
+zero-knowledge server only relays sealed signalling — it never sees or mixes
+media. On top of that, call waiting already works: you can put a call on hold,
+answer a second one, swap between them, and drop either (specs 0004/0005/2009).
+
+What's missing is **growing a call**. Today the only way to have more people on a
+call is to invite them all when it starts; once a call is running there is no way
+to bring a new person in, and a second incoming caller can only be held and
+swapped — never joined into the conversation you're already having. This feature
+adds two ways to grow a live call, keeps the existing per-kind size limits (a
+video call tops out at 4 people, an audio call at 8), and does a broader
+reliability pass over the add/merge/roster machinery.
+
+1. **Merge an incoming caller into your current call.** When someone calls you
+   while you're already in a call, alongside today's "accept and hold" you get a
+   third choice: **add them to this call**. A 1:1 becomes a small group; a group
+   call gains one more person. You keep using the same microphone and camera — no
+   second setup, no dropped audio.
+
+2. **Add people to an ongoing call.** From inside a call, an **Add people** action
+   lets you pick one or more contacts and ring them into the call you're already
+   on. They ring like any call invite and can decline; when they accept, they join
+   the mesh and everyone sees them appear.
+
+Both paths respect the existing limits: a **video call never exceeds 4
+participants and an audio call never exceeds 8**. Those limits are already
+enforced by the server; this feature makes the client refuse an over-limit add
+*before* it's attempted, with a clear reason, instead of letting it fail after
+the fact.
+
+This is a mesh-only feature by design (Ring has no media server), so the size
+limits exist because every added person adds a connection to everyone else. The
+server learns nothing new: it already relays group-call signalling and enforces
+room size; growing a call reuses exactly that.
+
+## Clarifications
+
+### Session 2026-07-02
+
+- Q: When a 1:1 is promoted to a group by merging a 3rd person, what does the
+  EXISTING peer experience? → A: Their device auto-follows into the group
+  (it follows the new roster, the same path a late joiner already uses) AND shows a
+  brief "{name} joined the call" cue — no consent prompt (they are already in the
+  call with you). The added person consents by answering the ring.
+- Q: Merging a caller whose kind differs from the current call — what kind results?
+  → A: Upgrade to video if either side wants it, subject to the 4-person video cap.
+  Merging a video caller into an audio call triggers the EXISTING consent-gated
+  video-upgrade flow when the combined call has ≤ 4 people; if it already has more
+  than 4, no upgrade — the merged person joins audio-only and the call stays audio.
+- Q: Does "Add to call" also apply to an incoming GROUP invite, not just a direct
+  1:1 caller? → A: Yes. You can merge an incoming group invite into your current
+  call too, folding the two rosters into one call, subject to the kind cap on the
+  combined distinct participants (if it wouldn't fit, the merge is blocked with a
+  clear reason, per the US3 pre-emptive gate). The direct second caller remains the
+  primary, simplest path.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Merge an incoming caller into the call you're on (Priority: P1)
+
+You're on a call with Ana. Ben calls you. The incoming banner offers **Add to
+call** in addition to Hold and Decline. You tap Add to call: Ben rings in, and
+when he answers, you, Ana, and Ben are all in one call together. Your mic and
+camera keep working the whole time; you never had to hang up or re-setup.
+
+**Why this priority**: This is the headline capability the user asked for and the
+one with no equivalent today (a second caller can only be held/swapped).
+
+**Independent Test**: Three accounts. A calls B (they connect). C calls A. A
+chooses "Add to call". Assert all three end up connected to each other in one
+call and media flows among them, with A's existing stream reused (no second
+capture).
+
+**Acceptance Scenarios**:
+
+1. **Given** you're in a 1:1 call, **When** a third person calls and you choose Add
+   to call, **Then** the 1:1 becomes a group call containing all three and media
+   flows among everyone.
+2. **Given** you're in a group call, **When** another person calls and you choose
+   Add to call, **Then** they are rung into the existing call and join the group on
+   accept.
+3. **Given** you merge an incoming caller, **When** they are added, **Then** your
+   microphone/camera keep running uninterrupted (the existing capture is reused).
+4. **Given** the incoming caller declines to be added or doesn't answer, **When**
+   the ring lapses, **Then** your existing call is unaffected and continues.
+5. **Given** a 1:1 is promoted to a group, **When** the third person joins, **Then**
+   the existing peer's device auto-follows into the group and shows a brief
+   "{name} joined the call" cue (no consent prompt for them).
+6. **Given** you're in an audio call and merge a video caller, **When** the combined
+   call has 4 or fewer people, **Then** the existing consent-gated video-upgrade
+   flow runs; **when** it already has more than 4, the merged person joins audio-only
+   and the call stays audio.
+
+---
+
+### User Story 2 - Add people to an ongoing call (Priority: P1)
+
+You're in a call and want to pull in a couple more friends. You tap **Add people**,
+pick them from your contacts, and confirm. They ring into the call; as each
+accepts, they appear in the call and everyone can hear/see them.
+
+**Why this priority**: The second half of "grow a live call" — proactively adding,
+not just reacting to an incoming caller. No path exists today for someone not
+invited at the start.
+
+**Independent Test**: A and B are in a call. A uses Add people to invite C. C's
+device rings with a call invite; on accept, C joins the mesh and media flows among
+A, B, C. Assert B (who didn't initiate) also meshes with C.
+
+**Acceptance Scenarios**:
+
+1. **Given** you're in a call, **When** you open Add people, **Then** you can select
+   one or more contacts who aren't already in the call.
+2. **Given** you confirm an add, **When** the invitee accepts, **Then** they join
+   the call and mesh with every existing participant (not just you).
+3. **Given** an invitee declines or doesn't answer, **When** the ring ends, **Then**
+   the call continues unchanged and the invitee is not shown as a participant.
+4. **Given** you add someone, **When** they join, **Then** the participant list and
+   tiles update for everyone already in the call.
+
+---
+
+### User Story 3 - Size limits are respected before you add (Priority: P1)
+
+A video call can hold 4 people and an audio call 8. When adding another person
+would exceed the limit for the call's type, the add is blocked up front with a
+clear explanation — you never watch someone ring only to be rejected.
+
+**Why this priority**: The user stated the limits explicitly; enforcing them
+*pre-emptively* is the difference between a clean UX and a confusing after-the-fact
+failure. The limits already exist server-side, but the new add paths must gate
+before attempting.
+
+**Independent Test**: Fill an audio call to 8 and a video call to 4; assert Add
+people and Add-to-call are disabled/blocked with a reason at the limit, and allowed
+just below it. Assert an over-limit attempt that somehow reaches the server is
+still refused (defense in depth).
+
+**Acceptance Scenarios**:
+
+1. **Given** a video call with 4 participants, **When** you try to add another,
+   **Then** the action is unavailable with a clear reason ("Video calls are limited
+   to 4 people").
+2. **Given** an audio call with 8 participants, **When** you try to add another,
+   **Then** the action is unavailable with a clear reason.
+3. **Given** an add-people picker, **When** selecting contacts, **Then** you cannot
+   select more than the remaining capacity for the call's type.
+4. **Given** any add path, **When** the limit would be exceeded, **Then** the
+   existing authoritative server refusal remains as a backstop and the local call is
+   left undisturbed.
+
+---
+
+### User Story 4 - Merge coexists with call waiting (Priority: P2)
+
+Add-to-call is a distinct choice from hold/swap. Merging brings the caller into
+your **active** call; any separate call you're holding is untouched. You still have
+your one hold slot and can swap to it afterwards.
+
+**Why this priority**: The two features must not collide. Users who rely on
+hold/swap (spec 0005) must keep it, and the single-held-slot rule (spec 2009) must
+stay intact.
+
+**Independent Test**: A is in call X and holding call Y. C calls A. A chooses Add
+to call → C merges into X; Y stays held and can be swapped to. Assert Y's media is
+still paused and resumes correctly on swap.
+
+**Acceptance Scenarios**:
+
+1. **Given** you have an active call and a held call, **When** you merge an incoming
+   caller, **Then** they join the active call and the held call is unchanged.
+2. **Given** you merged a caller into the active call, **When** you swap to the held
+   call, **Then** hold/swap behaves exactly as before (the merged group call is now
+   the held one, paused; the other becomes active).
+3. **Given** the single-held-slot rule, **When** merge and hold are both available,
+   **Then** at most one call is ever held.
+
+---
+
+### User Story 5 - Robust under churn (Priority: P2)
+
+Growing a call is reliable even when things happen at once: someone joins while
+someone else leaves, two people are added close together, an invitee reloads
+mid-ring, or you add a person right before swapping calls. Tiles, participant
+lists, and connections converge to the correct state without stuck "ringing"
+placeholders, duplicate tiles, or dropped legs.
+
+**Why this priority**: The add/merge/roster/leg lifecycle is where mesh calls are
+most fragile; the "evaluate and robusten" goal targets exactly these races.
+
+**Independent Test**: Scripted churn on an audio mesh (add C while D leaves; add two
+at once; invitee reloads mid-ring then rejoins) and assert the final roster, tiles,
+and connectivity are correct on every device, with no orphaned ringing state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a participant is joining, **When** another leaves at the same moment,
+   **Then** every device converges to the correct roster with no stuck tile.
+2. **Given** an invitee reloads while ringing, **When** they come back and accept,
+   **Then** they join cleanly (reusing the existing invite-recovery behaviour) with
+   no duplicate.
+3. **Given** you add a person then immediately swap to a held call, **Then** both the
+   add and the swap complete correctly and no leg is left half-open.
+
+---
+
+### User Story 6 - Merge an incoming group invite into your call (Priority: P2)
+
+You're in a call and a group invite comes in. Instead of only being able to hold it
+or let it be busy, you can **Add to call** — folding the invite's people into the
+call you're already on, so the two groups become one, as long as everyone fits under
+the call's size limit.
+
+**Why this priority**: The richer merge case the user asked for. It's the most
+complex (two rosters, combined cap math), so it's built and tested after the direct-
+caller merge (US1) proves out; it reuses the same promotion + roster machinery.
+
+**Independent Test**: A is in a call with B. C starts a group call inviting A (and D).
+A chooses Add to call on C's invite. Assert the combined call ends with A, B, and C's
+group folded into one call within the kind cap, everyone meshed; assert it is blocked
+with a clear reason when the combined distinct headcount would exceed the cap.
+
+**Acceptance Scenarios**:
+
+1. **Given** you're in a call and receive a group invite, **When** you choose Add to
+   call, **Then** the invite's not-yet-present members are rung into your current call
+   and join the mesh on accept, folding the two groups into one.
+2. **Given** merging a group invite would exceed the kind cap on the combined distinct
+   participants, **When** you try, **Then** the merge is blocked with a clear reason and
+   both your call and the invite are left as they were.
+3. **Given** a member appears in both your call and the incoming invite, **When** the
+   groups fold, **Then** they resolve to a single participant with one set of legs (no
+   duplicate).
+
+### Edge Cases
+
+- Adding a person who is **already in the call** (or already ringing) is a no-op, not
+  a duplicate.
+- Adding someone you're **not connected to**: handled by the existing same-room key
+  gate (they can fetch each other's keys for the call's duration) — reuse it; no new
+  connection requirement.
+- **Merging an incoming group invite** (US6): folds the invite's roster into the
+  current call; a member already present resolves to one participant; blocked with a
+  clear reason if the combined distinct headcount exceeds the kind cap.
+- **Both parties add each other / simultaneous adds** of the same new person:
+  converge to one participant, one set of legs.
+- **Video limit reached mid-upgrade**: an audio call above 4 people cannot switch to
+  video (reuse the existing upgrade block), so merging a video caller there keeps the
+  call audio (merged person joins audio-only); adding a person to a 4-person video
+  call is blocked.
+- **The one who is added** must consent — added people ring and can decline (no
+  silent pull-in).
+- **Promoting a 1:1 to a group**: the existing peer auto-follows into the group (their
+  device follows the roster, the late-joiner path) and sees a brief "{name} joined the
+  call" cue — no consent prompt for them.
+- Merge/add during **poor connectivity** or reconnect (spec 2012/2013) must not
+  corrupt the held-slot or roster state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Merge (US1)**
+
+- **FR-001**: While in a call, an incoming **direct caller** MUST offer an **Add to
+  call** action alongside the existing Hold and Decline choices; an incoming **group
+  invite** MUST also offer Add to call (US6).
+- **FR-002**: Choosing Add to call on a **1:1** MUST promote it to a group (mesh)
+  call containing the existing peer, yourself, and the new caller, reusing the
+  current microphone/camera capture (no second capture prompt). The existing peer's
+  device MUST auto-follow into the group and show a brief "{name} joined the call"
+  cue — with no consent prompt for them (the added party consents by answering).
+- **FR-003**: Choosing Add to call while in a **group** call MUST ring the new caller
+  into the existing call; on accept they join the mesh.
+- **FR-003a**: Choosing Add to call on an incoming **group invite** MUST fold the
+  invite's not-yet-present members into the current call (ringing them into it),
+  resolving any member already present to a single participant, subject to FR-010's
+  cap on the combined distinct headcount (US6).
+- **FR-004**: If the merged-in caller declines or does not answer, the existing call
+  MUST continue unaffected.
+- **FR-005**: Merge MUST apply only to the **active** call; a separately held call
+  MUST be left untouched (US4).
+- **FR-005a**: **Kind reconciliation** — when the merged caller's kind differs from
+  the active call, the combined call MUST upgrade to video via the existing
+  consent-gated upgrade flow **when the combined headcount is ≤ the video cap (4)**;
+  otherwise the call stays audio and the merged participant joins audio-only. A
+  video call absorbing an audio participant keeps video (that participant may enable
+  their camera under the same consent flow).
+
+**Add people (US2)**
+
+- **FR-006**: While in a call, an **Add people** action MUST let the user select one
+  or more contacts who are not already participants and ring them into the call.
+- **FR-007**: An added invitee MUST ring like any call invite and be able to decline;
+  on accept they MUST mesh with **every** existing participant, not only the inviter.
+- **FR-008**: The participant list and tiles MUST update for all existing
+  participants as invitees join or fail to join (no stuck "ringing" placeholder after
+  a decline/timeout).
+
+**Size limits (US3)**
+
+- **FR-009**: A **video** call MUST never exceed **4** participants and an **audio**
+  call MUST never exceed **8** (the existing caps — reused, not redefined).
+- **FR-010**: Every new add path (merge and add-people) MUST enforce the cap
+  **pre-emptively on the client** — blocking the action with a clear, kind-specific
+  reason before anyone is rung — while the existing authoritative server refusal
+  remains as a backstop.
+- **FR-011**: The add-people picker MUST prevent selecting more contacts than the
+  remaining capacity for the call's kind.
+- **FR-012**: The existing rule that an audio call above the video cap cannot switch
+  to video MUST remain consistent with the new add paths (adding a person that would
+  make video impossible is handled coherently).
+
+**Robustness (US5) + hardening**
+
+- **FR-013**: Adding/merging MUST be correct under churn — concurrent join/leave,
+  simultaneous adds of the same person, and an invitee reloading mid-ring — converging
+  every device to the correct roster, tiles, and connectivity with no orphaned state.
+- **FR-014**: Adding a participant then swapping to a held call MUST leave no
+  half-open connection and MUST preserve the hold/swap invariants (US4).
+- **FR-015**: Consent is required: no participant is ever added to a call without an
+  incoming ring they accept (merge and add-people both ring the added party).
+- **FR-016**: Misleading dead references to a removed media-server ("SFU") in the call
+  code MUST be corrected to reflect the mesh, and any dead code paths from that
+  removal cleaned up (no behaviour change).
+
+**Zero-knowledge / crypto**
+
+- **FR-017**: Growing a call MUST add no new server capability: per-pair signalling
+  stays sealed over each pair's existing encrypted session, the server relays opaque
+  frames and enforces only room membership + the numeric cap, and adding a participant
+  reuses the existing same-room key-fetch gate. No new plaintext reaches the server.
+
+### Key Entities *(include if feature involves data)*
+
+- **Call**: A live conversation with a kind (audio or video) and a set of
+  participants. A 1:1 has two; a group has a shared room identity and up to the
+  kind's cap. Promoting a 1:1 to a group gives it a room identity.
+- **Participant / roster**: Who is actually connected. Distinct from **invited** —
+  people who have been rung but haven't joined (shown as "ringing" placeholders).
+- **Held call**: At most one call may be held while another is active; merging never
+  touches the held one.
+- **Capacity**: Remaining slots = kind cap (4 video / 8 audio) minus current
+  participants-plus-ringing; gates every add.
+
+## Zero-Knowledge Impact *(mandatory — Constitution Principle I)*
+
+- **What crosses the wire**: Nothing new in kind. Growing a call reuses the existing
+  group-call signalling (join/roster/ring/leg offer-answer-ice), all of which the
+  server already relays as opaque, sealed frames. Promoting a 1:1 to a group adds a
+  room identifier to the signalling — a shape the server already handles for every
+  group call.
+- **What is encrypted / protected**: All SDP/ICE stays end-to-end encrypted over each
+  pair's existing Double Ratchet session; media is peer-to-peer DTLS-SRTP. The server
+  never sees media or call content.
+- **What metadata is unavoidably visible**: Unchanged from today's group calls — the
+  server sees room membership (who is in which call room) and enforces the numeric
+  size cap, exactly as it already does. Adding a participant makes them a room member,
+  which the server can already see for any group call; it learns nothing about content.
+- **Key fetch for added, unconnected people**: Reuses the existing same-room gate that
+  already lets ad-hoc call co-members fetch each other's prekey bundles for the call's
+  duration — no new server permission.
+- **Why this is safe**: Mesh-only, no server media, no new frame types or fields, no
+  new server capability — the feature composes existing encrypted signalling and the
+  existing membership/cap enforcement.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user in a 1:1 can merge an incoming caller into the call, ending with
+  all three connected and media flowing among them, in under 10 seconds from accept.
+- **SC-002**: A user in a call can add a contact who joins and meshes with **every**
+  existing participant (verified from a non-initiator's device), not just the inviter.
+- **SC-003**: 100% of over-limit add attempts (5th on a video call, 9th on an audio
+  call) are blocked before ringing, with a clear kind-specific reason; the existing
+  call is never disturbed.
+- **SC-004**: Merging a caller into the active call leaves a separately held call
+  fully intact and swappable in 100% of trials.
+- **SC-005**: Under scripted churn (concurrent join/leave, simultaneous add, invitee
+  reload mid-ring), every device converges to the correct roster and tiles with **zero**
+  orphaned "ringing" placeholders or duplicate participants.
+- **SC-006**: The reused microphone/camera is never re-prompted or interrupted during a
+  merge or add (a single capture for the session).
+- **SC-007**: All existing call e2e and unit tests stay green; the new behaviours are
+  covered by Playwright e2e (audio meshes + 2-person proxies) and drive scenarios
+  (video path), per the CI constraint.
+- **SC-008**: On a 1:1 → group promotion, the existing peer auto-follows into the
+  group and sees the "{name} joined the call" cue in 100% of trials, with no consent
+  prompt shown to them.
+- **SC-009**: Merging an incoming group invite folds both rosters into one call within
+  the kind cap, or is blocked with a clear reason when the combined headcount would
+  exceed it — verified in both the fits and doesn't-fit cases.
+
+## Assumptions
+
+- **Consent model reused**: Added people (merge or add-people) always ring and may
+  decline — same as today's group invite; there is no silent pull-in.
+- **1:1 → group promotion for the existing peer** (clarified): they auto-follow into
+  the group (their device follows the roster, the existing late-joiner path) and see a
+  brief "{name} joined the call" cue — no consent prompt, since they're already on the
+  call with the promoter.
+- **Kind reconciliation on merge** (clarified): upgrade to video via the existing
+  consent-gated flow when the combined call is ≤ 4; otherwise stay audio (merged party
+  audio-only). No new upgrade mechanism is invented.
+- **Group-invite merge** (clarified, US6): supported but is the most complex path;
+  built/tested after the direct-caller merge proves out, reusing the same
+  promotion/roster machinery, and blocked when the combined headcount exceeds the cap.
+- **Merge targets the active call only**; the held call (if any) is never merged into
+  and never disturbed.
+- **Caps are the existing 4 video / 8 audio**, enforced server-side already; this spec
+  adds the pre-emptive client gate on the new mid-call add paths and does not change
+  the numbers.
+- **CI cannot run 3-person+ video mesh reliably headless**: add-to-call flows are
+  e2e-tested primarily on **audio** meshes (3–4 people) and 2-person proxies; the video
+  path is validated via drive scenarios / real devices. Pure decision logic (cap gate,
+  roster/merge decisions) is unit-tested.
+- **Mesh only**: no SFU / server media mixing is introduced (constitution).
+
+## Out of Scope
+
+- An SFU or any server-side media mixing/relay of call content (mesh only, by
+  constitution) — and therefore raising the 4/8 caps.
+- PSTN / telephony bridging (calling non-Ring phone numbers is spec 1029's
+  native-dialer hand-off, not this).
+- More than one held call at a time (the single-held-slot rule stays).
+- Transferring an in-progress call to another device.
+- Changing the adaptive-quality, busy-signalling, or invite-recovery behaviour of
+  existing specs beyond what robustness fixes require.

--- a/specs/1028-robust-audio-and/spec.md
+++ b/specs/1028-robust-audio-and/spec.md
@@ -378,6 +378,13 @@ with a clear reason when the combined distinct headcount would exceed the cap.
 - **Key fetch for added, unconnected people**: Reuses the existing same-room gate that
   already lets ad-hoc call co-members fetch each other's prekey bundles for the call's
   duration — no new server permission.
+- **Trust of the `joinroom` signal**: It is only accepted from an authenticated pair
+  session (sealed and opened over the existing per-pair Double Ratchet), so it cannot be
+  forged or replayed by the server or a third party. A `joinroom` carrying an
+  unexpected room id is inert on its own — a device only ever participates in mesh legs
+  it can establish and decrypt, so a spurious room id pulls it into nothing it can
+  observe. Being added still requires the added party to answer their own ring
+  (FR-015).
 - **Why this is safe**: Mesh-only, no server media, no new frame types or fields, no
   new server capability — the feature composes existing encrypted signalling and the
   existing membership/cap enforcement.

--- a/specs/1028-robust-audio-and/tasks.md
+++ b/specs/1028-robust-audio-and/tasks.md
@@ -19,8 +19,8 @@ meshes (3–4) + 2-person proxies; the **video** path is drive/real-device only.
 
 **Purpose**: The pure cap math every add path depends on (blocks US2/US3/US6).
 
-- [ ] T001 (#639) [P] Failing unit tests in `src/services/call/capacity.test.ts`: `capOf` (video 4 / audio 8), `headcount` (distinct roster ∪ invited ∪ self), `remainingSlots`, `canAdd` — incl. invited-counts-against-cap, the 5th-video / 9th-audio boundaries, and the US6 combined-headcount case
-- [ ] T002 (#640) Implement `src/services/call/capacity.ts` (`capOf`/`headcount`/`remainingSlots`/`canAdd`, kind-specific reason copy) until T001 is green
+- [x] T001 (#639) [P] Failing unit tests in `src/services/call/capacity.test.ts`: `capOf` (video 4 / audio 8), `headcount` (distinct roster ∪ invited ∪ self), `remainingSlots`, `canAdd` — incl. invited-counts-against-cap, the 5th-video / 9th-audio boundaries, and the US6 combined-headcount case
+- [x] T002 (#640) Implement `src/services/call/capacity.ts` (`capOf`/`headcount`/`remainingSlots`/`canAdd`, kind-specific reason copy) until T001 is green
 - [ ] T003 (#641) Wire `callRemainingSlots()` in `src/composables/useCall.ts` to `capacity.ts` (reads the active call's kind + roster + invited)
 
 **Checkpoint**: cap math locked by unit tests.
@@ -31,7 +31,7 @@ meshes (3–4) + 2-person proxies; the **video** path is drive/real-device only.
 
 **Purpose**: The one new wire element (sealed, opaque to the server) + its receive path. R2/D1.
 
-- [ ] T004 (#642) [P] Extend the `CallSignal` union in `src/services/transport.ts` with `{ type: 'joinroom', roomId, kind }` (sealed payload only — rides the existing `call-ice` frame, no new transport frame)
+- [x] T004 (#642) [P] Extend the `CallSignal` union in `src/services/transport.ts` with `{ type: 'joinroom', roomId, kind }` (sealed payload only — rides the existing `call-ice` frame, no new transport frame)
 - [ ] T005 (#643) [P] Failing unit test in `src/services/call/signalling.test.ts` (or nearest): a `joinroom` `CallSignal` seals and opens round-trip over a pair's session (reusing `sealForChat`/`openPacket`), and its payload carries ONLY `{roomId, kind}` — assert the serialized signal contains no name/contact/plaintext beyond an opaque room id + the kind enum (FR-017 zero-knowledge bound)
 - [ ] T006 (#644) Implement `sendJoinRoom(chatId, peerUserId, callId, roomId, kind)` in `src/services/call/signalling.ts` (mirrors `sendHoldResume`)
 - [ ] T007 (#645) Add the `joinroom` dispatch case to `handleCallFrame`/`call-ice` handling in `src/composables/useCall.ts`: on receipt, auto-join the room (reuse the shared capture), tear the prior 1:1 PC down on leg-connect, and surface the join cue (US1 cue wired in Phase 3)
@@ -51,7 +51,7 @@ A, B, AND C (assert from B, a non-initiator).
 ### Tests (write first, must FAIL)
 
 - [ ] T008 (#646) [P] [US2] Failing Playwright e2e `e2e/call-add-merge.spec.ts` (part 1, audio 3→4): A/B/C in a group audio call, A adds D via Add people, D joins and meshes with every existing participant (verified from B)
-- [ ] T009 (#647) [P] [US2] Failing unit test for the pure invite-planning helper — dedup an id list against `roster ∪ invited` and clamp to `remainingSlots` — in a small pure module (e.g. `src/services/call/invite-plan.ts` + `.test.ts`), so `inviteToRoom`'s decision is testable without WebRTC
+- [x] T009 (#647) [P] [US2] Failing unit test for the pure invite-planning helper — dedup an id list against `roster ∪ invited` and clamp to `remainingSlots` — in a small pure module (e.g. `src/services/call/invite-plan.ts` + `.test.ts`), so `inviteToRoom`'s decision is testable without WebRTC
 
 ### Implementation
 

--- a/specs/1028-robust-audio-and/tasks.md
+++ b/specs/1028-robust-audio-and/tasks.md
@@ -1,0 +1,212 @@
+# Tasks: Robust Calls + Add-to-Call (Merge Incoming, Add People)
+
+**Input**: Design documents from `/specs/1028-robust-audio-and/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/internal-api.md, quickstart.md
+
+**Tests**: REQUIRED — constitution Principle III (TDD) + spec SC-007 (all call tests stay
+green). Pure helpers are unit-first; each user-facing slice writes a failing e2e before
+the orchestration lands. Design ids (R1–R10, D1–D6, INV-1..4) reference research/plan/data-model.
+
+**CI constraint**: 3-person **video** mesh is NOT runnable headless — e2e uses **audio**
+meshes (3–4) + 2-person proxies; the **video** path is drive/real-device only.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Setup & capacity gate (Slice 0 — pure, no WebRTC)
+
+**Purpose**: The pure cap math every add path depends on (blocks US2/US3/US6).
+
+- [ ] T001 (#639) [P] Failing unit tests in `src/services/call/capacity.test.ts`: `capOf` (video 4 / audio 8), `headcount` (distinct roster ∪ invited ∪ self), `remainingSlots`, `canAdd` — incl. invited-counts-against-cap, the 5th-video / 9th-audio boundaries, and the US6 combined-headcount case
+- [ ] T002 (#640) Implement `src/services/call/capacity.ts` (`capOf`/`headcount`/`remainingSlots`/`canAdd`, kind-specific reason copy) until T001 is green
+- [ ] T003 (#641) Wire `callRemainingSlots()` in `src/composables/useCall.ts` to `capacity.ts` (reads the active call's kind + roster + invited)
+
+**Checkpoint**: cap math locked by unit tests.
+
+---
+
+## Phase 2: Foundational — the `joinroom` sealed signal + dispatch (Slice 3 core, blocks merge/promotion)
+
+**Purpose**: The one new wire element (sealed, opaque to the server) + its receive path. R2/D1.
+
+- [ ] T004 (#642) [P] Extend the `CallSignal` union in `src/services/transport.ts` with `{ type: 'joinroom', roomId, kind }` (sealed payload only — rides the existing `call-ice` frame, no new transport frame)
+- [ ] T005 (#643) [P] Failing unit test in `src/services/call/signalling.test.ts` (or nearest): a `joinroom` `CallSignal` seals and opens round-trip over a pair's session (reusing `sealForChat`/`openPacket`), and its payload carries ONLY `{roomId, kind}` — assert the serialized signal contains no name/contact/plaintext beyond an opaque room id + the kind enum (FR-017 zero-knowledge bound)
+- [ ] T006 (#644) Implement `sendJoinRoom(chatId, peerUserId, callId, roomId, kind)` in `src/services/call/signalling.ts` (mirrors `sendHoldResume`)
+- [ ] T007 (#645) Add the `joinroom` dispatch case to `handleCallFrame`/`call-ice` handling in `src/composables/useCall.ts`: on receipt, auto-join the room (reuse the shared capture), tear the prior 1:1 PC down on leg-connect, and surface the join cue (US1 cue wired in Phase 3)
+
+**Checkpoint**: a device can be told to join a room over the sealed channel.
+
+---
+
+## Phase 3: User Story 2 — Add people to an ongoing GROUP call (Priority: P1) 🎯 MVP
+
+**Goal**: Ring new contacts into an existing group call; they mesh with everyone. No
+promotion yet (start from a group call).
+
+**Independent Test**: A+B+C in a group AUDIO call; A adds D; D rings, accepts, meshes with
+A, B, AND C (assert from B, a non-initiator).
+
+### Tests (write first, must FAIL)
+
+- [ ] T008 (#646) [P] [US2] Failing Playwright e2e `e2e/call-add-merge.spec.ts` (part 1, audio 3→4): A/B/C in a group audio call, A adds D via Add people, D joins and meshes with every existing participant (verified from B)
+- [ ] T009 (#647) [P] [US2] Failing unit test for the pure invite-planning helper — dedup an id list against `roster ∪ invited` and clamp to `remainingSlots` — in a small pure module (e.g. `src/services/call/invite-plan.ts` + `.test.ts`), so `inviteToRoom`'s decision is testable without WebRTC
+
+### Implementation
+
+- [ ] T010 (#648) [US2] Implement `inviteToRoom(ids)` in `src/composables/useCall.ts`: dedup vs `roster ∪ invited`, `canAdd` gate, add to `meta.invited`, `call-ring` each (reuses the in-room `call-ring` seam)
+- [ ] T011 (#649) [US2] Add an **Add people** button + existing contact-picker entry in `src/views/detail/CallActivePage.vue`, gated by `callRemainingSlots()`; confirm → `addPeople(ids)` (which for a group call is just `inviteToRoom`)
+- [ ] T012 (#650) [P] [US2] Extend `drive/scenarios/group-call-4.mjs` to add a 4th participant mid-call and assert the full mesh; also assert no camera/mic re-prompt on the adder (SC-006 on the add path, complementing the merge-path assertion in T015)
+
+**Checkpoint**: you can grow an existing group call — MVP add path.
+
+---
+
+## Phase 4: User Story 3 — Size limits respected before you add (Priority: P1)
+
+**Goal**: Pre-emptive client cap gate on every add path (FR-010/FR-011), server `call-full`
+as backstop.
+
+**Independent Test**: Fill an audio call to 8 and a video call to 4; Add people is
+disabled/blocked with a kind-specific reason; just-below is allowed; the local call is
+never disturbed by a refusal.
+
+### Tests (write first, must FAIL)
+
+- [ ] T013 (#651) [P] [US3] Failing Playwright e2e `e2e/call-add-cap.spec.ts`: audio call at 8 → Add people blocked with reason; video call at 4 → blocked; a call one below cap → allowed; assert the existing call is undisturbed when an over-cap attempt is refused
+
+### Implementation
+
+- [ ] T014 (#652) [US3] Enforce `canAdd` in the picker (disable selections past `callRemainingSlots()`) and as a guard in `addPeople`/`mergeIncoming`/`mergeGroupInvite` before any ring; surface the kind-specific reason (stock Ionic, Principle XI)
+
+**Checkpoint**: no add can exceed 4 video / 8 audio, and the user learns why up front.
+
+---
+
+## Phase 5: User Story 1 — Merge an incoming caller into your call (Priority: P1)
+
+**Goal**: Promote a 1:1 to a mesh room and merge an incoming DIRECT caller into it,
+reusing the capture; existing peer auto-follows with a cue; kind reconciliation. R2/R5/R6.
+
+**Independent Test**: A+B in a 1:1 call; C calls A; A taps Add to call → A, B, C all
+meshed, A's capture reused, B auto-followed with a cue; if C declines, the call is
+unaffected.
+
+### Tests (write first, must FAIL)
+
+- [ ] T015 (#653) [P] [US1] Failing Playwright e2e `e2e/call-add-merge.spec.ts` (part 2, audio 1:1→3): A+B in a 1:1, A promotes and merges incoming C → three-way audio mesh; assert B auto-followed (no ring shown to B) and saw the "{name} joined the call" cue (SC-008), and A's capture was reused (no second gUM — SC-006)
+- [ ] T016 (#654) [P] [US1] Failing unit test for kind reconciliation (D4): video caller + audio call ≤4 → wants-upgrade true; >4 → audio-only; pure decision function
+
+### Implementation
+
+- [ ] T017 (#655) [US1] Implement `ensureActiveIsRoom()` in `src/composables/useCall.ts` (R2): if active is 1:1, mint `roomId`, `MeshSession(roomId, kind).start(existingStream)`, `sendJoinRoom` to the existing peer, tear down the 1:1 PC on leg-connect; idempotent if already a room; add the promotion timeout / clean half-formed-room fallback (R7)
+- [ ] T018 (#656) [US1] Implement `mergeIncoming()` (`ensureActiveIsRoom()` → `sendJoinRoom` to the incoming caller so they join instead of a 1:1 answer) + the "{name} joined the call" cue on `joinroom`/new roster member, via existing toast/cue infra
+- [ ] T019 (#657) [US1] Kind reconciliation after merge: if wanted AND combined ≤ `VIDEO_MAX`, run the existing consent-gated `requestVideoUpgrade`; else audio-only (reuse — no new mechanism)
+- [ ] T020 (#658) [US1] Add the **Add to call** action for a direct incoming caller in `src/components/IncomingCallOverlay.vue` (alongside Hold/Decline) → `mergeIncoming`
+
+**Checkpoint**: the headline capability works on audio; capture reused; peer auto-follows.
+
+---
+
+## Phase 6: User Story 4 — Merge coexists with call waiting (Priority: P2)
+
+**Goal**: Merge acts only on the active call; a held call is untouched and still swappable.
+FR-005/FR-014, INV-1.
+
+**Independent Test**: A active with X, holding Y; C calls; A merges C into X; Y stays held
++ paused; swap to Y works; single-held-slot invariant holds.
+
+### Tests (write first, must FAIL)
+
+- [ ] T021 (#659) [P] [US4] Failing Playwright e2e (extend `e2e/call-waiting.spec.ts`): active + held, merge an incoming caller into the active call, assert the held call stays held/paused and swaps correctly afterward; at most one held call throughout
+
+### Implementation
+
+- [ ] T022 (#660) [US4] Add an add-in-flight guard so a merge/add completes (or cancels cleanly) before a swap parks the active call — no half-open leg (FR-014); confirm `heldSlot` is never read/written by merge/add paths
+
+**Checkpoint**: hold/swap (specs 0005/2009) fully intact alongside merge.
+
+---
+
+## Phase 7: User Story 6 — Merge an incoming GROUP INVITE (Priority: P2)
+
+**Goal**: Fold an incoming group invite's roster into the current call within the combined
+cap, or block with a reason. R3/D2, SC-009.
+
+**Independent Test**: A+B in a call; C invites A to a group with D; A Add to call → one
+combined call (A,B,C,D) within cap, shared members deduped; a variant where combined
+headcount exceeds the cap → blocked with reason.
+
+### Tests (write first, must FAIL)
+
+- [ ] T023 (#661) [P] [US6] Failing Playwright e2e `e2e/call-add-merge.spec.ts` (part 3, audio): merge a group invite into an ongoing call → combined mesh within cap; and a blocked case when combined headcount exceeds the cap (SC-009); a shared member resolves to one participant (INV-4)
+
+### Implementation
+
+- [ ] T024 (#662) [US6] Implement `mergeGroupInvite()`: `canAdd(combined distinct headcount)` → `ensureActiveIsRoom()` → `inviteToRoom(inviteRoster − present)` → `call-leave` the incoming invite room; block with a clear reason when over cap
+- [ ] T025 (#663) [US6] Add the **Add to call** action for an incoming group invite in `src/components/IncomingCallOverlay.vue` → `mergeGroupInvite`
+
+**Checkpoint**: the richest merge path works, cap-bounded, dedup-correct.
+
+---
+
+## Phase 8: User Story 5 — Robust under churn (Priority: P2)
+
+**Goal**: Correct convergence under concurrent join/leave, simultaneous same-person add,
+and invitee reload mid-ring. FR-013, SC-005.
+
+**Independent Test**: Scripted churn on an audio mesh — add C while D leaves; add two at
+once; invitee reloads mid-ring then accepts — final roster/tiles/connectivity correct on
+every device with no orphaned ringing or duplicate.
+
+### Tests (write first, must FAIL where behavior changes)
+
+- [ ] T026 (#664) [P] [US5] Failing/pinning Playwright e2e (audio mesh churn): concurrent join+leave and simultaneous add of the same person converge to the correct roster with no stuck tile / no duplicate; extend or add `e2e/call-add-churn.spec.ts`
+- [ ] T027 (#665) [P] [US5] Drive scenario `drive/scenarios/call-add-churn.mjs` for the harder multi-party churn on the live stack
+
+### Implementation
+
+- [ ] T028 (#666) [US5] Verify/harden `applyRoster` set semantics + `inviteToRoom` dedup + the join cue against the churn tests, INCLUDING the promotion-timeout path (R7): a peer that never joins after `joinroom` leaves a clean state (no stuck half-formed room, no orphaned tile); fix anything the tests expose (reuse the existing serialized `rosterChain`; reuse spec-2012 invite recovery for the reload case — no new mechanism)
+
+**Checkpoint**: growing a call is reliable under churn.
+
+---
+
+## Phase 9: Polish & Cross-Cutting
+
+- [ ] T029 (#667) [P] Fix the misleading "SFU" comments in `src/composables/useCall.ts` (~L1346, ~L1526) to say "mesh session"; `rg` the tree for dead SFU identifiers and remove any unreachable remnants (no behaviour change) (FR-016)
+- [ ] T030 (#668) Verify **no `server/` diff** is needed and FR-017 holds: `cd server && go build ./... && go vet ./... && go test ./...` green with the server untouched (constitution I/VI); confirm `git diff --stat origin/develop -- server/` is empty; if a gap is found, STOP and escalate before adding any server capability
+- [ ] T031 (#669) [P] Drive scenario `drive/scenarios/promote-1to1-video.mjs`: promote a 1:1 to a 3-way VIDEO call on the live stack (real-device/interactive — NOT headless CI); capture a screenshot of the 3-tile grid
+- [ ] T032 (#670) Run ALL existing call e2e + unit tests and confirm green (SC-007): `call-waiting`, `call-waiting-slot`, `call-caps`, `call-reinvite`, `calls`, `call-adaptive`, `call-quality`, `call-busy`, `call-connect-speed`, plus `quality`/`duration`/`slots` unit tests
+- [ ] T033 (#671) Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build ./... && go vet ./... && go test ./...`
+- [ ] T034 (#672) Bump spec `**Status**:` to `in-progress` → `make roadmap` (start of implement); bump to `in-review` + re-run at PR time
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1 (capacity)** and **Phase 2 (`joinroom` signal)** are foundational; Phase 2's
+  dispatch (T007) is needed by promotion (Phase 5).
+- **US2 (Phase 3)** is the MVP and needs only capacity — it starts from an existing group
+  call, no promotion. **US3 (Phase 4)** layers the pre-emptive gate over US2's add path.
+- **US1 (Phase 5)** needs Phase 2 (`joinroom`) + `ensureActiveIsRoom`; it is the riskiest.
+- **US4 (Phase 6)** needs US1's merge.
+- **US6 (Phase 7)** needs US1's promotion + US2's `inviteToRoom`.
+- **US5 (Phase 8)** exercises everything; do after the add/merge paths exist.
+- **Polish (Phase 9)** last; T030 (no-server-diff) and T033 (gates) gate the PR.
+
+### Parallel opportunities
+- T001+T004+T005 (pure/foundational tests), T008+T009, T015+T016, per-slice test pairs.
+- Drive-scenario tasks (T012, T027, T031) run parallel to their story's e2e.
+- The video drive validation (T031) is independent of the audio e2e path.
+
+---
+
+## Implementation Strategy
+
+**MVP = Phases 1–4 (US2 + US3)**: add people to an existing group call, cap-gated. That
+alone delivers "grow a call" for group calls with zero promotion risk. Then Phase 5 (US1
+merge + the risky 1:1→mesh promotion, isolated behind the proven late-join path), then US4
+(coexist with hold), US6 (group-invite merge), US5 (churn), and polish. Each checkpoint is
+independently testable; the server stays untouched throughout (verified by T030).

--- a/specs/1028-robust-audio-and/tasks.md
+++ b/specs/1028-robust-audio-and/tasks.md
@@ -21,7 +21,7 @@ meshes (3–4) + 2-person proxies; the **video** path is drive/real-device only.
 
 - [x] T001 (#639) [P] Failing unit tests in `src/services/call/capacity.test.ts`: `capOf` (video 4 / audio 8), `headcount` (distinct roster ∪ invited ∪ self), `remainingSlots`, `canAdd` — incl. invited-counts-against-cap, the 5th-video / 9th-audio boundaries, and the US6 combined-headcount case
 - [x] T002 (#640) Implement `src/services/call/capacity.ts` (`capOf`/`headcount`/`remainingSlots`/`canAdd`, kind-specific reason copy) until T001 is green
-- [ ] T003 (#641) Wire `callRemainingSlots()` in `src/composables/useCall.ts` to `capacity.ts` (reads the active call's kind + roster + invited)
+- [x] T003 (#641) Wire `callRemainingSlots()` in `src/composables/useCall.ts` to `capacity.ts` (reads the active call's kind + roster + invited)
 
 **Checkpoint**: cap math locked by unit tests.
 
@@ -50,13 +50,13 @@ A, B, AND C (assert from B, a non-initiator).
 
 ### Tests (write first, must FAIL)
 
-- [ ] T008 (#646) [P] [US2] Failing Playwright e2e `e2e/call-add-merge.spec.ts` (part 1, audio 3→4): A/B/C in a group audio call, A adds D via Add people, D joins and meshes with every existing participant (verified from B)
+- [x] T008 (#646) [P] [US2] Failing Playwright e2e `e2e/call-add-merge.spec.ts` (part 1, audio 3→4): A/B/C in a group audio call, A adds D via Add people, D joins and meshes with every existing participant (verified from B)
 - [x] T009 (#647) [P] [US2] Failing unit test for the pure invite-planning helper — dedup an id list against `roster ∪ invited` and clamp to `remainingSlots` — in a small pure module (e.g. `src/services/call/invite-plan.ts` + `.test.ts`), so `inviteToRoom`'s decision is testable without WebRTC
 
 ### Implementation
 
-- [ ] T010 (#648) [US2] Implement `inviteToRoom(ids)` in `src/composables/useCall.ts`: dedup vs `roster ∪ invited`, `canAdd` gate, add to `meta.invited`, `call-ring` each (reuses the in-room `call-ring` seam)
-- [ ] T011 (#649) [US2] Add an **Add people** button + existing contact-picker entry in `src/views/detail/CallActivePage.vue`, gated by `callRemainingSlots()`; confirm → `addPeople(ids)` (which for a group call is just `inviteToRoom`)
+- [x] T010 (#648) [US2] Implement `inviteToRoom(ids)` in `src/composables/useCall.ts`: dedup vs `roster ∪ invited`, `canAdd` gate, add to `meta.invited`, `call-ring` each (reuses the in-room `call-ring` seam)
+- [x] T011 (#649) [US2] Add an **Add people** button + existing contact-picker entry in `src/views/detail/CallActivePage.vue`, gated by `callRemainingSlots()`; confirm → `addPeople(ids)` (which for a group call is just `inviteToRoom`)
 - [ ] T012 (#650) [P] [US2] Extend `drive/scenarios/group-call-4.mjs` to add a 4th participant mid-call and assert the full mesh; also assert no camera/mic re-prompt on the adder (SC-006 on the add path, complementing the merge-path assertion in T015)
 
 **Checkpoint**: you can grow an existing group call — MVP add path.
@@ -74,11 +74,11 @@ never disturbed by a refusal.
 
 ### Tests (write first, must FAIL)
 
-- [ ] T013 (#651) [P] [US3] Failing Playwright e2e `e2e/call-add-cap.spec.ts`: audio call at 8 → Add people blocked with reason; video call at 4 → blocked; a call one below cap → allowed; assert the existing call is undisturbed when an over-cap attempt is refused
+- [x] T013 (#651) [P] [US3] Failing Playwright e2e `e2e/call-add-cap.spec.ts`: audio call at 8 → Add people blocked with reason; video call at 4 → blocked; a call one below cap → allowed; assert the existing call is undisturbed when an over-cap attempt is refused
 
 ### Implementation
 
-- [ ] T014 (#652) [US3] Enforce `canAdd` in the picker (disable selections past `callRemainingSlots()`) and as a guard in `addPeople`/`mergeIncoming`/`mergeGroupInvite` before any ring; surface the kind-specific reason (stock Ionic, Principle XI)
+- [x] T014 (#652) [US3] Enforce `canAdd` in the picker (disable selections past `callRemainingSlots()`) and as a guard in `addPeople`/`mergeIncoming`/`mergeGroupInvite` before any ring; surface the kind-specific reason (stock Ionic, Principle XI)
 
 **Checkpoint**: no add can exceed 4 video / 8 audio, and the user learns why up front.
 

--- a/specs/1029-tap-phone-and-email/plan.md
+++ b/specs/1029-tap-phone-and-email/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Tap a Phone Number or Email in Messages & Posts
+
+**Branch**: `feat/1028-robust-audio-and` (shared with 1028) | **Date**: 2026-07-02 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Detect phone numbers and email addresses in already-decrypted **message** and **Wall
+post** text and render each as a tappable element; a tap opens an action sheet that
+hands off to the OS — Call (`tel:`), Message (`sms:`), Email (`mailto:`), plus Copy.
+The correctness lives in a **pure, heavily unit-tested detector** (`src/utils/linkify.ts`)
+that returns typed segments; the two renderers (chat `bodyParts`, `EmojiText.vue`)
+consume it and stay token-based (XSS-safe by construction — no HTML strings). No
+server change, no new wire data.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5, Vue 3 `<script setup>` + Ionic 8 (pure PWA, no Capacitor)
+**Primary Dependencies**: none new — the browser handles `tel:`/`sms:`/`mailto:` schemes; reuse `appToast` (`src/services/toast.ts`) + `actionSheetController`
+**Storage**: none (entities are derived at render time, never stored)
+**Testing**: vitest (the pure detector — where correctness lives) + a lean Playwright e2e (renders tappable, action sheet appears, Copy works, `tel:`/`mailto:` targets are correct)
+**Target Platform**: PWA; the OS owns the actual call/SMS/email
+**Constraints**: token-based rendering stays injection-safe; detection conservative (no false Call/Email affordances); coexist with existing URL links + `@mentions`; no new server data
+**Scale/Scope**: 1 new pure util + 1 small action helper + integration into 2 renderers + tests
+
+## Constitution Check
+
+*GATE: constitution v1.2.0 — PASS.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Zero-Knowledge | ✅ | No new client→server data; detection is client-only over already-decrypted text; OS hand-off is local. ZK Impact section present. |
+| II. Spec-Driven | ✅ | Spec 1029 (ad-hoc); pipeline followed (clarify folded in — the 3 scoping Qs are answered in Clarifications; no residual ambiguity). |
+| III. TDD | ✅ | The pure detector is unit-first (the bulk of the feature); the user-facing render/action gets a lean e2e. |
+| IV. Crypto Discipline | ✅ (n/a) | No crypto touched; `/speckit-checklist` NOT required (spec touches neither Principle I wire boundary with new data nor IV). |
+| V. Offline-First | ✅ | No store/schema change. |
+| VI. Stateless Server | ✅ | Server untouched. |
+| VII. Quality Gates | ✅ | build + vitest + e2e where behaviour changed. |
+| X. Accessibility & i18n | ✅ | Tappable entities are real focusable controls with labels; RTL-safe (token order preserved); action-sheet copy is plain. |
+| XI. Ionic-First | ✅ | `actionSheetController` for the menu; no bespoke widgets; the tappable span reuses the existing `.msg-link` styling pattern. |
+
+## Design
+
+### D1. Pure detector `src/utils/linkify.ts`
+```ts
+type Seg = { text: string } | { kind: 'email'|'phone'; raw: string; value: string };
+// segmentContacts(text): Seg[] — splits a PLAIN text run (URL/@mention already
+//   handled by the caller) into text + email + phone segments, non-overlapping,
+//   left-to-right, longest-first (email before phone so a@1.com isn't half-eaten).
+export function segmentContacts(text: string): Seg[];
+export function telValue(raw: string): string;    // dial-safe: keep leading +, digits only
+export function telHref(raw): string; smsHref(raw): string; mailtoHref(raw): string;
+```
+- **EMAIL_RE**: conservative RFC-ish (`local@label(.label)+`), local part `[A-Za-z0-9._%+-]+`, domain with ≥1 dot and a 2+ alpha TLD; trailing punctuation excluded.
+- **PHONE_RE**: conservative — optional `+`, then 7–15 digits allowing spaces/dashes/dots/parens between groups, bounded so it won't grab long id/hash runs; require a digit count in [7,15] after stripping separators; not immediately adjacent to `@` (so it won't fire inside an email) or to other alphanumerics.
+- No HTML built; returns data only.
+
+### D2. Action sheet `src/services/entity-actions.ts`
+`presentEntityActions(seg)` → `actionSheetController` with, for phone: Call → `telHref`, Message → `smsHref`, Copy; for email: Email → `mailtoHref`, Copy. Copy = `navigator.clipboard.writeText(raw)` + `appToast('Copied')`. Scheme open via a new `openScheme(uri)` in `src/utils/external.ts` (transient anchor, no `target=_blank` for these schemes) with a graceful no-op if unhandled (Copy always available).
+
+### D3. Message integration `ChatDetailPage.vue`
+Extend `BodySeg` with `email?`/`phone?`(+`value`); in `bodyParts`, within each non-URL, non-mention text run, run `segmentContacts` and emit email/phone segments; render them as tappable spans (`.msg-link` style) → `@click.stop.prevent="presentEntityActions(...)"`. Order: URL → mention → **contacts** → emoji (contacts before emoji, after mention, so it never eats a URL/@handle).
+
+### D4. Post integration `EmojiText.vue`
+Currently emoji-only. Add `segmentContacts` over each text run before emoji segmentation, rendering email/phone as tappable → `presentEntityActions`. Used by WallPage + PostDetailPage + comments, so posts and comments both gain the feature. (URL linkification in posts stays out of scope — separate concern.)
+
+## Testing strategy
+1. **Unit (the core)**: `linkify.test.ts` — a large corpus: phone formats (plain/+/spaces/dashes/parens/dots), emails (plain/sub-addressed/dotted/multi-label), trailing-punctuation trimming, multiple entities in one string, non-overlap with an embedded `@` (email not phone), NON-matches (order numbers, hashes, times, code) → zero false positives (SC-005), and `telValue`/href normalization.
+2. **e2e (lean)**: a message with a phone + an email renders two tappable elements; tapping opens the action sheet; Copy places the value on the clipboard; assert the rendered `tel:`/`mailto:` targets (native open itself isn't invocable headless).
+3. Keep existing message/emoji tests green.
+
+## Complexity Tracking
+No violations. The only judgement call is the conservative phone regex; mitigated by the large NON-match corpus in the unit tests (SC-005).

--- a/specs/1029-tap-phone-and-email/spec.md
+++ b/specs/1029-tap-phone-and-email/spec.md
@@ -6,7 +6,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1029-tap-phone-and-email/spec.md
+++ b/specs/1029-tap-phone-and-email/spec.md
@@ -1,0 +1,214 @@
+# Feature Specification: Tap a Phone Number or Email in Messages & Posts
+
+**Feature Branch**: `feat/1028-robust-audio-and`
+<!-- Shares the 1028 branch by request: 1028 (calls) + 1029 (this) land in one PR to
+     develop. The spec id/category still come from this directory number (1029, ad-hoc). -->
+
+**Created**: 2026-07-02
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Make it possible to call a phone number detected in a post or message, or send an email to an email address found in a post or a message; also copy them, as well as placing a call, sending a message or sending an email."
+
+## Overview
+
+Text in Ring often contains a phone number or an email address — "call me on
++1 415 555 0134" or "email hello@example.com". Today those are inert plain text:
+you have to select, copy, switch apps, and paste. This feature detects phone
+numbers and email addresses inside **chat messages** and **Wall posts** and makes
+them tappable, so a tap offers the obvious actions and hands off to the device's
+own apps.
+
+Ring has no telephone network, SMS, or email of its own, so these actions hand off
+to the operating system: **Call** opens the phone dialer, **Message** opens the SMS
+app, **Email** opens the mail app, and **Copy** puts the value on the clipboard.
+Detection and the whole interaction happen entirely on the device, on text that is
+already decrypted locally — nothing new is sent to the server.
+
+## Clarifications
+
+### Session 2026-07-02
+
+- Q: What should the Call / Message / Email actions do, given Ring has no
+  PSTN/SMS/email of its own? → A: Native app hand-off — Call opens the device
+  dialer (`tel:`), Email opens the mail app (`mailto:`), plus Copy.
+- Q: For a detected PHONE number, what does "Send a message" do? → A: SMS via the
+  native app (`sms:`).
+- Q: How is this organized relative to the calls work? → A: A separate spec (1029)
+  built on the 1028 branch so both land in one PR to develop.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Act on a phone number in a message or post (Priority: P1)
+
+A friend messages "reach me at +1 415 555 0134" (or posts it on the Wall). The
+number appears as a tappable link. Tapping it offers **Call**, **Message**, and
+**Copy**. Call opens the phone dialer pre-filled with the number; Message opens the
+SMS app; Copy puts the number on the clipboard with a brief confirmation.
+
+**Why this priority**: Phone numbers are the most common actionable entity and the
+"call it" action is the headline of the request.
+
+**Independent Test**: Send a message containing a phone number; confirm it renders
+as a tappable link; tap it and confirm the action menu offers Call / Message /
+Copy; confirm Call and Message target the correct `tel:` / `sms:` value and Copy
+places the exact number on the clipboard.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message or post whose text contains a phone number, **When** it is
+   displayed, **Then** the number is rendered as a distinct tappable element while
+   the surrounding text is unchanged.
+2. **Given** a tappable phone number, **When** the user taps it, **Then** an action
+   menu offers Call, Message, and Copy.
+3. **Given** the action menu, **When** the user chooses Call, **Then** the device's
+   phone dialer opens targeting that number; **when** Message, the SMS app opens;
+   **when** Copy, the number is placed on the clipboard with a confirmation.
+
+---
+
+### User Story 2 - Act on an email address in a message or post (Priority: P1)
+
+A message or post contains "hello@example.com". It appears as a tappable link;
+tapping offers **Email** and **Copy**. Email opens the mail app composing to that
+address; Copy places it on the clipboard.
+
+**Why this priority**: Email is the second common actionable entity and pairs
+naturally with phone in the same detection/menu mechanism.
+
+**Independent Test**: Send a message containing an email address; confirm it renders
+tappable; tap it and confirm the menu offers Email / Copy; confirm Email targets the
+correct `mailto:` value and Copy places the exact address on the clipboard.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message or post whose text contains an email address, **When** it is
+   displayed, **Then** the address is rendered as a distinct tappable element.
+2. **Given** a tappable email address, **When** the user taps it, **Then** an action
+   menu offers Email and Copy.
+3. **Given** the action menu, **When** the user chooses Email, **Then** the mail app
+   opens composing to that address; **when** Copy, the address is placed on the
+   clipboard with a confirmation.
+
+---
+
+### Edge Cases
+
+- **Multiple entities in one text**: each detected number/email is independently
+  tappable; detecting one never swallows another or the text between them.
+- **Overlap with existing links**: a URL, an `@mention`, and an email in the same
+  message all render correctly without one detector clobbering another (email is
+  not mistaken for a URL, an `@mention` handle is not mistaken for an email).
+- **Ambiguous digit runs**: only plausible phone numbers are linkified (avoid
+  turning order numbers, code snippets, or long id strings into "call" links);
+  a conservative match is preferred over a false "Call" affordance.
+- **Formatting variety**: numbers with `+`, spaces, dashes, parentheses, or dots are
+  detected, and the value handed to the dialer is normalized to what a dialer
+  accepts.
+- **Email edge forms**: sub-addressing (`a+b@x.com`), dotted local parts, and
+  multi-label domains are detected; a trailing period/paren after the address is not
+  included in the address.
+- **No native handler**: on a platform where `tel:`/`sms:`/`mailto:` has no handler,
+  the action fails gracefully (Copy always works as a fallback).
+- **Right-to-left / mixed text**: a detected entity inside RTL text stays correctly
+  placed and tappable (no direction regression).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST detect phone numbers and email addresses within the
+  displayed text of **chat messages** and **Wall posts** and render each as a
+  distinct tappable element, leaving the surrounding text and its layout unchanged.
+- **FR-002**: Tapping a detected **phone number** MUST present actions: **Call**
+  (open the device dialer, `tel:`), **Message** (open the SMS app, `sms:`), and
+  **Copy** (place the number on the clipboard).
+- **FR-003**: Tapping a detected **email address** MUST present actions: **Email**
+  (open the mail app composing to it, `mailto:`) and **Copy**.
+- **FR-004**: **Copy** MUST place the exact detected value on the clipboard and show
+  a brief confirmation.
+- **FR-005**: Detection MUST coexist with the existing inline features (URL links and
+  `@mentions`) so that all render correctly in the same text with no detector
+  overriding another.
+- **FR-006**: Detection MUST be conservative — plausible phone numbers and
+  well-formed email addresses only — to avoid false "Call"/"Email" affordances on
+  unrelated digit runs or tokens.
+- **FR-007**: The value handed to the native app MUST be normalized appropriately
+  (a dial-safe phone string for `tel:`/`sms:`, the plain address for `mailto:`), and
+  trailing punctuation MUST NOT be included in the entity.
+- **FR-008**: All detection, rendering, and hand-off MUST happen on the device; the
+  feature MUST add no new client→server data and MUST NOT weaken text-rendering
+  safety (detected text stays escaped; nothing user-provided is rendered as raw
+  markup).
+- **FR-009**: When a native handler is unavailable, the action MUST fail gracefully
+  and Copy MUST remain available.
+
+### Key Entities *(include if feature involves data)*
+
+- **Detected entity**: a span within a text body classified as a phone number or an
+  email address, with its display text (as written) and its normalized action value
+  (dial string or address). Purely derived at render time; nothing is stored.
+
+## Zero-Knowledge Impact *(mandatory — Constitution Principle I)*
+
+- **What crosses the wire**: Nothing. Detection runs entirely on the client over text
+  that is already decrypted locally (a message body / post body). No new request,
+  field, or payload is introduced; the server never learns that an entity was
+  detected or acted on.
+- **What is encrypted / protected**: Message and post bodies remain end-to-end
+  encrypted exactly as today; this feature only affects how already-decrypted text is
+  displayed and what local OS action a tap triggers.
+- **What metadata is unavoidably visible**: Unchanged. Tapping Call/Message/Email
+  hands off to the operating system (`tel:`/`sms:`/`mailto:`), a purely local action
+  the Ring server has no part in and cannot observe.
+- **Why this is safe**: It is a client-only presentation + OS hand-off layer over
+  content that is already local and encrypted; it introduces nothing for the server
+  to know and no new attack surface beyond safe text rendering (which is preserved).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A phone number in a message or post is tappable and offers Call,
+  Message, and Copy in 100% of the supported formatting variations tested (plain,
+  `+`-prefixed, spaced, dashed, parenthesized).
+- **SC-002**: An email address in a message or post is tappable and offers Email and
+  Copy in 100% of tested well-formed variations (plain, sub-addressed, dotted local,
+  multi-label domain).
+- **SC-003**: Call/Message/Email target the exact normalized `tel:`/`sms:`/`mailto:`
+  value, and Copy places the exact detected value on the clipboard, in 100% of tests.
+- **SC-004**: URLs, `@mentions`, phone numbers, and emails in the same text all render
+  correctly together with zero cross-detector corruption across the test corpus.
+- **SC-005**: The conservative matcher produces zero false Call/Email affordances on a
+  corpus of non-entity digit/text runs (order numbers, hashes, code).
+- **SC-006**: No new data crosses the client/server boundary and text rendering stays
+  injection-safe (verified by the detector/renderer unit tests and the ZK check).
+
+## Assumptions
+
+- **Native hand-off model** (clarified): Call → `tel:`, Message → `sms:`, Email →
+  `mailto:`; the OS owns the actual call/SMS/email. Ring places no PSTN/SMS/email
+  itself.
+- **Detection surfaces**: chat message bodies and Wall post bodies (the two places
+  the user named). Other text surfaces (contact "about", captions) are out of scope.
+- **Rendering reuse**: detection plugs into the existing message/post text renderer
+  alongside URL/@mention handling rather than introducing a separate renderer.
+- **Clipboard + confirmation**: reuse the app's existing clipboard + toast pattern.
+- **Conservative matching**: err toward missing an unusual number over falsely
+  linkifying a non-number; the goal is no misleading "Call" affordances.
+
+## Out of Scope
+
+- Placing calls, sending SMS, or sending email from within Ring itself (all hand off
+  to native apps).
+- Detecting entities in surfaces other than chat messages and Wall posts.
+- Rich contact actions (add to contacts, detect names/addresses); only phone numbers
+  and email addresses are detected.
+- A settings toggle to disable detection (can be a later addition if wanted).
+- Deep phone-number libphonenumber-grade parsing/validation beyond a conservative,
+  dependency-light matcher.

--- a/specs/1029-tap-phone-and-email/tasks.md
+++ b/specs/1029-tap-phone-and-email/tasks.md
@@ -10,29 +10,29 @@ correctness); the render/action integration gets a lean e2e. No crypto/ZK checkl
 
 ## Phase 1: The pure detector (core — unit-first)
 
-- [x] T001 [P] Failing unit tests in `src/utils/linkify.test.ts`: `segmentContacts` over a large corpus — phone formats (plain, `+`, spaces, dashes, dots, parens), emails (plain, `a+b@x.com`, dotted local, multi-label domain), trailing-punctuation trimming, multiple entities in one string, an `@` inside an email not detected as a phone, and a NON-match corpus (order numbers, hashes, times like `12:30`, hex, long id strings) yielding ZERO false positives (SC-005); plus `telValue`/`telHref`/`smsHref`/`mailtoHref` normalization
-- [x] T002 Implement `src/utils/linkify.ts` (EMAIL_RE, conservative PHONE_RE with a 7–15 digit bound, non-overlapping left-to-right segmentation, email-before-phone, href/normalizer helpers) until T001 is green
+- [x] T001 (#673) [P] Failing unit tests in `src/utils/linkify.test.ts`: `segmentContacts` over a large corpus — phone formats (plain, `+`, spaces, dashes, dots, parens), emails (plain, `a+b@x.com`, dotted local, multi-label domain), trailing-punctuation trimming, multiple entities in one string, an `@` inside an email not detected as a phone, and a NON-match corpus (order numbers, hashes, times like `12:30`, hex, long id strings) yielding ZERO false positives (SC-005); plus `telValue`/`telHref`/`smsHref`/`mailtoHref` normalization
+- [x] T002 (#674) Implement `src/utils/linkify.ts` (EMAIL_RE, conservative PHONE_RE with a 7–15 digit bound, non-overlapping left-to-right segmentation, email-before-phone, href/normalizer helpers) until T001 is green
 
 ## Phase 2: Scheme open + action sheet
 
-- [x] T003 [P] Add `openScheme(uri)` to `src/utils/external.ts` (transient anchor for `tel:`/`sms:`/`mailto:`, no `target=_blank`, graceful no-op if unhandled)
-- [x] T004 Implement `src/services/entity-actions.ts` `presentEntityActions(seg)`: phone → Call/Message/Copy, email → Email/Copy, via `actionSheetController`; Copy = `navigator.clipboard.writeText(raw)` + `appToast('Copied')`
+- [x] T003 (#675) [P] Add `openScheme(uri)` to `src/utils/external.ts` (transient anchor for `tel:`/`sms:`/`mailto:`, no `target=_blank`, graceful no-op if unhandled)
+- [x] T004 (#676) Implement `src/services/entity-actions.ts` `presentEntityActions(seg)`: phone → Call/Message/Copy, email → Email/Copy, via `actionSheetController`; Copy = `navigator.clipboard.writeText(raw)` + `appToast('Copied')`
 
 ## Phase 3: User Story 1 & 2 — messages (P1)
 
-- [x] T005 [US1] Failing Playwright e2e `e2e/tap-entities.spec.ts` (messages): a received message containing a phone number and an email renders TWO tappable entities; tapping the phone opens an action sheet with Call/Message/Copy; tapping the email opens Email/Copy; Copy places the exact value on the clipboard; assert the rendered `tel:`/`mailto:` targets are the normalized values
-- [x] T006 [US1][US2] Extend `BodySeg` + `bodyParts` in `src/views/detail/ChatDetailPage.vue` to emit `email`/`phone` segments (URL → mention → contacts → emoji order) and render them as tappable spans → `presentEntityActions`
+- [x] T005 (#677) [US1] Failing Playwright e2e `e2e/tap-entities.spec.ts` (messages): a received message containing a phone number and an email renders TWO tappable entities; tapping the phone opens an action sheet with Call/Message/Copy; tapping the email opens Email/Copy; Copy places the exact value on the clipboard; assert the rendered `tel:`/`mailto:` targets are the normalized values
+- [x] T006 (#678) [US1][US2] Extend `BodySeg` + `bodyParts` in `src/views/detail/ChatDetailPage.vue` to emit `email`/`phone` segments (URL → mention → contacts → emoji order) and render them as tappable spans → `presentEntityActions`
 
 ## Phase 4: User Story 1 & 2 — Wall posts (P1)
 
-- [x] T007 [US1][US2] Add `segmentContacts` detection to `src/components/EmojiText.vue` (before emoji segmentation) so posts + comments render tappable phone/email → `presentEntityActions`; keep emoji-only rendering otherwise unchanged
-- [ ] T008 [P] [US1][US2] Extend the e2e (or a drive scenario) to cover a Wall post body with a phone + email rendering tappable
+- [x] T007 (#679) [US1][US2] Add `segmentContacts` detection to `src/components/EmojiText.vue` (before emoji segmentation) so posts + comments render tappable phone/email → `presentEntityActions`; keep emoji-only rendering otherwise unchanged
+- [ ] T008 (#680) [P] [US1][US2] Extend the e2e (or a drive scenario) to cover a Wall post body with a phone + email rendering tappable
 
 ## Phase 5: Polish & gates
 
-- [x] T009 [P] Confirm coexistence (FR-005): a message with a URL, an `@mention`, a phone, and an email renders all four correctly (add to the unit corpus + the e2e)
-- [ ] T010 Full gates: `npm run build`, `npx vitest run`, `npm run test:e2e` (the tap-entities spec), and confirm existing message/emoji unit tests stay green
-- [ ] T011 Bump spec `**Status**:` to `in-review` + `make roadmap`
+- [x] T009 (#681) [P] Confirm coexistence (FR-005): a message with a URL, an `@mention`, a phone, and an email renders all four correctly (add to the unit corpus + the e2e)
+- [x] T010 (#682) Full gates: `npm run build`, `npx vitest run`, `npm run test:e2e` (the tap-entities spec), and confirm existing message/emoji unit tests stay green
+- [x] T011 (#683) Bump spec `**Status**:` to `in-review` + `make roadmap`
 
 ## Dependencies
 Phase 1 (detector) → Phase 2 (actions) → Phases 3/4 (integration) → Phase 5. T005/T008 e2e are written before their integration lands. MVP is Phases 1–3 (messages); posts (Phase 4) layer on the same detector.

--- a/specs/1029-tap-phone-and-email/tasks.md
+++ b/specs/1029-tap-phone-and-email/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Tap a Phone Number or Email in Messages & Posts
+
+**Input**: Design documents from `/specs/1029-tap-phone-and-email/`
+
+**Prerequisites**: plan.md, spec.md. Shares the `feat/1028-robust-audio-and` branch.
+
+**Tests**: REQUIRED (constitution III). The pure detector is unit-first (the bulk of
+correctness); the render/action integration gets a lean e2e. No crypto/ZK checklist
+(this touches neither — no new wire data).
+
+## Phase 1: The pure detector (core — unit-first)
+
+- [x] T001 [P] Failing unit tests in `src/utils/linkify.test.ts`: `segmentContacts` over a large corpus — phone formats (plain, `+`, spaces, dashes, dots, parens), emails (plain, `a+b@x.com`, dotted local, multi-label domain), trailing-punctuation trimming, multiple entities in one string, an `@` inside an email not detected as a phone, and a NON-match corpus (order numbers, hashes, times like `12:30`, hex, long id strings) yielding ZERO false positives (SC-005); plus `telValue`/`telHref`/`smsHref`/`mailtoHref` normalization
+- [x] T002 Implement `src/utils/linkify.ts` (EMAIL_RE, conservative PHONE_RE with a 7–15 digit bound, non-overlapping left-to-right segmentation, email-before-phone, href/normalizer helpers) until T001 is green
+
+## Phase 2: Scheme open + action sheet
+
+- [x] T003 [P] Add `openScheme(uri)` to `src/utils/external.ts` (transient anchor for `tel:`/`sms:`/`mailto:`, no `target=_blank`, graceful no-op if unhandled)
+- [x] T004 Implement `src/services/entity-actions.ts` `presentEntityActions(seg)`: phone → Call/Message/Copy, email → Email/Copy, via `actionSheetController`; Copy = `navigator.clipboard.writeText(raw)` + `appToast('Copied')`
+
+## Phase 3: User Story 1 & 2 — messages (P1)
+
+- [x] T005 [US1] Failing Playwright e2e `e2e/tap-entities.spec.ts` (messages): a received message containing a phone number and an email renders TWO tappable entities; tapping the phone opens an action sheet with Call/Message/Copy; tapping the email opens Email/Copy; Copy places the exact value on the clipboard; assert the rendered `tel:`/`mailto:` targets are the normalized values
+- [x] T006 [US1][US2] Extend `BodySeg` + `bodyParts` in `src/views/detail/ChatDetailPage.vue` to emit `email`/`phone` segments (URL → mention → contacts → emoji order) and render them as tappable spans → `presentEntityActions`
+
+## Phase 4: User Story 1 & 2 — Wall posts (P1)
+
+- [x] T007 [US1][US2] Add `segmentContacts` detection to `src/components/EmojiText.vue` (before emoji segmentation) so posts + comments render tappable phone/email → `presentEntityActions`; keep emoji-only rendering otherwise unchanged
+- [ ] T008 [P] [US1][US2] Extend the e2e (or a drive scenario) to cover a Wall post body with a phone + email rendering tappable
+
+## Phase 5: Polish & gates
+
+- [x] T009 [P] Confirm coexistence (FR-005): a message with a URL, an `@mention`, a phone, and an email renders all four correctly (add to the unit corpus + the e2e)
+- [ ] T010 Full gates: `npm run build`, `npx vitest run`, `npm run test:e2e` (the tap-entities spec), and confirm existing message/emoji unit tests stay green
+- [ ] T011 Bump spec `**Status**:` to `in-review` + `make roadmap`
+
+## Dependencies
+Phase 1 (detector) → Phase 2 (actions) → Phases 3/4 (integration) → Phase 5. T005/T008 e2e are written before their integration lands. MVP is Phases 1–3 (messages); posts (Phase 4) layer on the same detector.

--- a/src/components/ContactPicker.vue
+++ b/src/components/ContactPicker.vue
@@ -3,7 +3,7 @@
     <ion-header>
       <ion-toolbar>
         <ion-buttons slot="start"><ion-button @click="$emit('close')">Cancel</ion-button></ion-buttons>
-        <ion-title>Share contact</ion-title>
+        <ion-title>{{ title ?? 'Share contact' }}</ion-title>
       </ion-toolbar>
       <ion-toolbar>
         <ion-searchbar
@@ -20,7 +20,7 @@
           <ion-label>{{ c.name }}</ion-label>
         </ion-item>
       </ion-list>
-      <div v-if="!filtered.length" class="empty"><ion-note>No contacts to share</ion-note></div>
+      <div v-if="!filtered.length" class="empty"><ion-note>{{ emptyText ?? 'No contacts to share' }}</ion-note></div>
     </ion-content>
   </ion-modal>
 </template>
@@ -33,7 +33,9 @@ import {
 } from '@ionic/vue';
 import type { Contact, SharedContact } from '@/db/types';
 
-const props = defineProps<{ open: boolean; contacts: Contact[] }>();
+// `title`/`emptyText` let callers repurpose the picker (e.g. "Add to call", spec
+// 1028) without changing the default "Share contact" behaviour.
+const props = defineProps<{ open: boolean; contacts: Contact[]; title?: string; emptyText?: string }>();
 const emit = defineEmits<{ (e: 'close'): void; (e: 'select', c: SharedContact): void }>();
 
 const q = ref('');

--- a/src/components/EmojiText.vue
+++ b/src/components/EmojiText.vue
@@ -2,12 +2,19 @@
   <!-- Renders a run of text with inline animated Noto emoji, the same way chat message
        bodies do: split into plain-text + emoji segments and render each emoji with
        <AnimatedEmoji>. Used for Wall post bodies and comments so their emoji match the
-       rest of the app (animated, self-hosted, animation-pref aware). -->
+       rest of the app (animated, self-hosted, animation-pref aware). Detected phone
+       numbers / email addresses render as tappable entities (spec 1029). -->
   <span class="emoji-text" dir="auto" :class="{ 'emoji-only': isBig }"><template
     v-for="(p, i) in parts"
     :key="i"
-  ><animated-emoji
-      v-if="p.emoji"
+  ><a
+      v-if="p.contact"
+      class="entity-link"
+      role="button"
+      :href="p.contact.kind === 'phone' ? telHref(p.contact.raw) : mailtoHref(p.contact.raw)"
+      @click.stop.prevent="presentEntityActions(p.contact)"
+    >{{ p.contact.raw }}</a><animated-emoji
+      v-else-if="p.emoji"
       :emoji="p.emoji"
       :animate="animEmoji"
       :large="isBig"
@@ -18,6 +25,8 @@
 import { computed } from 'vue';
 import AnimatedEmoji from '@/components/AnimatedEmoji.vue';
 import { segmentEmoji, emojiOnlyCount } from '@/utils/emoji';
+import { segmentContacts, telHref, mailtoHref } from '@/utils/linkify';
+import { presentEntityActions, type ContactEntity } from '@/services/entity-actions';
 import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
 
 // `big`: when set, a text that is ONLY emoji (≤3) renders enlarged, matching how chat
@@ -25,7 +34,28 @@ import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
 const props = withDefaults(defineProps<{ text: string; big?: boolean }>(), { big: false });
 
 const { animEmoji } = useAnimationPrefs();
-const parts = computed(() => segmentEmoji(props.text));
+
+interface Part {
+  text?: string;
+  emoji?: string;
+  contact?: ContactEntity;
+}
+// Detect phone/email first (spec 1029), then emoji-segment the plain runs between
+// them. Token-based like the chat renderer, so it stays injection-safe.
+const parts = computed<Part[]>(() => {
+  const out: Part[] = [];
+  for (const cs of segmentContacts(props.text)) {
+    if ('kind' in cs) {
+      out.push({ contact: cs });
+      continue;
+    }
+    for (const seg of segmentEmoji(cs.text)) {
+      if (seg.emoji) out.push({ emoji: seg.emoji });
+      else if (seg.text) out.push({ text: seg.text });
+    }
+  }
+  return out;
+});
 const isBig = computed(() => {
   if (!props.big) return false;
   const n = emojiOnlyCount(props.text);
@@ -39,5 +69,10 @@ const isBig = computed(() => {
 }
 .emoji-text.emoji-only {
   font-size: 2em;
+}
+/* Tappable phone/email (spec 1029) — matches the app's link accent. */
+.entity-link {
+  color: var(--ring-accent, var(--ion-color-primary));
+  cursor: pointer;
 }
 </style>

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -43,6 +43,8 @@ import { syncState } from '@/composables/useSync';
 import { startLoopTone, stopLoopTone, playTone, cue, type ToneName } from '@/services/sound';
 import type { CallState, CallMeta, CallKind, EndReason } from '@/services/call/types';
 import { VIDEO_MAX } from '@/services/call/types';
+import { remainingSlots, canAdd } from '@/services/call/capacity';
+import { planInvite } from '@/services/call/invite-plan';
 import {
   type Tier,
   type ControllerState,
@@ -1509,6 +1511,41 @@ export async function recallMember(memberId: string): Promise<void> {
   markNotJoining(memberId, false);
   armMemberRingTimer(memberId);
   await sendRecall(memberId, meta.roomId, meta.kind, meta.invited ?? []);
+}
+
+/** Free participant slots left in the ACTIVE call for its kind (spec 1028) — 0 when
+ *  there is no active call. Drives the Add-people gate (picker disables past this). */
+export function callRemainingSlots(): number {
+  const meta = callMeta.value;
+  if (!meta) return 0;
+  return remainingSlots(meta.kind, meta.roster, meta.invited ?? [], getSelfUserId() ?? '');
+}
+
+/**
+ * Add people to the ACTIVE call (spec 1028, US2). MVP scope: only while already
+ * in a GROUP call — promoting a 1:1 into a mesh (and merging an incoming caller)
+ * is the deferred follow-up, so a 1:1 has no add path yet. Rings each fresh,
+ * capacity-fitting id into the room via the existing in-room `call-ring` seam
+ * (same as recallMember); the roster/leg machinery meshes them on accept. Cap is
+ * enforced pre-emptively here (planInvite clamps + canAdd reason) with the server
+ * `JoinIfRoom` as the authoritative backstop.
+ */
+export async function addPeople(ids: string[]): Promise<void> {
+  const meta = callMeta.value;
+  if (!meta?.isGroup || !meta.roomId) return; // 1:1 add (via promotion) is deferred
+  const self = getSelfUserId() ?? '';
+  const plan = planInvite(meta.kind, meta.roster, meta.invited ?? [], self, ids);
+  for (const id of plan.toRing) {
+    meta.invited = [...(meta.invited ?? []), id];
+    markNotJoining(id, false);
+    armMemberRingTimer(id);
+    await sendRecall(id, meta.roomId, meta.kind, meta.invited);
+  }
+  // Anyone who didn't fit the cap → tell the user why (kind-specific copy).
+  if (plan.dropped.length) {
+    const gate = canAdd(meta.kind, meta.roster, meta.invited ?? [], self, 1);
+    await toast(gate.ok ? 'Some people are already in the call' : gate.reason);
+  }
 }
 
 /** Tap "Remove from call" on a non-joiner's tile → stop ringing them, drop them from the
@@ -3059,5 +3096,9 @@ export function useCall() {
     setVideoQuality,
     acceptUpgrade,
     rejectUpgrade,
+    addPeople,
+    callRemainingSlots,
+    recallMember,
+    cancelInvite,
   };
 }

--- a/src/db/badge-count.test.ts
+++ b/src/db/badge-count.test.ts
@@ -1,9 +1,9 @@
-// Unit tests for the badge total computation (spec 1027 T023, fixes bug B4).
-// The old page code failed closed to 0 for the WHOLE app while the hidden set
-// was still locked in modes never/revealed — blanking legitimate visible-chat
-// badges. The pure helper makes the fallback explicit: an unknown set falls
-// back to the last successfully computed (already preference-filtered) count,
-// never to zero, and never counts what it cannot classify.
+// Unit tests for the badge total computation (spec 1027 T023, fixes bug B4;
+// mode-at-write cache tightening in spec 1028). The naive code failed closed to
+// 0 for the WHOLE app while the hidden set was locked in modes never/revealed —
+// blanking legitimate visible-chat badges. The pure helper falls back to the
+// last HIDDEN-EXCLUDED count instead, and marks which results are safe to cache
+// so an always-mode (hidden-inclusive) total can never seed that fallback.
 import { describe, it, expect } from 'vitest';
 import { computeUnreadTotal } from './badge-count';
 
@@ -15,30 +15,47 @@ const chats = [
 const hidden = new Set(['h1']);
 
 describe('computeUnreadTotal', () => {
-  it("mode 'always' counts everything and needs no hidden knowledge", () => {
-    expect(computeUnreadTotal(chats, 'always', null, false, null)).toEqual({ total: 7, fresh: true });
-    expect(computeUnreadTotal(chats, 'always', hidden, false, null)).toEqual({ total: 7, fresh: true });
+  it("mode 'always' counts everything but is NOT cacheable (hidden-inclusive)", () => {
+    expect(computeUnreadTotal(chats, 'always', null, false, null)).toEqual({ total: 7, cacheable: false });
+    expect(computeUnreadTotal(chats, 'always', hidden, false, null)).toEqual({ total: 7, cacheable: false });
   });
 
-  it("mode 'never' excludes hidden unreads when the set is known", () => {
-    expect(computeUnreadTotal(chats, 'never', hidden, false, null)).toEqual({ total: 2, fresh: true });
+  it("mode 'never' excludes hidden unreads when the set is known, and is cacheable", () => {
+    expect(computeUnreadTotal(chats, 'never', hidden, false, null)).toEqual({ total: 2, cacheable: true });
   });
 
-  it("mode 'revealed' counts hidden unreads only during an active reveal", () => {
-    expect(computeUnreadTotal(chats, 'revealed', hidden, true, null)).toEqual({ total: 7, fresh: true });
-    expect(computeUnreadTotal(chats, 'revealed', hidden, false, null)).toEqual({ total: 2, fresh: true });
+  it("mode 'revealed' counts hidden only while revealed — and is cacheable ONLY when relocked", () => {
+    // Revealed → hidden counted → NOT safe to cache (would leak into a later
+    // locked cold-open fallback).
+    expect(computeUnreadTotal(chats, 'revealed', hidden, true, null)).toEqual({ total: 7, cacheable: false });
+    // Relocked → hidden excluded → cacheable.
+    expect(computeUnreadTotal(chats, 'revealed', hidden, false, null)).toEqual({ total: 2, cacheable: true });
   });
 
-  it('an unknown set falls back to the last good count — never a collateral zero (B4)', () => {
-    expect(computeUnreadTotal(chats, 'never', null, false, 2)).toEqual({ total: 2, fresh: false });
-    expect(computeUnreadTotal(chats, 'revealed', null, false, 4)).toEqual({ total: 4, fresh: false });
+  it('an unknown set falls back to the last good count — never a collateral zero (B4), never re-cached', () => {
+    expect(computeUnreadTotal(chats, 'never', null, false, 2)).toEqual({ total: 2, cacheable: false });
+    expect(computeUnreadTotal(chats, 'revealed', null, false, 4)).toEqual({ total: 4, cacheable: false });
   });
 
-  it('an unknown set with no cached count yields 0 without claiming freshness', () => {
-    expect(computeUnreadTotal(chats, 'never', null, false, null)).toEqual({ total: 0, fresh: false });
+  it('an unknown set with no cached count yields 0 (fail-closed under-count, no leak)', () => {
+    expect(computeUnreadTotal(chats, 'never', null, false, null)).toEqual({ total: 0, cacheable: false });
   });
 
-  it('empty chat list is 0 and fresh', () => {
-    expect(computeUnreadTotal([], 'never', hidden, false, 9)).toEqual({ total: 0, fresh: true });
+  it('empty chat list is 0 and cacheable', () => {
+    expect(computeUnreadTotal([], 'never', hidden, false, 9)).toEqual({ total: 0, cacheable: true });
+  });
+
+  it('mode-at-write leak is closed: an always-mode total never seeds the never/revealed fallback', () => {
+    // Sequence: user in 'always' → cache would hold the hidden-inclusive 7; but
+    // 'always' is not cacheable, so it never writes. User switches to 'never'
+    // and locks + cold-opens before a recompute: the fallback must NOT surface
+    // a hidden-inclusive number. With no cacheable write having happened, the
+    // fallback is whatever hidden-EXCLUDED value was last cached (here none → 0),
+    // and the always total (7) can never have been the cached seed.
+    const always = computeUnreadTotal(chats, 'always', hidden, false, null);
+    expect(always.cacheable).toBe(false); // 7 is never persisted
+    // The only value the fallback can reuse is a prior hidden-excluded total.
+    const cachedNever = computeUnreadTotal(chats, 'never', hidden, false, null);
+    expect(cachedNever).toEqual({ total: 2, cacheable: true }); // this one seeds it
   });
 });

--- a/src/db/badge-count.ts
+++ b/src/db/badge-count.ts
@@ -1,5 +1,5 @@
 /**
- * Badge total computation (spec 1027, fixes bug B4).
+ * Badge total computation (spec 1027, fixes bug B4; cache tightened in 1028).
  *
  * How hidden chats affect the unread badge is user-chosen
  * (`privacy.hiddenChatsBadge`):
@@ -9,13 +9,21 @@
  *   'never'    — hidden chats never contribute, so the badge can't betray one.
  *
  * The subtlety is the cold-open window in the non-'always' modes: before the
- * hidden set decrypts we cannot classify ANY chat, and the old code returned 0
+ * hidden set decrypts we cannot classify ANY chat, and the naive code returned 0
  * for the whole app — suppressing legitimate visible-chat badges. The fix:
- * `hidden === null` (unknown) falls back to `lastCount`, the most recent
- * successfully computed and ALREADY preference-filtered total (persisted as the
- * device-local `badge.lastCount`; it equals what the OS badge showed a moment
- * ago, so it reveals nothing new). `fresh` tells the caller whether the result
- * came from a real computation (persist it) or the fallback (don't).
+ * `hidden === null` (unknown) falls back to `lastCount`, a recent successfully
+ * computed HIDDEN-EXCLUDED total (persisted as the device-local
+ * `badge.lastCount`).
+ *
+ * `cacheable` tells the caller whether this result may seed `badge.lastCount`.
+ * ONLY a hidden-EXCLUDED count is cacheable: the `always` total is hidden-
+ * inclusive, and a `revealed`-while-revealed total counts hidden unreads —
+ * caching either would let a later locked cold-open under `never`/`revealed`
+ * briefly surface hidden activity against the user's choice (the mode-at-write
+ * leak). The fallback branch is not cacheable either (it would just rewrite
+ * itself). When nothing hidden-excluded has ever been cached, the fallback
+ * returns 0 — a brief under-count, which is the fail-closed-safe direction (no
+ * leak).
  *
  * Pure and dependency-free so both the page (`queries.countUnread`) and any
  * future SW use share one tested semantic.
@@ -29,17 +37,18 @@ export function computeUnreadTotal(
   hidden: ReadonlySet<string> | null, // null = set not yet decryptable (unknown)
   revealed: boolean,
   lastCount: number | null,
-): { total: number; fresh: boolean } {
+): { total: number; cacheable: boolean } {
   if (mode === 'always') {
-    return { total: chats.reduce((n, c) => n + (c.unread || 0), 0), fresh: true };
+    // Hidden-inclusive — correct to display, but must never seed the fallback.
+    return { total: chats.reduce((n, c) => n + (c.unread || 0), 0), cacheable: false };
   }
-  if (!hidden) return { total: lastCount ?? 0, fresh: false };
+  if (!hidden) return { total: lastCount ?? 0, cacheable: false };
   const countHidden = mode === 'revealed' && revealed;
   return {
     total: chats.reduce(
       (n, c) => n + (!countHidden && hidden.has(c.id) ? 0 : c.unread || 0),
       0,
     ),
-    fresh: true,
+    cacheable: !countHidden, // only a hidden-EXCLUDED total is safe to cache
   };
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3817,10 +3817,12 @@ export async function countUnread(): Promise<number> {
     hidden = isHiddenKnown() ? set : null;
   }
   const last = await getSetting<number | null>('badge.lastCount', null);
-  const { total, fresh } = computeUnreadTotal(chats, mode, hidden, isRevealed(), last);
-  // Persist only real computations (the fallback would just rewrite itself),
-  // and only on change (this runs on every badge refresh).
-  if (fresh && total !== last) await setSetting('badge.lastCount', total);
+  const { total, cacheable } = computeUnreadTotal(chats, mode, hidden, isRevealed(), last);
+  // Persist ONLY a hidden-excluded total (cacheable), so the never/revealed
+  // cold-open fallback can never reuse an always-mode (hidden-inclusive) or
+  // revealed-while-revealed value — the mode-at-write leak (spec 1028). Only on
+  // change (this runs on every badge refresh).
+  if (cacheable && total !== last) await setSetting('badge.lastCount', total);
   return total;
 }
 

--- a/src/services/call/capacity.test.ts
+++ b/src/services/call/capacity.test.ts
@@ -1,0 +1,85 @@
+// Unit tests for the pure call-capacity gate (spec 1028, T001). Every add path
+// (add-people, merge, group-invite merge) gates on these before ringing anyone;
+// the server JoinIfRoom stays the authoritative backstop. Caps: 4 video / 8 audio
+// (VIDEO_MAX/AUDIO_MAX), and an INVITED (ringing) person holds a slot so two
+// concurrent adds can't both overshoot.
+import { describe, it, expect } from 'vitest';
+import { capOf, headcount, remainingSlots, canAdd } from './capacity';
+
+const SELF = 'self';
+
+describe('capOf', () => {
+  it('is 4 for video and 8 for audio', () => {
+    expect(capOf('video')).toBe(4);
+    expect(capOf('audio')).toBe(8);
+  });
+});
+
+describe('headcount (distinct roster ∪ invited ∪ self)', () => {
+  it('counts self even when the roster is empty', () => {
+    expect(headcount([], [], SELF)).toBe(1);
+  });
+  it('dedups across roster, invited, and self', () => {
+    // roster has self+A; invited has A (ringing→joined race) + B. Distinct = self,A,B.
+    expect(headcount([SELF, 'a'], ['a', 'b'], SELF)).toBe(3);
+  });
+  it('a ringing invitee counts', () => {
+    expect(headcount([SELF, 'a'], ['b'], SELF)).toBe(3);
+  });
+});
+
+describe('remainingSlots', () => {
+  it('video 4-cap: self + 1 in room leaves 2', () => {
+    expect(remainingSlots('video', [SELF, 'a'], [], SELF)).toBe(2);
+  });
+  it('audio 8-cap: self + 3 leaves 4', () => {
+    expect(remainingSlots('audio', [SELF, 'a', 'b', 'c'], [], SELF)).toBe(4);
+  });
+  it('invited (ringing) people consume remaining slots', () => {
+    // video: self + a in room + b,c ringing = 4 → full.
+    expect(remainingSlots('video', [SELF, 'a'], ['b', 'c'], SELF)).toBe(0);
+  });
+  it('never goes negative (legacy over-cap state)', () => {
+    expect(remainingSlots('video', [SELF, 'a', 'b', 'c', 'd'], [], SELF)).toBe(0);
+  });
+});
+
+describe('canAdd', () => {
+  it('allows an add that fits', () => {
+    expect(canAdd('audio', [SELF, 'a'], [], SELF, 1)).toEqual({ ok: true });
+  });
+
+  it('blocks the 5th on a video call with a kind-specific reason', () => {
+    // self + 3 already = 4 (full). Adding 1 more → blocked.
+    const r = canAdd('video', [SELF, 'a', 'b', 'c'], [], SELF, 1);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/video calls.*4/i);
+  });
+
+  it('blocks the 9th on an audio call with a kind-specific reason', () => {
+    const roster = [SELF, 'a', 'b', 'c', 'd', 'e', 'f', 'g']; // 8 = full
+    const r = canAdd('audio', roster, [], SELF, 1);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/audio calls.*8/i);
+  });
+
+  it('blocks adding MORE than remaining even if one would fit', () => {
+    // video: self + 2 = 3, remaining 1. Adding 2 → blocked (the picker cap).
+    expect(canAdd('video', [SELF, 'a', 'b'], [], SELF, 2).ok).toBe(false);
+    expect(canAdd('video', [SELF, 'a', 'b'], [], SELF, 1).ok).toBe(true);
+  });
+
+  it('counts invited against the cap (no concurrent overshoot)', () => {
+    // audio: self + 6 in room + 1 ringing = 8 → full; another add blocked.
+    const roster = [SELF, 'a', 'b', 'c', 'd', 'e', 'f'];
+    expect(canAdd('audio', roster, ['g'], SELF, 1).ok).toBe(false);
+  });
+
+  it('US6 combined headcount: passing the union of two rosters as roster+invited', () => {
+    // Merge group invite: current [self,a] + incoming [c,d]; distinct combined = 4.
+    // Video cap 4 → exactly fits (adding c,d as the n via invited pre-union): allowed.
+    expect(canAdd('video', [SELF, 'a'], [], SELF, 2)).toEqual({ ok: true });
+    // One more (a 5th) → blocked.
+    expect(canAdd('video', [SELF, 'a'], [], SELF, 3).ok).toBe(false);
+  });
+});

--- a/src/services/call/capacity.ts
+++ b/src/services/call/capacity.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure call-capacity gate (spec 1028). A video call holds at most VIDEO_MAX (4)
+ * and an audio call at most AUDIO_MAX (8) participants — the existing caps, now
+ * enforced PRE-EMPTIVELY on every mid-call add path (add-people, merge,
+ * group-invite merge) so the user is stopped before anyone is rung, instead of
+ * failing after the fact with a server `call-full`. The server's `JoinIfRoom`
+ * stays the authoritative backstop; this is UX, not the security boundary.
+ *
+ * A person who has been INVITED (is ringing) but hasn't joined still holds a
+ * slot, so two concurrent adds can't both slip past the gate and overshoot the
+ * cap. Dependency-free (no WebRTC) so it is exhaustively unit-tested.
+ */
+import { VIDEO_MAX, AUDIO_MAX, type CallKind } from './types';
+
+export function capOf(kind: CallKind): number {
+  return kind === 'video' ? VIDEO_MAX : AUDIO_MAX;
+}
+
+/** Distinct heads currently occupying slots: everyone in the room, everyone
+ *  ringing, and self — counted once each. */
+export function headcount(roster: string[], invited: string[], selfId: string): number {
+  return new Set([selfId, ...roster, ...invited]).size;
+}
+
+/** Free slots left for the call's kind (never negative). */
+export function remainingSlots(
+  kind: CallKind,
+  roster: string[],
+  invited: string[],
+  selfId: string,
+): number {
+  return Math.max(0, capOf(kind) - headcount(roster, invited, selfId));
+}
+
+/** Pre-emptive add gate (FR-010/FR-011). `n` is how many NEW people the user is
+ *  trying to add. The reason copy is kind-specific and user-facing. */
+export function canAdd(
+  kind: CallKind,
+  roster: string[],
+  invited: string[],
+  selfId: string,
+  n: number,
+): { ok: true } | { ok: false; reason: string } {
+  if (n <= remainingSlots(kind, roster, invited, selfId)) return { ok: true };
+  const reason =
+    kind === 'video'
+      ? `Video calls are limited to ${VIDEO_MAX} people`
+      : `Audio calls are limited to ${AUDIO_MAX} people`;
+  return { ok: false, reason };
+}

--- a/src/services/call/invite-plan.test.ts
+++ b/src/services/call/invite-plan.test.ts
@@ -1,0 +1,56 @@
+// Unit tests for the pure invite-planning helper (spec 1028, T009). inviteToRoom
+// uses this to decide WHO to ring: drop ids already present/ringing/self, dedup
+// the request, and clamp to the remaining capacity so a mid-call add never
+// overshoots the cap. No WebRTC — pure decision.
+import { describe, it, expect } from 'vitest';
+import { planInvite } from './invite-plan';
+
+const SELF = 'self';
+
+describe('planInvite', () => {
+  it('rings a fresh contact that fits', () => {
+    expect(planInvite('audio', [SELF, 'a'], [], SELF, ['b'])).toEqual({
+      toRing: ['b'],
+      dropped: [],
+    });
+  });
+
+  it('drops ids already in the roster, already ringing, or self', () => {
+    const r = planInvite('audio', [SELF, 'a'], ['b'], SELF, ['a', 'b', SELF, 'c']);
+    expect(r.toRing).toEqual(['c']); // a (in room), b (ringing), self all dropped as present
+    expect(r.dropped).toEqual([]); // 'c' fits (audio cap 8)
+  });
+
+  it('dedups repeats within the request', () => {
+    expect(planInvite('audio', [SELF], [], SELF, ['c', 'c', 'd', 'c'])).toEqual({
+      toRing: ['c', 'd'],
+      dropped: [],
+    });
+  });
+
+  it('clamps to remaining capacity — the overflow is dropped, not rung', () => {
+    // video cap 4, self + a in room → remaining 2. Request 3 fresh → ring 2, drop 1.
+    const r = planInvite('video', [SELF, 'a'], [], SELF, ['b', 'c', 'd']);
+    expect(r.toRing).toEqual(['b', 'c']);
+    expect(r.dropped).toEqual(['d']);
+  });
+
+  it('rings nobody (and drops all) when the call is already full', () => {
+    const roster = [SELF, 'a', 'b', 'c']; // video full
+    expect(planInvite('video', roster, [], SELF, ['d'])).toEqual({
+      toRing: [],
+      dropped: ['d'],
+    });
+  });
+
+  it('counts already-ringing invitees against remaining capacity', () => {
+    // video: self + a in room + b ringing = 3, remaining 1. Request c,d → ring c, drop d.
+    const r = planInvite('video', [SELF, 'a'], ['b'], SELF, ['c', 'd']);
+    expect(r.toRing).toEqual(['c']);
+    expect(r.dropped).toEqual(['d']);
+  });
+
+  it('an empty request is a no-op', () => {
+    expect(planInvite('audio', [SELF, 'a'], [], SELF, [])).toEqual({ toRing: [], dropped: [] });
+  });
+});

--- a/src/services/call/invite-plan.ts
+++ b/src/services/call/invite-plan.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure invite planning for growing a call (spec 1028). Given the people the user
+ * wants to add, decide who actually gets rung: drop anyone already in the room,
+ * already ringing, or self; dedup the request; and clamp to the remaining
+ * capacity for the call's kind so a mid-call add can never overshoot the cap
+ * (the ids that don't fit are reported as `dropped` so the caller can surface the
+ * cap reason). Dependency-free (no WebRTC) so `inviteToRoom`'s decision is
+ * exhaustively unit-tested; the impure wrapper only performs the ring.
+ */
+import { remainingSlots } from './capacity';
+import type { CallKind } from './types';
+
+export function planInvite(
+  kind: CallKind,
+  roster: string[],
+  invited: string[],
+  selfId: string,
+  requested: string[],
+): { toRing: string[]; dropped: string[] } {
+  const present = new Set([selfId, ...roster, ...invited]);
+  const fresh: string[] = [];
+  const seen = new Set<string>();
+  for (const id of requested) {
+    if (!id || present.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    fresh.push(id);
+  }
+  const room = remainingSlots(kind, roster, invited, selfId);
+  return { toRing: fresh.slice(0, room), dropped: fresh.slice(room) };
+}

--- a/src/services/call/types.ts
+++ b/src/services/call/types.ts
@@ -7,8 +7,19 @@ export type { CallKind };
 // group call holds at most VIDEO_MAX, an audio one at most AUDIO_MAX; the audio→video upgrade
 // is blocked once a call has more than VIDEO_MAX participants. The client enforces these
 // pre-emptively (picker + upgrade gate); the server enforces them authoritatively at join.
-export const VIDEO_MAX = 4;
-export const AUDIO_MAX = 8;
+//
+// Exported as live `let` bindings (not `const`) ONLY so the dev/e2e harness can shrink them —
+// mirroring the server's SetVideoMaxForTest — to exercise the pre-emptive add gate (spec 1028)
+// without spinning up a real 8-person call. Production never calls the setter, so these stay 4/8.
+export let VIDEO_MAX = 4;
+export let AUDIO_MAX = 8;
+
+/** Dev/e2e only: override the client-side caps (the pre-emptive add gate reads these). Pass
+ *  `undefined` to leave a cap unchanged. Never called in production builds. */
+export function setCallCapsForTest(video?: number, audio?: number): void {
+  if (video != null) VIDEO_MAX = video;
+  if (audio != null) AUDIO_MAX = audio;
+}
 
 /**
  * Call lifecycle:

--- a/src/services/crypto/message.ts
+++ b/src/services/crypto/message.ts
@@ -93,7 +93,10 @@ export interface CallSignal {
   // max quality it wants/can use. Same trick: sealed inside the existing call-ice frame, coarse
   // enums + a counter ONLY (never raw bitrate/IP/location — Principle IX, FR-011), so the server
   // still only relays opaque ciphertext and can't tell it from any other sealed call signal.
-  type: 'offer' | 'answer' | 'ice' | 'key' | 'streamid' | 'hold' | 'resume' | 'qos';
+  // 'joinroom' (spec 1028): promote/merge — tell this peer to join a mesh room (carries only the
+  // opaque `roomId` + `kind` below). Same sealed-inside-call-ice trick as hold/resume/qos, so no
+  // new frame type reaches the server; it can't tell a promotion from any other sealed signal.
+  type: 'offer' | 'answer' | 'ice' | 'key' | 'streamid' | 'hold' | 'resume' | 'qos' | 'joinroom';
   kind?: 'audio' | 'video'; // on offer
   sdp?: string; // offer/answer
   sdpType?: RTCSdpType; // offer/answer

--- a/src/services/entity-actions.ts
+++ b/src/services/entity-actions.ts
@@ -1,0 +1,47 @@
+/**
+ * Action sheet for a tapped phone number / email address in message or post text
+ * (spec 1029). Phone → Call / Message / Copy; email → Email / Copy. Call, Message
+ * and Email hand off to the OS via tel:/sms:/mailto: (openScheme); Copy places the
+ * exact detected value on the clipboard with a brief confirmation. Everything is
+ * local — no server involvement.
+ */
+import { actionSheetController } from '@ionic/vue';
+import { callOutline, chatbubbleEllipsesOutline, mailOutline, copyOutline } from 'ionicons/icons';
+import { openScheme } from '@/utils/external';
+import { appToast } from '@/services/toast';
+import { telHref, smsHref, mailtoHref } from '@/utils/linkify';
+
+export interface ContactEntity {
+  kind: 'email' | 'phone';
+  raw: string; // as written in the text
+  value: string; // normalized (dial string for phone; the address for email)
+}
+
+async function copyValue(raw: string): Promise<void> {
+  try {
+    await navigator.clipboard?.writeText(raw);
+    await appToast('Copied');
+  } catch {
+    /* clipboard unavailable — best effort */
+  }
+}
+
+/** Present the OS-handoff actions for a detected phone/email. */
+export async function presentEntityActions(entity: ContactEntity): Promise<void> {
+  const buttons =
+    entity.kind === 'phone'
+      ? [
+          { text: 'Call', icon: callOutline, handler: () => openScheme(telHref(entity.raw)) },
+          { text: 'Message', icon: chatbubbleEllipsesOutline, handler: () => openScheme(smsHref(entity.raw)) },
+          { text: 'Copy', icon: copyOutline, handler: () => void copyValue(entity.raw) },
+        ]
+      : [
+          { text: 'Email', icon: mailOutline, handler: () => openScheme(mailtoHref(entity.raw)) },
+          { text: 'Copy', icon: copyOutline, handler: () => void copyValue(entity.raw) },
+        ];
+  const sheet = await actionSheetController.create({
+    header: entity.raw,
+    buttons: [...buttons, { text: 'Cancel', role: 'cancel' }],
+  });
+  await sheet.present();
+}

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -116,6 +116,7 @@ import {
   removeHidden as hcRemove,
   getHiddenSet as hcGetSet,
 } from '@/services/hidden-chats';
+import { setCallCapsForTest } from '@/services/call/types';
 import { startHiddenChat as hcStartChat } from '@/services/hidden-chats-start';
 import { resetHiddenChats as hcReset } from '@/services/hidden-chats-reset';
 import { canHide, canUnhide } from '@/services/hidden-pair';
@@ -157,6 +158,8 @@ import type { Call, Chat, FriendRequest, Media, Message, Post, OutboxPost } from
 import {
   startDirectCall,
   startGroupCall,
+  addPeople,
+  callRemainingSlots,
   acceptCall,
   rejectCall,
   hangupCall,
@@ -1277,6 +1280,16 @@ export function installTestHook(): void {
     accept: () => acceptCall(),
     reject: () => rejectCall(),
     hangup: () => hangupCall(),
+    /** Add people to the ACTIVE group call (spec 1028, US2): ring them into the room. */
+    addPeople: (ids: string[]) => addPeople(ids),
+    /** Free participant slots left in the active call (for cap-gate asserts). */
+    callRemainingSlots: () => callRemainingSlots(),
+    /** Dev/e2e: shrink the CLIENT caps so the pre-emptive add gate can be tested
+     *  without a real 8-person call (mirrors the server's call-config override). */
+    setCallCaps: (video?: number, audio?: number) => setCallCapsForTest(video, audio),
+    /** The active call's roster (who's actually in the room) + invited (ringing). */
+    callRoster: () => callMeta.value?.roster ?? [],
+    callInvited: () => callMeta.value?.invited ?? [],
     /** Toggle the mic (drives the mute/unmute cues). */
     toggleMute: () => toggleMute(),
     /** Toggle video: 1:1 audio->video sends a consent request; group is immediate. */

--- a/src/utils/external.ts
+++ b/src/utils/external.ts
@@ -21,3 +21,19 @@ export function openExternal(url: string): void {
   a.click();
   a.remove();
 }
+
+/**
+ * Hand a `tel:` / `sms:` / `mailto:` URI off to the OS's own app (spec 1029).
+ * Unlike openExternal these must NOT open a blank browser tab — they're app
+ * launches — so no `target="_blank"`: a same-frame anchor click lets the OS
+ * intercept the scheme. If no handler exists the click is a graceful no-op
+ * (the caller always also offers Copy).
+ */
+export function openScheme(uri: string): void {
+  const a = document.createElement('a');
+  a.href = uri;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}

--- a/src/utils/linkify.test.ts
+++ b/src/utils/linkify.test.ts
@@ -1,0 +1,95 @@
+// Unit tests for the pure phone/email detector (spec 1029). This is where the
+// feature's correctness lives — the renderers just consume these segments. The
+// matcher must be CONSERVATIVE: zero false "Call"/"Email" affordances on ordinary
+// digit/text runs (SC-005), while catching the common phone + email formats.
+import { describe, it, expect } from 'vitest';
+import { segmentContacts, telValue, telHref, smsHref, mailtoHref } from './linkify';
+
+// Helper: the detected entities (dropping plain-text segments).
+const entities = (t: string) =>
+  segmentContacts(t).filter((s): s is Extract<typeof s, { kind: string }> => 'kind' in s);
+
+describe('segmentContacts — emails', () => {
+  it('detects a plain address', () => {
+    expect(entities('mail hello@example.com please')).toEqual([
+      { kind: 'email', raw: 'hello@example.com', value: 'hello@example.com' },
+    ]);
+  });
+  it('detects sub-addressed, dotted-local, and multi-label domains', () => {
+    expect(entities('a.b+tag@mail.co.uk')[0]).toMatchObject({ kind: 'email', raw: 'a.b+tag@mail.co.uk' });
+  });
+  it('excludes a trailing period or paren', () => {
+    expect(entities('write to bob@x.com.')[0].raw).toBe('bob@x.com');
+    expect(entities('(see jane@y.io)')[0].raw).toBe('jane@y.io');
+  });
+  it('does not match a bare @handle or a domain without a TLD', () => {
+    expect(entities('hi @alice and foo@localhost')).toEqual([]);
+  });
+});
+
+describe('segmentContacts — phones', () => {
+  it('detects an international + number with separators', () => {
+    expect(entities('call +1 (415) 555-0134 now')[0]).toMatchObject({
+      kind: 'phone',
+      raw: '+1 (415) 555-0134',
+      value: '+14155550134',
+    });
+  });
+  it('detects dashed, dotted, and spaced forms', () => {
+    expect(entities('415-555-0134')[0].value).toBe('4155550134');
+    expect(entities('415.555.0134')[0].value).toBe('4155550134');
+    expect(entities('415 555 0134')[0].value).toBe('4155550134');
+  });
+  it('detects a bare 10+ digit run', () => {
+    expect(entities('4155550134')[0]).toMatchObject({ kind: 'phone', value: '4155550134' });
+  });
+  it('detects a long international run within the 15-digit cap', () => {
+    expect(entities('+441632960961')[0].value).toBe('+441632960961');
+  });
+});
+
+describe('segmentContacts — conservative NON-matches (SC-005, zero false positives)', () => {
+  const nonEntities = [
+    'order #1234567 shipped',        // 7 bare digits, no + / separator → not a phone
+    'build 8 of 9',
+    'meet at 12:30 today',           // time
+    'the hex is a1b2c3d4e5',
+    'id 550e8400e29b41d4',           // long alnum id
+    'ratio 16:9 and 4:3',
+    'page 42, line 7',
+    'v1.2.3 released',               // version — dotted but too few digits
+    '3.14159 is pi',                 // 6 digits, no phone shape
+    'error code 42',
+  ];
+  for (const t of nonEntities) {
+    it(`no entity in: "${t}"`, () => {
+      expect(entities(t)).toEqual([]);
+    });
+  }
+});
+
+describe('segmentContacts — coexistence + multiplicity (FR-005/SC-004)', () => {
+  it('finds both a phone and an email in one string, keeping text between', () => {
+    const segs = segmentContacts('ph +1 415 555 0134 or hi@x.com ok');
+    expect(entities('ph +1 415 555 0134 or hi@x.com ok').map((e) => e.kind)).toEqual(['phone', 'email']);
+    // the plain text between/around is preserved (round-trips to the original)
+    expect(segs.map((s) => ('kind' in s ? s.raw : s.text)).join('')).toBe('ph +1 415 555 0134 or hi@x.com ok');
+  });
+  it('does not treat the digits inside an email as a phone', () => {
+    expect(entities('reply to 4155550134@carrier.com')).toEqual([
+      { kind: 'email', raw: '4155550134@carrier.com', value: '4155550134@carrier.com' },
+    ]);
+  });
+});
+
+describe('normalizers', () => {
+  it('telValue keeps a leading + and strips separators', () => {
+    expect(telValue('+1 (415) 555-0134')).toBe('+14155550134');
+    expect(telValue('415.555.0134')).toBe('4155550134');
+  });
+  it('builds tel:/sms:/mailto: hrefs', () => {
+    expect(telHref('+1 415 555 0134')).toBe('tel:+14155550134');
+    expect(smsHref('415-555-0134')).toBe('sms:4155550134');
+    expect(mailtoHref('a@b.com')).toBe('mailto:a@b.com');
+  });
+});

--- a/src/utils/linkify.ts
+++ b/src/utils/linkify.ts
@@ -1,0 +1,93 @@
+/**
+ * Conservative phone-number + email detector (spec 1029). Pure and dependency-free
+ * so the two renderers (chat `bodyParts`, `EmojiText.vue`) can consume typed
+ * segments and stay token-based (XSS-safe — nothing here builds HTML). The caller
+ * has already split out URLs and @mentions; this segments the remaining plain text
+ * runs into text + email + phone.
+ *
+ * Design goal: NO false "Call"/"Email" affordances on ordinary digit/text runs
+ * (order numbers, hex ids, times, versions). Emails win over phones (so the digits
+ * inside `4155550134@carrier.com` are never a phone), and a bare digit run must be
+ * long enough (or carry a `+`/separator) to read as a phone.
+ */
+
+export type ContactSeg =
+  | { text: string }
+  | { kind: 'email' | 'phone'; raw: string; value: string };
+
+// local@ (label.)+ TLD — requires a dot and a 2+ alpha TLD, so `foo@localhost`
+// and trailing punctuation are excluded.
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}/g;
+
+// A phone CANDIDATE: optional +, then digits with common separators. Bounded so it
+// can't run away across a paragraph. Validated (digit count + shape) in isPhone.
+// The surrounding lookarounds keep it from firing inside a longer alphanumeric
+// token or an email local part.
+const PHONE_CAND_RE = /(?<![\w@+])\+?\d[\d\s().-]{4,}\d(?![\w])/g;
+
+interface Span {
+  start: number;
+  end: number;
+  seg: Extract<ContactSeg, { kind: string }>;
+}
+
+/** Digits only, preserving a single leading '+' (dial-safe for tel:/sms:). */
+export function telValue(raw: string): string {
+  const plus = raw.trimStart().startsWith('+') ? '+' : '';
+  return plus + raw.replace(/\D/g, '');
+}
+
+export function telHref(raw: string): string {
+  return `tel:${telValue(raw)}`;
+}
+export function smsHref(raw: string): string {
+  return `sms:${telValue(raw)}`;
+}
+export function mailtoHref(raw: string): string {
+  return `mailto:${raw}`;
+}
+
+/** Is a candidate run a plausible phone number? Conservative:
+ *  - 7–15 digits (E.164 upper bound), and
+ *  - a bare run (no '+' and no separator) must be ≥ 10 digits, so 7–9 bare digits
+ *    (order numbers, ids) are NOT linkified. */
+function isPhone(raw: string): boolean {
+  const digits = raw.replace(/\D/g, '');
+  if (digits.length < 7 || digits.length > 15) return false;
+  const hasPlus = raw.includes('+');
+  const hasSep = /[\s().-]/.test(raw);
+  if (!hasPlus && !hasSep) return digits.length >= 10;
+  return true;
+}
+
+export function segmentContacts(text: string): ContactSeg[] {
+  const spans: Span[] = [];
+
+  // Emails first — they take priority over any phone-shaped digits inside them.
+  for (const m of text.matchAll(EMAIL_RE)) {
+    const raw = m[0];
+    spans.push({ start: m.index, end: m.index + raw.length, seg: { kind: 'email', raw, value: raw } });
+  }
+
+  // Phones, skipping any range already covered by an email.
+  for (const m of text.matchAll(PHONE_CAND_RE)) {
+    const start = m.index;
+    const end = start + m[0].length;
+    if (spans.some((s) => start < s.end && end > s.start)) continue; // overlaps an email
+    if (!isPhone(m[0])) continue;
+    spans.push({ start, end, seg: { kind: 'phone', raw: m[0], value: telValue(m[0]) } });
+  }
+
+  if (!spans.length) return text ? [{ text }] : [];
+  spans.sort((a, b) => a.start - b.start);
+
+  const out: ContactSeg[] = [];
+  let cursor = 0;
+  for (const s of spans) {
+    if (s.start > cursor) out.push({ text: text.slice(cursor, s.start) });
+    out.push(s.seg);
+    cursor = s.end;
+  }
+  if (cursor < text.length) out.push({ text: text.slice(cursor) });
+  return out;
+}

--- a/src/views/detail/CallActivePage.vue
+++ b/src/views/detail/CallActivePage.vue
@@ -357,10 +357,28 @@
           >
             <ion-icon :icon="videocamOutline" />
           </button>
+          <!-- Add people to the call (group calls, spec 1028). Hidden when the call
+               is already at its kind's cap (4 video / 8 audio). -->
+          <button
+            v-if="canAddPeople"
+            class="ctl"
+            aria-label="Add people"
+            @click.stop="addPeopleOpen = true"
+          >
+            <ion-icon :icon="personAddOutline" />
+          </button>
           <button class="ctl hangup" aria-label="Hang up" @click.stop="hangup">
             <ion-icon :icon="callOutline" />
           </button>
         </div>
+        <ContactPicker
+          :open="addPeopleOpen"
+          :contacts="addPeopleContacts"
+          title="Add to call"
+          empty-text="No more contacts to add"
+          @close="addPeopleOpen = false"
+          @select="onAddPeople"
+        />
 
         <!-- DIAG(call-video): temporary on-screen diagnostics. A production deploy
              hides server logs and an iPhone's Safari console isn't readable, so the
@@ -400,11 +418,12 @@
 import { computed, ref, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import { IonPage, IonContent, IonAvatar, IonIcon, IonSpinner, actionSheetController } from '@ionic/vue';
 import Emoji from '@/components/Emoji.vue';
+import ContactPicker from '@/components/ContactPicker.vue';
 import {
   micOutline, micOffOutline, videocamOutline, videocamOffOutline, callOutline,
   volumeHighOutline, bluetoothOutline, warningOutline,
   phonePortraitOutline, cameraReverseOutline, desktopOutline, chevronDownOutline,
-  cellularOutline, informationCircleOutline, personOutline, refreshOutline,
+  cellularOutline, informationCircleOutline, personOutline, personAddOutline, refreshOutline,
   chatbubbleEllipsesOutline, pauseOutline, swapHorizontalOutline,
 } from 'ionicons/icons';
 import router from '@/router';
@@ -417,7 +436,7 @@ import {
   upgradePending, upgradeRequest, acceptUpgrade, rejectUpgrade,
   audioOutputId, isIOS, refreshAudioOutputs, audioRoute, availableRoutes, setRoute,
   iosSpeaker, setIosSpeakerphone,
-  notJoining, busyMembers, recallMember, cancelInvite,
+  notJoining, busyMembers, recallMember, cancelInvite, addPeople, callRemainingSlots,
   acceptCall, rejectCall, declineWithMessage,
   heldCall, remoteHeld, groupHeldPeers, resumeCountdown, peerResumeCountdown, remoteQueued, incomingSecond, acceptAndHold, rejectSecond, swapCalls,
   setGroupTileSize,
@@ -625,6 +644,25 @@ interface Tile {
 // synchronously (mirrors ChatDetailPage). Updates live if a contact card changes.
 const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
 const contactsMap = computed(() => new Map(contacts.value.map((c) => [c.id, c])));
+
+// Add people to the call (spec 1028, US2). MVP scope: group calls only — promoting
+// a 1:1 into a mesh is the deferred follow-up. The button appears when there's a
+// live group call with room left under its kind's cap; the picker excludes anyone
+// already in the room or ringing.
+const addPeopleOpen = ref(false);
+const canAddPeople = computed(() => !!callMeta.value?.isGroup && callRemainingSlots() > 0);
+const addPeopleContacts = computed(() => {
+  const inCall = new Set([
+    getSelfUserId() ?? '',
+    ...(callMeta.value?.roster ?? []),
+    ...(callMeta.value?.invited ?? []),
+  ]);
+  return contacts.value.filter((c) => !inCall.has(c.id));
+});
+async function onAddPeople(c: { userId: string }): Promise<void> {
+  addPeopleOpen.value = false;
+  await addPeople([c.userId]);
+}
 
 // Our own chosen name + avatar (shown on our own tile). Reactive so a rename mid-call
 // propagates, and shared with the rest of the app via useSelfProfile.

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -440,7 +440,13 @@
                 >@{{ p.mention.name }}</span><span
                   v-else-if="p.everyone"
                   class="mention everyone"
-                >@everyone</span><animated-emoji
+                >@everyone</span><a
+                  v-else-if="p.contact"
+                  class="msg-link"
+                  role="button"
+                  :href="p.contact.kind === 'phone' ? telHref(p.contact.raw) : mailtoHref(p.contact.raw)"
+                  @click.stop.prevent="presentEntityActions(p.contact)"
+                >{{ p.contact.raw }}</a><animated-emoji
                   v-else-if="p.emoji"
                   :emoji="p.emoji"
                   :animate="animEmoji"
@@ -1160,6 +1166,8 @@ import { jobProgress } from '@/services/media-jobs';
 import { generateVideoPoster, generateImageThumb, isAnimatedImage } from '@/utils/media-meta';
 import { type Quality } from '@/services/media-encode';
 import { openExternal } from '@/utils/external';
+import { segmentContacts, telHref, mailtoHref } from '@/utils/linkify';
+import { presentEntityActions, type ContactEntity } from '@/services/entity-actions';
 import { selectEvictions } from '@/utils/lru';
 import { normalizeOutgoing } from '@/utils/text';
 import { vEnterSend } from '@/directives/enter-send';
@@ -1703,6 +1711,7 @@ interface BodySeg {
   emoji?: string;
   mention?: { id: string; name: string; me: boolean };
   everyone?: boolean;
+  contact?: ContactEntity; // spec 1029: a tappable phone number / email address
 }
 const MENTION_RE = /@([a-zA-Z0-9_]+)/g;
 
@@ -1715,9 +1724,19 @@ function bodyParts(m: Message): BodySeg[] {
   const mentioned = new Set(m.mentions ?? []);
   const members = mentionByUsername.value;
   const emit = (t: string): void => {
-    for (const seg of segmentEmoji(t)) {
-      if (seg.emoji) out.push({ emoji: seg.emoji });
-      else if (seg.text) out.push({ text: seg.text });
+    // Detect phone/email first (spec 1029), then emoji-segment the plain runs
+    // between them. Contacts sit between @mention and emoji handling: URLs and
+    // @mentions are already resolved by the outer loop, so a detected entity can
+    // never eat a link or a handle.
+    for (const cs of segmentContacts(t)) {
+      if ('kind' in cs) {
+        out.push({ contact: cs });
+        continue;
+      }
+      for (const seg of segmentEmoji(cs.text)) {
+        if (seg.emoji) out.push({ emoji: seg.emoji });
+        else if (seg.text) out.push({ text: seg.text });
+      }
     }
   };
   for (const p of linkParts(m.body)) {


### PR DESCRIPTION
## Three things in one PR (as requested)

This branch carries a small privacy fix plus two ad-hoc specs. Both features are **client-only — the `server/` tree has zero diff** (verified).

### 1. Badge fix (follow-up to spec 1027)
The hidden-chat unread badge could briefly show a hidden-inclusive count right after switching to badge mode `never` (a locked cold-open reused a stale `always`-mode cached total). `badge.lastCount` now only ever caches a **hidden-excluded** total, so the fallback can't leak hidden activity against the user's choice. Regression test added.

### 2. Spec 1028 — Add people to a call (MVP: US2 + US3)
You can now **add people to an ongoing group call**: an in-call "Add people" button rings a chosen contact into the room via the existing in-room signalling; they mesh with everyone already in the call. The add is **gated pre-emptively by the per-kind caps (4 video / 8 audio)** so you can't overshoot, with the server's `JoinIfRoom` as the authoritative backstop.

Foundation for the rest of 1028 also landed: a pure capacity gate + invite planner (fully unit-tested) and the sealed `joinroom` control-signal type (rides the existing `call-ice` frame — no new server frame).

**Deferred to a focused follow-up** (issues left open, #643–#645, #650, #653–#672): the risky live **1:1→mesh promotion**, **merge an incoming caller/group-invite** (US1/US4/US6), churn hardening (US5). These need real-device video validation (headless CI can't run a 3-person video mesh), so they're best landed separately with your device in the loop.

### 3. Spec 1029 — Tap a phone number or email in messages & posts
A conservative on-device detector finds phone numbers and email addresses in already-decrypted message and Wall-post text and renders them tappable. Tapping opens an action sheet that hands off to the OS: **Call** (`tel:`), **Message** (`sms:`), **Email** (`mailto:`), plus **Copy**. Tuned for **zero false Call/Email affordances** on ordinary digit/text runs (order numbers, hex, times, versions). Nothing new crosses the wire; rendering stays token-based (injection-safe).

### Zero-knowledge / crypto
No new server capability in either spec. 1028's `joinroom` is an opaque sealed `CallSignal` (like hold/resume); its ZK checklist passed 20/20. 1029 is pure client presentation + OS hand-off over already-local text. Security review still welcome on the call-signal type.

### Testing (local, green)
- `npm run build`, **559 vitest**, `go build/vet/test` (server untouched — empty server diff)
- New e2e: `call-add-merge` (4-way audio mesh, verified from a non-initiator), `call-add-cap` (pre-emptive gate), `tap-entities` (tappable phone/email, correct `tel:`/`mailto:` targets, action sheet, clipboard copy)
- Regression: `calls.spec.ts` (1:1 + group mesh + audio→video upgrade + late-joiner) stays green
- CI runs the full Playwright suite on this PR.

Closes #639
Closes #640
Closes #641
Closes #642
Closes #646
Closes #647
Closes #648
Closes #649
Closes #651
Closes #652
Closes #673
Closes #674
Closes #675
Closes #676
Closes #677
Closes #678
Closes #679
Closes #681
Closes #682
Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbEauS9eXGW7W3c4AATXcF
