### PR TITLE
docs(spec): specs 0010 and 0011 shipped in #849; roadmap regenerated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,8 +21,8 @@ Specs are grouped by category band; status moves
 | [0007](specs/0007-adaptive-call-quality/spec.md) | Adaptive call quality — per-receiver, network- and screen-aware, with peer-reported health | 🔵 in-review |
 | [0008](specs/0008-chat-turn-based/spec.md) | In-Chat Turn-Based Games | 🟢 shipped |
 | [0009](specs/0009-game-challenges-groups/spec.md) | Game Challenges in Groups and on the Wall | 🟢 shipped |
-| [0010](specs/0010-connect-four-second/spec.md) | Connect Four, the Second Built-in Game | 🔵 in-review |
-| [0011](specs/0011-battleship-hidden-fleets/spec.md) | Battleship with Hidden Fleets | 🔵 in-review |
+| [0010](specs/0010-connect-four-second/spec.md) | Connect Four, the Second Built-in Game | 🟢 shipped |
+| [0011](specs/0011-battleship-hidden-fleets/spec.md) | Battleship with Hidden Fleets | 🟢 shipped |
 
 ## ⚡ Ad-hoc (1001–1999)
 

--- a/specs/0010-connect-four-second/spec.md
+++ b/specs/0010-connect-four-second/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-06
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/0011-battleship-hidden-fleets/spec.md
+++ b/specs/0011-battleship-hidden-fleets/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-06
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User description: "Add Battleship as the third built-in game before


### PR DESCRIPTION
Closes out both game specs after #849 merged: Status → shipped, ROADMAP regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE