### PR TITLE
feat(chat): Battleship becomes a submarine hunt, place your fleet by hand and fire under a sonar sweep

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,6 +58,7 @@ Specs are grouped by category band; status moves
 | [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🔵 in-review |
 | [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
 | [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟢 shipped |
+| [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,7 @@ Specs are grouped by category band; status moves
 | [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🔵 in-review |
 | [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
 | [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟢 shipped |
-| [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🟡 in-progress |
+| [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/docs/ANIMATED-EMOJI.md
+++ b/docs/ANIMATED-EMOJI.md
@@ -205,11 +205,9 @@ secret, so there is nothing to tell apart); shot results are a FIXED language:
 | Hit | 💥 `collision 1f4a5` | a ship is struck |
 | Sunk | 🔥 `fire 1f525` | the whole ship is gone |
 
-| Theme | Ship glyph | Accent |
-|-------|-----------|--------|
-| Classic | 🚢 `ship 1f6a2` | navy `30, 64, 175` |
-| Pirates | 🏴‍☠️ `pirate-flag 1f3f4_200d_2620_fe0f` | rum brown `120, 53, 15` |
-| Sea Monsters | 🐙 `octopus 1f419` | teal `13, 148, 136` |
+Since spec 1033, Battleship has ONE look: the submarine vector design from the
+vendored handoff (specs/1033-submarine-redesign-battleship/design/) — no theme
+choice, no emoji ship glyphs. Old theme ids fall back to it gracefully.
 
 ## Tic-tac-toe themes (spec 0008)
 

--- a/drive/scenarios/battleship.mjs
+++ b/drive/scenarios/battleship.mjs
@@ -17,9 +17,9 @@ await shot(bob, 'bs-1-placing');
 // Both lock fleets through the REAL buttons.
 await alice.page.goto(`http://localhost:5173/chat/${aChat}`);
 await alice.page.waitForTimeout(1200);
-await alice.page.getByRole('button', { name: /Ready/ }).click();
+await alice.page.getByRole('button', { name: /Deploy fleet/ }).click();
 await poll(() => bob.page.evaluate((m) => window.__ringTest.gameInfo(m), mid), g => g?.moves === 1, { label: 'a committed' });
-await bob.page.getByRole('button', { name: /Ready/ }).click();
+await bob.page.getByRole('button', { name: /Deploy fleet/ }).click();
 await poll(() => alice.page.evaluate((m) => window.__ringTest.gameInfo(m), mid), g => g?.moves === 2, { label: 'b committed' });
 
 // A few shots; defenders answer automatically (both chats are open).

--- a/e2e/games-battleship.spec.ts
+++ b/e2e/games-battleship.spec.ts
@@ -132,18 +132,18 @@ test('a full verified game: commitments, shots, forced reveals — and the loser
   for (const x of ctxs) await x.close();
 });
 
-test('the real flow: Ready buttons commit, and the defender device answers by itself', async ({ browser }) => {
+test('the real flow: Deploy fleet commits, and the defender device answers by itself', async ({ browser }) => {
   const { a, b, aChat, bChat, mid, ctxs } = await setupGame(browser, ['RINGBS3', 'RINGBS4']);
 
   // Both players open the chat and lock their randomly shuffled fleets.
   await a.page.goto(`/chat/${aChat}`);
   await b.page.goto(`/chat/${bChat}`);
-  await a.page.getByRole('button', { name: /Ready/ }).click();
+  await a.page.getByRole('button', { name: /Deploy fleet/ }).click();
   // Bisect: A's OWN device must apply the commit locally first…
   await expect.poll(async () => (await gameInfo(a, mid))?.moves, { timeout: 15_000 }).toBe(1);
   // …then the sealed signal reaches B.
   await expect.poll(async () => (await gameInfo(b, mid))?.moves, { timeout: 30_000 }).toBe(1);
-  await b.page.getByRole('button', { name: /Ready/ }).click();
+  await b.page.getByRole('button', { name: /Deploy fleet/ }).click();
   await expect.poll(async () => (await gameInfo(a, mid))?.moves, { timeout: 30_000 }).toBe(2);
 
   // A fires one shot; B's OPEN board answers automatically from its secret.

--- a/specs/1033-submarine-redesign-battleship/design/Ring Battleship Bubble v2.dc.html
+++ b/specs/1033-submarine-redesign-battleship/design/Ring Battleship Bubble v2.dc.html
@@ -1,0 +1,684 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: radial-gradient(120% 100% at 50% 0%, #26262e 0%, #17171c 60%, #101014 100%);
+      min-height: 100vh;
+    }
+    @keyframes overlayIn { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes heroPop { 0% { transform: scale(0.2) rotate(-14deg); opacity: 0; } 55% { transform: scale(1.2) rotate(6deg); } 100% { transform: scale(1) rotate(0); opacity: 1; } }
+    @keyframes reticleSpin { to { transform: rotate(360deg); } }
+    @keyframes reticlePulse { 0%,100% { opacity: .28; transform: scale(1); } 50% { opacity: .6; transform: scale(1.28); } }
+    @keyframes ripple { 0% { transform: scale(.32); opacity: .85; } 100% { transform: scale(1.7); opacity: 0; } }
+    @keyframes markPop { 0% { transform: scale(.15); opacity: 0; } 60% { transform: scale(1.2); } 100% { transform: scale(1); opacity: 1; } }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @keyframes shipIn { from { opacity: 0; transform: translateY(-2px) scale(.94); } to { opacity: 1; transform: translateY(0) scale(1); } }
+    @keyframes flicker { 0% { transform: scaleY(.86) scaleX(1.04); } 100% { transform: scaleY(1.14) scaleX(.94); } }
+    @keyframes ghostIn { 0% { opacity: 0; transform: translateY(7px) scale(.9) rotate(-3deg); } 60% { opacity: .8; } 100% { opacity: 1; transform: translateY(0) scale(1) rotate(-4deg); } }
+    @keyframes bob { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-2.5px); } }
+    @keyframes radarSweep { to { transform: rotate(-360deg); } }
+    @keyframes sonarPing { 0% { transform: scale(0.12); opacity: 0.55; } 80% { opacity: 0; } 100% { transform: scale(1); opacity: 0; } }
+  </style>
+</helmet>
+<div style="min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;padding:32px 16px;">
+
+  <div style="width:400px;height:812px;background:linear-gradient(160deg,#2a2a30,#0c0c10);border-radius:52px;padding:11px;box-shadow:0 40px 80px -20px rgba(0,0,0,0.7),0 0 0 2px rgba(255,255,255,0.04) inset;position:relative;flex:none;">
+    <div style="{{ screenStyle }}">
+
+      <!-- status bar -->
+      <div style="height:46px;display:flex;align-items:center;justify-content:space-between;padding:0 28px 0 32px;flex:none;font-weight:600;font-size:14px;color:{{ textColor }};">
+        <span>9:41</span>
+        <div style="display:flex;align-items:center;gap:6px;font-size:12px;">
+          <span>5G</span>
+          <span style="display:inline-block;width:22px;height:11px;border:1.5px solid {{ textColor }};border-radius:3px;position:relative;opacity:0.9;"><span style="position:absolute;inset:1.5px;right:5px;background:{{ textColor }};border-radius:1px;"></span></span>
+        </div>
+      </div>
+
+      <!-- chat header -->
+      <div style="height:56px;flex:none;display:flex;align-items:center;gap:10px;padding:0 14px;background:{{ headerBg }};border-bottom:1px solid {{ borderColor }};">
+        <span style="font-size:26px;line-height:1;color:{{ primary }};font-weight:300;margin-right:-2px;">‹</span>
+        <div style="width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,#f0a76b,#d9663f);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;font-size:15px;flex:none;">M</div>
+        <div style="display:flex;flex-direction:column;min-width:0;flex:1;">
+          <span style="font-weight:600;font-size:15px;color:{{ textColor }};">Mia Chen</span>
+          <span style="font-size:12px;color:{{ primary }};">online</span>
+        </div>
+        <span style="font-size:22px;color:{{ mutedColor }};letter-spacing:1px;">⋯</span>
+      </div>
+
+      <!-- messages -->
+      <div style="flex:1;min-height:0;overflow-y:auto;padding:16px 14px 12px;display:flex;flex-direction:column;justify-content:flex-start;gap:8px;">
+
+        <div style="align-self:flex-start;max-width:78%;background:{{ bubbleIn }};color:{{ textColor }};padding:8px 12px;border-radius:16px 16px 16px 5px;font-size:15px;">Rematch? Best of three.</div>
+        <div style="align-self:flex-end;max-width:78%;background:{{ bubbleOut }};color:{{ textColor }};padding:8px 12px;border-radius:16px 16px 5px 16px;font-size:15px;">You're on.</div>
+
+        <!-- GAME CARD (shared, full width) -->
+        <div style="align-self:stretch;background:{{ cardBg }};color:{{ textColor }};padding:14px;border-radius:18px;border:1px solid {{ cardBorder }};box-shadow:0 1px 2px rgba(0,0,0,0.06),0 10px 26px -14px rgba(0,0,0,0.28);">
+          <div style="width:100%;display:flex;flex-direction:column;gap:9px;">
+
+            <!-- matchup header -->
+            <div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:8px;font-size:16px;font-weight:600;">
+              <span style="display:flex;align-items:center;gap:8px;min-width:0;">
+                <span style="width:24px;height:24px;flex:none;display:flex;">{{ markIcon }}</span>
+                <span style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">You</span>
+              </span>
+              <span style="font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:{{ mutedColor }};">vs</span>
+              <span style="display:flex;align-items:center;justify-content:flex-end;gap:8px;min-width:0;">
+                <span style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">Mia</span>
+                <span style="width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,#f0a76b,#d9663f);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;font-size:10px;flex:none;">M</span>
+                <span style="width:24px;height:24px;flex:none;display:flex;transform:scaleX(-1);">{{ markIcon }}</span>
+              </span>
+            </div>
+
+            <!-- stage -->
+            <div style="position:relative;">
+
+              <!-- PLACING -->
+              <sc-if value="{{ isPlacing }}" hint-placeholder-val="{{ true }}">
+                <div style="display:flex;align-items:center;gap:6px;font-size:13px;font-weight:600;color:{{ primary }};margin:0 2px 8px;">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="{{ primary }}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex:none;"><polyline points="5 9 2 12 5 15"></polyline><polyline points="9 5 12 2 15 5"></polyline><polyline points="15 19 12 22 9 19"></polyline><polyline points="19 9 22 12 19 15"></polyline><line x1="2" y1="12" x2="22" y2="12"></line><line x1="12" y1="2" x2="12" y2="22"></line></svg>
+                  <span>Drag ships to move · tap to rotate</span>
+                </div>
+                <div style="position:relative;">
+                  <div style="display:grid;grid-template-columns:repeat(8,1fr);gap:2px;padding:4px;border-radius:10px;background:{{ gridBg }};">
+                    <sc-for list="{{ placingCells }}" as="cell" hint-placeholder-count="64">
+                      <button type="button" disabled="{{ cell.disabled }}" style="{{ cell.style }}"></button>
+                    </sc-for>
+                  </div>
+                  {{ placingOverlay }}
+                </div>
+                <div style="display:flex;justify-content:flex-end;align-items:center;gap:4px;margin-top:8px;">
+                  <button type="button" onClick="{{ shuffle }}" style="background:none;border:none;color:{{ primary }};font-size:13px;font-weight:600;padding:6px 8px;cursor:pointer;display:flex;align-items:center;gap:5px;">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="{{ primary }}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 3 21 3 21 8"></polyline><line x1="4" y1="20" x2="21" y2="3"></line><polyline points="21 16 21 21 16 21"></polyline><line x1="15" y1="15" x2="21" y2="21"></line><line x1="4" y1="4" x2="9" y2="9"></line></svg>
+                    Shuffle
+                  </button>
+                  <button type="button" onClick="{{ ready }}" style="background:{{ primary }};border:none;color:#04150f;font-size:13px;font-weight:700;padding:7px 15px;border-radius:999px;cursor:pointer;display:flex;align-items:center;gap:5px;box-shadow:0 4px 10px -3px rgba(16,185,129,0.6);">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#04150f" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                    Deploy fleet
+                  </button>
+                </div>
+              </sc-if>
+
+              <!-- BATTLE -->
+              <sc-if value="{{ isBattle }}" hint-placeholder-val="{{ true }}">
+                <sc-if value="{{ showTurnStrip }}" hint-placeholder-val="{{ true }}">
+                  <div style="{{ turnStripStyle }}">
+                    <sc-if value="{{ stripMine }}" hint-placeholder-val="{{ true }}">
+                      <svg width="16" height="16" viewBox="0 0 24 24" style="overflow:visible;flex:none;"><circle cx="12" cy="12" r="7" fill="none" stroke="{{ primary }}" stroke-width="2" stroke-dasharray="5 4.5" stroke-linecap="round" style="transform-box:fill-box;transform-origin:center;animation:reticleSpin 3.5s linear infinite;"></circle><circle cx="12" cy="12" r="2" fill="{{ primary }}"></circle></svg>
+                    </sc-if>
+                    <sc-if value="{{ stripWait }}" hint-placeholder-val="{{ false }}">
+                      <svg width="16" height="16" viewBox="0 0 24 24" style="flex:none;"><circle cx="12" cy="12" r="8" fill="none" stroke="{{ mutedColor }}" stroke-width="2.4" stroke-linecap="round" stroke-dasharray="13 40" style="transform-box:fill-box;transform-origin:center;animation:spin .9s linear infinite;"></circle></svg>
+                    </sc-if>
+                    <span>{{ turnStripText }}</span>
+                  </div>
+                </sc-if>
+
+                <div style="margin-bottom:6px;">
+                  <div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.03em;color:{{ mutedColor }};margin:2px 2px 3px;">Their sea</div>
+                  <div style="position:relative;">
+                    <div style="{{ theirGridStyle }}">
+                      <sc-for list="{{ theirCells }}" as="cell" hint-placeholder-count="64">
+                        <button type="button" disabled="{{ cell.disabled }}" onClick="{{ cell.onClick }}" style="{{ cell.style }}">
+                          <sc-if value="{{ cell.isTarget }}" hint-placeholder-val="{{ false }}">
+                            <svg width="80%" height="80%" viewBox="0 0 24 24" style="overflow:visible;">
+                              <circle cx="12" cy="12" r="9" fill="none" stroke="{{ primary }}" stroke-width="1.5" style="transform-box:fill-box;transform-origin:center;animation:reticlePulse 1.4s ease-in-out infinite;"></circle>
+                              <circle cx="12" cy="12" r="6.5" fill="none" stroke="{{ primary }}" stroke-width="2" stroke-dasharray="5 4.5" stroke-linecap="round" style="transform-box:fill-box;transform-origin:center;animation:reticleSpin 3.5s linear infinite;"></circle>
+                              <circle cx="12" cy="12" r="2" fill="{{ primary }}"></circle>
+                              <path d="M12 1v3.2M12 19.8V23M1 12h3.2M19.8 12H23" stroke="{{ primary }}" stroke-width="2" stroke-linecap="round"></path>
+                            </svg>
+                          </sc-if>
+                          <sc-if value="{{ cell.isMiss }}" hint-placeholder-val="{{ false }}">
+                            <svg width="76%" height="76%" viewBox="0 0 24 24" style="overflow:visible;">
+                              <circle cx="12" cy="12" r="6" fill="none" stroke="{{ ink }}" stroke-width="1.6" opacity="0.45"></circle>
+                              <circle cx="12" cy="12" r="6" fill="none" stroke="{{ ink }}" stroke-width="2" style="transform-box:fill-box;transform-origin:center;animation:ripple .7s ease-out both;"></circle>
+                              <circle cx="12" cy="12" r="6" fill="none" stroke="{{ ink }}" stroke-width="2" style="transform-box:fill-box;transform-origin:center;animation:ripple .7s .18s ease-out both;"></circle>
+                            </svg>
+                          </sc-if>
+                        </button>
+                      </sc-for>
+                    </div>
+                    <div style="position:absolute;inset:4px;border-radius:10px;overflow:hidden;pointer-events:none;opacity:{{ radarOpacity }};transition:opacity .35s ease;">
+                      <div style="position:absolute;left:50%;top:7%;bottom:7%;width:1px;margin-left:-0.5px;background:rgba(16,185,129,0.13);"></div>
+                      <div style="position:absolute;top:50%;left:7%;right:7%;height:1px;margin-top:-0.5px;background:rgba(16,185,129,0.13);"></div>
+                      <div style="position:absolute;inset:15%;border-radius:50%;border:1px solid rgba(16,185,129,0.16);"></div>
+                      <div style="position:absolute;inset:32%;border-radius:50%;border:1px solid rgba(16,185,129,0.13);"></div>
+                      <div style="position:absolute;inset:47%;border-radius:50%;border:1px solid rgba(16,185,129,0.11);"></div>
+                      <div style="position:absolute;left:-25%;top:-25%;width:150%;height:150%;border-radius:50%;transform-origin:center;animation:radarSweep 3.8s linear infinite;background:conic-gradient(from 0deg, rgba(16,185,129,0.32), rgba(16,185,129,0.06) 26deg, rgba(16,185,129,0) 56deg, rgba(16,185,129,0) 360deg);"></div>
+                      <div style="position:absolute;inset:15%;border-radius:50%;border:1.5px solid rgba(16,185,129,0.45);transform-origin:center;animation:sonarPing 3.8s ease-out infinite;"></div>
+                    </div>
+                    {{ theirOverlay }}
+                  </div>
+                </div>
+
+                <div>
+                  <div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.03em;color:{{ mutedColor }};margin:2px 2px 3px;">Your sea</div>
+                  <div style="position:relative;">
+                    <div style="display:grid;grid-template-columns:repeat(8,1fr);gap:2px;padding:4px;border-radius:10px;background:{{ gridBg }};">
+                      <sc-for list="{{ ownCells }}" as="cell" hint-placeholder-count="64">
+                        <button type="button" disabled="{{ cell.disabled }}" style="{{ cell.style }}">
+                          <sc-if value="{{ cell.isMiss }}" hint-placeholder-val="{{ false }}">
+                            <svg width="72%" height="72%" viewBox="0 0 24 24" style="overflow:visible;">
+                              <circle cx="12" cy="12" r="6" fill="none" stroke="{{ ink }}" stroke-width="1.6" opacity="0.45"></circle>
+                              <circle cx="12" cy="12" r="6" fill="none" stroke="{{ ink }}" stroke-width="2" style="transform-box:fill-box;transform-origin:center;animation:ripple .7s ease-out both;"></circle>
+                            </svg>
+                          </sc-if>
+                        </button>
+                      </sc-for>
+                    </div>
+                    {{ ownOverlay }}
+                  </div>
+                </div>
+              </sc-if>
+
+              <!-- RESULT OVERLAY -->
+              <sc-if value="{{ showOverlay }}" hint-placeholder-val="{{ false }}">
+                <div onClick="{{ peek }}" style="position:absolute;inset:0;border-radius:10px;background:rgba(6,10,18,0.62);backdrop-filter:blur(2px);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;cursor:pointer;animation:overlayIn 0.25s ease both;">
+                  <svg width="92" height="92" viewBox="0 0 32 32" style="filter:drop-shadow(0 6px 12px rgba(0,0,0,0.45));animation:heroPop 0.55s cubic-bezier(.2,1.3,.5,1) both;">
+                    <path d="M12 4 L12 8 M20 4 L20 8" stroke="{{ medalRing }}" stroke-width="2.4" stroke-linecap="round"></path>
+                    <circle cx="16" cy="18" r="12" fill="{{ medalFill }}" stroke="{{ medalRing }}" stroke-width="1.6"></circle>
+                    <circle cx="16" cy="18" r="8.6" fill="none" stroke="{{ medalRing }}" stroke-width="0.9" opacity="0.55"></circle>
+                    <svg x="8" y="10" width="16" height="16" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" fill="{{ medalStar }}"></path></svg>
+                  </svg>
+                  <span style="font-size:15px;font-weight:700;color:#fff;">{{ statusText }}</span>
+                  <button type="button" onClick="{{ playAgain }}" style="background:rgba(255,255,255,0.14);border:1px solid rgba(255,255,255,0.24);border-radius:999px;color:#fff;font-size:13px;font-weight:600;padding:6px 14px;cursor:pointer;display:flex;align-items:center;gap:6px;">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>
+                    Rematch
+                  </button>
+                </div>
+              </sc-if>
+            </div>
+
+            <!-- status + actions -->
+            <sc-if value="{{ showStatus }}" hint-placeholder-val="{{ true }}">
+              <div style="display:flex;align-items:center;gap:6px;font-size:13px;color:{{ mutedColor }};">
+                <sc-if value="{{ stTarget }}" hint-placeholder-val="{{ true }}">
+                  <svg width="15" height="15" viewBox="0 0 24 24" style="flex:none;"><circle cx="12" cy="12" r="7" fill="none" stroke="{{ primary }}" stroke-width="2" stroke-dasharray="5 4.5" stroke-linecap="round" style="transform-box:fill-box;transform-origin:center;animation:reticleSpin 3.5s linear infinite;"></circle><circle cx="12" cy="12" r="2" fill="{{ primary }}"></circle></svg>
+                </sc-if>
+                <sc-if value="{{ stSpin }}" hint-placeholder-val="{{ false }}">
+                  <svg width="15" height="15" viewBox="0 0 24 24" style="flex:none;"><circle cx="12" cy="12" r="8" fill="none" stroke="{{ mutedColor }}" stroke-width="2.4" stroke-linecap="round" stroke-dasharray="13 40" style="transform-box:fill-box;transform-origin:center;animation:spin .9s linear infinite;"></circle></svg>
+                </sc-if>
+                <sc-if value="{{ stMedal }}" hint-placeholder-val="{{ false }}">
+                  <svg width="16" height="16" viewBox="0 0 32 32" style="flex:none;"><circle cx="16" cy="18" r="12" fill="{{ medalFill }}" stroke="{{ medalRing }}" stroke-width="1.6"></circle><svg x="8" y="10" width="16" height="16" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" fill="{{ medalStar }}"></path></svg></svg>
+                </sc-if>
+                <span>{{ statusText }}</span>
+              </div>
+              <div style="display:flex;justify-content:flex-end;margin:-4px -4px -4px 0;">
+                <sc-if value="{{ showResign }}" hint-placeholder-val="{{ false }}">
+                  <button type="button" onClick="{{ resign }}" style="background:none;border:none;color:{{ mutedColor }};font-size:13px;padding:4px 8px;cursor:pointer;">Resign</button>
+                </sc-if>
+                <sc-if value="{{ showPlayAgain }}" hint-placeholder-val="{{ false }}">
+                  <button type="button" onClick="{{ playAgain }}" style="background:none;border:none;color:{{ primary }};font-size:13px;font-weight:600;padding:4px 8px;cursor:pointer;display:flex;align-items:center;gap:5px;">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="{{ primary }}" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>
+                    Rematch
+                  </button>
+                </sc-if>
+              </div>
+            </sc-if>
+
+          </div>
+        </div>
+
+        <div style="align-self:flex-end;font-size:11px;color:{{ mutedColor }};margin:-3px 6px 0;">Delivered</div>
+      </div>
+
+      <!-- composer -->
+      <div style="height:56px;flex:none;display:flex;align-items:center;gap:8px;padding:0 12px;background:{{ headerBg }};border-top:1px solid {{ borderColor }};">
+        <span style="font-size:24px;color:{{ mutedColor }};">＋</span>
+        <div style="flex:1;height:36px;border-radius:18px;background:{{ inputBg }};border:1px solid {{ borderColor }};display:flex;align-items:center;padding:0 14px;color:{{ mutedColor }};font-size:14px;">Message</div>
+        <div style="width:34px;height:34px;border-radius:50%;background:{{ primary }};display:flex;align-items:center;justify-content:center;color:#04150f;font-size:18px;font-weight:700;flex:none;">↑</div>
+      </div>
+
+    </div>
+  </div>
+
+  <button type="button" onClick="{{ restart }}" style="background:rgba(255,255,255,0.08);color:rgba(255,255,255,0.7);border:1px solid rgba(255,255,255,0.12);border-radius:999px;padding:7px 16px;font-size:13px;font-weight:500;cursor:pointer;">↺ Restart game</button>
+
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{
+  &quot;$preview&quot;: { &quot;width&quot;: 460, &quot;height&quot;: 920 },
+  &quot;scheme&quot;: { &quot;editor&quot;: &quot;enum&quot;, &quot;options&quot;: [&quot;light&quot;, &quot;dark&quot;], &quot;default&quot;: &quot;light&quot;, &quot;tsType&quot;: &quot;string&quot;, &quot;section&quot;: &quot;Appearance&quot; },
+  &quot;startPhase&quot;: { &quot;editor&quot;: &quot;enum&quot;, &quot;options&quot;: [&quot;placing&quot;, &quot;battle&quot;], &quot;default&quot;: &quot;placing&quot;, &quot;tsType&quot;: &quot;string&quot;, &quot;section&quot;: &quot;Game&quot; }
+}">
+const e = React.createElement;
+
+const ACCENT = '28, 92, 140';
+const FLEET = [4, 3, 3, 2];
+const FLEET_CELLS = 12;
+
+function placeFleet() {
+  for (;;) {
+    const ships = [];
+    const taken = new Set();
+    let ok = true;
+    for (const len of FLEET) {
+      let placed = false;
+      for (let a = 0; a < 200 && !placed; a++) {
+        const dir = Math.random() < 0.5 ? 'h' : 'v';
+        const r = Math.floor(Math.random() * (dir === 'v' ? 8 - len + 1 : 8));
+        const c = Math.floor(Math.random() * (dir === 'h' ? 8 - len + 1 : 8));
+        const cells = [];
+        for (let k = 0; k < len; k++) cells.push(dir === 'h' ? r * 8 + c + k : (r + k) * 8 + c);
+        if (cells.every((x) => !taken.has(x))) {
+          cells.forEach((x) => taken.add(x));
+          ships.push({ r, c, len, dir });
+          placed = true;
+        }
+      }
+      if (!placed) { ok = false; break; }
+    }
+    if (ok) return ships;
+  }
+}
+
+function shipCells(sh) {
+  const out = [];
+  for (let k = 0; k < sh.len; k++) out.push(sh.dir === 'h' ? sh.r * 8 + sh.c + k : (sh.r + k) * 8 + sh.c);
+  return out;
+}
+
+/* ---------- submarine artwork (drawn horizontal, bow to the right) ---------- */
+function subArt(W, len) {
+  const hull = '#454f5a', hullHi = '#707b86', hullLo = '#262d34', dark = '#1a2026', tower = '#374049', trim = '#8b96a1', glow = '#7dd3fc', prop = '#c6a24a';
+  const cx = W * 0.5;
+  const tx = cx - W * 0.05;
+  const els = [];
+  // stern shaft + rudder + propeller
+  els.push(e('line', { key: 'shaft', x1: 4, y1: 56, x2: 13, y2: 56, stroke: dark, strokeWidth: 3, strokeLinecap: 'round' }));
+  els.push(e('path', { key: 'rudder', d: `M11 49 L5 46 L5 66 L11 63 Z`, fill: tower, stroke: dark, strokeWidth: 1.2, strokeLinejoin: 'round' }));
+  els.push(e('g', { key: 'prop', transform: 'translate(5,56)' }, [
+    e('ellipse', { key: 'a', cx: 0, cy: 0, rx: 2, ry: 6, fill: prop }),
+    e('ellipse', { key: 'b', cx: 0, cy: 0, rx: 6, ry: 2, fill: prop }),
+    e('circle', { key: 'c', cx: 0, cy: 0, r: 1.7, fill: dark }),
+  ]));
+  // pressure hull (rounded capsule, bow to the right)
+  els.push(e('path', { key: 'hull', d: `M18 43 H${W - 20} Q${W - 4} 43 ${W - 4} 56 Q${W - 4} 69 ${W - 20} 69 H18 Q8 69 8 56 Q8 43 18 43 Z`, fill: hull, stroke: dark, strokeWidth: 2.5, strokeLinejoin: 'round' }));
+  els.push(e('path', { key: 'hi', d: `M16 49 Q${cx} 45.5 ${W - 18} 49`, fill: 'none', stroke: hullHi, strokeWidth: 2.4, strokeLinecap: 'round', opacity: 0.7 }));
+  els.push(e('path', { key: 'lo', d: `M18 64 H${W - 20}`, fill: 'none', stroke: hullLo, strokeWidth: 2.5, strokeLinecap: 'round', opacity: 0.5 }));
+  // bow dive plane
+  els.push(e('path', { key: 'plane', d: `M${W - 24} 60 L${W - 8} 63 L${W - 24} 66 Z`, fill: tower, stroke: dark, strokeWidth: 1, strokeLinejoin: 'round' }));
+  // glowing portholes
+  const lights = Math.max(2, len + 1);
+  for (let i = 0; i < lights; i++) { const lx = 24 + i * ((W - 48) / lights); if (Math.abs(lx - tx) < 12) continue; els.push(e('circle', { key: 'l' + i, cx: lx, cy: 57, r: 2, fill: glow, opacity: 0.9 })); }
+  // conning tower (sail)
+  els.push(e('path', { key: 'tower', d: `M${tx - 11} 44 V33 Q${tx - 11} 27 ${tx - 5} 27 H${tx + 7} Q${tx + 13} 27 ${tx + 13} 33 V44 Z`, fill: tower, stroke: dark, strokeWidth: 2, strokeLinejoin: 'round' }));
+  els.push(e('line', { key: 'twhi', x1: tx - 8, y1: 31, x2: tx + 9, y2: 31, stroke: trim, strokeWidth: 1.5, opacity: 0.55 }));
+  els.push(e('rect', { key: 'twl', x: tx - 2, y: 35, width: 4, height: 4, rx: 1, fill: glow, opacity: 0.85 }));
+  // periscope + antenna
+  els.push(e('line', { key: 'per', x1: tx - 3, y1: 27, x2: tx - 3, y2: 15, stroke: dark, strokeWidth: 2, strokeLinecap: 'round' }));
+  els.push(e('line', { key: 'pertop', x1: tx - 4, y1: 16, x2: tx + 1, y2: 16, stroke: dark, strokeWidth: 2, strokeLinecap: 'round' }));
+  els.push(e('line', { key: 'ant', x1: tx + 5, y1: 27, x2: tx + 5, y2: 19, stroke: trim, strokeWidth: 1.6, strokeLinecap: 'round' }));
+  return els;
+}
+function ghostArt(W) {
+  const g = 'rgba(200,214,226,0.58)', gd = 'rgba(255,255,255,0.55)', dk = 'rgba(6,12,20,0.32)';
+  const cx = W * 0.5;
+  return [
+    // broken, powerless sub hull
+    e('path', { key: 'h', d: `M18 44 H${W - 20} Q${W - 5} 44 ${W - 5} 56 Q${W - 5} 68 ${W - 20} 68 H18 Q8 68 8 56 Q8 44 18 44 Z`, fill: g, stroke: gd, strokeWidth: 2, strokeLinejoin: 'round' }),
+    e('path', { key: 'tw', d: `M${cx - 9} 44 V34 Q${cx - 9} 30 ${cx - 4} 30 H${cx + 6} Q${cx + 10} 30 ${cx + 10} 34 V44 Z`, fill: g, stroke: gd, strokeWidth: 1.6 }),
+    e('path', { key: 'crack', d: `M${cx - 20} 52 l7 4 l-4 4`, fill: 'none', stroke: dk, strokeWidth: 1.6, strokeLinecap: 'round', strokeLinejoin: 'round' }),
+    e('circle', { key: 'ho', cx: cx + W * 0.24, cy: 58, r: 3.5, fill: dk }),
+    // dead X eyes on the tower
+    e('path', { key: 'x1', d: `M${cx - 5} 35 l4 4 M${cx - 1} 35 l-4 4`, stroke: '#33414f', strokeWidth: 1.4, strokeLinecap: 'round' }),
+    e('path', { key: 'x2', d: `M${cx + 2} 35 l4 4 M${cx + 6} 35 l-4 4`, stroke: '#33414f', strokeWidth: 1.4, strokeLinecap: 'round' }),
+    e('circle', { key: 'bu1', cx: cx - W * 0.2, cy: 30, r: 2.4, fill: gd, style: { animation: 'bob 2.4s ease-in-out infinite' } }),
+    e('circle', { key: 'bu2', cx: cx + W * 0.26, cy: 26, r: 1.9, fill: gd, style: { animation: 'bob 2.8s ease-in-out .5s infinite' } }),
+  ];
+}
+
+function shipSvg(info, ghost, invalid) {
+  const W = info.len * 100;
+  const content = ghost ? ghostArt(W) : subArt(W, info.len);
+  const fat = e('g', { transform: 'translate(0,54) scale(1,1.14) translate(0,-54)' }, content);
+  const inner = info.horiz ? fat : e('g', { transform: `translate(100,0) rotate(90)` }, fat);
+  const shadow = invalid
+    ? 'drop-shadow(0 0 2px rgba(239,68,68,0.95)) drop-shadow(0 0 3px rgba(239,68,68,0.75))'
+    : 'drop-shadow(0 1px 1.5px rgba(0,0,0,0.28))';
+  return e('svg', {
+    viewBox: info.horiz ? `0 0 ${W} 100` : `0 0 100 ${W}`,
+    preserveAspectRatio: 'none', width: '100%', height: '100%',
+    style: { display: 'block', overflow: 'visible', filter: shadow, animation: ghost ? 'ghostIn .55s ease both' : 'shipIn .4s ease both' },
+  }, inner);
+}
+function flameSvg() {
+  return e('svg', { viewBox: '0 0 24 24', width: '74%', height: '74%', style: { overflow: 'visible', animation: 'markPop .3s ease-out both' } }, [
+    e('path', { key: 'a', d: 'M12 2 C15 7 18 9.5 16.5 14 A5.4 5.4 0 1 1 7.5 14 C6.6 10.6 9.6 9.6 10 6.4 C10.7 8.4 11 8.2 12 2 Z', fill: '#fb923c', style: { transformBox: 'fill-box', transformOrigin: '50% 92%', animation: 'flicker .5s ease-in-out infinite alternate' } }),
+    e('path', { key: 'b', d: 'M12 8 C13.7 10.6 15 11.6 14 14.6 A3 3 0 1 1 9.6 14.7 C9.3 12.7 11.1 12.1 12 8 Z', fill: '#fde047', style: { transformBox: 'fill-box', transformOrigin: '50% 92%', animation: 'flicker .38s ease-in-out .12s infinite alternate' } }),
+  ]);
+}
+
+// Absolute box for a cell region (col c, row r, spanning cs×rs cells) inside an
+// 8×8 board with 2px gaps. Each ship's box is a pure function of its OWN
+// coords — independent of every other ship, so moving/rotating one never
+// reflows the others (no shared grid to re-solve).
+function boxStyle(r, c, cs, rs) {
+  const off = (n) => `calc((100% - 14px) / 8 * ${n} + ${n * 2}px)`;
+  const sz = (n) => `calc((100% - 14px) / 8 * ${n} + ${(n - 1) * 2}px)`;
+  return { position: 'absolute', left: off(c), top: off(r), width: sz(cs), height: sz(rs) };
+}
+function flame(c) {
+  return e('div', { key: 'f' + c, style: { ...boxStyle(Math.floor(c / 8), c % 8, 1, 1), display: 'flex', alignItems: 'center', justifyContent: 'center' } }, flameSvg());
+}
+function buildOverlay(ships, sea, showIntact, opts) {
+  opts = opts || {};
+  const kids = [];
+  ships.forEach((ship, si) => {
+    const info = { r: ship.r, c: ship.c, len: ship.len, horiz: ship.dir === 'h' };
+    const cs = info.horiz ? info.len : 1, rs = info.horiz ? 1 : info.len;
+    const cells = shipCells(ship);
+    const hitCells = cells.filter((c) => sea[c] === 'hit' || sea[c] === 'sunk');
+    const sunk = cells.length > 0 && hitCells.length === cells.length;
+    const place = boxStyle(info.r, info.c, cs, rs);
+    if (sunk) {
+      kids.push(e('div', { key: 'g' + si, style: place }, shipSvg(info, true)));
+    } else if (showIntact) {
+      const active = opts.dragIdx === si;
+      const invalid = active && opts.dragInvalid;
+      const style = { ...place };
+      if (opts.interactive) {
+        style.pointerEvents = 'auto'; style.cursor = active ? 'grabbing' : 'grab'; style.touchAction = 'none';
+        style.zIndex = active ? 5 : 1;
+        if (active) style.filter = 'drop-shadow(0 4px 5px rgba(0,0,0,0.35))';
+      }
+      const props = { key: 's' + si, style };
+      if (opts.interactive) props.onPointerDown = (ev) => opts.onDown(si, ev);
+      kids.push(e('div', props, shipSvg(info, false, invalid)));
+      hitCells.forEach((c) => kids.push(flame(c)));
+    } else {
+      hitCells.forEach((c) => kids.push(flame(c)));
+    }
+  });
+  return e('div', { style: { position: 'absolute', inset: '4px', pointerEvents: 'none' } }, kids);
+}
+
+function fresh(phase) {
+  return {
+    phase: phase === 'battle' ? 'battle' : 'placing',
+    myShips: placeFleet(),
+    theirShips: placeFleet(),
+    theirSea: {},
+    mySea: {},
+    turn: 0,
+    busy: false,
+    winner: null,
+    resignedByMe: false,
+    peeked: false,
+    dragIdx: -1,
+    dragInvalid: false,
+  };
+}
+
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this._timers = [];
+    this.state = fresh(props.startPhase);
+  }
+  componentDidUpdate(prev) {
+    if (prev.startPhase !== this.props.startPhase) this.restart();
+  }
+  componentWillUnmount() {
+    this._timers.forEach(clearTimeout);
+    if (this._onMove) { window.removeEventListener('pointermove', this._onMove); window.removeEventListener('pointerup', this._onUp); }
+  }
+  later(fn, ms) { const t = setTimeout(fn, ms); this._timers.push(t); return t; }
+
+  hitCount(sea) { return Object.values(sea).filter((r) => r === 'hit' || r === 'sunk').length; }
+
+  judge(ships, sea, cell) {
+    const ship = ships.find((s) => shipCells(s).includes(cell));
+    if (!ship) return 'miss';
+    const hit = new Set();
+    for (const k in sea) if (sea[k] === 'hit' || sea[k] === 'sunk') hit.add(+k);
+    hit.add(cell);
+    return shipCells(ship).every((c) => hit.has(c)) ? 'sunk' : 'hit';
+  }
+
+  shuffle() { if (this.state.phase === 'placing') this.setState({ myShips: placeFleet(), dragIdx: -1, dragInvalid: false }); }
+  ready() { if (this.state.phase === 'placing') this.setState({ phase: 'battle', turn: 0 }); }
+
+  // ----- placement: drag to move, tap to rotate -----
+  canPlace(sh, exclude) {
+    const h = sh.dir === 'h';
+    if (sh.r < 0 || sh.c < 0 || (h ? sh.c + sh.len > 8 || sh.r > 7 : sh.r + sh.len > 8 || sh.c > 7)) return false;
+    const occ = new Set();
+    this.state.myShips.forEach((s, idx) => { if (idx === exclude) return; shipCells(s).forEach((c) => occ.add(c)); });
+    return shipCells(sh).every((c) => !occ.has(c));
+  }
+  cellAt(ev) {
+    const rect = this._dragGrid.getBoundingClientRect();
+    const cs = rect.width / 8;
+    return { r: Math.floor((ev.clientY - rect.top) / cs), c: Math.floor((ev.clientX - rect.left) / cs) };
+  }
+  shipDown(i, ev) {
+    if (this.state.phase !== 'placing') return;
+    ev.preventDefault(); ev.stopPropagation();
+    this._dragGrid = ev.currentTarget.parentElement;
+    const { r: pr, c: pc } = this.cellAt(ev);
+    const sh = this.state.myShips[i];
+    this._drag = { i, dr: pr - sh.r, dc: pc - sh.c, from: { r: sh.r, c: sh.c }, moved: false };
+    this._onMove = (e) => this.shipMove(e);
+    this._onUp = () => this.shipUp();
+    window.addEventListener('pointermove', this._onMove);
+    window.addEventListener('pointerup', this._onUp);
+    this.setState({ dragIdx: i, dragInvalid: false });
+  }
+  shipMove(ev) {
+    if (!this._drag) return;
+    ev.preventDefault();
+    const { r: pr, c: pc } = this.cellAt(ev);
+    const { i, dr, dc, from } = this._drag;
+    const sh = this.state.myShips[i];
+    const h = sh.dir === 'h';
+    let nr = Math.max(0, Math.min(h ? 7 : 8 - sh.len, pr - dr));
+    let nc = Math.max(0, Math.min(h ? 8 - sh.len : 7, pc - dc));
+    if (nr !== from.r || nc !== from.c) this._drag.moved = true;
+    const cand = { ...sh, r: nr, c: nc };
+    const ships = this.state.myShips.map((x, idx) => (idx === i ? cand : x));
+    this.setState({ myShips: ships, dragInvalid: !this.canPlace(cand, i) });
+  }
+  shipUp() {
+    window.removeEventListener('pointermove', this._onMove);
+    window.removeEventListener('pointerup', this._onUp);
+    const d = this._drag; this._drag = null;
+    if (!d) { this.setState({ dragIdx: -1, dragInvalid: false }); return; }
+    const sh = this.state.myShips[d.i];
+    if (!d.moved) {
+      // tap → rotate 90°
+      const dir = sh.dir === 'h' ? 'v' : 'h';
+      let r = sh.r, c = sh.c;
+      if (dir === 'v' && r + sh.len > 8) r = 8 - sh.len;
+      if (dir === 'h' && c + sh.len > 8) c = 8 - sh.len;
+      const cand = { ...sh, dir, r: Math.max(0, r), c: Math.max(0, c) };
+      if (this.canPlace(cand, d.i)) {
+        this.setState({ myShips: this.state.myShips.map((x, idx) => (idx === d.i ? cand : x)), dragIdx: -1, dragInvalid: false });
+        return;
+      }
+    } else if (this.state.dragInvalid) {
+      // invalid drop → snap back
+      this.setState({ myShips: this.state.myShips.map((x, idx) => (idx === d.i ? { ...x, r: d.from.r, c: d.from.c } : x)), dragIdx: -1, dragInvalid: false });
+      return;
+    }
+    this.setState({ dragIdx: -1, dragInvalid: false });
+  }
+  restart() { this._timers.forEach(clearTimeout); this._timers = []; this.setState(fresh(this.props.startPhase)); }
+  playAgain() { this.restart(); }
+  peek() { this.setState({ peeked: true }); }
+  resign() {
+    if (this.state.winner !== null) return;
+    this._timers.forEach(clearTimeout); this._timers = [];
+    this.setState({ winner: 1, resignedByMe: true, busy: false });
+  }
+
+  canFire() {
+    const s = this.state;
+    return s.phase === 'battle' && s.turn === 0 && s.winner === null && !s.busy;
+  }
+
+  fire(i) {
+    if (!this.canFire() || this.state.theirSea[i]) return;
+    this.setState({ theirSea: { ...this.state.theirSea, [i]: 'pending' }, busy: true });
+    this.later(() => {
+      const base = { ...this.state.theirSea };
+      delete base[i];
+      const r = this.judge(this.state.theirShips, base, i);
+      const sea = { ...this.state.theirSea, [i]: r };
+      if (this.hitCount(sea) >= FLEET_CELLS) {
+        this.setState({ theirSea: sea, winner: 0, busy: false });
+      } else {
+        this.setState({ theirSea: sea, turn: 1 });
+        this.later(() => this.opponentMove(), 900);
+      }
+    }, 640);
+  }
+
+  opponentMove() {
+    if (this.state.winner !== null) return;
+    const open = [];
+    for (let i = 0; i < 64; i++) if (!(i in this.state.mySea)) open.push(i);
+    let cell = -1;
+    const wounded = Object.keys(this.state.mySea).filter((k) => this.state.mySea[k] === 'hit').map(Number);
+    if (wounded.length) {
+      const adj = [];
+      for (const w of wounded) for (const d of [-8, 8, -1, 1]) {
+        const n = w + d;
+        if (n < 0 || n >= 64) continue;
+        if (d === -1 && w % 8 === 0) continue;
+        if (d === 1 && w % 8 === 7) continue;
+        if (!(n in this.state.mySea)) adj.push(n);
+      }
+      if (adj.length) cell = adj[Math.floor(Math.random() * adj.length)];
+    }
+    if (cell < 0) cell = open[Math.floor(Math.random() * open.length)];
+    if (cell == null) return;
+    const base = { ...this.state.mySea };
+    const r = this.judge(this.state.myShips, base, cell);
+    const sea = { ...this.state.mySea, [cell]: r };
+    if (this.hitCount(sea) >= FLEET_CELLS) {
+      this.setState({ mySea: sea, winner: 1, busy: false });
+    } else {
+      this.setState({ mySea: sea, turn: 0, busy: false });
+    }
+  }
+
+  renderVals() {
+    const s = this.state;
+    const dark = (this.props.scheme ?? 'light') === 'dark';
+    const accent = ACCENT;
+    const primary = '#10b981';
+
+    const base = dark ? '#000000' : '#ffffff';
+    const textColor = dark ? '#ffffff' : '#0b0b0c';
+    const mutedColor = dark ? 'rgba(255,255,255,0.6)' : 'rgba(0,0,0,0.55)';
+    const ink = dark ? 'rgba(255,255,255,0.55)' : 'rgba(2,6,23,0.42)';
+    const bg = `linear-gradient(165deg, rgba(16,185,129,${dark ? 0.22 : 0.16}), rgba(16,185,129,${dark ? 0.05 : 0.03}) 70%), ${base}`;
+    const screenStyle = `width:100%;height:100%;border-radius:42px;overflow:hidden;background:${bg};display:flex;flex-direction:column;position:relative;`;
+
+    const firable = this.canFire();
+    const water = `rgba(${accent}, 0.13)`;
+    const charHit = 'rgba(120,60,30,0.20)';
+    const charSunk = 'rgba(70,84,110,0.22)';
+    const gridBg = `linear-gradient(180deg, rgba(${accent}, 0.07), rgba(${accent}, 0.16))`;
+    const cellStyle = (bgc, cur) => `width:100%;aspect-ratio:1;border:none;padding:0;position:relative;display:flex;align-items:center;justify-content:center;background:${bgc};border-radius:4px;cursor:${cur};`;
+
+    const theirCells = [];
+    for (let i = 0; i < 64; i++) {
+      const r = s.theirSea[i];
+      const bgc = r === 'hit' ? charHit : r === 'sunk' ? charSunk : water;
+      theirCells.push({ style: cellStyle(bgc, firable && !r ? 'pointer' : 'default'), isTarget: r === 'pending', isMiss: r === 'miss', disabled: !(firable && !r), onClick: () => this.fire(i) });
+    }
+    const ownCells = [];
+    for (let i = 0; i < 64; i++) {
+      const r = s.mySea[i];
+      const bgc = r === 'hit' ? charHit : r === 'sunk' ? charSunk : water;
+      ownCells.push({ style: cellStyle(bgc, 'default'), isMiss: r === 'miss', disabled: true });
+    }
+    const placingCells = [];
+    for (let i = 0; i < 64; i++) placingCells.push({ style: cellStyle(water, 'default'), disabled: true });
+
+    let theirGridStyle = `display:grid;grid-template-columns:repeat(8,1fr);gap:2px;padding:4px;border-radius:10px;background:${gridBg};transition:opacity .25s ease,box-shadow .25s ease;`;
+    if (firable) theirGridStyle += 'box-shadow:0 0 0 2px rgba(16,185,129,0.55);';
+    else if (s.winner === null && s.turn === 1) theirGridStyle += 'opacity:0.6;';
+
+    const mineTurn = s.turn === 0 && s.winner === null;
+    const turnStripStyle = `display:flex;align-items:center;gap:6px;font-size:13px;font-weight:600;margin:0 2px 6px;color:${mineTurn ? primary : mutedColor};`;
+
+    let statusText;
+    const win = s.winner === 0;
+    if (s.winner !== null) {
+      if (win) statusText = 'You won!';
+      else if (s.resignedByMe) statusText = 'You gave up';
+      else statusText = 'Mia won';
+    } else {
+      statusText = s.turn === 0 ? 'Your move' : "Mia's move";
+    }
+    const medal = win
+      ? { medalFill: '#f6c453', medalRing: '#c99a2e', medalStar: '#fff8e6' }
+      : { medalFill: '#d7dde3', medalRing: '#98a2ac', medalStar: '#ffffff' };
+    const showOverlay = s.winner !== null && !s.peeked;
+
+    // submarine fleet mark for the header
+    const markIcon = e('svg', { viewBox: '0 0 100 100', width: '100%', height: '100%', preserveAspectRatio: 'xMidYMid meet' },
+      subArt(100, 1).map((el, i) => React.cloneElement(el, { key: 'm' + i })));
+
+    return {
+      screenStyle, primary, textColor, mutedColor, ink,
+      markIcon,
+      headerBg: dark ? 'rgba(16,185,129,0.05)' : 'rgba(16,185,129,0.06)',
+      borderColor: dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
+      inputBg: dark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)',
+      bubbleIn: dark ? '#232d33' : '#e7e8ec',
+      bubbleOut: dark ? '#103a2c' : '#d6f3cc',
+      cardBg: dark ? '#181f1b' : '#ffffff',
+      cardBorder: dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)',
+      gridBg,
+
+      isPlacing: s.phase === 'placing',
+      isBattle: s.phase === 'battle',
+      placingCells, theirCells, ownCells,
+      theirGridStyle,
+      ownOverlay: buildOverlay(s.myShips, s.mySea, true),
+      theirOverlay: buildOverlay(s.theirShips, s.theirSea, false),
+      placingOverlay: buildOverlay(s.myShips, {}, true, { interactive: true, onDown: (i, ev) => this.shipDown(i, ev), dragIdx: s.dragIdx, dragInvalid: s.dragInvalid }),
+
+      showTurnStrip: s.winner === null,
+      turnStripStyle,
+      stripMine: mineTurn,
+      stripWait: !mineTurn,
+      radarOpacity: mineTurn ? 0.95 : 0.5,
+      turnStripText: mineTurn ? 'Your shot — tap their sea' : 'Waiting for their move…',
+
+      showStatus: !showOverlay,
+      statusText,
+      stTarget: s.winner === null && s.turn === 0,
+      stSpin: s.winner === null && s.turn === 1,
+      stMedal: s.winner !== null,
+      showResign: s.phase === 'battle' && s.winner === null,
+      showPlayAgain: s.winner !== null,
+
+      showOverlay,
+      ...medal,
+
+      shuffle: () => this.shuffle(),
+      ready: () => this.ready(),
+      resign: () => this.resign(),
+      playAgain: () => this.playAgain(),
+      peek: () => this.peek(),
+      restart: () => this.restart(),
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/specs/1033-submarine-redesign-battleship/design/handoff.md
+++ b/specs/1033-submarine-redesign-battleship/design/handoff.md
@@ -1,0 +1,154 @@
+# Handoff: Submarine Game Bubble (Battleship redesign)
+
+## Overview
+A visual + UX redesign of the in‑chat Battleship game (spec `0011-battleship-hidden-fleets`) for the Ring messenger. It reskins the fleet as **submarines** (which fits the "opponent fires blind at hidden ships" mechanic), turns the game message into a **full‑width shared card**, and adds four things the current board doesn't have:
+
+1. **Full‑width game card** instead of a right‑aligned chat bubble (it's a shared experience, not "your" message).
+2. **Manual fleet placement** during the placing phase — drag a submarine to move it, tap to rotate 90°, with live overlap/out‑of‑bounds validation.
+3. **A sonar radar sweep** over the opponent's sea during battle (rotating beam + range rings + ping), brighter on your turn.
+4. **Custom vector art + animations everywhere** — submarines drawn as continuous multi‑cell vessels, per‑segment **fire** on hits, a **sunk‑submarine wreck** reveal, a targeting **reticle**, sonar **ripple** misses, and a struck **medallion** result. No emoji.
+
+## About the Design Files
+The files in this bundle are a **design reference built in HTML** (a self‑contained prototype that shows the intended look, motion, and interactions). They are **not** production code to copy verbatim.
+
+The Ring app is **Vue 3 + Ionic + TypeScript**. The task is to **recreate this design inside the existing components and patterns** of the ring repo — primarily:
+
+- `src/components/GameBubble.vue` — the card shell (matchup header, glanceable status, action row, result overlay).
+- `src/games/battleship/BattleshipBoard.vue` — the board itself (placing / battle faces, the two seas, shots, and now the radar + placement UX).
+- `src/games/battleship/logic.ts` / `session.ts` / `secret.ts` — **unchanged game rules**. See the "Keep the real protocol" note below.
+
+Reuse the existing tokens in `src/theme/variables.css` (`--ion-color-primary`, `--app-text-muted`, `--app-bubble-*`, etc.). Only the submarine art, the radar, and the placement‑editing UX are genuinely new.
+
+## Fidelity
+**High‑fidelity.** Final colors, sizes, spacing, motion, and interactions are all specified below and are the intended production values. Recreate pixel‑for‑pixel using the codebase's Vue/Ionic patterns (the prototype draws the ships/fire/ghost/medal with inline SVG via a small `React.createElement`‑style helper; in Vue these become `<svg>` in the SFC template or a small render function).
+
+## ⚠️ Keep the real protocol (important)
+The prototype contains a **mock opponent** (random return fire, instant "answers") purely so the prototype is playable in isolation. **Do not port that.** The real game is commit‑and‑reveal, zero‑knowledge, driven by `applyMove`/`status`/`replayState` over the shared move log, with the local fleet secret in `secret.ts`. This redesign only changes **presentation + the placement UI**:
+
+- The chosen/rearranged layout is exactly what today gets hashed in `BattleshipBoard.vue`'s `ready()` (`commitment(layout, salt)` → `setFleetSecret`). Manual placement just lets the player author `layout` instead of only shuffling a random one.
+- Shot results (`miss` / `hit` / `sunk`), turn derivation, the end‑of‑game reveal, and out‑of‑sync handling all stay in the engine. The visuals are a pure function of the replayed public state, same as today (FR‑004).
+
+## Layout & sizing
+- **Card**: full width of the message column. Padding `14px`, border‑radius `18px`, `1px` border, soft shadow `0 1px 2px rgba(0,0,0,.06), 0 10px 26px -14px rgba(0,0,0,.28)`. Background is a **neutral surface**, not the green outgoing bubble: `#ffffff` (light) / `#181f1b` (dark); border `rgba(0,0,0,.07)` / `rgba(255,255,255,.08)`.
+- **Inner column**: `display:flex; flex-direction:column; gap:9px`.
+- **Board**: 8×8. Each grid is `display:grid; grid-template-columns:repeat(8,1fr); gap:2px; padding:4px; border-radius:10px`. Cells are `aspect-ratio:1; border-radius:4px`.
+- **Fleet**: lengths `[4,3,3,2]` = **12 cells** (`FLEET`, `FLEET_CELLS` — matches `logic.ts`).
+- **Two seas stack vertically** in battle: *Their sea* on top (you fire here), *Your sea* below. Keep this order (prompt‑adjacency + parity with today's board).
+
+## Screens / faces
+
+### 1. Placing
+- **Your sea** (8×8) pre‑filled with your submarines.
+- Hint row above the grid: a four‑arrow move glyph + **"Drag ships to move · tap to rotate"** in the primary green, 13px/600.
+- Action row (right aligned): **Shuffle** (ghost button, primary text, shuffle icon) and **Deploy fleet** (solid primary pill `#10b981`, text `#04150f`, check icon, shadow `0 4px 10px -3px rgba(16,185,129,.6)`).
+- Ships are the interactive submarine vessels (see Interactions → Placement).
+
+### 2. Battle
+- **Turn strip** (above Their sea): spinning reticle + **"Your shot — tap their sea"** in primary when it's your turn; muted spinner + **"Waiting for their move…"** otherwise.
+- **Their sea** (top): tappable cells. Grid gets a green turn‑glow `box-shadow:0 0 0 2px rgba(16,185,129,.55)` on your turn, and dims to `opacity:.6` while waiting. **Radar** overlay on top of the water (see below). Subs are hidden until sunk.
+- **Your sea** (bottom): your submarines drawn in full; incoming shots land here as ripples/fire; a fully‑destroyed sub becomes a wreck.
+- **Status line** (below board): reticle + "Your move" / spinner + "Mia's move" (mirrors today's `GameBubble` status). **Resign** action while ongoing.
+
+### 3. Result overlay
+- Dark scrim `rgba(6,10,18,.62)` + `backdrop-filter:blur(2px)` over the board.
+- **Medallion** (92px), `heroPop` entrance. Gold = win `{fill:#f6c453, ring:#c99a2e, star:#fff8e6}`; silver = loss `{fill:#d7dde3, ring:#98a2ac, star:#ffffff}`.
+- Result text (`You won!` / `Mia won` / `You gave up`) + **Rematch** button (refresh icon).
+
+## Interactions & behavior
+
+### Placement (new)
+- **Drag**: `pointerdown` on a sub starts a drag; it follows the pointer and snaps to the nearest cell. While held it lifts with a shadow only (`filter: drop-shadow(0 4px 5px rgba(0,0,0,.35))`) — **no scale transform** (scaling made neighbours appear to wobble).
+- **Validity**: an illegal position (overlap or off‑board) tints the sub red (`drop-shadow` red glow); on release an invalid drop **snaps back** to where it started.
+- **Tap** (pointer down+up without moving): **rotate 90°** (`h`⇄`v`), clamped into bounds; if the rotation wouldn't fit it's declined (no‑op).
+- **Isolation requirement**: each sub is absolutely positioned from its **own** `{r,c,len,dir}` (see "Positioning math"), NOT via a shared CSS grid. This is deliberate — with a shared `1fr` grid, rotating one ship forces the browser to re‑solve tracks and sub‑pixel‑nudges the neighbours. With independent absolute boxes, moving/rotating one ship changes **only** that ship.
+
+### Battle
+- Tap an un‑fired enemy cell → a **reticle** (pending) shows (~640ms in the prototype; in production it's however long the answer takes) → resolves to **miss** (ripple), **hit** (fire on that cell), or **sunk** (all of that sub's cells were hit → its individual flames are removed and the **wreck** is revealed spanning the sub).
+- Only the player whose turn it is can fire (gate on the engine's `canMove`).
+
+### Radar (new)
+- Overlay on *Their sea* only, `position:absolute; inset:4px; border-radius:10px; overflow:hidden; pointer-events:none` (must NOT block taps — cells sit below it and stay clickable). Place it **above** the water grid but **below** the ships/shots overlay.
+- Opacity `0.95` on your turn, `0.5` while waiting (`transition:opacity .35s`).
+- Contents: faint crosshair (2 lines), 3 concentric range rings (`rgba(16,185,129, .11–.16)`), a rotating **conic‑gradient sweep**, and a **ping** ring.
+- **Sweep direction matters**: the beam must rotate so the **bright edge leads and the glow fades behind it** (trailing). Implemented as a full‑circle element (`150%`, `border-radius:50%`) with `background: conic-gradient(from 0deg, rgba(16,185,129,.32), rgba(16,185,129,.06) 26deg, rgba(16,185,129,0) 56deg, transparent)` animated `@keyframes radarSweep { to { transform: rotate(-360deg) } }` (note the **negative** rotation — that's what puts the fade on the trailing side). Duration `3.8s linear infinite`.
+- **Ping**: a ring `@keyframes sonarPing { 0%{transform:scale(.12);opacity:.55} 80%{opacity:0} 100%{transform:scale(1);opacity:0} }`, `3.8s ease-out infinite`.
+
+## Positioning math (ship & fire overlay)
+Overlay container: `position:absolute; inset:4px; pointer-events:none`. For a region at row `r`, col `c`, spanning `cs`×`rs` cells on an 8×8 board with 2px gaps:
+```
+offset(n) = calc((100% - 14px) / 8 * n + n*2px)      // 7 gaps × 2px = 14px
+size(n)   = calc((100% - 14px) / 8 * n + (n-1)*2px)
+style = { position:absolute, left:offset(c), top:offset(r), width:size(cs), height:size(rs) }
+```
+Ship: `cs = horizontal ? len : 1`, `rs = horizontal ? 1 : len`. A fire marker is a single cell (`cs=rs=1`, flex‑center the flame). Each submarine SVG fills its box with `preserveAspectRatio:"none"`.
+
+## Submarine artwork
+Drawn horizontally (bow to the right) in a `len*100 × 100` viewBox; for vertical subs wrap the art in `translate(100,0) rotate(90)` and use a `100 × len*100` viewBox. A gentle `scale(1,1.14)` around y=54 fattens the beam. Parts (scale with length):
+- **Pressure hull**: rounded capsule, fill `#454f5a`, outline `#1a2026` 2.5; top highlight `#707b86`, bottom shadow `#262d34`.
+- **Conning tower (sail)** amidships: `#374049`, with a small `#7dd3fc` window light.
+- **Periscope + antenna** rising from the tower.
+- **Propeller** (stern/left): brass `#c6a24a` crossed ellipses + hub, plus a rudder fin.
+- **Bow dive plane** (right).
+- **Glowing portholes**: `#7dd3fc` dots along the hull (count scales with length).
+- Drop shadow `0 1px 1.5px rgba(0,0,0,.28)`.
+
+**Sunk wreck** (replaces the sub when all its cells are hit): same capsule silhouette in spectral `rgba(200,214,226,.58)` with white stroke, a hull crack, dark breaches, dead **X** eyes on the tower, and two rising bubbles (`bob` animation). Entrance `ghostIn` (fade + rise + settle at `rotate(-4deg)`).
+
+## Shot / status iconography (all custom SVG, no emoji)
+- **Reticle / target** (pending shot, "your move"): `#10b981` — outer pulsing ring (`reticlePulse`), dashed spinning ring (`reticleSpin`), center dot, crosshair ticks.
+- **Miss**: concentric sonar **ripple** rings, stroke = "ink" `rgba(2,6,23,.42)` light / `rgba(255,255,255,.55)` dark (`ripple` keyframe).
+- **Hit fire**: layered flames, outer `#fb923c`, inner `#fde047`, core `#ff5a2c` (`flicker` keyframe, transform‑origin bottom).
+- **Waiting spinner**: dashed arc in `--app-text-muted` (`spin`).
+- **Medallion**: ring + 5‑point star, gold/silver values above (`heroPop`).
+- **Buttons**: Feather‑style **shuffle**, **check** (Deploy), **refresh** (Rematch), four‑arrow **move** (placement hint).
+- **Header fleet mark**: a mini submarine beside each player name (mirrored for the opponent).
+
+## State
+```
+phase: 'placing' | 'battle'            // battle also carries the result overlay
+myShips / theirShips: { r,c,len,dir }[] // dir: 'h' | 'v'  (theirShips hidden until sunk)
+theirSea / mySea: Record<cellIndex, 'pending'|'miss'|'hit'|'sunk'>
+turn: 0 | 1        // seat, from the engine
+winner: 0 | 1 | null
+dragIdx: number    // ship being dragged (-1 = none)
+dragInvalid: bool  // current drag/rotate position illegal
+```
+Helpers: `shipCells({r,c,len,dir})` → cell indices; a ship is **sunk** when all its cells are `hit`/`sunk`. In production these map onto the engine's derived state — `myShips` comes from the local secret layout, `theirShips` are only known (for the wreck reveal) once revealed at game end; before that, render fire on hit cells and reveal the wreck only when the sub is confirmed sunk.
+
+## Design tokens
+**Color**
+- Primary / accent (green): `#10b981` (= `--ion-color-primary`); pill text on primary: `#04150f`
+- Sea accent: `rgb(28, 92, 140)`
+  - water cell: `rgba(28,92,140,0.13)`
+  - grid background (depth gradient): `linear-gradient(180deg, rgba(28,92,140,0.07), rgba(28,92,140,0.16))`
+  - charred hit cell: `rgba(120,60,30,0.20)`; sunk cell: `rgba(70,84,110,0.22)`
+- Card: bg `#ffffff` / `#181f1b`; border `rgba(0,0,0,.07)` / `rgba(255,255,255,.08)`
+- Text: `#0b0b0c` / `#ffffff`; muted `rgba(0,0,0,.55)` / `rgba(255,255,255,.6)`
+- Submarine: hull `#454f5a`, hi `#707b86`, lo `#262d34`, outline `#1a2026`, tower `#374049`, trim `#8b96a1`, porthole `#7dd3fc`, propeller `#c6a24a`
+- Fire: `#fb923c` / `#fde047` / core `#ff5a2c`
+- Ghost/wreck: `rgba(200,214,226,.58)` fill, `rgba(255,255,255,.55)` stroke
+- Miss ink: `rgba(2,6,23,.42)` / `rgba(255,255,255,.55)`
+- Medal gold `#f6c453 / #c99a2e / #fff8e6`; silver `#d7dde3 / #98a2ac / #ffffff`
+- Radar: `#10b981` at `.11–.45` alpha
+- Turn glow: `rgba(16,185,129,.55)`
+
+**Spacing / shape** — card padding 14, radius 18; grid padding 4, radius 10, gap 2; cell radius 4; board 8×8.
+
+**Type** — matchup names 16/600; "vs" 12/700 uppercase; sea labels 11/600 uppercase; turn strip & status 13/600 & 13; hint 13/600. Inherit the app font stack.
+
+**Motion** — `radarSweep` 3.8s linear (rotate −360°), `sonarPing` 3.8s, `flicker` ~.5s alternate, `ripple` .7s, `reticleSpin` 3.5s / `reticlePulse` 1.4s, `spin` .9s, `markPop` .3s, `ghostIn` .55s, `bob` 2.4–2.8s, `heroPop` .55s.
+
+## Assets
+No external assets — everything is inline SVG (submarines, fire, wreck, reticle, ripple, spinner, medallion, radar, and the Feather‑style button icons). No image files, no icon fonts. The avatar is a placeholder monogram; wire it to the real chat avatar (`UserAvatar.vue`).
+
+## Files in this bundle
+- `Ring Battleship Bubble v2.dc.html` — the design prototype (all layout, submarine/fire/wreck/radar SVG, placement drag‑and‑drop, and animations live here).
+- `support.js` — runtime the prototype needs to render. Open the `.dc.html` in a browser with this file alongside it to view/interact with the design. (This runtime is prototype‑only; do not port it.)
+
+## Suggested implementation order
+1. Full‑width neutral card in `GameBubble.vue` (layout + tokens).
+2. Submarine SVG vessels as a positioned overlay in `BattleshipBoard.vue` (both seas) using the positioning math above.
+3. Custom shot icons (reticle/ripple/fire) + sunk‑sub wreck reveal, replacing today's emoji marks.
+4. Manual placement (drag/tap‑rotate + validation) feeding the existing `ready()` commitment.
+5. Radar overlay on *Their sea*.
+6. Result medallion overlay.

--- a/specs/1033-submarine-redesign-battleship/design/support.js
+++ b/specs/1033-submarine-redesign-battleship/design/support.js
@@ -1,0 +1,1687 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+      const raw = t ? parseDcText(t) : null;
+      if (raw?.template) runtime.updateHtml(rootName, raw.template);
+    }).catch(() => {
+    });
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || el.getAttribute("src") || el.getAttribute("import") || "";
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const kids = hasContent ? walkChildren(el, host) : [];
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...kids.map((b, j) => b(vals, ctx, j)));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = BABEL_URL;
+        s.integrity = BABEL_SRI;
+        s.crossOrigin = "anonymous";
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => fetch(url)).then((r) => {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.text();
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          doc.documentElement.dataset.theme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const sel = pseudo === "before" || pseudo === "after" ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(sel + "{" + css + "}", el.sheet.cssRules.length);
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      fetch(url).then((res) => {
+        if (!res.ok) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/> failed:",
+            url,
+            "returned",
+            res.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res.text();
+      }).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/>:",
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          "[dc-runtime] sibling fetch for <" + name + "/> threw:",
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      s.integrity = integrity;
+      s.crossOrigin = "anonymous";
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    return Promise.all([
+      loadScript(REACT_URL, REACT_SRI),
+      loadScript(REACT_DOM_URL, REACT_DOM_SRI)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`<sc-comp>`,
+       *  `sc-camel-*` attrs); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/specs/1033-submarine-redesign-battleship/spec.md
+++ b/specs/1033-submarine-redesign-battleship/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Submarine Redesign of the Battleship Card
+
+**Feature Branch**: `feat/1033-submarine-redesign-battleship`
+
+**Created**: 2026-07-06
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: A high-fidelity design handoff (vendored at
+[design/handoff.md](design/handoff.md), with the interactive prototype beside
+it) redesigning the in-chat Battleship experience: submarine vector art, a
+full-width shared game card, manual fleet placement, a sonar radar sweep, and
+custom shot/result iconography. The handoff is the authoritative pixel spec;
+this document fixes its scope, contracts, and acceptance.
+
+**Depends on**: spec 0011 (Battleship). **Changes NO game rules**: the
+commit-and-reveal protocol, engine, secret store, and wire shapes stay
+byte-identical — the handoff itself mandates this ("Keep the real protocol").
+
+## Scope decisions (this repo's reading of the handoff)
+
+- **Full-width neutral card applies to ALL game bubbles** (tic-tac-toe,
+  Connect Four, Battleship, challenges): a game is a shared surface, not one
+  side's message; per-game full-width would be inconsistent side by side.
+- **Submarine art, radar, custom shot icons, manual placement, and the
+  medallion overlay are Battleship-only.** Other games keep their emoji
+  language (their specs' design), rendered inside the new card shell.
+- **Wreck reveal timing follows the protocol**, as the handoff instructs: your
+  own sunk sub becomes a wreck immediately (you know your layout); the
+  opponent's wrecks appear only at the end-of-game reveal. During battle their
+  sunk cells show the charred/sunk tint.
+- **Themes**: the three shipped Battleship theme ids stay registered (wire ids
+  are frozen); the board's new art supersedes their marks visually. The picker
+  keeps offering them (they still tint accents); marks remain for previews.
+
+## User Stories
+
+### US1 — The game card (all games)
+A game message renders as a full-width neutral card (light/dark surface per
+the handoff tokens), not a right-aligned green bubble.
+
+**Acceptance**: game and challenge bubbles span the message column with the
+card surface/border/radius from the handoff in both themes; every other
+message kind is untouched; existing game e2e suites pass unchanged.
+
+### US2 — Submarines, shots, and radar (Battleship battle)
+The two seas render water-depth gradients with continuous submarine vessels
+positioned by the handoff's overlay math. Shots use the custom iconography:
+reticle while pending, sonar ripple for a miss, layered flames per hit cell,
+charred/sunk tints, and wreck reveals per the protocol timing. A sonar radar
+(trailing-fade sweep, range rings, ping) overlays the opponent sea — brighter
+on your turn — while never blocking taps.
+
+**Acceptance**: a full game shows every state visually (verified on the live
+UI); the radar rotates with the fade trailing the bright edge; observers see
+both public seas with no fleet data (unchanged secrecy).
+
+### US3 — Manual fleet placement
+During placing, your pre-shuffled submarines can be dragged to new cells
+(snap-to-grid, shadow lift, red tint + snap-back when illegal) and tapped to
+rotate 90° (declined when it would not fit). Shuffle remains; **Deploy fleet**
+commits exactly like today's Ready (same `commitment(layout, salt)` →
+`setFleetSecret` → commit move).
+
+**Acceptance**: drag, rotate, invalid-drop snap-back, and deploy all work by
+touch and mouse; the committed layout is whatever was authored; the protocol
+e2e still passes with the renamed button.
+
+### US4 — Result medallion (Battleship)
+The finished Battleship board shows the gold/silver medallion overlay with the
+result line and Rematch, per the handoff; other games keep their emoji
+overlay. Observer endgame rules (spec 0009) are preserved: named winner, no
+peek, "Start your own challenge".
+
+## Zero-Knowledge Impact
+
+None on the wire or server: presentation and local placement only. The
+authored layout feeds the SAME sealed commitment; no new data crosses.
+`git diff develop -- server/ src/games/battleship/logic.ts src/games/battleship/secret.ts src/services/crypto/` must be empty.
+
+## Success Criteria
+
+- **SC-001**: Protocol untouched by diff (files above) and the full Battleship
+  e2e suite passes (with only the Ready→Deploy label updated in tests).
+- **SC-002**: All game e2e suites pass; no engine/challenge-layer changes.
+- **SC-003**: The handoff's states verified visually on the live UI: placing
+  (drag + rotate + invalid), battle (reticle/ripple/fire/sunk/radar, both
+  turn states), own-wreck, end-of-game their-wreck, medallion, dark mode.
+- **SC-004**: The card shell renders all four bubble kinds full-width without
+  regressing non-game messages (visual pass).

--- a/specs/1033-submarine-redesign-battleship/spec.md
+++ b/specs/1033-submarine-redesign-battleship/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-06
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: A high-fidelity design handoff (vendored at

--- a/specs/1033-submarine-redesign-battleship/spec.md
+++ b/specs/1033-submarine-redesign-battleship/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-06
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: A high-fidelity design handoff (vendored at

--- a/specs/1033-submarine-redesign-battleship/tasks.md
+++ b/specs/1033-submarine-redesign-battleship/tasks.md
@@ -3,12 +3,12 @@
 **Input**: [spec.md](spec.md) + the authoritative pixel spec [design/handoff.md](design/handoff.md)
 **Order**: the handoff's own implementation order. Rules/protocol files are OFF LIMITS (SC-001).
 
-- [ ] T001 Full-width neutral game card: `.bubble-row`/`.bubble` game treatment in ChatDetailPage + GameBubble shell tokens (all game kinds, both themes)
-- [ ] T002 Submarine vessels: SubmarineSvg (hull/tower/periscope/prop/portholes/dive plane, h/v, wreck variant) + the positioned overlay math on both seas in BattleshipBoard
-- [ ] T003 Custom shot iconography replacing emoji marks: reticle (pending), sonar ripple (miss), layered flames (hit), charred/sunk tints, own-wreck immediate + their-wreck at reveal
-- [ ] T004 Manual placement: drag (snap, lift shadow, red invalid tint, snap-back), tap-rotate with fit clamp, hint row, Shuffle ghost + Deploy fleet pill feeding the unchanged ready()/commitment flow (e2e label updated)
-- [ ] T005 Sonar radar overlay on Their sea: crosshair, rings, trailing-fade sweep (negative rotation), ping; bright on your turn; never blocks taps
-- [ ] T006 Medallion result overlay (battleship only) + full visual matrix (SC-003), gates (unit + all game e2e), diff verification (SC-001), roadmap
+- [X] T001 Full-width neutral game card: `.bubble-row`/`.bubble` game treatment in ChatDetailPage + GameBubble shell tokens (all game kinds, both themes)
+- [X] T002 Submarine vessels: SubmarineSvg (hull/tower/periscope/prop/portholes/dive plane, h/v, wreck variant) + the positioned overlay math on both seas in BattleshipBoard
+- [X] T003 Custom shot iconography replacing emoji marks: reticle (pending), sonar ripple (miss), layered flames (hit), charred/sunk tints, own-wreck immediate + their-wreck at reveal
+- [X] T004 Manual placement: drag (snap, lift shadow, red invalid tint, snap-back), tap-rotate with fit clamp, hint row, Shuffle ghost + Deploy fleet pill feeding the unchanged ready()/commitment flow (e2e label updated)
+- [X] T005 Sonar radar overlay on Their sea: crosshair, rings, trailing-fade sweep (negative rotation), ping; bright on your turn; never blocks taps
+- [X] T006 Medallion result overlay (battleship only) + full visual matrix (SC-003), gates (unit + all game e2e), diff verification (SC-001), roadmap
 
 ## GitHub Issues
 

--- a/specs/1033-submarine-redesign-battleship/tasks.md
+++ b/specs/1033-submarine-redesign-battleship/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: Submarine Redesign of the Battleship Card
+
+**Input**: [spec.md](spec.md) + the authoritative pixel spec [design/handoff.md](design/handoff.md)
+**Order**: the handoff's own implementation order. Rules/protocol files are OFF LIMITS (SC-001).
+
+- [ ] T001 Full-width neutral game card: `.bubble-row`/`.bubble` game treatment in ChatDetailPage + GameBubble shell tokens (all game kinds, both themes)
+- [ ] T002 Submarine vessels: SubmarineSvg (hull/tower/periscope/prop/portholes/dive plane, h/v, wreck variant) + the positioned overlay math on both seas in BattleshipBoard
+- [ ] T003 Custom shot iconography replacing emoji marks: reticle (pending), sonar ripple (miss), layered flames (hit), charred/sunk tints, own-wreck immediate + their-wreck at reveal
+- [ ] T004 Manual placement: drag (snap, lift shadow, red invalid tint, snap-back), tap-rotate with fit clamp, hint row, Shuffle ghost + Deploy fleet pill feeding the unchanged ready()/commitment flow (e2e label updated)
+- [ ] T005 Sonar radar overlay on Their sea: crosshair, rings, trailing-fade sweep (negative rotation), ping; bright on your turn; never blocks taps
+- [ ] T006 Medallion result overlay (battleship only) + full visual matrix (SC-003), gates (unit + all game e2e), diff verification (SC-001), roadmap
+
+## GitHub Issues
+
+One issue per task (created 2026-07-06):
+T001 #852 · T002 #853 · T003 #854 · T004 #855 · T005 #856 · T006 #857 · 

--- a/src/components/ChallengeBubble.vue
+++ b/src/components/ChallengeBubble.vue
@@ -107,8 +107,7 @@ const lostRace = computed(() => {
 
 <style scoped>
 .ch {
-  width: 230px;
-  max-width: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/src/components/GameBubble.vue
+++ b/src/components/GameBubble.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="game">
+  <div class="game" :class="{ wide: game.gameType === 'battleship' }">
     <!-- A gameType this build doesn't know (a newer app started it): show a
          graceful fallback rather than a broken board (contract §1). -->
     <div v-if="!module || !boardComponent" class="game-fallback">
@@ -50,7 +50,14 @@
           @click.stop="isObserver ? undefined : (peeked = true)"
           @keydown.enter.stop="isObserver ? undefined : (peeked = true)"
         >
-          <animated-emoji :emoji="overlayEmoji" large class="game-overlay-result" />
+          <!-- Battleship earns the struck medallion (spec 1033); the other
+               games keep the platform's emoji result language. -->
+          <medallion-svg
+            v-if="game.gameType === 'battleship' && status.state !== 'draw'"
+            :kind="overlayEmoji === '🏆' ? 'gold' : 'silver'"
+          />
+          <animated-emoji v-else :emoji="overlayEmoji" large class="game-overlay-result" />
+          <span v-if="game.gameType === 'battleship' && !isObserver" class="game-overlay-line">{{ statusLine }}</span>
           <span v-if="isObserver" class="game-overlay-line">{{ statusLine }}</span>
           <ion-button
             v-if="!isObserver"
@@ -125,6 +132,7 @@ import { gameControllerOutline } from 'ionicons/icons';
 import AnimatedEmoji from '@/components/AnimatedEmoji.vue';
 import GameMark from '@/components/GameMark.vue';
 import UserAvatar from '@/components/UserAvatar.vue';
+import MedallionSvg from '@/games/battleship/MedallionSvg.vue';
 import { GAMES } from '@/games/registry';
 import { GAME_BOARDS } from '@/games/boards';
 import { deriveStatus, replayState } from '@/games/session';
@@ -270,11 +278,19 @@ async function confirmResign(): Promise<void> {
 
 <style scoped>
 .game {
-  width: 220px;
-  max-width: 100%;
+  /* Full-width inside the shared game card (spec 1033). Small square boards
+     (tic-tac-toe, Connect Four) stay their compact size, centered; 'wide'
+     games (Battleship's two seas) use the whole card. */
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+.game:not(.wide) .game-vs,
+.game:not(.wide) .game-stage {
+  width: 100%;
+  max-width: 240px;
+  margin-inline: auto;
 }
 /* Grid keeps "vs" DEAD CENTER regardless of name lengths (T041): the two
    sides get equal tracks and ellipsize long names instead of pushing it. */

--- a/src/components/GameBubble.vue
+++ b/src/components/GameBubble.vue
@@ -12,7 +12,8 @@
            1:1 keeps you-first exactly as shipped. -->
       <div class="game-vs">
         <span class="game-side you">
-          <game-mark :mark="theme.marks?.[leftSeat]" :player="leftSeat" />
+          <span v-if="game.gameType === 'battleship'" class="mini-sub" aria-hidden="true"><submarine-svg :len="1" /></span>
+          <game-mark v-else :mark="theme.marks?.[leftSeat]" :player="leftSeat" />
           <user-avatar v-if="seatAvatar(leftSeat)" :src="seatAvatar(leftSeat)!" :alt="seatName(leftSeat)" class="side-face" />
           <span class="side-name">{{ seatName(leftSeat) }}</span>
         </span>
@@ -20,7 +21,8 @@
         <span class="game-side">
           <span class="side-name">{{ seatName(rightSeat) }}</span>
           <user-avatar v-if="seatAvatar(rightSeat)" :src="seatAvatar(rightSeat)!" :alt="seatName(rightSeat)" class="side-face" />
-          <game-mark :mark="theme.marks?.[rightSeat]" :player="rightSeat" />
+          <span v-if="game.gameType === 'battleship'" class="mini-sub mirrored" aria-hidden="true"><submarine-svg :len="1" /></span>
+          <game-mark v-else :mark="theme.marks?.[rightSeat]" :player="rightSeat" />
         </span>
       </div>
 
@@ -133,6 +135,7 @@ import AnimatedEmoji from '@/components/AnimatedEmoji.vue';
 import GameMark from '@/components/GameMark.vue';
 import UserAvatar from '@/components/UserAvatar.vue';
 import MedallionSvg from '@/games/battleship/MedallionSvg.vue';
+import SubmarineSvg from '@/games/battleship/SubmarineSvg.vue';
 import { GAMES } from '@/games/registry';
 import { GAME_BOARDS } from '@/games/boards';
 import { deriveStatus, replayState } from '@/games/session';
@@ -310,6 +313,15 @@ async function confirmResign(): Promise<void> {
 }
 .game-side:last-child {
   justify-content: flex-end;
+}
+.mini-sub {
+  width: 30px;
+  height: 22px;
+  flex: none;
+  display: inline-flex;
+}
+.mini-sub.mirrored {
+  transform: scaleX(-1);
 }
 .game-side .side-face {
   width: 18px;

--- a/src/components/GamePicker.vue
+++ b/src/components/GamePicker.vue
@@ -68,7 +68,16 @@ watch(
   },
 );
 
-const choose = (id: string) => (selected.value = GAMES[id] ?? null);
+// A game with ONE style has nothing to choose either — start it directly
+// (Battleship's submarine design is its whole identity, spec 1033).
+const choose = (id: string): void => {
+  const g = GAMES[id] ?? null;
+  if (g && g.themes.length <= 1) {
+    emit('pick', g.id, g.themes[0]?.id ?? 'classic');
+    return;
+  }
+  selected.value = g;
+};
 const close = () => {
   emit('close');
 };

--- a/src/components/MessageActions.vue
+++ b/src/components/MessageActions.vue
@@ -8,7 +8,7 @@
         <ion-icon slot="start" :icon="expandOutline" />
         <ion-label>View</ion-label>
       </ion-item>
-      <ion-item button :detail="false" @click="choose('reply')">
+      <ion-item v-if="canReply ?? true" button :detail="false" @click="choose('reply')">
         <ion-icon slot="start" :icon="arrowUndoOutline" />
         <ion-label>Reply</ion-label>
       </ion-item>
@@ -44,7 +44,7 @@
         <ion-icon slot="start" :icon="checkmarkCircleOutline" />
         <ion-label>Select</ion-label>
       </ion-item>
-      <ion-item button :detail="false" @click="choose('delete')">
+      <ion-item v-if="canDelete ?? true" button :detail="false" @click="choose('delete')">
         <ion-icon slot="start" :icon="trashOutline" color="danger" />
         <ion-label color="danger">Delete</ion-label>
       </ion-item>
@@ -65,6 +65,8 @@ defineProps<{
   canCopy: boolean;
   canView?: boolean; // image/video/album: offer "View" (open the full-screen viewer)
   canForward?: boolean; // games are excluded (spec 0008 FR-014); default true
+  canReply?: boolean; // games are excluded too — a shared board isn't a quotable line; default true
+  canDelete?: boolean; // an UNFINISHED game can't be deleted out from under the players; default true
   canEdit?: boolean; // own, not-deleted text message: offer "Edit"
   canSave?: boolean; // single image/video/file/audio: offer "Save"
   canSaveAll?: boolean; // album bubble: offer "Save all"

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1073,8 +1073,12 @@ export async function playGameMove(chatId: string, messageId: string, move: unkn
   const opponent = seq === 1 && m.game.players?.length === 2 ? m.game.players[1] : undefined;
   if ((await applyGameMove(m, me, { seq, action: 'move', move, at })) !== 'applied') return;
   // Your own move ticks (or lands the result cue when it ends the game, FR-026);
-  // playing is inherently in-chat, so no isChatActive check here.
-  void playGameCue(gameCueFor(deriveGameStatus(module, m.game), me));
+  // playing is inherently in-chat, so no isChatActive check here. A game may
+  // name its own foley for the move (spec 1033), falling back to the generic cue.
+  {
+    const st = deriveGameStatus(module, m.game);
+    void playGameCue((module.moveCue?.(move, st, me) as Parameters<typeof playGameCue>[0] | null) ?? gameCueFor(st, me));
+  }
   await bumpOwnGamePreview(m, 'move', at);
   const chat = await getChat(m.chatId);
   const signal: GameMoveSignal = { messageId, seq, action: 'move', move, at, opponent };
@@ -1155,7 +1159,12 @@ async function handleGameMove(from: string, signal: GameMoveSignal): Promise<voi
   const status = deriveGameStatus(GAMES[message.game.gameType] ?? null, message.game);
 
   // Their move sounds only while this chat is on screen (FR-026) — players only.
-  if (me !== null && isChatActive(message.chatId)) void playGameCue(gameCueFor(status, me));
+  if (me !== null && isChatActive(message.chatId)) {
+    const gmod = GAMES[message.game.gameType] ?? null;
+    void playGameCue(
+      (gmod?.moveCue?.(signal.move, status, me) as Parameters<typeof playGameCue>[0] | null) ?? gameCueFor(status, me),
+    );
+  }
 
   // Chat-list preview for EVERYONE (it's just the list line), name-first, with
   // third-person copy for observers.
@@ -3731,7 +3740,10 @@ export async function playWallGameMove(postId: string, move: unknown): Promise<v
   const opponent = seq === 1 && session.players?.length === 2 ? session.players[1] : undefined;
   await submitWallGame(post, { t: 'move', seq, action: 'move', move, at, opponent });
   const after = await wallGameSession(postId);
-  if (after) void playGameCue(gameCueFor(deriveGameStatus(module, after), me));
+  if (after) {
+    const st = deriveGameStatus(module, after);
+    void playGameCue((module.moveCue?.(move, st, me) as Parameters<typeof playGameCue>[0] | null) ?? gameCueFor(st, me));
+  }
 }
 
 /** Concede a Wall game (players only, once seated). */

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1043,6 +1043,11 @@ async function applyGameMove(message: Message, sender: 0 | 1, signal: SessionSig
  *  move legal) and refused SILENTLY otherwise — an honest device never emits an
  *  invalid move, so anything invalid inbound is by definition tampering (FR-003). */
 export async function playGameMove(chatId: string, messageId: string, move: unknown): Promise<void> {
+  // Choke-point normalization: boards may hand us Vue-reactive move objects
+  // (a Proxy inside the move throws DataCloneError when the applied session is
+  // stored — the trap has now bitten posts, fleet secrets, AND auto-reveals).
+  // Moves are small plain JSON by contract, so a round-trip is free.
+  if (move && typeof move === 'object') move = JSON.parse(JSON.stringify(move)) as unknown;
   const m = await getMessage(messageId);
   if (!m?.game || m.chatId !== chatId) return;
   const module = GAMES[m.game.gameType];

--- a/src/games/battleship/BattleshipBoard.vue
+++ b/src/games/battleship/BattleshipBoard.vue
@@ -1,108 +1,158 @@
 <template>
-  <!-- Battleship (spec 0011). Three faces:
-       placing → YOUR sea, randomly fleeted, with Shuffle / Ready;
-       battle  → the opponent's sea on top (tap to fire), your own mini sea
-                 below with their shots marked;
-       observer → both PUBLIC seas, no ships (this device holds no secret).
-       The board also runs the protocol's automatic moves: answering incoming
-       shots from the local secret and the winner's closing reveal — both are
-       ordinary @move emissions, validated by the same engine as taps. -->
-  <div class="bs" :style="accent ? { '--game-accent': accent } : undefined">
-    <!-- PLACING: my fleet preview until Ready; then a waiting note. -->
-    <template v-if="phase === 'placing' && myPlayer !== null && !iCommitted">
-      <div class="bs-grid bs-own-lg">
-        <button
-          v-for="cell in 64"
-          :key="cell"
-          type="button"
-          class="bs-cell"
-          :class="{ ship: previewCells.has(cell - 1) }"
-          disabled
-        >
-          <span v-if="previewCells.has(cell - 1)" class="bs-ship-glyph">{{ shipGlyph }}</span>
-        </button>
+  <!-- Battleship, submarine edition (spec 1033 — the vendored handoff is the
+       pixel spec). Three faces, unchanged protocol:
+       placing → your sea with draggable/rotatable submarines, Shuffle, Deploy;
+       battle  → Their sea (fire here; radar sweep; ripples/fire/charred cells;
+                 wrecks only after the end-of-game reveal) over Your sea (your
+                 boats; incoming shots; your sunk subs become wrecks at once);
+       observer → both public seas, no fleets until the reveal.
+       Answers and the winner's reveal remain the device's automatic duties. -->
+  <div class="bs">
+    <!-- PLACING: author your fleet. -->
+    <template v-if="phase === 'placing' && !iCommitted">
+      <div class="bs-hint">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="5 9 2 12 5 15" /><polyline points="9 5 12 2 15 5" /><polyline points="15 19 12 22 9 19" /><polyline points="19 9 22 12 19 15" />
+          <line x1="2" y1="12" x2="22" y2="12" /><line x1="12" y1="2" x2="12" y2="22" />
+        </svg>
+        <span>Drag ships to move · tap to rotate</span>
+      </div>
+      <div ref="placeWrap" class="bs-sea-wrap">
+        <div class="bs-grid">
+          <div v-for="cell in 64" :key="cell" class="bs-cell" />
+        </div>
+        <div class="bs-overlay">
+          <div
+            v-for="(ship, i) in preview"
+            :key="i"
+            class="bs-ship bs-ship-live"
+            :style="boxStyle(dragIdx === i ? dragPos.r : ship.r, dragIdx === i ? dragPos.c : ship.c, ship.dir === 'h' ? ship.len : 1, ship.dir === 'h' ? 1 : ship.len)"
+            :class="{ dragging: dragIdx === i }"
+            @pointerdown="onShipDown(i, $event)"
+            @pointermove="onShipMove($event)"
+            @pointerup="onShipUp($event)"
+            @pointercancel="onShipCancel()"
+          >
+            <submarine-svg :len="ship.len" :vertical="ship.dir === 'v'" :invalid="dragIdx === i && dragInvalid" />
+          </div>
+        </div>
       </div>
       <div class="bs-actions">
-        <ion-button size="small" fill="clear" @click.stop="shuffle">
-          <animated-emoji emoji="🎲" />&nbsp;Shuffle
-        </ion-button>
-        <ion-button size="small" shape="round" @click.stop="ready">
-          <animated-emoji emoji="⚓" />&nbsp;Ready
-        </ion-button>
+        <button type="button" class="bs-btn-ghost" @click.stop="shuffle">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="16 3 21 3 21 8" /><line x1="4" y1="20" x2="21" y2="3" /><polyline points="21 16 21 21 16 21" /><line x1="15" y1="15" x2="21" y2="21" /><line x1="4" y1="4" x2="9" y2="9" />
+          </svg>
+          Shuffle
+        </button>
+        <button type="button" class="bs-btn-deploy" @click.stop="ready">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#04150f" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+          Deploy fleet
+        </button>
       </div>
     </template>
     <template v-else-if="phase === 'placing'">
       <p class="bs-note">
-        <animated-emoji emoji="⏳" />
-        {{ iCommitted ? 'Waiting for their fleet…' : 'Fleets are being placed…' }}
+        <span class="bs-spinner" aria-hidden="true" />
+        Waiting for their fleet…
       </p>
     </template>
 
-    <!-- BATTLE / VERIFY / DONE: the public seas. -->
+    <!-- BATTLE / VERIFY / DONE -->
     <template v-else>
-      <!-- The turn strip: one glance says whether the next shot is YOURS.
-           (The bubble's generic status line sits below two tall grids, too far
-           away to answer that question here.) -->
       <div v-if="!gameOver" class="bs-turn" :class="{ mine: canFire }">
         <template v-if="canFire">
-          <animated-emoji emoji="🎯" />
+          <svg width="16" height="16" viewBox="0 0 24 24" class="bs-strip-ret">
+            <circle cx="12" cy="12" r="7" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="5 4.5" stroke-linecap="round" class="bs-ret-spin" />
+            <circle cx="12" cy="12" r="2" fill="currentColor" />
+          </svg>
           <span>Your shot — tap their sea</span>
         </template>
-        <template v-else-if="observing">
-          <animated-emoji emoji="⏳" />
-          <span>Battle under way</span>
-        </template>
         <template v-else>
-          <animated-emoji emoji="⏳" />
-          <span>Waiting for their move…</span>
+          <span class="bs-spinner" aria-hidden="true" />
+          <span>{{ observing ? 'Battle under way' : 'Waiting for their move…' }}</span>
         </template>
       </div>
+
+      <!-- Their sea -->
       <div class="bs-sea">
         <div class="bs-sea-label">{{ observing ? "Second player's sea" : 'Their sea' }}</div>
-        <div class="bs-grid" :class="{ 'bs-live': canFire, 'bs-dim': !canFire && !observing && !gameOver }">
-          <button
-            v-for="cell in 64"
-            :key="cell"
-            type="button"
-            class="bs-cell"
-            :class="{ hit: theirSea.get(cell - 1) === 'hit' || theirSea.get(cell - 1) === 'sunk' }"
-            :disabled="!canFire || theirSea.has(cell - 1)"
-            :aria-label="fireLabel(cell - 1)"
-            @click.stop="fire(cell - 1)"
-          >
-            <!-- Every splash/explosion PLAYS (two loops, then rests on its
-                 first frame); the latest shot keeps looping until the next
-                 move — the board's attention cue (FR-023). -->
-            <animated-emoji
-              v-if="theirSea.has(cell - 1)"
-              :key="theirSea.get(cell - 1)"
-              :emoji="resultEmoji(theirSea.get(cell - 1)!)"
-              :plays="lastShot?.by === myIdx && lastShot?.cell === cell - 1 ? undefined : 2"
-              class="bs-mark"
+        <div class="bs-sea-wrap" :class="{ 'bs-live': canFire, 'bs-dim': !canFire && !observing && !gameOver }">
+          <div class="bs-grid">
+            <button
+              v-for="cell in 64"
+              :key="cell"
+              type="button"
+              class="bs-cell"
+              :class="cellTint(theirSea.get(cell - 1))"
+              :disabled="!canFire || theirSea.has(cell - 1)"
+              :aria-label="fireLabel(cell - 1)"
+              @click.stop="fire(cell - 1)"
             />
-          </button>
+          </div>
+          <!-- sonar radar: above the water, below the shots; never blocks taps -->
+          <div class="bs-radar" :style="{ opacity: canFire ? 0.95 : 0.5 }" aria-hidden="true">
+            <div class="bs-radar-v" /><div class="bs-radar-h" />
+            <div class="bs-radar-ring r1" /><div class="bs-radar-ring r2" /><div class="bs-radar-ring r3" />
+            <div class="bs-radar-sweep" /><div class="bs-radar-ping" />
+          </div>
+          <div class="bs-overlay">
+            <!-- their wrecks: only once the END-OF-GAME reveal made them public -->
+            <div v-for="(ship, i) in theirWrecks" :key="'w' + i" class="bs-ship" :style="shipBox(ship)">
+              <submarine-svg :len="ship.len" :vertical="ship.dir === 'v'" wreck />
+            </div>
+            <div v-for="[cell, r] in theirSea" :key="'s' + cell" class="bs-mark" :style="boxStyle(Math.floor(cell / 8), cell % 8, 1, 1)">
+              <span v-if="r === 'pending'" class="bs-reticle" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.4" class="bs-ret-pulse" />
+                  <circle cx="12" cy="12" r="6.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-dasharray="4 3.6" class="bs-ret-spin" />
+                  <circle cx="12" cy="12" r="1.8" fill="currentColor" />
+                  <path d="M12 1v3.2M12 19.8V23M1 12h3.2M19.8 12H23" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                </svg>
+              </span>
+              <span v-else-if="r === 'miss'" class="bs-ripple" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <circle cx="12" cy="12" r="6" fill="none" stroke="currentColor" stroke-width="1.6" opacity="0.45" />
+                  <circle cx="12" cy="12" r="6" fill="none" stroke="currentColor" stroke-width="2" class="rip rip-a" />
+                  <circle cx="12" cy="12" r="6" fill="none" stroke="currentColor" stroke-width="2" class="rip rip-b" />
+                </svg>
+              </span>
+              <span v-else-if="!theirWrecks.length || r === 'hit'" class="bs-flame" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <path d="M12 2 C15 7 18 9.5 16.5 14 A5.4 5.4 0 1 1 7.5 14 C6.6 10.6 9.6 9.6 10 6.4 C10.7 8.4 11 8.2 12 2 Z" fill="#fb923c" class="fl fl-a" />
+                  <path d="M12 8 C13.7 10.6 15 11.6 14 14.6 A3 3 0 1 1 9.6 14.7 C9.3 12.7 11.1 12.1 12 8 Z" fill="#fde047" class="fl fl-b" />
+                </svg>
+              </span>
+            </div>
+          </div>
         </div>
       </div>
+
+      <!-- Your sea -->
       <div class="bs-sea">
         <div class="bs-sea-label">{{ observing ? "First player's sea" : 'Your sea' }}</div>
-        <div class="bs-grid bs-own">
-          <button
-            v-for="cell in 64"
-            :key="cell"
-            type="button"
-            class="bs-cell"
-            :class="{ ship: ownCells.has(cell - 1) }"
-            disabled
-          >
-            <animated-emoji
-              v-if="mySea.has(cell - 1)"
-              :key="mySea.get(cell - 1)"
-              :emoji="resultEmoji(mySea.get(cell - 1)!)"
-              :plays="lastShot?.by !== myIdx && lastShot?.cell === cell - 1 ? undefined : 2"
-              class="bs-mark"
-            />
-            <span v-else-if="ownCells.has(cell - 1)" class="bs-ship-glyph">{{ shipGlyph }}</span>
-          </button>
+        <div class="bs-sea-wrap">
+          <div class="bs-grid">
+            <div v-for="cell in 64" :key="cell" class="bs-cell" :class="cellTint(mySea.get(cell - 1))" />
+          </div>
+          <div class="bs-overlay">
+            <div v-for="(ship, i) in ownShips" :key="'o' + i" class="bs-ship" :style="shipBox(ship.ship)">
+              <submarine-svg :len="ship.ship.len" :vertical="ship.ship.dir === 'v'" :wreck="ship.sunk" />
+            </div>
+            <div v-for="[cell, r] in mySeaMarks" :key="'m' + cell" class="bs-mark" :style="boxStyle(Math.floor(cell / 8), cell % 8, 1, 1)">
+              <span v-if="r === 'miss'" class="bs-ripple" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <circle cx="12" cy="12" r="6" fill="none" stroke="currentColor" stroke-width="1.6" opacity="0.45" />
+                  <circle cx="12" cy="12" r="6" fill="none" stroke="currentColor" stroke-width="2" class="rip rip-a" />
+                </svg>
+              </span>
+              <span v-else class="bs-flame" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <path d="M12 2 C15 7 18 9.5 16.5 14 A5.4 5.4 0 1 1 7.5 14 C6.6 10.6 9.6 9.6 10 6.4 C10.7 8.4 11 8.2 12 2 Z" fill="#fb923c" class="fl fl-a" />
+                  <path d="M12 8 C13.7 10.6 15 11.6 14 14.6 A3 3 0 1 1 9.6 14.7 C9.3 12.7 11.1 12.1 12 8 Z" fill="#fde047" class="fl fl-b" />
+                </svg>
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     </template>
@@ -110,9 +160,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, onMounted } from 'vue';
-import { IonButton } from '@ionic/vue';
-import AnimatedEmoji from '@/components/AnimatedEmoji.vue';
+import { computed, onMounted, ref, watch } from 'vue';
+import SubmarineSvg from './SubmarineSvg.vue';
 import { ready as sodiumReady } from '@/services/crypto/primitives';
 import {
   randomLayout,
@@ -120,10 +169,12 @@ import {
   commitment,
   judgeShot,
   cellsOf,
+  layoutLegal,
   FLEET_CELLS,
   type BsMove,
   type BsState,
   type Layout,
+  type Ship,
 } from './logic';
 import { getFleetSecret, setFleetSecret, clearFleetSecret } from './secret';
 
@@ -137,33 +188,109 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{ (e: 'move', move: BsMove): void }>();
 
-// GameBubble passes observers as myPlayer 0 with canMove false — a REAL seat
-// is telling: my commitment slot is what makes me a player (observers never
-// commit, and their device holds no secret, so ship rendering is naturally
-// empty for them even before this check).
 const iCommitted = computed(() => props.state.commits[props.myPlayer] !== null);
 const bothCommitted = computed(() => props.state.commits[0] !== null && props.state.commits[1] !== null);
 const phase = computed(() => (bothCommitted.value ? 'battle' : 'placing'));
 const myIdx = computed(() => props.myPlayer);
-// Observers reach boards as seat 0 with canMove false and, crucially, NO local
-// secret — a real player in battle always holds theirs (it was stored at
-// Ready). Secretless-in-battle is therefore the observer signal for labels;
-// ship rendering is safe either way because there is nothing to render.
-const observing = computed(() => phase.value === 'battle' && !secret.value);
-const shipGlyph = computed(() => props.marks?.[props.myPlayer] ?? '🚢');
+// A real player in battle always holds their secret (stored at Deploy);
+// observers never do — the observer signal for labels (spec 0011).
+const observing = computed(() => phase.value === 'battle' && !secret.value && !myReveal.value);
+const gameOver = computed(
+  () => props.state.finalBy !== null && props.state.reveals[0] !== null && props.state.reveals[1] !== null,
+);
 
-/* ---- placing ---- */
+/* ---- overlay positioning math (handoff §Positioning math) ---- */
+const off = (n: number): string => `calc((100% - 14px) / 8 * ${n} + ${n * 2}px)`;
+const sz = (n: number): string => `calc((100% - 14px) / 8 * ${n} + ${(n - 1) * 2}px)`;
+const boxStyle = (r: number, c: number, cs: number, rs: number) => ({
+  position: 'absolute' as const,
+  left: off(c),
+  top: off(r),
+  width: sz(cs),
+  height: sz(rs),
+});
+const shipBox = (s: Ship) => boxStyle(s.r, s.c, s.dir === 'h' ? s.len : 1, s.dir === 'h' ? 1 : s.len);
+
+/* ---- placing: authorable fleet (drag to move, tap to rotate) ---- */
 const preview = ref<Layout>(randomLayout());
-const previewCells = computed(() => new Set(preview.value.flatMap(cellsOf)));
 const shuffle = (): void => {
   preview.value = randomLayout();
 };
+const placeWrap = ref<HTMLElement>();
+const dragIdx = ref(-1);
+const dragPos = ref({ r: 0, c: 0 });
+const dragInvalid = ref(false);
+let dragMoved = false;
+let grabOffset = { r: 0, c: 0 };
+let dragStart = { r: 0, c: 0 };
+
+function cellFromPointer(ev: PointerEvent): { r: number; c: number } | null {
+  const grid = placeWrap.value?.querySelector('.bs-grid') as HTMLElement | null;
+  if (!grid) return null;
+  const rect = grid.getBoundingClientRect();
+  const pitch = (rect.width - 8 - 14) / 8 + 2;
+  const c = Math.floor((ev.clientX - rect.left - 4) / pitch);
+  const r = Math.floor((ev.clientY - rect.top - 4) / pitch);
+  return { r, c };
+}
+const clampShip = (s: Ship): Ship => ({
+  ...s,
+  r: Math.max(0, Math.min(s.dir === 'v' ? 8 - s.len : 7, s.r)),
+  c: Math.max(0, Math.min(s.dir === 'h' ? 8 - s.len : 7, s.c)),
+});
+const candidateLegal = (idx: number, moved: Ship): boolean =>
+  layoutLegal(preview.value.map((s, i) => (i === idx ? moved : s)));
+
+function onShipDown(i: number, ev: PointerEvent): void {
+  (ev.currentTarget as HTMLElement).setPointerCapture(ev.pointerId);
+  const cell = cellFromPointer(ev);
+  const ship = preview.value[i];
+  dragIdx.value = i;
+  dragMoved = false;
+  dragInvalid.value = false;
+  dragStart = { r: ship.r, c: ship.c };
+  dragPos.value = { r: ship.r, c: ship.c };
+  grabOffset = cell ? { r: cell.r - ship.r, c: cell.c - ship.c } : { r: 0, c: 0 };
+}
+function onShipMove(ev: PointerEvent): void {
+  if (dragIdx.value < 0) return;
+  const cell = cellFromPointer(ev);
+  if (!cell) return;
+  const ship = preview.value[dragIdx.value];
+  const next = clampShip({ ...ship, r: cell.r - grabOffset.r, c: cell.c - grabOffset.c });
+  if (next.r !== dragPos.value.r || next.c !== dragPos.value.c) dragMoved = true;
+  dragPos.value = { r: next.r, c: next.c };
+  dragInvalid.value = !candidateLegal(dragIdx.value, next);
+}
+function onShipUp(ev: PointerEvent): void {
+  if (dragIdx.value < 0) return;
+  const i = dragIdx.value;
+  const ship = preview.value[i];
+  if (!dragMoved) {
+    // Tap = rotate 90°, clamped into bounds; declined when it can't fit.
+    const rotated = clampShip({ ...ship, dir: ship.dir === 'h' ? 'v' : 'h' });
+    if (candidateLegal(i, rotated)) {
+      preview.value = preview.value.map((s, k) => (k === i ? rotated : s));
+    }
+  } else {
+    const dropped = { ...ship, r: dragPos.value.r, c: dragPos.value.c };
+    // Invalid drop snaps back to where the drag began.
+    preview.value = preview.value.map((s, k) =>
+      k === i ? (candidateLegal(i, dropped) ? dropped : { ...ship, ...dragStart }) : s,
+    );
+  }
+  dragIdx.value = -1;
+  dragInvalid.value = false;
+  void ev;
+}
+function onShipCancel(): void {
+  dragIdx.value = -1;
+  dragInvalid.value = false;
+}
+
+/** Deploy = exactly the old Ready: commit the AUTHORED layout. */
 const ready = (): void => {
-  const layout = preview.value;
-  // Salting and hashing need the crypto core — a fast tap right after a cold
-  // load can land before libsodium finishes initializing, so await it (the
-  // caught failure leaves the button armed for another tap rather than a
-  // half-committed fleet).
+  const layout = preview.value.map((s) => ({ r: s.r, c: s.c, len: s.len, dir: s.dir }));
   void (async () => {
     await sodiumReady();
     const salt = randomSalt();
@@ -173,46 +300,40 @@ const ready = (): void => {
   })().catch(() => {});
 };
 
-/* ---- battle rendering (all PUBLIC data) ---- */
+/* ---- battle rendering (public data + my own fleet) ---- */
 const shotMap = (attacker: 0 | 1) => {
   const m = new Map<number, 'miss' | 'hit' | 'sunk' | 'pending'>();
   for (const rec of props.state.shots[attacker]) m.set(rec.cell, rec.r);
   const p = props.state.pending;
-  if (p && p.by === attacker) m.set(p.cell, 'pending'); // aimed, no answer yet
+  if (p && p.by === attacker) m.set(p.cell, 'pending');
   return m;
 };
-const theirSea = computed(() => shotMap(myIdx.value)); // MY shots land on THEIR sea
+const theirSea = computed(() => shotMap(myIdx.value));
 const mySea = computed(() => shotMap((1 - myIdx.value) as 0 | 1));
-// The shot language, all from the ANIMATED set (docs/ANIMATED-EMOJI.md):
-// 🎯 while the shot awaits its answer, then 🌊 rolling water for a miss,
-// 💥 for a hit, 🔥 for a sunk ship.
-const resultEmoji = (r: 'miss' | 'hit' | 'sunk' | 'pending'): string =>
-  r === 'pending' ? '🎯' : r === 'miss' ? '🌊' : r === 'sunk' ? '🔥' : '💥';
-const lastShot = computed(() => {
-  const p = props.state.pending;
-  if (p) return { by: p.by, cell: p.cell };
-  const a = props.state.shots[0].length + props.state.shots[1].length;
-  if (!a) return null;
-  const more0 = props.state.shots[0].length > props.state.shots[1].length;
-  const even = props.state.shots[0].length === props.state.shots[1].length;
-  const by = more0 ? 0 : even ? 1 : 1;
-  const rec = props.state.shots[by][props.state.shots[by].length - 1];
-  return rec ? { by, cell: rec.cell } : null;
-});
+const mySeaMarks = computed(() => [...mySea.value.entries()].filter(([, r]) => r !== 'pending'));
+const cellTint = (r?: 'miss' | 'hit' | 'sunk' | 'pending'): string =>
+  r === 'hit' ? 'charred' : r === 'sunk' ? 'sunken' : '';
 const canFire = computed(
   () => props.canMove && bothCommitted.value && !props.state.pending && props.state.finalBy === null,
-);
-const gameOver = computed(
-  () => props.state.finalBy !== null && props.state.reveals[0] !== null && props.state.reveals[1] !== null,
 );
 const fire = (cell: number): void => emit('move', { t: 'shot', cell });
 const fireLabel = (cell: number): string =>
   `Fire at row ${Math.floor(cell / 8) + 1}, column ${(cell % 8) + 1}`;
 
-/* ---- my ships (from the DEVICE-LOCAL secret; observers have none) ---- */
+// My fleet: the device-local secret while playing, or my reveal once public
+// (the secret is cleared at game end). A sub whose every cell is hit is a wreck.
 const secret = ref<{ layout: Layout; salt: string } | null>(null);
-const iCommittedSecret = computed(() => !!secret.value);
-const ownCells = computed(() => new Set(secret.value?.layout.flatMap(cellsOf) ?? []));
+const myReveal = computed(() => props.state.reveals[myIdx.value]);
+const ownLayout = computed<Layout | null>(() => secret.value?.layout ?? myReveal.value?.layout ?? null);
+const ownShips = computed(() => {
+  const layout = ownLayout.value;
+  if (!layout) return [] as { ship: Ship; sunk: boolean }[];
+  const hits = new Set([...mySea.value.entries()].filter(([, r]) => r === 'hit' || r === 'sunk').map(([c]) => c));
+  return layout.map((ship) => ({ ship, sunk: cellsOf(ship).every((c) => hits.has(c)) }));
+});
+// Their fleet exists for us ONLY as the end-of-game reveal (protocol timing).
+const theirWrecks = computed<Layout>(() => props.state.reveals[(1 - myIdx.value) as 0 | 1]?.layout ?? []);
+
 async function loadSecret(): Promise<void> {
   const h = props.state.commits[props.myPlayer];
   secret.value = h ? await getFleetSecret(h) : null;
@@ -220,18 +341,17 @@ async function loadSecret(): Promise<void> {
 onMounted(() => void loadSecret().then(autoActions));
 watch(() => props.state.commits[props.myPlayer], () => void loadSecret().then(autoActions));
 
-/* ---- the protocol's automatic moves ---- */
-// Answering an incoming shot, and the winner's closing reveal, are the
-// device's duties, not the user's. Each emission is deduped by a state
-// signature so watcher re-fires can't double-send (the engine would drop a
-// duplicate anyway — this just avoids the noise).
+/* ---- the protocol's automatic moves (unchanged from spec 0011) ---- */
+// The secret ref deep-reactifies its layout; a Proxy-wrapped array inside an
+// emitted move throws DataCloneError when the applied move is stored — the
+// reveal must leave as PLAIN data.
+const plainLayout = (l: Layout): Layout => l.map((sp) => ({ r: sp.r, c: sp.c, len: sp.len, dir: sp.dir }));
 const lastAuto = ref('');
 function autoActions(): void {
   const s = props.state;
   const sec = secret.value;
   if (!sec) return;
   const me = props.myPlayer;
-  // Answer a pending shot aimed at me.
   const p = s.pending;
   if (p && p.by !== me) {
     const key = `answer:${p.by}:${p.cell}:${s.shots[p.by].length}`;
@@ -241,21 +361,19 @@ function autoActions(): void {
     const r = judgeShot(sec.layout, p.cell, incoming);
     const declared = s.shots[p.by].filter((x) => x.r !== 'miss').length + (r === 'miss' ? 0 : 1);
     if (declared >= FLEET_CELLS) {
-      emit('move', { t: 'answer', r: 'sunk', reveal: { layout: sec.layout, salt: sec.salt } });
+      emit('move', { t: 'answer', r: 'sunk', reveal: { layout: plainLayout(sec.layout), salt: sec.salt } });
     } else {
       emit('move', { t: 'answer', r });
     }
     return;
   }
-  // The winner's closing reveal.
   if (s.finalBy === me && s.reveals[me] === null) {
     const key = `reveal:${me}`;
     if (lastAuto.value === key) return;
     lastAuto.value = key;
-    emit('move', { t: 'reveal', layout: sec.layout, salt: sec.salt });
+    emit('move', { t: 'reveal', layout: plainLayout(sec.layout), salt: sec.salt });
     return;
   }
-  // Terminal with both reveals → the secret is public now; drop it.
   if (s.finalBy !== null && s.reveals[0] && s.reveals[1]) {
     const h = s.commits[me];
     if (h) void clearFleetSecret(h);
@@ -268,8 +386,14 @@ watch(() => props.state, autoActions, { deep: true });
 .bs {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 9px;
   width: 100%;
+}
+/* Water (handoff sea tokens): depth gradient behind cells, sea-blue fills. */
+.bs-sea-wrap {
+  position: relative;
+  transition: opacity 0.25s ease, box-shadow 0.25s ease;
+  border-radius: 10px;
 }
 .bs-grid {
   display: grid;
@@ -277,17 +401,140 @@ watch(() => props.state, autoActions, { deep: true });
   gap: 2px;
   padding: 4px;
   border-radius: 10px;
-  background: rgba(var(--game-accent, 30, 64, 175), 0.1);
-  transition: opacity 0.25s ease, box-shadow 0.25s ease;
+  background: linear-gradient(180deg, rgba(28, 92, 140, 0.07), rgba(28, 92, 140, 0.16));
 }
-/* Your shot: the TARGET grid glows; waiting: it visibly rests. Together with
-   the turn strip, the state reads without any words at all. */
+.bs-cell {
+  aspect-ratio: 1;
+  border: none;
+  border-radius: 4px;
+  background: rgba(28, 92, 140, 0.13);
+  padding: 0;
+  cursor: pointer;
+}
+.bs-cell:disabled {
+  cursor: default;
+}
+.bs-cell.charred {
+  background: rgba(120, 60, 30, 0.2);
+}
+.bs-cell.sunken {
+  background: rgba(70, 84, 110, 0.22);
+}
 .bs-live {
-  box-shadow: 0 0 0 2px rgba(var(--ion-color-primary-rgb), 0.55);
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.55);
 }
 .bs-dim {
-  opacity: 0.55;
+  opacity: 0.6;
 }
+/* Ships / shots overlay: each box positions from its OWN coords (handoff:
+   independent absolute boxes so moving one ship never reflows another). */
+.bs-overlay {
+  position: absolute;
+  inset: 4px;
+  pointer-events: none;
+}
+.bs-ship {
+  pointer-events: none;
+}
+.bs-ship-live {
+  pointer-events: auto;
+  cursor: grab;
+  touch-action: none;
+}
+.bs-ship-live.dragging {
+  cursor: grabbing;
+  filter: drop-shadow(0 4px 5px rgba(0, 0, 0, 0.35));
+}
+.bs-mark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.bs-mark > span {
+  width: 74%;
+  height: 74%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: mark-pop 0.3s ease-out both;
+}
+.bs-mark svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+.bs-reticle {
+  color: var(--ion-color-primary);
+}
+.bs-ret-spin {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: ret-spin 3.5s linear infinite;
+}
+.bs-ret-pulse {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: ret-pulse 1.4s ease-in-out infinite;
+}
+.bs-ripple {
+  color: rgba(2, 6, 23, 0.42);
+}
+:root.ion-palette-dark .bs-ripple {
+  color: rgba(255, 255, 255, 0.55);
+}
+.rip {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: rip 0.7s ease-out both;
+}
+.rip-b {
+  animation-delay: 0.18s;
+}
+.fl {
+  transform-box: fill-box;
+  transform-origin: 50% 92%;
+  animation: flicker 0.5s ease-in-out infinite alternate;
+}
+.fl-b {
+  animation-duration: 0.38s;
+  animation-delay: 0.12s;
+}
+/* Radar (handoff §Radar): above the water, below ships/shots, taps unblocked. */
+.bs-radar {
+  position: absolute;
+  inset: 4px;
+  border-radius: 10px;
+  overflow: hidden;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+.bs-radar-v { position: absolute; left: 50%; top: 7%; bottom: 7%; width: 1px; margin-left: -0.5px; background: rgba(16, 185, 129, 0.13); }
+.bs-radar-h { position: absolute; top: 50%; left: 7%; right: 7%; height: 1px; margin-top: -0.5px; background: rgba(16, 185, 129, 0.13); }
+.bs-radar-ring { position: absolute; border-radius: 50%; }
+.bs-radar-ring.r1 { inset: 15%; border: 1px solid rgba(16, 185, 129, 0.16); }
+.bs-radar-ring.r2 { inset: 32%; border: 1px solid rgba(16, 185, 129, 0.13); }
+.bs-radar-ring.r3 { inset: 47%; border: 1px solid rgba(16, 185, 129, 0.11); }
+/* The NEGATIVE rotation keeps the bright edge leading and the fade trailing. */
+.bs-radar-sweep {
+  position: absolute;
+  left: -25%;
+  top: -25%;
+  width: 150%;
+  height: 150%;
+  border-radius: 50%;
+  transform-origin: center;
+  animation: radar-sweep 3.8s linear infinite;
+  background: conic-gradient(from 0deg, rgba(16, 185, 129, 0.32), rgba(16, 185, 129, 0.06) 26deg, rgba(16, 185, 129, 0) 56deg, rgba(16, 185, 129, 0) 360deg);
+}
+.bs-radar-ping {
+  position: absolute;
+  inset: 15%;
+  border-radius: 50%;
+  border: 1.5px solid rgba(16, 185, 129, 0.45);
+  transform-origin: center;
+  animation: sonar-ping 3.8s ease-out infinite;
+}
+/* Turn strip + placing chrome */
 .bs-turn {
   display: flex;
   align-items: center;
@@ -300,33 +547,18 @@ watch(() => props.state, autoActions, { deep: true });
 .bs-turn.mine {
   color: var(--ion-color-primary);
 }
-.bs-cell {
-  aspect-ratio: 1;
-  border: none;
-  border-radius: 4px;
-  background: rgba(var(--game-accent, 30, 64, 175), 0.14);
-  padding: 0;
+.bs-strip-ret {
+  overflow: visible;
+  flex: none;
+}
+.bs-hint {
   display: flex;
   align-items: center;
-  justify-content: center;
+  gap: 6px;
   font-size: 13px;
-  cursor: pointer;
-}
-.bs-cell:disabled {
-  cursor: default;
-}
-.bs-cell.ship {
-  background: rgba(var(--game-accent, 30, 64, 175), 0.42);
-}
-.bs-cell.hit {
-  background: rgba(239, 68, 68, 0.28);
-}
-.bs-own .bs-cell,
-.bs-own-lg .bs-cell {
-  border-radius: 3px;
-}
-.bs-own {
-  transform-origin: top left;
+  font-weight: 600;
+  color: var(--ion-color-primary);
+  margin: 0 2px;
 }
 .bs-sea-label {
   font-size: 11px;
@@ -335,14 +567,6 @@ watch(() => props.state, autoActions, { deep: true });
   letter-spacing: 0.03em;
   color: var(--app-text-muted);
   margin: 2px 2px 3px;
-}
-.bs-ship-glyph {
-  font-size: 12px;
-  line-height: 1;
-}
-.bs-mark {
-  font-size: 13px;
-  line-height: 1;
 }
 .bs-note {
   display: flex;
@@ -355,10 +579,49 @@ watch(() => props.state, autoActions, { deep: true });
 .bs-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 4px;
+  align-items: center;
+  gap: 8px;
 }
-.bs-actions ion-button {
+.bs-btn-ghost {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  color: var(--ion-color-primary);
   font-size: 13px;
-  text-transform: none;
+  font-weight: 600;
+  padding: 7px 10px;
+  cursor: pointer;
 }
+.bs-btn-deploy {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--ion-color-primary);
+  border: none;
+  color: #04150f;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 7px 15px;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 4px 10px -3px rgba(16, 185, 129, 0.6);
+}
+.bs-spinner {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  border-radius: 50%;
+  border: 2px dashed var(--app-text-muted);
+  animation: bs-spin 0.9s linear infinite;
+}
+@keyframes ret-spin { to { transform: rotate(360deg); } }
+@keyframes ret-pulse { 0%, 100% { opacity: 0.28; transform: scale(1); } 50% { opacity: 0.6; transform: scale(1.28); } }
+@keyframes rip { 0% { transform: scale(0.32); opacity: 0.85; } 100% { transform: scale(1.7); opacity: 0; } }
+@keyframes mark-pop { 0% { transform: scale(0.15); opacity: 0; } 60% { transform: scale(1.2); } 100% { transform: scale(1); opacity: 1; } }
+@keyframes flicker { 0% { transform: scaleY(0.86) scaleX(1.04); } 100% { transform: scaleY(1.14) scaleX(0.94); } }
+@keyframes radar-sweep { to { transform: rotate(-360deg); } }
+@keyframes sonar-ping { 0% { transform: scale(0.12); opacity: 0.55; } 80% { opacity: 0; } 100% { transform: scale(1); opacity: 0; } }
+@keyframes bs-spin { to { transform: rotate(360deg); } }
 </style>

--- a/src/games/battleship/BattleshipBoard.vue
+++ b/src/games/battleship/BattleshipBoard.vue
@@ -139,7 +139,12 @@
             <div v-for="(ship, i) in ownShips" :key="'o' + i" class="bs-ship" :style="shipBox(ship.ship)">
               <submarine-svg :len="ship.ship.len" :vertical="ship.ship.dir === 'v'" :wreck="ship.sunk" />
             </div>
-            <div v-for="[cell, r] in mySeaMarks" :key="'m' + cell" class="bs-mark" :style="boxStyle(Math.floor(cell / 8), cell % 8, 1, 1)">
+            <div
+              v-for="[cell, r] in mySeaMarks.filter(([c, rr]) => rr === 'miss' || !myWreckCells.has(c))"
+              :key="'m' + cell"
+              class="bs-mark"
+              :style="boxStyle(Math.floor(cell / 8), cell % 8, 1, 1)"
+            >
               <span v-if="r === 'miss'" class="bs-ripple" aria-hidden="true">
                 <svg viewBox="0 0 24 24">
                   <circle cx="12" cy="12" r="6" fill="none" stroke="currentColor" stroke-width="1.6" opacity="0.45" />
@@ -331,6 +336,12 @@ const ownShips = computed(() => {
   if (!layout) return [] as { ship: Ship; sunk: boolean }[];
   const hits = new Set([...mySea.value.entries()].filter(([, r]) => r === 'hit' || r === 'sunk').map(([c]) => c));
   return layout.map((ship) => ({ ship, sunk: cellsOf(ship).every((c) => hits.has(c)) }));
+});
+// A wreck burns no more (either sea): its cells drop their flames.
+const myWreckCells = computed(() => {
+  const set = new Set<number>();
+  for (const { ship, sunk } of ownShips.value) if (sunk) cellsOf(ship).forEach((c) => set.add(c));
+  return set;
 });
 // Their SUNK boats surface as wrecks the moment the sunk answer lands (the
 // handoff's rule): each 'sunk' closes the straight run of hits through its
@@ -558,7 +569,10 @@ watch(() => props.state, autoActions, { deep: true });
 .bs-radar-ring.r1 { inset: 15%; border: 1px solid rgba(16, 185, 129, 0.16); }
 .bs-radar-ring.r2 { inset: 32%; border: 1px solid rgba(16, 185, 129, 0.13); }
 .bs-radar-ring.r3 { inset: 47%; border: 1px solid rgba(16, 185, 129, 0.11); }
-/* The NEGATIVE rotation keeps the bright edge leading and the fade trailing. */
+/* Real radar sweeps CLOCKWISE (a PPI scope follows compass bearings). The
+   glow must trail BEHIND the bright leading edge, so the gradient is mirrored
+   (bright at 360° fading backwards through ~334°/304°) and the rotation is
+   positive — same trailing-fade effect as the handoff, authentic direction. */
 .bs-radar-sweep {
   position: absolute;
   left: -25%;
@@ -568,7 +582,7 @@ watch(() => props.state, autoActions, { deep: true });
   border-radius: 50%;
   transform-origin: center;
   animation: radar-sweep 3.8s linear infinite;
-  background: conic-gradient(from 0deg, rgba(16, 185, 129, 0.32), rgba(16, 185, 129, 0.06) 26deg, rgba(16, 185, 129, 0) 56deg, rgba(16, 185, 129, 0) 360deg);
+  background: conic-gradient(from 0deg, rgba(16, 185, 129, 0) 0deg, rgba(16, 185, 129, 0) 304deg, rgba(16, 185, 129, 0.06) 334deg, rgba(16, 185, 129, 0.32) 360deg);
 }
 .bs-radar-ping {
   position: absolute;
@@ -665,7 +679,7 @@ watch(() => props.state, autoActions, { deep: true });
 @keyframes rip { 0% { transform: scale(0.32); opacity: 0.85; } 100% { transform: scale(1.7); opacity: 0; } }
 @keyframes mark-pop { 0% { transform: scale(0.15); opacity: 0; } 60% { transform: scale(1.2); } 100% { transform: scale(1); opacity: 1; } }
 @keyframes flicker { 0% { transform: scaleY(0.86) scaleX(1.04); } 100% { transform: scaleY(1.14) scaleX(0.94); } }
-@keyframes radar-sweep { to { transform: rotate(-360deg); } }
+@keyframes radar-sweep { to { transform: rotate(360deg); } }
 @keyframes sonar-ping { 0% { transform: scale(0.12); opacity: 0.55; } 80% { opacity: 0; } 100% { transform: scale(1); opacity: 0; } }
 @keyframes bs-spin { to { transform: rotate(360deg); } }
 </style>

--- a/src/games/battleship/BattleshipBoard.vue
+++ b/src/games/battleship/BattleshipBoard.vue
@@ -183,6 +183,7 @@ import {
   type Ship,
 } from './logic';
 import { getFleetSecret, setFleetSecret, clearFleetSecret } from './secret';
+import { playGameCue } from '@/services/game-sounds';
 
 const props = defineProps<{
   state: BsState;
@@ -323,6 +324,11 @@ const canFire = computed(
   () => props.canMove && bothCommitted.value && !props.state.pending && props.state.finalBy === null,
 );
 const fire = (cell: number): void => emit('move', { t: 'shot', cell });
+// The scope brightening is audible too: one sonar ping when the turn becomes
+// yours (gated by the same Game sounds setting as every cue).
+watch(canFire, (now, was) => {
+  if (now && !was) void playGameCue('bs-sonar');
+});
 const fireLabel = (cell: number): string =>
   `Fire at row ${Math.floor(cell / 8) + 1}, column ${(cell % 8) + 1}`;
 

--- a/src/games/battleship/BattleshipBoard.vue
+++ b/src/games/battleship/BattleshipBoard.vue
@@ -96,9 +96,10 @@
             <div class="bs-radar-sweep" /><div class="bs-radar-ping" />
           </div>
           <div class="bs-overlay">
-            <!-- their wrecks: only once the END-OF-GAME reveal made them public -->
-            <div v-for="(ship, i) in theirWrecks" :key="'w' + i" class="bs-ship" :style="shipBox(ship)">
-              <submarine-svg :len="ship.len" :vertical="ship.dir === 'v'" wreck />
+            <!-- their boats: sunk ones as wrecks the moment they're confirmed;
+                 survivors appear (as ordinary subs) only with the final reveal -->
+            <div v-for="({ ship, sunk }, i) in theirShips" :key="'w' + i" class="bs-ship" :style="shipBox(ship)">
+              <submarine-svg :len="ship.len" :vertical="ship.dir === 'v'" :wreck="sunk" />
             </div>
             <div v-for="[cell, r] in theirSea" :key="'s' + cell" class="bs-mark" :style="boxStyle(Math.floor(cell / 8), cell % 8, 1, 1)">
               <span v-if="r === 'pending'" class="bs-reticle" aria-hidden="true">
@@ -116,7 +117,7 @@
                   <circle cx="12" cy="12" r="6" fill="none" stroke="currentColor" stroke-width="2" class="rip rip-b" />
                 </svg>
               </span>
-              <span v-else-if="!theirWrecks.length || r === 'hit'" class="bs-flame" aria-hidden="true">
+              <span v-else-if="!theirWreckCells.has(cell)" class="bs-flame" aria-hidden="true">
                 <svg viewBox="0 0 24 24">
                   <path d="M12 2 C15 7 18 9.5 16.5 14 A5.4 5.4 0 1 1 7.5 14 C6.6 10.6 9.6 9.6 10 6.4 C10.7 8.4 11 8.2 12 2 Z" fill="#fb923c" class="fl fl-a" />
                   <path d="M12 8 C13.7 10.6 15 11.6 14 14.6 A3 3 0 1 1 9.6 14.7 C9.3 12.7 11.1 12.1 12 8 Z" fill="#fde047" class="fl fl-b" />
@@ -331,8 +332,51 @@ const ownShips = computed(() => {
   const hits = new Set([...mySea.value.entries()].filter(([, r]) => r === 'hit' || r === 'sunk').map(([c]) => c));
   return layout.map((ship) => ({ ship, sunk: cellsOf(ship).every((c) => hits.has(c)) }));
 });
-// Their fleet exists for us ONLY as the end-of-game reveal (protocol timing).
-const theirWrecks = computed<Layout>(() => props.state.reveals[(1 - myIdx.value) as 0 | 1]?.layout ?? []);
+// Their SUNK boats surface as wrecks the moment the sunk answer lands (the
+// handoff's rule): each 'sunk' closes the straight run of hits through its
+// cell. Ships may touch, so a collinear pair can briefly read as one long
+// wreck — the end-of-game reveal corrects any such guess, and additionally
+// shows their SURVIVING boats as ordinary submarines.
+const theirDerivedWrecks = computed<Ship[]>(() => {
+  const shots = props.state.shots[myIdx.value];
+  const hitCells = new Set<number>();
+  const assigned = new Set<number>();
+  const wrecks: Ship[] = [];
+  const avail = (cell: number): boolean => hitCells.has(cell) && !assigned.has(cell);
+  for (const rec of shots) {
+    if (rec.r !== 'miss') hitCells.add(rec.cell);
+    if (rec.r !== 'sunk') continue;
+    const r0 = Math.floor(rec.cell / 8);
+    const c0 = rec.cell % 8;
+    let c1 = c0, c2 = c0, r1 = r0, r2 = r0;
+    while (c1 > 0 && avail(r0 * 8 + c1 - 1)) c1--;
+    while (c2 < 7 && avail(r0 * 8 + c2 + 1)) c2++;
+    while (r1 > 0 && avail((r1 - 1) * 8 + c0)) r1--;
+    while (r2 < 7 && avail((r2 + 1) * 8 + c0)) r2++;
+    const hLen = c2 - c1 + 1;
+    const vLen = r2 - r1 + 1;
+    const ship: Ship =
+      hLen >= vLen ? { r: r0, c: c1, len: hLen, dir: 'h' } : { r: r1, c: c0, len: vLen, dir: 'v' };
+    if (ship.len < 2) continue;
+    wrecks.push(ship);
+    cellsOf(ship).forEach((c) => assigned.add(c));
+  }
+  return wrecks;
+});
+const theirShips = computed(() => {
+  const reveal = props.state.reveals[(1 - myIdx.value) as 0 | 1]?.layout;
+  if (reveal) {
+    const hits = new Set(props.state.shots[myIdx.value].filter((x) => x.r !== 'miss').map((x) => x.cell));
+    return reveal.map((ship) => ({ ship, sunk: cellsOf(ship).every((c) => hits.has(c)) }));
+  }
+  return theirDerivedWrecks.value.map((ship) => ({ ship, sunk: true }));
+});
+// Cells whose flames the wreck replaced (handoff: a finished sub burns no more).
+const theirWreckCells = computed(() => {
+  const set = new Set<number>();
+  for (const { ship, sunk } of theirShips.value) if (sunk) cellsOf(ship).forEach((c) => set.add(c));
+  return set;
+});
 
 async function loadSecret(): Promise<void> {
   const h = props.state.commits[props.myPlayer];

--- a/src/games/battleship/MedallionSvg.vue
+++ b/src/games/battleship/MedallionSvg.vue
@@ -1,0 +1,33 @@
+<template>
+  <!-- The struck result medallion (spec 1033 handoff §Result overlay):
+       gold for the winner's view, silver for the loss. heroPop entrance. -->
+  <svg width="92" height="92" viewBox="0 0 32 32" class="medal" aria-hidden="true">
+    <path d="M12 4 L12 8 M20 4 L20 8" :stroke="ring" stroke-width="2.4" stroke-linecap="round" />
+    <circle cx="16" cy="18" r="12" :fill="fill" :stroke="ring" stroke-width="1.6" />
+    <circle cx="16" cy="18" r="8.6" fill="none" :stroke="ring" stroke-width="0.9" opacity="0.55" />
+    <svg x="8" y="10" width="16" height="16" viewBox="0 0 24 24">
+      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" :fill="star" />
+    </svg>
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{ kind: 'gold' | 'silver' }>();
+const fill = computed(() => (props.kind === 'gold' ? '#f6c453' : '#d7dde3'));
+const ring = computed(() => (props.kind === 'gold' ? '#c99a2e' : '#98a2ac'));
+const star = computed(() => (props.kind === 'gold' ? '#fff8e6' : '#ffffff'));
+</script>
+
+<style scoped>
+.medal {
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.45));
+  animation: hero-pop 0.55s cubic-bezier(0.2, 1.3, 0.5, 1) both;
+}
+@keyframes hero-pop {
+  0% { transform: scale(0.2) rotate(-14deg); opacity: 0; }
+  55% { transform: scale(1.2) rotate(6deg); }
+  100% { transform: scale(1) rotate(0); opacity: 1; }
+}
+</style>

--- a/src/games/battleship/SubmarineSvg.vue
+++ b/src/games/battleship/SubmarineSvg.vue
@@ -1,0 +1,128 @@
+<template>
+  <!-- One continuous submarine vessel (spec 1033 handoff §Submarine artwork).
+       Drawn horizontally (bow to the right) in a len*100 × 100 space; vertical
+       boats wrap the same art in translate(100,0) rotate(90). The gentle
+       scale(1,1.14) around y=54 fattens the beam. `wreck` swaps in the sunken
+       ghost: spectral hull, crack, breach, dead X eyes, rising bubbles. -->
+  <svg
+    :viewBox="vertical ? `0 0 100 ${W}` : `0 0 ${W} 100`"
+    preserveAspectRatio="none"
+    width="100%"
+    height="100%"
+    class="sub"
+    :class="{ wreck, invalid }"
+  >
+    <g :transform="vertical ? 'translate(100,0) rotate(90)' : undefined">
+      <g transform="translate(0,54) scale(1,1.14) translate(0,-54)">
+        <template v-if="!wreck">
+          <!-- stern shaft + rudder + propeller -->
+          <line x1="4" y1="56" x2="13" y2="56" :stroke="C.dark" stroke-width="3" stroke-linecap="round" />
+          <path d="M11 49 L5 46 L5 66 L11 63 Z" :fill="C.tower" :stroke="C.dark" stroke-width="1.2" stroke-linejoin="round" />
+          <g transform="translate(5,56)">
+            <ellipse cx="0" cy="0" rx="2" ry="6" :fill="C.prop" />
+            <ellipse cx="0" cy="0" rx="6" ry="2" :fill="C.prop" />
+            <circle cx="0" cy="0" r="1.7" :fill="C.dark" />
+          </g>
+          <!-- pressure hull -->
+          <path :d="hullPath" :fill="C.hull" :stroke="C.dark" stroke-width="2.5" stroke-linejoin="round" />
+          <path :d="`M16 49 Q${cx} 45.5 ${W - 18} 49`" fill="none" :stroke="C.hullHi" stroke-width="2.4" stroke-linecap="round" opacity="0.7" />
+          <path :d="`M18 64 H${W - 20}`" fill="none" :stroke="C.hullLo" stroke-width="2.5" stroke-linecap="round" opacity="0.5" />
+          <!-- bow dive plane -->
+          <path :d="`M${W - 24} 60 L${W - 8} 63 L${W - 24} 66 Z`" :fill="C.tower" :stroke="C.dark" stroke-width="1" stroke-linejoin="round" />
+          <!-- glowing portholes -->
+          <circle v-for="lx in portholes" :key="lx" :cx="lx" cy="57" r="2" :fill="C.glow" opacity="0.9" />
+          <!-- conning tower + light + periscope + antenna -->
+          <path :d="`M${tx - 11} 44 V33 Q${tx - 11} 27 ${tx - 5} 27 H${tx + 7} Q${tx + 13} 27 ${tx + 13} 33 V44 Z`" :fill="C.tower" :stroke="C.dark" stroke-width="2" stroke-linejoin="round" />
+          <line :x1="tx - 8" y1="31" :x2="tx + 9" y2="31" :stroke="C.trim" stroke-width="1.5" opacity="0.55" />
+          <rect :x="tx - 2" y="35" width="4" height="4" rx="1" :fill="C.glow" opacity="0.85" />
+          <line :x1="tx - 3" y1="27" :x2="tx - 3" y2="15" :stroke="C.dark" stroke-width="2" stroke-linecap="round" />
+          <line :x1="tx - 4" y1="16" :x2="tx + 1" y2="16" :stroke="C.dark" stroke-width="2" stroke-linecap="round" />
+          <line :x1="tx + 5" y1="27" :x2="tx + 5" y2="19" :stroke="C.trim" stroke-width="1.6" stroke-linecap="round" />
+        </template>
+        <template v-else>
+          <!-- the broken, powerless wreck -->
+          <path :d="ghostHull" :fill="G.g" :stroke="G.gd" stroke-width="2" stroke-linejoin="round" />
+          <path :d="`M${cx - 9} 44 V34 Q${cx - 9} 30 ${cx - 4} 30 H${cx + 6} Q${cx + 10} 30 ${cx + 10} 34 V44 Z`" :fill="G.g" :stroke="G.gd" stroke-width="1.6" />
+          <path :d="`M${cx - 20} 52 l7 4 l-4 4`" fill="none" :stroke="G.dk" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+          <circle :cx="cx + W * 0.24" cy="58" r="3.5" :fill="G.dk" />
+          <path :d="`M${cx - 5} 35 l4 4 M${cx - 1} 35 l-4 4`" stroke="#33414f" stroke-width="1.4" stroke-linecap="round" />
+          <path :d="`M${cx + 2} 35 l4 4 M${cx + 6} 35 l-4 4`" stroke="#33414f" stroke-width="1.4" stroke-linecap="round" />
+          <circle class="bub bub-a" :cx="cx - W * 0.2" cy="30" r="2.4" :fill="G.gd" />
+          <circle class="bub bub-b" :cx="cx + W * 0.26" cy="26" r="1.9" :fill="G.gd" />
+        </template>
+      </g>
+    </g>
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+  len: number;
+  vertical?: boolean;
+  wreck?: boolean;
+  invalid?: boolean;
+}>();
+
+// Palette from the handoff design tokens (fixed art colors, not themed).
+const C = {
+  hull: '#454f5a', hullHi: '#707b86', hullLo: '#262d34', dark: '#1a2026',
+  tower: '#374049', trim: '#8b96a1', glow: '#7dd3fc', prop: '#c6a24a',
+} as const;
+const G = { g: 'rgba(200,214,226,0.58)', gd: 'rgba(255,255,255,0.55)', dk: 'rgba(6,12,20,0.32)' } as const;
+
+const W = computed(() => props.len * 100);
+const cx = computed(() => W.value * 0.5);
+const tx = computed(() => cx.value - W.value * 0.05);
+const hullPath = computed(
+  () => `M18 43 H${W.value - 20} Q${W.value - 4} 43 ${W.value - 4} 56 Q${W.value - 4} 69 ${W.value - 20} 69 H18 Q8 69 8 56 Q8 43 18 43 Z`,
+);
+const ghostHull = computed(
+  () => `M18 44 H${W.value - 20} Q${W.value - 5} 44 ${W.value - 5} 56 Q${W.value - 5} 68 ${W.value - 20} 68 H18 Q8 68 8 56 Q8 44 18 44 Z`,
+);
+const portholes = computed(() => {
+  const lights = Math.max(2, props.len + 1);
+  const out: number[] = [];
+  for (let i = 0; i < lights; i++) {
+    const lx = 24 + i * ((W.value - 48) / lights);
+    if (Math.abs(lx - tx.value) < 12) continue;
+    out.push(lx);
+  }
+  return out;
+});
+</script>
+
+<style scoped>
+.sub {
+  display: block;
+  overflow: visible;
+  filter: drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.28));
+  animation: ship-in 0.4s ease both;
+}
+.sub.invalid {
+  filter: drop-shadow(0 0 2px rgba(239, 68, 68, 0.95)) drop-shadow(0 0 3px rgba(239, 68, 68, 0.75));
+}
+.sub.wreck {
+  animation: ghost-in 0.55s ease both;
+}
+.bub-a {
+  animation: bob 2.4s ease-in-out infinite;
+}
+.bub-b {
+  animation: bob 2.8s ease-in-out 0.5s infinite;
+}
+@keyframes ship-in {
+  from { opacity: 0; transform: translateY(-2px) scale(0.94); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes ghost-in {
+  0% { opacity: 0; transform: translateY(7px) scale(0.9) rotate(-3deg); }
+  60% { opacity: 0.8; }
+  100% { opacity: 1; transform: translateY(0) scale(1) rotate(-4deg); }
+}
+@keyframes bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2.5px); }
+}
+</style>

--- a/src/games/battleship/index.ts
+++ b/src/games/battleship/index.ts
@@ -5,7 +5,7 @@
 
 import { boatOutline } from 'ionicons/icons'
 import type { GameModule } from '../types'
-import { applyMove, createInitialState, status, turn, type BsMove, type BsState } from './logic'
+import { applyMove, createInitialState, mayMove as bsMayMove, status, turn, type BsMove, type BsState } from './logic'
 
 /** The foley a just-applied move deserves (spec 1033): torpedo, splash,
  *  impact, or the groan of a sinking boat. Terminal moves fall back to the
@@ -29,6 +29,7 @@ const battleship: GameModule<BsState, BsMove> = {
   turn,
   status,
   moveCue,
+  mayMove: (state, player) => bsMayMove(state as BsState, player),
   // ONE look (spec 1033): the submarine design from the handoff IS Battleship's
   // identity — no theme choice. The id stays 'classic' (frozen default), and
   // ids from games started on older builds ('pirates', 'sea-monsters') fall

--- a/src/games/battleship/index.ts
+++ b/src/games/battleship/index.ts
@@ -16,12 +16,11 @@ const battleship: GameModule<BsState, BsMove> = {
   applyMove,
   turn,
   status,
-  // Marks are the SHIP glyphs (your fleet's look); results are always 💦💥🔥.
-  themes: [
-    { id: 'classic', name: 'Classic', marks: ['🚢', '🚢'], accent: '30, 64, 175' },
-    { id: 'pirates', name: 'Pirates', marks: ['🏴‍☠️', '🏴‍☠️'], accent: '120, 53, 15' },
-    { id: 'sea-monsters', name: 'Sea Monsters', marks: ['🐙', '🐙'], accent: '13, 148, 136' },
-  ],
+  // ONE look (spec 1033): the submarine design from the handoff IS Battleship's
+  // identity — no theme choice. The id stays 'classic' (frozen default), and
+  // ids from games started on older builds ('pirates', 'sea-monsters') fall
+  // back here gracefully per the 0008 theme contract.
+  themes: [{ id: 'classic', name: 'Submarine' }],
 }
 
 export default battleship

--- a/src/games/battleship/index.ts
+++ b/src/games/battleship/index.ts
@@ -7,6 +7,18 @@ import { boatOutline } from 'ionicons/icons'
 import type { GameModule } from '../types'
 import { applyMove, createInitialState, status, turn, type BsMove, type BsState } from './logic'
 
+/** The foley a just-applied move deserves (spec 1033): torpedo, splash,
+ *  impact, or the groan of a sinking boat. Terminal moves fall back to the
+ *  platform's win/lose fanfare; commits and reveals are silent bookkeeping. */
+function moveCue(move: unknown, st: { state: string }, _me: 0 | 1): string | null {
+  const m = move as BsMove | null
+  if (!m || typeof m !== 'object') return null
+  if (st.state !== 'ongoing') return null // the result fanfare owns the ending
+  if (m.t === 'shot') return 'bs-fire'
+  if (m.t === 'answer') return m.r === 'miss' ? 'bs-splash' : m.r === 'sunk' ? 'bs-sunk' : 'bs-hit'
+  return null
+}
+
 const battleship: GameModule<BsState, BsMove> = {
   id: 'battleship',
   displayName: 'Battleship',
@@ -16,6 +28,7 @@ const battleship: GameModule<BsState, BsMove> = {
   applyMove,
   turn,
   status,
+  moveCue,
   // ONE look (spec 1033): the submarine design from the handoff IS Battleship's
   // identity — no theme choice. The id stays 'classic' (frozen default), and
   // ids from games started on older builds ('pirates', 'sea-monsters') fall

--- a/src/games/battleship/logic.test.ts
+++ b/src/games/battleship/logic.test.ts
@@ -6,6 +6,7 @@ import { ready } from '@/services/crypto/primitives';
 import {
   createInitialState,
   applyMove,
+  mayMove,
   status,
   turn,
   randomLayout,
@@ -115,14 +116,19 @@ describe('placement', () => {
 });
 
 describe('phase machine', () => {
-  it('commits go P0 then P1; nothing else is legal while placing', () => {
+  it('placement is PARALLEL: either player may commit first, once each, and nothing else is legal', () => {
     let s = createInitialState();
-    expect(turn(s)).toBe(0);
-    expect(applyMove(s, { t: 'commit', h: 'x' }, 1)).toBeNull(); // P1 cannot jump the queue
+    expect(turn(s)).toBe(0); // the nudge still points at the inviter
+    expect(mayMove(s, 0)).toBe(true);
+    expect(mayMove(s, 1)).toBe(true);
     expect(applyMove(s, { t: 'shot', cell: 0 }, 0)).toBeNull();
+    // The INVITEE deploys first — legal (spec 1033: don't block their placing).
+    s = apply(s, { t: 'commit', h: commitment(L1, S1) }, 1);
+    expect(mayMove(s, 1)).toBe(false); // committed players wait
+    expect(applyMove(s, { t: 'commit', h: 'y' }, 1)).toBeNull(); // no double commit
+    expect(turn(s)).toBe(0);
     s = apply(s, { t: 'commit', h: commitment(L0, S0) }, 0);
-    expect(turn(s)).toBe(1);
-    expect(applyMove(s, { t: 'commit', h: 'y' }, 0)).toBeNull(); // no double commit
+    expect(turn(s)).toBe(0); // battle: P0 fires first as always
   });
 
   it('battle alternates shot → answer, P0 firing first', () => {

--- a/src/games/battleship/logic.ts
+++ b/src/games/battleship/logic.ts
@@ -189,10 +189,19 @@ function lastOf(s: BsState): 0 | 1 {
   return 1
 }
 
+/** May this player act right now? Placement is PARALLEL: while fleets are
+ *  being placed, each player owes exactly their own commit, in any order
+ *  (neither depends on the other). From battle on, strict turn order rules.
+ *  `turn()` still names the player being waited on for nudges/previews. */
+export function mayMove(s: BsState, player: 0 | 1): boolean {
+  if (status(s).state !== 'ongoing') return false
+  if (s.commits[0] === null || s.commits[1] === null) return s.commits[player] === null
+  return player === turn(s)
+}
+
 export function applyMove(s: BsState, move: BsMove, player: 0 | 1): BsState | null {
   if (!move || typeof move !== 'object') return null
-  if (status(s).state !== 'ongoing') return null
-  if (player !== turn(s)) return null
+  if (!mayMove(s, player)) return null
 
   // Placing.
   if (s.commits[0] === null || s.commits[1] === null) {

--- a/src/games/session.ts
+++ b/src/games/session.ts
@@ -63,7 +63,9 @@ export function localMoveAllowed(
 ): boolean {
   if (!module) return false
   const status = deriveStatus(module, session)
-  return status.state === 'ongoing' && status.turn === player
+  if (status.state !== 'ongoing') return false
+  if (module.mayMove) return module.mayMove(replayState(module, session), player)
+  return status.turn === player
 }
 
 function broken(session: GameSession): { session: GameSession; outcome: ApplyOutcome } {
@@ -131,7 +133,8 @@ export function applySignal(
 
   // Rules 6/7 — turn order, then legality, judged on the replayed state.
   const state = replayState(module, session)
-  if (module.turn(state) !== sender) return broken(session)
+  const allowed = module.mayMove ? module.mayMove(state, sender) : module.turn(state) === sender
+  if (!allowed) return broken(session)
   if (module.applyMove(state, signal.move, sender) === null) return broken(session)
 
   return {

--- a/src/games/types.ts
+++ b/src/games/types.ts
@@ -36,6 +36,12 @@ export interface GameModule<S = unknown, M = unknown> {
   turn(state: S): 0 | 1
   status(state: S): GameStatusResult
   /** Bundled visual themes; the first entry is the default (FR-022). */
+  /** Optional finer-grained acting gate (spec 1033): when defined, it replaces
+   *  the strict `turn(state) === player` check in BOTH the local-send gate and
+   *  inbound validation — e.g. Battleship's parallel fleet placement, where
+   *  each player owes their own commit in any order. `turn()` still names who
+   *  is being waited on (nudges, previews). */
+  mayMove?: (state: unknown, player: 0 | 1) => boolean
   /** Optional per-move FOLEY (spec 1033): the game may name the cue a just-
    *  applied move deserves (e.g. Battleship's splash vs impact); null/absent
    *  falls back to the platform's generic status cues. */

--- a/src/games/types.ts
+++ b/src/games/types.ts
@@ -36,6 +36,10 @@ export interface GameModule<S = unknown, M = unknown> {
   turn(state: S): 0 | 1
   status(state: S): GameStatusResult
   /** Bundled visual themes; the first entry is the default (FR-022). */
+  /** Optional per-move FOLEY (spec 1033): the game may name the cue a just-
+   *  applied move deserves (e.g. Battleship's splash vs impact); null/absent
+   *  falls back to the platform's generic status cues. */
+  moveCue?: (move: unknown, status: GameSessionStatus, me: 0 | 1) => string | null
   themes: GameTheme[]
 }
 

--- a/src/services/game-sounds.ts
+++ b/src/services/game-sounds.ts
@@ -21,6 +21,11 @@ export type GameCue =
   | 'gamedraw'
   | 'gamechallenge'
   | 'gameaccept'
+  | 'bs-fire'
+  | 'bs-splash'
+  | 'bs-hit'
+  | 'bs-sunk'
+  | 'bs-sonar'
 
 /** The cue a game's new status earns for the player `me` — null for silence
  *  (out of sync is a failure state, not a moment; FR-026). */

--- a/src/services/sound.test.ts
+++ b/src/services/sound.test.ts
@@ -49,6 +49,12 @@ describe('claimCue — call-cue rate limiter (spec 0004 US5)', () => {
     }
   });
 
+  it('has a recipe for every Battleship foley cue (spec 1033)', () => {
+    for (const name of ['bs-fire', 'bs-splash', 'bs-hit', 'bs-sunk', 'bs-sonar']) {
+      expect(RECIPE_NAMES).toContain(name);
+    }
+  });
+
   it('de-dups a rapid hold→swap→hold storm so cue-fatigue is bounded (spec 0005 T027)', () => {
     // Fumbling the swap button shouldn't machine-gun the same cue.
     expect(claimCue('swap', 10_000)).toBe(true);

--- a/src/services/sound.test.ts
+++ b/src/services/sound.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { claimCue, RECIPE_NAMES } from './sound';
+import { claimCue, FX_NAMES, RECIPE_NAMES } from './sound';
 
 describe('claimCue — call-cue rate limiter (spec 0004 US5)', () => {
   it('allows the first play and suppresses an immediate repeat of the same cue', () => {
@@ -49,9 +49,9 @@ describe('claimCue — call-cue rate limiter (spec 0004 US5)', () => {
     }
   });
 
-  it('has a recipe for every Battleship foley cue (spec 1033)', () => {
+  it('has an effect for every Battleship foley cue (spec 1033)', () => {
     for (const name of ['bs-fire', 'bs-splash', 'bs-hit', 'bs-sunk', 'bs-sonar']) {
-      expect(RECIPE_NAMES).toContain(name);
+      expect([...RECIPE_NAMES, ...FX_NAMES]).toContain(name);
     }
   });
 

--- a/src/services/sound.ts
+++ b/src/services/sound.ts
@@ -60,7 +60,14 @@ export type ToneName =
   // Group challenge cues (spec 0009): the announcement fanfare-let and the
   // "someone's in!" confirmation.
   | 'gamechallenge'
-  | 'gameaccept';
+  | 'gameaccept'
+  // Battleship foley (spec 1033): torpedo away, splash, impact, the groan of a
+  // sinking boat, and the sonar ping when the scope is yours.
+  | 'bs-fire'
+  | 'bs-splash'
+  | 'bs-hit'
+  | 'bs-sunk'
+  | 'bs-sonar';
 
 interface Note {
   freq: number;
@@ -231,6 +238,36 @@ const RECIPES: Record<Exclude<ToneName, 'none'>, Note[]> = {
   gameaccept: [
     { freq: C5, start: 0, dur: 0.09, type: 'triangle', gain: 0.22 },
     { freq: G5, start: 0.09, dur: 0.16, type: 'triangle', gain: 0.24 },
+  ],
+  // Torpedo away: a fast falling sawtooth thunk-whoosh.
+  'bs-fire': [
+    { freq: 180, start: 0, dur: 0.06, type: 'sawtooth', gain: 0.16 },
+    { freq: 140, start: 0.05, dur: 0.07, type: 'sawtooth', gain: 0.14 },
+    { freq: 110, start: 0.11, dur: 0.09, type: 'sawtooth', gain: 0.12 },
+  ],
+  // Nothing but water: a soft descending bloop.
+  'bs-splash': [
+    { freq: 420, start: 0, dur: 0.05, type: 'sine', gain: 0.12 },
+    { freq: 300, start: 0.06, dur: 0.08, type: 'sine', gain: 0.11 },
+    { freq: 220, start: 0.13, dur: 0.12, type: 'sine', gain: 0.1 },
+  ],
+  // Impact: a low boom with a sharp crack riding it.
+  'bs-hit': [
+    { freq: 240, start: 0, dur: 0.04, type: 'square', gain: 0.14 },
+    { freq: 90, start: 0, dur: 0.12, type: 'square', gain: 0.22 },
+    { freq: 55, start: 0.02, dur: 0.18, type: 'sawtooth', gain: 0.2 },
+  ],
+  // A boat goes down: a longer descending groan under a final boom.
+  'bs-sunk': [
+    { freq: 90, start: 0, dur: 0.14, type: 'square', gain: 0.22 },
+    { freq: 70, start: 0.1, dur: 0.16, type: 'sawtooth', gain: 0.2 },
+    { freq: 55, start: 0.24, dur: 0.2, type: 'sawtooth', gain: 0.16 },
+    { freq: 45, start: 0.42, dur: 0.28, type: 'sine', gain: 0.12 },
+  ],
+  // The scope is yours: a clean sonar ping with a faint echo.
+  'bs-sonar': [
+    { freq: 1150, start: 0, dur: 0.18, type: 'sine', gain: 0.12 },
+    { freq: 1150, start: 0.45, dur: 0.22, type: 'sine', gain: 0.045 },
   ],
 };
 

--- a/src/services/sound.ts
+++ b/src/services/sound.ts
@@ -63,11 +63,10 @@ export type ToneName =
   | 'gameaccept'
   // Battleship foley (spec 1033): torpedo away, splash, impact, the groan of a
   // sinking boat, and the sonar ping when the scope is yours.
-  | 'bs-fire'
-  | 'bs-splash'
-  | 'bs-hit'
-  | 'bs-sunk'
-  | 'bs-sonar';
+  | FxName;
+
+/** Effect-layer cues (spec 1033): synthesized foley, not note recipes. */
+export type FxName = 'bs-fire' | 'bs-splash' | 'bs-hit' | 'bs-sunk' | 'bs-sonar';
 
 interface Note {
   freq: number;
@@ -90,7 +89,7 @@ const A4 = 440.0;
 const F4 = 349.23;
 const Bb4 = 466.16;
 
-const RECIPES: Record<Exclude<ToneName, 'none'>, Note[]> = {
+const RECIPES: Record<Exclude<ToneName, 'none' | FxName>, Note[]> = {
   // Soft single blip, the default.
   note: [{ freq: A5, start: 0, dur: 0.18, type: 'sine' }],
   // Two ascending bell-like notes.
@@ -239,36 +238,6 @@ const RECIPES: Record<Exclude<ToneName, 'none'>, Note[]> = {
     { freq: C5, start: 0, dur: 0.09, type: 'triangle', gain: 0.22 },
     { freq: G5, start: 0.09, dur: 0.16, type: 'triangle', gain: 0.24 },
   ],
-  // Torpedo away: a fast falling sawtooth thunk-whoosh.
-  'bs-fire': [
-    { freq: 180, start: 0, dur: 0.06, type: 'sawtooth', gain: 0.16 },
-    { freq: 140, start: 0.05, dur: 0.07, type: 'sawtooth', gain: 0.14 },
-    { freq: 110, start: 0.11, dur: 0.09, type: 'sawtooth', gain: 0.12 },
-  ],
-  // Nothing but water: a soft descending bloop.
-  'bs-splash': [
-    { freq: 420, start: 0, dur: 0.05, type: 'sine', gain: 0.12 },
-    { freq: 300, start: 0.06, dur: 0.08, type: 'sine', gain: 0.11 },
-    { freq: 220, start: 0.13, dur: 0.12, type: 'sine', gain: 0.1 },
-  ],
-  // Impact: a low boom with a sharp crack riding it.
-  'bs-hit': [
-    { freq: 240, start: 0, dur: 0.04, type: 'square', gain: 0.14 },
-    { freq: 90, start: 0, dur: 0.12, type: 'square', gain: 0.22 },
-    { freq: 55, start: 0.02, dur: 0.18, type: 'sawtooth', gain: 0.2 },
-  ],
-  // A boat goes down: a longer descending groan under a final boom.
-  'bs-sunk': [
-    { freq: 90, start: 0, dur: 0.14, type: 'square', gain: 0.22 },
-    { freq: 70, start: 0.1, dur: 0.16, type: 'sawtooth', gain: 0.2 },
-    { freq: 55, start: 0.24, dur: 0.2, type: 'sawtooth', gain: 0.16 },
-    { freq: 45, start: 0.42, dur: 0.28, type: 'sine', gain: 0.12 },
-  ],
-  // The scope is yours: a clean sonar ping with a faint echo.
-  'bs-sonar': [
-    { freq: 1150, start: 0, dur: 0.18, type: 'sine', gain: 0.12 },
-    { freq: 1150, start: 0.45, dur: 0.22, type: 'sine', gain: 0.045 },
-  ],
 };
 
 /** All defined recipe names (for tests / completeness checks). */
@@ -307,9 +276,135 @@ function playNote(ac: AudioContext, note: Note): void {
 }
 
 /** Play a notification tone by name. No-op for 'none' or when audio is blocked. */
+/* ---- synthesized sound effects (spec 1033) ----
+ *
+ * The note recipes above are melodic: fixed-frequency oscillator beeps. Real
+ * FOLEY — explosions, water, sonar — is the other classic synthesis family:
+ * filtered NOISE with swept envelopes. An explosion is a noise burst through a
+ * closing low-pass over a sub-bass drop; a splash is a high-passed spray with
+ * a pitch-falling bloop; a sonar ping is a long exponential sine decay with a
+ * gentle bend and an echo. Still zero audio files, still royalty-free. */
+
+const EPS = 0.0001; // exponential ramps cannot reach zero
+
+let noiseBuf: AudioBuffer | null = null;
+function noise(ac: AudioContext): AudioBufferSourceNode {
+  if (!noiseBuf || noiseBuf.sampleRate !== ac.sampleRate) {
+    noiseBuf = ac.createBuffer(1, ac.sampleRate, ac.sampleRate);
+    const d = noiseBuf.getChannelData(0);
+    for (let i = 0; i < d.length; i++) d[i] = Math.random() * 2 - 1;
+  }
+  const src = ac.createBufferSource();
+  src.buffer = noiseBuf;
+  src.loop = true;
+  return src;
+}
+
+/** Gain node with an attack + exponential-decay envelope. */
+function env(ac: AudioContext, t0: number, peak: number, attack: number, end: number): GainNode {
+  const g = ac.createGain();
+  g.gain.setValueAtTime(EPS, t0);
+  g.gain.exponentialRampToValueAtTime(peak, t0 + attack);
+  g.gain.exponentialRampToValueAtTime(EPS, t0 + end);
+  return g;
+}
+
+/** Filtered-noise burst whose filter frequency sweeps f0 → f1. */
+function noiseSweep(
+  ac: AudioContext,
+  t0: number,
+  type: BiquadFilterType,
+  f0: number,
+  f1: number,
+  sweep: number,
+  q: number,
+  peak: number,
+  attack: number,
+  end: number,
+): void {
+  const src = noise(ac);
+  const filt = ac.createBiquadFilter();
+  filt.type = type;
+  filt.frequency.setValueAtTime(f0, t0);
+  filt.frequency.exponentialRampToValueAtTime(Math.max(f1, 20), t0 + sweep);
+  filt.Q.value = q;
+  const g = env(ac, t0, peak, attack, end);
+  src.connect(filt).connect(g).connect(ac.destination);
+  src.start(t0);
+  src.stop(t0 + end + 0.05);
+}
+
+/** Oscillator whose pitch sweeps f0 → f1 under an envelope. */
+function oscSweep(
+  ac: AudioContext,
+  t0: number,
+  type: OscillatorType,
+  f0: number,
+  f1: number,
+  sweep: number,
+  peak: number,
+  attack: number,
+  end: number,
+): void {
+  const o = ac.createOscillator();
+  o.type = type;
+  o.frequency.setValueAtTime(f0, t0);
+  o.frequency.exponentialRampToValueAtTime(Math.max(f1, 20), t0 + sweep);
+  const g = env(ac, t0, peak, attack, end);
+  o.connect(g).connect(ac.destination);
+  o.start(t0);
+  o.stop(t0 + end + 0.05);
+}
+
+const FX: Record<string, (ac: AudioContext, t0: number) => void> = {
+  // Torpedo away: a compressed-air whoosh (band-passed noise diving from
+  // bright to low) over a soft launch thump.
+  'bs-fire': (ac, t0) => {
+    noiseSweep(ac, t0, 'bandpass', 2200, 250, 0.38, 1.2, 0.2, 0.012, 0.42);
+    oscSweep(ac, t0, 'sine', 110, 55, 0.12, 0.16, 0.008, 0.16);
+  },
+  // Nothing but water: a droplet plop with its spray, and a tiny second drip.
+  'bs-splash': (ac, t0) => {
+    noiseSweep(ac, t0, 'highpass', 900, 700, 0.3, 0.7, 0.12, 0.006, 0.32);
+    oscSweep(ac, t0, 'sine', 330, 130, 0.18, 0.16, 0.006, 0.22);
+    oscSweep(ac, t0 + 0.22, 'sine', 520, 220, 0.1, 0.045, 0.006, 0.12);
+  },
+  // Impact: the classic synthesized explosion — a noise burst through a
+  // closing low-pass, a sub-bass drop, and a bright initial crack.
+  'bs-hit': (ac, t0) => {
+    noiseSweep(ac, t0, 'lowpass', 3200, 120, 0.5, 0.7, 0.32, 0.008, 0.6);
+    oscSweep(ac, t0, 'sine', 90, 33, 0.4, 0.3, 0.008, 0.5);
+    noiseSweep(ac, t0, 'highpass', 2500, 2000, 0.06, 0.7, 0.1, 0.004, 0.07);
+  },
+  // A boat goes down: a deeper, longer blast, a groan sliding down the
+  // register, and a couple of bubbles gurgling up after.
+  'bs-sunk': (ac, t0) => {
+    noiseSweep(ac, t0, 'lowpass', 2400, 60, 0.9, 0.7, 0.32, 0.01, 1.0);
+    oscSweep(ac, t0, 'sine', 75, 26, 0.8, 0.3, 0.01, 0.9);
+    oscSweep(ac, t0 + 0.08, 'sawtooth', 90, 34, 1.0, 0.07, 0.1, 1.15);
+    oscSweep(ac, t0 + 0.85, 'sine', 280, 540, 0.09, 0.04, 0.008, 0.12);
+    oscSweep(ac, t0 + 1.02, 'sine', 340, 640, 0.08, 0.03, 0.008, 0.1);
+  },
+  // The scope is yours: a long decaying ping with a gentle downward bend, a
+  // watery band-passed tail, and a fainter echo.
+  'bs-sonar': (ac, t0) => {
+    oscSweep(ac, t0, 'sine', 1500, 1380, 1.1, 0.14, 0.008, 1.15);
+    noiseSweep(ac, t0, 'bandpass', 1500, 1400, 0.8, 9, 0.02, 0.02, 0.8);
+    oscSweep(ac, t0 + 0.55, 'sine', 1500, 1390, 0.7, 0.045, 0.008, 0.8);
+  },
+};
+
+/** Names of the effect-layer cues (unioned with RECIPE_NAMES for coverage tests). */
+export const FX_NAMES = Object.keys(FX);
+
 export function playTone(name: string): void {
   if (!name || name === 'none') return;
-  const recipe = RECIPES[name as Exclude<ToneName, 'none'>];
+  const ac0 = FX[name] ? audioCtx() : null;
+  if (FX[name]) {
+    if (ac0) FX[name](ac0, ac0.currentTime);
+    return;
+  }
+  const recipe = RECIPES[name as Exclude<ToneName, 'none' | FxName>];
   if (!recipe) return;
   const ac = audioCtx();
   if (!ac) return;

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -30,6 +30,11 @@
   /* Wall pending/unfinished post card — a warm amber so an unsent, uploading or failed post reads
      as "not final yet" against the settled green posts. Opaque, like the bubbles, for legible text. */
   --app-bubble-pending: #ffe6ad;
+  /* Game cards (spec 1033): games render as a full-width NEUTRAL shared card,
+     not a sided bubble — a game belongs to both players. Values from the
+     submarine-redesign handoff. */
+  --app-game-card-bg: #ffffff;
+  --app-game-card-border: rgba(0, 0, 0, 0.07);
   /* Full-screen media viewer (spec 1014 FR-023): follows the app theme rather than a
      hardcoded black surface. Light defaults here; dark overrides below. The chrome (top/
      bottom bars) sits over the media, so the scrims + pill fills are theme-tinted for
@@ -60,6 +65,9 @@
   --app-bubble-out: #103a2c;
   /* Deep amber pending card for dark mode (mirrors the light --app-bubble-pending). */
   --app-bubble-pending: #43320c;
+  /* Game cards, dark (spec 1033 handoff). */
+  --app-game-card-bg: #181f1b;
+  --app-game-card-border: rgba(255, 255, 255, 0.08);
   /* Media viewer — immersive dark surface in dark mode (spec 1014 FR-023). */
   --viewer-surface: #000000;
   --viewer-text: #ffffff;

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1180,6 +1180,9 @@ import LocationBubble from '@/components/LocationBubble.vue';
 import PollBubble from '@/components/PollBubble.vue';
 import ContactBubble from '@/components/ContactBubble.vue';
 import GameBubble from '@/components/GameBubble.vue';
+import { GAMES } from '@/games/registry';
+import { deriveStatus as deriveGameStatus } from '@/games/session';
+import { challengePhase } from '@/games/challenge';
 import ChallengeBubble from '@/components/ChallengeBubble.vue';
 import GamePicker from '@/components/GamePicker.vue';
 import PollComposer from '@/components/PollComposer.vue';
@@ -1674,7 +1677,9 @@ async function openMenu(m: Message, ev: Event) {
       canInfo: m.outgoing || hasMedia || m.kind === 'game',
       canCopy: !!m.body,
       canView,
-      canForward: m.kind !== 'game', // a game belongs to its conversation (spec 0008 FR-014)
+      canForward: m.kind !== 'game' && m.kind !== 'gamechallenge', // a game belongs to its conversation (spec 0008 FR-014)
+      canReply: m.kind !== 'game' && m.kind !== 'gamechallenge', // a shared board isn't a quotable line
+      canDelete: !gameLocked(m), // a live board can't be ripped out from under the players
       canEdit: m.outgoing && m.kind === 'text' && !m.deleted,
       canSave,
       canSaveAll,
@@ -1971,7 +1976,11 @@ function forwardSelected(): void {
   forwardOpen.value = true;
 }
 function confirmDeleteSelected(): void {
-  if (selected.value.length) void presentDeleteSheet(selectedMessages.value);
+  const targets = selectedMessages.value.filter((m) => !gameLocked(m));
+  if (targets.length < selectedMessages.value.length) {
+    void appToast({ message: 'Games still being played were left out.', duration: 2200 });
+  }
+  if (targets.length) void presentDeleteSheet(targets);
 }
 
 /* ---- reply ---- */
@@ -2336,6 +2345,7 @@ function swipeStyle(id: string): Record<string, string> | undefined {
 }
 function onSwipeStart(e: TouchEvent, m: Message): void {
   if (m.deleted || selecting.value) return;
+  if (m.kind === 'game' || m.kind === 'gamechallenge') return; // boards aren't reply-swipeable
   swipeStartX = e.touches[0].clientX;
   swipeStartY = e.touches[0].clientY;
   swipeDir = null;
@@ -2386,7 +2396,20 @@ function onSwipeEnd(): void {
     else void confirmDelete(m);
   }
 }
+/** An unfinished game is not deletable: pulling a live board out from under
+ *  both players breaks placement and play alike. Cancelled challenges and any
+ *  terminal result delete like ordinary messages. */
+function gameLocked(m: Message): boolean {
+  if ((m.kind !== 'game' && m.kind !== 'gamechallenge') || !m.game || m.deleted) return false;
+  if (m.game.challenge && challengePhase(m.game) === 'cancelled') return false;
+  return deriveGameStatus(GAMES[m.game.gameType] ?? null, m.game).state === 'ongoing';
+}
+
 async function confirmDelete(m: Message): Promise<void> {
+  if (gameLocked(m)) {
+    await appToast({ message: 'Finish or resign the game first.', duration: 2200 });
+    return;
+  }
   const targets = m.albumId ? allMedia.value.filter((x) => x.albumId === m.albumId) : [m];
   await presentDeleteSheet(targets);
 }
@@ -4839,6 +4862,10 @@ function cancelRecording() {
 .bubble-row.game-row .bubble-col {
   max-width: 100%;
   width: 100%;
+}
+.bubble-row.game-row .swipe-wrap {
+  width: 100%;
+  align-items: stretch;
 }
 .bubble-row.game-row .bubble,
 .bubble-row.game-row .bubble.out {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1714,6 +1714,15 @@ async function openMenu(m: Message, ev: Event) {
 // viewer instead; the react button opens the quick-react popover. No long-press.
 function onBubbleTap(m: Message, ev: Event): void {
   if (m.deleted) return;
+  // Game boards are dense interactive surfaces — a stray tap between cells must
+  // not summon the message menu. For games, only the footer strip (timestamp +
+  // reactions) opens it.
+  if (
+    (m.kind === 'game' || m.kind === 'gamechallenge') &&
+    !(ev.target as HTMLElement | null)?.closest?.('.msg-foot')
+  ) {
+    return;
+  }
   void openMenu(m, ev);
 }
 

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -149,7 +149,7 @@
         <div
           v-else
           class="bubble-row"
-          :class="{ out: m.outgoing, 'sel-mode': selecting, 'sel-on': isSelected(m.id) }"
+          :class="{ out: m.outgoing, 'sel-mode': selecting, 'sel-on': isSelected(m.id), 'game-row': (m.kind === 'game' || m.kind === 'gamechallenge') && !m.deleted }"
           v-memo="[
             m.updatedAt,
             mediaInfo[m.mediaId!]?.posterUrl,
@@ -4832,6 +4832,22 @@ function cancelRecording() {
 }
 .bubble.out {
   background: var(--app-bubble-out);
+}
+/* Game cards (spec 1033): a game is a SHARED surface, not one side's message —
+   full message-column width and a neutral card either direction (the
+   submarine-handoff shell: 18px radius, 14px padding, soft double shadow). */
+.bubble-row.game-row .bubble-col {
+  max-width: 100%;
+  width: 100%;
+}
+.bubble-row.game-row .bubble,
+.bubble-row.game-row .bubble.out {
+  width: 100%;
+  background: var(--app-game-card-bg);
+  border: 1px solid var(--app-game-card-border);
+  border-radius: 18px;
+  padding: 14px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 10px 26px -14px rgba(0, 0, 0, 0.28);
 }
 /* Reserve a minimum bubble width that fits ~3 reaction pills side by side, so a
    short message NEVER (a) shrinks when the react button hides at the 3-reaction cap,


### PR DESCRIPTION
## Spec 1033 — the submarine redesign (Claude Design handoff, realized)

The vendored design handoff (specs/1033-submarine-redesign-battleship/design/) is the pixel spec; this PR recreates it in the real components with the commit-and-reveal protocol untouched (`git diff develop -- server/ src/games/battleship/logic.ts* src/services/crypto/` — logic gained ONLY the placement-parallelism rule below; server and crypto zero-diff).

### The look
- **Full-width shared game card** for ALL games (neutral surface both themes) — a game belongs to both players.
- **Real submarine vessels** (hull/tower/periscope/propeller/portholes, the prototype's exact geometry) positioned by the handoff's overlay math; **one identity** — the three emoji themes are gone (old theme ids fall back gracefully), mini-subs face each other in the header, picking Battleship goes straight to placement.
- **Custom shot language**: spinning reticle pending, sonar ripples, flickering flames, charred cells; wrecks surface the moment a kill is confirmed (yours immediately, theirs derived from the hit-run; the final reveal corrects touch-ambiguity and shows survivors as subs). Wrecks stop burning.
- **Sonar radar** over their sea (crosshair, rings, trailing-fade sweep — corrected to CLOCKWISE like a real scope — and ping), brighter on your turn, never blocking taps.
- **Gold/silver medallion** result overlay.

### The feel
- **Manual placement**: drag with snap + red-tint/snap-back on illegal drops, tap to rotate, Shuffle, "Deploy fleet".
- **Parallel placement** (protocol fix): either player deploys first — the invitee is no longer blocked behind the inviter's commit. New optional `GameModule.mayMove` acting rule honored by both engine gates; battle stays strictly turn-based.
- **Synthesized foley** (no audio files): filtered-noise explosions, droplet splash, torpedo whoosh, sinking groan with bubbles, and a decaying sonar ping with echo when the turn becomes yours — behind the existing Game sounds setting, via a new optional `GameModule.moveCue` hook.
- **Board etiquette**: game cards aren't quotable/forwardable, the reply/delete swipe is disabled on boards (it fought the placement drag), live games can't be deleted until finished, and the message menu opens only from the footer strip.

### Platform fixes found along the way
- The auto-sent final answer embedded a Vue-reactive layout that IndexedDB rejected (games couldn't END through the auto path); reveals now leave plain and playGameMove normalizes every move at the choke point.

### Verification
- 782 unit tests (incl. new placement-parallelism + foley coverage), all 10 game e2e, typecheck/build clean.
- Every state verified on the live UI via drive screenshots: placing/drag, battle with radar both turn states, own + derived enemy wrecks, medallion, dark mode, invitee-first deploy.

Closes #852
Closes #853
Closes #854
Closes #855
Closes #856
Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE