### PR TITLE
docs(spec): spec 0009 shipped in #829; roadmap regenerated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Specs are grouped by category band; status moves
 | [0005](specs/0005-call-waiting-hold/spec.md) | Call waiting — hold, swap & drop between two concurrent calls | 🔵 in-review |
 | [0007](specs/0007-adaptive-call-quality/spec.md) | Adaptive call quality — per-receiver, network- and screen-aware, with peer-reported health | 🔵 in-review |
 | [0008](specs/0008-chat-turn-based/spec.md) | In-Chat Turn-Based Games | 🟢 shipped |
-| [0009](specs/0009-game-challenges-groups/spec.md) | Game Challenges in Groups and on the Wall | 🔵 in-review |
+| [0009](specs/0009-game-challenges-groups/spec.md) | Game Challenges in Groups and on the Wall | 🟢 shipped |
 
 ## ⚡ Ad-hoc (1001–1999)
 

--- a/specs/0009-game-challenges-groups/spec.md
+++ b/specs/0009-game-challenges-groups/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-05
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Closes out the spec 0009 lifecycle after #829 merged: Status → shipped, ROADMAP regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE