### PR TITLE
fix(notifications): push failures name their reason, and dead subscriptions heal themselves

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,3 +85,4 @@ Specs are grouped by category band; status moves
 | [2019](specs/2019-typing-works-again/spec.md) | Typing works again after sending pasted media, and captions reach every attachment | 🟡 in-progress |
 | [2020](specs/2020-fast-message-bursts/spec.md) | Fast message bursts stop showing duplicate notifications | 🟡 in-progress |
 | [2021](specs/2021-remove-save-to-photos/spec.md) | Remove the "Save to Photos" chat setting | 🟡 in-progress |
+| [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🔵 in-review |

--- a/server/internal/push/prune_test.go
+++ b/server/internal/push/prune_test.go
@@ -1,0 +1,39 @@
+package push
+
+import "testing"
+
+// Spec 2022: the pure prune decision. Dead-subscription reasons prune; reasons
+// that mean OUR request was malformed never prune (that would silently
+// unsubscribe every healthy device over a server-side bug).
+func TestShouldPrune(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"404 always prunes", 404, ``, true},
+		{"410 always prunes", 410, `{"reason":"Unregistered"}`, true},
+		{"400 dead subscription reasons prune", 400, `{"reason":"BadDeviceToken"}`, true},
+		{"400 Unregistered prunes", 400, `{"reason":"Unregistered"}`, true},
+		{"403 ExpiredToken prunes", 403, `{"reason":"ExpiredToken"}`, true},
+		{"400 DeviceTokenNotForTopic prunes", 400, `{"reason":"DeviceTokenNotForTopic"}`, true},
+		{"400 SubscriptionExpired prunes", 400, `{"reason":"SubscriptionExpired"}`, true},
+		{"400 our-bug topic reason keeps", 400, `{"reason":"BadWebPushTopic"}`, false},
+		{"400 our-bug ttl reason keeps", 400, `{"reason":"BadWebPushTtl"}`, false},
+		{"403 our-bug jwt reason keeps", 403, `{"reason":"BadJwtToken"}`, false},
+		{"413 payload keeps", 413, `{"reason":"PayloadTooLarge"}`, false},
+		{"429 rate limit keeps", 429, ``, false},
+		{"400 unknown reason keeps", 400, `{"reason":"SomethingNew"}`, false},
+		{"400 empty body keeps", 400, ``, false},
+		{"400 non-JSON body keeps", 400, `bad gateway`, false},
+		{"success never prunes", 201, ``, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldPrune(c.status, []byte(c.body)); got != c.want {
+				t.Fatalf("shouldPrune(%d, %q) = %v, want %v", c.status, c.body, got, c.want)
+			}
+		})
+	}
+}

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -167,7 +168,7 @@ func NewSender(vapidPublic, vapidPrivate, subject string) *Sender {
 
 // attempt makes a single delivery and reports the HTTP status, any Retry-After
 // hint, and a transport error (status 0).
-func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p pushParams) (status int, retryAfter time.Duration, err error) {
+func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p pushParams) (status int, retryAfter time.Duration, body []byte, err error) {
 	// webpush-go prepends "mailto:" to any non-https subscriber, so pass the bare
 	// address (a leading "mailto:" would yield "mailto:mailto:…", which Apple
 	// rejects as BadJwtToken). An https URL is left untouched.
@@ -193,13 +194,20 @@ func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p push
 		Topic:           topic,
 	})
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
 	defer resp.Body.Close()
 	if ra := resp.Header.Get("Retry-After"); ra != "" {
 		retryAfter = parseRetryAfter(ra)
 	}
-	return resp.StatusCode, retryAfter, nil
+	// On a rejection, the push service names its reason in the body (Apple:
+	// {"reason":"BadJwtToken"} etc). Capture it (bounded) so failures are
+	// diagnosable from the log and prunable by reason (spec 2022). The body is
+	// the SERVICE's own error JSON — never user data.
+	if resp.StatusCode >= 300 {
+		body, _ = io.ReadAll(io.LimitReader(resp.Body, 512))
+	}
+	return resp.StatusCode, retryAfter, body, nil
 }
 
 // msgDebounceWindow folds a fast burst of messages to one recipient into at most a
@@ -341,14 +349,19 @@ func recoverLog(where string) {
 func (n *Notifier) deliver(ctx context.Context, sub store.PushSubscription, p pushParams) {
 	backoff := 500 * time.Millisecond
 	for attempt := 0; ; attempt++ {
-		status, retryAfter, err := n.sender.attempt(ctx, sub, p)
+		status, retryAfter, body, err := n.sender.attempt(ctx, sub, p)
 		switch {
 		case err == nil && status < 300:
 			slog.Info("push: delivered", "endpoint", endpointHost(sub.Endpoint))
 			return
-		case status == http.StatusNotFound || status == http.StatusGone:
-			// Subscription is dead - stop trying to use it. Log a failed prune so a
-			// dead endpoint that keeps failing every send is at least visible.
+		case shouldPrune(status, body):
+			// Subscription is dead — stop trying to use it. In practice Apple
+			// reports dead subscriptions with 400/403 reasons too, not just
+			// 404/410 (spec 2022, found live: one iPhone got 123 straight 400s
+			// across two days and was silently push-dead the whole time). The
+			// client re-registers on every app foreground, so a pruned device
+			// heals itself the next time the app opens.
+			slog.Info("push: pruning dead subscription", "status", status, "reason", string(body), "endpoint", endpointHost(sub.Endpoint))
 			if err := n.store.DeleteSubscriptionByEndpoint(ctx, sub.Endpoint); err != nil {
 				slog.Warn("push: prune dead subscription failed", "err", err, "endpoint", endpointHost(sub.Endpoint))
 			}
@@ -369,12 +382,47 @@ func (n *Notifier) deliver(ctx context.Context, sub store.PushSubscription, p pu
 			if err != nil {
 				slog.Warn("push: send failed", "err", err, "endpoint", endpointHost(sub.Endpoint))
 			} else {
-				// e.g. Apple 403 BadJwtToken if the VAPID subject isn't a mailto:.
-				slog.Warn("push: non-success status", "status", status, "endpoint", endpointHost(sub.Endpoint))
+				// The body is the push service's own reason (e.g. Apple's
+				// BadJwtToken) — logged verbatim so a failure names itself.
+				slog.Warn("push: non-success status", "status", status, "body", string(body), "endpoint", endpointHost(sub.Endpoint))
 			}
 			return
 		}
 	}
+}
+
+// deadReasons are the push-service body reasons that mean THIS SUBSCRIPTION is
+// dead or invalidated at the service — safe and correct to prune. Reasons that
+// mean OUR REQUEST was malformed (BadWebPushTopic, BadWebPushTtl, BadJwtToken,
+// PayloadTooLarge, rate limits, …) must NEVER prune: that failure is ours, and
+// pruning on it would silently unsubscribe every healthy device.
+var deadReasons = map[string]bool{
+	"unregistered":           true,
+	"baddevicetoken":         true,
+	"devicetokennotfortopic": true,
+	"expiredtoken":           true,
+	"gone":                   true,
+	"invalidsubscription":    true,
+	"subscriptionexpired":    true,
+}
+
+// shouldPrune is the pure prune decision (unit-tested): 404/410 always prune;
+// 400/403 prune only when the response body names a dead-subscription reason;
+// everything else keeps the subscription.
+func shouldPrune(status int, body []byte) bool {
+	if status == http.StatusNotFound || status == http.StatusGone {
+		return true
+	}
+	if status != http.StatusBadRequest && status != http.StatusForbidden {
+		return false
+	}
+	var parsed struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil || parsed.Reason == "" {
+		return false
+	}
+	return deadReasons[strings.ToLower(parsed.Reason)]
 }
 
 // retryable reports whether a failed attempt is worth retrying: any transport

--- a/specs/2022-push-failures-name/spec.md
+++ b/specs/2022-push-failures-name/spec.md
@@ -1,0 +1,57 @@
+# Bug: Push failures hide their reason, and dead subscriptions are retried forever
+
+**Feature Branch**: `fix/2022-push-failures-name`
+
+**Created**: 2026-07-07
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: Live incident on the dev server (2026-07-05 → 07-06): one iPhone's
+push subscription was rejected by Apple with HTTP 400 on 123 consecutive
+message tickles across two days. The device silently received NO notifications
+the whole time. Two defects compounded:
+
+1. **The send path discards the response body.** Apple names every rejection
+   (`{"reason":"BadJwtToken"}`, `BadWebPushTopic`, expired-subscription
+   variants…) in the body; the log recorded only `status=400`, so diagnosing
+   required re-sending pushes by hand with a probe.
+2. **Pruning only triggers on 404/410.** In practice Apple reports dead or
+   invalidated subscriptions with 400/403 reasons too. Such a subscription is
+   retried forever — and since a device holds one subscription, that device is
+   push-dead with no self-healing, even though the client re-registers on every
+   app foreground and would recover immediately if the server dropped the corpse.
+
+## Fix (server only, `internal/push`)
+
+- **FR-001**: On any non-success push response, read (bounded) and log the
+  response body alongside status + endpoint host, so the push service's own
+  reason lands in the log.
+- **FR-002**: A pure, unit-tested decision `shouldPrune(status, body)`:
+  - 404 / 410 → prune (existing behavior, unchanged).
+  - 400 / 403 → prune ONLY when the body's reason names a dead subscription
+    (`Unregistered`, `BadDeviceToken`, `DeviceTokenNotForTopic`,
+    `ExpiredToken`, `Gone`, `InvalidSubscription`, `SubscriptionExpired`).
+  - NEVER prune on reasons that mean OUR REQUEST was malformed
+    (`BadWebPushTopic`, `BadWebPushTtl`, `BadJwtToken`, `PayloadTooLarge`,
+    rate limiting…) — pruning healthy subscriptions over a server-side bug
+    would be the worse failure (it silently unsubscribes every device).
+  - Unknown reason / empty body → do not prune, log loudly.
+- **FR-003**: Recovery is client-driven and already ships: the app re-registers
+  its subscription on every foreground; once the dead row is pruned, the next
+  register writes a fresh one.
+
+## Zero-Knowledge Impact
+
+None. Push payloads remain the same content-free tickles; only failure
+handling and logging change (bodies logged are the PUSH SERVICE's own error
+JSON, never user data).
+
+## Success Criteria
+
+- **SC-001**: Unit tests cover the prune decision for every reason class above
+  (dead → prune; our-bug → keep; unknown → keep).
+- **SC-002**: Non-success sends log the response body (visible in a fake-server
+  test).
+- **SC-003**: `go build ./... && go vet ./... && go test ./...` green; no
+  client or wire changes.


### PR DESCRIPTION
## Spec 2022 (hotfix) — from a live dev incident

One iPhone's subscription was rejected by Apple with 123 consecutive HTTP 400s across two days; the log said only `status=400` (the body with Apple's reason was discarded) and pruning only fires on 404/410, so the dead row was retried forever — that device was silently push-dead.

- Non-success responses now log the service's own reason body (bounded; it's the SERVICE's error JSON, never user data).
- Pure, unit-tested `shouldPrune(status, body)`: 404/410 always; 400/403 only on dead-subscription reasons (Unregistered, BadDeviceToken, ExpiredToken, …); NEVER on our-request-malformed reasons (BadWebPushTopic/Ttl, BadJwtToken, PayloadTooLarge, 429) — pruning healthy subs over a server bug would be the worse failure. Unknown/empty → keep, log loudly.
- Recovery is already client-driven: the app re-registers on every foreground, so a pruned device heals on next open.

Server-only, no wire/client changes. `go build/vet/test ./...` green (16 new prune-decision cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE