### PR TITLE
docs(spec): spec 1031 shipped in #716; roadmap regenerated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ Specs are grouped by category band; status moves
 | [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🔵 in-review |
 | [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🔵 in-review |
 | [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🔵 in-review |
-| [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🔵 in-review |
+| [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1031-wall-notifications-only/spec.md
+++ b/specs/1031-wall-notifications-only/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-03
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Post-merge housekeeping for spec 1031 (PR #716): flip the spec's **Status** line to `shipped` and regenerate ROADMAP.md via `make roadmap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE