### PR TITLE
feat(notifications): your messages are ready the moment you open the app

### DIFF
--- a/src/services/sw-drain.test.ts
+++ b/src/services/sw-drain.test.ts
@@ -338,10 +338,10 @@ describe('drain: atomic apply + exactly-once + ack discipline (T014)', () => {
 });
 
 describe('drain: gate degrades (T019/T022 core)', () => {
-  it('explicit flag=false → degrade flag-off, nothing touched (the production-parity control)', async () => {
-    // Production builds default the flag OFF (SW_FULL_PERSIST_DEFAULT is import.meta.env.DEV);
-    // under vitest DEV is true, so the off state is pinned via an explicit stored false —
-    // which must ALWAYS win over the default, in dev and prod alike.
+  it('explicit flag=false → degrade flag-off, nothing touched (the kill-switch control)', async () => {
+    // The default is now ON for everyone (SW_FULL_PERSIST_DEFAULT = true); an explicitly
+    // stored `false` is the per-device kill switch and must ALWAYS win over that default,
+    // which is how this pins the exact pre-1032 behavior.
     storeOf('settings').set(SW_FULL_PERSIST_KEY, { key: SW_FULL_PERSIST_KEY, value: false });
     queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
     const r = await drainPersistPending();
@@ -349,11 +349,11 @@ describe('drain: gate degrades (T019/T022 core)', () => {
     expect(msgRows().length).toBe(0);
   });
 
-  it('no stored value in a dev build → the dev default turns the drain ON', async () => {
+  it('no stored value → the default (ON for everyone) turns the drain ON', async () => {
     storeOf('settings').delete(SW_FULL_PERSIST_KEY);
     queued = [{ t: 'msg', id: 'm1', from: PEER, ciphertext: N(pay()) }];
     const r = await drainPersistPending();
-    expect(r.mode).toBe('applied'); // vitest runs DEV=true, same as make start / ring-dev
+    expect(r.mode).toBe('applied');
     expect(r.applied).toBe(1);
   });
 

--- a/src/services/sw-drain.ts
+++ b/src/services/sw-drain.ts
@@ -42,12 +42,12 @@ const API = `${import.meta.env.VITE_API_URL ?? ''}/v1`;
  *  overridable via dev tooling (`__ringTest.setSetting`). */
 export const SW_FULL_PERSIST_KEY = 'sw.fullPersist';
 
-/** The flag's default when the device has no stored value: ON in dev builds
- *  (`make start`, the ring-dev deployment, e2e's Vite server — so local + soak
- *  devices exercise the drain without console surgery), OFF in production builds
- *  until the deliberate default-flip release. An explicitly stored value always
- *  wins in both, which is how the flag-off control tests pin today's behavior. */
-export const SW_FULL_PERSIST_DEFAULT = import.meta.env.DEV === true;
+/** The flag's default when the device has no stored value: ON for everyone (spec
+ *  1032 rollout completion — messages are saved the moment a notification arrives,
+ *  so the app opens up to date). An explicitly stored `false` still wins as a
+ *  per-device kill switch (and pins today's-behavior control tests) until the flag
+ *  is removed entirely in a later cleanup. */
+export const SW_FULL_PERSIST_DEFAULT = true;
 
 // How long the SW waits for a cross-context lock before degrading that frame (and
 // the rest of the wake) to preview-only. A frozen-but-alive page can hold a lock


### PR DESCRIPTION
Completes the spec 1032 rollout: flips `sw.fullPersist` to **default ON for everyone** (was dev/soak-only). When a push arrives, the service worker decrypts and stores the message at notification time, so the app opens already up to date. An explicitly stored `false` remains a per-device kill switch until the flag is retired in a later cleanup.

**Safety (version-skew rule from the 1032 security review, F5):** the guidance was to flip default-on *at least one release after* the lock plumbing ships. The cross-context lock discipline is already on `develop` (#749). The residual concern is a desktop multi-tab upgrade where one tab keeps running pre-1032 code (no lock usage) under the new SW; iOS installed PWAs are single-window and unaffected, and any transient ratchet desync self-heals via the existing rekey path. See the release-sequencing note in the merge discussion before cutting the production release.

Device-soaked on ring-dev. Unit: the flag-off kill-switch and default-on paths are pinned in `sw-drain.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE