### PR TITLE
feat(notifications): messages are saved the moment a notification arrives, so the app opens instantly up to date

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1031-wall-notifications-only/plan.md`
+`specs/1032-store-messages-push/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ Specs are grouped by category band; status moves
 | [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🔵 in-review |
 | [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🔵 in-review |
 | [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
-| [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | ⚪ planned |
+| [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,6 +53,7 @@ Specs are grouped by category band; status moves
 | [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🔵 in-review |
 | [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🔵 in-review |
 | [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
+| [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ Specs are grouped by category band; status moves
 | [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🔵 in-review |
 | [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🔵 in-review |
 | [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
-| [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟡 in-progress |
+| [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/sw-persist.spec.ts
+++ b/e2e/sw-persist.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair, type RingClient } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 1032 — the SW AUTHORITATIVE drain (sw.fullPersist): messages received while
+ * "closed" (WS dropped) are decrypted, PERSISTED (row + unread + chat preview +
+ * ratchet advance, one atomic commit), and ACKED at notification time, so the app
+ * opens warm. Deferred/ineligible frames keep today's preview-only behavior and
+ * drain on reconnect. Driven through __ringTest.drainPending(), which runs the
+ * exact module the push handler runs.
+ */
+
+const enableFlag = (c: RingClient) =>
+  c.page.evaluate(() => (window as any).__ringTest.setSetting('sw.fullPersist', true));
+const drain = (c: RingClient) => c.page.evaluate(() => (window as any).__ringTest.drainPending());
+const previewFullOf = (c: RingClient) => c.page.evaluate(() => (window as any).__ringTest.previewPendingFull());
+const bodiesOf = (c: RingClient, chatId: string): Promise<string[]> =>
+  c.page.evaluate((id: string) => (window as any).__ringTest.messages(id).then((ms: any[]) => ms.map((m) => m.body)), chatId);
+const chatOf = (c: RingClient, peerId: string) =>
+  c.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
+const unreadOf = (c: RingClient) => c.page.evaluate(() => (window as any).__ringTest.unreadBadge());
+
+/** T018 — warm open: rows + unread + empty queue BEFORE reconnect; no duplicates after. */
+test('sw persist: queued messages are stored + acked at notification time; reconnect adds nothing', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SWPERS01');
+  const b = await createAccount(ctxB, 'SWPERS02');
+  await a.page.evaluate(([n, av]) => (window as any).__ringTest.setProfile(n, av), ['Alice', 'data:image/svg+xml,<svg/>']);
+  await pair(a, b);
+  await enableFlag(b);
+
+  // Warm the pair so B has the chat + session (the drain only applies to existing chats).
+  const aChat = (await chatOf(a, b.id)) as string;
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'warmup'), aChat);
+  await expect.poll(() => chatOf(b, a.id), { timeout: 30_000 }).toBeTruthy();
+  const bChat = (await chatOf(b, a.id)) as string;
+  await b.page.evaluate((id: string) => (window as any).__ringTest.markChatRead(id), bChat);
+
+  // B "closes" (drops the WS) → A's messages queue on the relay.
+  await b.page.evaluate(() => (window as any).__ringTest.disconnect());
+  await b.page.waitForTimeout(800);
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'warm one'), aChat);
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'warm two'), aChat);
+
+  // The drain applies both: committed rows + unread BEFORE any reconnect.
+  await expect
+    .poll(async () => ((await drain(b)) as any).applied, { timeout: 30_000 })
+    .toBeGreaterThanOrEqual(1);
+  await expect.poll(() => bodiesOf(b, bChat), { timeout: 10_000 }).toEqual(expect.arrayContaining(['warm one', 'warm two']));
+  expect(await unreadOf(b)).toBe(2);
+
+  // Acked: the relay queue is EMPTY while still offline (the preview finds no frames).
+  await expect.poll(async () => ((await previewFullOf(b)) as any).pending, { timeout: 10_000 }).toBe(0);
+
+  // Reconnect → the WS drain finds nothing new: exactly one copy of each, unread unchanged.
+  await b.page.evaluate(() => (window as any).__ringTest.reconnect());
+  await b.page.waitForTimeout(2500);
+  const bodies = await bodiesOf(b, bChat);
+  expect(bodies.filter((x) => x === 'warm one').length).toBe(1);
+  expect(bodies.filter((x) => x === 'warm two').length).toBe(1);
+  expect(await unreadOf(b)).toBe(2);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+/** T024b — drain racing the page's reconnect drain: exactly one row, one unread. */
+test('sw persist: drain vs reconnect race stays exactly-once', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SWPERS03');
+  const b = await createAccount(ctxB, 'SWPERS04');
+  await pair(a, b);
+  await enableFlag(b);
+
+  const aChat = (await chatOf(a, b.id)) as string;
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'warmup'), aChat);
+  await expect.poll(() => chatOf(b, a.id), { timeout: 30_000 }).toBeTruthy();
+  const bChat = (await chatOf(b, a.id)) as string;
+  await b.page.evaluate((id: string) => (window as any).__ringTest.markChatRead(id), bChat);
+
+  await b.page.evaluate(() => (window as any).__ringTest.disconnect());
+  await b.page.waitForTimeout(800);
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'race message'), aChat);
+  // Ensure the frame is queued before racing.
+  await expect.poll(async () => ((await previewFullOf(b)) as any).pending, { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
+
+  // Fire the authoritative drain AND the reconnect drain concurrently.
+  await b.page.evaluate(() => {
+    const t = (window as any).__ringTest;
+    return Promise.all([t.drainPending(), t.reconnect()]);
+  });
+  await b.page.waitForTimeout(2500);
+
+  const bodies = await bodiesOf(b, bChat);
+  expect(bodies.filter((x) => x === 'race message').length).toBe(1);
+  expect(await unreadOf(b)).toBe(1);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+/** T024a — deferral: a stranger's first-contact message is NOT applied/acked by the
+ *  drain; the page's reconnect applies it exactly once (friend-gate intact). */
+test('sw persist: first-contact frames defer to the page drain', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SWPERS05');
+  const b = await createAccount(ctxB, 'SWPERS06');
+  await enableFlag(b);
+
+  // A and B are NOT paired. B goes offline; A sends a friend request (a card frame —
+  // both first-contact AND an ineligible type).
+  await b.page.evaluate(() => (window as any).__ringTest.disconnect());
+  await b.page.waitForTimeout(800);
+  await a.page.evaluate((id: string) => (window as any).__ringTest.requestFriend(id), b.id);
+
+  // The drain defers it: nothing applied, nothing acked, frame still queued.
+  await expect
+    .poll(
+      async () => {
+        const r = (await drain(b)) as any;
+        return r.mode === 'applied' ? r.deferred : 0;
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThanOrEqual(1);
+  const r = (await drain(b)) as any;
+  expect(r.applied).toBe(0);
+  expect(r.ackIds ?? []).toEqual([]);
+
+  // Reconnect → the page applies the request for real, exactly once.
+  await b.page.evaluate(() => (window as any).__ringTest.reconnect());
+  await expect
+    .poll(() => b.page.evaluate(() => (window as any).__ringTest.pendingRequestIds()), { timeout: 30_000 })
+    .toContain(a.id);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+/** T021 — PIN-locked posture: the drain degrades ('locked'), stores nothing, the
+ *  frame stays queued; unlock + reconnect delivers it exactly once. */
+test('sw persist: PIN lock → nothing stored, frame stays queued, arrives after unlock', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SWPERS07');
+  const b = await createAccount(ctxB, 'SWPERS08');
+  await pair(a, b);
+  await enableFlag(b);
+
+  const aChat = (await chatOf(a, b.id)) as string;
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'warmup'), aChat);
+  await expect.poll(() => chatOf(b, a.id), { timeout: 30_000 }).toBeTruthy();
+  const bChat = (await chatOf(b, a.id)) as string;
+
+  // Enable the passcode lock (removes the device auto-unlock) and lock memory,
+  // simulating the closed, PIN-locked device the SW would wake as.
+  await b.page.evaluate(() => (window as any).__ringTest.enableLock('2468'));
+  await b.page.evaluate(() => (window as any).__ringTest.disconnect());
+  await b.page.evaluate(() => (window as any).__ringTest.lockNow());
+  await b.page.waitForTimeout(800);
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'locked away msg'), aChat);
+
+  // Drain degrades: locked, zero applied, zero acked...
+  await expect.poll(async () => ((await drain(b)) as any).reason, { timeout: 30_000 }).toBe('locked');
+  // ...nothing stored...
+  expect(await bodiesOf(b, bChat)).not.toContain('locked away msg');
+  // ...and the frame is still queued server-side (the preview still counts it).
+  expect(((await previewFullOf(b)) as any).pending).toBeGreaterThanOrEqual(1);
+
+  // Reload B (locked identities re-unlock via PIN), unlock, reconnect → delivered once.
+  await b.page.reload();
+  await b.page.waitForFunction(() => !!(window as any).__ringTest);
+  await b.page.evaluate((pin: string) => (window as any).__ringTest.disableLock(pin), '2468');
+  await b.page.evaluate(() => (window as any).__ringTest.reconnect());
+  await expect.poll(() => bodiesOf(b, bChat), { timeout: 30_000 }).toContain('locked away msg');
+  const bodies = await bodiesOf(b, bChat);
+  expect(bodies.filter((x) => x === 'locked away msg').length).toBe(1);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+/** T024c — flag OFF (the default): the drain refuses; behavior is byte-for-byte
+ *  today's (preview-only, nothing stored, nothing acked). */
+test('sw persist: flag off → drain degrades and the preview path owns the wake', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'SWPERS09');
+  const b = await createAccount(ctxB, 'SWPERS10');
+  await pair(a, b);
+  // NOTE: no enableFlag(b) — default off.
+
+  const aChat = (await chatOf(a, b.id)) as string;
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'warmup'), aChat);
+  await expect.poll(() => chatOf(b, a.id), { timeout: 30_000 }).toBeTruthy();
+  const bChat = (await chatOf(b, a.id)) as string;
+
+  await b.page.evaluate(() => (window as any).__ringTest.disconnect());
+  await b.page.waitForTimeout(800);
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'flag off msg'), aChat);
+  await expect.poll(async () => ((await previewFullOf(b)) as any).pending, { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
+
+  const r = (await drain(b)) as any;
+  expect(r.mode).toBe('degrade');
+  expect(r.reason).toBe('flag-off');
+  expect(await bodiesOf(b, bChat)).not.toContain('flag off msg');
+  // Frame untouched: still queued, still previewable (today's Choice A).
+  expect(((await previewFullOf(b)) as any).pending).toBeGreaterThanOrEqual(1);
+
+  await b.page.evaluate(() => (window as any).__ringTest.reconnect());
+  await expect.poll(() => bodiesOf(b, bChat), { timeout: 30_000 }).toContain('flag off msg');
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/e2e/sw-persist.spec.ts
+++ b/e2e/sw-persist.spec.ts
@@ -103,20 +103,33 @@ test('sw persist: drain vs reconnect race stays exactly-once', async ({ browser 
   await ctxB.close();
 });
 
-/** T024a — deferral: a stranger's first-contact message is NOT applied/acked by the
- *  drain; the page's reconnect applies it exactly once (friend-gate intact). */
-test('sw persist: first-contact frames defer to the page drain', async ({ browser }) => {
+/** T024a — deferral: an ineligible frame type (a reaction — a side-effect frame whose
+ *  handler lives page-side) is NOT applied/acked by the drain; the page's reconnect
+ *  applies it exactly once. (First-contact deferral is pinned at the unit level in
+ *  sw-drain.test.ts; friend requests ride the connections API, not relay frames.) */
+test('sw persist: ineligible frames (reaction) defer to the page drain', async ({ browser }) => {
   const ctxA = await browser.newContext();
   const ctxB = await browser.newContext();
   const a = await createAccount(ctxA, 'SWPERS05');
   const b = await createAccount(ctxB, 'SWPERS06');
+  await pair(a, b);
   await enableFlag(b);
 
-  // A and B are NOT paired. B goes offline; A sends a friend request (a card frame —
-  // both first-contact AND an ineligible type).
+  // B sends a message A can react to; both sides settle.
+  await expect.poll(() => chatOf(b, a.id), { timeout: 30_000 }).toBeTruthy();
+  const bChat = (await chatOf(b, a.id)) as string;
+  await b.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'react to me'), bChat);
+  const aChat = (await chatOf(a, b.id)) as string;
+  await expect.poll(() => bodiesOf(a, aChat), { timeout: 30_000 }).toContain('react to me');
+  const targetId = (await a.page.evaluate(async (id: string) => {
+    const ms = await (window as any).__ringTest.messages(id);
+    return ms.find((m: any) => m.body === 'react to me')?.id ?? '';
+  }, aChat)) as string;
+
+  // B goes offline; A reacts → a reaction frame queues on the relay.
   await b.page.evaluate(() => (window as any).__ringTest.disconnect());
   await b.page.waitForTimeout(800);
-  await a.page.evaluate((id: string) => (window as any).__ringTest.requestFriend(id), b.id);
+  await a.page.evaluate((id: string) => (window as any).__ringTest.reactToMessage(id, '👍'), targetId);
 
   // The drain defers it: nothing applied, nothing acked, frame still queued.
   await expect
@@ -131,12 +144,19 @@ test('sw persist: first-contact frames defer to the page drain', async ({ browse
   const r = (await drain(b)) as any;
   expect(r.applied).toBe(0);
   expect(r.ackIds ?? []).toEqual([]);
+  // The reaction is NOT on B's copy yet.
+  expect(
+    await b.page.evaluate((id: string) => (window as any).__ringTest.getReactions(id), targetId),
+  ).toEqual([]);
 
-  // Reconnect → the page applies the request for real, exactly once.
+  // Reconnect → the page applies the reaction for real, exactly once.
   await b.page.evaluate(() => (window as any).__ringTest.reconnect());
   await expect
-    .poll(() => b.page.evaluate(() => (window as any).__ringTest.pendingRequestIds()), { timeout: 30_000 })
-    .toContain(a.id);
+    .poll(
+      () => b.page.evaluate((id: string) => (window as any).__ringTest.getReactions(id), targetId),
+      { timeout: 30_000 },
+    )
+    .toEqual([{ emoji: '👍', count: 1 }]);
 
   await ctxA.close();
   await ctxB.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/node": "^25.9.1",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vitest/coverage-v8": "^3.2.6",
+        "fake-indexeddb": "^6.2.5",
         "sharp": "^0.34.5",
         "typescript": "^5.6.3",
         "vite": "^6.0.5",
@@ -4710,6 +4711,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/node": "^25.9.1",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vitest/coverage-v8": "^3.2.6",
+    "fake-indexeddb": "^6.2.5",
     "sharp": "^0.34.5",
     "typescript": "^5.6.3",
     "vite": "^6.0.5",

--- a/server/internal/store/relay.go
+++ b/server/internal/store/relay.go
@@ -48,12 +48,13 @@ func (s *Store) PendingForRecipient(ctx context.Context, recipient string) ([]Re
 }
 
 // SweepRelayOlderThan deletes queued frames older than age, returning the number
-// removed. The service worker's read-only preview never acks, so a recipient who
-// never opens the app would otherwise accumulate frames forever. Payloads are
-// E2EE and idempotent (unique on recipient,msg_id), so aging one out only risks a
-// stale notification - never message loss for a recipient who actually returns
-// (the page WS-drains everything still present). Keep age >= the push TTL so a
-// long-held tickle always still has a frame to fetch.
+// removed. The service worker's preview path never acks (and even the spec-1032
+// authoritative drain acks only what it durably committed, leaving deferred frame
+// types queued), so a recipient who never opens the app would otherwise accumulate
+// frames forever. Payloads are E2EE and idempotent (unique on recipient,msg_id), so
+// aging one out only risks a stale notification - never message loss for a
+// recipient who actually returns (the page WS-drains everything still present).
+// Keep age >= the push TTL so a long-held tickle always still has a frame to fetch.
 func (s *Store) SweepRelayOlderThan(ctx context.Context, age time.Duration) (int64, error) {
 	tag, err := s.pool.Exec(ctx,
 		`DELETE FROM relay_queue WHERE created_at < now() - make_interval(secs => $1)`,

--- a/specs/1032-store-messages-push/checklists/requirements.md
+++ b/specs/1032-store-messages-push/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Messages store on push so the app opens warm
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec deliberately names platform-neutral concepts ("background worker",
+  "secure-channel state", "exactly-once ledger") instead of Web Locks / IndexedDB /
+  Double Ratchet specifics; the agreed mechanisms live in the approved implementation
+  plan and will be carried into plan.md by /speckit-plan.
+- Terms like "service worker" and "push" appear because they are the product's user-visible
+  delivery mechanics (the user description is phrased in them), not implementation choices
+  this spec is making.
+- No [NEEDS CLARIFICATION] markers: scope (eligibility v1), privacy posture behavior, and
+  fallback semantics were all decided with the user during the pre-spec design review; the
+  decisions are recorded in Context, FR-004/006/008, and Assumptions.

--- a/specs/1032-store-messages-push/checklists/zero-knowledge.md
+++ b/specs/1032-store-messages-push/checklists/zero-knowledge.md
@@ -1,0 +1,109 @@
+# Zero-Knowledge & Crypto-Discipline Checklist: Messages store on push (spec 1032)
+
+**Purpose**: Validate that the requirements for the SW authoritative receive path are
+complete, unambiguous, and consistent with constitution Principles I (Zero-Knowledge
+Boundary) and IV (Crypto Discipline) — before implementation. This checklist tests the
+requirements writing, not the implementation.
+**Created**: 2026-07-03
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [research.md](../research.md) · [contracts/sw-receive.md](../contracts/sw-receive.md)
+
+## Zero-Knowledge Boundary (Principle I)
+
+- [x] CHK001 - Does the spec contain the mandated Zero-Knowledge Impact section answering
+  all four questions (what crosses the wire, what is encrypted, what metadata is visible,
+  why)? [Completeness, Spec §Zero-Knowledge Impact]
+- [x] CHK002 - Is it explicitly stated that no new wire surface is introduced (same tickle,
+  same pending fetch, same ack endpoint) and that only ack *timing* changes? [Clarity,
+  Spec §FR-012, Contracts §Wire]
+- [x] CHK003 - Is the claim "earlier confirmation adds no new server signal" grounded in a
+  documented existing behavior (delivered receipts already emitted at fetch time)?
+  [Traceability, Spec §Zero-Knowledge Impact, Research §D5/D8]
+- [x] CHK004 - Are requirements explicit that decryption and storage happen only on the
+  recipient's device, in every mode (applied, deferred, degraded)? [Coverage, Spec §FR-001,
+  §FR-006, §FR-008]
+- [x] CHK005 - Is the notification-content requirement stated posture-by-posture (default,
+  generic previews, hidden conversations, PIN/passkey lock) with "identical to today" as
+  the measurable bar? [Measurability, Spec §FR-006, §SC-005]
+- [x] CHK006 - Does the spec avoid requiring any server-side change, and is that stated as
+  a testable requirement rather than an aspiration? [Clarity, Spec §FR-012]
+
+## Crypto Discipline (Principle IV)
+
+- [x] CHK007 - Do the requirements reuse the existing Double Ratchet/X3DH core without
+  inventing primitives, and is the *only* crypto-layer change (a staged open that defers
+  persistence to the caller) explicitly bounded? [Completeness, Contracts §messaging.ts,
+  Research §D2]
+- [x] CHK008 - Is the superseded invariant ("SW never persists DH steps") explicitly
+  identified with its original rationale, the reason it can now be retired (cross-context
+  locks), and the requirement to rewrite the code comments that encode it? [Traceability,
+  Research §D3, Plan §Design details]
+- [x] CHK009 - Is the purity boundary preserved in the requirements (crypto core pure;
+  messaging.ts crypto-only; one-directional dependency sw-drain→messaging mirroring
+  queries→messaging)? [Consistency, Plan §Constitution Check IV, Contracts §messaging.ts]
+- [x] CHK010 - Are first-contact X3DH establishment and prekey re-init explicitly OUT of
+  the SW path (deferred), so one-time-prekey/session-replacement semantics never run
+  headless? [Coverage, Spec §FR-004, Contracts §openPacketStaged]
+- [x] CHK011 - Do the requirements mandate adversarial crypto tests — forgery, replay,
+  out-of-order (>50 backlog via skipped keys), and send-chain integrity after an
+  SW-persisted DH step? [Completeness, Plan §Verification, Contracts §Invariants 2/5]
+- [x] CHK012 - Is a security review explicitly required for the crypto behavior change?
+  [Completeness, Plan §Constitution Check IV, §Complexity Tracking]
+- [x] CHK013 - Is the PIN/passkey posture requirement stated as an absolute (no decrypt,
+  no storage, generic notification, frame stays queued) rather than a best-effort?
+  [Clarity, Spec §FR-006, US2 scenarios]
+
+## Concurrency & Exactly-Once (the risk this design carries)
+
+- [x] CHK014 - Is the mutual-exclusion requirement stated as a hard invariant ("the two
+  contexts MUST never advance the secure channel concurrently") with the coordination
+  mechanism, lock names, ordering, and timeout behavior specified? [Clarity, Spec §FR-007,
+  Contracts §Lock contract]
+- [x] CHK015 - Is exactly-once application defined across BOTH delivery paths with the
+  arbiter named (shared seen-ledger) and the double-count hazard (unread+1) addressed by
+  requirement, not implementation hope? [Measurability, Spec §FR-003, §FR-005]
+- [x] CHK016 - Is atomicity scoped precisely (which writes commit together) and is the
+  ack-after-durable-commit ordering a standalone requirement? [Completeness, Spec §FR-002,
+  §FR-005, Data-model §State transitions]
+- [x] CHK017 - Are ALL interruption orderings enumerated with their required outcomes
+  (killed pre-commit, killed post-commit pre-ack, storage failure)? [Edge Case Coverage,
+  Spec §Edge Cases, Data-model §State transitions]
+- [x] CHK018 - Is the live-call hazard (call signalling rides the same pairwise ratchet)
+  addressed by an explicit requirement that message storage never disrupts signalling?
+  [Coverage, Spec §Edge Cases, Research §D3]
+
+## Degrade & Fallback Semantics
+
+- [x] CHK019 - Is "degrade to exactly today's behavior" enumerated per trigger (flag off,
+  locked, no Web Locks, lock timeout, decrypt failure, storage failure, interrupted run)
+  rather than as a blanket sentence? [Completeness, Spec §FR-008, Quickstart §Degrade
+  checklist]
+- [x] CHK020 - Is the deferral list (ineligible frame types) exhaustive and mutually
+  exclusive with the eligibility definition, so no frame type is unspecified? [Consistency,
+  Spec §FR-004, Research §D4]
+- [x] CHK021 - Is the page-wins policy (live client claiming the drain) kept as an explicit
+  precondition of the SW path? [Consistency, Spec US3 scenario 4, Plan §Gate]
+
+## Dependencies & Assumptions
+
+- [x] CHK022 - Is the single-device invariant documented as a *precondition* with evidence
+  (one push subscription per user, overwrite-on-register) and a stated obligation to
+  revisit the ack rule if multi-device ever ships? [Assumption, Spec §Assumptions,
+  Research §D8]
+- [x] CHK023 - Is the durability framing (acked ⇒ device-only copy, symmetric with today's
+  page behavior; un-acked ⇒ server retention) stated as an accepted trade-off rather than
+  left implicit? [Assumption, Spec §Assumptions, Research §D8]
+- [x] CHK024 - Is the SW/page version-skew constraint (serialized session format frozen for
+  this release) recorded with its trigger (`registerType: 'prompt'` keeps old SWs alive)?
+  [Dependency, Research §D9, Plan §Constitution Check]
+- [x] CHK025 - Is the >50-frame backlog bound documented with the required user-visible
+  outcome (no ordering anomaly; remainder drains on open) and a test obligation? [Edge
+  Case, Research §D9, Plan §Verification]
+
+## Notes
+
+- All 25 items pass against the current spec/plan/research/contracts set. Items were
+  validated by reading the artifacts, not the codebase — implementation conformance is
+  the job of the test suites ordered in tasks.md, not this checklist.
+- The riskiest requirement (CHK014/CHK008: retiring the no-DH-persist rule under locks)
+  is deliberately covered by three layers: hard invariant in the spec (FR-007), lock
+  contract in contracts/, and a mandated security review (CHK012).

--- a/specs/1032-store-messages-push/contracts/sw-receive.md
+++ b/specs/1032-store-messages-push/contracts/sw-receive.md
@@ -1,0 +1,102 @@
+# Contracts: SW authoritative receive (spec 1032)
+
+## Wire contracts (existing, unchanged — listed for traceability)
+
+### GET /v1/relay/pending  (bearer auth)
+
+Returns `{ frames: [{ id, from, ciphertext, ... }] }`, newest 50. Side effect (existing):
+emits delivered receipts for returned frames. This spec adds no parameters and changes no
+semantics.
+
+### POST /v1/relay/ack  (bearer auth)
+
+Body `{ ids: string[] }`. Deletes the frames from the queue; idempotent (unknown/already
+deleted ids are no-ops); emits durable delivered receipts. This spec only changes WHO calls
+it (the SW, after atomic commit) and WHEN (while the app is closed). No server change.
+
+## Cross-context lock contract (new, device-local)
+
+| Lock name | Scope | Held by | Rules |
+|-----------|-------|---------|-------|
+| `ring:inbound` | global | page `receiveIncoming` chain step; SW per-frame apply loop | Outermost only. Never acquired while holding a session lock. SW: 3s AbortSignal → degrade frame/wake to preview-only. Page: no timeout. |
+| `ring:session:<chatId>` | per chat | every ratchet load→advance→save in both contexts (seal, open, preview) | Acquired via `withSessionLock` only. Nothing inside acquires any other lock. Fallback when Web Locks absent: in-context KeyedMutex only (and the SW gate turns the feature off). |
+
+## Module contracts (new/changed client modules)
+
+### src/services/cross-lock.ts (new)
+
+```ts
+withInboundLock<T>(fn: () => Promise<T>, opts?: { timeoutMs?: number }): Promise<T>
+withSessionLock<T>(chatId: string, fn: () => Promise<T>, opts?): Promise<T>
+locksAvailable(): boolean
+```
+- Composes in-context KeyedMutex FIFO with `navigator.locks.request` (exclusive).
+- Timeout (SW callers) rejects with a typed `LockTimeoutError`; callers degrade.
+- Import-clean: no DOM, no Ionic, no page-only modules (SW-safe).
+
+### src/services/messaging.ts (changed)
+
+```ts
+// Existing (unchanged behavior, now internally under withSessionLock):
+sealForChat(chatId, payload): Promise<Envelope | null>
+openPacket(chatId, from, ciphertext): Promise<Payload>        // page path, persists
+previewPacket(sessionKey, ciphertext): Promise<Payload>       // fallback path, same-chain-only persist
+
+// New (SW authoritative path):
+openPacketStaged(chatId, from, ciphertext): Promise<{
+  payload: Payload
+  sessionToPersist: SerializedSession   // advanced state incl. DH steps — NOT yet persisted
+  metaWrites: SettingWrite[]            // e.g. send-preamble clear, session meta
+}>
+```
+- `openPacketStaged` performs the full authoritative open (DH steps included) but persists
+  NOTHING; the caller commits atomically. It must be called under
+  `withSessionLock(chatId, …)`.
+- First-contact X3DH / prekey re-init is NOT staged (classifier defers those frames).
+- messaging.ts stays crypto-only: no imports of chats/messages/queries.
+
+### src/db/idb.ts (changed)
+
+```ts
+transact(stores: StoreName[], fn: (tx: TxHandle) => void): Promise<void>
+```
+- One native IDB transaction across the named stores; `notify()` fires per touched store
+  after commit; abort → no writes, no notifications.
+- `notify()` additionally posts the store name on `BroadcastChannel('ring:idb')`;
+  a received message fires local listeners only (never re-broadcast).
+
+### src/services/sw-drain.ts (new)
+
+```ts
+drainAndPersist(): Promise<{
+  applied: AppliedFrame[]     // committed + to-notify
+  deferred: DeferredFrame[]   // preview-path frames (today's behavior)
+  ackIds: string[]            // sent to /v1/relay/ack after notifications
+  reason?: 'flag-off' | 'locked' | 'no-locks' | 'lock-timeout' | 'no-frames'
+}>
+classifyFrame(payload, ctx): 'eligible' | 'defer'   // pure, table-tested
+```
+- Import-clean (idb + messaging + cross-lock + notify-preview only).
+- Called from the sw.ts push handler behind the gate; on ANY throw the caller falls back
+  to `previewPending()`.
+
+### src/services/testhook.ts (dev-only, e2e)
+
+```ts
+window.__ringTest.drainPending(): Promise<DrainResult>   // triggers the SW drain path
+window.__ringTest.setSetting('sw.fullPersist', true)      // flag control (or existing setter)
+```
+
+## Behavioral invariants (testable)
+
+1. Ack ⇒ committed: no frame id is ever POSTed to `/v1/relay/ack` unless its atomic
+   transaction committed in this or a previous wake.
+2. Exactly-once: for any interleaving of SW drain and page WS drain over the same frames,
+   each message row exists once and each chat's `unread` counts it once.
+3. Degrade-to-today: flag off / locked / no Web Locks / lock timeout / any throw ⇒ the
+   observable behavior (notifications, storage, server queue) is identical to current
+   production.
+4. Privacy parity: notification content for every posture (default, generic, hidden,
+   locked) is identical to current production.
+5. Send-chain integrity: after the SW persists a DH-step advance, the page's next seal for
+   that chat produces ciphertext the peer decrypts (no competing-writer clobber).

--- a/specs/1032-store-messages-push/data-model.md
+++ b/specs/1032-store-messages-push/data-model.md
@@ -1,0 +1,83 @@
+# Data Model: Messages store on push so the app opens warm (spec 1032)
+
+No new object stores; no `DB_VERSION` bump; no server schema change. The feature reuses
+existing entities and adds two settings-store records plus one internal flag.
+
+## Entities
+
+### Queued frame (server, existing — unchanged)
+
+A sealed envelope in `relay_queue` (recipient, sender, msg_id, payload). Deleted only by
+an authenticated ack (`WS ack` or `POST /v1/relay/ack`); swept after 35 days. The SW's
+`/relay/pending` fetch returns the newest 50 and (already today) earns delivered receipts.
+
+### Message row (`messages` store, existing — written by a new writer)
+
+Same shape the page writes in `receiveIncomingInner`: keyed by the sender's `remoteId`
+(idempotent overwrite), with `pendingMedia: MediaRef` for media-by-reference (bytes are
+never downloaded in the SW; the page backfills). New: the SW may now be the first writer,
+inside the atomic transaction.
+
+### Chat summary (`chats` store, existing — read-modify-write)
+
+`unread` (+1 per applied frame), `unreadMentions` (per existing mention rules),
+`lastMessage`, `lastKind`, `lastMessageTime`. The RMW rides inside the atomic transaction,
+under `ring:inbound`, so it can never race the page or double-apply. No `isChatActive`
+check in the SW (a live page was already deferred to by the gate).
+
+### Ratchet session (`sessions` store, existing — new staged write path)
+
+`messaging.ts` gains a staged open: it returns the advanced `SerializedSession` (and any
+session-meta effects) instead of persisting internally, so the SW commits it atomically
+with the message row. Format is UNCHANGED — and must not change in the same release
+(SW/page version-skew guard, research.md D9).
+
+### Exactly-once ledger (`settings` store, existing `inboundSeenIds`)
+
+The arbiter between the two delivery paths. The SW marks a frame seen inside the atomic
+transaction; the page's `receiveIncoming` skips seen frames and re-acks. Existing cap and
+pruning behavior unchanged.
+
+## New settings-store records
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `sw.fullPersist` | boolean, default absent/off | Internal rollout flag, read per wake in the SW gate. Not in the Settings UI. Set via dev tooling (`window.__ringTest` / direct idb) during the soak. |
+| *(none else)* | | Deferred frames keep using the existing `swNotifiedIds` / `swShownSummary` records; applied frames need no ledger beyond `inboundSeenIds` because they are acked. |
+
+## State transitions (one frame's lifecycle, flag on)
+
+```
+                        ┌────────────────────────────────────────────────┐
+                        │ queued on server (≤35 days)                    │
+                        └───────────────┬────────────────────────────────┘
+              push wake, gate passes    │        gate fails (locked, no locks API,
+                        ┌───────────────┤        page claimed, flag off)
+                        ▼               │                    ▼
+              eligible? (classifier)    │         preview-only notification
+               ┌────────┴────────┐      │         (frame stays queued → page
+               ▼                 ▼      │          drains + acks on open)
+        staged decrypt       DEFER: preview-only
+        under session lock   notification, no ack
+               │
+               ▼
+        ATOMIC COMMIT: session + message + chat RMW + seen-ledger
+               │  (abort/kill before commit → frame still queued, clean redelivery)
+               ▼
+        notification shown from committed data
+               │
+               ▼
+        POST /v1/relay/ack  ──── kill before ack → redelivery hits ledger,
+               │                 re-ack only, no re-apply
+               ▼
+        deleted on server; app opens warm
+```
+
+## Validation rules
+
+- A frame is applied at most once across both paths (ledger inside the transaction).
+- `unread` increments exactly once per applied frame (same transaction).
+- An acked frame is always durably committed first (ack is the wake's last step).
+- A deferred or failed frame is byte-for-byte today's behavior (no ack, no writes beyond
+  the existing preview bookkeeping).
+- Locked posture: no decrypt, no writes, generic notification (gate).

--- a/specs/1032-store-messages-push/plan.md
+++ b/specs/1032-store-messages-push/plan.md
@@ -1,0 +1,215 @@
+# Implementation Plan: Messages store on push so the app opens warm
+
+**Branch**: `feat/1032-store-messages-push` | **Date**: 2026-07-03 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/1032-store-messages-push/spec.md`
+
+## Summary
+
+When a push wakes the service worker and no app window claims it, the SW — which today
+decrypts the queued E2EE frames read-only for a notification — will run an authoritative
+receive for eligible frames: decrypt under cross-context Web Locks, commit the message row,
+chat summary (unread/lastMessage/lastMessageTime), advanced ratchet session, and dedup-ledger
+mark in ONE atomic multi-store IndexedDB transaction, then ack via the existing idempotent
+`POST /v1/relay/ack`. Notifications keep the existing privacy rules; every failure path
+degrades to today's preview-only behavior; the page's WS drain still delivers everything the
+SW deferred. Behind an internal `sw.fullPersist` flag, default off. No server changes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (Vue 3 + Ionic PWA, Vite); service-worker context
+(`src/sw.ts` + import-clean service modules)
+
+**Primary Dependencies**: libsodium-wrappers-sumo (existing crypto core), Web Locks API
+(`navigator.locks`, feature-detected), BroadcastChannel, IndexedDB via `src/db/idb.ts`
+
+**Storage**: IndexedDB (single DB, existing stores: `sessions`, `messages`, `chats`,
+`settings`); no new object store, no `DB_VERSION` bump; server Postgres untouched
+
+**Testing**: vitest unit tests (crypto core is pure; SW modules tested with a fake
+`navigator.locks` + fake idb), Playwright e2e (`e2e/`, extending `sw-decrypt.spec.ts`)
+
+**Target Platform**: installable PWA — Chrome/Edge/Firefox desktop + Android, iOS Safari
+16.4+ home-screen PWA (web push floor)
+
+**Project Type**: web app (client-only change; Go server: zero changes)
+
+**Performance Goals**: notification wake handles a full pending batch (≤50 frames) within
+the SW `waitUntil` budget; lock acquisition time-boxed at ~3s; app-open first paint shows
+correct chats list with zero network round-trips for already-applied messages
+
+**Constraints**: zero-knowledge boundary untouched (same tickle/fetch/ack wire surface);
+exactly-once application across SW and page paths; every failure degrades to today's
+behavior; PIN/passkey-locked posture never decrypts or stores in the SW
+
+**Scale/Scope**: ~6 client files touched + 1 new module + tests; single-device-per-user
+product invariant (verified: `server/internal/store/push.go:17`)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary**: PASS — nothing new crosses the wire; same content-free
+  tickle, same `/v1/relay/pending` fetch, same idempotent `/v1/relay/ack`; only ack timing
+  changes. The server already learns "device received these frames" at fetch time
+  (delivered receipts). Spec carries the required Zero-Knowledge Impact section.
+- **II. Spec-Driven Development**: PASS — spec 1032 (ad-hoc band), pipeline followed in
+  order; this plan is stage 3.
+- **III. Test-Driven Development**: PASS — tasks.md will order failing unit tests (locks,
+  eligibility, atomicity, ratchet send-chain integrity, replay/out-of-order/skipped-key)
+  and e2e (warm-open, deferral, race, locked posture) before implementation.
+- **IV. Crypto Discipline**: PASS with review — no new primitives; the existing Double
+  Ratchet core is reused. `messaging.ts` gains a *staged* open variant (returns the
+  advanced session for the caller to persist) so the crypto core stays pure and
+  `messaging.ts` stays crypto-only (no chats/messages imports; dependency remains
+  one-directional: sw-drain.ts → messaging.ts, mirroring queries.ts → messaging.ts).
+  The change to the SW-persistence rule (supersedes `messaging.ts:294-300`) is a crypto
+  behavior change → security review + `/speckit-checklist` REQUIRED (zero-knowledge +
+  crypto checklist, like spec 1031's).
+- **V. Offline-First Data Integrity**: PASS — all writes via `idb.ts`; no store/schema
+  change; the change bus gains a cross-context bridge (additive); atomic multi-store
+  transaction helper added to `idb.ts` (uses native IDB transaction semantics).
+- **VI. Stateless Server & Migrations**: PASS — zero server changes.
+- **VII. Quality Gates**: PASS — build/vet/test/e2e gates unchanged and required; commit
+  subjects will be release-note copy.
+- **VIII. Traceable Delivery**: PASS — taskstoissues + `Closes #N` on the PR.
+- **IX–XI (Privacy, A11y/i18n, Ionic-first)**: PASS — no data collection change; no UI
+  change at all (internal flag, no settings screen).
+
+**Post-Phase-1 re-check**: no new violations introduced by the design artifacts. The one
+deliberate rule change (SW may persist DH steps *under lock, behind flag*) is documented in
+research.md D3 and called out for security review.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1032-store-messages-push/
+├── spec.md              # Feature specification (with Zero-Knowledge Impact)
+├── plan.md              # This file
+├── research.md          # Phase 0: decisions D1–D9
+├── data-model.md        # Phase 1: entities & state transitions
+├── quickstart.md        # Phase 1: how to run/verify locally
+├── contracts/
+│   └── sw-receive.md    # Phase 1: module + wire contracts
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 (/speckit-tasks — not created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── sw.ts                          # push handler: route to sw-drain when gated on;
+│                                  #   badge math (pending → deferred-only when applied)
+├── services/
+│   ├── sw-drain.ts                # NEW: gate, eligibility classifier, per-frame
+│   │                              #   critical section, atomic commit, ack, notifications
+│   ├── sw-inbox.ts                # preview path retained (fallback + deferred frames);
+│   │                              #   shared helpers exported for sw-drain
+│   ├── messaging.ts               # withSessionLock (KeyedMutex + Web Locks);
+│   │                              #   staged open API; rewrite 240-266/294-300 comments
+│   ├── cross-lock.ts              # NEW: named-lock helpers (ring:inbound,
+│   │                              #   ring:session:<chatId>), timeout + fallback
+│   └── testhook.ts                # expose drainPending() for e2e (dev-only)
+├── db/
+│   ├── idb.ts                     # transact([...stores], fn) helper;
+│   │                              #   BroadcastChannel('ring:idb') bridge on notify()
+│   └── queries.ts                 # receiveIncoming under ring:inbound; ledger check
+│                                  #   already idempotent (wasInboundSeen)
+└── composables/
+    └── useSync.ts                 # touch() on visibility resume (belt-and-braces)
+
+e2e/
+└── sw-persist.spec.ts             # NEW (or extend sw-decrypt.spec.ts): warm-open,
+                                   #   deferral, race, locked-posture scenarios
+```
+
+**Structure Decision**: single-project PWA layout (existing). One new service module
+(`sw-drain.ts`) mirroring the import-clean discipline of `sw-inbox.ts`, one small shared
+lock helper, surgical edits elsewhere. Server untouched.
+
+## Design details (how the pieces fit)
+
+### Gate (in src/sw.ts push handler, before today's preview call)
+
+1. `sw.fullPersist` setting on; 2. `navigator.locks` present; 3. `attemptDeviceUnlock()`
+succeeds (passwordless posture — PIN/passkey devices can't decrypt in the SW by design);
+4. no live client claimed the alert via the existing `pageWillNotify` handshake.
+Any gate failing → `previewPending()` exactly as today.
+
+### Per-frame critical section (sw-drain.ts)
+
+```
+fetch /v1/relay/pending                     (unchanged; earns 'delivered')
+for each msg frame, under 'ring:inbound' (3s AbortSignal):
+  1. wasInboundSeen(id)? → collect for re-ack, skip
+  2. classify (pure): existing connected contact AND resolvable chat
+     (1:1 or payload.groupId → existing group) AND plain message
+     (text | media-by-reference) → eligible; else DEFER (preview path, no ack)
+  3. staged authoritative decrypt under 'ring:session:<chatId>'
+     (full open incl. DH steps; returns advanced session, does NOT persist)
+  4. ONE idb transaction: sessions.put + messages.put(remoteId) +
+     chats RMW (unread+1, lastMessage, lastMessageTime, unreadMentions)
+     + settings markInboundSeen
+  5. collect id for ack
+show notifications from committed data (existing privacy rules via noteForPayload)
+POST /v1/relay/ack {ids}                    (LAST step of the wake)
+badge = unreadCount() (+ deferred-only pending count)
+```
+
+Media: persist the message row with the existing `pendingMedia` ref; never download bytes
+in the SW. The page backfills via `resumePendingMediaJobs()` on reconnect (already called
+at `useSync.ts:246`).
+
+### Lock discipline (cross-lock.ts + messaging.ts)
+
+- Only the outermost inbound layer takes `ring:inbound` (SW: sw-drain loop; page: the
+  `receiveIncoming` chain step at `queries.ts:4515`). Nothing inside a session lock
+  acquires another lock. Page acquisitions have no timeout; SW acquisitions abort at ~3s
+  and degrade that frame (or the wake) to preview-only.
+- `sessionMutex.run(chatId, fn)` in messaging.ts (seal at :117, open at :197, preview at
+  :277) becomes `withSessionLock(chatId, fn)` = in-context KeyedMutex FIFO + Web Locks
+  `ring:session:<chatId>` (fallback to bare KeyedMutex when Web Locks are absent). This
+  also serializes live call/`qos` seals against SW opens — strictly safer than today.
+
+### Exactly-once & page interplay
+
+- The `inboundSeenIds` ledger (`queries.ts:4499`) is the arbiter for both paths; the
+  ledger mark rides inside the SW's atomic transaction, and the page's `receiveIncoming`
+  already skips seen frames. The page's WS re-ack of an SW-acked frame is an idempotent
+  no-op server-side.
+- Notification dedup keeps its current shape: the gate defers to live pages
+  (`pageWillNotify`/`ring:handled`); SW-applied frames are acked so they can never
+  re-notify; `swNotifiedIds` keeps serving only deferred frames.
+
+### Reactivity
+
+`idb.ts notify()` additionally posts the store name on `BroadcastChannel('ring:idb')`;
+received names fire local listeners only (no echo). `useSync`'s visibility-resume handler
+adds `touch('chats'); touch('messages')` so an iOS-frozen page repaints on resume even if
+the channel message was dropped.
+
+## Verification approach (drives tasks.md test-first ordering)
+
+- **Unit (vitest)**: cross-lock ordering/timeout/fallback; eligibility classifier table
+  over every payload type; atomic apply (row + unread + ledger + session in one
+  transaction; abort → nothing); replay of an applied frame is a no-op; ratchet
+  send-chain integrity after an SW-persisted DH step (page seal still decrypts at peer);
+  out-of-order >50-backlog apply via skipped-key cache; forgery/replay/skipped-key suites
+  extended per Principle IV; idb bridge no-echo.
+- **E2E (Playwright)**: warm-open (rows + unread + empty server queue before reconnect;
+  no duplicates after reconnect); deferral (stranger first-contact drains on open);
+  SW-drain vs page-reconnect race (exactly one row); PIN-locked posture unchanged;
+  existing call + sw-decrypt suites green with flag off AND on.
+- **Manual**: real-device soak on the dev deployment (installed iOS PWA; client changes
+  need `npm run build` to show there); message during a live call while a push lands.
+
+## Complexity Tracking
+
+No constitution violations to justify. The one rule *change* (SW may persist DH-ratchet
+steps) is not a violation of a principle but a revision of an internal invariant, made
+safe by cross-context locking; it is flagged for security review in research.md D3 and
+via the required `/speckit-checklist`.

--- a/specs/1032-store-messages-push/quickstart.md
+++ b/specs/1032-store-messages-push/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Messages store on push so the app opens warm (spec 1032)
+
+## Run it locally
+
+```sh
+make start                 # Postgres + ringd (:8080) + Vite (:5173)
+```
+
+Create two dev accounts (invite codes `RINGDEV1`..`RINGDEV9`), pair them, then on the
+receiving account's browser console enable the flag:
+
+```js
+await window.__ringTest.setSetting('sw.fullPersist', true)
+```
+
+Simulate the closed-app path (the e2e/testhook drives the same code):
+
+```js
+await window.__ringTest.disconnect()        // drop the WS (app "closed")
+// ...send messages from the other account...
+await window.__ringTest.drainPending()      // the SW-drain path: decrypt → commit → ack
+```
+
+Verify warm state BEFORE reconnecting: the chat row shows the new preview + unread count,
+the messages exist in IndexedDB (DevTools → Application → IndexedDB → messages), and
+`GET /v1/relay/pending` returns no frames. Then `window.__ringTest.reconnect()` and confirm
+no duplicates and unchanged unread.
+
+## Fast automated checks
+
+```sh
+npx vitest run src/services/sw-drain.test.ts src/services/cross-lock.test.ts
+npx vitest run src/services/crypto/            # ratchet integrity suites
+npm run build                                  # typecheck gate
+npm run test:e2e -- sw-persist                 # warm-open / deferral / race / locked
+```
+
+## Real-device soak (the true target)
+
+Deploy to the dev deployment (`ring-dev.zuptalo.com`); remember client changes need
+`npm run build` to show on the installed PWA. On the phone: enable the flag, close the app
+fully, have the other account send messages, watch notifications arrive, then open the app
+on airplane mode — the conversation must be fully there. Repeat with PIN lock enabled
+(generic notifications, nothing stored while locked) and during a live call (signalling
+must not hiccup while a push lands).
+
+## Degrade checklist (each must behave exactly like today)
+
+- Flag off (default) — byte-for-byte current behavior.
+- PIN/passkey lock on — generic notification, no decrypt, no storage, frame stays queued.
+- Web Locks unsupported — feature silently off.
+- Lock timeout (page hung/frozen) — that wake previews only.
+- Kill the SW mid-drain (DevTools → stop worker) — no partial state; frames redeliver.

--- a/specs/1032-store-messages-push/research.md
+++ b/specs/1032-store-messages-push/research.md
@@ -1,0 +1,138 @@
+# Research: Messages store on push so the app opens warm (spec 1032)
+
+All decisions below were made during an explicit design review (two independent design
+passes plus an adversarial risk analysis) before this spec was cut; the approved design
+lives in the session plan and is consolidated here. No NEEDS CLARIFICATION items remain.
+
+## D1. Cross-context serialization primitive
+
+- **Decision**: Web Locks API (`navigator.locks`), feature-detected, with two named
+  exclusive locks: global `ring:inbound` (per-frame apply-and-ack critical section) and
+  per-chat `ring:session:<chatId>` (every ratchet load→advance→save in both contexts).
+- **Rationale**: Web Locks are origin-scoped, shared between window and service-worker
+  contexts, and — decisively — auto-released when the holding context dies, so a killed SW
+  can never deadlock the page. Available everywhere Ring's push works (Safari 15.4+ vs
+  push's 16.4+ floor; Chrome 69+; Firefox 96+). The SW time-boxes acquisition (~3s via
+  AbortSignal) and degrades to preview-only when it can't get the lock (frozen page,
+  contention); the page waits without a timeout.
+- **Alternatives considered**: leader election via a held-while-alive lock (rejected: a
+  frozen-but-alive iOS page would hold leadership while unable to run); an IndexedDB-based
+  mutex with lease expiry (rejected: hand-rolled, polling, worse than the platform
+  primitive); `clients.matchAll()` "page always wins" checks alone (kept as *policy* — the
+  existing `pageWillNotify` handshake still runs first — but rejected as a *safety*
+  mechanism because it is racy).
+
+## D2. Crash safety: one atomic multi-store IndexedDB transaction
+
+- **Decision**: commit the advanced ratchet session, the message row, the chat summary
+  read-modify-write (unread+1, lastMessage, lastMessageTime), and the `inboundSeenIds`
+  dedup-ledger mark in ONE IndexedDB transaction spanning `sessions`, `messages`, `chats`,
+  and `settings`. The server ack (`POST /v1/relay/ack`) is sent strictly after commit.
+- **Rationale**: all Ring stores live in one IndexedDB database (`src/db/idb.ts` STORES),
+  so a single transaction is possible and collapses every interruption ordering into
+  all-or-nothing: killed pre-commit → the frame redelivers cleanly (nothing advanced);
+  killed post-commit pre-ack → redelivery hits the ledger and re-acks without reapplying.
+  The non-idempotent `unread+1` rides inside the same transaction as the ledger mark, so it
+  can never double-apply.
+- **Consequence for the crypto layer**: the SW cannot let `openPacket` persist the session
+  internally (that would be a separate transaction). `messaging.ts` gains a *staged* open
+  variant that returns `{ payload, sessionToPersist, metaWrites }` without persisting;
+  the caller commits everything atomically. This keeps the crypto core pure (Principle IV)
+  and messaging.ts crypto-only; sw-drain owns the transaction the way queries.ts owns the
+  page-side writes today.
+- **Alternatives considered**: separate transactions with careful ordering (rejected: the
+  "session advanced but message row lost" ordering forces the heavyweight rekey recovery —
+  routine SW termination would make it common); write-ahead journal replayed on open
+  (rejected: more machinery than a single transaction, same guarantee).
+
+## D3. Superseding the "SW never persists DH steps" rule
+
+- **Decision**: with the flag on and under `ring:session:<chatId>`, the SW performs the
+  full authoritative open — including DH-ratchet steps — and persists the result (in the
+  atomic transaction of D2). The existing preview path (`previewPacket`, same-chain-only
+  persistence) remains as the fallback for flag-off, locked posture, deferred frames, and
+  lock-timeout degrade. The long rationale comments at `src/services/messaging.ts:240-266`
+  and `294-300` are rewritten to describe the new two-mode contract.
+- **Rationale**: the old rule existed because page and SW had no cross-context mutual
+  exclusion — "competing writer of send-state" was unsolvable then. The Web Locks
+  discipline removes the race the rule guarded against; keeping the rule would forbid the
+  feature. Live call/`qos` signalling (which rides the same pairwise ratchet) becomes
+  *safer*: the same lock now serializes page seals against SW opens, closing the race the
+  old comment merely tolerated.
+
+## D4. Eligibility scope v1
+
+- **Decision**: the SW applies plain messages (text, and media-by-reference stored as the
+  existing `pendingMedia` ref on the message row) in *existing* chats from *existing*
+  connected contacts, including group messages (groups ride pairwise ratchets with
+  `payload.groupId`). Everything else — first-contact X3DH establishment, contact/group
+  cards, reactions, edits, erases, poll votes, rekey/control frames — defers: preview-only
+  notification exactly as today, no ack, applied by the page drain on open.
+- **Rationale**: the page's full receive path (`receiveIncomingInner`) is welded to
+  page-only modules (Ionic notify, canvas media pipeline, contact/group side effects) and
+  cannot be imported by the SW; the eligible subset covers essentially all real traffic
+  (active conversations) while deferring exactly the frames whose side effects are complex
+  or risky. Deferred frames don't render message bubbles, so the app still *looks* fully
+  warm. Media bytes are never downloaded in the SW — the page backfills via the existing
+  `resumePendingMediaJobs()` on reconnect (`src/composables/useSync.ts:246`).
+- **Alternatives considered**: refactoring queries.ts into an SW-importable core (rejected
+  for v1: large, ongoing drift risk); full parity in the SW (rejected: side effects like
+  provisional-contact rollback and rekey-triggered resends must not run headless).
+
+## D5. Server ack channel
+
+- **Decision**: reuse the existing idempotent `POST /v1/relay/ack`
+  (`server/internal/api/relay_handlers.go`, routed at `router.go:276`). No server changes.
+- **Rationale**: the endpoint already exists for the page, is bearer-authenticated, deletes
+  queued frames, and emits the same delivered receipts as the WS ack. Zero-knowledge
+  surface unchanged — only ack timing moves.
+
+## D6. Cross-context reactivity
+
+- **Decision**: bridge the in-context idb change bus over `BroadcastChannel('ring:idb')`:
+  `notify()` additionally posts the store name; a received name fires *local* listeners
+  only (no re-broadcast, no echo loop). Belt-and-braces: `touch('chats')`/`touch('messages')`
+  on visibility resume in useSync, for iOS pages frozen while the channel message fired.
+- **Rationale**: `useLiveQuery` subscribes to a module-level listener map that never
+  crosses JS contexts, so a backgrounded-but-alive page would otherwise show a stale chat
+  list that contradicts the notification the user just tapped. The bridge also fixes
+  multi-tab staleness for free.
+- **Alternatives considered**: SW→client `postMessage` fan-out (rejected: duplicates the
+  bus semantics; BroadcastChannel is symmetrical and covers tab↔tab too); polling on
+  focus only (rejected: covers resume but not the live-in-background case).
+
+## D7. Rollout flag
+
+- **Decision**: internal device-local flag `sw.fullPersist` in the settings store, default
+  off, read per wake in the SW gate; NOT exposed in the Settings UI (clarified with the
+  product owner). Enabled via dev tooling on the dev deployment during the soak, then
+  flipped default-on in a later release and eventually removed.
+- **Rationale**: it's a delivery mechanism, not a user preference; a visible toggle would
+  add copy and support burden. The gate composes with the existing gates (device-unlock
+  posture, Web Locks presence, no live client claiming the drain), and every failure path
+  degrades to today's shipped behavior — which is the design's spine.
+
+## D8. Single-device invariant (safety precondition)
+
+- **Finding**: `SaveSubscription` (`server/internal/store/push.go:17-26`) stores the user's
+  ONE push subscription, overwriting any previous — a second-device login revokes the
+  first's push. Therefore no stale device can be push-woken to ack (and thereby consume)
+  frames meant for the active device. Recorded as a spec assumption: if multi-device ever
+  ships, this feature's ack rule must be revisited first.
+- **Durability framing**: the page already acks immediately after persisting, so app-open
+  messages are already device-IDB-only; the SW doing persist→ack is symmetric, not a new
+  durability class. Un-acked (deferred/failed) frames keep the server's 35-day retention
+  (`server/cmd/ringd/main.go:454`) and drain on open.
+
+## D9. Known bounded behaviors (accepted)
+
+- `/relay/pending` returns the newest 50 frames (`relay_handlers.go`): a larger backlog is
+  partially applied newest-first; the ratchet's skipped-key cache handles the out-of-order
+  apply and the page drains the remainder on open. Ordering in the UI is by timestamp — no
+  visible anomaly. Covered by an explicit test.
+- Applied-but-killed-before-notification: the message is safely stored and acked but the OS
+  notification for that wake may be lost. Mitigation: build and show notifications from the
+  committed data *before* sending the ack, so the ack is the last step of the wake.
+- SW/page version skew (`registerType: 'prompt'` keeps an old SW alive against a new page):
+  the serialized session format must not change in the same release as this feature; if it
+  ever changes, add a version field and make old readers defer.

--- a/specs/1032-store-messages-push/research.md
+++ b/specs/1032-store-messages-push/research.md
@@ -136,3 +136,11 @@ lives in the session plan and is consolidated here. No NEEDS CLARIFICATION items
 - SW/page version skew (`registerType: 'prompt'` keeps an old SW alive against a new page):
   the serialized session format must not change in the same release as this feature; if it
   ever changes, add a version field and make old readers defer.
+- Version-skew on the LOCK DISCIPLINE itself (security review F5): a pre-1032 page kept
+  alive across an update takes no Web Locks, so the SW drain could interleave with it.
+  Rollout rule: enable `sw.fullPersist` only after every open tab runs ≥ this release, and
+  ship the default-on flip at least one release after the lock plumbing.
+- The page's inbound/session lock waits are unbounded across contexts (security review F9):
+  a second live window queued behind a frozen sibling stalls until it unfreezes/dies.
+  Accepted — iOS PWAs are effectively single-window, locks auto-release on context death,
+  and a timeout-bypass would reintroduce the two-writers race.

--- a/specs/1032-store-messages-push/spec.md
+++ b/specs/1032-store-messages-push/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-03
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1032-store-messages-push/spec.md
+++ b/specs/1032-store-messages-push/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-03
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1032-store-messages-push/spec.md
+++ b/specs/1032-store-messages-push/spec.md
@@ -34,6 +34,16 @@ old device's push registration, so exactly one device is ever woken for a user's
 This is what makes it safe for that device to confirm receipt on the server's behalf while
 the app is closed.
 
+## Clarifications
+
+### Session 2026-07-03
+
+- Q: Should the rollout setting be user-visible in Settings, or an internal flag? → A:
+  Internal flag — a hidden device-local flag, not in the Settings UI. Enabled via dev
+  tooling on the development deployment during the soak, then flipped default-on in a later
+  release and eventually removed. Notification-time storage is a delivery mechanism, not a
+  user preference.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - The app opens warm (Priority: P1)
@@ -193,9 +203,10 @@ counts correct, server queue empty only for messages that are safely stored.
   totals MUST agree; messages already stored MUST NOT be counted twice in any badge.
 - **FR-010**: An app window that is alive (foreground or background) while the background
   path stores messages MUST reflect the new data in its views without requiring a reload.
-- **FR-011**: The feature MUST ship behind a device-local setting, default off, so it can be
-  proven on the development deployment before being enabled broadly; with the setting off,
-  behavior is byte-for-byte today's.
+- **FR-011**: The feature MUST ship behind an internal device-local flag (not exposed in
+  the Settings UI), default off, so it can be proven on the development deployment before
+  being enabled broadly; with the flag off, behavior is byte-for-byte today's. The flag is
+  a rollout vehicle, expected to become default-on and eventually be removed.
 - **FR-012**: The server MUST require no changes and MUST see no new information: the same
   sealed messages, the same fetch, the same receipt confirmations — only their timing
   changes. The zero-knowledge boundary is untouched.

--- a/specs/1032-store-messages-push/spec.md
+++ b/specs/1032-store-messages-push/spec.md
@@ -224,6 +224,21 @@ counts correct, server queue empty only for messages that are safely stored.
 - **Deferred frame**: a queued message the background path chose not to apply (ineligible or
   failed); it keeps today's notification behavior and is applied on app open.
 
+## Zero-Knowledge Impact *(constitution Principle I)*
+
+- **What crosses the wire**: nothing new. The same content-free push tickle, the same
+  fetch of the sealed pending queue, and the same receipt confirmation the open app
+  already sends. Only the *timing* of the confirmation changes (it can now happen while
+  the app is closed).
+- **What is encrypted**: everything, unchanged — messages remain sealed end-to-end;
+  decryption and storage happen only on the recipient's device.
+- **What metadata the server unavoidably sees**: identical to today — that a device
+  fetched its queue and which sealed frames it confirmed. The server already learns
+  "device received these frames" at fetch time (delivered receipts), so earlier
+  confirmation adds no new signal.
+- **Why**: this feature is purely a client-side change in when the device does its own
+  local bookkeeping; the server's knowledge, storage, and API surface are unchanged.
+
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes

--- a/specs/1032-store-messages-push/spec.md
+++ b/specs/1032-store-messages-push/spec.md
@@ -1,0 +1,254 @@
+# Feature Specification: Messages store on push so the app opens warm
+
+**Feature Branch**: `feat/1032-store-messages-push`
+
+**Created**: 2026-07-03
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "When a web push notification arrives while the Ring app is
+closed, the service worker should not just preview the queued messages read-only — it should
+pull them, decrypt them, store them directly into the device database, show the notification
+in detailed or generic mode per the existing privacy rules, and then acknowledge the frames
+to the server. When the user later opens the app, it opens fully warm — chats list, unread
+pills, and tab badges already correct at first paint. On open, the app still checks for and
+pulls anything that was missed during push notification events."
+
+## Context: what happens today
+
+When a message arrives while the app is closed, the push wakes the device's background
+worker, which fetches the waiting sealed messages and decrypts them just enough to show a
+notification — then throws the result away. Nothing is saved. The messages are saved only
+later, when the user opens the app and it reconnects. The visible symptom this spec removes:
+the app opens "cold" — the chats list, per-chat unread pills, and tab badges lag for a
+moment while the app re-fetches and re-decrypts everything the notification already handled,
+and the app-icon badge can briefly disagree with the badges inside the app.
+
+Ring is a single-device-per-user product: registering the app on a new device replaces the
+old device's push registration, so exactly one device is ever woken for a user's messages.
+This is what makes it safe for that device to confirm receipt on the server's behalf while
+the app is closed.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The app opens warm (Priority: P1)
+
+I got message notifications while my phone was in my pocket. When I open Ring, everything is
+simply there: the conversations are already in place with the new messages in them, the
+chats list shows the right previews and unread counts, and the badges inside the app match
+the badge I saw on the app icon. There is no visible catch-up or re-fetch.
+
+**Why this priority**: This is the reported gap — the work of receiving a message is done
+twice today (once for the notification, again on open), and the user sees the seam. Storing
+messages when the notification arrives is the whole point of the feature.
+
+**Independent Test**: With account B's app closed (and A connected), A sends B two messages.
+B's device shows notifications. Before the app reconnects to the server, verify on B's
+device that both messages are stored locally, the chat's unread count is 2, and the server
+no longer holds the two frames as pending. Open the app with networking delayed: the chat
+list and both messages render correctly from local data alone.
+
+**Acceptance Scenarios**:
+
+1. **Given** B's app is closed and B receives push notifications for two messages from A,
+   **When** B opens the app, **Then** the chats list already shows A's chat on top with the
+   correct preview and unread count of 2, before any server round-trip completes.
+2. **Given** messages were stored at notification time, **When** the app later connects and
+   the server re-checks for pending messages, **Then** no duplicates appear — each message
+   exists exactly once and unread counts are unchanged.
+3. **Given** a message carrying a photo arrives while the app is closed, **When** the user
+   opens the app, **Then** the message is already in the conversation and the photo loads
+   (its download may complete after open; the message itself is never missing).
+4. **Given** the app-icon badge showed N after a burst of notifications, **When** the user
+   opens the app, **Then** the total of the in-app badges equals N.
+
+---
+
+### User Story 2 - Privacy behavior is unchanged (Priority: P2)
+
+Notifications keep behaving exactly as I configured them. If my app is protected by a PIN or
+passkey, notifications stay generic ("New message") and nothing is stored while locked. If a
+conversation is hidden or set to generic previews, its notifications stay generic. Nothing
+about this feature sends any readable content to the server — it only changes when my own
+device does its local bookkeeping.
+
+**Why this priority**: This feature touches the message-receiving pipeline, which is the
+most privacy-sensitive path in the product. It must be provably behavior-preserving for
+every privacy posture before the convenience is worth anything.
+
+**Independent Test**: Enable the PIN lock on B; A sends a message. Verify B's notification
+is generic, nothing new is stored locally while locked, and the message is still waiting on
+the server; unlock and open — the message arrives through the normal open-the-app path.
+Repeat with a hidden conversation: generic notification, no readable preview anywhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** B has a PIN/passkey lock, **When** a message arrives while the app is closed,
+   **Then** the notification is generic, nothing is stored, the server still holds the
+   message, and opening + unlocking the app delivers it exactly as today.
+2. **Given** a conversation is configured for generic previews (e.g. hidden chats), **When**
+   a message in it arrives while the app is closed, **Then** the notification shows no
+   sender or content, matching today's behavior.
+3. **Given** any message handled by this feature, **When** it is stored and confirmed,
+   **Then** the server has seen only the same sealed data and receipt signals it sees today
+   — no readable content, no new metadata.
+
+---
+
+### User Story 3 - Nothing is lost, nothing is doubled (Priority: P3)
+
+Whatever happens — the background work is cut short mid-way, the message is an unusual kind
+the background path doesn't handle, my device has no support for the required coordination —
+the outcome is never worse than today: the message waits on the server and arrives when I
+open the app. And a message is never applied twice, even when the background path and the
+open-app path both see it.
+
+**Why this priority**: Guard rails. The feature's value is convenience; its risk is
+correctness of message delivery. Every failure path must degrade to today's shipped
+behavior, and the two delivery paths must agree on exactly-once application.
+
+**Independent Test**: Simulate each fallback: a message from a stranger (first contact), a
+reaction/edit/control frame, an interrupted background run, and the open-app path racing the
+background path. In every case the end state is: every message present exactly once, unread
+counts correct, server queue empty only for messages that are safely stored.
+
+**Acceptance Scenarios**:
+
+1. **Given** the background handling is interrupted before a message is safely stored,
+   **When** the user opens the app, **Then** the message is delivered through the normal
+   open-the-app path — never lost, never half-applied.
+2. **Given** a message was safely stored but its receipt confirmation to the server was
+   interrupted, **When** the message is presented again, **Then** the device recognizes it
+   as already applied, confirms it, and stores nothing twice.
+3. **Given** a message the background path does not handle (first message from a new
+   contact, reactions, edits, group/contact cards, control messages), **When** it arrives
+   while the app is closed, **Then** the user still gets the same notification as today and
+   the message is applied when the app opens.
+4. **Given** the app is already open and visible when a push arrives, **Then** the app
+   handles it exactly as today (in-app banner, immediate storage) and the background path
+   stays out of the way.
+
+---
+
+### Edge Cases
+
+- Background work cut short by the platform mid-run (workers get only seconds): any message
+  not yet safely stored simply waits on the server; any message stored but not yet confirmed
+  is recognized and confirmed later without duplication.
+- A large backlog (more than one fetch's worth of pending messages): the background path
+  stores what it fetched; the remainder arrives on open. No ordering anomalies visible to
+  the user.
+- The app is open-but-frozen in the background (e.g. iOS suspends it) while a push arrives:
+  the background path must not fight the frozen app for shared state; if it cannot proceed
+  promptly it falls back to notification-only for that wake.
+- The app is alive in the background while the background path stores messages: the app's
+  views must reflect the new data when it comes back to the foreground (no stale chat list
+  contradicting the notification the user just tapped).
+- Device/browser lacks the required cross-context coordination capability: the feature
+  silently stays off; behavior is exactly today's.
+- A message arrives while the user is mid-call (the call and the message share the same
+  secure channel per contact): storing the message must never disrupt the call's signalling.
+- Storage full / write failure: nothing partial is kept, no confirmation is sent, the
+  message waits on the server.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When a push arrives while no app window claims it, the device MUST fetch the
+  waiting messages and, for eligible ones (see FR-004), store them locally — the message
+  itself, the conversation's updated preview/recency, and its unread count — before the app
+  is next opened.
+- **FR-002**: The device MUST confirm receipt of a message to the server only after that
+  message is durably stored locally; messages never confirmed remain on the server and are
+  delivered on next app open.
+- **FR-003**: Message application MUST be exactly-once across both delivery paths
+  (notification-time and app-open): re-presentation of an already-applied message results in
+  re-confirmation only, with no duplicate row and no double unread count.
+- **FR-004**: Eligible for notification-time storage: ordinary messages (text, and media
+  references whose bytes may download later) in existing conversations from existing
+  contacts, including group messages. Everything else (first contact, contact/group cards,
+  reactions, edits, deletions, poll votes, control messages) MUST fall back to today's
+  notification-only handling and be applied on app open.
+- **FR-005**: All local bookkeeping (message store, conversation summaries, unread counts,
+  the secure-channel state advance, and the exactly-once ledger) for one message MUST be
+  committed atomically — an interruption leaves either the complete result or nothing.
+- **FR-006**: The notification shown MUST follow the existing privacy rules unchanged:
+  detailed or generic per app-level and per-conversation settings; on a PIN/passkey-locked
+  device the background path MUST NOT decrypt or store anything and MUST show today's
+  generic notification.
+- **FR-007**: The two contexts that can update the secure channel with a contact (the open
+  app and the background worker) MUST never do so concurrently; coordination MUST be
+  device-local, and if the background path cannot acquire its turn promptly it MUST fall
+  back to notification-only handling for that wake.
+- **FR-008**: Every failure or unsupported-capability path (no coordination primitive, lock
+  timeout, decrypt failure, storage failure, interrupted run) MUST degrade to exactly
+  today's shipped behavior for the affected messages.
+- **FR-009**: After notification-time storage, the app-icon badge and the in-app badge
+  totals MUST agree; messages already stored MUST NOT be counted twice in any badge.
+- **FR-010**: An app window that is alive (foreground or background) while the background
+  path stores messages MUST reflect the new data in its views without requiring a reload.
+- **FR-011**: The feature MUST ship behind a device-local setting, default off, so it can be
+  proven on the development deployment before being enabled broadly; with the setting off,
+  behavior is byte-for-byte today's.
+- **FR-012**: The server MUST require no changes and MUST see no new information: the same
+  sealed messages, the same fetch, the same receipt confirmations — only their timing
+  changes. The zero-knowledge boundary is untouched.
+
+### Key Entities
+
+- **Queued message (frame)**: a sealed envelope waiting on the server for this user; deleted
+  from the server only when the device confirms durable receipt.
+- **Conversation summary**: the chat's preview line, recency ordering, and unread count —
+  what the chats list renders at first paint.
+- **Exactly-once ledger**: the device's record of which frames have been applied, shared by
+  both delivery paths; the arbiter that prevents duplication.
+- **Secure-channel state**: the per-contact cryptographic state that advances as messages
+  are received; exactly one context may advance it at a time.
+- **Deferred frame**: a queued message the background path chose not to apply (ineligible or
+  failed); it keeps today's notification behavior and is applied on app open.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After receiving messages while the app is closed, opening the app shows the
+  correct chats list (ordering, previews, unread counts) at first paint with zero network
+  round-trips required for those messages.
+- **SC-002**: 100% of messages handled at notification time appear exactly once after the
+  app opens and reconnects — zero duplicates, zero double-counted unread, across all tested
+  interruption points.
+- **SC-003**: Zero message loss in every fallback and failure scenario: any message not
+  durably stored remains deliverable on app open (interrupted runs, storage failures,
+  locked devices, ineligible types).
+- **SC-004**: The app-icon badge and the sum of in-app badges agree immediately on open in
+  100% of tested notification scenarios.
+- **SC-005**: For every privacy posture (default, generic previews, hidden conversations,
+  PIN/passkey lock), notification content is identical to today's behavior.
+- **SC-006**: With the feature setting off, all existing message, notification, and call
+  test suites pass unchanged.
+
+## Assumptions
+
+- Single device per user is a product invariant: registering push on a new device replaces
+  the previous device's registration, so no second device can be push-woken to confirm (and
+  thereby consume) this user's queued messages. If multi-device ever ships, this feature's
+  confirmation rule must be revisited first.
+- Confirming receipt at notification time gives the stored copy the same durability class as
+  messages received with the app open today (device-local storage); the server's queue
+  (with its multi-week retention) continues to back only unconfirmed messages. This is
+  accepted as symmetric with existing behavior, not a regression.
+- The existing receipt-confirmation channel is idempotent and usable outside an open app
+  session; no server work is planned.
+- The device platforms that support Ring's push notifications also support the required
+  device-local cross-context coordination; where they don't, the feature silently stays off.
+- The approved design (locking discipline, atomic commit, eligibility list, fallback
+  ladder) recorded in the implementation plan accompanying this spec is the agreed technical
+  approach; this spec intentionally describes outcomes, not mechanisms.
+- v1 eligibility deliberately excludes first-contact messages and non-message frames; the
+  open-app path remains their delivery vehicle. Widening eligibility is future work.

--- a/specs/1032-store-messages-push/tasks.md
+++ b/specs/1032-store-messages-push/tasks.md
@@ -28,41 +28,41 @@ PR into `develop` must list `Closes #718` … `Closes #748`.
 **Purpose**: the lock discipline, atomic transaction, and reactivity bridge every story
 depends on. Ships safely even with the flag off.
 
-- [ ] T003 [P] Write failing unit tests for the named-lock helpers in
+- [x] T003 [P] Write failing unit tests for the named-lock helpers in
       `src/services/cross-lock.test.ts`: exclusive ordering across two simulated contexts
       (fake `navigator.locks`), `ring:inbound` vs `ring:session:<chatId>` never inverted,
       SW-side timeout raises typed `LockTimeoutError`, missing-API fallback runs the
       in-context path
-- [ ] T004 Implement `src/services/cross-lock.ts`: `withInboundLock`, `withSessionLock`
+- [x] T004 Implement `src/services/cross-lock.ts`: `withInboundLock`, `withSessionLock`
       (KeyedMutex FIFO composed with `navigator.locks.request`, AbortSignal timeout),
       `locksAvailable()`; import-clean (no DOM/Ionic) per contracts/sw-receive.md
-- [ ] T005 [P] Write failing unit tests for the atomic multi-store transaction helper in
+- [x] T005 [P] Write failing unit tests for the atomic multi-store transaction helper in
       `src/db/idb.transact.test.ts`: all-or-nothing commit across
       `sessions`+`messages`+`chats`+`settings`, abort → zero writes and zero
       notifications, notify fires once per touched store after commit
-- [ ] T006 Implement `transact(stores, fn)` in `src/db/idb.ts` (one native IDB transaction;
+- [x] T006 Implement `transact(stores, fn)` in `src/db/idb.ts` (one native IDB transaction;
       notifications deferred to commit)
-- [ ] T007 [P] Write failing unit tests for the BroadcastChannel bridge in
+- [x] T007 [P] Write failing unit tests for the BroadcastChannel bridge in
       `src/db/idb.bridge.test.ts`: `notify()` posts the store name on
       `BroadcastChannel('ring:idb')`, a received name fires local listeners only, no echo
       loop, graceful no-op where BroadcastChannel is absent
-- [ ] T008 Implement the `ring:idb` BroadcastChannel bridge in `src/db/idb.ts`
-- [ ] T009 [P] Write failing ratchet tests in the crypto suite
+- [x] T008 Implement the `ring:idb` BroadcastChannel bridge in `src/db/idb.ts`
+- [x] T009 [P] Write failing ratchet tests in the crypto suite
       (`src/services/crypto/ratchet.staged.test.ts`): staged authoritative open returns
       advanced state (incl. DH step) without persisting; after the caller persists it, a
       subsequent seal on the reloaded state produces ciphertext the peer decrypts
       (send-chain integrity); replay of the same packet fails; forged ciphertext fails;
       out-of-order >50-frame backlog decrypts via the skipped-key cache
-- [ ] T010 Implement `openPacketStaged(chatId, from, ciphertext)` in
+- [x] T010 Implement `openPacketStaged(chatId, from, ciphertext)` in
       `src/services/messaging.ts` per contracts/sw-receive.md (full open incl. DH steps,
       persists nothing, returns `{payload, sessionToPersist, metaWrites}`; first-contact
       X3DH/prekey re-init NOT staged — throws a typed `DeferFrame` signal)
-- [ ] T011 Replace `sessionMutex.run(chatId, …)` with `withSessionLock(chatId, …)` at the
+- [x] T011 Replace `sessionMutex.run(chatId, …)` with `withSessionLock(chatId, …)` at the
       three call sites in `src/services/messaging.ts` (seal ~:117, open ~:197, preview
       ~:277) and rewrite the two-mode rationale comments at ~:240-266 and ~:294-300
       (preview stays same-chain-only as the fallback; authoritative SW open under lock is
       the new normal)
-- [ ] T012 Wrap the page's inbound chain step in `withInboundLock` in `src/db/queries.ts`
+- [x] T012 Wrap the page's inbound chain step in `withInboundLock` in `src/db/queries.ts`
       (~:4515, `receiveIncoming`), falling back to the bare chain when locks are absent;
       confirm `wasInboundSeen` short-circuit stays first inside the lock
 

--- a/specs/1032-store-messages-push/tasks.md
+++ b/specs/1032-store-messages-push/tasks.md
@@ -102,7 +102,7 @@ empty server queue BEFORE reconnect; reconnect → no duplicates.
       handler in `src/composables/useSync.ts` (~:472) so a frozen page repaints on resume;
       confirm `resumePendingMediaJobs()` (~:246) covers SW-persisted `pendingMedia` rows
       on reconnect
-- [ ] T018 [US1] Write the warm-open e2e in `e2e/sw-persist.spec.ts`: offline B receives
+- [x] T018 [US1] Write the warm-open e2e in `e2e/sw-persist.spec.ts`: offline B receives
       2 messages → `drainPending()` → assert rows exist, unread=2, `/v1/relay/pending`
       empty, icon-badge count = in-app total; `reconnect()` → exactly one copy of each
       message, unread unchanged
@@ -125,7 +125,7 @@ stays queued; hidden chat stays generic.
       gate short-circuits before any fetch-decrypt when locked; notification construction
       delegates to the exact same privacy/suppression helpers `previewPending` uses (no
       forked copy)
-- [ ] T021 [US2] Extend `e2e/sw-persist.spec.ts`: enable PIN lock → send → generic
+- [x] T021 [US2] Extend `e2e/sw-persist.spec.ts`: enable PIN lock → send → generic
       notification, no local rows, frame still pending server-side; unlock + open → message
       arrives via page drain exactly once. Add a hidden-chat scenario asserting generic
       content
@@ -149,11 +149,11 @@ race all end with each message exactly once and correct unread.
       (typed reasons `flag-off | locked | no-locks | lock-timeout | no-frames` surfaced in
       the drain result for the test hook), ensuring deferred frames keep flowing through
       `swNotifiedIds`/`swShownSummary` exactly as today
-- [ ] T024 [US3] Extend `e2e/sw-persist.spec.ts`: (a) stranger's first-contact message →
+- [x] T024 [US3] Extend `e2e/sw-persist.spec.ts`: (a) stranger's first-contact message →
       drain defers → page reconnect applies it once (friend-gate behavior intact);
       (b) concurrent `drainPending()` + `reconnect()` → exactly one row, one unread;
       (c) flag OFF run of the whole suite asserting byte-for-byte today's behavior
-- [ ] T025 [US3] Run the existing regression suites with the flag on and off —
+- [x] T025 [US3] Run the existing regression suites with the flag on and off —
       `e2e/sw-decrypt.spec.ts` (preview assertions updated only if the flag-on path
       legitimately changes them) and the `e2e/call-*.spec.ts` suites (message push landing
       mid-call must not disturb signalling; lock contention path)
@@ -171,11 +171,14 @@ race all end with each message exactly once and correct unread.
 - [ ] T028 Walk `specs/1032-store-messages-push/quickstart.md` end-to-end on the dev stack
       (`make start`), including the degrade checklist and the DevTools kill-mid-drain
       probe; fix anything that drifted
+      *(hermetic e2e covers the disconnect→drain→verify→reconnect + flag-off + locked
+      rows; remaining: kill-mid-drain probe + the real-device soak on the dev
+      deployment — flag defaults OFF, so no exposure until then)*
 - [ ] T029 Security review (constitution Principle IV): adversarial pass over the lock
       discipline, `openPacketStaged`, and the atomic-commit/ack ordering against
       `specs/1032-store-messages-push/contracts/sw-receive.md` invariants 1–5; record the
       outcome in the PR description before requesting merge
-- [ ] T030 Full gates: `npm run build`, `npx vitest run` (coverage floors hold),
+- [x] T030 Full gates: `npm run build`, `npx vitest run` (coverage floors hold),
       `cd server && go build ./... && go vet ./... && go test ./...`,
       `npm run test:e2e` — all green with the flag defaulted off
 - [ ] T031 Flip spec `**Status**` to `in-review` in

--- a/specs/1032-store-messages-push/tasks.md
+++ b/specs/1032-store-messages-push/tasks.md
@@ -10,6 +10,9 @@ Principle IV adversarial suites (forgery, replay, out-of-order, skipped-key).
 **Organization**: Foundational lock/transaction plumbing first (it is a strict safety
 improvement even with the flag off), then user stories in priority order.
 
+**GitHub issues**: T001–T031 map 1:1 to issues #718–#748 (TNNN → #(717+NNN)). The feature
+PR into `develop` must list `Closes #718` … `Closes #748`.
+
 ## Phase 1: Setup
 
 - [ ] T001 Define the internal rollout flag: add the `sw.fullPersist` settings-store key

--- a/specs/1032-store-messages-push/tasks.md
+++ b/specs/1032-store-messages-push/tasks.md
@@ -80,8 +80,8 @@ empty server queue BEFORE reconnect; reconnect → no duplicates.
       vote, rekey/control → defer), unknown sender → defer, unresolvable chat → defer
 - [ ] T014 [P] [US1] Write failing unit tests for the apply path in
       `src/services/sw-drain.test.ts`: applied frame = message row + chat RMW
-      (unread+1/lastMessage/lastMessageTime) + ledger mark + session in ONE transaction and
-      its id queued for ack; replay of an applied frame = re-ack only (unread stays 1);
+      (unread+1/lastMessage/lastMessageTime) + ledger mark + session + staged `metaWrites`
+      (e.g. send-preamble clear) in ONE transaction and its id queued for ack; replay of an applied frame = re-ack only (unread stays 1);
       transaction abort → no ledger mark, no ack; ack POSTed only after commit;
       media-by-reference persists `pendingMedia` without any fetch
 - [ ] T015 [US1] Implement `src/services/sw-drain.ts` per contracts/sw-receive.md: gate
@@ -168,10 +168,14 @@ race all end with each message exactly once and correct unread.
 - [ ] T028 Walk `specs/1032-store-messages-push/quickstart.md` end-to-end on the dev stack
       (`make start`), including the degrade checklist and the DevTools kill-mid-drain
       probe; fix anything that drifted
-- [ ] T029 Full gates: `npm run build`, `npx vitest run` (coverage floors hold),
+- [ ] T029 Security review (constitution Principle IV): adversarial pass over the lock
+      discipline, `openPacketStaged`, and the atomic-commit/ack ordering against
+      `specs/1032-store-messages-push/contracts/sw-receive.md` invariants 1–5; record the
+      outcome in the PR description before requesting merge
+- [ ] T030 Full gates: `npm run build`, `npx vitest run` (coverage floors hold),
       `cd server && go build ./... && go vet ./... && go test ./...`,
       `npm run test:e2e` — all green with the flag defaulted off
-- [ ] T030 Flip spec `**Status**` to `in-review` in
+- [ ] T031 Flip spec `**Status**` to `in-review` in
       `specs/1032-store-messages-push/spec.md` and run `make roadmap`
 
 ## Dependencies & Execution Order

--- a/specs/1032-store-messages-push/tasks.md
+++ b/specs/1032-store-messages-push/tasks.md
@@ -15,11 +15,11 @@ PR into `develop` must list `Closes #718` … `Closes #748`.
 
 ## Phase 1: Setup
 
-- [ ] T001 Define the internal rollout flag: add the `sw.fullPersist` settings-store key
+- [x] T001 Define the internal rollout flag: add the `sw.fullPersist` settings-store key
       (typed constant + default-absent read helper) where SW-safe settings constants live,
       alongside its read in `src/services/sw-inbox.ts` style — no Settings UI entry
       (`src/services/sw-inbox.ts` / shared constants module)
-- [ ] T002 Extend the dev-only test hook with `drainPending()` and a settings setter for
+- [x] T002 Extend the dev-only test hook with `drainPending()` and a settings setter for
       the flag in `src/services/testhook.ts` (stripped from production builds; mirrors the
       existing `previewPending`/`disconnect`/`reconnect` hooks)
 
@@ -77,28 +77,28 @@ with correct chats list/unread/badges from local data alone.
 **Independent test**: B offline, A sends 2 messages, `drainPending()` → rows + unread=2 +
 empty server queue BEFORE reconnect; reconnect → no duplicates.
 
-- [ ] T013 [P] [US1] Write failing unit tests for the eligibility classifier in
+- [x] T013 [P] [US1] Write failing unit tests for the eligibility classifier in
       `src/services/sw-drain.test.ts`: table over every payload type (plain text, media
       ref, group message → eligible; first-contact, cards, reaction, edit, erase, poll
       vote, rekey/control → defer), unknown sender → defer, unresolvable chat → defer
-- [ ] T014 [P] [US1] Write failing unit tests for the apply path in
+- [x] T014 [P] [US1] Write failing unit tests for the apply path in
       `src/services/sw-drain.test.ts`: applied frame = message row + chat RMW
       (unread+1/lastMessage/lastMessageTime) + ledger mark + session + staged `metaWrites`
       (e.g. send-preamble clear) in ONE transaction and its id queued for ack; replay of an applied frame = re-ack only (unread stays 1);
       transaction abort → no ledger mark, no ack; ack POSTed only after commit;
       media-by-reference persists `pendingMedia` without any fetch
-- [ ] T015 [US1] Implement `src/services/sw-drain.ts` per contracts/sw-receive.md: gate
+- [x] T015 [US1] Implement `src/services/sw-drain.ts` per contracts/sw-receive.md: gate
       composition, `/v1/relay/pending` fetch (reuse sw-inbox helpers), per-frame
       `withInboundLock` loop (ledger check → classify → `openPacketStaged` under
       `withSessionLock` → `transact` commit → collect ack id), notifications built from
       committed data via the existing `noteForPayload` path, single
       `POST /v1/relay/ack {ids}` as the wake's last step
-- [ ] T016 [US1] Route the push handler in `src/sw.ts`: behind the gate (flag on + locks
+- [x] T016 [US1] Route the push handler in `src/sw.ts`: behind the gate (flag on + locks
       present + device-unlock + no client claimed via existing `pageWillNotify`), call
       sw-drain; on ANY throw or degrade reason fall back to `previewPending()`; adjust
       badge math so applied frames aren't double-counted (`unreadCount()` already includes
       them; add deferred-only pending count)
-- [ ] T017 [P] [US1] Add `touch('chats'); touch('messages')` to the visibility-resume
+- [x] T017 [P] [US1] Add `touch('chats'); touch('messages')` to the visibility-resume
       handler in `src/composables/useSync.ts` (~:472) so a frozen page repaints on resume;
       confirm `resumePendingMediaJobs()` (~:246) covers SW-persisted `pendingMedia` rows
       on reconnect
@@ -117,11 +117,11 @@ devices never decrypt or store in the SW.
 **Independent test**: PIN-locked B gets a generic notification, nothing stored, frame
 stays queued; hidden chat stays generic.
 
-- [ ] T019 [P] [US2] Write failing unit tests in `src/services/sw-drain.test.ts`: locked
+- [x] T019 [P] [US2] Write failing unit tests in `src/services/sw-drain.test.ts`: locked
       posture (device-unlock fails) → gate returns `reason:'locked'`, zero writes, zero
       acks; hidden-chat / generic-preview rules produce the same notification payloads as
       the preview path (share the fixtures from `sw-inbox` tests)
-- [ ] T020 [US2] Implement the posture guards in `src/services/sw-drain.ts` + `src/sw.ts`:
+- [x] T020 [US2] Implement the posture guards in `src/services/sw-drain.ts` + `src/sw.ts`:
       gate short-circuits before any fetch-decrypt when locked; notification construction
       delegates to the exact same privacy/suppression helpers `previewPending` uses (no
       forked copy)
@@ -140,12 +140,12 @@ under interleaving.
 **Independent test**: interrupted drain, stranger first-contact, and drain-vs-reconnect
 race all end with each message exactly once and correct unread.
 
-- [ ] T022 [P] [US3] Write failing unit tests in `src/services/sw-drain.test.ts`:
+- [x] T022 [P] [US3] Write failing unit tests in `src/services/sw-drain.test.ts`:
       lock-timeout (`LockTimeoutError`) degrades the wake to preview-only (no ack, no
       writes); missing Web Locks → gate off; decrypt failure on one frame defers that
       frame and continues the loop; kill-between-commit-and-ack simulation → next wake
       re-acks via ledger without re-applying
-- [ ] T023 [US3] Implement the degrade ladder in `src/services/sw-drain.ts`/`src/sw.ts`
+- [x] T023 [US3] Implement the degrade ladder in `src/services/sw-drain.ts`/`src/sw.ts`
       (typed reasons `flag-off | locked | no-locks | lock-timeout | no-frames` surfaced in
       the drain result for the test hook), ensuring deferred frames keep flowing through
       `swNotifiedIds`/`swShownSummary` exactly as today

--- a/specs/1032-store-messages-push/tasks.md
+++ b/specs/1032-store-messages-push/tasks.md
@@ -1,0 +1,203 @@
+# Tasks: Messages store on push so the app opens warm
+
+**Input**: Design documents from `specs/1032-store-messages-push/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/sw-receive.md
+
+**Tests**: TDD is constitutionally mandated (Principle III). Every phase orders failing
+tests before the implementation that satisfies them. Crypto changes additionally carry the
+Principle IV adversarial suites (forgery, replay, out-of-order, skipped-key).
+
+**Organization**: Foundational lock/transaction plumbing first (it is a strict safety
+improvement even with the flag off), then user stories in priority order.
+
+## Phase 1: Setup
+
+- [ ] T001 Define the internal rollout flag: add the `sw.fullPersist` settings-store key
+      (typed constant + default-absent read helper) where SW-safe settings constants live,
+      alongside its read in `src/services/sw-inbox.ts` style — no Settings UI entry
+      (`src/services/sw-inbox.ts` / shared constants module)
+- [ ] T002 Extend the dev-only test hook with `drainPending()` and a settings setter for
+      the flag in `src/services/testhook.ts` (stripped from production builds; mirrors the
+      existing `previewPending`/`disconnect`/`reconnect` hooks)
+
+## Phase 2: Foundational (blocking — cross-context safety plumbing)
+
+**Purpose**: the lock discipline, atomic transaction, and reactivity bridge every story
+depends on. Ships safely even with the flag off.
+
+- [ ] T003 [P] Write failing unit tests for the named-lock helpers in
+      `src/services/cross-lock.test.ts`: exclusive ordering across two simulated contexts
+      (fake `navigator.locks`), `ring:inbound` vs `ring:session:<chatId>` never inverted,
+      SW-side timeout raises typed `LockTimeoutError`, missing-API fallback runs the
+      in-context path
+- [ ] T004 Implement `src/services/cross-lock.ts`: `withInboundLock`, `withSessionLock`
+      (KeyedMutex FIFO composed with `navigator.locks.request`, AbortSignal timeout),
+      `locksAvailable()`; import-clean (no DOM/Ionic) per contracts/sw-receive.md
+- [ ] T005 [P] Write failing unit tests for the atomic multi-store transaction helper in
+      `src/db/idb.transact.test.ts`: all-or-nothing commit across
+      `sessions`+`messages`+`chats`+`settings`, abort → zero writes and zero
+      notifications, notify fires once per touched store after commit
+- [ ] T006 Implement `transact(stores, fn)` in `src/db/idb.ts` (one native IDB transaction;
+      notifications deferred to commit)
+- [ ] T007 [P] Write failing unit tests for the BroadcastChannel bridge in
+      `src/db/idb.bridge.test.ts`: `notify()` posts the store name on
+      `BroadcastChannel('ring:idb')`, a received name fires local listeners only, no echo
+      loop, graceful no-op where BroadcastChannel is absent
+- [ ] T008 Implement the `ring:idb` BroadcastChannel bridge in `src/db/idb.ts`
+- [ ] T009 [P] Write failing ratchet tests in the crypto suite
+      (`src/services/crypto/ratchet.staged.test.ts`): staged authoritative open returns
+      advanced state (incl. DH step) without persisting; after the caller persists it, a
+      subsequent seal on the reloaded state produces ciphertext the peer decrypts
+      (send-chain integrity); replay of the same packet fails; forged ciphertext fails;
+      out-of-order >50-frame backlog decrypts via the skipped-key cache
+- [ ] T010 Implement `openPacketStaged(chatId, from, ciphertext)` in
+      `src/services/messaging.ts` per contracts/sw-receive.md (full open incl. DH steps,
+      persists nothing, returns `{payload, sessionToPersist, metaWrites}`; first-contact
+      X3DH/prekey re-init NOT staged — throws a typed `DeferFrame` signal)
+- [ ] T011 Replace `sessionMutex.run(chatId, …)` with `withSessionLock(chatId, …)` at the
+      three call sites in `src/services/messaging.ts` (seal ~:117, open ~:197, preview
+      ~:277) and rewrite the two-mode rationale comments at ~:240-266 and ~:294-300
+      (preview stays same-chain-only as the fallback; authoritative SW open under lock is
+      the new normal)
+- [ ] T012 Wrap the page's inbound chain step in `withInboundLock` in `src/db/queries.ts`
+      (~:4515, `receiveIncoming`), falling back to the bare chain when locks are absent;
+      confirm `wasInboundSeen` short-circuit stays first inside the lock
+
+**Checkpoint**: `npx vitest run` green; `npm run build` green; behavior unchanged with the
+flag off (existing e2e suites still pass).
+
+## Phase 3: User Story 1 — The app opens warm (P1) 🎯 MVP
+
+**Goal**: push wake → eligible frames decrypted, committed atomically, acked; app opens
+with correct chats list/unread/badges from local data alone.
+
+**Independent test**: B offline, A sends 2 messages, `drainPending()` → rows + unread=2 +
+empty server queue BEFORE reconnect; reconnect → no duplicates.
+
+- [ ] T013 [P] [US1] Write failing unit tests for the eligibility classifier in
+      `src/services/sw-drain.test.ts`: table over every payload type (plain text, media
+      ref, group message → eligible; first-contact, cards, reaction, edit, erase, poll
+      vote, rekey/control → defer), unknown sender → defer, unresolvable chat → defer
+- [ ] T014 [P] [US1] Write failing unit tests for the apply path in
+      `src/services/sw-drain.test.ts`: applied frame = message row + chat RMW
+      (unread+1/lastMessage/lastMessageTime) + ledger mark + session in ONE transaction and
+      its id queued for ack; replay of an applied frame = re-ack only (unread stays 1);
+      transaction abort → no ledger mark, no ack; ack POSTed only after commit;
+      media-by-reference persists `pendingMedia` without any fetch
+- [ ] T015 [US1] Implement `src/services/sw-drain.ts` per contracts/sw-receive.md: gate
+      composition, `/v1/relay/pending` fetch (reuse sw-inbox helpers), per-frame
+      `withInboundLock` loop (ledger check → classify → `openPacketStaged` under
+      `withSessionLock` → `transact` commit → collect ack id), notifications built from
+      committed data via the existing `noteForPayload` path, single
+      `POST /v1/relay/ack {ids}` as the wake's last step
+- [ ] T016 [US1] Route the push handler in `src/sw.ts`: behind the gate (flag on + locks
+      present + device-unlock + no client claimed via existing `pageWillNotify`), call
+      sw-drain; on ANY throw or degrade reason fall back to `previewPending()`; adjust
+      badge math so applied frames aren't double-counted (`unreadCount()` already includes
+      them; add deferred-only pending count)
+- [ ] T017 [P] [US1] Add `touch('chats'); touch('messages')` to the visibility-resume
+      handler in `src/composables/useSync.ts` (~:472) so a frozen page repaints on resume;
+      confirm `resumePendingMediaJobs()` (~:246) covers SW-persisted `pendingMedia` rows
+      on reconnect
+- [ ] T018 [US1] Write the warm-open e2e in `e2e/sw-persist.spec.ts`: offline B receives
+      2 messages → `drainPending()` → assert rows exist, unread=2, `/v1/relay/pending`
+      empty, icon-badge count = in-app total; `reconnect()` → exactly one copy of each
+      message, unread unchanged
+
+**Checkpoint**: US1 independently deliverable — warm open works end-to-end behind the flag.
+
+## Phase 4: User Story 2 — Privacy behavior is unchanged (P2)
+
+**Goal**: every privacy posture produces byte-identical notification behavior; locked
+devices never decrypt or store in the SW.
+
+**Independent test**: PIN-locked B gets a generic notification, nothing stored, frame
+stays queued; hidden chat stays generic.
+
+- [ ] T019 [P] [US2] Write failing unit tests in `src/services/sw-drain.test.ts`: locked
+      posture (device-unlock fails) → gate returns `reason:'locked'`, zero writes, zero
+      acks; hidden-chat / generic-preview rules produce the same notification payloads as
+      the preview path (share the fixtures from `sw-inbox` tests)
+- [ ] T020 [US2] Implement the posture guards in `src/services/sw-drain.ts` + `src/sw.ts`:
+      gate short-circuits before any fetch-decrypt when locked; notification construction
+      delegates to the exact same privacy/suppression helpers `previewPending` uses (no
+      forked copy)
+- [ ] T021 [US2] Extend `e2e/sw-persist.spec.ts`: enable PIN lock → send → generic
+      notification, no local rows, frame still pending server-side; unlock + open → message
+      arrives via page drain exactly once. Add a hidden-chat scenario asserting generic
+      content
+
+**Checkpoint**: privacy parity proven for default, generic, hidden, and locked postures.
+
+## Phase 5: User Story 3 — Nothing is lost, nothing is doubled (P3)
+
+**Goal**: every failure/ineligible path degrades to today's behavior; exactly-once holds
+under interleaving.
+
+**Independent test**: interrupted drain, stranger first-contact, and drain-vs-reconnect
+race all end with each message exactly once and correct unread.
+
+- [ ] T022 [P] [US3] Write failing unit tests in `src/services/sw-drain.test.ts`:
+      lock-timeout (`LockTimeoutError`) degrades the wake to preview-only (no ack, no
+      writes); missing Web Locks → gate off; decrypt failure on one frame defers that
+      frame and continues the loop; kill-between-commit-and-ack simulation → next wake
+      re-acks via ledger without re-applying
+- [ ] T023 [US3] Implement the degrade ladder in `src/services/sw-drain.ts`/`src/sw.ts`
+      (typed reasons `flag-off | locked | no-locks | lock-timeout | no-frames` surfaced in
+      the drain result for the test hook), ensuring deferred frames keep flowing through
+      `swNotifiedIds`/`swShownSummary` exactly as today
+- [ ] T024 [US3] Extend `e2e/sw-persist.spec.ts`: (a) stranger's first-contact message →
+      drain defers → page reconnect applies it once (friend-gate behavior intact);
+      (b) concurrent `drainPending()` + `reconnect()` → exactly one row, one unread;
+      (c) flag OFF run of the whole suite asserting byte-for-byte today's behavior
+- [ ] T025 [US3] Run the existing regression suites with the flag on and off —
+      `e2e/sw-decrypt.spec.ts` (preview assertions updated only if the flag-on path
+      legitimately changes them) and the `e2e/call-*.spec.ts` suites (message push landing
+      mid-call must not disturb signalling; lock contention path)
+
+**Checkpoint**: all three stories complete; exactly-once and degrade-to-today proven.
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T026 [P] Update the stale server comment in `server/internal/store/relay.go`
+      (~:50-56, `SweepRelayOlderThan`): the SW *can* now ack behind the flag; the sweep
+      rationale (never-returning recipients) is unchanged. Comment-only, no behavior
+- [ ] T027 [P] Rewrite the header design-note in `src/services/sw-inbox.ts` (~:1-19,
+      "Choice A") to describe the two-mode world (authoritative sw-drain behind the flag;
+      preview as fallback/deferred path), and cross-reference `specs/1032-store-messages-push/`
+- [ ] T028 Walk `specs/1032-store-messages-push/quickstart.md` end-to-end on the dev stack
+      (`make start`), including the degrade checklist and the DevTools kill-mid-drain
+      probe; fix anything that drifted
+- [ ] T029 Full gates: `npm run build`, `npx vitest run` (coverage floors hold),
+      `cd server && go build ./... && go vet ./... && go test ./...`,
+      `npm run test:e2e` — all green with the flag defaulted off
+- [ ] T030 Flip spec `**Status**` to `in-review` in
+      `specs/1032-store-messages-push/spec.md` and run `make roadmap`
+
+## Dependencies & Execution Order
+
+- **Phase 1 → Phase 2 → Phase 3**: strictly sequential phases (foundational plumbing
+  blocks every story; US1 builds the module US2/US3 harden).
+- **US1 (Phase 3) is the MVP**: independently shippable behind the flag.
+- **US2 (Phase 4) and US3 (Phase 5)** both extend sw-drain from US1 — start US2 first
+  (privacy is the higher bar); their e2e tasks (T021, T024) are mutually parallel once
+  T020/T023 land.
+- Within phases, `[P]` tasks touch different files and may run in parallel; test tasks
+  always precede their implementation task (Red → Green).
+
+### Parallel example (Phase 2)
+
+```
+T003 (cross-lock tests) ─┐
+T005 (transact tests)   ─┼─ in parallel, then T004 → T006 → T008 …
+T007 (bridge tests)     ─┤
+T009 (ratchet tests)    ─┘
+```
+
+## Implementation Strategy
+
+Ship in two PR-sized slices if review size demands it: (1) Phase 1–2 — pure safety
+plumbing, flag-off no-op, zero behavior change; (2) Phase 3–6 — the sw-drain feature
+behind the flag. Otherwise one feature PR is fine: the flag keeps production behavior
+byte-identical until the dev-deployment soak (quickstart.md) passes, after which a
+follow-up release flips the default.

--- a/specs/1032-store-messages-push/tasks.md
+++ b/specs/1032-store-messages-push/tasks.md
@@ -162,10 +162,10 @@ race all end with each message exactly once and correct unread.
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T026 [P] Update the stale server comment in `server/internal/store/relay.go`
+- [x] T026 [P] Update the stale server comment in `server/internal/store/relay.go`
       (~:50-56, `SweepRelayOlderThan`): the SW *can* now ack behind the flag; the sweep
       rationale (never-returning recipients) is unchanged. Comment-only, no behavior
-- [ ] T027 [P] Rewrite the header design-note in `src/services/sw-inbox.ts` (~:1-19,
+- [x] T027 [P] Rewrite the header design-note in `src/services/sw-inbox.ts` (~:1-19,
       "Choice A") to describe the two-mode world (authoritative sw-drain behind the flag;
       preview as fallback/deferred path), and cross-reference `specs/1032-store-messages-push/`
 - [ ] T028 Walk `specs/1032-store-messages-push/quickstart.md` end-to-end on the dev stack
@@ -174,7 +174,7 @@ race all end with each message exactly once and correct unread.
       *(hermetic e2e covers the disconnect→drain→verify→reconnect + flag-off + locked
       rows; remaining: kill-mid-drain probe + the real-device soak on the dev
       deployment — flag defaults OFF, so no exposure until then)*
-- [ ] T029 Security review (constitution Principle IV): adversarial pass over the lock
+- [x] T029 Security review (constitution Principle IV): adversarial pass over the lock
       discipline, `openPacketStaged`, and the atomic-commit/ack ordering against
       `specs/1032-store-messages-push/contracts/sw-receive.md` invariants 1–5; record the
       outcome in the PR description before requesting merge

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -9,7 +9,7 @@
  * the real WebSocket transport is a one-line change here.
  */
 import { ref, watch } from 'vue';
-import { subscribe } from '@/db/idb';
+import { subscribe, touch } from '@/db/idb';
 import { isAuthenticated, getToken, verifySessionOrReset, getPendingInviter } from '@/services/auth';
 import {
   WebSocketTransport,
@@ -483,6 +483,13 @@ function start(): void {
         // Throttled internally, so this is cheap to run every time.
         void revalidatePushSubscription();
         void sweepExpiredMessages(); // drop anything that expired while backgrounded
+        // Spec 1032: the SW may have PERSISTED messages while this page sat frozen
+        // (iOS freezes JS but keeps the page alive), and a frozen page can miss the
+        // idb bridge's BroadcastChannel message. Re-fire the chats/messages bus on
+        // resume so useLiveQuery re-reads what the SW wrote — a read-only nudge; if
+        // nothing changed the queries just return the same rows.
+        touch('chats');
+        touch('messages');
       }
       void sendPresenceSelf(selfActive()); // online only when visible AND unlocked
     });

--- a/src/db/idb.bridge.test.ts
+++ b/src/db/idb.bridge.test.ts
@@ -1,0 +1,62 @@
+// Spec 1032 (T007) — the BroadcastChannel bridge on the idb change bus. The bus is a
+// module-level Map, so it never crosses JS contexts: a page useLiveQuery is blind to
+// service-worker writes (and tab B is blind to tab A). The bridge posts each store
+// name on BroadcastChannel('ring:idb'); a RECEIVED name fires local listeners only
+// (never re-broadcast), so two bridged contexts can't echo-loop each other.
+//
+// Node ≥18 ships BroadcastChannel natively (same-thread instances deliver to each
+// other), so the "other context" here is simply a second channel instance.
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'vitest';
+import { put, subscribe } from './idb';
+
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+describe('idb change-bus BroadcastChannel bridge', () => {
+  it('a write posts the store name on ring:idb (what another context would receive)', async () => {
+    const rx = new BroadcastChannel('ring:idb');
+    const received: unknown[] = [];
+    rx.onmessage = (e) => received.push(e.data);
+    await put('chats', { id: 'bridge-1', unread: 0 });
+    await flush();
+    rx.close();
+    expect(received).toContain('chats');
+  });
+
+  it('a received store name fires local subscribers (the SW→page repaint path)', async () => {
+    let fired = 0;
+    const unsub = subscribe(['messages'], () => fired++);
+    const tx = new BroadcastChannel('ring:idb');
+    tx.postMessage('messages'); // simulate the SW's bridge after a drain commit
+    await flush();
+    tx.close();
+    unsub();
+    expect(fired).toBeGreaterThan(0);
+  });
+
+  it('a received message is NOT re-broadcast (no echo loop)', async () => {
+    const spyA = new BroadcastChannel('ring:idb');
+    const seen: unknown[] = [];
+    spyA.onmessage = (e) => seen.push(e.data);
+    const sender = new BroadcastChannel('ring:idb');
+    sender.postMessage('contacts');
+    await flush();
+    // The spy sees the ONE original post; if idb.ts re-broadcast on receive, a second
+    // 'contacts' (and then an infinite storm) would appear here.
+    expect(seen.filter((d) => d === 'contacts').length).toBe(1);
+    spyA.close();
+    sender.close();
+  });
+
+  it('garbage on the channel is ignored (only known store names fire)', async () => {
+    let fired = 0;
+    const unsub = subscribe(['chats'], () => fired++);
+    const tx = new BroadcastChannel('ring:idb');
+    tx.postMessage('not-a-store');
+    tx.postMessage({ weird: true });
+    await flush();
+    tx.close();
+    unsub();
+    expect(fired).toBe(0);
+  });
+});

--- a/src/db/idb.transact.test.ts
+++ b/src/db/idb.transact.test.ts
@@ -1,0 +1,106 @@
+// Spec 1032 (T005) — the atomic multi-store transaction helper that makes the SW's
+// per-frame commit all-or-nothing: the advanced ratchet session, the message row,
+// the chat read-modify-write, and the exactly-once ledger mark either ALL land or
+// NONE do. Runs against fake-indexeddb (real IDB transaction semantics, in-process),
+// because atomicity is exactly the part an in-memory Map mock can't prove.
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { transact, get, put, subscribe, type StoreName } from './idb';
+
+// A fresh DB per test file run is enough; per-test we just use distinct keys.
+const STORES: StoreName[] = ['sessions', 'messages', 'chats', 'settings'];
+
+interface Row {
+  id: string;
+  [k: string]: unknown;
+}
+
+describe('transact: all-or-nothing commit across stores', () => {
+  it('commits writes to every named store in one transaction', async () => {
+    await transact(STORES, (tx) => {
+      tx.put('sessions', { id: 'c1', rk: 'advanced' });
+      tx.put('messages', { id: 'm1', chatId: 'c1', body: 'hi' });
+      tx.put('chats', { id: 'c1', unread: 1 });
+      tx.put('settings', { key: 'inboundSeenIds', value: ['m1'] });
+    });
+    expect((await get<Row>('sessions', 'c1'))?.rk).toBe('advanced');
+    expect((await get<Row>('messages', 'm1'))?.body).toBe('hi');
+    expect((await get<Row>('chats', 'c1'))?.unread).toBe(1);
+    expect((await get<{ key: string; value: string[] }>('settings', 'inboundSeenIds'))?.value).toEqual(['m1']);
+  });
+
+  it('a throwing callback aborts: zero writes land in ANY store', async () => {
+    await put('chats', { id: 'c2', unread: 0 });
+    await expect(
+      transact(STORES, (tx) => {
+        tx.put('messages', { id: 'm2', chatId: 'c2', body: 'lost' });
+        tx.put('chats', { id: 'c2', unread: 1 });
+        throw new Error('mid-transaction failure');
+      }),
+    ).rejects.toThrow('mid-transaction failure');
+    expect(await get<Row>('messages', 'm2')).toBeUndefined();
+    expect((await get<Row>('chats', 'c2'))?.unread).toBe(0); // RMW rolled back
+  });
+
+  it('an async callback can read-modify-write within the same transaction', async () => {
+    await put('chats', { id: 'c3', unread: 4 });
+    await transact(['chats', 'settings'], async (tx) => {
+      const chat = await tx.get<Row>('chats', 'c3');
+      tx.put('chats', { ...chat, unread: (chat?.unread as number) + 1 });
+      const seen = ((await tx.get<{ key: string; value: string[] }>('settings', 'seen-c3'))?.value ?? []) as string[];
+      tx.put('settings', { key: 'seen-c3', value: [...seen, 'm3'] });
+    });
+    expect((await get<Row>('chats', 'c3'))?.unread).toBe(5);
+    expect((await get<{ key: string; value: string[] }>('settings', 'seen-c3'))?.value).toEqual(['m3']);
+  });
+
+  it('an async throw after a read still aborts everything', async () => {
+    await put('chats', { id: 'c4', unread: 7 });
+    await expect(
+      transact(['chats', 'messages'], async (tx) => {
+        const chat = await tx.get<Row>('chats', 'c4');
+        tx.put('chats', { ...chat, unread: 8 });
+        tx.put('messages', { id: 'm4', chatId: 'c4' });
+        throw new Error('late failure');
+      }),
+    ).rejects.toThrow('late failure');
+    expect((await get<Row>('chats', 'c4'))?.unread).toBe(7);
+    expect(await get<Row>('messages', 'm4')).toBeUndefined();
+  });
+});
+
+describe('transact: change-bus notification discipline', () => {
+  let fired: string[];
+  let unsub: () => void;
+
+  beforeEach(() => {
+    fired = [];
+    unsub = subscribe(STORES, () => {
+      /* per-store capture below */
+    });
+    unsub();
+    const subs = STORES.map((name) => subscribe([name], () => fired.push(name)));
+    unsub = () => subs.forEach((u) => u());
+  });
+
+  it('fires once per TOUCHED store, only after commit', async () => {
+    await transact(STORES, (tx) => {
+      tx.put('messages', { id: 'm5', chatId: 'c5' });
+      tx.put('chats', { id: 'c5', unread: 1 });
+      // sessions + settings deliberately untouched
+    });
+    expect(fired.sort()).toEqual(['chats', 'messages']);
+    unsub();
+  });
+
+  it('fires nothing when the transaction aborts', async () => {
+    await expect(
+      transact(STORES, (tx) => {
+        tx.put('messages', { id: 'm6', chatId: 'c6' });
+        throw new Error('abort');
+      }),
+    ).rejects.toThrow('abort');
+    expect(fired).toEqual([]);
+    unsub();
+  });
+});

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -342,6 +342,79 @@ export async function update<T>(
   if (wrote) notify(name);
 }
 
+/** The handle a `transact` callback drives. Reads/writes all ride ONE readwrite
+ *  IndexedDB transaction, so everything commits together or nothing does. */
+export interface Tx {
+  get<T>(name: StoreName, key: IDBValidKey): Promise<T | undefined>;
+  put<T>(name: StoreName, value: T): void;
+  delete(name: StoreName, key: IDBValidKey): void;
+}
+
+/**
+ * Run `fn` inside ONE readwrite transaction spanning `names` (spec 1032). This is
+ * what makes the service worker's per-frame commit crash-safe: the advanced ratchet
+ * session, the message row, the chat read-modify-write, and the exactly-once ledger
+ * mark are all-or-nothing — an interruption (worker killed, quota error, thrown
+ * callback) leaves either the complete result or no trace, never a half-applied
+ * frame. Change-bus notifications fire only after commit, once per touched store;
+ * an abort notifies nothing.
+ *
+ * Constraint inherited from IndexedDB itself: `fn` may await the handle's own
+ * `get` (the transaction stays alive across IDB-request microtasks), but awaiting
+ * anything else (fetch, timers, crypto) lets the transaction auto-commit early —
+ * do all slow work BEFORE calling transact and pass the results in.
+ */
+export async function transact(names: StoreName[], fn: (tx: Tx) => void | Promise<void>): Promise<void> {
+  const run = (db: IDBDatabase): Promise<Set<StoreName>> =>
+    new Promise<Set<StoreName>>((resolve, reject) => {
+      const tx = db.transaction(names, 'readwrite'); // may throw InvalidStateError synchronously
+      const touched = new Set<StoreName>();
+      const handle: Tx = {
+        get: (name, key) => promisify(tx.objectStore(name).get(key)),
+        put: (name, value) => {
+          tx.objectStore(name).put(value);
+          touched.add(name);
+        },
+        delete: (name, key) => {
+          tx.objectStore(name).delete(key);
+          touched.add(name);
+        },
+      };
+      let failed: unknown = null;
+      Promise.resolve()
+        .then(() => fn(handle))
+        .catch((e) => {
+          // Abort so nothing lands; reject with the CALLBACK's error (more useful
+          // than the generic AbortError the abort event carries).
+          failed = e;
+          try {
+            tx.abort();
+          } catch {
+            /* already aborted/finished */
+          }
+        });
+      tx.oncomplete = () => resolve(touched);
+      tx.onabort = () => reject(failed ?? tx.error ?? new Error('transaction aborted'));
+      tx.onerror = () => {
+        /* the abort handler reports; individual request errors bubble to onabort */
+      };
+    });
+  let touched: Set<StoreName>;
+  try {
+    touched = await run(await openDB());
+  } catch (e) {
+    // Cached connection was closing (storage cleared / other-tab upgrade); drop it
+    // and reopen once, like store()/update(), so this doesn't fail until a reload.
+    if (e instanceof DOMException && e.name === 'InvalidStateError') {
+      dbPromise = null;
+      touched = await run(await openDB());
+    } else {
+      throw e;
+    }
+  }
+  for (const name of touched) notify(name);
+}
+
 export async function bulkPut<T>(name: StoreName, values: T[]): Promise<void> {
   const db = await openDB();
   await new Promise<void>((resolve, reject) => {
@@ -380,8 +453,33 @@ export async function wipeAllStores(): Promise<void> {
 
 const listeners = new Map<StoreName, Set<() => void>>();
 
-function notify(name: StoreName): void {
+function fireLocal(name: StoreName): void {
   listeners.get(name)?.forEach((cb) => cb());
+}
+
+/* Cross-context bridge (spec 1032): the listener Map above is module-level, so it
+ * never crosses JS contexts — a live page's useLiveQuery was blind to service-worker
+ * writes (and tab B to tab A's). Every notify() ALSO posts the store name on
+ * BroadcastChannel('ring:idb'); a RECEIVED name fires the LOCAL listeners only and is
+ * never re-broadcast, so two bridged contexts can't echo-loop each other. Unknown
+ * payloads are ignored (a newer context may know stores this one doesn't). Contexts
+ * without BroadcastChannel just skip the bridge (today's in-context behavior). */
+const bridge: BroadcastChannel | null =
+  typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel('ring:idb') : null;
+if (bridge) {
+  bridge.onmessage = (e: MessageEvent) => {
+    const name = e.data as StoreName;
+    if ((STORES as readonly string[]).includes(name)) fireLocal(name);
+  };
+}
+
+function notify(name: StoreName): void {
+  fireLocal(name);
+  try {
+    bridge?.postMessage(name);
+  } catch {
+    /* a closing channel must never fail a write */
+  }
 }
 
 /**

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -14,6 +14,7 @@ import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
 import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, keepAlivePost as apiKeepAlivePost, addPostEnvelopes as apiAddPostEnvelopes, removePostRecipient as apiRemovePostRecipient, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
 import { sealForChat, openPacket } from '@/services/messaging';
 import { withInboundLock } from '@/services/cross-lock';
+import { mediaPreview, previewKind, chatListPreview } from '@/services/message-preview';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
 import { autoSaveIncomingMedia } from '@/services/media-autosave';
 import { wallSyncedOnce } from '@/services/wall-load';
@@ -1421,28 +1422,9 @@ export async function leaveGroup(chatId: string): Promise<void> {
   await deleteChat(chatId);
 }
 
-const durLabel = (sec?: number) =>
-  sec ? ` (${Math.floor(sec / 60)}:${String(Math.round(sec % 60)).padStart(2, '0')})` : '';
-
-/** Chats-list preview text for a media message (label + duration). The chats
- *  list pairs this with an Ionic icon derived from `previewKind`, so no emoji. */
-function mediaPreview(kind: string, durationSec?: number, name?: string, videoNote?: boolean): string {
-  if (kind === 'voice') return `Voice message${durLabel(durationSec)}`;
-  if (kind === 'video') return videoNote ? `Video note${durLabel(durationSec)}` : 'Video';
-  if (kind === 'image') return 'Photo';
-  if (kind === 'audio') return name && name !== 'attachment' ? name : 'Audio';
-  if (kind === 'file') return `${name && name !== 'attachment' ? name : 'Document'}`;
-  return 'Attachment';
-}
-
-/** The icon category for the chats-list preview of a (possibly media) message. */
-function previewKind(kind: string, albumName?: string, videoNote?: boolean): Chat['lastKind'] {
-  if (albumName) return 'album';
-  if (kind === 'video') return videoNote ? 'videonote' : 'video';
-  if (kind === 'image' || kind === 'voice' || kind === 'file' || kind === 'audio') return kind;
-  if (kind === 'location' || kind === 'poll' || kind === 'contact') return kind;
-  return 'text';
-}
+// mediaPreview/previewKind/chatListPreview moved to services/message-preview.ts
+// (spec 1032): the SW's notification-time apply writes chat rows too, and both
+// writers must derive identical preview lines. Imported at the top of this file.
 
 /** Short snapshot of a message's content, for quotes / reaction previews. */
 function previewText(m: Message): string {
@@ -1972,6 +1954,18 @@ export async function resumePendingMediaJobs(): Promise<void> {
   const msgs = await getAll<Message>('messages');
   for (const m of msgs) {
     if (m.status === 'compressing') void processMediaJob(m.id);
+  }
+  // Spec 1032: the SW's notification-time apply NEVER downloads media bytes (no
+  // canvas pipeline, tight push budget) — it stores the reference as pendingMedia
+  // unconditionally, including media this device's auto-download preference would
+  // have fetched inline. Backfill those here (same call sites: app start +
+  // reconnect), so a photo received while closed is ready by the time the chat is
+  // opened. Deliberate defers (auto-download off / over the size limit) stay
+  // deferred — the same shouldAutoDownloadMedia gate the live path uses decides.
+  for (const m of msgs) {
+    if (m.outgoing || !m.pendingMedia || m.mediaId) continue;
+    if (!(await shouldAutoDownloadMedia((m.kind as MessageKind) || 'text', !!m.videoNote, m.pendingMedia.size))) continue;
+    void downloadMessageMedia(m.id).catch(() => {}); // failure keeps the manual tap path
   }
 }
 
@@ -4787,17 +4781,7 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
   };
   await put('messages', message);
 
-  const preview = payload.albumName
-    ? payload.albumName
-    : kind === 'location'
-      ? payload.location?.label || 'Location'
-      : kind === 'poll'
-        ? payload.poll?.question || 'Poll'
-        : kind === 'contact'
-          ? payload.contact?.name || 'Contact'
-          : kind === 'audio'
-            ? payload.audio?.title || mediaPreview('audio', durationSec, payload.mediaRef?.name)
-            : payload.body || mediaPreview(kind, durationSec, undefined, payload.videoNote);
+  const preview = chatListPreview(payload, kind, durationSec);
   const chat = await getChat(targetChatId);
   // @mentions (spec 1020): am I called out in this group message? Individual mention by
   // id, or an @everyone that the sender is actually the group OWNER of (re-validated on

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -13,6 +13,7 @@ import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination
 import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
 import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, keepAlivePost as apiKeepAlivePost, addPostEnvelopes as apiAddPostEnvelopes, removePostRecipient as apiRemovePostRecipient, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
 import { sealForChat, openPacket } from '@/services/messaging';
+import { withInboundLock } from '@/services/cross-lock';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
 import { autoSaveIncomingMedia } from '@/services/media-autosave';
 import { wallSyncedOnce } from '@/services/wall-load';
@@ -4511,10 +4512,15 @@ async function markInboundSeen(id: string): Promise<void> {
 // lock) runs OFF that chain, so two receiveIncoming calls for the same id could
 // otherwise overlap at the wasInboundSeen → openPacket → markInboundSeen await
 // points, letting a duplicate re-establish (clobber) the live Double Ratchet. This
-// module-level chain guarantees one inbound decrypt runs at a time.
+// module-level chain guarantees one inbound decrypt runs at a time IN THIS context;
+// withInboundLock (spec 1032) extends the same guarantee across contexts, so the
+// service worker's authoritative drain (sw-drain.ts) can never interleave its
+// check-ledger → decrypt → commit → ack section with ours. The page waits without a
+// timeout (only the SW side must degrade rather than stall its push budget), and
+// where Web Locks don't exist the helper is just this chain again.
 let inboundSerial: Promise<void> = Promise.resolve();
 export function receiveIncoming(from: string, remoteId: string, ciphertext: unknown): Promise<void> {
-  const run = inboundSerial.then(() => receiveIncomingInner(from, remoteId, ciphertext));
+  const run = inboundSerial.then(() => withInboundLock(() => receiveIncomingInner(from, remoteId, ciphertext)));
   inboundSerial = run.then(
     () => undefined,
     () => undefined,

--- a/src/services/cross-lock.test.ts
+++ b/src/services/cross-lock.test.ts
@@ -1,0 +1,199 @@
+// Spec 1032 (T003) — the cross-context named locks that make the SW a safe second
+// writer of ratchet state. These tests drive withInboundLock / withSessionLock
+// against a FAKE navigator.locks (a faithful little exclusive-lock manager with
+// AbortSignal support), asserting: mutual exclusion, FIFO ordering, the SW-side
+// timeout raising a typed LockTimeoutError without running the section, and the
+// missing-API fallback still serializing within the context.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  withInboundLock,
+  withSessionLock,
+  locksAvailable,
+  LockTimeoutError,
+  INBOUND_LOCK,
+  sessionLockName,
+} from './cross-lock';
+
+/* ---- a minimal exclusive LockManager fake (grant order = request order) ---- */
+
+type Waiter = { name: string; grant: () => void; signal?: AbortSignal };
+
+class FakeLocks {
+  held = new Set<string>();
+  queue: Waiter[] = [];
+  granted: string[] = []; // grant log, for ordering asserts
+
+  request<T>(
+    name: string,
+    opts: { mode: 'exclusive'; signal?: AbortSignal },
+    cb: () => T | Promise<T>,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const tryRun = () => {
+        this.held.add(name);
+        this.granted.push(name);
+        Promise.resolve()
+          .then(cb)
+          .then(resolve, reject)
+          .finally(() => {
+            this.held.delete(name);
+            this.pump();
+          });
+      };
+      const w: Waiter = { name, grant: tryRun, signal: opts.signal };
+      if (opts.signal) {
+        if (opts.signal.aborted) {
+          reject(new DOMException('aborted', 'AbortError'));
+          return;
+        }
+        opts.signal.addEventListener('abort', () => {
+          const i = this.queue.indexOf(w);
+          if (i >= 0) {
+            this.queue.splice(i, 1);
+            reject(new DOMException('aborted', 'AbortError'));
+          }
+        });
+      }
+      this.queue.push(w);
+      this.pump();
+    });
+  }
+
+  private pump(): void {
+    for (let i = 0; i < this.queue.length; i++) {
+      const w = this.queue[i];
+      if (!this.held.has(w.name)) {
+        this.queue.splice(i, 1);
+        w.grant();
+        return; // one grant per pump; the section's finally pumps again
+      }
+    }
+  }
+}
+
+// Node's globalThis.navigator is getter-only, so swap it via vitest's stubGlobal.
+let fake: FakeLocks;
+const noLocks = () => vi.stubGlobal('navigator', undefined);
+
+beforeEach(() => {
+  fake = new FakeLocks();
+  vi.stubGlobal('navigator', { locks: fake });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('cross-lock: mutual exclusion + ordering', () => {
+  it('locksAvailable reflects the presence of navigator.locks', () => {
+    expect(locksAvailable()).toBe(true);
+    noLocks();
+    expect(locksAvailable()).toBe(false);
+  });
+
+  it('two sections on the same session lock never interleave, and run FIFO', async () => {
+    const events: string[] = [];
+    const a = withSessionLock('chat-1', async () => {
+      events.push('a-start');
+      await sleep(20);
+      events.push('a-end');
+    });
+    const b = withSessionLock('chat-1', async () => {
+      events.push('b-start');
+      await sleep(5);
+      events.push('b-end');
+    });
+    await Promise.all([a, b]);
+    expect(events).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+
+  it('different chats run concurrently (per-chat locks, not one global)', async () => {
+    const events: string[] = [];
+    const a = withSessionLock('chat-1', async () => {
+      events.push('a-start');
+      await sleep(20);
+      events.push('a-end');
+    });
+    const b = withSessionLock('chat-2', async () => {
+      events.push('b-start');
+      await sleep(5);
+      events.push('b-end');
+    });
+    await Promise.all([a, b]);
+    expect(events.slice(0, 2)).toEqual(['a-start', 'b-start']); // b didn't wait for a
+  });
+
+  it('inbound → session nesting acquires in the documented outer→inner order', async () => {
+    await withInboundLock(async () => {
+      await withSessionLock('chat-1', async () => {});
+    });
+    expect(fake.granted).toEqual([INBOUND_LOCK, sessionLockName('chat-1')]);
+  });
+
+  it('a rejecting section releases the lock for the next waiter', async () => {
+    const failing = withSessionLock('chat-1', async () => {
+      throw new Error('boom');
+    });
+    const after = withSessionLock('chat-1', async () => 'ran');
+    await expect(failing).rejects.toThrow('boom');
+    await expect(after).resolves.toBe('ran');
+  });
+});
+
+describe('cross-lock: SW-side timeout (degrade-to-preview trigger)', () => {
+  it('raises LockTimeoutError when the lock is held past timeoutMs, without running fn', async () => {
+    let release!: () => void;
+    const holder = withSessionLock('chat-1', () => new Promise<void>((r) => (release = r)));
+    await sleep(1); // let the holder acquire
+    let ran = false;
+    // Bypass the in-context mutex by contending from "another context": call the
+    // fake directly for the holder? No — contend via a DIFFERENT helper instance
+    // isn't possible (module-level mutex), so simulate the cross-context case by
+    // having the FAKE hold the name out from under the helper.
+    fake.held.add(sessionLockName('chat-2'));
+    const waiter = withSessionLock(
+      'chat-2',
+      async () => {
+        ran = true;
+      },
+      { timeoutMs: 20 },
+    );
+    await expect(waiter).rejects.toBeInstanceOf(LockTimeoutError);
+    expect(ran).toBe(false);
+    fake.held.delete(sessionLockName('chat-2'));
+    release();
+    await holder;
+  });
+
+  it('a granted lock ignores the timeout (the signal only guards acquisition)', async () => {
+    const out = await withSessionLock(
+      'chat-1',
+      async () => {
+        await sleep(30); // longer than the timeout — must NOT abort a running section
+        return 'done';
+      },
+      { timeoutMs: 10 },
+    );
+    expect(out).toBe('done');
+  });
+});
+
+describe('cross-lock: missing-API fallback (in-context serialization only)', () => {
+  it('still serializes same-name sections through the KeyedMutex', async () => {
+    noLocks(); // no Web Locks anywhere
+    const events: string[] = [];
+    const a = withInboundLock(async () => {
+      events.push('a-start');
+      await sleep(15);
+      events.push('a-end');
+    });
+    const b = withInboundLock(async () => {
+      events.push('b-start');
+      events.push('b-end');
+    });
+    await Promise.all([a, b]);
+    expect(events).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+});

--- a/src/services/cross-lock.test.ts
+++ b/src/services/cross-lock.test.ts
@@ -178,6 +178,41 @@ describe('cross-lock: SW-side timeout (degrade-to-preview trigger)', () => {
     );
     expect(out).toBe('done');
   });
+
+  it('F2: the timeout covers the in-context QUEUE wait, not just the Web Lock request', async () => {
+    // A same-context caller parked on the cross-context lock holds the KeyedMutex
+    // slot; a later timed caller must still degrade at its deadline instead of
+    // waiting in the queue forever.
+    fake.held.add(sessionLockName('chat-9')); // "another context" holds the Web Lock
+    const parked = withSessionLock('chat-9', async () => 'never'); // untimed → waits, occupies the slot
+    await sleep(1);
+    let ran = false;
+    const timed = withSessionLock(
+      'chat-9',
+      async () => {
+        ran = true;
+      },
+      { timeoutMs: 25 },
+    );
+    await expect(timed).rejects.toBeInstanceOf(LockTimeoutError);
+    expect(ran).toBe(false);
+    fake.held.delete(sessionLockName('chat-9'));
+    fake['pump']();
+    await parked; // the parked holder completes once the lock frees
+  });
+
+  it("F6: a section error after the deadline fired is the section's error, never LockTimeoutError", async () => {
+    await expect(
+      withSessionLock(
+        'chat-1',
+        async () => {
+          await sleep(30); // deadline (10ms) fires mid-section
+          throw new Error('quota exceeded');
+        },
+        { timeoutMs: 10 },
+      ),
+    ).rejects.toThrow('quota exceeded');
+  });
 });
 
 describe('cross-lock: missing-API fallback (in-context serialization only)', () => {

--- a/src/services/cross-lock.ts
+++ b/src/services/cross-lock.ts
@@ -24,7 +24,17 @@
  * navigator.locks (the cross-context guarantee). SW callers pass a timeout: a
  * frozen-but-alive iOS page can hold a lock indefinitely while unable to run,
  * and the SW must degrade to the preview-only path rather than blow its
- * waitUntil budget waiting. Page callers wait without a timeout (they can).
+ * waitUntil budget waiting. Page callers wait without a timeout — accepted
+ * trade-off (security review F9): a SECOND live window queued behind a frozen
+ * sibling's inbound lock would stall until the sibling unfreezes or dies (locks
+ * auto-release on context death, and iOS PWAs are effectively single-window);
+ * bypassing on timeout would reintroduce the two-writers race this exists for.
+ *
+ * Version-skew caveat (security review F5): the guarantee holds only when EVERY
+ * live context runs lock-taking code. A pre-1032 page kept alive across an
+ * update (registerType 'prompt') takes no Web Locks, so the SW drain flag
+ * (sw.fullPersist) must only be enabled once all tabs run ≥ this release, and
+ * its default-on flip must ship at least one release after this code.
  */
 import { KeyedMutex } from './keyed-mutex';
 
@@ -69,26 +79,60 @@ export function locksAvailable(): boolean {
 // the mutex hands them to navigator.locks one at a time, in arrival order.
 const localMutex = new KeyedMutex();
 
+/** The cross-context half of an acquisition: request the Web Lock (if present)
+ *  and run fn under it. `started` disambiguates the two ways the request can
+ *  reject after the caller's deadline fired (security review F6): an abort
+ *  BEFORE the grant is a timeout; an error AFTER fn started is fn's own failure
+ *  and must propagate verbatim, never be misreported as a LockTimeoutError. */
+async function requestCross<T>(
+  name: string,
+  fn: () => Promise<T>,
+  signal: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+): Promise<T> {
+  const locks = locksApi();
+  if (!locks) return fn(); // no cross-context primitive → in-context serialization only
+  let started = false;
+  try {
+    return await locks.request(name, { mode: 'exclusive', signal }, async () => {
+      started = true;
+      return fn();
+    });
+  } catch (e) {
+    if (!started && signal?.aborted) throw new LockTimeoutError(name, timeoutMs ?? 0);
+    throw e;
+  }
+}
+
 async function withNamedLock<T>(name: string, fn: () => Promise<T>, opts?: LockOptions): Promise<T> {
-  return localMutex.run(name, async () => {
-    const locks = locksApi();
-    if (!locks) return fn(); // no cross-context primitive → in-context serialization only
-    if (opts?.timeoutMs == null) {
-      return locks.request(name, { mode: 'exclusive' }, fn);
-    }
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs);
-    try {
-      return await locks.request(name, { mode: 'exclusive', signal: ctrl.signal }, fn);
-    } catch (e) {
-      // Only the acquisition can abort (the signal is ignored once granted), so an
-      // abort here always means "timed out waiting", never "interrupted mid-section".
-      if (ctrl.signal.aborted) throw new LockTimeoutError(name, opts.timeoutMs);
-      throw e;
-    } finally {
-      clearTimeout(timer);
-    }
-  });
+  if (opts?.timeoutMs == null) {
+    return localMutex.run(name, () => requestCross(name, fn, undefined, undefined));
+  }
+  // The deadline must cover the WHOLE acquisition — the in-context KeyedMutex wait
+  // AND the Web Lock request (security review F2). A previous same-context caller
+  // parked on the cross-context lock holds the KeyedMutex slot too; starting the
+  // timer only inside the slot would let a "3s timeout" wait forever in the queue.
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs);
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      let claimed = false; // our KeyedMutex turn arrived before the deadline
+      ctrl.signal.addEventListener('abort', () => {
+        if (!claimed) reject(new LockTimeoutError(name, opts.timeoutMs as number));
+      });
+      void localMutex.run(name, async () => {
+        if (ctrl.signal.aborted && !claimed) return; // deadline already rejected us; release the slot
+        claimed = true;
+        try {
+          resolve(await requestCross(name, fn, ctrl.signal, opts.timeoutMs));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export const INBOUND_LOCK = 'ring:inbound';

--- a/src/services/cross-lock.ts
+++ b/src/services/cross-lock.ts
@@ -1,0 +1,111 @@
+/**
+ * Cross-context named locks for the inbound message path (spec 1032).
+ *
+ * The page and the service worker share one IndexedDB but are separate JS
+ * contexts, so in-context mutexes (KeyedMutex, useSync's inboundChain) cannot
+ * stop a page seal and an SW open from interleaving a load→advance→save on the
+ * same Double Ratchet session. The Web Locks API is the platform primitive that
+ * does span contexts: origin-scoped, exclusive, and — decisively — auto-released
+ * when the holding context dies, so a killed SW can never deadlock the page.
+ *
+ * Two lock names, strict outer→inner ordering (never inverted):
+ *   - 'ring:inbound'            — one frame's check-ledger → decrypt → commit →
+ *                                 ack section (page receiveIncoming / SW drain).
+ *   - 'ring:session:<chatId>'   — every ratchet load→advance→save (seal, open,
+ *                                 preview), in both contexts.
+ * Nothing inside a session lock may acquire any other lock, and only the
+ * outermost inbound layer takes 'ring:inbound'. Web Locks are NOT reentrant:
+ * nesting the same name in one async chain deadlocks, which is why
+ * openPacketStaged (messaging.ts) takes no locks and documents that its caller
+ * must hold the session lock across decrypt AND commit.
+ *
+ * Each helper composes the in-context KeyedMutex (FIFO fairness within a
+ * context, and the entire serialization story where Web Locks are absent) with
+ * navigator.locks (the cross-context guarantee). SW callers pass a timeout: a
+ * frozen-but-alive iOS page can hold a lock indefinitely while unable to run,
+ * and the SW must degrade to the preview-only path rather than blow its
+ * waitUntil budget waiting. Page callers wait without a timeout (they can).
+ */
+import { KeyedMutex } from './keyed-mutex';
+
+/** Thrown when a lock isn't granted within the caller's timeout. SW callers
+ *  catch this and degrade the frame/wake to today's preview-only behavior. */
+export class LockTimeoutError extends Error {
+  constructor(name: string, timeoutMs: number) {
+    super(`lock ${name} not granted within ${timeoutMs}ms`);
+    this.name = 'LockTimeoutError';
+  }
+}
+
+export interface LockOptions {
+  /** Abort the acquisition (NOT the running section) after this many ms. */
+  timeoutMs?: number;
+}
+
+// Minimal structural type for navigator.locks so this module typechecks in both
+// the DOM and the service-worker lib without lib-juggling.
+interface LocksApi {
+  request<T>(
+    name: string,
+    opts: { mode: 'exclusive'; signal?: AbortSignal },
+    cb: () => T | Promise<T>,
+  ): Promise<T>;
+}
+
+function locksApi(): LocksApi | undefined {
+  const nav = (globalThis as { navigator?: { locks?: LocksApi } }).navigator;
+  return nav?.locks && typeof nav.locks.request === 'function' ? nav.locks : undefined;
+}
+
+/** Whether the cross-context Web Locks API exists here. When false, the helpers
+ *  still serialize within this context (KeyedMutex) — today's shipped behavior —
+ *  and the SW drain gate keeps the full-persist feature off. */
+export function locksAvailable(): boolean {
+  return !!locksApi();
+}
+
+// In-context FIFO per lock name. Also what guarantees fairness under Web Locks:
+// the browser doesn't promise request order across queued same-context calls,
+// the mutex hands them to navigator.locks one at a time, in arrival order.
+const localMutex = new KeyedMutex();
+
+async function withNamedLock<T>(name: string, fn: () => Promise<T>, opts?: LockOptions): Promise<T> {
+  return localMutex.run(name, async () => {
+    const locks = locksApi();
+    if (!locks) return fn(); // no cross-context primitive → in-context serialization only
+    if (opts?.timeoutMs == null) {
+      return locks.request(name, { mode: 'exclusive' }, fn);
+    }
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs);
+    try {
+      return await locks.request(name, { mode: 'exclusive', signal: ctrl.signal }, fn);
+    } catch (e) {
+      // Only the acquisition can abort (the signal is ignored once granted), so an
+      // abort here always means "timed out waiting", never "interrupted mid-section".
+      if (ctrl.signal.aborted) throw new LockTimeoutError(name, opts.timeoutMs);
+      throw e;
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+}
+
+export const INBOUND_LOCK = 'ring:inbound';
+
+/** Serialize one inbound frame's apply-and-ack critical section across contexts.
+ *  Outermost lock only — the section may take session locks, never the reverse. */
+export function withInboundLock<T>(fn: () => Promise<T>, opts?: LockOptions): Promise<T> {
+  return withNamedLock(INBOUND_LOCK, fn, opts);
+}
+
+export function sessionLockName(chatId: string): string {
+  return `ring:session:${chatId}`;
+}
+
+/** Serialize a chat's ratchet load→advance→save across contexts. Every seal,
+ *  open, and preview goes through here (messaging.ts); the SW drain holds it
+ *  across decrypt AND the atomic commit of the advanced session. */
+export function withSessionLock<T>(chatId: string, fn: () => Promise<T>, opts?: LockOptions): Promise<T> {
+  return withNamedLock(sessionLockName(chatId), fn, opts);
+}

--- a/src/services/crypto/ratchet.staged.test.ts
+++ b/src/services/crypto/ratchet.staged.test.ts
@@ -1,0 +1,206 @@
+// Spec 1032 (T009) — the staged authoritative open (openPacketStaged) that lets the
+// service worker persist the FULL ratchet advance (DH steps included) atomically
+// with the message row. Constitution Principle IV adversarial set:
+//   - staged open returns the advanced state WITHOUT persisting;
+//   - after the caller persists it, a subsequent SEAL on the reloaded state still
+//     decrypts at the peer (send-chain integrity across a staged DH step);
+//   - replaying the same packet fails (the key was consumed);
+//   - forged ciphertext fails;
+//   - a >50-frame out-of-order backlog (newest-first apply, like a capped
+//     /relay/pending fetch) decrypts via the skipped-key cache.
+//
+// Same harness as messaging-preview.test.ts: mock idb with in-memory Maps
+// (structuredClone on write), run the real X3DH + Double Ratchet.
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+const stores: Record<string, Map<string, unknown>> = {};
+function storeOf(name: string): Map<string, unknown> {
+  return (stores[name] ??= new Map());
+}
+vi.mock('@/db/idb', () => ({
+  get: vi.fn(async (store: string, key: string) => storeOf(store).get(key)),
+  put: vi.fn(async (store: string, value: { id?: string; key?: string }) => {
+    const k = (value.id ?? value.key) as string;
+    storeOf(store).set(k, structuredClone(value));
+  }),
+  remove: vi.fn(async (store: string, key: string) => {
+    storeOf(store).delete(key);
+  }),
+}));
+vi.mock('../api', () => ({
+  publishPreKeys: vi.fn(),
+  preKeyCount: vi.fn(),
+  addOneTimeKeys: vi.fn(),
+  fetchPeerBundle: vi.fn(),
+}));
+
+import { ready } from './primitives';
+import {
+  x3dhInitiator,
+  x3dhResponder,
+  ratchetInitAlice,
+  ratchetInitBob,
+  saveSession,
+  loadSession,
+  type RatchetState,
+} from './ratchet';
+import { sealMessage, openMessage } from './message';
+import { generateIdentityMaterial, type SecretBundle } from './identity';
+import * as identity from './identity';
+import type { WirePacket, StagedOpen } from '../messaging';
+
+let bob: SecretBundle;
+let alice: RatchetState;
+
+vi.spyOn(identity, 'getIdentityKeys').mockImplementation(() => ({ ed: bob.ed, x: bob.x }));
+vi.spyOn(identity, 'getSignedPreKey').mockImplementation(() => ({
+  id: bob.signedPreKey.id,
+  keypair: bob.signedPreKey.keypair,
+}));
+vi.spyOn(identity, 'getOneTimePreKeyById').mockImplementation(
+  (id: string) => bob.oneTimePreKeys.find((p) => p.id === id)?.keypair ?? null,
+);
+
+import { openPacket, openPacketStaged, DeferFrame } from '../messaging';
+
+beforeAll(async () => {
+  await ready();
+});
+
+const CHAT = 'chat-with-alice';
+const body = (s: string) => ({ body: s, kind: 'text', timestamp: 1 });
+
+async function setupPersistedPair(): Promise<void> {
+  bob = generateIdentityMaterial(2);
+  const a: SecretBundle = generateIdentityMaterial(2);
+  const otk = bob.oneTimePreKeys[0];
+  const init = x3dhInitiator(a.x.privateKey, {
+    identityX: bob.x.publicKey,
+    signedPreKey: bob.signedPreKey.keypair.publicKey,
+    oneTimePreKey: otk.keypair.publicKey,
+  });
+  const bobSK = x3dhResponder({
+    identityXPriv: bob.x.privateKey,
+    signedPreKeyPriv: bob.signedPreKey.keypair.privateKey,
+    oneTimePreKeyPriv: otk.keypair.privateKey,
+    initiatorIdentityX: a.x.publicKey,
+    initiatorEphemeral: init.ephemeral.publicKey,
+  });
+  alice = ratchetInitAlice(init.sk, bob.signedPreKey.keypair.publicKey);
+  await saveSession(CHAT, ratchetInitBob(bobSK, bob.signedPreKey.keypair));
+}
+
+const N = (b: string): WirePacket => ({ v: 1, type: 'normal', msg: sealMessage(alice, body(b)) });
+
+/** What sw-drain does after a staged open: commit the staged rows. Here that's
+ *  just writes into the mock idb (atomicity itself is proven in idb.transact.test.ts). */
+async function commitStaged(staged: StagedOpen): Promise<void> {
+  const idb = await import('@/db/idb');
+  await idb.put('sessions', staged.sessionRow);
+  for (const w of staged.metaWrites) await idb.put('settings', { key: w.key, value: w.value });
+}
+
+beforeEach(() => {
+  for (const m of Object.values(stores)) m.clear();
+});
+
+describe('openPacketStaged: stages, never persists', () => {
+  it('decrypts (incl. the very first DH step) and leaves the persisted session untouched', async () => {
+    await setupPersistedPair();
+    const before = structuredClone(storeOf('sessions').get(CHAT));
+
+    const staged = await openPacketStaged(CHAT, N('hello')); // Bob's first receive = a DH step
+    expect(staged.payload.body).toBe('hello');
+    expect(staged.sessionRow.id).toBe(CHAT);
+    // Nothing persisted by the call itself:
+    expect(storeOf('sessions').get(CHAT)).toEqual(before);
+  });
+
+  it('first contact (no session) → DeferFrame, never a partial establish', async () => {
+    await setupPersistedPair();
+    const idb = await import('@/db/idb');
+    await idb.remove('sessions', CHAT);
+    await expect(openPacketStaged(CHAT, N('first'))).rejects.toBeInstanceOf(DeferFrame);
+    expect(await loadSession(CHAT)).toBeNull(); // still nothing persisted
+  });
+
+  it('forged ciphertext → DeferFrame(undecryptable), session untouched', async () => {
+    await setupPersistedPair();
+    const wire = N('real');
+    const forged = structuredClone(wire) as WirePacket & { msg: { env: { ct: string } } };
+    forged.msg.env.ct = forged.msg.env.ct.slice(0, -4) + 'AAAA'; // corrupt ciphertext||tag
+    const before = structuredClone(storeOf('sessions').get(CHAT));
+    await expect(openPacketStaged(CHAT, forged)).rejects.toBeInstanceOf(DeferFrame);
+    expect(storeOf('sessions').get(CHAT)).toEqual(before);
+    // The genuine packet still opens afterwards (nothing was consumed).
+    expect((await openPacketStaged(CHAT, wire)).payload.body).toBe('real');
+  });
+});
+
+describe('send-chain integrity across a staged, committed DH step', () => {
+  it('after commit, a seal on the RELOADED state still decrypts at the peer', async () => {
+    await setupPersistedPair();
+
+    // Alice → Bob: staged authoritative open TAKES a DH step (Bob's first receive
+    // mints a fresh DHs); the caller commits it.
+    const staged = await openPacketStaged(CHAT, N('takes a DH step'));
+    await commitStaged(staged);
+
+    // Bob now SEALS from the reloaded (committed) state — the exact write the old
+    // "SW never persists DH steps" rule protected. If the staged commit had
+    // clobbered/forked the send-state, Alice couldn't decrypt this.
+    const bobSession = (await loadSession(CHAT)) as RatchetState;
+    const reply = sealMessage(bobSession, body('reply after staged DH'));
+    await saveSession(CHAT, bobSession);
+    expect(openMessage(alice, reply).body).toBe('reply after staged DH');
+
+    // And the round-trip continues both ways.
+    const staged2 = await openPacketStaged(CHAT, N('second inbound'));
+    await commitStaged(staged2);
+    expect(staged2.payload.body).toBe('second inbound');
+  });
+
+  it('interleaved with the PAGE authoritative open: page open → staged open → page seal', async () => {
+    await setupPersistedPair();
+    // Page opens one authoritatively (persists), then the SW stages + commits the next,
+    // then the page seals — everything through the one persisted row, like real life
+    // under the session lock.
+    expect((await openPacket(CHAT, N('page-opened'))).body).toBe('page-opened');
+    const staged = await openPacketStaged(CHAT, N('sw-applied'));
+    await commitStaged(staged);
+    const s = (await loadSession(CHAT)) as RatchetState;
+    const out = sealMessage(s, body('page seal after sw commit'));
+    await saveSession(CHAT, s);
+    expect(openMessage(alice, out).body).toBe('page seal after sw commit');
+  });
+});
+
+describe('replay + out-of-order backlog', () => {
+  it('replaying an already-committed frame fails to open (key consumed)', async () => {
+    await setupPersistedPair();
+    const wire = N('once only');
+    const staged = await openPacketStaged(CHAT, wire);
+    await commitStaged(staged);
+    // The authoritative open consumed the message key; a replay must not decrypt.
+    await expect(openPacketStaged(CHAT, wire)).rejects.toBeInstanceOf(DeferFrame);
+  });
+
+  it('newest-first apply of a capped backlog: older frames still open via skipped keys', async () => {
+    await setupPersistedPair();
+    // 60 queued frames but the fetch is capped to the newest 50 (relay behavior):
+    // the SW applies 10..59 first; the page later opens 0..9.
+    const frames: WirePacket[] = [];
+    for (let i = 0; i < 60; i++) frames.push(N(`m${i}`));
+
+    for (let i = 10; i < 60; i++) {
+      const staged = await openPacketStaged(CHAT, frames[i]);
+      expect(staged.payload.body).toBe(`m${i}`);
+      await commitStaged(staged);
+    }
+    // The skipped-key cache (persisted with the staged advances) still reaches the
+    // 10 older frames, in any order.
+    for (const i of [3, 0, 9, 5, 1, 2, 4, 6, 8, 7]) {
+      expect((await openPacket(CHAT, frames[i])).body).toBe(`m${i}`);
+    }
+  });
+});

--- a/src/services/crypto/ratchet.ts
+++ b/src/services/crypto/ratchet.ts
@@ -268,7 +268,12 @@ function dhRatchet(state: RatchetState, headerDh: Uint8Array): void {
 
 /* ---- (de)serialization + persistence (sessions store, keyed by chatId) ---- */
 
-interface SerializedSession {
+// Exported (spec 1032): the SW's atomic per-frame commit writes the advanced session
+// row itself (via idb `transact`), so it needs the serialized record without this
+// module persisting it. The FORMAT is a cross-context contract — an old waiting SW
+// can run against a new page (registerType 'prompt') — so it must not change in the
+// same release as a feature that adds a second writer; version it if it ever does.
+export interface SerializedSession {
   id: string;
   dhsPub: string;
   dhsPriv: string;
@@ -314,6 +319,12 @@ function deserialize(j: SerializedSession): RatchetState {
     PN: j.pn,
     skipped,
   };
+}
+
+/** The sessions-store row for a state, WITHOUT persisting it — for callers that
+ *  commit the advance atomically with their other writes (spec 1032 SW drain). */
+export function sessionRecord(chatId: string, state: RatchetState): SerializedSession {
+  return serialize(chatId, state);
 }
 
 export async function loadSession(chatId: string): Promise<RatchetState | null> {

--- a/src/services/message-preview.ts
+++ b/src/services/message-preview.ts
@@ -1,0 +1,49 @@
+/**
+ * Chats-list preview derivation for a message — the text line and the icon
+ * category the list renders next to it. Pure and import-clean (no idb/DOM), so
+ * BOTH writers of chat rows produce identical previews: the page's authoritative
+ * receive (db/queries.ts) and the service worker's notification-time apply
+ * (sw-drain.ts, spec 1032). Extracted from queries.ts verbatim — behavior must
+ * not drift between the two.
+ */
+import type { Chat } from '@/db/types';
+import type { MessagePayload } from './crypto/message';
+
+const durLabel = (sec?: number) =>
+  sec ? ` (${Math.floor(sec / 60)}:${String(Math.round(sec % 60)).padStart(2, '0')})` : '';
+
+/** Chats-list preview text for a media message (label + duration). The chats
+ *  list pairs this with an Ionic icon derived from `previewKind`, so no emoji. */
+export function mediaPreview(kind: string, durationSec?: number, name?: string, videoNote?: boolean): string {
+  if (kind === 'voice') return `Voice message${durLabel(durationSec)}`;
+  if (kind === 'video') return videoNote ? `Video note${durLabel(durationSec)}` : 'Video';
+  if (kind === 'image') return 'Photo';
+  if (kind === 'audio') return name && name !== 'attachment' ? name : 'Audio';
+  if (kind === 'file') return `${name && name !== 'attachment' ? name : 'Document'}`;
+  return 'Attachment';
+}
+
+/** The icon category for the chats-list preview of a (possibly media) message. */
+export function previewKind(kind: string, albumName?: string, videoNote?: boolean): Chat['lastKind'] {
+  if (albumName) return 'album';
+  if (kind === 'video') return videoNote ? 'videonote' : 'video';
+  if (kind === 'image' || kind === 'voice' || kind === 'file' || kind === 'audio') return kind;
+  if (kind === 'location' || kind === 'poll' || kind === 'contact') return kind;
+  return 'text';
+}
+
+/** The chats-list preview line for an incoming payload — the exact expression the
+ *  page's receive path builds (queries.ts), shared so the SW writes the same line. */
+export function chatListPreview(payload: MessagePayload, kind: string, durationSec?: number): string {
+  return payload.albumName
+    ? payload.albumName
+    : kind === 'location'
+      ? payload.location?.label || 'Location'
+      : kind === 'poll'
+        ? payload.poll?.question || 'Poll'
+        : kind === 'contact'
+          ? payload.contact?.name || 'Contact'
+          : kind === 'audio'
+            ? payload.audio?.title || mediaPreview('audio', durationSec, payload.mediaRef?.name)
+            : payload.body || mediaPreview(kind, durationSec, undefined, payload.videoNote);
+}

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -30,7 +30,7 @@ import {
 } from './crypto/ratchet';
 import { sealMessage, openMessage, openMessagePreview, type MessagePayload, type WireMessage } from './crypto/message';
 import { sessionRecord, type SerializedSession } from './crypto/ratchet';
-import { withSessionLock } from './cross-lock';
+import { withSessionLock, LockTimeoutError } from './cross-lock';
 import {
   getIdentityKeys,
   getSignedPreKey,
@@ -280,6 +280,13 @@ export async function openPacket(chatId: string, raw: unknown): Promise<MessageP
  *
  * Throws if it can't decrypt/authenticate.
  */
+// How long a PREVIEW waits for the cross-context session lock before falling back
+// to a fully read-only decrypt. The preview is the SW's no-persist fallback path;
+// it must never park behind a lock a frozen page holds (security review F1) — a
+// hung preview inside sw.ts's straggler loop would block the notify chain for the
+// rest of the SW instance's life, silencing every later push.
+const PREVIEW_LOCK_TIMEOUT_MS = 3000;
+
 export async function previewPacket(chatId: string, raw: unknown): Promise<MessagePayload> {
   const packet = raw as WirePacket;
   if (!packet || (packet.type !== 'prekey' && packet.type !== 'normal')) {
@@ -287,9 +294,27 @@ export async function previewPacket(chatId: string, raw: unknown): Promise<Messa
   }
   // Serialize with the matching seals/opens AND with other background previews —
   // now that this path persists, two concurrent SW push handlers must not interleave
-  // a load→advance→save on the same session. See withSessionLock.
-  return withSessionLock(chatId, async () => {
-  let session = await loadSession(chatId);
+  // a load→advance→save on the same session. Bounded: if the lock can't be had
+  // promptly (a frozen page can hold it indefinitely), decrypt READ-ONLY instead —
+  // persisting nothing is always safe without the lock, and a rich notification
+  // still beats a generic one. (Read-only can't advance the persisted base, so a
+  // very long backlog may degrade to generic past MAX_SKIP — the pre-2015 behavior,
+  // only under lock contention.)
+  try {
+    return await withSessionLock(chatId, () => previewOpen(chatId, packet, true), {
+      timeoutMs: PREVIEW_LOCK_TIMEOUT_MS,
+    });
+  } catch (e) {
+    if (e instanceof LockTimeoutError) return previewOpen(chatId, packet, false);
+    throw e;
+  }
+}
+
+/** The preview decrypt body. `persistAdvance` is true only under the session lock;
+ *  without it this is PURE read-only (loads a fresh session copy, writes nothing),
+ *  which needs no serialization at all. */
+async function previewOpen(chatId: string, packet: WirePacket, persistAdvance: boolean): Promise<MessagePayload> {
+  const session = await loadSession(chatId);
   const hadExistingSession = !!session;
   if (!session) {
     // No session yet → this must be a first-contact prekey packet. Establish a
@@ -314,7 +339,8 @@ export async function previewPacket(chatId: string, raw: unknown): Promise<Messa
     // pre-1032). The AUTHORITATIVE persist-everything path is openPacketStaged below, which the SW
     // uses only when the cross-context lock is actually held (spec 1032). The DH-step frame still
     // decrypted in-memory for this preview; the page performs (and persists) that ratchet on drain.
-    if (!advancedDh) await saveSession(chatId, session);
+    // `persistAdvance` is false on the lock-timeout fallback: no lock held → no writes at all.
+    if (persistAdvance && !advancedDh) await saveSession(chatId, session);
     return payload;
   } catch (e) {
     // The established session couldn't open this. If it's a prekey packet the peer
@@ -328,7 +354,6 @@ export async function previewPacket(chatId: string, raw: unknown): Promise<Messa
   }
   // Deliberately NO session-meta writes: the send-preamble is cleared only by
   // openPacket (FR-004), never by a preview.
-  });
 }
 
 /* ---- authoritative SW receive (spec 1032) ---- */

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -29,7 +29,8 @@ import {
   type PreKeyBundlePub,
 } from './crypto/ratchet';
 import { sealMessage, openMessage, openMessagePreview, type MessagePayload, type WireMessage } from './crypto/message';
-import { KeyedMutex } from './keyed-mutex';
+import { sessionRecord, type SerializedSession } from './crypto/ratchet';
+import { withSessionLock } from './cross-lock';
 import {
   getIdentityKeys,
   getSignedPreKey,
@@ -67,11 +68,17 @@ interface SessionMeta {
  * so several seal/open calls for one chatId run at once. Each loads the same state, advances
  * independently, and the last saveSession wins — silently corrupting the ratchet, which only
  * surfaces messages later as "ciphertext cannot be decrypted". (Interleaved chat messages and
- * call signals on the same session hit the same race.) Running each chat's critical section
- * through this mutex forces them to take turns, in arrival order; out-of-order delivery is
- * still handled by the ratchet's own skipped-key mechanism. Same-process only, which is all we
- * need: the SW preview path is read-only and never persists. */
-const sessionMutex = new KeyedMutex();
+ * call signals on the same session hit the same race.)
+ *
+ * Since spec 1032 the critical sections run under withSessionLock (cross-lock.ts): the same
+ * in-context FIFO as before, PLUS the cross-context Web Lock 'ring:session:<chatId>'. That
+ * upgrade exists because the SW is no longer read-only — behind the sw.fullPersist flag it
+ * performs the full authoritative open (openPacketStaged below, incl. DH-ratchet steps) and
+ * persists the advance, so page and SW are two writers of the same session row and only a
+ * cross-context lock can keep them from interleaving. Where Web Locks don't exist the helper
+ * degrades to the in-context mutex — exactly the pre-1032 guarantee — and the SW drain gate
+ * keeps full-persist off. Out-of-order delivery is still handled by the ratchet's own
+ * skipped-key mechanism. */
 
 /* ---- session metadata (settings store; separate from the ratchet state) ---- */
 
@@ -113,8 +120,8 @@ export async function sealForChat(
 ): Promise<{ to: string; packet: WirePacket } | null> {
   if (isGroup) return null; // group messaging (sender keys) is not relay-wired yet
   // Serialize the whole load→advance→save (incl. first-use X3DH bootstrap) per chat so
-  // concurrent seals/opens can't corrupt the ratchet — see sessionMutex.
-  return sessionMutex.run(chatId, async () => {
+  // concurrent seals/opens — in THIS context and in the SW — can't corrupt the ratchet.
+  return withSessionLock(chatId, async () => {
   let session = await loadSession(chatId);
   let meta = await getSessionMeta(chatId);
 
@@ -193,8 +200,8 @@ export async function openPacket(chatId: string, raw: unknown): Promise<MessageP
   if (!packet || (packet.type !== 'prekey' && packet.type !== 'normal')) {
     throw new Error('malformed wire packet');
   }
-  // Serialize per chat with the matching seals — see sessionMutex.
-  return sessionMutex.run(chatId, async () => {
+  // Serialize per chat with the matching seals — see withSessionLock.
+  return withSessionLock(chatId, async () => {
   let session = await loadSession(chatId);
   const hadExistingSession = !!session;
   if (!session) {
@@ -239,6 +246,13 @@ export async function openPacket(chatId: string, raw: unknown): Promise<MessageP
 /**
  * Decrypt an incoming packet for PREVIEW ONLY (service-worker notifications).
  *
+ * Since spec 1032 this is the SW's FALLBACK path: with sw.fullPersist on (and Web
+ * Locks available, device unlockable, no live page claiming the drain) the SW runs
+ * the authoritative openPacketStaged below instead. The preview remains the whole
+ * story for: the flag off, PIN/passkey-locked devices, deferred frame types
+ * (first-contact, cards, reactions, controls), and any lock-timeout/failure
+ * degrade — so its conservative rules below still matter.
+ *
  * Unlike openPacket this never consumes one-time prekeys, never persists a newly
  * ESTABLISHED responder (X3DH) session, and never clears the initiator send-
  * preamble — first-contact/X3DH and the preamble stay strictly the page's job.
@@ -273,8 +287,8 @@ export async function previewPacket(chatId: string, raw: unknown): Promise<Messa
   }
   // Serialize with the matching seals/opens AND with other background previews —
   // now that this path persists, two concurrent SW push handlers must not interleave
-  // a load→advance→save on the same session. See sessionMutex.
-  return sessionMutex.run(chatId, async () => {
+  // a load→advance→save on the same session. See withSessionLock.
+  return withSessionLock(chatId, async () => {
   let session = await loadSession(chatId);
   const hadExistingSession = !!session;
   if (!session) {
@@ -292,12 +306,14 @@ export async function previewPacket(chatId: string, raw: unknown): Promise<Messa
     // the cache). A prekey re-init (the catch below) deliberately does NOT reach here.
     const { payload, advancedDh } = openMessagePreview(session, packet.msg);
     // Persist ONLY a same-receiving-chain advance (the base moves forward so a backlog previews in
-    // order and can pass a point live call/`qos` signalling already advanced). If this frame
-    // triggered a DH-ratchet step, do NOT persist: a DH ratchet mints a fresh SENDING keypair (DHs),
-    // and the SW persisting it would make the worker a competing writer of the send-state — the
-    // page↔SW last-write-wins race could then clobber the page's authoritative DHs and permanently
-    // break outbound to the peer (adversarial review). The DH-step frame still decrypted in-memory
-    // for this preview; the page authoritatively performs (and persists) that ratchet when it drains.
+    // order and can pass a point live call/`qos` signalling already advanced). A DH-ratchet step is
+    // still NOT persisted here: a DH ratchet mints a fresh SENDING keypair (DHs), i.e. send-state.
+    // The preview is the fallback that also runs where Web Locks are ABSENT (withSessionLock then
+    // only serializes within this context), and there a page↔SW last-write-wins race could clobber
+    // the page's authoritative DHs and permanently break outbound to the peer (adversarial review,
+    // pre-1032). The AUTHORITATIVE persist-everything path is openPacketStaged below, which the SW
+    // uses only when the cross-context lock is actually held (spec 1032). The DH-step frame still
+    // decrypted in-memory for this preview; the page performs (and persists) that ratchet on drain.
     if (!advancedDh) await saveSession(chatId, session);
     return payload;
   } catch (e) {
@@ -313,6 +329,76 @@ export async function previewPacket(chatId: string, raw: unknown): Promise<Messa
   // Deliberately NO session-meta writes: the send-preamble is cleared only by
   // openPacket (FR-004), never by a preview.
   });
+}
+
+/* ---- authoritative SW receive (spec 1032) ---- */
+
+/** Thrown by openPacketStaged for frames the SW must NOT apply authoritatively —
+ *  first contact (no session), a peer's prekey re-init, or an undecryptable frame.
+ *  The caller defers the frame (preview-only notification, no ack); the page's
+ *  drain remains their delivery vehicle. */
+export class DeferFrame extends Error {
+  constructor(public readonly why: 'no-session' | 'prekey-reinit' | 'undecryptable') {
+    super(`frame deferred to the page drain: ${why}`);
+    this.name = 'DeferFrame';
+  }
+}
+
+/** Everything openPacketStaged decrypted but did NOT persist. The caller commits
+ *  the rows in ONE idb transaction with the message row + chat update + ledger
+ *  mark, so an interruption leaves either the complete result or nothing. */
+export interface StagedOpen {
+  payload: MessagePayload;
+  /** The advanced session (incl. any DH-ratchet step) as a sessions-store row. */
+  sessionRow: SerializedSession;
+  /** Settings-store rows to commit alongside (the cleared send-preamble, if any). */
+  metaWrites: Array<{ key: string; value: unknown }>;
+}
+
+/**
+ * The service worker's AUTHORITATIVE open (spec 1032, sw.fullPersist): decrypts
+ * exactly like openPacket — full consuming open, DH-ratchet steps included — but
+ * persists NOTHING. It stages the advanced session + session-meta effects for the
+ * caller (sw-drain.ts) to commit atomically with the message row and the
+ * exactly-once ledger, so the ack that follows can never outrun a durable commit.
+ *
+ * This deliberately supersedes, for the locked path only, the old "the SW never
+ * persists DH steps" rule: the race that rule guarded against is gone when the
+ * caller holds the cross-context session lock. Hence the hard requirements:
+ *
+ *   - The caller MUST hold withSessionLock(chatId) across THIS CALL AND the
+ *     commit of sessionRow/metaWrites. Locks are non-reentrant, so this function
+ *     takes none itself; a gap between decrypt and commit would let a page seal
+ *     interleave and be clobbered by the stale staged row.
+ *   - First-contact X3DH and a peer's prekey re-init are NOT staged (DeferFrame):
+ *     consuming a one-time prekey and replacing a live ratchet stay the page's
+ *     authoritative jobs, exactly as in previewPacket.
+ */
+export async function openPacketStaged(chatId: string, raw: unknown): Promise<StagedOpen> {
+  const packet = raw as WirePacket;
+  if (!packet || (packet.type !== 'prekey' && packet.type !== 'normal')) {
+    throw new Error('malformed wire packet');
+  }
+  const session = await loadSession(chatId);
+  if (!session) throw new DeferFrame('no-session'); // first contact → page runs X3DH
+  let payload: MessagePayload;
+  try {
+    payload = openMessage(session, packet.msg); // consuming open; mutates `session`
+  } catch {
+    // An established session that can't open a PREKEY packet = the peer re-initiated
+    // (they deleted the chat and re-ran X3DH). Replacing the live ratchet is the
+    // page's call (see openPacket's catch); anything else is simply undecryptable
+    // here (e.g. we lost the session) and the page's rekey recovery handles it.
+    throw new DeferFrame(packet.type === 'prekey' ? 'prekey-reinit' : 'undecryptable');
+  }
+  const metaWrites: StagedOpen['metaWrites'] = [];
+  // Mirror openPacket: hearing from the peer confirms the session, so the initiator
+  // stops prepending the prekey preamble — staged into the same commit.
+  const meta = await getSessionMeta(chatId);
+  if (meta?.sendPreamble) {
+    metaWrites.push({ key: `smeta:${chatId}`, value: { ...meta, sendPreamble: false } });
+  }
+  return { payload, sessionRow: sessionRecord(chatId, session), metaWrites };
 }
 
 /* ---- own prekey publication ---- */

--- a/src/services/sw-drain.test.ts
+++ b/src/services/sw-drain.test.ts
@@ -1,0 +1,427 @@
+// Spec 1032 (T013/T014, extended by T019/T022) — the SW authoritative drain.
+// Same harness style as messaging-preview.test.ts: mock idb with in-memory Maps
+// (plus a transact fake honoring throw→nothing-lands), run the REAL X3DH + Double
+// Ratchet, stub navigator.locks and fetch. Covers:
+//   - the pure eligibility classifier over every payload type (FR-004)
+//   - apply = row + chat RMW + ledger + session in ONE commit, id queued for ack
+//   - replay of an applied frame = re-ack only (unread stays 1, single row)
+//   - transaction abort → no ledger mark, no ack id
+//   - media-by-reference persists pendingMedia without fetching bytes
+//   - the drain itself never acks (caller's job, strictly after commit+notify)
+//   - gate degrades: flag-off, no-locks, locked (nothing fetched when locked)
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+/* ---- in-memory idb with an abortable transact ---- */
+const stores: Record<string, Map<string, unknown>> = {};
+function storeOf(name: string): Map<string, unknown> {
+  return (stores[name] ??= new Map());
+}
+let failNextTransact = false;
+vi.mock('@/db/idb', () => ({
+  get: vi.fn(async (store: string, key: string) => storeOf(store).get(key)),
+  getAll: vi.fn(async (store: string) => [...storeOf(store).values()]),
+  put: vi.fn(async (store: string, value: { id?: string; key?: string }) => {
+    storeOf(store).set((value.id ?? value.key) as string, structuredClone(value));
+  }),
+  remove: vi.fn(async (store: string, key: string) => {
+    storeOf(store).delete(key);
+  }),
+  transact: vi.fn(async (_names: string[], fn: (tx: unknown) => Promise<void> | void) => {
+    if (failNextTransact) {
+      failNextTransact = false;
+      throw new Error('simulated quota/abort');
+    }
+    // Stage writes; apply only if fn completes (all-or-nothing, like the real helper).
+    const staged: Array<{ store: string; value?: { id?: string; key?: string }; del?: string }> = [];
+    const tx = {
+      get: async (store: string, key: string) => structuredClone(storeOf(store).get(key)),
+      put: (store: string, value: { id?: string; key?: string }) => staged.push({ store, value }),
+      delete: (store: string, key: string) => staged.push({ store, del: key }),
+    };
+    await fn(tx);
+    for (const w of staged) {
+      if (w.del !== undefined) storeOf(w.store).delete(w.del);
+      else storeOf(w.store).set((w.value!.id ?? w.value!.key) as string, structuredClone(w.value));
+    }
+  }),
+}));
+vi.mock('./api', () => ({
+  publishPreKeys: vi.fn(),
+  preKeyCount: vi.fn(),
+  addOneTimeKeys: vi.fn(),
+  fetchPeerBundle: vi.fn(),
+}));
+vi.mock('./posts', () => ({ openPostEngagement: vi.fn() }));
+vi.mock('./session', () => ({
+  readSessionToken: vi.fn(async () => 'test-token'),
+  readSessionUserId: vi.fn(async () => 'bob-self'),
+}));
+let hiddenSet: Set<string> | null = new Set<string>();
+vi.mock('./hidden-chats', () => ({
+  readHiddenSet: vi.fn(async () => hiddenSet ?? new Set<string>()),
+  readHiddenSetOrNull: vi.fn(async () => hiddenSet),
+}));
+
+import { ready } from './crypto/primitives';
+import {
+  x3dhInitiator,
+  x3dhResponder,
+  ratchetInitAlice,
+  ratchetInitBob,
+  saveSession,
+  type RatchetState,
+} from './crypto/ratchet';
+import { sealMessage, type MessagePayload } from './crypto/message';
+import { generateIdentityMaterial, type SecretBundle } from './crypto/identity';
+import * as identity from './crypto/identity';
+import type { WirePacket } from './messaging';
+import type { Chat, Contact, Message, Setting } from '@/db/types';
+
+let bob: SecretBundle;
+let alice: RatchetState;
+
+vi.spyOn(identity, 'getIdentityKeys').mockImplementation(() => ({ ed: bob.ed, x: bob.x }));
+vi.spyOn(identity, 'getSignedPreKey').mockImplementation(() => ({
+  id: bob.signedPreKey.id,
+  keypair: bob.signedPreKey.keypair,
+}));
+vi.spyOn(identity, 'getOneTimePreKeyById').mockImplementation(
+  (id: string) => bob.oneTimePreKeys.find((p) => p.id === id)?.keypair ?? null,
+);
+const unlockSpy = vi.spyOn(identity, 'attemptDeviceUnlock').mockResolvedValue(true);
+
+import { drainPersistPending, ackFrames, classifyPayload, directChatFor, SW_FULL_PERSIST_KEY } from './sw-drain';
+
+beforeAll(async () => {
+  await ready();
+});
+
+const CHAT = 'chat-with-alice';
+const PEER = 'alice';
+const pay = (over: Partial<MessagePayload> = {}): MessagePayload => ({
+  body: 'hi there',
+  kind: 'text',
+  timestamp: 1234,
+  ...over,
+});
+const N = (p: MessagePayload): WirePacket => ({ v: 1, type: 'normal', msg: sealMessage(alice, p) });
+
+/* ---- fetch stub: /relay/pending returns `queued`; /relay/ack records ids ---- */
+let queued: Array<{ t: string; id: string; from: string; ciphertext: unknown }> = [];
+let ackedIds: string[][] = [];
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async (url: string, init?: { body?: string }) => {
+    if (String(url).includes('/relay/pending')) {
+      return { ok: true, json: async () => ({ frames: queued }) } as Response;
+    }
+    if (String(url).includes('/relay/ack')) {
+      ackedIds.push((JSON.parse(init?.body ?? '{}') as { ids: string[] }).ids);
+      return { ok: true, status: 204, json: async () => ({}) } as Response;
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }),
+);
+
+/* ---- a locks fake: always-grant, unless `lockBlocked` matches the name (then it
+ *      waits for the caller's AbortSignal — the frozen-page-holds-the-lock case) ---- */
+let lockBlocked: ((name: string) => boolean) | null = null;
+const locksStub = () => ({
+  locks: {
+    request: async <T>(name: string, opts: { signal?: AbortSignal }, cb: () => Promise<T>): Promise<T> => {
+      if (lockBlocked?.(name)) {
+        await new Promise<never>((_, reject) => {
+          if (opts.signal?.aborted) reject(new DOMException('aborted', 'AbortError'));
+          opts.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        });
+      }
+      return cb();
+    },
+  },
+});
+vi.stubGlobal('navigator', locksStub());
+
+async function setupWorld(): Promise<void> {
+  for (const m of Object.values(stores)) m.clear();
+  queued = [];
+  ackedIds = [];
+  hiddenSet = new Set<string>();
+  lockBlocked = null;
+  unlockSpy.mockResolvedValue(true);
+
+  bob = generateIdentityMaterial(2);
+  const a: SecretBundle = generateIdentityMaterial(2);
+  const otk = bob.oneTimePreKeys[0];
+  const init = x3dhInitiator(a.x.privateKey, {
+    identityX: bob.x.publicKey,
+    signedPreKey: bob.signedPreKey.keypair.publicKey,
+    oneTimePreKey: otk.keypair.publicKey,
+  });
+  const bobSK = x3dhResponder({
+    identityXPriv: bob.x.privateKey,
+    signedPreKeyPriv: bob.signedPreKey.keypair.privateKey,
+    oneTimePreKeyPriv: otk.keypair.privateKey,
+    initiatorIdentityX: a.x.publicKey,
+    initiatorEphemeral: init.ephemeral.publicKey,
+  });
+  alice = ratchetInitAlice(init.sk, bob.signedPreKey.keypair.publicKey);
+  await saveSession(CHAT, ratchetInitBob(bobSK, bob.signedPreKey.keypair));
+
+  storeOf('contacts').set(PEER, { id: PEER, name: 'Alice Smith', avatar: '', phone: '', about: '' } as Contact);
+  storeOf('chats').set(CHAT, {
+    id: CHAT,
+    name: 'Alice Smith',
+    avatar: '',
+    isGroup: false,
+    participantIds: [PEER],
+    lastMessage: '',
+    lastMessageTime: 0,
+    unread: 0,
+    updatedAt: 0,
+  } as Chat);
+  storeOf('settings').set(SW_FULL_PERSIST_KEY, { key: SW_FULL_PERSIST_KEY, value: true });
+  storeOf('settings').set('connectedPeers', { key: 'connectedPeers', value: { [PEER]: true } });
+}
+
+const chatRow = (): Chat => storeOf('chats').get(CHAT) as Chat;
+const msgRows = (): Message[] => [...storeOf('messages').values()] as Message[];
+const ledger = (): string[] =>
+  ((storeOf('settings').get('inboundSeenIds') as Setting<string[]> | undefined)?.value ?? []) as string[];
+
+beforeEach(async () => {
+  await setupWorld();
+});
+
+describe('classifyPayload: the FR-004 eligibility table (pure)', () => {
+  const groupChat: Chat = { id: 'g1', isGroup: true, participantIds: [PEER, 'carol'] } as Chat;
+  const table: Array<[string, Partial<MessagePayload>, 'eligible' | 'defer']> = [
+    ['plain text', {}, 'eligible'],
+    ['media by reference', { kind: 'image', mediaRef: { blobId: 'b', fileKey: 'k', mime: 'image/png', size: 9, name: 'p.png' } }, 'eligible'],
+    ['group message into an existing group', { groupId: 'g1' }, 'eligible'],
+    ['group message into an UNKNOWN group', { groupId: 'nope' }, 'defer'],
+    ['contact card', { card: { t: 'request', name: 'A', avatar: '' } }, 'defer'],
+    ['group card', { group: { t: 'invite', groupId: 'g', name: 'G', members: [], at: 1 } }, 'defer'],
+    ['reaction', { reaction: { messageId: 'm', emoji: '👍', at: 1 } }, 'defer'],
+    ['poll vote', { pollVote: { messageId: 'm', option: 0, at: 1 } }, 'defer'],
+    ['edit', { edit: { messageId: 'm', body: 'x', at: 1 } }, 'defer'],
+    ['erase', { erase: { messageId: 'm', at: 1 } }, 'defer'],
+    ['link-preview attach', { linkPreviewSig: { messageId: 'm', preview: { url: 'u', domain: 'd' }, at: 1 } }, 'defer'],
+    ['call signal', { call: { callId: 'c', type: 'offer' } }, 'defer'],
+    ['rekey control', { rekey: true }, 'defer'],
+    ['ttl control', { ttl: 60_000 }, 'defer'],
+    ['ttl-off control (ttl: null)', { ttl: null }, 'defer'],
+  ];
+  for (const [name, over, want] of table) {
+    it(`${name} → ${want}`, () => {
+      expect(classifyPayload(pay(over), [groupChat]).verdict).toBe(want);
+    });
+  }
+
+  it('directChatFor: unknown sender has no chat → null (defer); prefers the visible 1:1', () => {
+    const visible = { id: 'v', isGroup: false, participantIds: [PEER] } as Chat;
+    const pending = { id: 'p', isGroup: false, participantIds: [PEER], pending: true } as Chat;
+    expect(directChatFor([pending, visible], PEER)?.id).toBe('v');
+    expect(directChatFor([visible], 'stranger')).toBeNull();
+  });
+});
+
+describe('drain: atomic apply + exactly-once + ack discipline (T014)', () => {
+  it('applies a plain message: row + unread + lastMessage + ledger in the store, id queued for ack', async () => {
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
+    const r = await drainPersistPending();
+    expect(r.mode).toBe('applied');
+    expect(r.applied).toBe(1);
+    expect(r.ackIds).toEqual(['m1']);
+    expect(r.deferred).toBe(0);
+
+    const rows = msgRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].body).toBe('hi there');
+    expect(rows[0].id).toBe('m1');
+    expect(rows[0].status).toBe('delivered');
+    expect(chatRow().unread).toBe(1);
+    expect(chatRow().lastMessage).toBe('hi there');
+    expect(chatRow().lastMessageTime).toBe(1234);
+    expect(ledger()).toContain('m1');
+    // The drain itself never acks — the caller does, after notifications.
+    expect(ackedIds).toEqual([]);
+    // The advanced session was committed (a second message still opens).
+  });
+
+  it('a burst applies in order and counts unread per frame', async () => {
+    queued = [
+      { t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay({ body: 'one' })) },
+      { t: 'msg', id: 'm2', from: PEER, ciphertext: N(pay({ body: 'two' })) },
+    ];
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(2);
+    expect(chatRow().unread).toBe(2);
+    expect(chatRow().lastMessage).toBe('two');
+    expect(msgRows().map((m) => m.body).sort()).toEqual(['one', 'two']);
+  });
+
+  it('replay of an applied frame = re-ack only: no duplicate row, unread stays 1', async () => {
+    const wire = N(pay());
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: wire }];
+    await drainPersistPending();
+    expect(chatRow().unread).toBe(1);
+    // Same frame redelivered (e.g. we were killed before the ack landed):
+    const r2 = await drainPersistPending();
+    expect(r2.applied).toBe(0);
+    expect(r2.ackIds).toEqual(['m1']); // bare re-ack
+    expect(msgRows().length).toBe(1);
+    expect(chatRow().unread).toBe(1);
+  });
+
+  it('transaction abort → no row, no ledger mark, NO ack id (frame stays queued)', async () => {
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
+    failNextTransact = true;
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(0);
+    expect(r.deferred).toBe(1);
+    expect(r.ackIds).toEqual([]);
+    expect(msgRows().length).toBe(0);
+    expect(ledger()).toEqual([]);
+    expect(chatRow().unread).toBe(0);
+  });
+
+  it('media-by-reference: pendingMedia persisted, bytes NEVER fetched', async () => {
+    const mediaRef = { blobId: 'blob-9', fileKey: 'k', mime: 'image/jpeg', size: 1000, name: 'p.jpg', width: 10, height: 10 };
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay({ body: '', kind: 'image', mediaRef })) }];
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(1);
+    const m = msgRows()[0];
+    expect(m.pendingMedia?.blobId).toBe('blob-9');
+    expect(m.mediaId).toBeUndefined();
+    expect(chatRow().lastMessage).toBe('Photo');
+    expect(chatRow().lastKind).toBe('image');
+    const calls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(calls.some((u) => u.includes('/blob'))).toBe(false);
+  });
+
+  it('deferred frame types are NOT applied and NOT acked (stranger / reaction)', async () => {
+    queued = [
+      { t: 'msg', id: 's1', from: 'stranger', ciphertext: N(pay()) },
+      { t: 'msg', id: 'r1', from: PEER, ciphertext: N(pay({ reaction: { messageId: 'x', emoji: '❤️', at: 1 } })) },
+    ];
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(0);
+    expect(r.deferred).toBe(2);
+    expect(r.ackIds).toEqual([]);
+    expect(msgRows().length).toBe(0);
+    expect(chatRow().unread).toBe(0);
+    // The deferred reaction's staged decrypt was discarded — a later drain of a
+    // subsequent plain message must still work (session on disk untouched by it).
+    queued = [{ t: 'msg', id: 'm2', from: PEER, ciphertext: N(pay({ body: 'after' })) }];
+    const r2 = await drainPersistPending();
+    expect(r2.applied).toBe(1);
+  });
+
+  it('ackFrames posts exactly the committed ids to /relay/ack', async () => {
+    expect(await ackFrames(['a', 'b'])).toBe(true);
+    expect(ackedIds).toEqual([['a', 'b']]);
+    expect(await ackFrames([])).toBe(true); // no-op, no request
+    expect(ackedIds.length).toBe(1);
+  });
+});
+
+describe('drain: gate degrades (T019/T022 core)', () => {
+  it('flag off (default) → degrade flag-off, nothing touched', async () => {
+    storeOf('settings').delete(SW_FULL_PERSIST_KEY);
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
+    const r = await drainPersistPending();
+    expect(r).toMatchObject({ mode: 'degrade', reason: 'flag-off', applied: 0, ackIds: [] });
+    expect(msgRows().length).toBe(0);
+  });
+
+  it('no Web Locks → degrade no-locks', async () => {
+    vi.stubGlobal('navigator', {});
+    const r = await drainPersistPending();
+    expect(r).toMatchObject({ mode: 'degrade', reason: 'no-locks' });
+    vi.stubGlobal('navigator', locksStub());
+  });
+
+  it('locked device → degrade locked BEFORE any fetch/decrypt/write (FR-006)', async () => {
+    unlockSpy.mockResolvedValue(false);
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
+    const before = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length;
+    const r = await drainPersistPending();
+    expect(r).toMatchObject({ mode: 'degrade', reason: 'locked', applied: 0, ackIds: [] });
+    expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(before); // no fetch at all
+    expect(msgRows().length).toBe(0);
+    expect(ledger()).toEqual([]);
+  });
+
+  it('empty queue → degrade no-frames (caller runs the preview path / nothing-new logic)', async () => {
+    queued = [];
+    const r = await drainPersistPending();
+    expect(r).toMatchObject({ mode: 'degrade', reason: 'no-frames' });
+  });
+
+  it('hidden set unreadable → degrade hidden-unknown (fail closed, like the page)', async () => {
+    hiddenSet = null;
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
+    const r = await drainPersistPending();
+    expect(r).toMatchObject({ mode: 'degrade', reason: 'hidden-unknown', applied: 0 });
+    expect(msgRows().length).toBe(0);
+  });
+});
+
+describe('privacy posture parity (T019): applied frames use the SAME note rules as the preview', () => {
+  it('a hidden chat is APPLIED (content lands silently) but its note is generic', async () => {
+    hiddenSet = new Set([CHAT]);
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay({ body: 'secret hello' })) }];
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(1); // spec 1027 routing: the hidden 1:1 still receives content
+    expect(msgRows()[0].body).toBe('secret hello');
+    // ...but the notification is the spec-1019 content-free shape: no sender, no body.
+    expect(r.notes.length).toBe(1);
+    expect(r.notes[0].title).toBe('Ring');
+    expect(r.notes[0].body).toBe('New message');
+    expect(r.notes[0].url).toBe('/tabs/chats'); // never deep-links the hidden chat
+  });
+
+  it('a muted chat is applied with NO note (badge-only), never a content leak', async () => {
+    const c = chatRow();
+    c.mutedUntil = Date.now() + 60_000;
+    storeOf('chats').set(CHAT, c);
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay({ body: 'muted content' })) }];
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(1);
+    expect(chatRow().unread).toBe(1); // stored + counted...
+    expect(r.notes.length).toBe(0); // ...but silent, exactly like the preview path
+  });
+});
+
+describe('degrade ladder (T022): lock timeout + per-frame failures', () => {
+  it('a held inbound lock times out → wake degrades, remaining frames deferred, nothing acked', { timeout: 15_000 }, async () => {
+    lockBlocked = (name) => name === 'ring:inbound'; // a frozen page holds it
+    queued = [
+      { t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay({ body: 'one' })) },
+      { t: 'msg', id: 'm2', from: PEER, ciphertext: N(pay({ body: 'two' })) },
+    ];
+    const r = await drainPersistPending();
+    expect(r.mode).toBe('applied');
+    expect(r.reason).toBe('lock-timeout');
+    expect(r.applied).toBe(0);
+    expect(r.deferred).toBe(2);
+    expect(r.ackIds).toEqual([]);
+    expect(msgRows().length).toBe(0);
+    expect(ledger()).toEqual([]);
+  });
+
+  it('one undecryptable frame defers WITHOUT stopping the rest of the wake', async () => {
+    const good = N(pay({ body: 'fine' }));
+    const forged = structuredClone(N(pay({ body: 'broken' }))) as WirePacket & { msg: { env: { ct: string } } };
+    forged.msg.env.ct = forged.msg.env.ct.slice(0, -4) + 'AAAA';
+    queued = [
+      { t: 'msg', id: 'bad1', from: PEER, ciphertext: forged },
+      { t: 'msg', id: 'ok1', from: PEER, ciphertext: good },
+    ];
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(1);
+    expect(r.deferred).toBe(1);
+    expect(r.ackIds).toEqual(['ok1']);
+    expect(msgRows().map((m) => m.body)).toEqual(['fine']);
+  });
+});

--- a/src/services/sw-drain.test.ts
+++ b/src/services/sw-drain.test.ts
@@ -218,10 +218,22 @@ describe('classifyPayload: the FR-004 eligibility table (pure)', () => {
   }
 
   it('directChatFor: unknown sender has no chat → null (defer); prefers the visible 1:1', () => {
+    const none = new Set<string>();
     const visible = { id: 'v', isGroup: false, participantIds: [PEER] } as Chat;
     const pending = { id: 'p', isGroup: false, participantIds: [PEER], pending: true } as Chat;
-    expect(directChatFor([pending, visible], PEER)?.id).toBe('v');
-    expect(directChatFor([visible], 'stranger')).toBeNull();
+    expect(directChatFor([pending, visible], none, PEER)?.id).toBe('v');
+    expect(directChatFor([visible], none, 'stranger')).toBeNull();
+  });
+
+  it('directChatFor: routes like the page (F3) — visible PENDING beats hidden non-pending', () => {
+    // The exact split-conversation hazard: a pending visible 1:1 plus a non-pending
+    // hidden 1:1. The page routes to the visible one; the SW must match, or it
+    // commits + acks into the PIN-locked hidden chat and the page never sees it.
+    const visiblePending = { id: 'vp', isGroup: false, participantIds: [PEER], pending: true } as Chat;
+    const hiddenChat = { id: 'h', isGroup: false, participantIds: [PEER] } as Chat;
+    expect(directChatFor([hiddenChat, visiblePending], new Set(['h']), PEER)?.id).toBe('vp');
+    // Only a hidden chat exists → content still lands there (spec 1027 rule R).
+    expect(directChatFor([hiddenChat], new Set(['h']), PEER)?.id).toBe('h');
   });
 });
 
@@ -409,6 +421,50 @@ describe('degrade ladder (T022): lock timeout + per-frame failures', () => {
     expect(msgRows().length).toBe(0);
     expect(ledger()).toEqual([]);
   });
+
+  it('F7: applied 1:1 content un-pends a pending chat (mirrors the page path)', async () => {
+    const c = chatRow();
+    c.pending = true;
+    storeOf('chats').set(CHAT, c);
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(1);
+    expect(chatRow().pending).toBeUndefined();
+  });
+
+  it('F4: a committed-but-never-shown frame re-acks WITH a rebuilt notification', async () => {
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay({ body: 'nearly lost' })) }];
+    // Wake 1 commits (row + ledger); the SW dies before showNotes/markShown/ack —
+    // i.e. nothing lands in swNotifiedIds. Simulated by just... not marking shown.
+    await drainPersistPending();
+    // Wake 2: redelivery. The frame is in the seen ledger → ack-only, but the note
+    // must be REBUILT from the stored row (never a silent consume).
+    const r2 = await drainPersistPending();
+    expect(r2.applied).toBe(0);
+    expect(r2.ackIds).toEqual(['m1']);
+    expect(r2.notes.length).toBe(1);
+    expect(r2.notes[0].body).toBe('nearly lost');
+    // Once shown (markShown ran), a further redelivery is a bare, silent re-ack.
+    storeOf('settings').set('swNotifiedIds', { key: 'swNotifiedIds', value: [{ id: 'm1', ts: Date.now() }] });
+    const r3 = await drainPersistPending();
+    expect(r3.ackIds).toEqual(['m1']);
+    expect(r3.notes.length).toBe(0);
+  });
+
+  it('F1: previewPacket under a held session lock falls back to a READ-ONLY decrypt', async () => {
+    const { previewPacket } = await import('./messaging');
+    const wire = N(pay({ body: 'previewed under contention' }));
+    lockBlocked = (name) => name.startsWith('ring:session:');
+    const before = structuredClone(storeOf('sessions').get(CHAT));
+    const p = await previewPacket(CHAT, wire);
+    expect(p.body).toBe('previewed under contention');
+    // No lock → no writes: the persisted session is byte-identical.
+    expect(storeOf('sessions').get(CHAT)).toEqual(before);
+    lockBlocked = null;
+    // The page's later authoritative open still decrypts the same frame.
+    const { openPacket } = await import('./messaging');
+    expect((await openPacket(CHAT, wire)).body).toBe('previewed under contention');
+  }, 15_000);
 
   it('one undecryptable frame defers WITHOUT stopping the rest of the wake', async () => {
     const good = N(pay({ body: 'fine' }));

--- a/src/services/sw-drain.ts
+++ b/src/services/sw-drain.ts
@@ -1,0 +1,369 @@
+/**
+ * Service-worker AUTHORITATIVE receive (spec 1032, behind `sw.fullPersist`).
+ *
+ * Where sw-inbox.ts previews the queued E2EE frames read-only, this module — when
+ * the gate below passes — applies eligible ones for real at notification time:
+ * decrypt under the cross-context locks, commit the message row + chat summary +
+ * advanced ratchet session + exactly-once ledger mark in ONE IndexedDB
+ * transaction, and (the caller, after showing notifications) ack the frames so
+ * the app opens warm. Everything it does NOT handle keeps today's preview-only
+ * behavior and drains over the page's WebSocket on next open.
+ *
+ * Eligibility (v1, spec FR-004): plain messages — text, or media-by-reference
+ * stored as `pendingMedia` for the page to download — in an EXISTING chat from an
+ * EXISTING connected contact, including group messages into an existing group.
+ * First-contact X3DH, contact/group cards, reactions, edits, erases, poll votes,
+ * link-preview attaches, call signals, rekey/TTL controls: deferred.
+ *
+ * Degrade-to-today is the spine (spec FR-008): flag off, no Web Locks, locked
+ * device, fetch failure, lock timeout (a frozen page can hold a lock), transaction
+ * failure — every path returns a degrade/defer that leaves the frame queued and
+ * the caller on the preview path. An ack is only ever sent for a frame whose
+ * commit completed (in this wake or a previous one).
+ *
+ * Import-clean for the SW like sw-inbox.ts: idb, crypto/messaging, cross-lock,
+ * sw-inbox helpers, notify-preview, types. No DOM / Ionic / page-only modules.
+ */
+import { attemptDeviceUnlock } from './crypto/identity';
+import { openPacketStaged, DeferFrame, type StagedOpen } from './messaging';
+import { withInboundLock, withSessionLock, locksAvailable, LockTimeoutError } from './cross-lock';
+import { readSessionToken, readSessionUserId } from './session';
+import { readHiddenSetOrNull } from './hidden-chats';
+import { fetchPendingFrames, noteForPayload, aggregate, setting, type MsgFrame, type SwNote } from './sw-inbox';
+import { chatListPreview, previewKind } from './message-preview';
+import { transact } from '@/db/idb';
+import { getAll } from '@/db/idb';
+import type { Chat, Contact, Message, Setting } from '@/db/types';
+import type { MessagePayload } from './crypto/message';
+
+const API = `${import.meta.env.VITE_API_URL ?? ''}/v1`;
+
+/** Internal rollout flag (spec 1032 FR-011). Device-local, default off, NOT in the
+ *  Settings UI — set via dev tooling (`__ringTest.setSetting`) during the soak,
+ *  flipped default-on in a later release, then removed. */
+export const SW_FULL_PERSIST_KEY = 'sw.fullPersist';
+
+// How long the SW waits for a cross-context lock before degrading that frame (and
+// the rest of the wake) to preview-only. A frozen-but-alive page can hold a lock
+// indefinitely; the push handler must not burn its waitUntil budget waiting.
+const LOCK_TIMEOUT_MS = 3000;
+
+// The exactly-once ledger SHARED with the page path (db/queries.ts
+// wasInboundSeen/markInboundSeen — same key, same cap). The SW marks a frame
+// inside its atomic commit; the page skips marked frames and just re-acks.
+const INBOUND_SEEN_KEY = 'inboundSeenIds';
+const INBOUND_SEEN_CAP = 2000;
+
+export type DegradeReason =
+  | 'flag-off'
+  | 'no-locks'
+  | 'no-token'
+  | 'locked'
+  | 'hidden-unknown'
+  | 'relay-error'
+  | 'no-frames';
+
+export interface DrainResult {
+  /** 'applied' = the drain ran (even if some frames deferred); 'degrade' = the
+   *  caller must run today's preview path instead. */
+  mode: 'applied' | 'degrade';
+  reason?: DegradeReason | 'lock-timeout';
+  /** Frames committed in THIS wake. */
+  applied: number;
+  /** Frame ids safe to ack: committed now, or found already-committed (re-ack). */
+  ackIds: string[];
+  /** msg frames left queued for the page (ineligible / failed / lock-timeout). */
+  deferred: number;
+  /** Notifications for the APPLIED frames (existing privacy rules), aggregated. */
+  notes: SwNote[];
+}
+
+interface ApplyCtx {
+  chats: Chat[];
+  contacts: Contact[];
+  connected: Record<string, boolean>;
+  blocked: Record<string, boolean>;
+  hidden: Set<string>;
+  selfId: string;
+  showMessages: boolean;
+  showPreview: boolean;
+  keepArchived: boolean;
+}
+
+/** The plain-1:1 session chat for a peer, mirroring the page's routeInboundFrom
+ *  preference order: the visible plain 1:1 first, else the hidden one. Returns
+ *  null when no chat row exists — which also covers the hidden-chat reset block
+ *  (the reset destroyed the row), so those frames defer to the page. */
+export function directChatFor(chats: Chat[], from: string): Chat | null {
+  const mine = chats.filter((c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === from);
+  return mine.find((c) => !c.pending) ?? mine[0] ?? null;
+}
+
+/** Pure eligibility classifier over a DECRYPTED payload (spec FR-004). Anything
+ *  that is not a plain displayable message defers to the page — those frames are
+ *  side effects (cards, reactions, controls) whose handlers live page-side. */
+export function classifyPayload(
+  payload: MessagePayload,
+  chats: Chat[],
+): { verdict: 'eligible'; targetChatId: string | null } | { verdict: 'defer'; why: string } {
+  if (payload.card) return { verdict: 'defer', why: 'card' };
+  if (payload.group) return { verdict: 'defer', why: 'group-card' };
+  if (payload.reaction) return { verdict: 'defer', why: 'reaction' };
+  if (payload.pollVote) return { verdict: 'defer', why: 'poll-vote' };
+  if (payload.edit) return { verdict: 'defer', why: 'edit' };
+  if (payload.erase) return { verdict: 'defer', why: 'erase' };
+  if (payload.linkPreviewSig) return { verdict: 'defer', why: 'link-preview' };
+  if (payload.call) return { verdict: 'defer', why: 'call-signal' };
+  if (payload.rekey) return { verdict: 'defer', why: 'rekey' };
+  if (payload.ttl !== undefined) return { verdict: 'defer', why: 'ttl-control' };
+  if (payload.groupId) {
+    const g = chats.find((c) => c.id === payload.groupId && c.isGroup);
+    if (!g) return { verdict: 'defer', why: 'unknown-group' };
+    return { verdict: 'eligible', targetChatId: g.id };
+  }
+  return { verdict: 'eligible', targetChatId: null }; // null = the 1:1 session chat
+}
+
+type ApplyOutcome = { kind: 'applied'; note: SwNote | null } | { kind: 'ack-only' } | { kind: 'defer'; why: string };
+
+/** Apply ONE frame under the session lock: staged decrypt → classify → atomic
+ *  commit. Caller holds `ring:inbound`. Never acks — it only reports. */
+async function applyOne(f: MsgFrame, ctx: ApplyCtx): Promise<ApplyOutcome> {
+  const id = f.id as string;
+  const from = f.from as string;
+
+  // Exactly-once (shared ledger): already committed by us or the page → just re-ack.
+  const seenNow = await setting<string[]>(INBOUND_SEEN_KEY, []);
+  if (seenNow.includes(id)) return { kind: 'ack-only' };
+
+  if (ctx.blocked[from]) return { kind: 'defer', why: 'blocked' }; // page drops + acks on open
+  const contact = ctx.contacts.find((c) => c.id === from);
+  if (!contact || !ctx.connected[from]) return { kind: 'defer', why: 'not-connected' };
+  const direct = directChatFor(ctx.chats, from);
+  if (!direct) return { kind: 'defer', why: 'no-chat' };
+
+  // The session lock spans decrypt AND commit: openPacketStaged persists nothing,
+  // so a gap here would let a page seal interleave and be clobbered by our commit.
+  return withSessionLock(
+    direct.id,
+    async () => {
+      let staged: StagedOpen;
+      try {
+        staged = await openPacketStaged(direct.id, f.ciphertext);
+      } catch (e) {
+        if (e instanceof DeferFrame) return { kind: 'defer' as const, why: e.why };
+        throw e;
+      }
+      const payload = staged.payload;
+      const cls = classifyPayload(payload, ctx.chats);
+      if (cls.verdict === 'defer') return { kind: 'defer' as const, why: cls.why };
+      const targetChatId = cls.targetChatId ?? direct.id;
+
+      const ts = payload.timestamp || Date.now();
+      const kind = (payload.kind as Message['kind']) || 'text';
+      const isGroupMsg = !!payload.groupId;
+      // Media bytes are NEVER downloaded in the SW (no canvas pipeline, tight
+      // budget): store the reference as pendingMedia; the page backfills via
+      // resumePendingMediaJobs on reconnect.
+      const message: Message = {
+        id, // the sender's message id: receipts correlate + redelivery dedupes
+        chatId: targetChatId,
+        senderId: from,
+        senderName: contact.name,
+        body: payload.body,
+        kind,
+        durationSec: payload.mediaRef?.durationSec,
+        timestamp: ts,
+        outgoing: false,
+        status: 'delivered',
+        replyTo: payload.reply,
+        albumId: payload.albumId,
+        albumName: payload.albumName,
+        videoNote: payload.videoNote,
+        location: payload.location,
+        poll: payload.poll,
+        contact: payload.contact,
+        audio: payload.audio,
+        linkPreview: payload.linkPreview,
+        mentions: payload.mentions,
+        mentionsEveryone: payload.mentionsEveryone,
+        expiresAt: payload.expiresAt,
+        mediaWidth: payload.mediaRef?.width,
+        mediaHeight: payload.mediaRef?.height,
+        mediaSize: payload.mediaRef?.size,
+        mediaQuality: payload.mediaRef?.quality as Message['mediaQuality'],
+        posterData: payload.mediaRef?.poster,
+        pendingMedia: payload.mediaRef,
+        updatedAt: Date.now(),
+      };
+
+      // ONE transaction: session advance + message row + chat RMW + ledger mark.
+      // All-or-nothing (see idb transact): a kill/quota error leaves the frame
+      // queued and unmarked → clean redelivery; committed-but-unacked → the ledger
+      // turns the redelivery into a bare re-ack. The chat row is re-read INSIDE the
+      // transaction (the pre-loaded ctx.chats is classification-only) so this RMW
+      // can't clobber a concurrent page write — the inbound lock already excludes
+      // the page's receive path, and same-store writes serialize in IDB.
+      await transact(['sessions', 'messages', 'chats', 'settings'], async (tx) => {
+        tx.put('sessions', staged.sessionRow);
+        for (const w of staged.metaWrites) tx.put('settings', { key: w.key, value: w.value });
+        tx.put('messages', message);
+        const chat = await tx.get<Chat>('chats', targetChatId);
+        if (chat) {
+          const preview = chatListPreview(payload, kind, payload.mediaRef?.durationSec);
+          chat.lastMessage = isGroupMsg ? `${contact.name.split(' ')[0]}: ${preview}` : preview;
+          chat.lastKind = previewKind(kind, payload.albumName, payload.videoNote);
+          chat.lastMessageTime = ts;
+          chat.interactions = (chat.interactions ?? 0) + 1;
+          // No isChatActive here: the gate already deferred to any live page that
+          // claimed the wake, so nobody is viewing this chat right now.
+          chat.unread = (chat.unread ?? 0) + 1;
+          const selfMentioned =
+            isGroupMsg &&
+            (!!payload.mentions?.includes(ctx.selfId) ||
+              (!!payload.mentionsEveryone && !!chat.createdBy && from === chat.createdBy));
+          if (selfMentioned) chat.unreadMentions = (chat.unreadMentions ?? 0) + 1;
+          if (chat.archived && !chat.locked && !ctx.keepArchived) {
+            delete chat.archived;
+          }
+          chat.updatedAt = Date.now();
+          tx.put('chats', chat);
+        }
+        const seen = (await tx.get<Setting<string[]>>('settings', INBOUND_SEEN_KEY))?.value ?? [];
+        if (!seen.includes(id)) {
+          tx.put('settings', { key: INBOUND_SEEN_KEY, value: [...seen, id].slice(-INBOUND_SEEN_CAP) });
+        }
+      });
+
+      // The notification for what we just committed — the exact same privacy rules
+      // as the preview path (mute / hidden / content prefs / mentions), so posture
+      // behavior is byte-identical (spec FR-006).
+      const { note } = noteForPayload(
+        f,
+        payload,
+        ctx.chats,
+        ctx.contacts,
+        ctx.showMessages,
+        ctx.showPreview,
+        ctx.hidden,
+        ctx.selfId,
+      );
+      return { kind: 'applied' as const, note };
+    },
+    { timeoutMs: LOCK_TIMEOUT_MS },
+  );
+}
+
+/**
+ * The drain: gate → fetch → per-frame apply under `ring:inbound` → result. Does
+ * NOT ack — the caller shows the notifications first (so a kill after commit
+ * can't lose the wake's alert), then calls ackFrames(result.ackIds) as the LAST
+ * step. Any degrade leaves the world exactly as today's preview path expects it.
+ */
+export async function drainPersistPending(): Promise<DrainResult> {
+  const degrade = (reason: DegradeReason): DrainResult => ({
+    mode: 'degrade',
+    reason,
+    applied: 0,
+    ackIds: [],
+    deferred: 0,
+    notes: [],
+  });
+
+  if (!(await setting<boolean>(SW_FULL_PERSIST_KEY, false))) return degrade('flag-off');
+  if (!locksAvailable()) return degrade('no-locks');
+  const token = await readSessionToken();
+  if (!token) return degrade('no-token');
+  // PIN/passkey posture (spec FR-006): no device key → no decrypt, no storage —
+  // BEFORE any fetch, so the wake is byte-identical to today's locked behavior
+  // (previewPending does its own fetch and shows the generic).
+  if (!(await attemptDeviceUnlock().catch(() => false))) return degrade('locked');
+
+  const fetched = await fetchPendingFrames(token);
+  if ('failure' in fetched) return degrade('relay-error');
+  const frames = fetched.frames.filter((f) => f.t === 'msg' && !!f.id && !!f.from);
+  if (!frames.length) return degrade('no-frames');
+
+  // Fail closed while the hidden-chat set can't be read (mirrors the page's
+  // routeInboundFrom defer): we can't route or classify safely without it.
+  const hidden = await readHiddenSetOrNull();
+  if (hidden === null) return degrade('hidden-unknown');
+
+  const [chats, contacts, selfId, showMessages, showPreview, connected, blocked, keepArchived] = await Promise.all([
+    getAll<Chat>('chats'),
+    getAll<Contact>('contacts'),
+    readSessionUserId(),
+    setting<boolean>('notifications.message.show', true),
+    setting<boolean>('notifications.showPreview', true),
+    setting<Record<string, boolean>>('connectedPeers', {}),
+    setting<Record<string, boolean>>('blockedPeers', {}),
+    setting<boolean>('chats.keepArchived', false),
+  ]);
+  const ctx: ApplyCtx = {
+    chats,
+    contacts,
+    connected,
+    blocked,
+    hidden,
+    selfId: selfId ?? '',
+    showMessages,
+    showPreview,
+    keepArchived,
+  };
+
+  const ackIds: string[] = [];
+  const rawNotes: SwNote[] = [];
+  let applied = 0;
+  let deferred = 0;
+  let reason: DrainResult['reason'];
+
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i];
+    try {
+      const out = await withInboundLock(() => applyOne(f, ctx), { timeoutMs: LOCK_TIMEOUT_MS });
+      if (out.kind === 'applied') {
+        applied += 1;
+        ackIds.push(f.id as string);
+        if (out.note) rawNotes.push(out.note);
+      } else if (out.kind === 'ack-only') {
+        ackIds.push(f.id as string);
+      } else {
+        deferred += 1;
+      }
+    } catch (e) {
+      if (e instanceof LockTimeoutError) {
+        // Someone (a frozen page?) holds a lock: stop fighting, defer the rest of
+        // the wake to the preview path — it needs no locks and the page drains later.
+        reason = 'lock-timeout';
+        deferred += frames.length - i;
+        break;
+      }
+      console.warn('[sw-drain] frame apply failed → deferred', e);
+      deferred += 1; // stays queued; today's behavior for this frame
+    }
+  }
+
+  return { mode: 'applied', reason, applied, ackIds, deferred, notes: aggregate(rawNotes) };
+}
+
+/** Ack committed frames (idempotent server-side): deletes them from the relay
+ *  queue and emits the durable delivered receipts, exactly like the page's WS
+ *  ack. STRICTLY after commit + notifications — the wake's last step. Returns
+ *  false on failure; the frames then linger (harmless: the ledger makes their
+ *  redelivery a bare re-ack). */
+export async function ackFrames(ids: string[]): Promise<boolean> {
+  if (!ids.length) return true;
+  const token = await readSessionToken();
+  if (!token) return false;
+  try {
+    const res = await fetch(`${API}/relay/ack`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids }),
+    });
+    return res.ok;
+  } catch (e) {
+    console.warn('[sw-drain] ack failed (frames linger; ledger dedupes)', e);
+    return false;
+  }
+}

--- a/src/services/sw-drain.ts
+++ b/src/services/sw-drain.ts
@@ -29,10 +29,10 @@ import { openPacketStaged, DeferFrame, type StagedOpen } from './messaging';
 import { withInboundLock, withSessionLock, locksAvailable, LockTimeoutError } from './cross-lock';
 import { readSessionToken, readSessionUserId } from './session';
 import { readHiddenSetOrNull } from './hidden-chats';
-import { fetchPendingFrames, noteForPayload, aggregate, setting, type MsgFrame, type SwNote } from './sw-inbox';
+import { resolveInboundDirectChat } from './hidden-pair';
+import { fetchPendingFrames, noteForPayload, aggregate, setting, loadShown, type MsgFrame, type SwNote } from './sw-inbox';
 import { chatListPreview, previewKind } from './message-preview';
-import { transact } from '@/db/idb';
-import { getAll } from '@/db/idb';
+import { transact, getAll, get } from '@/db/idb';
 import type { Chat, Contact, Message, Setting } from '@/db/types';
 import type { MessagePayload } from './crypto/message';
 
@@ -47,6 +47,9 @@ export const SW_FULL_PERSIST_KEY = 'sw.fullPersist';
 // the rest of the wake) to preview-only. A frozen-but-alive page can hold a lock
 // indefinitely; the push handler must not burn its waitUntil budget waiting.
 const LOCK_TIMEOUT_MS = 3000;
+
+// Bound on the /relay/ack POST, mirroring sw-inbox's PENDING_FETCH_TIMEOUT_MS.
+const ACK_TIMEOUT_MS = 8000;
 
 // The exactly-once ledger SHARED with the page path (db/queries.ts
 // wasInboundSeen/markInboundSeen — same key, same cap). The SW marks a frame
@@ -90,13 +93,15 @@ interface ApplyCtx {
   keepArchived: boolean;
 }
 
-/** The plain-1:1 session chat for a peer, mirroring the page's routeInboundFrom
- *  preference order: the visible plain 1:1 first, else the hidden one. Returns
- *  null when no chat row exists — which also covers the hidden-chat reset block
- *  (the reset destroyed the row), so those frames defer to the page. */
-export function directChatFor(chats: Chat[], from: string): Chat | null {
-  const mine = chats.filter((c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === from);
-  return mine.find((c) => !c.pending) ?? mine[0] ?? null;
+/** The plain-1:1 session chat for a peer: EXACTLY the page's rule-R resolver
+ *  (resolveInboundDirectChat — visible non-pending first, then visible pending,
+ *  then hidden), so both writers route a frame to the same chat (security review
+ *  F3: a pending-flag-only preference could commit into a hidden chat the page
+ *  would have routed visibly). Returns null when no chat row exists — which also
+ *  covers the hidden-chat reset block (the reset destroyed the row), so those
+ *  frames defer to the page. */
+export function directChatFor(chats: Chat[], hidden: ReadonlySet<string>, from: string): Chat | null {
+  return resolveInboundDirectChat(chats, hidden, from);
 }
 
 /** Pure eligibility classifier over a DECRYPTED payload (spec FR-004). Anything
@@ -124,7 +129,48 @@ export function classifyPayload(
   return { verdict: 'eligible', targetChatId: null }; // null = the 1:1 session chat
 }
 
-type ApplyOutcome = { kind: 'applied'; note: SwNote | null } | { kind: 'ack-only' } | { kind: 'defer'; why: string };
+type ApplyOutcome =
+  | { kind: 'applied'; note: SwNote | null }
+  | { kind: 'ack-only'; note: SwNote | null }
+  | { kind: 'defer'; why: string };
+
+/** Rebuild the notification for a frame that was COMMITTED in a previous wake but
+ *  never shown (SW killed between commit and showNotes — its id is in the seen
+ *  ledger but not the shown ledger). The message row is the durable source: map it
+ *  back to a payload shape and run the exact same noteForPayload privacy rules.
+ *  Returns null when the note was already shown, or the row can't be found (page
+ *  applied it — its own notify path ran). */
+async function noteFromCommittedFrame(id: string, ctx: ApplyCtx): Promise<SwNote | null> {
+  if ((await loadShown()).includes(id)) return null; // already alerted (normal re-ack)
+  const m = await get<Message>('messages', id);
+  if (!m || m.outgoing) return null;
+  const chat = ctx.chats.find((c) => c.id === m.chatId);
+  const payload: MessagePayload = {
+    body: m.body,
+    kind: m.kind,
+    timestamp: m.timestamp,
+    groupId: chat?.isGroup ? chat.id : undefined,
+    albumName: m.albumName,
+    videoNote: m.videoNote,
+    location: m.location,
+    poll: m.poll,
+    contact: m.contact,
+    audio: m.audio,
+    mentions: m.mentions,
+    mentionsEveryone: m.mentionsEveryone,
+  };
+  const { note } = noteForPayload(
+    { t: 'msg', id, from: m.senderId },
+    payload,
+    ctx.chats,
+    ctx.contacts,
+    ctx.showMessages,
+    ctx.showPreview,
+    ctx.hidden,
+    ctx.selfId,
+  );
+  return note;
+}
 
 /** Apply ONE frame under the session lock: staged decrypt → classify → atomic
  *  commit. Caller holds `ring:inbound`. Never acks — it only reports. */
@@ -132,14 +178,19 @@ async function applyOne(f: MsgFrame, ctx: ApplyCtx): Promise<ApplyOutcome> {
   const id = f.id as string;
   const from = f.from as string;
 
-  // Exactly-once (shared ledger): already committed by us or the page → just re-ack.
+  // Exactly-once (shared ledger): already committed by us or the page → re-ack.
+  // But NEVER silently (security review F4): if a prior wake committed this frame
+  // and was killed before its notification/ack, the redelivery is the only chance
+  // to alert — rebuild the note from the stored row unless it was already shown.
   const seenNow = await setting<string[]>(INBOUND_SEEN_KEY, []);
-  if (seenNow.includes(id)) return { kind: 'ack-only' };
+  if (seenNow.includes(id)) {
+    return { kind: 'ack-only', note: await noteFromCommittedFrame(id, ctx) };
+  }
 
   if (ctx.blocked[from]) return { kind: 'defer', why: 'blocked' }; // page drops + acks on open
   const contact = ctx.contacts.find((c) => c.id === from);
   if (!contact || !ctx.connected[from]) return { kind: 'defer', why: 'not-connected' };
-  const direct = directChatFor(ctx.chats, from);
+  const direct = directChatFor(ctx.chats, ctx.hidden, from);
   if (!direct) return { kind: 'defer', why: 'no-chat' };
 
   // The session lock spans decrypt AND commit: openPacketStaged persists nothing,
@@ -223,6 +274,10 @@ async function applyOne(f: MsgFrame, ctx: ApplyCtx): Promise<ApplyOutcome> {
             (!!payload.mentions?.includes(ctx.selfId) ||
               (!!payload.mentionsEveryone && !!chat.createdBy && from === chat.createdBy));
           if (selfMentioned) chat.unreadMentions = (chat.unreadMentions ?? 0) + 1;
+          // Accepted 1:1 content un-pends the chat, mirroring the page path (security
+          // review F7): the frame is acked, so the page never reprocesses it — leaving
+          // pending set would strand delivered messages in a hidden "request" chat.
+          if (!isGroupMsg && chat.pending) delete chat.pending;
           if (chat.archived && !chat.locked && !ctx.keepArchived) {
             delete chat.archived;
           }
@@ -327,6 +382,7 @@ export async function drainPersistPending(): Promise<DrainResult> {
         if (out.note) rawNotes.push(out.note);
       } else if (out.kind === 'ack-only') {
         ackIds.push(f.id as string);
+        if (out.note) rawNotes.push(out.note); // committed earlier but never alerted (F4)
       } else {
         deferred += 1;
       }
@@ -356,11 +412,22 @@ export async function ackFrames(ids: string[]): Promise<boolean> {
   const token = await readSessionToken();
   if (!token) return false;
   try {
-    const res = await fetch(`${API}/relay/ack`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ids }),
-    });
+    // Bounded like every other SW-context fetch (security review F10): a hung ack on
+    // a flaky post-wake network must not stall the notify chain past the push budget —
+    // an unacked frame just lingers and redelivers as a bare re-ack via the ledger.
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), ACK_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(`${API}/relay/ack`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids }),
+        signal: ctrl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
     return res.ok;
   } catch (e) {
     console.warn('[sw-drain] ack failed (frames linger; ledger dedupes)', e);

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -1,12 +1,20 @@
 /**
- * Service-worker background decryption for rich notifications (Choice A).
+ * Service-worker background decryption for rich notifications.
  *
- * Woken by a content-free push tickle while the app is closed, the SW fetches the
- * queued E2EE frames over HTTP, decrypts them READ-ONLY (previewPacket never
- * persists the ratchet or acks), and builds notification previews. The page still
- * drains + persists the messages for real over its WebSocket when it next
- * connects, so this adds notification content WITHOUT touching shared ratchet
- * state. Only a content-free tickle ever flows through Apple/Google.
+ * Two modes since spec 1032 (specs/1032-store-messages-push/):
+ *   - AUTHORITATIVE (sw-drain.ts, behind the internal `sw.fullPersist` flag):
+ *     eligible plain messages are decrypted, PERSISTED atomically, and acked at
+ *     notification time, so the app opens warm. sw-drain reuses this module's
+ *     fetch + note-building helpers, so notification content and privacy rules
+ *     are identical in both modes.
+ *   - PREVIEW (this module, the original "Choice A"): woken by a content-free
+ *     push tickle, the SW fetches the queued E2EE frames over HTTP, decrypts
+ *     them READ-ONLY (previewPacket never persists the ratchet or acks), and
+ *     builds notification previews. The page still drains + persists for real
+ *     over its WebSocket on next open. This remains the whole story for: the
+ *     flag off, PIN/passkey-locked devices, frame types the drain defers
+ *     (first-contact, cards, reactions, controls), and every degrade path.
+ * Only a content-free tickle ever flows through Apple/Google in either mode.
  *
  * Mirrors the live page dispatch (db/queries.ts `receiveIncoming` → services/notify
  * `notifyIncoming`): plain messages honor `notifications.message.show`, while
@@ -140,7 +148,10 @@ async function loadShownEntries(): Promise<ShownEntry[]> {
   }
   return out;
 }
-async function loadShown(): Promise<string[]> {
+/** Frame ids already SHOWN as notifications (TTL-pruned). Exported for sw-drain's
+ *  re-ack path (spec 1032): a committed-but-never-shown frame gets its note rebuilt
+ *  on redelivery, and this ledger is what distinguishes "never shown" from shown. */
+export async function loadShown(): Promise<string[]> {
   return (await loadShownEntries()).map((e) => e.id);
 }
 
@@ -431,7 +442,16 @@ export async function previewPending(): Promise<PreviewResult> {
 
   // Queued message frames = the undelivered backlog → the app-icon badge. Known
   // from the fetch alone, so the badge is right even if we can't decrypt.
-  const pending = frames.filter((f) => f.t === 'msg' && !!f.id).length;
+  //
+  // Spec 1032 (security review F8): frames the authoritative drain already
+  // COMMITTED can linger here (their ack failed, or a redelivery raced the ack) —
+  // they are already inside the stored unread count, so counting them as pending
+  // would double-badge, and re-decrypting them would fail (their message keys are
+  // consumed) and masquerade as a decrypt failure. Treat committed frames as
+  // neither pending nor previewable; they resolve to a bare re-ack on the next
+  // drain or page open.
+  const committed = new Set(await setting<string[]>('inboundSeenIds', []));
+  const pending = frames.filter((f) => f.t === 'msg' && !!f.id && !committed.has(f.id)).length;
   console.info('[sw-inbox] fetched frames', { total: frames.length, pending });
 
   // Badge mode (spec 1027, B4): under 'never'/'revealed' only frames we can
@@ -474,7 +494,7 @@ export async function previewPending(): Promise<PreviewResult> {
   let silencedMessage = false; // a message intentionally silenced by per-chat prefs
   let decryptFailed = 0; // frames we couldn't decrypt (cold start / session not reachable)
   for (const f of frames) {
-    if (f.t !== 'msg' || !f.from || !f.id || seen.has(f.id)) continue;
+    if (f.t !== 'msg' || !f.from || !f.id || seen.has(f.id) || committed.has(f.id)) continue;
     let payload: MessagePayload;
     try {
       payload = await previewPacket(sessionKeyForPeer(chats, f.from), f.ciphertext);

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -32,7 +32,8 @@ import type { MessagePayload } from './crypto/message';
 // VITE_API_URL is baked in only when targeting a different backend host.
 const API = `${import.meta.env.VITE_API_URL ?? ''}/v1`;
 
-interface MsgFrame {
+// Exported (spec 1032): sw-drain.ts drains the same queue authoritatively.
+export interface MsgFrame {
   t: string;
   id?: string;
   from?: string;
@@ -371,6 +372,35 @@ export async function ackCall(): Promise<void> {
   }
 }
 
+/** Fetch the queued (undelivered) frames. Fetching is what tells the server the
+ *  device received them (→ "delivered" receipts), so callers do it before any
+ *  decryption or settings gate. Bounded so a cold-start fetch can't hang the
+ *  handler. Shared by the preview path below and the authoritative drain
+ *  (sw-drain.ts, spec 1032). `failure` carries the preview-path reason label. */
+export async function fetchPendingFrames(token: string): Promise<{ frames: MsgFrame[] } | { failure: string }> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), PENDING_FETCH_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(`${API}/relay/pending`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: ctrl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) {
+      console.warn('[sw-inbox] /relay/pending not ok', res.status);
+      return { failure: `relay-${res.status}` };
+    }
+    return { frames: ((await res.json()) as { frames?: MsgFrame[] }).frames ?? [] };
+  } catch (e) {
+    console.warn('[sw-inbox] /relay/pending fetch failed', e);
+    return { failure: 'relay-error' };
+  }
+}
+
 export async function previewPending(): Promise<PreviewResult> {
   const token = await readSessionToken();
   if (!token) {
@@ -390,32 +420,11 @@ export async function previewPending(): Promise<PreviewResult> {
   // before the key is ready).
   const unlockReady = attemptDeviceUnlock().catch(() => false);
 
-  // Fetch the queue, before any decryption or settings gate. Fetching is what tells
-  // the server the device received these frames (→ "delivered" receipts), so it must
-  // happen even if we later withhold or can't decrypt. Bounded so a cold-start fetch
-  // can't hang the handler.
-  let frames: MsgFrame[] = [];
-  try {
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), PENDING_FETCH_TIMEOUT_MS);
-    let res: Response;
-    try {
-      res = await fetch(`${API}/relay/pending`, {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: ctrl.signal,
-      });
-    } finally {
-      clearTimeout(timer);
-    }
-    if (!res.ok) {
-      console.warn('[sw-inbox] /relay/pending not ok', res.status);
-      return { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: true, reason: `relay-${res.status}` };
-    }
-    frames = ((await res.json()) as { frames?: MsgFrame[] }).frames ?? [];
-  } catch (e) {
-    console.warn('[sw-inbox] /relay/pending fetch failed', e);
-    return { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: true, reason: 'relay-error' };
+  const fetched = await fetchPendingFrames(token);
+  if ('failure' in fetched) {
+    return { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: true, reason: fetched.failure };
   }
+  const frames = fetched.frames;
   // No pending frames: the message was already drained (page / a prior straggler) or this push carried
   // no queued message (a settings / own-data sync wake). Nothing genuinely new → no placeholder (2016).
   if (!frames.length) return { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: false, reason: 'no-frames' };

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -10,6 +10,7 @@
 import { register, getSelfUserId, getSelfUsername } from '@/services/auth';
 import { syncDirectory, importDirectoryUser, searchDirectory, publishOwnProfile, refetchContactProfile } from '@/services/directory';
 import { previewPending } from '@/services/sw-inbox';
+import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { disconnectTransport, nudgeReconnect, forceReconnect, sendDownloadedReceipts, sendSeenReceipts, applySeenPref } from '@/composables/useSync';
 import {
   ensureIdentity,
@@ -292,6 +293,16 @@ export function installTestHook(): void {
     /** Full background-preview result (notes + pending + suppressed + silenced), so a
      *  test can assert the closed-app SW decision (spec 1015 badge-only / web-push-off). */
     previewPendingFull: () => previewPending(),
+    /** Spec 1032: the SW AUTHORITATIVE drain (sw.fullPersist) — decrypt + persist +
+     *  ack eligible queued frames, exactly the module the push handler runs. Returns
+     *  the drain result plus whether the ack landed, so e2e can assert commit-before-
+     *  ack, exactly-once, and every degrade reason. Enable with
+     *  `setSetting('sw.fullPersist', true)` and `disconnect()` first. */
+    drainPending: async () => {
+      const r = await drainPersistPending();
+      const ackOk = r.mode === 'applied' ? await ackFrames(r.ackIds) : false;
+      return { ...r, ackOk };
+    },
     /** Drop the WebSocket so the server queues messages (simulate app closed). */
     disconnect: () => disconnectTransport(),
     /** Reconnect the WebSocket (drains the queue for real). */

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -25,6 +25,7 @@ import {
   coalesceForShow, loadShownSummary, setting,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
+import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { resubscribePush } from '@/services/sw-push';
 import { setPendingNav } from '@/services/pending-nav';
 import { userFacing, prettify, displayVersion } from '@/services/release-notes';
@@ -246,9 +247,11 @@ async function reassertFromSummary(): Promise<void> {
 
 const allIds = (notes: SwNote[]): string[] => notes.flatMap((n) => n.ids);
 
-// Set the app-icon badge to the unread total. The new message isn't persisted yet
-// (read-only SW), so we add the count of notifications we're showing on top of the
-// already-stored unread count. `newCount` is the fresh-notification count.
+// Set the app-icon badge to the unread total. On the preview path the new message
+// isn't persisted, so we add the count of fresh notifications on top of the
+// already-stored unread count (`newCount`). On the authoritative drain path
+// (spec 1032) applied frames ARE persisted — unreadCount() already includes them —
+// so the caller passes only the still-pending (deferred) count, never both.
 async function updateAppBadge(newCount: number): Promise<void> {
   try {
     const nav = self.navigator as Navigator & { setAppBadge?: (n?: number) => Promise<void> };
@@ -399,6 +402,42 @@ async function showConnNotification(): Promise<number> {
     data: { url: '/tabs/contacts' },
   });
   return pendingIncoming;
+}
+
+/**
+ * Spec 1032 (sw.fullPersist): attempt the AUTHORITATIVE drain — decrypt + persist
+ * eligible frames atomically, show their notifications, then ack. Returns true
+ * when this wake is fully handled; false hands the wake (or its deferred
+ * remainder) to showMessageNotification() below, whose preview flow is also the
+ * fallback for every degrade (flag off, no Web Locks, locked device, lock
+ * timeout, fetch/commit failure). Ordering per frame is commit → notify → ack:
+ * an ack is only ever sent for a durably-committed frame, and the notification
+ * is shown before the ack so a kill can't consume a frame silently.
+ */
+async function tryAuthoritativeDrain(): Promise<boolean> {
+  try {
+    return await serializeNotify(async () => {
+      const r = await drainPersistPending();
+      if (r.mode === 'degrade') return false; // includes 'no-frames' — the preview
+      // path owns the nothing-new / re-assert behavior (spec 2016/2017).
+      if (r.notes.length) {
+        await closeByTag(GENERIC_TAG);
+        await showNotes(r.notes);
+      }
+      // Mark applied frames in the preview ledger too: if the ack below fails they
+      // linger in the queue, and the preview path must not re-decrypt them (their
+      // message keys are consumed — it would misread them as decrypt failures).
+      await markShown(r.ackIds);
+      await ackFrames(r.ackIds); // strictly after commit + notifications
+      if (r.deferred > 0) return false; // preview flow handles the deferred remainder
+      // Fully handled: applied rows are already in unreadCount(), nothing pending.
+      await updateAppBadge(0);
+      return true;
+    });
+  } catch (e) {
+    console.warn('[sw] authoritative drain failed → preview fallback', e);
+    return false;
+  }
 }
 
 /**
@@ -637,6 +676,10 @@ self.addEventListener('push', (event) => {
       // show a banner reliably claims it, while a hidden/locked/frozen page (which
       // never acks) still falls through to the SW promptly enough.
       if (clients.length && (await pageWillNotify(clients, 2200))) return;
+      // Spec 1032: with sw.fullPersist on (and no page claiming the wake), persist
+      // + ack eligible frames right now so the app opens warm. Any degrade — and
+      // any deferred remainder — falls through to today's preview flow.
+      if (await tryAuthoritativeDrain()) return;
       await showMessageNotification();
     })(),
   );


### PR DESCRIPTION
Spec 1032 (`specs/1032-store-messages-push/`): when a push wakes the service worker and no
page claims it, eligible messages are now decrypted, **persisted, and acked at notification
time** — so the app opens warm: the chats list, previews, and unread badges are already
correct at first paint, with nothing re-fetched on open.

Behind the internal `sw.fullPersist` flag, **default OFF** — with the flag off this PR is
byte-for-byte today's behavior (proven by the flag-off e2e). Intended rollout: enable on the
dev deployment for a real-device soak, then flip the default in a later release.

## How it stays safe (the four load-bearing invariants)

1. **Cross-context locks** (`src/services/cross-lock.ts`): `ring:inbound` +
   `ring:session:<chatId>` Web Locks serialize the page and the SW around every ratchet
   advance and inbound apply; the SW times out (~3s) and degrades, the page waits. This
   supersedes the old "SW never persists DH steps" rule — the preview path keeps that rule
   as the fallback wherever the locks aren't actually held.
2. **Atomic commit** (`transact()` in `src/db/idb.ts`): session advance + message row +
   chat summary + exactly-once ledger land in ONE IndexedDB transaction. A kill leaves
   either the complete result or nothing.
3. **Ack after commit** (`src/services/sw-drain.ts` + `src/sw.ts`): commit → notify → ack,
   in that order. An ack is only ever sent for a durably-committed frame; a
   committed-but-unacked frame redelivers as a bare re-ack via the shared
   `inboundSeenIds` ledger.
4. **Degrade-to-today**: flag off, PIN/passkey lock, missing Web Locks, lock timeout,
   fetch/commit failure, ineligible frame types (first-contact X3DH, cards, reactions,
   edits, controls) — all fall back to the existing preview-only path and the page drain.

Zero-knowledge: nothing new crosses the wire — same content-free tickle, same
`/v1/relay/pending` fetch, same idempotent `/v1/relay/ack`; only ack timing changes.
Single-device is the precondition (one push subscription per user, overwrite-on-register);
revisit before any multi-device work.

Extras that ship active even with the flag off (strict safety improvements): the
cross-context lock discipline, the `BroadcastChannel('ring:idb')` bridge (a live page now
repaints on writes from another context/tab), and the resume `touch()` in useSync.

## Verification

- Unit: 661 tests green, including new suites — cross-lock ordering/timeout/fallback,
  idb transaction atomicity (fake-indexeddb), staged-open ratchet integrity
  (forgery/replay/out-of-order/>50 backlog/send-chain-after-DH-step), and 32 sw-drain
  tests (eligibility table, atomic apply, exactly-once, degrade ladder, posture parity).
- E2E: new `e2e/sw-persist.spec.ts` (warm-open, drain-vs-reconnect race, reaction
  deferral, PIN-locked posture, flag-off control) + full suite: 180 passed, 2 unrelated
  UI-timing flakes (chat-media-scroll seek, tab-transitions) that pass in isolation.
- Server: `go build/vet/test` green (comment-only change in relay.go).

## Security review (constitution Principle IV — T029)

A 27-agent adversarial review (independent finders per angle + per-finding verification)
ran against the contracts' invariants 1–5. It surfaced **7 confirmed findings, all fixed
in this branch** (`fix(notifications): harden background message saving…`):

- **F1/F2/F6 (locks)**: the preview path could park forever behind a lock a frozen page
  held (blocking the SW's notify chain for its lifetime); the 3s timeout didn't cover the
  in-context queue wait; a real section error could be misreported as a timeout. Fixed:
  timeouts now span the whole acquisition, section errors propagate verbatim, and the
  preview falls back to a fully read-only decrypt under contention.
- **F3 (hidden-chat routing)**: the SW now uses the page's exact rule-R resolver
  (`resolveInboundDirectChat`), so it can never commit + ack into a hidden chat the page
  would have routed visibly.
- **F4 (silent consume)**: a frame committed right before the SW was killed now gets its
  notification rebuilt from the stored row on redelivery, instead of a silent re-ack.
- **F7 (pending chat)**: applied 1:1 content un-pends a pending chat, mirroring the page.
- **F8 (badge double-count)**: committed-but-unacked frames are excluded from the preview
  path's pending/badge counts and its decrypt loop.
- **F10**: the ack POST is now time-bounded like every other SW fetch.

Two PLAUSIBLE hazards were accepted and documented (cross-lock.ts + research.md D9):
**F5** — a pre-1032 page kept alive across an update takes no locks, so the flag must only
be enabled once all tabs run this release, and the default-on flip ships ≥1 release later;
**F9** — a second live window queued behind a frozen sibling's lock waits unbounded
(iOS PWAs are effectively single-window; locks auto-release on context death).

Every fix carries a pinning unit test (F1–F4, F6–F8 in `cross-lock.test.ts` /
`sw-drain.test.ts`).

## Closes

Closes #718, Closes #719, Closes #720, Closes #721, Closes #722, Closes #723,
Closes #724, Closes #725, Closes #726, Closes #727, Closes #728, Closes #729,
Closes #730, Closes #731, Closes #732, Closes #733, Closes #734, Closes #735,
Closes #736, Closes #737, Closes #738, Closes #739, Closes #740, Closes #741,
Closes #742, Closes #743, Closes #744, Closes #745, Closes #746, Closes #747,
Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE
