### PR TITLE
feat(call): see who joins your call, and add a whole group call into it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1028-robust-audio-and/plan.md`
+`specs/1030-finish-call-kind/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,9 +49,9 @@ Specs are grouped by category band; status moves
 | [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
 | [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
 | [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🔵 in-review |
-| [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🟡 in-progress |
+| [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🔵 in-review |
 | [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🔵 in-review |
-| [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | ⚪ planned |
+| [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,7 @@ Specs are grouped by category band; status moves
 | [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🔵 in-review |
 | [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🟡 in-progress |
 | [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🔵 in-review |
+| [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/call-add-churn.mjs
+++ b/drive/scenarios/call-add-churn.mjs
@@ -1,0 +1,94 @@
+/**
+ * Spec 1030, US5 — harder multi-party churn on the live stack: a 3-way audio
+ * call grows and shrinks under pressure and must converge everywhere.
+ *
+ *   1. Alice+Bob+Carol in a group audio call.
+ *   2. Alice AND Bob add Dave simultaneously → ONE participant, one leg.
+ *   3. Eve is added WHILE Carol hangs up (join races leave).
+ *   4. Bob's socket blips ~3s and recovers → rejoins, and NOBODY re-announces
+ *      him ("joined the call" fires at most once per member per call).
+ *   5. Final roster {Alice,Bob,Dave,Eve} everywhere, no duplicates, no stuck tiles.
+ *
+ *   node drive/scenarios/call-add-churn.mjs
+ *
+ * Drives the live `make start` stack; screenshots land in .tmp/drive/.
+ */
+import { createAccount, pair, group, shot, sweep, done, poll } from '../driver.mjs';
+
+const issues = [];
+const note = (ok, label, detail) => {
+  console.log(`${ok ? '  ✓' : '  ✗ ISSUE'} ${label}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) issues.push(`${label}${detail ? ` — ${detail}` : ''}`);
+};
+const act = (c, fn, ...args) => c.page.evaluate(([f, a]) => window.__ringTest[f](...a), [fn, args]);
+const info = (c) =>
+  c.page.evaluate(() => {
+    const t = window.__ringTest;
+    const meta = t.callMeta();
+    return {
+      state: t.callState(),
+      roster: meta?.roster ?? [],
+      invited: meta?.invited ?? [],
+      remotes: t.remoteStreamCount(),
+      cues: t.joinCues(),
+    };
+  });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const rosterIs = (i, ids) =>
+  i.roster.length === ids.length && ids.every((id) => i.roster.includes(id)) && new Set(i.roster).size === i.roster.length;
+
+console.log('\n=== SETUP: five accounts, all pairwise paired ===');
+const alice = await createAccount({ name: 'Alice', label: 'Alice' });
+const bob = await createAccount({ name: 'Bob', label: 'Bob' });
+const carol = await createAccount({ name: 'Carol', label: 'Carol' });
+const dave = await createAccount({ name: 'Dave', label: 'Dave' });
+const eve = await createAccount({ name: 'Eve', label: 'Eve' });
+const all = [alice, bob, carol, dave, eve];
+for (let i = 0; i < all.length; i++)
+  for (let j = i + 1; j < all.length; j++) await pair(all[i], all[j]);
+
+console.log('\n=== A: Alice+Bob+Carol in a group AUDIO call ===');
+const gid = await group(alice, 'Churn', [bob, carol]);
+for (const c of [alice, bob, carol]) await act(c, 'startGroup', gid, 'audio', []);
+for (const c of [alice, bob, carol]) await poll(() => info(c), (i) => i.remotes >= 2, { label: `${c.label} meshed`, timeout: 60_000 });
+
+console.log('\n=== B: Alice AND Bob add Dave at the same instant (dedup to one leg) ===');
+await Promise.all([act(alice, 'addPeople', [dave.id]), act(bob, 'addPeople', [dave.id])]);
+await poll(() => info(dave), (i) => i.state === 'incoming', { label: 'Dave ringing' });
+await act(dave, 'accept');
+for (const c of [alice, bob, carol, dave]) {
+  await poll(() => info(c), (i) => rosterIs(i, [alice.id, bob.id, carol.id, dave.id]), { label: `${c.label} roster {A,B,C,D}`, timeout: 60_000 });
+}
+const dupCheck = await info(alice);
+note(dupCheck.roster.filter((x) => x === dave.id).length === 1, 'Dave appears exactly once', JSON.stringify(dupCheck.roster));
+note((await info(dave)).remotes === 3, 'Dave has exactly one leg per peer', `remotes=${(await info(dave)).remotes}`);
+
+console.log('\n=== C: Eve is added WHILE Carol hangs up (join races leave) ===');
+await Promise.all([act(alice, 'addPeople', [eve.id]), act(carol, 'hangup')]);
+await poll(() => info(eve), (i) => i.state === 'incoming', { label: 'Eve ringing' });
+await act(eve, 'accept');
+for (const c of [alice, bob, dave, eve]) {
+  await poll(() => info(c), (i) => rosterIs(i, [alice.id, bob.id, dave.id, eve.id]), { label: `${c.label} roster {A,B,D,E}`, timeout: 60_000 });
+}
+await poll(() => info(carol), (i) => i.state === 'idle' || i.state === 'ended', { label: 'Carol fully out' });
+note(true, 'Carol is fully out');
+
+console.log('\n=== D: Bob blips (~3s socket drop) and recovers — no re-announce, no dup ===');
+const cuesBefore = (await info(alice)).cues;
+await act(bob, 'disconnect');
+await wait(3000);
+await act(bob, 'reconnect');
+await poll(() => info(bob), (i) => i.remotes >= 3, { label: 'Bob re-meshed', timeout: 60_000 });
+await wait(2000);
+const cuesAfter = (await info(alice)).cues;
+note(JSON.stringify(cuesAfter) === JSON.stringify(cuesBefore), 'a reconnect is NOT a new joiner (no extra cue)', `${cuesBefore} → ${cuesAfter}`);
+const final = await info(alice);
+note(rosterIs(final, [alice.id, bob.id, dave.id, eve.id]), 'final roster stable after the blip', JSON.stringify(final.roster));
+
+// No route: a goto() reloads the SPA and drops the live call — capture as-is.
+await shot(alice, 'add-churn-final');
+for (const c of [alice, bob, dave, eve]) await act(c, 'hangup').catch(() => {});
+console.log(issues.length ? `\nISSUES (${issues.length}):\n - ${issues.join('\n - ')}` : '\nAll churn checks passed.');
+await sweep(all);
+await done();
+if (issues.length) process.exitCode = 1;

--- a/drive/scenarios/merge-video.mjs
+++ b/drive/scenarios/merge-video.mjs
@@ -1,0 +1,86 @@
+/**
+ * Spec 1030, US1 — the VIDEO result of a merge (the part headless CI can't run).
+ * Alice and Bob are in a 1:1 AUDIO call; Carol video-calls Alice; Alice taps
+ * "Add to call" (merge). The combined call is 3 people (≤ 4) so it is
+ * VIDEO-CAPABLE: each participant turns their OWN camera on with the normal
+ * control (no auto-camera — verified), and video then flows among all three.
+ *
+ *   node drive/scenarios/merge-video.mjs
+ *   HEADED=1 node drive/scenarios/merge-video.mjs
+ *
+ * Drives the live `make start` stack; real WebRTC via chromium fake media.
+ * Screenshots land in .tmp/drive/.
+ */
+import { createAccount, pair, shot, sweep, done, poll } from '../driver.mjs';
+
+const issues = [];
+const note = (ok, label, detail) => {
+  console.log(`${ok ? '  ✓' : '  ✗ ISSUE'} ${label}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) issues.push(`${label}${detail ? ` — ${detail}` : ''}`);
+};
+const act = (c, fn, ...args) => c.page.evaluate(([f, a]) => window.__ringTest[f](...a), [fn, args]);
+const info = (c) =>
+  c.page.evaluate(() => {
+    const t = window.__ringTest;
+    const meta = t.callMeta();
+    return {
+      state: t.callState(),
+      kind: meta?.kind ?? null,
+      isGroup: !!meta?.isGroup,
+      roster: meta?.roster ?? [],
+      remotes: t.remoteStreamCount(),
+      localVideo: t.localVideoTracks(),
+    };
+  });
+const meshFrames = (c) => c.page.evaluate(() => window.__ringTest.groupCallDiag());
+
+console.log('\n=== SETUP: three accounts, all paired ===');
+const alice = await createAccount({ name: 'Alice', label: 'Alice' });
+const bob = await createAccount({ name: 'Bob', label: 'Bob' });
+const carol = await createAccount({ name: 'Carol', label: 'Carol' });
+for (const [x, y] of [[alice, bob], [alice, carol], [bob, carol]]) await pair(x, y);
+
+console.log('\n=== A: Alice and Bob in a 1:1 AUDIO call ===');
+await act(alice, 'startCall', bob.id, 'audio');
+await poll(() => info(bob), (i) => i.state === 'incoming', { label: 'Bob ringing' });
+await act(bob, 'accept');
+await poll(() => info(alice), (i) => i.state === 'connected', { label: 'A↔B connected' });
+
+console.log('\n=== B: Carol VIDEO-calls Alice; Alice merges her in ===');
+await act(carol, 'startCall', alice.id, 'video');
+await poll(() => alice.page.evaluate(() => window.__ringTest.hasSecondIncoming()), (v) => v === true, { label: 'call-waiting prompt on Alice' });
+await act(alice, 'mergeIncoming');
+for (const c of [alice, bob, carol]) {
+  await poll(() => info(c), (i) => i.remotes >= 2, { label: `${c.label} meshed with 2`, timeout: 60_000 });
+}
+const merged = await info(alice);
+note(merged.isGroup, 'merge produced a group call', JSON.stringify(merged));
+note(merged.kind === 'audio', 'merged call starts AUDIO (nobody auto-upgraded)', `kind=${merged.kind}`);
+
+console.log('\n=== C: no auto-camera — everyone joined with zero local video tracks ===');
+for (const c of [alice, bob, carol]) {
+  const i = await info(c);
+  note(i.localVideo === 0, `${c.label} camera OFF after merge (no auto-camera)`, `localVideo=${i.localVideo}`);
+}
+
+console.log('\n=== D: each participant turns their OWN camera on (per-participant control) ===');
+for (const c of [alice, bob, carol]) {
+  await act(c, 'toggleVideo');
+  await poll(() => info(c), (i) => i.localVideo === 1, { label: `${c.label} camera on` });
+}
+
+console.log('\n=== E: video actually FLOWS among all three (inbound mesh frames) ===');
+for (const c of [alice, bob, carol]) {
+  await poll(() => meshFrames(c), (d) => d.inboundVideoFrames > 0, { label: `${c.label} decoding video`, timeout: 60_000 });
+  const d = await meshFrames(c);
+  note(d.inboundVideoFrames > 0, `${c.label} inbound video frames`, `${d.inboundVideoFrames}`);
+}
+// No route: a goto() reloads the SPA and drops the live call — Alice is already
+// on the call screen, so capture the page as-is.
+await shot(alice, 'merge-video-grid');
+
+for (const c of [alice, bob, carol]) await act(c, 'hangup').catch(() => {});
+console.log(issues.length ? `\nISSUES (${issues.length}):\n - ${issues.join('\n - ')}` : '\nAll merge-video checks passed.');
+await sweep([alice, bob, carol]);
+await done();
+if (issues.length) process.exitCode = 1;

--- a/e2e/call-busy.spec.ts
+++ b/e2e/call-busy.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import {
   createAccount, pair, startCall, startGroup, accept, hangup,
   waitCallState, waitRemotes, callState, busyMemberIds, resetCallConfig,
+  hasSecondIncoming, rejectSecond,
 } from './helpers';
 
 /**
@@ -48,7 +49,7 @@ test('a second 1:1 call to someone in a call is offered Accept & hold (call wait
   await ctxC.close();
 });
 
-test('a group invite to a busy member resolves to "unavailable" on the caller', async ({ browser }) => {
+test('a group invite to a busy member resolves to "unavailable" on the caller once declined', async ({ browser }) => {
   const ctxA = await browser.newContext();
   const ctxB = await browser.newContext();
   const ctxC = await browser.newContext();
@@ -65,9 +66,15 @@ test('a group invite to a busy member resolves to "unavailable" on the caller', 
   await accept(b);
   await waitCallState(a, ['connected']);
 
-  // C starts a group call ringing A (who is busy). A should auto-reply busy, so C marks A
-  // as unavailable rather than ringing them indefinitely.
+  // C starts a group call ringing A (who is busy). Since spec 1030 (US3) an in-call A
+  // with a FREE waiting slot is no longer silently auto-busied — the invite is offered
+  // as the second-incoming prompt (Add to call / Accept & hold / Decline) instead…
   await startGroup(c, 'busy-group-room', 'audio', [a.id]);
+  await a.page.waitForFunction(() => !!(window as any).__ringTest.hasSecondIncoming(), null, { timeout: 15_000 });
+  expect(await hasSecondIncoming(a)).toBe(true);
+  // …and DECLINING it sends the busy, so C marks A unavailable rather than ringing
+  // them indefinitely (the auto-busy still applies when the slot is taken — spec 2009).
+  await rejectSecond(a);
   await c.page.waitForFunction(
     (id: string) => (window as any).__ringTest.busyMemberIds().includes(id),
     a.id,

--- a/e2e/call-churn.spec.ts
+++ b/e2e/call-churn.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startCall, startGroup, accept, hangup, waitCallState, waitRemotes,
+  waitHook, goOffline, setCallConfig, resetCallConfig, callState,
+} from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1030, US5 — growing a call converges under churn: a join racing a leave,
+// two people adding the SAME person at once (one participant, one leg), an
+// invitee reloading mid-ring (spec-2012 recovery), and a promotion whose peer
+// never follows (clean end via the lone-in-the-room timeout — no stuck ringing,
+// no orphans). AUDIO meshes only (headless CI constraint).
+
+const addPeople = (c: any, ids: string[]): Promise<void> =>
+  c.page.evaluate((x: string[]) => (window as any).__ringTest.addPeople(x), ids);
+const waitIncoming = (c: any): Promise<void> =>
+  c.page.waitForFunction(() => (window as any).__ringTest.callState() === 'incoming', null, { timeout: 30_000 });
+const rosterOf = (c: any): Promise<string[]> =>
+  c.page.evaluate(() => (window as any).__ringTest.callRoster());
+const remoteStreams = (c: any): Promise<number> =>
+  c.page.evaluate(() => (window as any).__ringTest.remoteStreamCount());
+
+/** Poll until the client's roster is exactly `ids` (set-equal, no duplicates). */
+async function waitRoster(c: any, ids: string[], timeout = 30_000): Promise<void> {
+  await c.page.waitForFunction(
+    (want: string[]) => {
+      const r = (window as any).__ringTest.callRoster() as string[];
+      return r.length === want.length && want.every((id) => r.includes(id)) && new Set(r).size === r.length;
+    },
+    ids, { timeout },
+  );
+}
+
+test.afterEach(async () => {
+  await resetCallConfig();
+});
+
+test('a join racing a leave converges to the correct roster on every device (US5)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const ctx = await Promise.all([0, 1, 2, 3].map(() => browser.newContext()));
+  const [a, b, c, d] = await Promise.all([
+    createAccount(ctx[0], 'CHA1'), createAccount(ctx[1], 'CHA2'),
+    createAccount(ctx[2], 'CHA3'), createAccount(ctx[3], 'CHA4'),
+  ]);
+  await pair(a, b); await pair(a, c); await pair(a, d);
+  await pair(b, c); await pair(b, d); await pair(c, d);
+
+  const room = 'e2e-churn-joinleave';
+  await startGroup(a, room, 'audio');
+  await startGroup(b, room, 'audio');
+  await startGroup(c, room, 'audio');
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+
+  // D is rung in while C leaves — fired in the same instant.
+  await Promise.all([addPeople(a, [d.id]), hangup(c)]);
+  await waitIncoming(d);
+  await accept(d);
+
+  // Every remaining device converges to exactly {A, B, D}: no stuck tile for C,
+  // no duplicate, and the mesh is fully connected.
+  for (const p of [a, b, d]) await waitRoster(p, [a.id, b.id, d.id]);
+  for (const p of [a, b, d]) await waitRemotes(p, 2);
+  expect(await callState(c)).toMatch(/idle|ended/);
+
+  for (const p of [a, b, d]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});
+
+test('two participants adding the SAME person at once resolve to one participant with one leg (US5)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const ctx = await Promise.all([0, 1, 2, 3].map(() => browser.newContext()));
+  const [a, b, c, d] = await Promise.all([
+    createAccount(ctx[0], 'CHB1'), createAccount(ctx[1], 'CHB2'),
+    createAccount(ctx[2], 'CHB3'), createAccount(ctx[3], 'CHB4'),
+  ]);
+  await pair(a, b); await pair(a, c); await pair(a, d);
+  await pair(b, c); await pair(b, d); await pair(c, d);
+
+  const room = 'e2e-churn-dupadd';
+  await startGroup(a, room, 'audio');
+  await startGroup(b, room, 'audio');
+  await startGroup(c, room, 'audio');
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+
+  // A and B add D simultaneously.
+  await Promise.all([addPeople(a, [d.id]), addPeople(b, [d.id])]);
+  await waitIncoming(d);
+  await accept(d);
+
+  // D is ONE participant everywhere: exactly one roster entry, one leg per pair
+  // (each of the 4 sees exactly 3 remote streams — not 4).
+  for (const p of [a, b, c, d]) await waitRoster(p, [a.id, b.id, c.id, d.id]);
+  for (const p of [a, b, c, d]) await waitRemotes(p, 3);
+  expect(await remoteStreams(a)).toBe(3);
+  expect(await remoteStreams(d)).toBe(3);
+
+  for (const p of [a, b, c, d]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});
+
+test('an invitee reloading mid-ring returns, is re-rung, and joins cleanly with no duplicate (US5)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  // Fast reminder rounds so the reloaded invitee is re-rung within seconds.
+  await setCallConfig({ ringIntervalMs: 1500, ringCount: 8 });
+  const ctx = await Promise.all([0, 1, 2].map(() => browser.newContext()));
+  const [a, b, c] = await Promise.all([
+    createAccount(ctx[0], 'CHC1'), createAccount(ctx[1], 'CHC2'), createAccount(ctx[2], 'CHC3'),
+  ]);
+  await pair(a, b); await pair(a, c); await pair(b, c);
+
+  const room = 'e2e-churn-reload';
+  await startGroup(a, room, 'audio');
+  await startGroup(b, room, 'audio');
+  for (const p of [a, b]) await waitRemotes(p, 1);
+
+  await addPeople(a, [c.id]);
+  await waitIncoming(c);
+
+  // C reloads mid-ring (app killed and reopened). Device-key auto-unlock brings
+  // the hook back; the server's reminder round (spec 2012 recovery) re-rings C.
+  await c.page.reload();
+  await waitHook(c.page);
+  await waitIncoming(c);
+  await accept(c);
+
+  // C joins exactly once; everyone converges with no duplicate or stuck tile.
+  for (const p of [a, b, c]) await waitRoster(p, [a.id, b.id, c.id]);
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+
+  for (const p of [a, b, c]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});
+
+test('a promotion whose peer never follows (and nobody joins) ends cleanly via the idle timeout (US5)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const ctx = await Promise.all([0, 1, 2].map(() => browser.newContext()));
+  const [a, b, d] = await Promise.all([
+    createAccount(ctx[0], 'CHD1'), createAccount(ctx[1], 'CHD2'), createAccount(ctx[2], 'CHD3'),
+  ]);
+  await pair(a, b); await pair(a, d);
+
+  // A and B in a 1:1 audio call.
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+
+  // Shrink A's lone-in-the-room window so the test runs in seconds (prod: 60s).
+  await a.page.evaluate(() => (window as any).__ringTest.setGroupIdleMs(5000));
+
+  // B drops off the network, so the sealed `joinroom` never reaches it — the
+  // promoted peer NEVER follows. A promotes by adding D, who never answers.
+  await goOffline(b);
+  await addPeople(a, [d.id]);
+
+  // The half-formed room (A alone, D ringing, B never following) must end
+  // CLEANLY on the idle timeout: back to idle (past the ended dwell), no stuck
+  // ringing tile, no orphan.
+  await waitCallState(a, ['idle'], 30_000);
+  expect(await a.page.evaluate(() => (window as any).__ringTest.callMeta())).toBeFalsy();
+  expect(await a.page.evaluate(() => (window as any).__ringTest.hasSecondIncoming())).toBe(false);
+
+  // D's phantom ring dies with the room (server-side give-up); just tidy up.
+  await d.page.evaluate(() => (window as any).__ringTest.reject()).catch(() => {});
+  await Promise.all(ctx.map((x) => x.close()));
+});

--- a/e2e/call-group-merge.spec.ts
+++ b/e2e/call-group-merge.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startCall, startGroup, accept, hangup, waitCallState, waitRemotes,
+  hasSecondIncoming, acceptAndHold, endHeld, rejectSecond, setCallConfig, resetCallConfig,
+} from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1030, US3 — merge an incoming GROUP invite: "Add to call" now applies to a
+// group invite arriving mid-call, folding its people into the CURRENT call
+// (promoting a 1:1 first), deduping a member present in both, and leaving the
+// invite's own room (FR-008). An over-cap fold is blocked with a reason and both
+// calls stay untouched (FR-007). AUDIO only (headless CI constraint).
+
+const mergeGroupInvite = (c: any): Promise<void> =>
+  c.page.evaluate(() => (window as any).__ringTest.mergeGroupInvite());
+const isGroup = (c: any): Promise<boolean> =>
+  c.page.evaluate(() => !!(window as any).__ringTest.callMeta()?.isGroup);
+const roomOf = (c: any): Promise<string | undefined> =>
+  c.page.evaluate(() => (window as any).__ringTest.callMeta()?.roomId);
+const rosterOf = (c: any): Promise<string[]> =>
+  c.page.evaluate(() => (window as any).__ringTest.callRoster());
+const invitedOf = (c: any): Promise<string[]> =>
+  c.page.evaluate(() => (window as any).__ringTest.callInvited());
+const setCaps = (c: any, video?: number, audio?: number): Promise<void> =>
+  c.page.evaluate(([v, x]: (number | undefined)[]) => (window as any).__ringTest.setCallCaps(v, x), [video, audio]);
+const waitSecondIncoming = (c: any): Promise<unknown> =>
+  c.page.waitForFunction(() => !!(window as any).__ringTest.hasSecondIncoming(), null, { timeout: 30_000 });
+const noticeSeen = (c: any, needle: string): Promise<unknown> =>
+  c.page.waitForFunction(
+    (t: string) => ((window as any).__ringTest.notices() as { body: string }[]).some((n) => (n.name + n.body).includes(t)),
+    needle, { timeout: 15_000 },
+  );
+
+test.afterEach(async () => {
+  await resetCallConfig();
+});
+
+test('folding a group invite brings its people into the current call, dedups a shared member, and leaves the invite room (US3)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  // Fast re-ring so "the server stopped ringing us for the folded room" is
+  // observable in seconds: if A had NOT left the invite's room, the next reminder
+  // round would re-raise the prompt below.
+  await setCallConfig({ ringIntervalMs: 1500, ringCount: 5 });
+  const ctx = await Promise.all([0, 1, 2].map(() => browser.newContext()));
+  const [a, b, c] = await Promise.all([
+    createAccount(ctx[0], 'GMA1'),
+    createAccount(ctx[1], 'GMA2'),
+    createAccount(ctx[2], 'GMA3'),
+  ]);
+  await pair(a, b); await pair(a, c); await pair(b, c);
+
+  // A and B in a 1:1 audio call.
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+
+  // C starts a group call inviting BOTH A and B (B is the shared member — already
+  // in A's call). Both get the second-incoming prompt (new in 1030: no auto-busy).
+  const inviteRoom = 'e2e-group-merge-src';
+  await startGroup(c, inviteRoom, 'audio', [a.id, b.id]);
+  await waitSecondIncoming(a);
+  await waitSecondIncoming(b);
+  await rejectSecond(b); // B ignores its copy; A does the folding
+
+  // A folds the invite into the current call: 1:1 promoted, C rung into A's room,
+  // B deduped (already present), A leaves the invite's room.
+  await mergeGroupInvite(a);
+
+  // C, still alone in its own room, is rung for A's room and joins it (holding,
+  // then dropping, its now-empty original room).
+  await waitSecondIncoming(c);
+  await acceptAndHold(c);
+  await endHeld(c).catch(() => {});
+
+  // Everyone converges in A's ONE combined call.
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+  expect(await isGroup(a)).toBe(true);
+  expect(await isGroup(b)).toBe(true);
+  const mergedRoom = await roomOf(a);
+  expect(mergedRoom).not.toBe(inviteRoom); // folded INTO A's call, not into C's room (FR-008)
+  for (const p of [a, b, c]) {
+    const r = await rosterOf(p);
+    for (const id of [a.id, b.id, c.id]) expect(r).toContain(id);
+    expect(new Set(r).size).toBe(r.length); // no duplicate participants
+  }
+  // The shared member B was never re-rung: only C was invited into A's room.
+  expect(await invitedOf(a)).not.toContain(b.id);
+
+  // FR-008: A left the invite's room — with the fast re-ring config, a still-live
+  // membership would re-raise the prompt within ~2s. It must not.
+  await a.page.waitForTimeout(4000);
+  expect(await hasSecondIncoming(a)).toBe(false);
+  expect(await roomOf(a)).toBe(mergedRoom);
+
+  for (const p of [a, b, c]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});
+
+test('an over-cap group fold is blocked with a clear reason and both calls stay unchanged (US3)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const ctx = await Promise.all([0, 1, 2, 3].map(() => browser.newContext()));
+  const [a, b, c, d] = await Promise.all([
+    createAccount(ctx[0], 'GMB1'),
+    createAccount(ctx[1], 'GMB2'),
+    createAccount(ctx[2], 'GMB3'),
+    createAccount(ctx[3], 'GMB4'),
+  ]);
+  await pair(a, b); await pair(a, c); await pair(a, d); await pair(c, d);
+
+  // A and B in a 1:1 audio call; A's client audio cap shrunk to 3 (mirrors the
+  // server override) so C's 2-newcomer invite (C + D) won't fit: 2 + 2 = 4 > 3.
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+  await setCaps(a, undefined, 3);
+
+  const inviteRoom = 'e2e-group-merge-cap';
+  await startGroup(c, inviteRoom, 'audio', [a.id, d.id]);
+  await a.page.waitForFunction(() => !!(window as any).__ringTest.hasSecondIncoming(), null, { timeout: 30_000 });
+
+  // The fold is blocked with the kind-specific cap reason…
+  await mergeGroupInvite(a);
+  await noticeSeen(a, 'Audio calls are limited to 3 people');
+  // …and BOTH calls are exactly as they were: A still in the 1:1 with B (never
+  // promoted), the invite still in the waiting slot (Hold/Decline still work),
+  // and C's own room untouched.
+  expect(await isGroup(a)).toBe(false);
+  expect(await hasSecondIncoming(a)).toBe(true);
+  expect(await a.page.evaluate(() => (window as any).__ringTest.callMeta()?.peerUserId)).toBe(b.id);
+  expect(await a.page.evaluate(() => (window as any).__ringTest.callState())).toBe('connected');
+  expect(await roomOf(c)).toBe(inviteRoom);
+
+  await rejectSecond(a);
+  await hangup(a);
+  await hangup(b).catch(() => {});
+  await hangup(c).catch(() => {});
+  await Promise.all(ctx.map((x) => x.close()));
+});

--- a/e2e/call-join-cue.spec.ts
+++ b/e2e/call-join-cue.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startGroup, hangup, waitRemotes, goOffline, goOnline,
+} from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1030, US2 — the join cue. When a genuinely-new participant joins a call,
+// every EXISTING participant sees a "{name} joined the call" cue; nobody sees a
+// cue for their own arrival, and a reconnect (which doesn't change the server
+// roster) never re-fires one. AUDIO mesh (headless CI can't run a 3+ person
+// video mesh). The cue history is read via the dev joinCues hook (the visible
+// banner is asserted once, on the adder, while it's still on screen).
+
+const addPeople = (c: any, ids: string[]): Promise<void> =>
+  c.page.evaluate((x: string[]) => (window as any).__ringTest.addPeople(x), ids);
+const acceptCall = (c: any): Promise<void> =>
+  c.page.evaluate(() => (window as any).__ringTest.accept());
+const waitIncoming = (c: any): Promise<void> =>
+  c.page.waitForFunction(() => (window as any).__ringTest.callState() === 'incoming', null, { timeout: 30_000 });
+const joinCues = (c: any): Promise<string[]> =>
+  c.page.evaluate(() => (window as any).__ringTest.joinCues());
+
+test('every existing participant sees a "joined the call" cue — never for self or a reconnect (US2)', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const ctx = await Promise.all([0, 1, 2, 3].map(() => browser.newContext()));
+  const [a, b, c, d] = await Promise.all([
+    createAccount(ctx[0], 'CUE01'),
+    createAccount(ctx[1], 'CUE02'),
+    createAccount(ctx[2], 'CUE03'),
+    createAccount(ctx[3], 'CUE04'),
+  ]);
+  await pair(a, b); await pair(a, c); await pair(a, d);
+  await pair(b, c); await pair(b, d); await pair(c, d);
+
+  // A, B, C form a group audio call.
+  const room = 'e2e-join-cue';
+  await startGroup(a, room, 'audio');
+  await startGroup(b, room, 'audio');
+  await startGroup(c, room, 'audio');
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+
+  // A adds D. While D's join propagates, watch A's banner surface for the visible
+  // cue text (it only stays up ~3.5s, so the watcher is armed BEFORE the join).
+  const bannerSeen = a.page.waitForFunction(
+    () => ((window as any).__ringTest.notices() as { body: string }[])
+      .some((n) => (n.name + n.body).includes('joined the call')),
+    null, { timeout: 30_000 },
+  );
+  await addPeople(a, [d.id]);
+  await waitIncoming(d);
+  await acceptCall(d);
+  await bannerSeen; // the cue was actually shown to the user (FR-004)
+
+  // Every EXISTING participant announced D — including the non-adders B and C.
+  for (const p of [a, b, c]) {
+    await p.page.waitForFunction(
+      (id: string) => ((window as any).__ringTest.joinCues() as string[]).includes(id),
+      d.id, { timeout: 30_000 },
+    );
+  }
+
+  // The joiner sees no cue for their own arrival, nor for the people they walked
+  // in on (they were already in the call) — FR-005.
+  for (const p of [a, b, c, d]) await waitRemotes(p, 3);
+  expect(await joinCues(d)).toEqual([]);
+  // And nobody ever announces themselves.
+  for (const p of [a, b, c, d]) expect(await joinCues(p)).not.toContain(p.id);
+
+  // A reconnect is NOT a new arrival: bounce B's transport; after B's legs recover,
+  // nobody's cue history has changed (the server roster membership never changed).
+  const cuesA = await joinCues(a);
+  const cuesC = await joinCues(c);
+  await goOffline(b);
+  await b.page.waitForTimeout(1500);
+  await goOnline(b);
+  await waitRemotes(b, 3); // B's mesh recovered
+  await b.page.waitForTimeout(1000); // let any (wrong) cue land before we look
+  expect(await joinCues(a)).toEqual(cuesA);
+  expect(await joinCues(c)).toEqual(cuesC);
+
+  for (const p of [a, b, c, d]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});

--- a/e2e/call-merge-held.spec.ts
+++ b/e2e/call-merge-held.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startCall, accept, reject, hangup, waitCallState, waitRemotes,
+  acceptAndHold, swapCalls, endHeld, heldCallId, isRemoteHeld, hasSecondIncoming,
+} from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1030, US4 — growing the ACTIVE call never disturbs a separately HELD call
+// (FR-009), and a swap can't race a promotion/add mid-conversion (FR-010, the
+// add-in-flight guard): the add completes first, so no half-open connection is
+// ever parked. AUDIO only (headless CI constraint).
+
+const addPeople = (c: any, ids: string[]): Promise<void> =>
+  c.page.evaluate((x: string[]) => (window as any).__ringTest.addPeople(x), ids);
+const waitIncoming = (c: any): Promise<void> =>
+  c.page.waitForFunction(() => (window as any).__ringTest.callState() === 'incoming', null, { timeout: 30_000 });
+const callId = (c: any): Promise<string | undefined> =>
+  c.page.evaluate(() => (window as any).__ringTest.callMeta()?.callId);
+const isGroup = (c: any): Promise<boolean> =>
+  c.page.evaluate(() => !!(window as any).__ringTest.callMeta()?.isGroup);
+const rosterOf = (c: any): Promise<string[]> =>
+  c.page.evaluate(() => (window as any).__ringTest.callRoster());
+const peerOf = (c: any): Promise<string | undefined> =>
+  c.page.evaluate(() => (window as any).__ringTest.callMeta()?.peerUserId);
+
+test('adding to the active call leaves the held call intact and swappable; a swap cannot race the promotion (US4)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const ctx = await Promise.all([0, 1, 2, 3, 4].map(() => browser.newContext()));
+  const [a, b, c, d, e] = await Promise.all([
+    createAccount(ctx[0], 'MHA1'),
+    createAccount(ctx[1], 'MHA2'),
+    createAccount(ctx[2], 'MHA3'),
+    createAccount(ctx[3], 'MHA4'),
+    createAccount(ctx[4], 'MHA5'),
+  ]);
+  await pair(a, b); await pair(a, c); await pair(a, d); await pair(a, e);
+  await pair(c, d);
+
+  // Call X: A and B in a 1:1 audio call.
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+  const xId = await callId(a);
+
+  // C calls A; A accepts & holds → X is HELD (B on hold), active is A↔C.
+  await startCall(c, a.id, 'audio');
+  await a.page.waitForFunction(() => !!(window as any).__ringTest.hasSecondIncoming(), null, { timeout: 30_000 });
+  await acceptAndHold(a);
+  await waitCallState(c, ['connected']);
+  await b.page.waitForFunction(() => (window as any).__ringTest.isRemoteHeld() === true, null, { timeout: 15_000 });
+  expect(await heldCallId(a)).toBe(xId);
+
+  // A grows the ACTIVE call (promote A↔C to a room, ring D in). The held X must
+  // stay exactly as it is throughout (FR-009).
+  await addPeople(a, [d.id]);
+  await waitIncoming(d);
+  await accept(d);
+  for (const p of [a, c, d]) await waitRemotes(p, 2);
+  expect(await heldCallId(a)).toBe(xId); // held slot untouched by the add
+  expect(await isRemoteHeld(b)).toBe(true); // B is still (only) on hold
+  expect(await hasSecondIncoming(a)).toBe(false); // and only ONE call is parked
+
+  // The held call is still swappable: swap back to X…
+  await swapCalls(a);
+  expect(await callId(a)).toBe(xId);
+  expect(await isGroup(a)).toBe(false);
+  expect(await peerOf(a)).toBe(b.id);
+  await b.page.waitForFunction(() => (window as any).__ringTest.isRemoteHeld() === false, null, { timeout: 15_000 });
+  // …and the group is now the (single) held call, its peers seeing A on hold.
+  const heldGroupId = await heldCallId(a);
+  expect(heldGroupId).not.toBeNull();
+  expect(heldGroupId).not.toBe(xId);
+  await c.page.waitForFunction(
+    (id: string) => ((window as any).__ringTest.groupHeldPeers() as string[]).includes(id),
+    a.id, { timeout: 15_000 },
+  );
+
+  // FR-010 race: fire an add (which PROMOTES the active 1:1 X — the riskiest
+  // conversion) and a swap in the same tick. The guard makes the swap drain the
+  // in-flight add first, so nothing half-built is ever parked.
+  await a.page.evaluate((eid: string) => Promise.all([
+    (window as any).__ringTest.addPeople([eid]),
+    (window as any).__ringTest.swapCalls(),
+  ]), e.id);
+  // The swap landed on the COMPLETED promotion: active is the C+D group again…
+  expect(await isGroup(a)).toBe(true);
+  const r = await rosterOf(a);
+  expect(r).toContain(c.id);
+  expect(r).toContain(d.id);
+  // …the promoted X' (now a room, with E ringing into it) is the one held call…
+  expect(await heldCallId(a)).not.toBeNull();
+  expect(await hasSecondIncoming(a)).toBe(false);
+  // …and E really was rung by the completed add (no dropped half-open invite).
+  await waitIncoming(e);
+  await reject(e);
+
+  // Still swappable both ways after the race.
+  await swapCalls(a);
+  expect(await isGroup(a)).toBe(true); // X' is a room now (B followed the promotion)
+  expect(await heldCallId(a)).not.toBeNull();
+
+  await hangup(a);
+  for (const p of [b, c, d]) await hangup(p).catch(() => {});
+  await endHeld(a).catch(() => {});
+  await Promise.all(ctx.map((x) => x.close()));
+});

--- a/e2e/call-merge-kind.spec.ts
+++ b/e2e/call-merge-kind.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startCall, accept, hangup, waitCallState, waitRemotes,
+} from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 1030, US1 — kind reconciliation after a merge. A merged/promoted call that
+// still fits the video cap is VIDEO-CAPABLE: the per-participant "Turn on video"
+// control works, and turning it on enables ONLY that person's camera (no
+// auto-camera, no room-wide consent). Past the cap it refuses. AUDIO mesh with a
+// single video publisher (the full multi-camera video RESULT is drive/real-device
+// — see drive/scenarios/merge-video.mjs).
+
+const startDial = (c: any, peer: string): Promise<void> =>
+  c.page.evaluate((p: string) => (window as any).__ringTest.startCall(p, 'audio'), peer);
+const mergeIncoming = (c: any): Promise<void> =>
+  c.page.evaluate(() => (window as any).__ringTest.mergeIncoming());
+const toggleVideo = (c: any): Promise<void> =>
+  c.page.evaluate(() => (window as any).__ringTest.toggleVideo());
+const callKind = (c: any): Promise<string> =>
+  c.page.evaluate(() => (window as any).__ringTest.callMeta()?.kind);
+const localVideoTracks = (c: any): Promise<number> =>
+  c.page.evaluate(() => (window as any).__ringTest.localVideoTracks());
+const setCaps = (c: any, video?: number, audio?: number): Promise<void> =>
+  c.page.evaluate(([v, x]: (number | undefined)[]) => (window as any).__ringTest.setCallCaps(v, x), [video, audio]);
+const noticeSeen = (c: any, needle: string): Promise<unknown> =>
+  c.page.waitForFunction(
+    (t: string) => ((window as any).__ringTest.notices() as { body: string }[]).some((n) => (n.name + n.body).includes(t)),
+    needle, { timeout: 15_000 },
+  );
+
+async function mergedAudioTrio(browser: any, codes: [string, string, string]) {
+  const ctx = await Promise.all([0, 1, 2].map(() => browser.newContext()));
+  const [a, b, c] = await Promise.all(codes.map((code, i) => createAccount(ctx[i], code)));
+  await pair(a, b); await pair(a, c); await pair(b, c);
+  // A and B in a 1:1 audio call; C calls A; A merges C in → 3-way audio mesh.
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+  await startDial(c, a.id);
+  await a.page.waitForFunction(() => !!(window as any).__ringTest.hasSecondIncoming(), null, { timeout: 30_000 });
+  await mergeIncoming(a);
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+  return { ctx, a, b, c };
+}
+
+test('a merged call ≤ the video cap is video-capable per participant — no auto-camera (US1)', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const { ctx, a, b, c } = await mergedAudioTrio(browser, ['MKA1', 'MKA2', 'MKA3']);
+
+  // The merged call is an audio GROUP of 3 (≤ 4) → video-capable: the existing
+  // per-participant control works for one participant…
+  expect(await callKind(a)).toBe('audio');
+  await toggleVideo(a);
+  await a.page.waitForFunction(() => (window as any).__ringTest.callMeta()?.kind === 'video', null, { timeout: 15_000 });
+  expect(await localVideoTracks(a)).toBe(1); // A's own camera is on
+
+  // …and does NOT touch anyone else's camera: B and C stay audio, zero local
+  // video tracks, and their own "Turn on video" control still applies (kind audio).
+  await a.page.waitForTimeout(1500); // give a (wrong) auto-enable time to happen
+  for (const p of [b, c]) {
+    expect(await callKind(p)).toBe('audio');
+    expect(await localVideoTracks(p)).toBe(0);
+  }
+
+  for (const p of [a, b, c]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});
+
+test('a merged call past the video cap stays audio-only — turning on video is refused (US1)', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const { ctx, a, b, c } = await mergedAudioTrio(browser, ['MKB1', 'MKB2', 'MKB3']);
+
+  // Shrink the CLIENT video cap to 2 so this 3-person call is "past the cap"
+  // without spinning up 5 browsers (mirrors the server's call-config override).
+  await setCaps(a, 2, undefined);
+  await toggleVideo(a);
+  await noticeSeen(a, 'Video is limited to 2 people'); // refused with the cap reason
+  expect(await callKind(a)).toBe('audio'); // still audio-only…
+  expect(await localVideoTracks(a)).toBe(0); // …and no camera was enabled
+
+  for (const p of [a, b, c]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});

--- a/specs/1028-robust-audio-and/spec.md
+++ b/specs/1028-robust-audio-and/spec.md
@@ -4,7 +4,10 @@
 
 **Created**: 2026-07-02
 
-**Status**: in-progress
+**Status**: in-review
+<!-- The four deferred items (kind upgrade on merge, join cue, group-invite merge,
+     churn robustness) are completed by spec 1030 (feat/1030-finish-call-kind);
+     both specs ship with that branch's PR into develop. -->
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1030-finish-call-kind/checklists/requirements.md
+++ b/specs/1030-finish-call-kind/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Finish Add-to-Call
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This spec completes spec 1028's deferred items; it names 1028's shipped functions
+  (`ensureActiveIsRoom`, `mergeIncoming`, `joinroom`, …) in Assumptions only as the
+  dependency it builds on, not as new design.
+- The 1028 clarifications already settled the product decisions this spec implements
+  (auto-follow + cue, video-upgrade-on-merge ≤ 4, group-invite merge), so no new
+  clarifications are expected; `/speckit-clarify` may confirm there are none.

--- a/specs/1030-finish-call-kind/contracts/internal-api.md
+++ b/specs/1030-finish-call-kind/contracts/internal-api.md
@@ -1,0 +1,46 @@
+# Internal Module Contracts: 1030 Finish Add-to-Call
+
+**No HTTP/wire API change.** Server untouched (a task asserts an empty `server/` diff).
+No new sealed signal (1028's `joinroom` is reused). These are the client module contracts.
+
+## NEW `src/services/call/merge-kind.ts` (pure leaf)
+```ts
+import { VIDEO_MAX, type CallKind } from './types';
+/** Is the call video-capable after a merge? (US1) True = the per-participant "Turn on
+ *  video" control is offered; never auto-enables a camera. */
+export function videoCapableAfterMerge(activeKind: CallKind, combinedHeadcount: number): boolean;
+```
+
+## NEW `src/services/call/join-cue.ts` (pure leaf)
+```ts
+/** Roster members to announce as new joiners (US2): not self, not already announced. */
+export function newJoiners(announced: ReadonlySet<string>, roster: string[], selfId: string): string[];
+```
+
+## CHANGED `src/composables/useCall.ts`
+```ts
+/** US3 — merge the pending incoming GROUP INVITE into the current call. */
+export async function mergeGroupInvite(): Promise<void>;
+```
+- `handleGroupInvite`: when `callState !== 'idle'` AND `canRaiseSecondIncoming()`, raise
+  `incomingSecond` as `kind:'group'` (roomId + members) instead of `sendGroupBusy`; keep
+  auto-busy when no slot is free.
+- `call-roster` handler: before assigning `callMeta.roster`, announce `newJoiners(...)`
+  via `appToast`; maintain a per-call `announced` set (reset on new call).
+- `mergeIncoming` / a merge completion: apply `videoCapableAfterMerge` — no new UI when
+  false; when true the existing "Turn on video" affordance already applies (no code beyond
+  ensuring `meta.kind`/roster are correct so `toggleVideoMode` gates right).
+- `addInFlight` guard: set around `ensureActiveIsRoom`+`inviteToRoom`; `swapCalls` /
+  `parkActiveAsHeld` await it (or no-op with a toast) so a swap can't race a promotion.
+- Export `mergeGroupInvite` in the `useCall()` accessor + a testhook.
+
+## CHANGED `src/views/detail/CallActivePage.vue`
+- The second-incoming prompt shows **Add to call** for a `kind:'group'` invite too
+  (currently only `kind:'direct'`), wired to `mergeGroupInvite`; Hold + Decline unchanged.
+
+## UNCHANGED (contract pinned by the suite staying green)
+- `server/` — no diff.
+- `toggleVideoMode`, `addVideoTrack`, the roster/leg machinery, hold/swap/drop, `heldSlot`.
+- 1028's `ensureActiveIsRoom` / `mergeIncoming` / `inviteToRoom` / `sendJoinRoom` /
+  `capacity` / `invite-plan` — reused, not modified (beyond the guard + group path).
+- Crypto core / `messaging.ts` — untouched; no new signal.

--- a/specs/1030-finish-call-kind/data-model.md
+++ b/specs/1030-finish-call-kind/data-model.md
@@ -1,0 +1,64 @@
+# Data Model: Finish Add-to-Call
+
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-02
+
+Calls are ephemeral (no IndexedDB change). This defines the two new pure decisions and
+the in-memory state the four items touch.
+
+## Pure decisions (new, unit-tested)
+
+### videoCapableAfterMerge (US1)
+```
+videoCapableAfterMerge(activeKind, combinedHeadcount) ->
+  activeKind === 'video'                    -> true   (already a video call)
+  combinedHeadcount <= VIDEO_MAX (4)         -> true   (audio call, still fits video)
+  else                                       -> false  (audio-only, > 4)
+```
+"true" means the call is video-capable (the per-participant "Turn on video" control is
+offered); it NEVER auto-enables a camera. The merged video caller uses the same control.
+
+### newJoiners (US2)
+```
+newJoiners(announced: Set<string>, roster: string[], selfId) -> string[]
+  = roster members that are not selfId and not already in `announced`
+```
+Caller appends the result to `announced` and toasts "{name} joined the call" for each.
+`announced` is per-call (reset when a new call starts). A reconnect doesn't change roster
+membership, so a member is announced at most once per call.
+
+## In-memory state (existing, reused / lightly extended)
+
+- **CallMeta.roster / invited** — the roster update (`call-roster` handler) is the cue's
+  hook and the source for the combined-headcount check.
+- **incomingSecond** (`kind: 'direct' | 'group'`) — the single waiting slot. Newly USED
+  for a group invite (US3): `handleGroupInvite` raises it here instead of auto-busy when a
+  slot is free. Carries `roomId` + the invite's `members` for the fold.
+- **heldSlot** — untouched by merge/add (US4 invariant).
+- **addInFlight** (NEW, module-level) — a promise set while a promotion/add is converting
+  the active call; `swapCalls`/`parkActiveAsHeld` await it so a swap can't race a promote.
+
+## Group-invite merge fold (US3)
+
+```
+mergeGroupInvite():
+  inc = incomingSecond (kind 'group', roomId=R, members=M)
+  combined = distinct(currentRoster ∪ currentInvited ∪ self ∪ M)
+  if canAdd over combined exceeds cap:  toast(reason); leave both unchanged; return
+  ensureActiveIsRoom()                  # promote a 1:1 first (no-op if group)
+  inviteToRoom(M − present)             # planInvite dedups; rings the newcomers
+  sendGroupLeave(R)                     # leave the invite's own room (not in two rooms)
+  incomingSecond = null
+```
+INV: a member in both M and the current call resolves to one participant/one leg
+(`planInvite` dedup + set-based `applyRoster`). Blocked-when-over-cap leaves both calls
+exactly as they were.
+
+## Invariants
+
+- **INV-1**: caps unchanged (4 video / 8 audio), pre-emptive client gate + server backstop.
+- **INV-2**: single active + single held call; merge/add act only on the active call.
+- **INV-3**: no camera is ever auto-enabled (video is per-participant opt-in).
+- **INV-4**: a genuinely-new participant is announced exactly once per call; self and
+  reconnects are never announced.
+- **INV-5**: after a group-invite fold, the user is in exactly ONE room (the invite's room
+  is left).

--- a/specs/1030-finish-call-kind/plan.md
+++ b/specs/1030-finish-call-kind/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness
+
+**Branch**: `feat/1030-finish-call-kind` | **Date**: 2026-07-02 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1030-finish-call-kind/spec.md`
+
+## Summary
+
+Completes spec 1028's deferred items on top of its merged promotion/merge code, all
+client-only and mesh-only with **no new server capability**. The audit found the
+happy result that **US1 (kind reconciliation) is mostly already provided** by Ring's
+per-participant group-video toggle (`toggleVideoMode`, cap ≤ 4) — the clarification
+("offer per participant, no auto-camera") maps straight onto it, so US1 is chiefly
+verification + tests. The genuinely-new work: a **join cue** (roster-diff → toast),
+**group-invite merge** (stop the current auto-busy, route the invite into the waiting
+slot, fold its members into your room), an **add-in-flight guard** so a swap can't
+race a promotion, and **churn tests**. Design + code anchors: [research.md](./research.md).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (Vue 3 `<script setup>`, Ionic 8); **no server changes**
+(Go untouched — verified by a task)
+
+**Primary Dependencies**: the existing `src/services/call/` engine + the 1028
+promotion/merge code (`ensureActiveIsRoom`, `mergeIncoming`, `convertActiveToRoom`,
+`inviteToRoom`, `sendJoinRoom`, `capacity.ts`, `invite-plan.ts`, `toggleVideoMode`); the
+existing `appToast`/cue infra
+
+**Storage**: none new (calls are ephemeral)
+
+**Testing**: vitest (pure decision helpers), Playwright `e2e/` (audio meshes + 2-person
+proxies), `drive/` scenarios (video paths / real device)
+
+**Target Platform**: PWA; WebRTC mesh
+
+**Constraints**: mesh only; zero-knowledge (no new server-visible data); caps 4/8 unchanged;
+single held slot unchanged; CI cannot run 3-person video mesh headless
+
+**Scale/Scope**: ~4 client files touched + 2 small pure helpers + tests; crypto core and
+server NOT modified
+
+## Constitution Check
+
+*GATE: constitution v1.2.0 — re-checked after Phase 1: PASS.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Zero-Knowledge Boundary | ✅ | No new server-visible data. Kind-video reuses the per-participant group-video path; the cue is a local roster diff; group-invite merge reuses existing ring/roster/leave signalling. ZK Impact section present. |
+| II. Spec-Driven | ✅ | Spec 1030 (ad-hoc), pipeline followed: specify → clarify (1 Q) → plan → tasks → analyze → taskstoissues → implement. |
+| III. TDD | ✅ | Pure helpers (`videoCapableAfterMerge`, `newJoiners`, combined-headcount) unit-first; each user-facing item gets a failing e2e before the code. |
+| IV. Crypto Discipline | ✅ (n/a-heavy) | No crypto touched; no new signal (unlike 1028's joinroom). `/speckit-checklist` NOT required — this touches neither new wire data nor crypto (reuses 1028's already-reviewed signalling). |
+| V. Offline-First | ✅ | No store/schema change. |
+| VI. Stateless Server | ✅ | Server untouched (a task asserts an empty `server/` diff). |
+| VII. Quality Gates | ✅ | build + vitest + e2e where behaviour changed; go build/vet/test. |
+| VIII. Traceable Delivery | ✅ | `make roadmap`; taskstoissues (reuse the open 1028 issues where they map); PR `Closes #N`. |
+| IX. Privacy & Data Minimization | ✅ | No new data collected; room membership is the same signal group calls already expose. |
+| X. Accessibility & i18n | ✅ | The cue is plain, transient text; "Add to call" on a stock button; the video affordance already exists. |
+| XI. Ionic-First UI | ✅ | Reuses `appToast`/cue + the existing incoming-prompt buttons + the existing "Turn on video" control — no bespoke widgets. |
+
+No violations → Complexity Tracking omitted.
+
+## Project Structure
+
+```text
+specs/1030-finish-call-kind/
+├── plan.md · research.md · data-model.md · quickstart.md
+├── contracts/internal-api.md
+├── checklists/requirements.md
+└── tasks.md   (/speckit-tasks)
+
+src/services/call/
+├── merge-kind.ts + .test.ts     # NEW pure: videoCapableAfterMerge(kind, combinedHeadcount)
+├── join-cue.ts + .test.ts       # NEW pure: newJoiners(announced, roster, selfId)
+├── capacity.ts / invite-plan.ts # reused (extend tests for combined headcount)
+src/composables/useCall.ts       # join-cue on roster update; mergeGroupInvite;
+                                 #   handleGroupInvite → waiting slot; add-in-flight guard
+src/views/detail/CallActivePage.vue  # "Add to call" for a group second-incoming
+e2e/  (+ call-join-cue, call-merge-kind, call-group-merge, call-merge-held, call-churn)
+drive/scenarios/ (+ merge-video, call-add-churn)
+```
+
+**Structure Decision**: two new pure leaves (`merge-kind.ts`, `join-cue.ts`) keep the
+decision logic unit-testable without WebRTC; everything else composes the existing 1028
+orchestration and the existing group-video/roster/hold machinery — no forks.
+
+## Design (Phase 1 summary)
+
+### D1. Kind reconciliation (US1) — R1
+Verify the merged/promoted **audio group** exposes the existing per-participant "Turn on
+video" affordance when combined ≤ 4 and refuses at > 4 (both already in `toggleVideoMode`).
+Pure `videoCapableAfterMerge(activeKind, combinedHeadcount)` encodes the rule for tests.
+No auto-camera; the merged video caller opts in via the same control. No new signalling.
+
+### D2. Join cue (US2) — R2
+In the `call-roster` handler, before assigning `callMeta.roster`, compute
+`newJoiners(announced, frame.members, selfId)`; `appToast("{name} joined the call")` for
+each (name via contacts / stream-owner map, else "Someone"); add them to the per-call
+`announced` set. Reset `announced` on each new call. Not the local user; a reconnect
+doesn't change roster membership so it never re-fires.
+
+### D3. Group-invite merge (US3) — R3
+`handleGroupInvite`: in a call + free slot → raise `incomingSecond` (kind `group`, roomId,
+members) instead of auto-busy; no free slot → keep auto-busy. `mergeGroupInvite()`:
+combined-headcount `canAdd` → `ensureActiveIsRoom` → `inviteToRoom(members − present)` →
+`sendGroupLeave(inviteRoomId)` → clear slot. UI: "Add to call" shown for a group
+second-incoming. Dedup via `planInvite`.
+
+### D4. Add-in-flight guard + held coexistence (US4) — R4
+Module `addInFlight` promise set around `ensureActiveIsRoom`+`inviteToRoom`; `swapCalls`/
+`parkActiveAsHeld` await it (or no-op with a toast) so a swap can't park mid-conversion.
+Merge/add never touch `heldSlot` (already true) — e2e asserts it.
+
+### D5. Churn (US5) — R5
+Tests over the existing serialized `rosterChain` + set-based `applyRoster` + `planInvite`
+dedup + spec-2012 recovery + `armGroupIdleTimeout` (promotion timeout). Fix only what the
+tests expose.
+
+## Zero-Knowledge & Crypto Review Notes
+- No new frame/field/request. Video-capable reuses the per-participant renegotiation a
+  camera toggle already does; the cue is a local roster diff; group-invite merge reuses
+  ring/roster/leave. Room membership + cap are the only server-visible signals — unchanged.
+- Crypto core / `messaging.ts` untouched; no new sealed signal (1028's `joinroom` reused).
+- A task verifies the `server/` tree diff is empty. `/speckit-checklist` not required
+  (no new Principle I/IV surface).
+
+## Testing strategy
+Red → Green: pure helpers first; per-item failing e2e before the code. Audio meshes +
+2-person proxies for e2e; video results via drive/real device. Keep ALL existing call
+tests green (SC-006).
+
+## Complexity Tracking
+No violations — table empty. The scope is deliberately small (completion/polish over the
+already-shipped, real-device-validated 1028 core).

--- a/specs/1030-finish-call-kind/quickstart.md
+++ b/specs/1030-finish-call-kind/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: 1030 Finish Add-to-Call — implementation slices
+
+**Plan**: [plan.md](./plan.md) | Ordered smallest/safest first; tests precede code in each
+slice (Red → Green). Builds on the merged 1028 promotion/merge code.
+
+## Slice 1 — Join cue (US2)
+
+1. `src/services/call/join-cue.test.ts` first: `newJoiners` (excludes self, dedups vs
+   announced, multiple new members, empty roster).
+2. Implement `src/services/call/join-cue.ts`.
+3. Failing e2e `e2e/call-join-cue.spec.ts` (audio): A+B+C in a group call, A adds D →
+   every existing participant sees a "{name} joined the call" cue naming D; force a
+   reconnect of an existing participant → NO cue.
+4. Wire it into the `call-roster` handler in `useCall.ts` (per-call `announced` set,
+   `appToast`, name via contacts/stream-owner map, "Someone" for a non-contact).
+
+## Slice 2 — Kind reconciliation (US1)
+
+1. `src/services/call/merge-kind.test.ts`: `videoCapableAfterMerge` (video call → true;
+   audio ≤4 → true; audio >4 → false).
+2. Implement `src/services/call/merge-kind.ts`.
+3. Failing e2e `e2e/call-merge-kind.spec.ts` (audio): after promoting/merging to a ≤4
+   audio group, the "Turn on video" affordance is available and turning it on works for
+   one participant (no auto-camera on others); after a >4 audio group, turning on video is
+   refused. (Video RESULT — cameras actually flowing among 3 — is a drive/real-device
+   check, not headless.)
+4. Ensure `meta.kind`/roster are correct post-merge so `toggleVideoMode` gates right; add
+   the affordance verification. (Likely no behavioural code change — mostly confirm + test.)
+
+## Slice 3 — Add-in-flight guard + held coexistence (US4)
+
+1. Failing e2e `e2e/call-merge-held.spec.ts` (audio): active call X + held call Y; merge a
+   caller into X; assert Y stays held/paused and swaps correctly; single-held rule holds.
+2. Add the `addInFlight` guard: set around `ensureActiveIsRoom`+`inviteToRoom`;
+   `swapCalls`/`parkActiveAsHeld` await it (or no-op with a toast) so a swap can't race a
+   promotion (FR-010). Confirm merge/add never touch `heldSlot`.
+
+## Slice 4 — Group-invite merge (US3)
+
+1. Failing e2e `e2e/call-group-merge.spec.ts` (audio): A+B in a call; C starts a group
+   inviting A (+D); A's prompt shows **Add to call**; choosing it folds C(+D) into A's call
+   within the cap, a member in both dedups to one participant; a separate over-cap case is
+   blocked with a reason and leaves both calls unchanged.
+2. `handleGroupInvite`: raise `incomingSecond` (kind group) instead of auto-busy when a
+   slot is free.
+3. `mergeGroupInvite()` (combined `canAdd` → `ensureActiveIsRoom` → `inviteToRoom(members −
+   present)` → `sendGroupLeave` → clear slot); extend the capacity/invite-plan unit tests
+   for the combined headcount.
+4. UI: **Add to call** for a group second-incoming in `CallActivePage.vue`.
+
+## Slice 5 — Churn (US5)
+
+1. Failing e2e/drive `e2e/call-churn.spec.ts` + `drive/scenarios/call-add-churn.mjs`:
+   concurrent join+leave converges; two callers add the same person → one leg (dedup);
+   invitee reload mid-ring → clean rejoin; promotion timeout (peer never follows, nobody
+   else joins) → clean end via the idle timeout, no orphaned ringing tile.
+2. Fix only what the churn tests expose (reuse `rosterChain`/`applyRoster`/`planInvite`/
+   spec-2012 recovery/`armGroupIdleTimeout` — no new mechanism).
+
+## Slice 6 — Video validation + gates
+
+1. `drive/scenarios/merge-video.mjs`: merge into a ≤4 call, turn on cameras, confirm video
+   flows (real device / live stack — NOT headless CI).
+2. Verify **no `server/` diff**: `cd server && go build/vet/test` green + `git diff --stat
+   origin/develop -- server/` empty.
+3. Full gates: `npm run build`, `npx vitest run`, `npm run test:e2e`; keep ALL existing
+   call e2e/unit green.
+4. Bump spec `**Status**:` → `in-review`; `make roadmap`.

--- a/specs/1030-finish-call-kind/research.md
+++ b/specs/1030-finish-call-kind/research.md
@@ -1,0 +1,116 @@
+# Phase 0 Research: Finish Add-to-Call
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-07-02
+
+This completes spec 1028's deferred items on top of the merged promotion/merge code.
+Research is a precise audit of the seams each item hooks into (the branch already
+has #684 + #685), plus one happy discovery: the per-participant clarification makes
+US1 mostly free.
+
+## R1. Kind reconciliation (US1) — mostly ALREADY provided
+
+**Finding**: Ring's group video is already per-participant with the exact cap the spec
+wants. `toggleVideoMode` (`useCall.ts:2727`): for a group call it refuses when
+`roster.length > VIDEO_MAX` (toast "Video is limited to 4 people"), else turns on
+**only the caller's own** camera (`getUserMedia` → `groupSession.addVideoTrack` →
+`meta.kind='video'`). The "Turn on video" button shows whenever `!isVideoMode`
+(`CallActivePage.vue`). A promoted/merged call is an **audio group** (`convertActiveToRoom`
+passes the active call's kind), so:
+- Combined ≤ 4 → the "Turn on video" affordance is present and works (each person opts
+  in; no auto-camera) — exactly the clarified behaviour.
+- Combined > 4 → `toggleVideoMode` already refuses.
+
+**Decision**: US1 is chiefly **verification + tests**, not new mechanism. The only code
+touch: make sure the merged **video caller** (who joins an audio room) is presented the
+same per-participant camera control and that the affordance/cap is correct after a
+promotion (audio group, roster-driven). No auto-camera, no 1:1 `requestVideoUpgrade` for
+the group (that stays 1:1-only). A tiny pure helper `videoCapableAfterMerge(kind,
+combinedHeadcount)` encodes the ≤4 rule for a unit test.
+
+**Alternative rejected**: a room-wide consent prompt or auto-enabling the merger's
+camera — the clarification chose per-participant, no auto-camera.
+
+## R2. Join cue (US2) — hook the roster update
+
+**Finding**: `callMeta.value.roster = frame.members` is set in the `call-roster`
+handler (`useCall.ts:3094`), server-authoritative. A transient network blip does NOT
+change room membership (the leg reconnects; the server roster is unchanged), so a
+roster-membership ADD is a genuine join, not a reconnect.
+
+**Decision**: On each roster update, diff the new members against an "already announced
+this call" set; for each genuinely-new member that is not self, show a transient
+"{name} joined the call" via the existing `appToast`/cue infra (name resolved from
+contacts / the stream-owner map; "Someone" for a non-contact). Reset the announced set
+per call. Pure helper `newJoiners(prevAnnounced, nextRoster, selfId)` → the names to
+announce, unit-tested (self excluded, re-adds not re-announced within a call, dedup).
+
+**Alternative rejected**: firing off `onRemoteStreams` — streams can flap on a
+reconnect; the server roster is the stable "who's in the room" signal.
+
+## R3. Group-invite merge (US6/US3 here) — stop the auto-busy, add the fold
+
+**Finding**: `handleGroupInvite` (`useCall.ts:1456-1461`) currently **auto-busies**
+(`sendGroupBusy`) any group invite that arrives while `callState !== 'idle'`. So today a
+group invite while you're in a call is silently declined — there is no "Add to call"
+opportunity. The single waiting slot (`incomingSecond`) already supports
+`kind:'group'` with `roomId`, and `acceptAndHold` already has a group-second path.
+
+**Decision**:
+1. In `handleGroupInvite`, when in a call AND a waiting slot is free
+   (`canRaiseSecondIncoming()`), raise the invite into `incomingSecond` as
+   `kind:'group'` (roomId + the invite's member set) instead of auto-busy; keep the
+   auto-busy fallback when no slot is free (spec 2009 single-slot rule).
+2. `mergeGroupInvite()`: `canAdd` over the **combined distinct** headcount (current
+   roster+invited ∪ the invite's members) → if blocked, toast the reason and leave both
+   calls unchanged; else `ensureActiveIsRoom()` → `inviteToRoom(inviteMembers − present)`
+   (dedup handled by `planInvite`) → `sendGroupLeave(inviteRoomId)` so we're not in two
+   rooms → clear the slot.
+3. UI: the second-incoming prompt shows **Add to call** for a `kind:'group'` invite too
+   (it already shows it for `kind:'direct'`).
+
+**Alternative rejected**: a brand-new "combine rooms" server operation — the fold is
+just ringing the invite's members into our existing room + leaving theirs; no server
+change.
+
+## R4. US4 — merge coexists with hold; add-in-flight guard
+
+**Finding**: `mergeIncoming`/`addPeople` act only on the ACTIVE call and never read/write
+`heldSlot`, so the held call is untouched by construction. The residual risk is a swap
+firing WHILE a promotion/add is mid-flight (the active call is being converted).
+
+**Decision**: a module-level `addInFlight` promise/flag set around
+`ensureActiveIsRoom`+`inviteToRoom`; `swapCalls`/`parkActiveAsHeld` await it (or no-op
+with a toast if a conversion is in progress) so an add completes before a park — no
+half-open leg (FR-010). Plus an explicit e2e: active + held, merge into active, assert
+held intact + swappable.
+
+## R5. US5 — churn robustness
+
+**Finding**: `applyRoster` is set-based and serialized through `rosterChain`; `planInvite`
+dedups against `roster ∪ invited`; invitee reload reuses spec-2012 recovery unchanged.
+Promotion-timeout: `enterGroupCall` already arms `armGroupIdleTimeout` (GROUP_NOBODY_MS,
+60s) that ends a room where nobody else joins — so a promoted peer never following, with
+no one else joining, already resolves cleanly.
+
+**Decision**: mostly **tests** that assert convergence: concurrent join+leave, two
+callers adding the same person (dedup to one leg), invitee reload mid-ring, and the
+promotion-timeout path (peer never follows → clean end via the idle timeout, no orphaned
+ringing tile). Fix only what the tests expose; no new mechanism planned.
+
+## R6. No server changes (verify)
+
+**Decision**: target zero `server/` diff (all four items are client-only). A task runs
+`go build/vet/test` and asserts an empty `git diff --stat origin/develop -- server/`.
+
+## R7. Testing under the CI constraint
+
+- **Unit**: `videoCapableAfterMerge` (≤4 rule), `newJoiners` (cue diff), and the
+  combined-headcount cap for group-invite merge (extend `capacity`/`invite-plan` tests).
+- **e2e (audio + 2-person proxies)**: join cue fires for a new joiner and NOT for a
+  reconnect; group-invite merge fits vs blocked + dedup; merge-leaves-held-intact; churn
+  convergence; video-capable affordance present ≤4 / absent >4 after a merge.
+- **drive/real device**: the actual video result of a merge (a merged call where people
+  turn on cameras) and 3-person video churn — never headless.
+
+All spec decisions resolved (the one clarification is folded into R1); no NEEDS
+CLARIFICATION remain.

--- a/specs/1030-finish-call-kind/spec.md
+++ b/specs/1030-finish-call-kind/spec.md
@@ -1,0 +1,304 @@
+# Feature Specification: Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness
+
+**Feature Branch**: `feat/1030-finish-call-kind`
+
+**Created**: 2026-07-02
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Finish the add-to-call work (completes spec 1028): kind auto-upgrade on merge, a 'joined the call' cue, group-invite merge, and churn robustness."
+
+## Overview
+
+Spec 1028 delivered the core of growing a live call: adding people to a group
+call, promoting a 1:1 into a mesh, merging an incoming direct caller, and the
+per-kind size caps (4 video / 8 audio). Four pieces were deliberately deferred to
+keep that work shippable and to give the risky WebRTC changes a real-device check.
+This spec finishes them:
+
+1. **Kind upgrade on merge** — when the person you merge in was on a different kind
+   of call (a video caller into your audio call, say) and everyone still fits under
+   the video limit, the call offers to become video for everyone; otherwise it stays
+   audio and the new person joins audio-only.
+2. **A "joined the call" cue** — when someone new appears in the call, a brief
+   "{name} joined the call" message, instead of a tile silently appearing.
+3. **Group-invite merge** — "Add to call" now works for an incoming *group* invite
+   too, folding its people into the call you're already on (within the limit).
+4. **Robustness under churn** — growing a call stays correct when people join and
+   leave at once, when two people add the same person, when an invitee reloads
+   mid-ring, and when a promoted peer never follows in.
+
+Everything is client-only and mesh-only: no new server capability, no new wire
+frame, and all kind reconciliation reuses the existing consent-gated video upgrade
+rather than inventing anything.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The call becomes video when it makes sense (Priority: P1)
+
+You're in an audio call. You merge in someone who was video-calling you. If the
+combined call has room for video (4 or fewer people), everyone is offered the usual
+"turn on video?" consent and the call becomes video. If the call is already bigger
+than the video limit, it stays audio and the new person simply joins audio-only.
+
+**Why this priority**: Completes the merge behaviour promised in 1028 (clarification
+2) and avoids the surprise of a video caller silently landing as audio with no path
+to video.
+
+**Independent Test**: Merge a video caller into a small audio call and confirm the
+consent-gated video upgrade runs and the call ends up video; repeat with the call
+already over the video limit and confirm it stays audio with the new person
+audio-only.
+
+**Acceptance Scenarios**:
+
+1. **Given** an audio call with a combined headcount of 4 or fewer after the merge,
+   **When** a video caller is merged in, **Then** the existing consent-gated
+   video-upgrade flow runs and, on acceptance, the call becomes video.
+2. **Given** an audio call whose combined headcount would exceed the video limit,
+   **When** a video caller is merged in, **Then** no upgrade is offered and the
+   merged person joins audio-only while the call stays audio.
+3. **Given** a video call, **When** an audio-only participant is merged in, **Then**
+   the call stays video and that participant may turn on their camera via the normal
+   control.
+
+---
+
+### User Story 2 - A cue when someone joins (Priority: P1)
+
+While you're in a call and a new person joins — whether a 1:1 you promoted, a person
+you added, or a merged caller — you see a brief "{name} joined the call" message.
+People re-connecting after a network blip do not trigger it, and you never see a cue
+for your own arrival.
+
+**Why this priority**: Without it, a new participant appears with no acknowledgement;
+the cue makes growing a call legible (1028 SC-008).
+
+**Independent Test**: Add a person to a call and confirm every existing participant
+sees a "{name} joined the call" cue naming the joiner; force a reconnect of an
+existing participant and confirm no cue fires.
+
+**Acceptance Scenarios**:
+
+1. **Given** you are in a call, **When** a genuinely new participant joins, **Then**
+   a brief "{name} joined the call" cue is shown (naming the joiner, or "Someone" for
+   a non-contact).
+2. **Given** a participant briefly disconnects and reconnects, **When** their leg
+   recovers, **Then** no join cue is shown (it is not a new arrival).
+3. **Given** you join or promote a call yourself, **When** you enter, **Then** no cue
+   is shown for your own arrival.
+
+---
+
+### User Story 3 - Merge an incoming group invite (Priority: P2)
+
+You're in a call and a group invite comes in. "Add to call" now appears for it too
+(alongside Hold and Decline). Choosing it folds the invite's people into your current
+call — promoting your 1:1 first if needed — as long as everyone fits under the limit;
+if not, it's blocked with a clear reason and both calls are left as they were.
+
+**Why this priority**: The richer merge case from 1028 US6; more complex (two rosters,
+combined cap) and less common than a direct caller, so it lands after US1/US2.
+
+**Independent Test**: With a call in progress, receive a group invite and choose Add
+to call; confirm the invite's members are rung into your call and join within the
+limit, a shared member resolves to one participant, and an over-limit fold is blocked
+with a reason.
+
+**Acceptance Scenarios**:
+
+1. **Given** you're in a call and receive a group invite, **When** you choose Add to
+   call, **Then** the invite's not-yet-present members are rung into your current call
+   (your 1:1 promoted first if needed) and join on accept, and you leave the invite's
+   own room.
+2. **Given** folding the invite would exceed the kind cap on the combined distinct
+   headcount, **When** you try, **Then** it's blocked with a clear reason and both your
+   call and the invite are unchanged.
+3. **Given** a person is in both your call and the incoming invite, **When** the groups
+   fold, **Then** they resolve to a single participant with one connection.
+
+---
+
+### User Story 4 - Merge never disturbs a held call (Priority: P2)
+
+Merging a caller into your active call leaves any separate call you're holding fully
+intact and swappable. Adding or merging while a swap is imminent completes (or cancels)
+cleanly, never leaving a half-open connection.
+
+**Why this priority**: The new merge/add paths must not break the existing
+hold/swap/drop guarantees (specs 0005/2009).
+
+**Independent Test**: Hold call Y, be active on call X, merge a caller into X, then
+swap to Y — confirm Y was untouched and still swaps correctly, and the single-held
+rule held throughout.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active call and a held call, **When** you merge an incoming caller,
+   **Then** the held call is unchanged and still swappable, and at most one call is
+   ever held.
+2. **Given** an add/merge is in progress, **When** a swap is triggered, **Then** the
+   add/merge completes or cancels cleanly first and no connection is left half-open.
+
+---
+
+### User Story 5 - Correct under churn (Priority: P2)
+
+Growing a call converges to the right state even under pressure: someone joins while
+another leaves, two people add the same new person at once, an invitee reloads
+mid-ring, or a promoted peer never follows in. No stuck "ringing" tiles, no duplicate
+participants, no orphaned connections.
+
+**Why this priority**: The add/merge/roster/leg lifecycle is where mesh calls are most
+fragile; this is the hardening the "robusten" ask targets.
+
+**Independent Test**: Script the churn cases on an audio mesh and assert the final
+roster, tiles, and connectivity are correct on every device with no orphaned state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a participant is joining, **When** another leaves simultaneously, **Then**
+   every device converges to the correct roster with no stuck tile.
+2. **Given** two participants add the same new person at once, **When** they join,
+   **Then** that person resolves to a single participant with one connection.
+3. **Given** an invitee reloads while ringing, **When** they return and accept, **Then**
+   they join cleanly with no duplicate (reusing the existing invite recovery).
+4. **Given** you promote a 1:1 but the existing peer never follows into the room,
+   **When** the follow times out, **Then** the half-formed room is left cleanly with no
+   stuck ringing or orphaned tile.
+
+### Edge Cases
+
+- **Kind upgrade declined**: if the offered video upgrade is declined, the call stays
+  audio and the merged party stays audio-only (no half-video state).
+- **Merge that would exceed the video cap via upgrade**: never auto-upgrades past 4;
+  the call stays audio.
+- **Group-invite fold with a shared member**: deduped to one participant/one leg.
+- **Group-invite fold over the combined cap**: blocked with a reason; nothing changes.
+- **Cue for a burst of joiners**: each genuinely-new participant is acknowledged; a
+  reconnect is not a joiner.
+- **Promotion timeout / peer never follows**: clean fallback, no orphaned room.
+- **Merge while holding a call**: held call untouched.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: On a merge where the merged party's kind differs from the active call and
+  the combined headcount is at most the video cap (4), the system MUST run the EXISTING
+  consent-gated video-upgrade flow so participants opt in; the call becomes video on
+  acceptance and stays audio on decline (no partial-video state).
+- **FR-002**: When the combined headcount would exceed the video cap, the system MUST
+  NOT offer an upgrade; the merged party joins audio-only and the call stays audio.
+- **FR-003**: Kind reconciliation MUST behave coherently whether the active call was a
+  just-promoted 1:1 or an already-group call, and MUST reuse the existing upgrade
+  mechanism (no new upgrade scheme).
+- **FR-004**: When a genuinely new participant joins the active call (promotion,
+  add-people, or merge), the system MUST show a brief transient "{name} joined the call"
+  cue naming the joiner (or a generic "Someone joined the call" for a non-contact).
+- **FR-005**: The join cue MUST NOT fire for the local user's own arrival, nor for a
+  participant re-connecting after a transient disconnect (only genuinely new roster
+  members).
+- **FR-006**: "Add to call" MUST be offered for an incoming GROUP INVITE (alongside Hold
+  and Decline), and choosing it MUST fold the invite's not-yet-present members into the
+  current call — promoting a 1:1 first if needed — ringing them in; added members ring
+  and consent by answering (no silent pull-in).
+- **FR-007**: Folding a group invite MUST be blocked with a clear reason when the
+  combined DISTINCT headcount would exceed the kind cap, leaving both the current call
+  and the invite unchanged; a member present in both MUST resolve to a single
+  participant/one connection.
+- **FR-008**: After folding a group invite, the user MUST leave the invite's own room so
+  they are never in two rooms at once.
+- **FR-009**: Merging or adding MUST leave any separately HELD call fully intact and
+  swappable, preserving the single-held-slot rule.
+- **FR-010**: An add/merge in progress MUST complete or cancel cleanly before a swap
+  parks the active call — no half-open connection (an add-in-flight guard).
+- **FR-011**: Growing a call MUST converge every device to the correct roster, tiles,
+  and connectivity under: concurrent join/leave, simultaneous adds of the same person
+  (dedup to one participant/one connection), an invitee reloading mid-ring (reuse the
+  existing invite recovery), and a promotion timeout where the peer never follows
+  (leave the half-formed room cleanly). No stuck ringing, no duplicates, no orphaned
+  connections.
+- **FR-012**: The existing 4-video / 8-audio caps MUST be preserved (reused, enforced
+  pre-emptively on the client and authoritatively by the server) and the single
+  active + single held call rule MUST be preserved.
+- **FR-013**: The feature MUST add NO new server capability, no new wire frame or field;
+  signalling stays sealed over the per-pair session and newly-added members use the
+  existing same-room key gate. A verification MUST confirm the server tree is unchanged.
+
+### Key Entities *(include if feature involves data)*
+
+- **Merge (kind reconciliation)**: the decision, from the active call's kind, the merged
+  party's kind, and the combined headcount, of whether to run the consent-gated upgrade
+  (combined ≤ 4) or stay audio (> 4).
+- **Join cue**: a transient, informational message naming a genuinely-new participant;
+  derived from a roster diff (new members only), never persisted.
+- **Combined roster (group-invite merge)**: the distinct union of the current call's
+  participants and the incoming invite's members, gated by the kind cap.
+
+## Zero-Knowledge Impact *(mandatory — Constitution Principle I)*
+
+- **What crosses the wire**: Nothing new. Kind upgrade reuses the existing
+  `call-upgrade-*` flow; the cue is purely local (a roster diff already delivered);
+  group-invite merge reuses the existing ring/roster/leg signalling. No new frame, field,
+  or request.
+- **What is encrypted / protected**: All SDP/ICE stays end-to-end encrypted over each
+  pair's session; media is peer-to-peer. The server never sees media or content.
+- **What metadata is unavoidably visible**: Unchanged from today's group calls — the
+  server sees room membership and enforces the cap, exactly as it already does. A folded
+  group invite makes people room members, which the server already sees for any group.
+- **Why this is safe**: A client-only presentation + orchestration layer composing
+  existing encrypted signalling; the crypto core and messaging path are untouched, and
+  the server tree is verified unchanged.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Merging a video caller into a small audio call ends with a video call in
+  100% of trials where the combined headcount is ≤ 4 and participants accept the
+  upgrade; when the headcount is > 4, the merge stays audio in 100% of trials.
+- **SC-002**: Every existing participant sees a "{name} joined the call" cue for a
+  genuinely-new joiner in 100% of trials, and 0 cues fire for a reconnect or the local
+  user's own join.
+- **SC-003**: Folding a group invite yields one combined call within the cap, or is
+  blocked with a clear reason when over the cap — verified in both the fits and
+  doesn't-fit cases, with a shared member deduped to one participant.
+- **SC-004**: Merging into the active call leaves a separately held call intact and
+  swappable in 100% of trials, with at most one call ever held.
+- **SC-005**: Under scripted churn (concurrent join/leave, simultaneous same-person add,
+  invitee reload, promotion timeout), every device converges to the correct roster/tiles
+  with 0 stuck ringing tiles, 0 duplicate participants, and 0 orphaned connections.
+- **SC-006**: All existing call e2e + unit tests stay green; the new behaviours are
+  covered by Playwright e2e (audio meshes + 2-person proxies) and drive scenarios (the
+  video paths), and the server tree diff is empty.
+
+## Assumptions
+
+- **Builds on 1028's shipped code**: `ensureActiveIsRoom`, `mergeIncoming`,
+  `convertActiveToRoom`, `sendJoinRoom`, `addPeople`, the capacity gate, and the
+  `joinroom` signal already exist (this spec depends on the merged 1028 promotion/merge
+  work).
+- **Kind reconciliation reuses the existing consent-gated upgrade** (`call-upgrade-*` /
+  the group video path); no new upgrade mechanism.
+- **The cue reuses the existing toast/cue infra** and resolves names from contacts / the
+  roster owner map.
+- **Caps unchanged** (4 video / 8 audio) and the **single-held-slot** rule unchanged.
+- **CI cannot run a 3-person+ video mesh headless**: video paths (upgrade result, video
+  churn) validated via drive scenarios / real device; audio meshes + 2-person proxies +
+  pure unit tests carry the e2e.
+- **Mesh only**: no SFU / server media.
+
+## Out of Scope
+
+- An SFU or server-side media (mesh only) — and therefore raising the 4/8 caps.
+- More than one held call at a time.
+- Transferring an in-progress call to another device.
+- Anything already shipped in 1028's earlier PRs (add people, promotion, direct-caller
+  merge, the cap gate).
+- A settings toggle for the join cue (informational, always on for now).

--- a/specs/1030-finish-call-kind/spec.md
+++ b/specs/1030-finish-call-kind/spec.md
@@ -34,17 +34,30 @@ This spec finishes them:
    mid-ring, and when a promoted peer never follows in.
 
 Everything is client-only and mesh-only: no new server capability, no new wire
-frame, and all kind reconciliation reuses the existing consent-gated video upgrade
-rather than inventing anything.
+frame, and all kind reconciliation reuses the existing per-participant group-video
+mechanism rather than inventing anything.
+
+## Clarifications
+
+### Session 2026-07-02
+
+- Q: When a merge makes an audio call eligible to become video (≤ 4 people), how does
+  the switch to video happen, given Ring group calls have no room-wide consent? → A:
+  Offer it PER PARTICIPANT — the merge makes the call video-capable, and each person
+  turns on their camera via the normal control; NO camera is enabled without that
+  person's own tap (no auto-camera, no room-wide consent prompt). This is the existing
+  group-video model; the 1:1 `requestVideoUpgrade` consent flow is NOT used for the
+  merged (group) call.
 
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - The call becomes video when it makes sense (Priority: P1)
 
 You're in an audio call. You merge in someone who was video-calling you. If the
-combined call has room for video (4 or fewer people), everyone is offered the usual
-"turn on video?" consent and the call becomes video. If the call is already bigger
-than the video limit, it stays audio and the new person simply joins audio-only.
+combined call has room for video (4 or fewer people), the call becomes video-capable
+and each person can turn their camera on with the normal control — no one's camera
+turns on by itself. If the call is already bigger than the video limit, it stays
+audio and the new person simply joins audio-only.
 
 **Why this priority**: Completes the merge behaviour promised in 1028 (clarification
 2) and avoids the surprise of a video caller silently landing as audio with no path
@@ -58,11 +71,12 @@ audio-only.
 **Acceptance Scenarios**:
 
 1. **Given** an audio call with a combined headcount of 4 or fewer after the merge,
-   **When** a video caller is merged in, **Then** the existing consent-gated
-   video-upgrade flow runs and, on acceptance, the call becomes video.
+   **When** a video caller is merged in, **Then** the call becomes video-capable and
+   each participant may enable their own camera via the normal control (no camera is
+   auto-enabled).
 2. **Given** an audio call whose combined headcount would exceed the video limit,
-   **When** a video caller is merged in, **Then** no upgrade is offered and the
-   merged person joins audio-only while the call stays audio.
+   **When** a video caller is merged in, **Then** the call stays audio-only and the
+   merged person joins audio-only (video is not enabled for anyone).
 3. **Given** a video call, **When** an audio-only participant is merged in, **Then**
    the call stays video and that participant may turn on their camera via the normal
    control.
@@ -174,10 +188,10 @@ roster, tiles, and connectivity are correct on every device with no orphaned sta
 
 ### Edge Cases
 
-- **Kind upgrade declined**: if the offered video upgrade is declined, the call stays
-  audio and the merged party stays audio-only (no half-video state).
-- **Merge that would exceed the video cap via upgrade**: never auto-upgrades past 4;
-  the call stays audio.
+- **Nobody turns on video after a merge makes the call video-capable**: it simply
+  behaves as an audio call until someone enables their camera (no forced state).
+- **Merge that would exceed the video cap**: never becomes video-capable past 4; the
+  call stays audio for everyone.
 - **Group-invite fold with a shared member**: deduped to one participant/one leg.
 - **Group-invite fold over the combined cap**: blocked with a reason; nothing changes.
 - **Cue for a burst of joiners**: each genuinely-new participant is acknowledged; a
@@ -190,14 +204,17 @@ roster, tiles, and connectivity are correct on every device with no orphaned sta
 ### Functional Requirements
 
 - **FR-001**: On a merge where the merged party's kind differs from the active call and
-  the combined headcount is at most the video cap (4), the system MUST run the EXISTING
-  consent-gated video-upgrade flow so participants opt in; the call becomes video on
-  acceptance and stays audio on decline (no partial-video state).
+  the combined headcount is at most the video cap (4), the system MUST make the call
+  video-capable so each participant can enable their own camera via the existing
+  per-participant control; NO camera is enabled without that participant's own action
+  (no auto-camera, no room-wide consent prompt).
 - **FR-002**: When the combined headcount would exceed the video cap, the system MUST
-  NOT offer an upgrade; the merged party joins audio-only and the call stays audio.
+  NOT make the call video-capable; the merged party joins audio-only and the call stays
+  audio for everyone.
 - **FR-003**: Kind reconciliation MUST behave coherently whether the active call was a
-  just-promoted 1:1 or an already-group call, and MUST reuse the existing upgrade
-  mechanism (no new upgrade scheme).
+  just-promoted 1:1 or an already-group call, and MUST reuse the existing
+  per-participant group-video mechanism (no new upgrade scheme, and NOT the 1:1
+  `requestVideoUpgrade` consent flow).
 - **FR-004**: When a genuinely new participant joins the active call (promotion,
   add-people, or merge), the system MUST show a brief transient "{name} joined the call"
   cue naming the joiner (or a generic "Someone joined the call" for a non-contact).
@@ -234,8 +251,8 @@ roster, tiles, and connectivity are correct on every device with no orphaned sta
 ### Key Entities *(include if feature involves data)*
 
 - **Merge (kind reconciliation)**: the decision, from the active call's kind, the merged
-  party's kind, and the combined headcount, of whether to run the consent-gated upgrade
-  (combined ≤ 4) or stay audio (> 4).
+  party's kind, and the combined headcount, of whether the call becomes video-capable
+  (combined ≤ 4 — cameras allowed per participant) or stays audio-only (> 4).
 - **Join cue**: a transient, informational message naming a genuinely-new participant;
   derived from a roster diff (new members only), never persisted.
 - **Combined roster (group-invite merge)**: the distinct union of the current call's
@@ -243,10 +260,11 @@ roster, tiles, and connectivity are correct on every device with no orphaned sta
 
 ## Zero-Knowledge Impact *(mandatory — Constitution Principle I)*
 
-- **What crosses the wire**: Nothing new. Kind upgrade reuses the existing
-  `call-upgrade-*` flow; the cue is purely local (a roster diff already delivered);
-  group-invite merge reuses the existing ring/roster/leg signalling. No new frame, field,
-  or request.
+- **What crosses the wire**: Nothing new. Making a call video-capable reuses the
+  existing per-participant group-video path (a participant enabling their camera
+  renegotiates their own legs, as today); the cue is purely local (a roster diff already
+  delivered); group-invite merge reuses the existing ring/roster/leg signalling. No new
+  frame, field, or request.
 - **What is encrypted / protected**: All SDP/ICE stays end-to-end encrypted over each
   pair's session; media is peer-to-peer. The server never sees media or content.
 - **What metadata is unavoidably visible**: Unchanged from today's group calls — the
@@ -260,9 +278,10 @@ roster, tiles, and connectivity are correct on every device with no orphaned sta
 
 ### Measurable Outcomes
 
-- **SC-001**: Merging a video caller into a small audio call ends with a video call in
-  100% of trials where the combined headcount is ≤ 4 and participants accept the
-  upgrade; when the headcount is > 4, the merge stays audio in 100% of trials.
+- **SC-001**: Merging a video caller into an audio call makes the call video-capable
+  (cameras allowed, per-participant) in 100% of trials where the combined headcount is
+  ≤ 4, and keeps it audio-only in 100% of trials where the headcount is > 4; no camera
+  is ever auto-enabled.
 - **SC-002**: Every existing participant sees a "{name} joined the call" cue for a
   genuinely-new joiner in 100% of trials, and 0 cues fire for a reconnect or the local
   user's own join.
@@ -284,8 +303,9 @@ roster, tiles, and connectivity are correct on every device with no orphaned sta
   `convertActiveToRoom`, `sendJoinRoom`, `addPeople`, the capacity gate, and the
   `joinroom` signal already exist (this spec depends on the merged 1028 promotion/merge
   work).
-- **Kind reconciliation reuses the existing consent-gated upgrade** (`call-upgrade-*` /
-  the group video path); no new upgrade mechanism.
+- **Kind reconciliation reuses the existing per-participant group-video mechanism**
+  (making the call video-capable so each person's camera toggle works); no new upgrade
+  mechanism, and not the 1:1 `requestVideoUpgrade` consent flow.
 - **The cue reuses the existing toast/cue infra** and resolves names from contacts / the
   roster owner map.
 - **Caps unchanged** (4 video / 8 audio) and the **single-held-slot** rule unchanged.

--- a/specs/1030-finish-call-kind/spec.md
+++ b/specs/1030-finish-call-kind/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category
@@ -203,11 +203,11 @@ roster, tiles, and connectivity are correct on every device with no orphaned sta
 
 ### Functional Requirements
 
-- **FR-001**: On a merge where the merged party's kind differs from the active call and
-  the combined headcount is at most the video cap (4), the system MUST make the call
-  video-capable so each participant can enable their own camera via the existing
-  per-participant control; NO camera is enabled without that participant's own action
-  (no auto-camera, no room-wide consent prompt).
+- **FR-001**: After any merge whose combined headcount is at most the video cap (4),
+  the system MUST make (or keep) the call video-capable — regardless of the merged
+  party's original call kind — so each participant can enable their own camera via the
+  existing per-participant control; NO camera is enabled without that participant's own
+  action (no auto-camera, no room-wide consent prompt).
 - **FR-002**: When the combined headcount would exceed the video cap, the system MUST
   NOT make the call video-capable; the merged party joins audio-only and the call stays
   audio for everyone.

--- a/specs/1030-finish-call-kind/tasks.md
+++ b/specs/1030-finish-call-kind/tasks.md
@@ -24,10 +24,10 @@ never for self or a reconnect.
 **Independent Test**: A+B+C in a group audio call; A adds D → every existing
 participant sees a cue naming D; force a reconnect of an existing participant → no cue.
 
-- [ ] T001 [P] [US2] Failing unit tests in `src/services/call/join-cue.test.ts`: `newJoiners(announced, roster, selfId)` — excludes self, dedups vs already-announced, returns multiple genuinely-new members, empty roster → none
-- [ ] T002 [US2] Implement `src/services/call/join-cue.ts` (`newJoiners`) until T001 is green
-- [ ] T003 [P] [US2] Failing Playwright e2e `e2e/call-join-cue.spec.ts` (audio): A/B/C in a group call, A adds D, every existing participant sees a "{name} joined the call" cue naming D; a forced reconnect of an existing participant shows NO cue; no cue for the local user's own join
-- [ ] T004 [US2] Wire the cue into the `call-roster` handler in `src/composables/useCall.ts`: maintain a per-call `announced` set (reset on new call), and for each `newJoiners(...)` toast "{name} joined the call" via `appToast` (name from contacts / stream-owner map; "Someone" for a non-contact)
+- [X] T001 [P] [US2] Failing unit tests in `src/services/call/join-cue.test.ts`: `newJoiners(announced, roster, selfId)` — excludes self, dedups vs already-announced, returns multiple genuinely-new members, empty roster → none
+- [X] T002 [US2] Implement `src/services/call/join-cue.ts` (`newJoiners`) until T001 is green
+- [X] T003 [P] [US2] Failing Playwright e2e `e2e/call-join-cue.spec.ts` (audio): A/B/C in a group call, A adds D, every existing participant sees a "{name} joined the call" cue naming D; a forced reconnect of an existing participant shows NO cue; no cue for the local user's own join
+- [X] T004 [US2] Wire the cue into the `call-roster` handler in `src/composables/useCall.ts`: maintain a per-call `announced` set (reset on new call), and for each `newJoiners(...)` toast "{name} joined the call" via `appToast` (name from contacts / stream-owner map; "Someone" for a non-contact)
 
 **Checkpoint**: growing a call is legible — every new arrival is acknowledged once.
 
@@ -42,10 +42,10 @@ control offered, no auto-camera); a call > 4 stays audio-only.
 works for one participant without enabling others' cameras; a >4 audio group → turning
 on video is refused.
 
-- [ ] T005 [P] [US1] Failing unit tests in `src/services/call/merge-kind.test.ts`: `videoCapableAfterMerge(activeKind, combinedHeadcount)` — video call → true; audio ≤ VIDEO_MAX → true; audio > VIDEO_MAX → false
-- [ ] T006 [US1] Implement `src/services/call/merge-kind.ts` (`videoCapableAfterMerge`) until T005 is green
-- [ ] T007 [P] [US1] Failing Playwright e2e `e2e/call-merge-kind.spec.ts` (audio): after promoting/merging into a ≤4 audio group, the "Turn on video" affordance is present and one participant turning it on does NOT enable others' cameras (no auto-camera); after a >4 audio group, turning on video is refused with the cap reason
-- [ ] T008 [US1] Ensure `meta.kind`/roster are correct after promotion/merge so the existing `toggleVideoMode` gate (≤ VIDEO_MAX) and the "Turn on video" affordance apply — fix only what T007 exposes (expected minimal/no behavioural change beyond confirmation); the merged video caller opts in via the same control
+- [X] T005 [P] [US1] Failing unit tests in `src/services/call/merge-kind.test.ts`: `videoCapableAfterMerge(activeKind, combinedHeadcount)` — video call → true; audio ≤ VIDEO_MAX → true; audio > VIDEO_MAX → false
+- [X] T006 [US1] Implement `src/services/call/merge-kind.ts` (`videoCapableAfterMerge`) until T005 is green
+- [X] T007 [P] [US1] Failing Playwright e2e `e2e/call-merge-kind.spec.ts` (audio): after promoting/merging into a ≤4 audio group, the "Turn on video" affordance is present and one participant turning it on does NOT enable others' cameras (no auto-camera); after a >4 audio group, turning on video is refused with the cap reason
+- [X] T008 [US1] Ensure `meta.kind`/roster are correct after promotion/merge so the existing `toggleVideoMode` gate (≤ VIDEO_MAX) and the "Turn on video" affordance apply — fix only what T007 exposes (expected minimal/no behavioural change beyond confirmation); the merged video caller opts in via the same control
 
 **Checkpoint**: kind reconciliation matches the per-participant clarification.
 
@@ -59,8 +59,8 @@ promotion/add.
 **Independent Test**: Active call X + held call Y; merge a caller into X; Y stays
 held/paused and swaps correctly; single-held rule holds throughout.
 
-- [ ] T009 [P] [US4] Failing Playwright e2e `e2e/call-merge-held.spec.ts` (audio): A active on X while holding Y; merge an incoming caller into X; assert Y is still held + paused and swaps back correctly, and at most one call is ever held
-- [ ] T010 [US4] Add the `addInFlight` guard in `src/composables/useCall.ts` (set around `ensureActiveIsRoom`+`inviteToRoom`); make `swapCalls`/`parkActiveAsHeld` await it (or no-op with a toast) so a swap can't park mid-conversion (FR-010); confirm merge/add never read/write `heldSlot`
+- [X] T009 [P] [US4] Failing Playwright e2e `e2e/call-merge-held.spec.ts` (audio): A active on X while holding Y; merge an incoming caller into X; assert Y is still held + paused and swaps back correctly, and at most one call is ever held; ALSO cover the FR-010 race: trigger a swap while the promotion/add is still in flight and assert it completes or cancels cleanly with no half-open connection (a unit-level test of the `addInFlight` guard is an acceptable substitute if the e2e race proves too timing-sensitive to force deterministically)
+- [X] T010 [US4] Add the `addInFlight` guard in `src/composables/useCall.ts` (set around `ensureActiveIsRoom`+`inviteToRoom`); make `swapCalls`/`parkActiveAsHeld` await it (or no-op with a toast) so a swap can't park mid-conversion (FR-010); confirm merge/add never read/write `heldSlot`
 
 **Checkpoint**: hold/swap (specs 0005/2009) fully intact alongside merge.
 
@@ -75,11 +75,11 @@ call within the combined cap, dedup shared members, block over cap.
 Add to call; choosing it folds C(+D) into A's call within the cap; a member in both
 dedups to one; an over-cap fold is blocked with a reason leaving both calls unchanged.
 
-- [ ] T011 [P] [US3] Failing unit tests: combined-headcount cap for a group fold — extend `src/services/call/capacity.test.ts` / `invite-plan.test.ts` for the distinct union of two rosters (fits vs over-cap; a shared member counted once)
-- [ ] T012 [P] [US3] Failing Playwright e2e `e2e/call-group-merge.spec.ts` (audio): A+B in a call, C starts a group inviting A(+D); A's second-incoming prompt offers Add to call; folding brings C(+D) into A's call within cap, a shared member resolves to one participant, and a separate over-cap case is blocked with a reason (both calls unchanged)
-- [ ] T013 [US3] In `handleGroupInvite` (`src/composables/useCall.ts`): when `callState !== 'idle'` AND `canRaiseSecondIncoming()`, raise `incomingSecond` as `kind:'group'` (roomId + members) instead of `sendGroupBusy`; keep auto-busy when no slot is free (spec 2009)
-- [ ] T014 [US3] Implement `mergeGroupInvite()` in `src/composables/useCall.ts`: `canAdd` over the combined distinct headcount → block with reason if over cap; else `ensureActiveIsRoom()` → `inviteToRoom(members − present)` (planInvite dedups) → `sendGroupLeave(inviteRoomId)` → clear the slot; export it in the `useCall()` accessor + a testhook
-- [ ] T015 [US3] Show **Add to call** for a `kind:'group'` second-incoming in `src/views/detail/CallActivePage.vue` (alongside Hold + Decline), wired to `mergeGroupInvite`
+- [X] T011 [P] [US3] Failing unit tests: combined-headcount cap for a group fold — extend `src/services/call/capacity.test.ts` / `invite-plan.test.ts` for the distinct union of two rosters (fits vs over-cap; a shared member counted once)
+- [X] T012 [P] [US3] Failing Playwright e2e `e2e/call-group-merge.spec.ts` (audio): A+B in a call, C starts a group inviting A(+D); A's second-incoming prompt offers Add to call; folding brings C(+D) into A's call within cap, a shared member resolves to one participant, A has left the invite's own room after the fold (never in two rooms at once — FR-008), and a separate over-cap case is blocked with a reason (both calls unchanged)
+- [X] T013 [US3] In `handleGroupInvite` (`src/composables/useCall.ts`): when `callState !== 'idle'` AND `canRaiseSecondIncoming()`, raise `incomingSecond` as `kind:'group'` (roomId + members) instead of `sendGroupBusy`; keep auto-busy when no slot is free (spec 2009)
+- [X] T014 [US3] Implement `mergeGroupInvite()` in `src/composables/useCall.ts`: `canAdd` over the combined distinct headcount → block with reason if over cap; else `ensureActiveIsRoom()` → `inviteToRoom(members − present)` (planInvite dedups) → `sendGroupLeave(inviteRoomId)` → clear the slot; export it in the `useCall()` accessor + a testhook
+- [X] T015 [US3] Show **Add to call** for a `kind:'group'` second-incoming in `src/views/detail/CallActivePage.vue` (alongside Hold + Decline), wired to `mergeGroupInvite`
 
 **Checkpoint**: the richest merge path works, cap-bounded and dedup-correct.
 
@@ -94,9 +94,9 @@ orphaned connections.
 **Independent Test**: Scripted churn on an audio mesh; final roster/tiles/connectivity
 correct on every device with no orphaned state.
 
-- [ ] T016 [P] [US5] Failing Playwright e2e `e2e/call-churn.spec.ts` (audio): concurrent join+leave converges to the correct roster with no stuck tile; two callers adding the SAME new person → one participant/one leg (dedup); an invitee reloading mid-ring returns and joins cleanly (no duplicate)
-- [ ] T017 [P] [US5] Drive scenario `drive/scenarios/call-add-churn.mjs` for harder multi-party churn on the live stack
-- [ ] T018 [US5] Add/verify the promotion-timeout path: a promoted 1:1 whose peer never follows and where no one else joins ends cleanly via the existing `armGroupIdleTimeout` with no orphaned ringing tile; harden `applyRoster`/`inviteToRoom`/the cue against whatever T016/T017 expose (reuse the serialized `rosterChain` + set semantics — no new mechanism)
+- [X] T016 [P] [US5] Failing Playwright e2e `e2e/call-churn.spec.ts` (audio): concurrent join+leave converges to the correct roster with no stuck tile; two callers adding the SAME new person → one participant/one leg (dedup); an invitee reloading mid-ring returns and joins cleanly (no duplicate)
+- [X] T017 [P] [US5] Drive scenario `drive/scenarios/call-add-churn.mjs` for harder multi-party churn on the live stack
+- [X] T018 [US5] Add/verify the promotion-timeout path: a promoted 1:1 whose peer never follows and where no one else joins ends cleanly via the existing `armGroupIdleTimeout` with no orphaned ringing tile; harden `applyRoster`/`inviteToRoom`/the cue against whatever T016/T017 expose (reuse the serialized `rosterChain` + set semantics — no new mechanism)
 
 **Checkpoint**: growing a call is reliable under pressure.
 
@@ -104,11 +104,11 @@ correct on every device with no orphaned state.
 
 ## Phase 6: Video validation, cleanup & gates
 
-- [ ] T019 [P] Drive scenario `drive/scenarios/merge-video.mjs`: merge into a ≤4 call, turn cameras on per participant, confirm video flows among 3 (real device / live stack — NOT headless CI); screenshot the grid
-- [ ] T020 Verify **no `server/` diff** (FR-013): `cd server && go build ./... && go vet ./... && go test ./...` green AND `git diff --stat origin/develop -- server/` is empty; STOP + escalate if a server change appears necessary
-- [ ] T021 Run ALL existing call e2e + unit green (SC-006): `calls`, `call-waiting`, `call-waiting-slot`, `call-caps`, `call-reinvite`, `call-promote`, `call-merge`, `call-add-merge`, `call-add-cap`, plus the call unit tests
-- [ ] T022 Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build/vet/test`
-- [ ] T023 Bump spec `**Status**:` to `in-review` → `make roadmap`; and bump spec 1028 `**Status**:` if all its remaining items are now complete
+- [X] T019 [P] Drive scenario `drive/scenarios/merge-video.mjs`: merge into a ≤4 call, turn cameras on per participant, confirm video flows among 3 (real device / live stack — NOT headless CI); screenshot the grid
+- [X] T020 Verify **no `server/` diff** (FR-013): `cd server && go build ./... && go vet ./... && go test ./...` green AND `git diff --stat origin/develop -- server/` is empty; STOP + escalate if a server change appears necessary
+- [X] T021 Run ALL existing call e2e + unit green (SC-006): `calls`, `call-waiting`, `call-waiting-slot`, `call-caps`, `call-reinvite`, `call-promote`, `call-merge`, `call-add-merge`, `call-add-cap`, plus the call unit tests
+- [X] T022 Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build/vet/test`
+- [X] T023 Bump spec `**Status**:` to `in-review` → `make roadmap`; and bump spec 1028 `**Status**:` if all its remaining items are now complete
 
 ---
 

--- a/specs/1030-finish-call-kind/tasks.md
+++ b/specs/1030-finish-call-kind/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness
+
+**Input**: Design documents from `/specs/1030-finish-call-kind/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/internal-api.md, quickstart.md. Builds on the merged 1028 promotion/merge code.
+
+**Tests**: REQUIRED (constitution III). Pure decision helpers are unit-first; each
+user-facing item writes a failing e2e before the code. No crypto/ZK checklist (no new
+wire data — reuses 1028's already-reviewed signalling). Design ids (R1–R7, D1–D5,
+INV-1..5) reference research/plan/data-model.
+
+**CI constraint**: 3-person VIDEO mesh is NOT runnable headless — e2e uses AUDIO meshes
+(3–4) + 2-person proxies; the VIDEO result of a merge is drive/real-device only.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+---
+
+## Phase 1: Join cue (US2, Priority: P1) 🎯 first slice
+
+**Goal**: A brief "{name} joined the call" when a genuinely-new participant joins;
+never for self or a reconnect.
+
+**Independent Test**: A+B+C in a group audio call; A adds D → every existing
+participant sees a cue naming D; force a reconnect of an existing participant → no cue.
+
+- [ ] T001 [P] [US2] Failing unit tests in `src/services/call/join-cue.test.ts`: `newJoiners(announced, roster, selfId)` — excludes self, dedups vs already-announced, returns multiple genuinely-new members, empty roster → none
+- [ ] T002 [US2] Implement `src/services/call/join-cue.ts` (`newJoiners`) until T001 is green
+- [ ] T003 [P] [US2] Failing Playwright e2e `e2e/call-join-cue.spec.ts` (audio): A/B/C in a group call, A adds D, every existing participant sees a "{name} joined the call" cue naming D; a forced reconnect of an existing participant shows NO cue; no cue for the local user's own join
+- [ ] T004 [US2] Wire the cue into the `call-roster` handler in `src/composables/useCall.ts`: maintain a per-call `announced` set (reset on new call), and for each `newJoiners(...)` toast "{name} joined the call" via `appToast` (name from contacts / stream-owner map; "Someone" for a non-contact)
+
+**Checkpoint**: growing a call is legible — every new arrival is acknowledged once.
+
+---
+
+## Phase 2: Kind reconciliation (US1, Priority: P1)
+
+**Goal**: After a merge, a call ≤ 4 is video-capable (per-participant "Turn on video"
+control offered, no auto-camera); a call > 4 stays audio-only.
+
+**Independent Test**: Promote/merge to a ≤4 audio group → "Turn on video" available and
+works for one participant without enabling others' cameras; a >4 audio group → turning
+on video is refused.
+
+- [ ] T005 [P] [US1] Failing unit tests in `src/services/call/merge-kind.test.ts`: `videoCapableAfterMerge(activeKind, combinedHeadcount)` — video call → true; audio ≤ VIDEO_MAX → true; audio > VIDEO_MAX → false
+- [ ] T006 [US1] Implement `src/services/call/merge-kind.ts` (`videoCapableAfterMerge`) until T005 is green
+- [ ] T007 [P] [US1] Failing Playwright e2e `e2e/call-merge-kind.spec.ts` (audio): after promoting/merging into a ≤4 audio group, the "Turn on video" affordance is present and one participant turning it on does NOT enable others' cameras (no auto-camera); after a >4 audio group, turning on video is refused with the cap reason
+- [ ] T008 [US1] Ensure `meta.kind`/roster are correct after promotion/merge so the existing `toggleVideoMode` gate (≤ VIDEO_MAX) and the "Turn on video" affordance apply — fix only what T007 exposes (expected minimal/no behavioural change beyond confirmation); the merged video caller opts in via the same control
+
+**Checkpoint**: kind reconciliation matches the per-participant clarification.
+
+---
+
+## Phase 3: Merge coexists with hold + add-in-flight guard (US4, Priority: P2)
+
+**Goal**: Merging into the active call never disturbs a held call; a swap can't race a
+promotion/add.
+
+**Independent Test**: Active call X + held call Y; merge a caller into X; Y stays
+held/paused and swaps correctly; single-held rule holds throughout.
+
+- [ ] T009 [P] [US4] Failing Playwright e2e `e2e/call-merge-held.spec.ts` (audio): A active on X while holding Y; merge an incoming caller into X; assert Y is still held + paused and swaps back correctly, and at most one call is ever held
+- [ ] T010 [US4] Add the `addInFlight` guard in `src/composables/useCall.ts` (set around `ensureActiveIsRoom`+`inviteToRoom`); make `swapCalls`/`parkActiveAsHeld` await it (or no-op with a toast) so a swap can't park mid-conversion (FR-010); confirm merge/add never read/write `heldSlot`
+
+**Checkpoint**: hold/swap (specs 0005/2009) fully intact alongside merge.
+
+---
+
+## Phase 4: Group-invite merge (US3, Priority: P2)
+
+**Goal**: "Add to call" works for an incoming GROUP invite — fold its members into your
+call within the combined cap, dedup shared members, block over cap.
+
+**Independent Test**: A+B in a call; C starts a group inviting A (+D); A's prompt shows
+Add to call; choosing it folds C(+D) into A's call within the cap; a member in both
+dedups to one; an over-cap fold is blocked with a reason leaving both calls unchanged.
+
+- [ ] T011 [P] [US3] Failing unit tests: combined-headcount cap for a group fold — extend `src/services/call/capacity.test.ts` / `invite-plan.test.ts` for the distinct union of two rosters (fits vs over-cap; a shared member counted once)
+- [ ] T012 [P] [US3] Failing Playwright e2e `e2e/call-group-merge.spec.ts` (audio): A+B in a call, C starts a group inviting A(+D); A's second-incoming prompt offers Add to call; folding brings C(+D) into A's call within cap, a shared member resolves to one participant, and a separate over-cap case is blocked with a reason (both calls unchanged)
+- [ ] T013 [US3] In `handleGroupInvite` (`src/composables/useCall.ts`): when `callState !== 'idle'` AND `canRaiseSecondIncoming()`, raise `incomingSecond` as `kind:'group'` (roomId + members) instead of `sendGroupBusy`; keep auto-busy when no slot is free (spec 2009)
+- [ ] T014 [US3] Implement `mergeGroupInvite()` in `src/composables/useCall.ts`: `canAdd` over the combined distinct headcount → block with reason if over cap; else `ensureActiveIsRoom()` → `inviteToRoom(members − present)` (planInvite dedups) → `sendGroupLeave(inviteRoomId)` → clear the slot; export it in the `useCall()` accessor + a testhook
+- [ ] T015 [US3] Show **Add to call** for a `kind:'group'` second-incoming in `src/views/detail/CallActivePage.vue` (alongside Hold + Decline), wired to `mergeGroupInvite`
+
+**Checkpoint**: the richest merge path works, cap-bounded and dedup-correct.
+
+---
+
+## Phase 5: Churn robustness (US5, Priority: P2)
+
+**Goal**: Growing a call converges under churn — concurrent join/leave, simultaneous
+same-person add, invitee reload, promotion timeout — no stuck ringing, duplicates, or
+orphaned connections.
+
+**Independent Test**: Scripted churn on an audio mesh; final roster/tiles/connectivity
+correct on every device with no orphaned state.
+
+- [ ] T016 [P] [US5] Failing Playwright e2e `e2e/call-churn.spec.ts` (audio): concurrent join+leave converges to the correct roster with no stuck tile; two callers adding the SAME new person → one participant/one leg (dedup); an invitee reloading mid-ring returns and joins cleanly (no duplicate)
+- [ ] T017 [P] [US5] Drive scenario `drive/scenarios/call-add-churn.mjs` for harder multi-party churn on the live stack
+- [ ] T018 [US5] Add/verify the promotion-timeout path: a promoted 1:1 whose peer never follows and where no one else joins ends cleanly via the existing `armGroupIdleTimeout` with no orphaned ringing tile; harden `applyRoster`/`inviteToRoom`/the cue against whatever T016/T017 expose (reuse the serialized `rosterChain` + set semantics — no new mechanism)
+
+**Checkpoint**: growing a call is reliable under pressure.
+
+---
+
+## Phase 6: Video validation, cleanup & gates
+
+- [ ] T019 [P] Drive scenario `drive/scenarios/merge-video.mjs`: merge into a ≤4 call, turn cameras on per participant, confirm video flows among 3 (real device / live stack — NOT headless CI); screenshot the grid
+- [ ] T020 Verify **no `server/` diff** (FR-013): `cd server && go build ./... && go vet ./... && go test ./...` green AND `git diff --stat origin/develop -- server/` is empty; STOP + escalate if a server change appears necessary
+- [ ] T021 Run ALL existing call e2e + unit green (SC-006): `calls`, `call-waiting`, `call-waiting-slot`, `call-caps`, `call-reinvite`, `call-promote`, `call-merge`, `call-add-merge`, `call-add-cap`, plus the call unit tests
+- [ ] T022 Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e`, `cd server && go build/vet/test`
+- [ ] T023 Bump spec `**Status**:` to `in-review` → `make roadmap`; and bump spec 1028 `**Status**:` if all its remaining items are now complete
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1 (US2 cue)** is the smallest self-contained win — start here (MVP-ish).
+- **Phase 2 (US1)** is mostly verification (the group-video toggle already exists).
+- **Phase 3 (US4 guard)** is independent and small.
+- **Phase 4 (US3 group merge)** builds on 1028's `ensureActiveIsRoom`/`inviteToRoom` and
+  the waiting-slot; do after the guard so a fold-then-swap is safe.
+- **Phase 5 (US5 churn)** exercises everything; do after the add/merge paths.
+- **Phase 6** last; T020 (no-server-diff) + T022 (gates) gate the PR.
+
+### Parallel opportunities
+- T001/T005/T011 (pure unit tests) and each phase's failing e2e are [P].
+- Drive scenarios (T017, T019) run parallel to their story's e2e.
+
+---
+
+## Implementation Strategy
+
+Small completion spec — no big-bang. Land the **join cue** first (visible, self-contained),
+then kind reconciliation (mostly tests), the hold guard, group-invite merge, churn
+hardening, and video validation. Each checkpoint is independently testable; the server
+stays untouched throughout (verified by T020). Reuse the open 1028 issues where a task
+maps to a deferred 1028 item; create new issues only for genuinely-new work (the cue's
+pure helper, the group-invite waiting-slot change).

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -45,6 +45,7 @@ import type { CallState, CallMeta, CallKind, EndReason } from '@/services/call/t
 import { VIDEO_MAX } from '@/services/call/types';
 import { remainingSlots, canAdd } from '@/services/call/capacity';
 import { planInvite } from '@/services/call/invite-plan';
+import { newJoiners } from '@/services/call/join-cue';
 import {
   type Tier,
   type ControllerState,
@@ -494,6 +495,35 @@ const GRACE_MS = 18_000; // mid-call: tolerate a blip/handoff before ending (mat
 // Group calls: the set of OTHER participants that actually joined during the call
 // (accumulated from call-roster frames), for the call log + Calls-tab record.
 const groupJoined = new Set<string>();
+
+// (spec 1030 US2) Join-cue bookkeeping: everyone already announced as "joined the
+// call" this call, and whether the FIRST roster snapshot was consumed. Members in
+// that first snapshot were here before us (or are us) — people we walked in on,
+// not joiners — so they seed `announcedJoiners` silently; every LATER update cues
+// each not-yet-announced member exactly once. A reconnect doesn't change room
+// membership and a re-broadcast is deduped by the set, so neither re-fires
+// (INV-4). Reset per call (enterGroupCall). joinCueLog is dev/e2e introspection.
+const announcedJoiners = new Set<string>();
+let joinCuePrimed = false;
+const joinCueLog: string[] = [];
+
+/** Dev/e2e: the userIds announced as "joined the call" this call, in order. */
+export function joinCuesShown(): string[] {
+  return [...joinCueLog];
+}
+
+/** "{name} joined the call" (spec 1030 US2): the name comes from the local
+ *  contacts store, "Someone" for a non-contact — resolved on-device only (the
+ *  server never sees a name; zero-knowledge). */
+async function announceJoinCue(id: string): Promise<void> {
+  let name = '';
+  try {
+    name = (await getContact(id))?.name ?? '';
+  } catch {
+    /* contact lookup failing must never break the roster update */
+  }
+  await toast(`${name || 'Someone'} joined the call`);
+}
 
 // Group calls (caller side): invitees we've stopped ringing — the ~30s reminder window
 // elapsed without them joining. Their tile then offers recall (ring again) / remove. A
@@ -1376,6 +1406,11 @@ async function enterGroupCall(
     avatar,
   };
   setState('connecting');
+  // (spec 1030 US2) Fresh join-cue bookkeeping for this call: nobody announced yet,
+  // and the first roster snapshot we receive seeds (not cues) the announced set.
+  announcedJoiners.clear();
+  joinCuePrimed = false;
+  joinCueLog.length = 0;
   // Start the per-invitee give-up timers so a member who never joins flips to the
   // recall/remove tile after the reminder window. EVERY participant arms these (not just the
   // initiator) so anyone in the call can ring a no-show again or remove them (spec 0004): a
@@ -1453,10 +1488,19 @@ async function handleGroupInvite(frame: Extract<CallFrame, { t: 'call-group-invi
   if (!roomId || !frame.from) return;
   // Already ringing/connected for this room → ignore duplicate invites.
   if (callMeta.value?.roomId === roomId) return;
+  // Already prompting for this room in the waiting slot → a server re-ring; keep the prompt.
+  if (incomingSecond.value?.roomId === roomId) return;
   if (callState.value !== 'idle') {
-    // Busy in another call → tell the caller we're unavailable instead of letting their tile
-    // for us ring forever, and stop their server-side re-ring of us (spec 0004 US2).
-    void sendGroupBusy(frame.from, roomId);
+    // (spec 1030 US3) In a call: a group invite used to be auto-busied — silently
+    // declined with no way to combine the calls. Now, when the single waiting slot
+    // is free, it's raised as the second-incoming prompt (Add to call / Accept &
+    // hold / Decline), like a direct second caller. The busy fallback remains for
+    // a taken slot (spec 2009: at most one waiter) or a locked device.
+    if (canRaiseSecondIncoming() && isUnlockedNow()) {
+      await presentSecondGroup(frame, roomId);
+    } else {
+      void sendGroupBusy(frame.from, roomId);
+    }
     return;
   }
   if (!isUnlockedNow()) return; // locked → can't decrypt the sealed signalling; skip the ring
@@ -1496,6 +1540,86 @@ async function handleGroupInvite(frame: Extract<CallFrame, { t: 'call-group-invi
     void sendGroupLeave(roomId);
     void teardown('timeout');
   }, RING_TIMEOUT_MS);
+}
+
+/** A group invite arriving while we're in a call and the waiting slot is free (spec 1030
+ *  US3): stash it as the second-incoming prompt — offering Add to call (fold it into the
+ *  current call), Accept & hold, or Decline — instead of the old silent auto-busy.
+ *  Mirrors presentSecondDirect; the call-waiting cue rides the incomingSecond watcher. */
+async function presentSecondGroup(
+  frame: Extract<CallFrame, { t: 'call-group-invite' }>,
+  roomId: string,
+): Promise<void> {
+  const from = frame.from ?? '';
+  const self = getSelfUserId() ?? '';
+  // The invite's people (initiator + named members, minus ourselves): the fold's
+  // ring list and the prompt's title source.
+  const participants = [...new Set([from, ...(frame.members ?? [])])].filter((id) => id && id !== self);
+  const chat = await getChat(roomId);
+  incomingSecond.value = {
+    kind: 'group',
+    callId: roomId,
+    from,
+    roomId,
+    name: chat?.name || (await deriveGroupCallTitle(participants)),
+    avatar: chat?.avatar || groupAvatar(roomId),
+    callKind: frame.kind ?? 'audio',
+    members: participants,
+  };
+  // If unanswered within the ring window, drop the prompt and stop the server's
+  // re-ring of us (same as letting a foreground group invite lapse).
+  setTimeout(() => {
+    if (incomingSecond.value?.roomId === roomId) {
+      incomingSecond.value = null;
+      void sendGroupLeave(roomId);
+    }
+  }, RING_TIMEOUT_MS);
+}
+
+/**
+ * Fold the pending second incoming GROUP INVITE into the current call (spec 1030,
+ * US3) — "Add to call" for a whole group. Gated on the combined DISTINCT headcount
+ * (a member already in/ringing in our call counts once — FR-007); then a 1:1 is
+ * promoted first if needed, the invite's not-yet-present members are rung into OUR
+ * room (they consent by answering, exactly like add-people), and we leave the
+ * invite's own room so we're never in two rooms at once (FR-008, INV-5). When the
+ * fold wouldn't fit the cap it's blocked with the kind-specific reason and BOTH
+ * calls stay exactly as they were (the prompt is kept so Hold/Decline still work).
+ */
+export async function mergeGroupInvite(): Promise<void> {
+  const inc = incomingSecond.value;
+  if (!inc || inc.kind !== 'group' || !inc.roomId) return;
+  const meta = callMeta.value;
+  if (!meta || callState.value === 'idle') return;
+  const self = getSelfUserId() ?? '';
+  // Distinct newcomers = the invite's members not already in (or ringing into) our
+  // call; on a 1:1 the roster already carries the peer, so the math is uniform.
+  const present = new Set([self, ...meta.roster, ...(meta.invited ?? [])]);
+  const newcomers = [...new Set(inc.members ?? [])].filter((id) => id && !present.has(id));
+  const gate = canAdd(meta.kind, meta.roster, meta.invited ?? [], self, newcomers.length);
+  if (!gate.ok) {
+    await toast(gate.reason);
+    return; // both calls unchanged; the invite stays in the waiting slot
+  }
+  const inviteRoomId = inc.roomId;
+  incomingSecond.value = null;
+  // The promote+ring section holds the add-in-flight guard so a swap/park can't
+  // interleave with the conversion (spec 1030 FR-010).
+  await withAddInFlight(async () => {
+    await ensureActiveIsRoom(); // promote a 1:1 first (no-op if already a room)
+    const m = callMeta.value;
+    if (!m?.isGroup || !m.roomId) return;
+    const plan = planInvite(m.kind, m.roster, m.invited ?? [], self, newcomers);
+    for (const id of plan.toRing) {
+      m.invited = [...(m.invited ?? []), id];
+      markNotJoining(id, false);
+      armMemberRingTimer(id);
+      await sendRecall(id, m.roomId, m.kind, m.invited);
+    }
+  });
+  // Leave the invite's own room: we fold people into OUR call, we don't join theirs
+  // (and the server stops re-ringing us for it).
+  void sendGroupLeave(inviteRoomId);
 }
 
 /** Accept the current incoming GROUP call → join the room (no members → no re-ring). */
@@ -1540,6 +1664,16 @@ async function convertActiveToRoom(
   direction: 'incoming' | 'outgoing',
 ): Promise<void> {
   const stream = localStream.value ?? undefined;
+  // (spec 1030 US1/T008) A VIDEO 1:1 being folded into an AUDIO room: drop the live
+  // camera track before entering, so the merged caller joins audio-only — in an
+  // audio-kind room video is strictly per-participant OPT-IN via the normal control
+  // (a camera-carrying join would publish video the room's kind doesn't reflect and
+  // desync the self-view state). The camera is one tap away again once inside.
+  if (kind === 'audio' && stream?.getVideoTracks().length) {
+    setLocalVideoTrack(null, true);
+    cameraOff.value = false; // reset the toggle state for the (audio) room
+  }
+  const prevPeer = callMeta.value?.peerUserId; // the 1:1 peer who will follow us in
   if (pc) {
     pc.onicecandidate = null;
     pc.ontrack = null;
@@ -1558,6 +1692,12 @@ async function convertActiveToRoom(
   reprimeBytes = true; // re-baseline byte counters against the new mesh session
   if (callMeta.value) callMeta.value.tornDown = true; // the old 1:1 meta is retired
   await enterGroupCall(roomId, kind, name, avatar, direction, [], stream);
+  // (spec 1030 US2) The 1:1 peer following us into the promoted room isn't a new
+  // arrival — they were already in the call — so seed them as announced (no
+  // "joined the call" cue for the promotion itself). Safe against a fast follow:
+  // a roster frame is a WS macrotask, so it can't land between enterGroupCall
+  // resolving and this line.
+  if (prevPeer) announcedJoiners.add(prevPeer);
 }
 
 /**
@@ -1587,20 +1727,27 @@ async function ensureActiveIsRoom(): Promise<void> {
  */
 export async function addPeople(ids: string[]): Promise<void> {
   if (!callMeta.value || callState.value === 'idle') return;
-  await ensureActiveIsRoom(); // promote a 1:1 first (no-op if already a room)
-  const meta = callMeta.value;
-  if (!meta?.isGroup || !meta.roomId) return;
-  const self = getSelfUserId() ?? '';
-  const plan = planInvite(meta.kind, meta.roster, meta.invited ?? [], self, ids);
-  for (const id of plan.toRing) {
-    meta.invited = [...(meta.invited ?? []), id];
-    markNotJoining(id, false);
-    armMemberRingTimer(id);
-    await sendRecall(id, meta.roomId, meta.kind, meta.invited);
-  }
+  // The whole promote+ring section holds the add-in-flight guard so a swap/park
+  // can't interleave with the conversion (spec 1030 FR-010).
+  const dropped = await withAddInFlight(async () => {
+    await ensureActiveIsRoom(); // promote a 1:1 first (no-op if already a room)
+    const meta = callMeta.value;
+    if (!meta?.isGroup || !meta.roomId) return [];
+    const self = getSelfUserId() ?? '';
+    const plan = planInvite(meta.kind, meta.roster, meta.invited ?? [], self, ids);
+    for (const id of plan.toRing) {
+      meta.invited = [...(meta.invited ?? []), id];
+      markNotJoining(id, false);
+      armMemberRingTimer(id);
+      await sendRecall(id, meta.roomId, meta.kind, meta.invited);
+    }
+    return plan.dropped;
+  });
   // Anyone who didn't fit the cap → tell the user why (kind-specific copy).
-  if (plan.dropped.length) {
-    const gate = canAdd(meta.kind, meta.roster, meta.invited ?? [], self, 1);
+  if (dropped.length) {
+    const meta = callMeta.value;
+    const self = getSelfUserId() ?? '';
+    const gate = meta ? canAdd(meta.kind, meta.roster, meta.invited ?? [], self, 1) : { ok: true as const };
     await toast(gate.ok ? 'Some people are already in the call' : gate.reason);
   }
 }
@@ -1632,7 +1779,15 @@ async function onGroupIceFailed(): Promise<void> {
 
 // Lone-in-the-room timeout: a group call where nobody else joins ends after a grace
 // window (the group-call analogue of the 1:1 dial timeout), instead of hanging.
-const GROUP_NOBODY_MS = 60_000;
+// A live `let` ONLY so the dev/e2e harness can shrink it (like setCallCapsForTest) to
+// exercise the promotion-timeout path (spec 1030 US5) in seconds; production never
+// calls the setter, so it stays 60s.
+let GROUP_NOBODY_MS = 60_000;
+
+/** Dev/e2e only: shrink the lone-in-the-room timeout. Never called in production. */
+export function setGroupIdleMsForTest(ms: number): void {
+  GROUP_NOBODY_MS = ms;
+}
 let groupIdleTimer: ReturnType<typeof setTimeout> | null = null;
 function armGroupIdleTimeout(): void {
   if (groupIdleTimer) return; // already counting down
@@ -1867,11 +2022,38 @@ export async function acceptCall(): Promise<void> {
 
 /* ---- call waiting (spec 0005): hold the active call, take a second, swap, drop ---- */
 
+/* (spec 1030 US4, FR-010) The add-in-flight guard. A promotion/add converts the ACTIVE
+ * call (close the 1:1 pc → mint a room → re-enter as a mesh) across several awaits; a
+ * swap/park interleaving mid-conversion would capture a half-built call into the held
+ * slot (a dead pc, no group session yet) — a half-open connection. Every add/merge path
+ * claims this slot for its critical section, and swapCalls/parkActiveAsHeld drain it
+ * before touching the active call. Adds also serialize against EACH OTHER, so two
+ * concurrent adds can't both promote. */
+let addInFlight: Promise<void> | null = null;
+
+async function withAddInFlight<T>(fn: () => Promise<T>): Promise<T> {
+  while (addInFlight) await addInFlight; // serialize behind any add already converting
+  let release!: () => void;
+  addInFlight = new Promise<void>((r) => (release = r));
+  try {
+    return await fn();
+  } finally {
+    addInFlight = null;
+    release();
+  }
+}
+
+/** Wait until no promotion/add is converting the active call (no-op when idle). */
+async function drainAddInFlight(): Promise<void> {
+  while (addInFlight) await addInFlight;
+}
+
 /** Pause the current ACTIVE call and move it into the held slot, keeping its connection +
  *  ICE alive. 1:1: detach the senders + send a sealed hold to the peer. Group: pause every
  *  leg (MeshSession.pause). The active singleton refs are then cleared for the new call to
  *  populate — we do NOT teardown. */
 async function parkActiveAsHeld(): Promise<void> {
+  await drainAddInFlight(); // never park a call mid-promotion (spec 1030 FR-010)
   const meta = callMeta.value;
   if (!meta) return;
   bankActiveTime(meta); // freeze the parked call's duration clock — held time isn't talk time
@@ -1947,6 +2129,7 @@ async function restoreHeldCall(): Promise<void> {
  *  held one into the active slot, and park the just-paused call as the new held. The shared
  *  camera/mic stays live (no re-capture) — only which call sends it changes. */
 export async function swapCalls(): Promise<void> {
+  await drainAddInFlight(); // an add/promotion completes before the swap parks it (FR-010)
   const slot = heldSlot;
   const activeMeta = callMeta.value;
   if (!slot || !activeMeta) return;
@@ -2093,23 +2276,34 @@ async function connectSecondDirect(
 export async function mergeIncoming(): Promise<void> {
   const inc = incomingSecond.value;
   if (!inc || inc.kind !== 'direct' || !inc.from || !inc.chatId) return;
-  await ensureActiveIsRoom(); // promote the active 1:1 (no-op if already a room)
-  const meta = callMeta.value;
-  if (!meta?.roomId) return;
-  const self = getSelfUserId() ?? '';
-  const gate = canAdd(meta.kind, meta.roster, meta.invited ?? [], self, 1);
-  if (!gate.ok) {
-    await toast(gate.reason);
-    return; // leave the caller in the waiting slot so the user can still hold/decline
+  // Gate BEFORE promoting: on a 1:1 the roster already carries the peer, so the
+  // distinct headcount is right either way, and a blocked merge leaves the active
+  // call exactly as it was (still a 1:1).
+  {
+    const meta = callMeta.value;
+    if (!meta) return;
+    const self = getSelfUserId() ?? '';
+    const gate = canAdd(meta.kind, meta.roster, meta.invited ?? [], self, 1);
+    if (!gate.ok) {
+      await toast(gate.reason);
+      return; // leave the caller in the waiting slot so the user can still hold/decline
+    }
   }
-  // Tell the caller to join our room instead of the 1:1 they dialed; they show as a
-  // "ringing" tile until their leg connects.
-  await sendJoinRoom(inc.chatId, inc.from, inc.callId, meta.roomId, meta.kind);
-  meta.invited = [...(meta.invited ?? []), inc.from];
-  markNotJoining(inc.from, false);
-  armMemberRingTimer(inc.from);
-  incomingSecond.value = null;
-  secondIce = [];
+  // The promote+ring section holds the add-in-flight guard so a swap/park can't
+  // interleave with the conversion (spec 1030 FR-010).
+  await withAddInFlight(async () => {
+    await ensureActiveIsRoom(); // promote the active 1:1 (no-op if already a room)
+    const meta = callMeta.value;
+    if (!meta?.roomId) return;
+    // Tell the caller to join our room instead of the 1:1 they dialed; they show as a
+    // "ringing" tile until their leg connects.
+    await sendJoinRoom(inc.chatId!, inc.from!, inc.callId, meta.roomId, meta.kind);
+    meta.invited = [...(meta.invited ?? []), inc.from!];
+    markNotJoining(inc.from!, false);
+    armMemberRingTimer(inc.from!);
+    incomingSecond.value = null;
+    secondIce = [];
+  });
 }
 
 /** Accept the pending second incoming call (US1): put the current call on hold and connect
@@ -3082,6 +3276,19 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
         markNotJoining(id, false);
         markMemberBusy(id, false); // a free device joined → no longer "unavailable" (US2)
       }
+      // (spec 1030 US2) "{name} joined the call": the first roster of a call seeds
+      // silently (whoever is already in the room was here before us, or is us);
+      // every later update announces each genuinely-new member exactly once.
+      if (!joinCuePrimed) {
+        joinCuePrimed = true;
+        for (const id of frame.members) announcedJoiners.add(id);
+      } else {
+        for (const id of newJoiners(announcedJoiners, frame.members, self)) {
+          announcedJoiners.add(id);
+          joinCueLog.push(id);
+          void announceJoinCue(id);
+        }
+      }
       const afterSet = new Set(after);
       const left = [...before].filter((id) => !afterSet.has(id));
       // Someone who WAS in the room and is now gone has left → drop them from the invited set
@@ -3194,6 +3401,7 @@ export function useCall() {
     rejectUpgrade,
     addPeople,
     mergeIncoming,
+    mergeGroupInvite,
     callRemainingSlots,
     recallMember,
     cancelInvite,

--- a/src/services/call/capacity.test.ts
+++ b/src/services/call/capacity.test.ts
@@ -82,4 +82,34 @@ describe('canAdd', () => {
     // One more (a 5th) → blocked.
     expect(canAdd('video', [SELF, 'a'], [], SELF, 3).ok).toBe(false);
   });
+
+  // (spec 1030, T011) Group-invite fold gate: `n` is the count of DISTINCT
+  // newcomers — the invite's members minus anyone already in/ringing in our call
+  // — so a shared member is counted once across the two rosters (FR-007).
+  describe('group-invite fold — distinct union of two rosters (spec 1030 US3)', () => {
+    // Current audio call: self + a. Incoming invite room: c + b + a (a is shared).
+    const roster = [SELF, 'a'];
+    const inviteMembers = ['c', 'b', 'a'];
+    const distinctNewcomers = inviteMembers.filter((id) => !new Set([SELF, ...roster]).has(id));
+
+    it('a member in both rosters is counted once', () => {
+      expect(distinctNewcomers).toEqual(['c', 'b']); // 'a' shared → not a newcomer
+      // Combined distinct = self, a, c, b = 4 ≤ audio cap → fits.
+      expect(canAdd('audio', roster, [], SELF, distinctNewcomers.length)).toEqual({ ok: true });
+    });
+
+    it('blocks the fold when the combined DISTINCT headcount exceeds the cap', () => {
+      // Video cap 4: self + a (2) folding 3 distinct newcomers → 5 → blocked with reason.
+      const r = canAdd('video', roster, [], SELF, 3);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/video calls.*4/i);
+    });
+
+    it('the fits vs does-not-fit boundary sits exactly at the cap', () => {
+      // Audio cap 8: self + 5 in room = 6. Two newcomers fit (8), three don't (9).
+      const six = [SELF, 'a', 'b', 'c', 'd', 'e'];
+      expect(canAdd('audio', six, [], SELF, 2).ok).toBe(true);
+      expect(canAdd('audio', six, [], SELF, 3).ok).toBe(false);
+    });
+  });
 });

--- a/src/services/call/invite-plan.test.ts
+++ b/src/services/call/invite-plan.test.ts
@@ -53,4 +53,30 @@ describe('planInvite', () => {
   it('an empty request is a no-op', () => {
     expect(planInvite('audio', [SELF, 'a'], [], SELF, [])).toEqual({ toRing: [], dropped: [] });
   });
+
+  // (spec 1030, T011) Group-invite fold: the request is the INVITE's member list.
+  // A member in both the invite and the current call must resolve to one
+  // participant (never re-rung), and the fold clamps like any other add.
+  describe('group-invite fold (spec 1030 US3)', () => {
+    it('a shared member is not re-rung — one participant, one leg', () => {
+      // Current call: self + a + b. Invite room: c (initiator) + b (shared) + self.
+      const r = planInvite('audio', [SELF, 'a', 'b'], [], SELF, ['c', 'b', SELF]);
+      expect(r.toRing).toEqual(['c']); // b and self already present — deduped
+      expect(r.dropped).toEqual([]);
+    });
+
+    it('a shared member who is still RINGING in our call is also deduped', () => {
+      const r = planInvite('audio', [SELF, 'a'], ['b'], SELF, ['b', 'c']);
+      expect(r.toRing).toEqual(['c']);
+      expect(r.dropped).toEqual([]);
+    });
+
+    it('clamps the fold to the remaining capacity of the combined call', () => {
+      // audio cap 8: self + 5 in room = 6, remaining 2; invite brings 3 fresh → 1 dropped.
+      const roster = [SELF, 'a', 'b', 'c', 'd', 'e'];
+      const r = planInvite('audio', roster, [], SELF, ['f', 'g', 'h']);
+      expect(r.toRing).toEqual(['f', 'g']);
+      expect(r.dropped).toEqual(['h']);
+    });
+  });
 });

--- a/src/services/call/join-cue.test.ts
+++ b/src/services/call/join-cue.test.ts
@@ -1,0 +1,43 @@
+// Unit tests for the pure join-cue diff (spec 1030, T001). The `call-roster`
+// handler feeds every server roster update through newJoiners to decide who gets
+// a "{name} joined the call" cue: only genuinely-new members — never self, never
+// someone already announced this call (a reconnect or roster re-broadcast doesn't
+// change membership, so an announced member can never re-fire — INV-4).
+import { describe, it, expect } from 'vitest';
+import { newJoiners } from './join-cue';
+
+const SELF = 'self';
+
+describe('newJoiners', () => {
+  it('announces a genuinely new member', () => {
+    expect(newJoiners(new Set([SELF, 'a']), [SELF, 'a', 'b'], SELF)).toEqual(['b']);
+  });
+
+  it('never announces self', () => {
+    expect(newJoiners(new Set(), [SELF], SELF)).toEqual([]);
+    expect(newJoiners(new Set(['a']), ['a', SELF], SELF)).toEqual([]);
+  });
+
+  it('dedups against the already-announced set (reconnect / re-broadcast)', () => {
+    // 'a' was announced earlier this call; an identical roster re-broadcast (or a
+    // leave+rejoin re-add) must not re-announce them.
+    expect(newJoiners(new Set([SELF, 'a']), [SELF, 'a'], SELF)).toEqual([]);
+  });
+
+  it('returns multiple genuinely-new members in roster order', () => {
+    expect(newJoiners(new Set([SELF]), [SELF, 'b', 'c'], SELF)).toEqual(['b', 'c']);
+  });
+
+  it('a coalesced join+leave still announces only the joiner', () => {
+    // 'a' left and 'd' joined in one update: 'a' is simply absent; only 'd' is new.
+    expect(newJoiners(new Set([SELF, 'a', 'b']), [SELF, 'b', 'd'], SELF)).toEqual(['d']);
+  });
+
+  it('empty roster → none', () => {
+    expect(newJoiners(new Set([SELF, 'a']), [], SELF)).toEqual([]);
+  });
+
+  it('ignores empty ids and duplicates within one update', () => {
+    expect(newJoiners(new Set([SELF]), ['', 'b', 'b'], SELF)).toEqual(['b']);
+  });
+});

--- a/src/services/call/join-cue.ts
+++ b/src/services/call/join-cue.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure join-cue diff (spec 1030, US2). Each server `call-roster` update is fed
+ * through this to decide who deserves a "{name} joined the call" cue: roster
+ * members that are not us and have not already been announced this call. The
+ * caller owns the `announced` set (per call, reset when a new call starts) and
+ * appends the result to it, so a member is announced at most once per call —
+ * a reconnect doesn't change room membership and a leave+rejoin re-add stays
+ * silent (INV-4). Dependency-free (no WebRTC) so it is exhaustively unit-tested.
+ */
+export function newJoiners(
+  announced: ReadonlySet<string>,
+  roster: string[],
+  selfId: string,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const id of roster) {
+    if (!id || id === selfId || announced.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}

--- a/src/services/call/merge-kind.test.ts
+++ b/src/services/call/merge-kind.test.ts
@@ -1,0 +1,25 @@
+// Unit tests for the pure kind-reconciliation rule (spec 1030, T005). After a
+// merge, a call whose combined distinct headcount still fits the video cap is
+// video-capable (the per-participant "Turn on video" control applies); past the
+// cap it stays audio-only for everyone. A call that is already video stays video.
+import { describe, it, expect } from 'vitest';
+import { videoCapableAfterMerge } from './merge-kind';
+import { VIDEO_MAX } from './types';
+
+describe('videoCapableAfterMerge', () => {
+  it('a video call stays video-capable', () => {
+    expect(videoCapableAfterMerge('video', 2)).toBe(true);
+    expect(videoCapableAfterMerge('video', VIDEO_MAX)).toBe(true);
+  });
+
+  it('an audio call at or under the video cap is video-capable', () => {
+    expect(videoCapableAfterMerge('audio', 2)).toBe(true);
+    expect(videoCapableAfterMerge('audio', 3)).toBe(true);
+    expect(videoCapableAfterMerge('audio', VIDEO_MAX)).toBe(true);
+  });
+
+  it('an audio call past the video cap stays audio-only', () => {
+    expect(videoCapableAfterMerge('audio', VIDEO_MAX + 1)).toBe(false);
+    expect(videoCapableAfterMerge('audio', 8)).toBe(false);
+  });
+});

--- a/src/services/call/merge-kind.ts
+++ b/src/services/call/merge-kind.ts
@@ -1,0 +1,15 @@
+/**
+ * Pure kind-reconciliation rule for a merge (spec 1030, US1). "Video-capable"
+ * means the per-participant "Turn on video" control is offered — the existing
+ * group-video model (toggleVideoMode's ≤ VIDEO_MAX gate): each person opts their
+ * OWN camera in; nothing is ever auto-enabled, and the 1:1 requestVideoUpgrade
+ * consent flow is never used for a group. This helper encodes the decision the
+ * live call machinery already enforces, so it can be exhaustively unit-tested
+ * (the e2e then pins the affordance to it). Dependency-light (caps only).
+ */
+import { VIDEO_MAX, type CallKind } from './types';
+
+export function videoCapableAfterMerge(activeKind: CallKind, combinedHeadcount: number): boolean {
+  if (activeKind === 'video') return true; // already a video call — stays one
+  return combinedHeadcount <= VIDEO_MAX; // audio: still fits video → cameras allowed
+}

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -201,6 +201,9 @@ import {
   incomingSecond,
   recordConnect,
   connectMarksSnapshot,
+  joinCuesShown,
+  mergeGroupInvite,
+  setGroupIdleMsForTest,
 } from '@/composables/useCall';
 
 /**
@@ -1285,11 +1288,18 @@ export function installTestHook(): void {
     addPeople: (ids: string[]) => addPeople(ids),
     /** Merge the pending second incoming DIRECT caller into the current call (spec 1028, US1). */
     mergeIncoming: () => mergeIncoming(),
+    /** Fold the pending second incoming GROUP INVITE into the current call (spec 1030, US3). */
+    mergeGroupInvite: () => mergeGroupInvite(),
+    /** The userIds announced as "{name} joined the call" this call (spec 1030, US2). */
+    joinCues: () => joinCuesShown(),
     /** Free participant slots left in the active call (for cap-gate asserts). */
     callRemainingSlots: () => callRemainingSlots(),
     /** Dev/e2e: shrink the CLIENT caps so the pre-emptive add gate can be tested
      *  without a real 8-person call (mirrors the server's call-config override). */
     setCallCaps: (video?: number, audio?: number) => setCallCapsForTest(video, audio),
+    /** Dev/e2e: shrink the lone-in-the-room timeout so the promotion-timeout path
+     *  (spec 1030, US5) runs in seconds instead of 60s. */
+    setGroupIdleMs: (ms: number) => setGroupIdleMsForTest(ms),
     /** The active call's roster (who's actually in the room) + invited (ringing). */
     callRoster: () => callMeta.value?.roster ?? [],
     callInvited: () => callMeta.value?.invited ?? [],
@@ -1366,6 +1376,8 @@ export function installTestHook(): void {
      *  of the receiver track's muted attribute (unreliable in headless Chromium). */
     inboundVideoFrames: () => inboundVideoFrames(),
     localTracks: () => localStream.value?.getTracks().length ?? 0,
+    /** Local VIDEO tracks only — asserts the no-auto-camera invariant (spec 1030, US1). */
+    localVideoTracks: () => localStream.value?.getVideoTracks().length ?? 0,
   };
   (window as unknown as { __ringTest: typeof api }).__ringTest = api;
 }

--- a/src/views/detail/CallActivePage.vue
+++ b/src/views/detail/CallActivePage.vue
@@ -75,13 +75,15 @@
           </div>
           <div class="cw-actions">
             <button class="cw-btn cw-decline" aria-label="Decline second call" @click.stop="rejectSecond">Decline</button>
-            <!-- Merge the caller into the current call (spec 1028) — direct callers only,
-                 and only when there's room under the cap. Sits alongside Hold. -->
+            <!-- Fold the caller into the current call — a direct second caller (spec 1028)
+                 or a whole incoming group invite (spec 1030) — when there's room under the
+                 cap. Sits alongside Hold; a group fold that doesn't fit is blocked with the
+                 cap reason on tap (the distinct combined headcount isn't known here). -->
             <button
-              v-if="incomingSecond.kind === 'direct' && callRemainingSlots() > 0"
+              v-if="callRemainingSlots() > 0"
               class="cw-btn cw-accept"
-              aria-label="Add caller to this call"
-              @click.stop="mergeIncoming"
+              :aria-label="incomingSecond.kind === 'direct' ? 'Add caller to this call' : 'Add this group call into your call'"
+              @click.stop="mergeSecond"
             >Add to call</button>
             <button class="cw-btn cw-accept" aria-label="Hold current call and answer" @click.stop="acceptAndHold">Accept &amp; hold</button>
           </div>
@@ -446,7 +448,7 @@ import {
   iosSpeaker, setIosSpeakerphone,
   notJoining, busyMembers, recallMember, cancelInvite, addPeople, callRemainingSlots,
   acceptCall, rejectCall, declineWithMessage,
-  heldCall, remoteHeld, groupHeldPeers, resumeCountdown, peerResumeCountdown, remoteQueued, incomingSecond, acceptAndHold, rejectSecond, mergeIncoming, swapCalls,
+  heldCall, remoteHeld, groupHeldPeers, resumeCountdown, peerResumeCountdown, remoteQueued, incomingSecond, acceptAndHold, rejectSecond, mergeIncoming, mergeGroupInvite, swapCalls,
   setGroupTileSize,
   type AudioRoute,
 } from '@/composables/useCall';
@@ -466,6 +468,12 @@ const stageEl = ref<HTMLElement | null>(null);
 
 // Full-screen incoming-call answer view (the consent line is shared with the banner).
 const { participantsLine } = useCallParticipants();
+
+/** "Add to call" on the second-incoming prompt: a direct caller merges (spec 1028),
+ *  a group invite folds its people into the current call (spec 1030 US3). */
+function mergeSecond(): void {
+  void (incomingSecond.value?.kind === 'direct' ? mergeIncoming() : mergeGroupInvite());
+}
 async function incomingDeclineMenu(): Promise<void> {
   const replies = await getQuickDeclines();
   const sheet = await actionSheetController.create({


### PR DESCRIPTION
Completes spec **1028**'s four deferred items as spec **1030** (`specs/1030-finish-call-kind/`) — all client-only, mesh-only, **zero server changes** (the `server/` diff against `develop` is empty).

## What's in it

**Join cue (US2)** — every genuinely-new participant is announced with a transient "{name} joined the call" banner ("Someone" for a non-contact). Never for your own arrival, never for a reconnect: a pure `newJoiners()` roster diff plus a per-call announced set, seeded from the first roster snapshot so the people you walk in on aren't mislabelled as joiners.

**Kind reconciliation (US1)** — after any merge, a call at or under the video cap (4) is video-capable through the existing per-participant "Turn on video" control; past the cap it refuses with the cap reason. No camera is ever auto-enabled — including the merged party's: a video 1:1 caller folded into an audio room now drops their live camera track at join and re-enables with one tap (found by the new `merge-video` drive scenario, fixed in `convertActiveToRoom`).

**Group-invite merge (US3)** — an incoming group invite while you're in a call now raises the second-incoming prompt (**Add to call** / Accept & hold / Decline) instead of the old silent auto-busy, whenever the single waiting slot is free (the busy fallback stays for a taken slot — spec 2009 — or a locked device). `mergeGroupInvite()` gates on the combined **distinct** headcount, promotes a 1:1 first, rings only not-yet-present members (a shared member dedups to one participant/one leg), leaves the invite's own room (never in two rooms at once), and an over-cap fold is blocked with the kind-specific reason leaving both calls untouched.

**Hold safety + add-in-flight guard (US4)** — growing the active call never touches the held slot, and `swapCalls`/`parkActiveAsHeld` now drain a module-level add-in-flight guard so a swap can never park a half-converted call (FR-010). `mergeIncoming` also gates on the cap *before* promoting, so a blocked merge leaves the 1:1 exactly as it was.

**Churn robustness (US5)** — e2e coverage for: a join racing a leave, two people adding the same person at once (one participant, one leg), an invitee reloading mid-ring (re-rung and joins cleanly), and a promotion whose peer never follows (clean end via the lone-in-the-room timeout — no stuck ringing, no orphans). The existing serialized roster/dedup/recovery machinery passed all of it without changes.

## Testing

- **Unit** (vitest, all green): `join-cue`, `merge-kind`, extended `capacity` + `invite-plan` (combined-headcount fold, shared-member dedup) — 80 call-module tests.
- **e2e** (Playwright, all green): new `call-join-cue`, `call-merge-kind` (×2), `call-merge-held` (incl. the FR-010 swap-vs-add race), `call-group-merge` (fits+dedup+leave-room / over-cap), `call-churn` (×4); plus the full existing call regression set (`calls`, `call-waiting`, `call-waiting-slot`, `call-caps`, `call-reinvite`, `call-promote`, `call-merge`, `call-add-merge`, `call-add-cap`, `call-cues`, `call-busy`). `call-busy`'s group case was updated to the new contract (unavailable once *declined*).
- **Drive (live stack)**: `merge-video.mjs` — merge a video caller into an audio call, all three opt cameras in per-participant, inbound video frames confirmed on every device; `call-add-churn.mjs` — 5-party churn (simultaneous add, join-vs-leave race, socket blip, cue dedup). Both pass.
- **Server**: `go build/vet/test` green; `git diff origin/develop -- server/` is **empty** (FR-013).
- Real-device validation of the video paths happens on the `develop` deployment after merge.

## Zero-knowledge

Nothing new crosses the wire: no new frame, field, or request. The cue is a local roster diff; video-capable reuses the per-participant renegotiation a camera toggle already does; the group fold reuses ring/roster/leave signalling sealed over each pair's session. Crypto core and `messaging.ts` untouched.

## Issues

Closes #686
Closes #687
Closes #688
Closes #689
Closes #690
Closes #654
Closes #657
Closes #659
Closes #660
Closes #661
Closes #662
Closes #663
Closes #664
Closes #665
Closes #666
Closes #668
Closes #669
Closes #670
Closes #671
Closes #672
Closes #650

(#650's substance — adding a 4th person mid-call on the live stack with no camera re-prompt — is covered by `call-add-churn.mjs` + `merge-video.mjs`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbEauS9eXGW7W3c4AATXcF
