### PR TITLE
docs(spec): spec 0008 shipped in #810; roadmap regenerated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Specs are grouped by category band; status moves
 | [0004](specs/0004-group-call-reliability/spec.md) | Group call reliability, adaptive quality, caps, audio cues & busy signalling | 🔵 in-review |
 | [0005](specs/0005-call-waiting-hold/spec.md) | Call waiting — hold, swap & drop between two concurrent calls | 🔵 in-review |
 | [0007](specs/0007-adaptive-call-quality/spec.md) | Adaptive call quality — per-receiver, network- and screen-aware, with peer-reported health | 🔵 in-review |
-| [0008](specs/0008-chat-turn-based/spec.md) | In-Chat Turn-Based Games | 🔵 in-review |
+| [0008](specs/0008-chat-turn-based/spec.md) | In-Chat Turn-Based Games | 🟢 shipped |
 
 ## ⚡ Ad-hoc (1001–1999)
 

--- a/specs/0008-chat-turn-based/spec.md
+++ b/specs/0008-chat-turn-based/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-05
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Closes out the spec 0008 lifecycle after #810 merged: Status → shipped, ROADMAP regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE