### PR TITLE
fix(chat): tapping a notification for another chat now returns you to the Chats list, not the previous chat

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,3 +76,4 @@ Specs are grouped by category band; status moves
 | [2015](specs/2015-sw-preview-ratchet/spec.md) | Background notifications decrypt queued messages reliably | 🔵 in-review |
 | [2016](specs/2016-sw-no-spurious-generic/spec.md) | Stop background notifications showing a generic placeholder when there's nothing new | 🔵 in-review |
 | [2017](specs/2017-sw-burst-coalesce/spec.md) | Coalesce burst notifications into one clean per-chat notification | 🔵 in-review |
+| [2018](specs/2018-notification-tap-opens/spec.md) | Notification tap opens the chat, not a stuck chat list | 🟡 in-progress |

--- a/e2e/notification-nav.spec.ts
+++ b/e2e/notification-nav.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 2018 (hotfix) — tapping a notification while the app is closed must land IN the
+ * chat, with the chat actually RENDERED (not just the URL changed), and back must return
+ * to the Chats list (the ecdf5f3 behavior).
+ *
+ * Repro shape: the SW stashes the tap target (pending-nav) and opens the window; on iOS
+ * the window lands on the default tab and the app consumes the stash after unlock. The
+ * bug: the consume's replace+push raced Ionic's first outlet transition — URL became
+ * /chat/<id> while the Chats list stayed on screen. We simulate the cold start by writing
+ * the same pending-nav record the SW writes, then reloading the page.
+ */
+test('cold start with a pending notification target renders the chat (not a stuck list)', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'NOTNAV01');
+  const b = await createAccount(ctxB, 'NOTNAV02');
+  await pair(a, b);
+
+  // A message exists in B's chat with A, so the rendered chat has visible content.
+  const aChat = (await a.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), b.id)) as string;
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'tap target message'), aChat);
+  const bChatOf = () => b.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), a.id);
+  await expect.poll(bChatOf, { timeout: 30_000 }).toBeTruthy();
+  const bChat = (await bChatOf()) as string;
+
+  // Stash the pending-nav target exactly as the SW's notificationclick does, then
+  // cold-start the app (reload → boots at '/', auth gate lands on /tabs/chats, the
+  // unlock watcher consumes the stash and deep-links).
+  await b.page.evaluate(
+    (chatId: string) =>
+      (window as any).__ringTest.setSetting('sw.pendingNav', { url: `/chat/${chatId}`, ts: Date.now() }),
+    bChat,
+  );
+  // Throttle the CPU like a phone: the bug is a race between the pending-nav consume
+  // and Ionic's FIRST outlet transition — on a fast headless machine the transition
+  // wins and the race never shows; on a real device (the report) it loses nearly every
+  // time. 6× throttle makes the unfixed code lose it deterministically here too.
+  const cdp = await b.page.context().newCDPSession(b.page);
+  await cdp.send('Emulation.setCPUThrottlingRate', { rate: 6 });
+  await b.page.reload();
+  await b.page.waitForFunction(() => !!(window as any).__ringTest);
+
+  // The URL must become the chat's…
+  await b.page.waitForURL(`**/chat/${bChat}`, { timeout: 20_000 });
+  // …and the chat must actually be RENDERED: its message bubble is visible. On the buggy
+  // code the Chats list stays on screen under the chat URL, so no bubble ever appears.
+  await expect(b.page.locator('.bubble', { hasText: 'tap target message' })).toBeVisible({ timeout: 10_000 });
+
+  // ecdf5f3's guarantee stays: first back from the deep link lands on the Chats list.
+  await b.page.goBack();
+  await expect(b.page).toHaveURL(/\/tabs\/chats/, { timeout: 10_000 });
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/specs/2018-notification-tap-opens/plan.md
+++ b/specs/2018-notification-tap-opens/plan.md
@@ -1,0 +1,40 @@
+# Implementation Plan: Notification tap opens the chat (spec 2018, hotfix)
+
+**Branch**: `fix/2018-notification-tap-opens` | **Date**: 2026-07-04 | **Spec**: [spec.md](spec.md)
+
+## Root cause
+
+`src/App.vue`: the `isUnlocked` watcher (`immediate: true`) consumes the pending nav —
+potentially during component SETUP, before first paint — and `routeRelevant`'s cold-start
+branch runs `await router.replace('/tabs/chats')` + `await router.push(target)` back to
+back. vue-router's awaits do not cover Ionic's animated outlet transition, so the push can
+land while the outlet is mid-(first)-transition; Ionic drops the view swap and the URL/state
+diverge from the rendered view. Introduced by `ecdf5f3` (2026-07-02); made near-
+deterministic by spec 1032's faster cold open.
+
+## Fix (App.vue only)
+
+1. **First-paint gate**: a `firstPaint` promise resolved in `onMounted` + double
+   `requestAnimationFrame`. The cold-start branch awaits `router.isReady()` and
+   `firstPaint` before any navigation (FR-002).
+2. **No same-route churn**: skip the `replace('/tabs/chats')` when the current route is
+   already `/tabs/chats` (the iOS case — the auth gate has already landed there pre-mount);
+   otherwise (platform honored the deep link) do the replace, then wait a double-rAF settle
+   before the push so the two Ionic transitions never overlap (FR-001, FR-003).
+3. Live path (`ring:navigate` with `coldStart=false`) untouched (FR-004).
+
+## Constitution check
+
+- III (TDD): failing regression e2e first (`e2e/notification-nav.spec.ts`): stash
+  pending-nav via the settings store, reload (cold start), assert rendered chat content AND
+  URL, then back → Chats list. Note: the device race may not reproduce headless — the test
+  pins the invariant either way; device verification by the reporter precedes merge.
+- I (zero-knowledge): no wire impact. IV: no crypto. XI: no UI change.
+
+## Verification
+
+- `npx playwright test e2e/notification-nav.spec.ts` (new) + `e2e/sw-persist.spec.ts` +
+  `e2e/sw-decrypt.spec.ts` regression.
+- `npm run build`, `npx vitest run`.
+- Real-device verification on ring-dev by the reporter BEFORE anything is committed/pushed
+  (explicitly requested).

--- a/specs/2018-notification-tap-opens/spec.md
+++ b/specs/2018-notification-tap-opens/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Notification tap opens the chat, not a stuck chat list
+
+**Feature Branch**: `fix/2018-notification-tap-opens`
+
+**Created**: 2026-07-04
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: Bug report (real device, iOS installed PWA, dev build): "when I tap on a
+notification, instead of it taking me directly to the chat it belongs to, it takes me to the
+Chats list; tapping the chat it belongs to does nothing, but tapping any other chat works —
+and tapping back from there lands me on the chat the notification was about."
+
+## The bug
+
+Tapping a message notification while the app is fully closed cold-starts the app. On iOS the
+deep link can't ride the window-open call, so the service worker stashes the target and the
+app routes there after unlock (`pending-nav`). The consume path (`App.vue routeRelevant`,
+cold-start branch added in `ecdf5f3`, 2026-07-02) performs `router.replace('/tabs/chats')`
+immediately followed by `router.push('/chat/<id>')`. Those awaits settle when **vue-router**
+resolves — not when **Ionic's animated outlet transition** finishes. When the push fires
+while the outlet is still rendering its first view, Ionic drops the second view swap:
+
+- the URL (and router state) become `/chat/<id>`, but the **screen keeps showing the Chats
+  list** — the reported landing;
+- tapping the notification's chat is a push to the route already current → silent no-op;
+- tapping any other chat is a different route → navigates fine;
+- Back pops to the never-rendered `/chat/<id>` history entry → NOW it renders, which reads
+  as "back takes me to the chat the notification was about".
+
+Pre-existing (introduced by `ecdf5f3`, which fixed Back-underflow after a notification tap,
+two days before spec 1032 merged). Spec 1032 made it near-deterministic: with messages
+persisted at notification time and dev auto-unlock, the unlock watcher (`immediate: true`)
+consumes the pending nav during component SETUP — before the app has even painted — so the
+push lands inside the initial mount transition virtually every time.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A tapped notification lands IN the chat (Priority: P1)
+
+I tap a message notification while the app is closed. The app opens showing that
+conversation — the messages are on screen, not the chats list. Pressing back from there
+returns me to the chats list (the `ecdf5f3` behavior this fix must preserve).
+
+**Independent Test**: stash a pending-nav target for a chat with messages, cold-start the
+app (reload), and assert BOTH that the URL is the chat's AND that the chat's messages are
+actually rendered; then assert back returns to the chats list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pending-nav target `/chat/<id>` and a cold start, **When** the app finishes
+   opening, **Then** the chat's messages are visible on screen and the URL matches — never
+   a chats list rendered under a chat URL.
+2. **Given** the app landed in the chat via a notification tap, **When** the user presses
+   back, **Then** they land on the Chats list (no history underflow — regression guard for
+   `ecdf5f3`'s original fix).
+3. **Given** the app is already open when a notification is tapped (`ring:navigate` path),
+   **Then** in-app navigation to the chat keeps working as today.
+
+### Edge Cases
+
+- Consume fires before the app has painted (fast dev auto-unlock, `immediate` watcher —
+  the reported reproduction): navigation must wait for first paint.
+- Platform that honors the deep link (window opens at `/chat/<id>` directly): the
+  seed-Chats-beneath behavior must still produce [chats list ← chat] history without
+  dropping the rendered view.
+- Pending-nav to a non-chat target (`/tabs/contacts`, `/tabs/wall`): same rules.
+- No pending nav / expired (60s TTL): nothing changes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: After a cold start from a tapped notification, the rendered view MUST match
+  the routed URL — the deep-link navigation may not be dropped by an in-flight view
+  transition.
+- **FR-002**: The cold-start deep link MUST wait for the app's first paint before
+  navigating (the consume can run during component setup).
+- **FR-003**: The Back behavior from `ecdf5f3` is preserved: first back from the deep-link
+  target lands on the Chats list, never an underflow.
+- **FR-004**: The live-app path (`ring:navigate`) and manual navigation are unchanged.
+- **FR-005**: Regression coverage: an e2e that cold-starts with a stashed pending nav and
+  asserts the rendered view (not just the URL) matches the target.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Notification tap → chat content visible on screen, 100% of tested cold
+  starts (device + e2e).
+- **SC-002**: Back from the notification-opened chat lands on Chats list.
+- **SC-003**: All existing navigation/e2e suites stay green.
+
+## Zero-Knowledge Impact *(constitution Principle I)*
+
+None — client-side navigation timing only; nothing crosses the wire.
+
+## Assumptions
+
+- Hotfix scope: fix the navigation race; no changes to notification content, the SW, or
+  the pending-nav storage contract.
+- The headless e2e may not reproduce the exact device timing; the regression test pins the
+  invariant (rendered view matches URL after a pending-nav cold start) and the fix is
+  additionally verified on the reporting device before merge.

--- a/specs/2018-notification-tap-opens/tasks.md
+++ b/specs/2018-notification-tap-opens/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Notification tap opens the chat (spec 2018, hotfix)
+
+- [ ] T001 Failing regression e2e `e2e/notification-nav.spec.ts`: pending-nav cold start →
+      rendered chat content matches URL; back → Chats list (FR-001/003/005)
+- [ ] T002 Fix `src/App.vue` routeRelevant cold-start branch: first-paint gate +
+      conditional replace + transition settle (FR-001/002/003)
+- [ ] T003 Gates: new e2e + sw-persist + sw-decrypt green; npm run build; vitest
+- [ ] T004 Real-device verification on ring-dev by the reporter (BLOCKS commit/push)
+- [ ] T005 After verification: taskstoissues, commit, push, PR with Closes lines,
+      status → in-review, make roadmap
+
+Note: taskstoissues (T005) is deliberately deferred until the reporter verifies the fix
+on-device — nothing is committed or pushed before then (explicit request).

--- a/src/App.vue
+++ b/src/App.vue
@@ -178,6 +178,26 @@ watch(
   },
 );
 
+// First-paint gate (spec 2018): the pending-nav consume can fire very early (the
+// isUnlocked watcher is `immediate`, and a passwordless device unlock resolves in
+// milliseconds), and a deep-link push that lands while the root ion-router-outlet
+// is still mounting/animating its FIRST view gets its view swap DROPPED by Ionic —
+// the URL becomes /chat/<id> while the Chats list stays on screen (tapping that
+// chat is then a same-route no-op, and Back "returns" to the never-rendered chat
+// entry — the reported bug). Resolves after mount + two animation frames: the
+// frame after the first view committed.
+let markFirstPaint: () => void;
+const firstPaint = new Promise<void>((resolve) => (markFirstPaint = resolve));
+onMounted(() => {
+  requestAnimationFrame(() => requestAnimationFrame(() => markFirstPaint()));
+});
+
+// One settle between two programmatic Ionic navigations, so the second never
+// starts while the first is still animating (Ionic drops, not queues, an
+// overlapping view swap). Frame-based rather than a fixed duration.
+const settleFrames = (): Promise<void> =>
+  new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
 // When opened from a notification, land on the relevant place: the deep-link the
 // service worker hands us, or, for a content-free push, the most pertinent tab.
 // `coldStart` is true when we're launching fresh from a tapped notification: the deep-link
@@ -195,8 +215,26 @@ async function routeRelevant(url?: string, coldStart = false): Promise<void> {
     }
   }
   if (coldStart && target !== '/tabs/chats') {
-    await router.replace('/tabs/chats');
+    // Never navigate before the app has painted its first view (spec 2018, FR-002).
+    await router.isReady();
+    await firstPaint;
+    // Seed the Chats home beneath the deep link. When the auth gate already landed
+    // on /tabs/chats (iOS ignores the open-window path), the replace would be a
+    // same-route no-op — skip it and just push. When the platform DID honor the
+    // deep link (current route = the target), the replace really navigates, so let
+    // its transition settle before stacking the push (overlap = dropped swap).
+    if (router.currentRoute.value.path !== '/tabs/chats') {
+      await router.replace('/tabs/chats');
+      await settleFrames();
+    }
     await router.push(target);
+  } else if (target.startsWith('/chat/') && router.currentRoute.value.path.startsWith('/chat/')) {
+    // Live app, notification for chat B tapped while chat A (possibly A's sub-pages)
+    // is on top: REPLACE instead of push (spec 2018, US follow-up). A push would
+    // stack B over A, so Back/swipe from the notification's chat returned to the
+    // previous conversation instead of the Chats list the user expects. Replacing
+    // swaps A's entry for B, leaving the Chats list beneath.
+    router.replace(target);
   } else {
     router.push(target);
   }


### PR DESCRIPTION
Hotfix spec 2018. Two navigation fixes when opening a chat from a notification:

- **Cold start** (app fully closed): the deep-link now waits for the app's first paint before navigating, so Ionic's initial view transition can't drop it — previously the URL became `/chat/<id>` while the Chats list stayed on screen (tapping that chat did nothing; Back surfaced it).
- **Live app** (already open in another chat): a chat→chat notification tap now *replaces* instead of stacking, so Back/swipe from the notification's chat returns to the Chats list rather than the chat you were previously in.

Regression e2e (`e2e/notification-nav.spec.ts`) pins that a pending-nav cold start renders the chat (not just the URL) and Back lands on the Chats list. Device-verified on iOS by the reporter.

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE