### PR TITLE
chore(dev): notification-time message saving defaults ON in dev builds

### DIFF
--- a/e2e/sw-persist.spec.ts
+++ b/e2e/sw-persist.spec.ts
@@ -205,15 +205,17 @@ test('sw persist: PIN lock → nothing stored, frame stays queued, arrives after
   await ctxB.close();
 });
 
-/** T024c — flag OFF (the default): the drain refuses; behavior is byte-for-byte
- *  today's (preview-only, nothing stored, nothing acked). */
+/** T024c — flag OFF: the drain refuses; behavior is byte-for-byte today's
+ *  (preview-only, nothing stored, nothing acked). Dev builds default the flag ON
+ *  (SW_FULL_PERSIST_DEFAULT), so the production-off state is pinned by storing an
+ *  explicit false — which must always win over the default. */
 test('sw persist: flag off → drain degrades and the preview path owns the wake', async ({ browser }) => {
   const ctxA = await browser.newContext();
   const ctxB = await browser.newContext();
   const a = await createAccount(ctxA, 'SWPERS09');
   const b = await createAccount(ctxB, 'SWPERS10');
   await pair(a, b);
-  // NOTE: no enableFlag(b) — default off.
+  await b.page.evaluate(() => (window as any).__ringTest.setSetting('sw.fullPersist', false));
 
   const aChat = (await chatOf(a, b.id)) as string;
   await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'warmup'), aChat);

--- a/src/services/sw-drain.test.ts
+++ b/src/services/sw-drain.test.ts
@@ -338,12 +338,23 @@ describe('drain: atomic apply + exactly-once + ack discipline (T014)', () => {
 });
 
 describe('drain: gate degrades (T019/T022 core)', () => {
-  it('flag off (default) → degrade flag-off, nothing touched', async () => {
-    storeOf('settings').delete(SW_FULL_PERSIST_KEY);
+  it('explicit flag=false → degrade flag-off, nothing touched (the production-parity control)', async () => {
+    // Production builds default the flag OFF (SW_FULL_PERSIST_DEFAULT is import.meta.env.DEV);
+    // under vitest DEV is true, so the off state is pinned via an explicit stored false —
+    // which must ALWAYS win over the default, in dev and prod alike.
+    storeOf('settings').set(SW_FULL_PERSIST_KEY, { key: SW_FULL_PERSIST_KEY, value: false });
     queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
     const r = await drainPersistPending();
     expect(r).toMatchObject({ mode: 'degrade', reason: 'flag-off', applied: 0, ackIds: [] });
     expect(msgRows().length).toBe(0);
+  });
+
+  it('no stored value in a dev build → the dev default turns the drain ON', async () => {
+    storeOf('settings').delete(SW_FULL_PERSIST_KEY);
+    queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
+    const r = await drainPersistPending();
+    expect(r.mode).toBe('applied'); // vitest runs DEV=true, same as make start / ring-dev
+    expect(r.applied).toBe(1);
   });
 
   it('no Web Locks → degrade no-locks', async () => {

--- a/src/services/sw-drain.ts
+++ b/src/services/sw-drain.ts
@@ -38,10 +38,16 @@ import type { MessagePayload } from './crypto/message';
 
 const API = `${import.meta.env.VITE_API_URL ?? ''}/v1`;
 
-/** Internal rollout flag (spec 1032 FR-011). Device-local, default off, NOT in the
- *  Settings UI — set via dev tooling (`__ringTest.setSetting`) during the soak,
- *  flipped default-on in a later release, then removed. */
+/** Internal rollout flag (spec 1032 FR-011). Device-local, NOT in the Settings UI —
+ *  overridable via dev tooling (`__ringTest.setSetting`). */
 export const SW_FULL_PERSIST_KEY = 'sw.fullPersist';
+
+/** The flag's default when the device has no stored value: ON in dev builds
+ *  (`make start`, the ring-dev deployment, e2e's Vite server — so local + soak
+ *  devices exercise the drain without console surgery), OFF in production builds
+ *  until the deliberate default-flip release. An explicitly stored value always
+ *  wins in both, which is how the flag-off control tests pin today's behavior. */
+export const SW_FULL_PERSIST_DEFAULT = import.meta.env.DEV === true;
 
 // How long the SW waits for a cross-context lock before degrading that frame (and
 // the rest of the wake) to preview-only. A frozen-but-alive page can hold a lock
@@ -325,7 +331,7 @@ export async function drainPersistPending(): Promise<DrainResult> {
     notes: [],
   });
 
-  if (!(await setting<boolean>(SW_FULL_PERSIST_KEY, false))) return degrade('flag-off');
+  if (!(await setting<boolean>(SW_FULL_PERSIST_KEY, SW_FULL_PERSIST_DEFAULT))) return degrade('flag-off');
   if (!locksAvailable()) return degrade('no-locks');
   const token = await readSessionToken();
   if (!token) return degrade('no-token');


### PR DESCRIPTION
Follow-up to #749: default `sw.fullPersist` to ON in dev builds only (`import.meta.env.DEV`), so `make start` / ring-dev / e2e exercise the drain without console setup. Production default stays OFF; an explicitly stored value always wins (the flag-off control e2e now pins that explicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE