### PR TITLE
fix(notifications): a push never arrives invisibly, so iOS can't quietly kill your notifications

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,6 +59,7 @@ Specs are grouped by category band; status moves
 | [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
 | [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟢 shipped |
 | [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🟢 shipped |
+| [1034](specs/1034-every-push-wake/spec.md) | No Silent Pushes — Every Wake Shows a Notification Unless the App Is Visibly Open | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1034-every-push-wake/spec.md
+++ b/specs/1034-every-push-wake/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-07
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User directive after a live incident: "We should have 0 push

--- a/specs/1034-every-push-wake/spec.md
+++ b/specs/1034-every-push-wake/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: No Silent Pushes — Every Wake Shows a Notification Unless the App Is Visibly Open
+
+**Feature Branch**: `feat/1034-every-push-wake`
+
+**Created**: 2026-07-07
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User directive after a live incident: "We should have 0 push
+notifications which produce no visible notification on the device — even for
+badge-only updates on hidden chats. Silent is only acceptable when the user is
+online; offline, always show the generic message with no sender name or
+content."
+
+## Why (the incident)
+
+iOS enforces the Web Push `userVisibleOnly` contract: a service worker that
+repeatedly consumes a push without showing a notification gets its
+subscription silently revoked ("zombie": Apple keeps accepting sends with 201,
+the device never wakes again). A dev iPhone hit exactly this — backgrounded
+overnight, then push-dead. Audit found SEVEN wake outcomes that show nothing:
+
+1. Message wake, `suppressed` (master toggle off — a race window; the toggle
+   unsubscribes, but a wake in flight still consumes silently).
+2. Message wake, `silenced` (muted chat / per-chat web-push-off / badge-only /
+   hidden chats): badge updates, nothing shows.
+3. Message wake, nothing-new with no fresh summary: shows nothing.
+4. Message wake, nothing-new with an identical last-shown signature
+   (spec 2020's duplicate fix): skips entirely.
+5. Store-on-push drain (spec 1032) that persists + acks frames but produced
+   zero notes (all frames silenced): returns fully-handled, nothing shows.
+6. conn / post / post-activity / version wakes gate their notification on
+   `clients.length === 0` — but a FROZEN background PWA still counts as a
+   client (the norm on iOS), so these wakes show nothing exactly when the
+   phone is in the state that accrues strikes. (post/post-activity are also
+   silent when their toggle is off, and a reaction REMOVAL previews to zero
+   notes by design.)
+7. Message wake where the settle verdict closes a shown generic (visible flash
+   already happened — contract-satisfying; kept as is, listed for completeness).
+
+## Policy (FR-001)
+
+Every push wake MUST end with at least one visible notification **unless a
+Ring window is currently VISIBLE** (`WindowClient.visibilityState === 'visible'`
+— truly on screen, not merely an existing frozen/background client). The
+page-ack path (an unlocked page confirming it rendered the user-facing alert)
+also counts as visible handling.
+
+When the rich/preview path has nothing it may show (silenced, hidden,
+suppressed race, nothing-new, removal-only activity), show the **quiet
+generic**: content-free (no sender, no preview — the same zero-knowledge class
+as the push payload itself), `silent: true` (no sound/vibration, so mute and
+badge-only keep their spirit: the user is not buzzed, but the OS sees a
+visible notification), on the generic tag (self-replacing, never a pile).
+
+- Message-kind quiet generic: "New message" / "You have a new message."
+  (the existing generic copy).
+- Other kinds: "Ring" / "New activity".
+
+## Requirements
+
+- **FR-002**: The seven paths above (minus #7) each terminate in: rich note,
+  page-ack, visible client, or the quiet generic. No other outcome exists.
+- **FR-003**: The nothing-new identical-signature skip (spec 2020) becomes a
+  quiet generic instead of a skip: the duplicate-banner problem it fixed was
+  the RICH per-chat banner repeating; the quiet generic is silent, generic-
+  tagged, and self-replacing. (Deliberate spec-2020 amendment.)
+- **FR-004**: `conn`/`post`/`post-activity`/`version` wakes replace their
+  `clients.length` gate with the visible-client test for the SILENT outcome:
+  rich behavior is unchanged when the app is fully closed; a frozen background
+  app now yields at least the quiet generic. A hidden-but-running page (which
+  may itself show a rich note) can briefly coexist with one quiet generic —
+  accepted: it is silent, generic, self-replacing, and superseded/closed when
+  a rich note shows.
+- **FR-005**: The pure decisions (visible-client test, quiet-note content per
+  kind) are unit-tested; the wiring is reviewed against the path inventory.
+
+## Zero-Knowledge Impact
+
+None on the wire. The quiet generic carries no sender, no content — exactly
+the information the push payload itself already reveals (that *something*
+happened), now surfaced instead of silently consumed.
+
+## Success Criteria
+
+- **SC-001**: Unit tests cover the visible-test and quiet-note builders, plus
+  the reassert path returning "shown/not shown" so its caller can fall back.
+- **SC-002**: Code inventory shows zero remaining wake terminations without a
+  show/ack/visible outcome (documented in the PR).
+- **SC-003**: `npm run build` + full unit suite + the three notification e2e
+  suites pass.

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -477,6 +477,33 @@ export function mergeIntoSummary(prev: ShownSummary | undefined, note: SwNote, n
  * whenever the coalesced content hasn't changed. The signature records what the user
  * last SAW per tag (body + cumulative count); an identical re-assert is skipped —
  * the same iOS-tolerated outcome class as the mute/badge-only paths. ---- */
+/* ---- spec 1034: the no-silent-pushes policy's pure halves. iOS revokes a push
+ * subscription whose service worker repeatedly consumes a wake without showing a
+ * notification (the "zombie": the push service keeps accepting sends, the device
+ * never wakes again — observed live on a dev iPhone). So EVERY wake must end
+ * visibly unless a Ring window is actually ON SCREEN. ---- */
+
+/** Does any window client license a silent outcome? Only a truly VISIBLE one —
+ *  a frozen/background PWA still appears in matchAll() (the norm on iOS) but
+ *  shows the user nothing, which is exactly the state that accrues strikes. */
+export function anyClientVisible(clients: readonly { visibilityState?: string }[]): boolean {
+  return clients.some((c) => c.visibilityState === 'visible');
+}
+
+/** The content-free notification shown when the rich path has nothing it may
+ *  display (muted / hidden / badge-only / nothing-new / removal-only activity):
+ *  no sender, no content — the same zero-knowledge class as the push payload —
+ *  and silent, so mute keeps its spirit (no buzz) while the OS still sees the
+ *  visible notification the Web Push contract demands. Self-replacing tag. */
+export function quietNote(kind: 'msg' | 'activity'): {
+  title: string;
+  options: { body: string; tag: string; silent: boolean; renotify: boolean };
+} {
+  return kind === 'msg'
+    ? { title: 'New message', options: { body: 'You have a new message.', tag: 'ring-incoming', silent: true, renotify: false } }
+    : { title: 'Ring', options: { body: 'New activity', tag: 'ring-incoming', silent: true, renotify: false } };
+}
+
 export interface ShownSig {
   body: string;
   count: number;

--- a/src/services/sw-quiet.test.ts
+++ b/src/services/sw-quiet.test.ts
@@ -1,0 +1,42 @@
+// Spec 1034 — the pure halves of the no-silent-pushes policy: the visible-client
+// test that licenses a silent outcome, and the content-free quiet note shown when
+// the rich path has nothing it may display.
+import { describe, it, expect } from 'vitest';
+import { anyClientVisible, quietNote } from './sw-inbox';
+
+describe('spec 1034: anyClientVisible', () => {
+  it('no clients → not visible (fully closed app must always show)', () => {
+    expect(anyClientVisible([])).toBe(false);
+  });
+  it('a hidden/frozen background client does NOT license silence', () => {
+    expect(anyClientVisible([{ visibilityState: 'hidden' }])).toBe(false);
+  });
+  it('a visible client licenses a silent outcome', () => {
+    expect(anyClientVisible([{ visibilityState: 'hidden' }, { visibilityState: 'visible' }])).toBe(true);
+  });
+  it('clients without a visibilityState (older platforms) count as not visible', () => {
+    expect(anyClientVisible([{}])).toBe(false);
+  });
+});
+
+describe('spec 1034: quietNote', () => {
+  it('message kind keeps the generic message copy, content-free', () => {
+    const n = quietNote('msg');
+    expect(n.title).toBe('New message');
+    expect(n.options.body).toBe('You have a new message.');
+    expect(n.options.silent).toBe(true);
+  });
+  it('activity kinds are the neutral Ring note', () => {
+    const n = quietNote('activity');
+    expect(n.title).toBe('Ring');
+    expect(n.options.body).toBe('New activity');
+    expect(n.options.silent).toBe(true);
+  });
+  it('both flavors are self-replacing on the generic tag with no re-alert', () => {
+    for (const kind of ['msg', 'activity'] as const) {
+      const n = quietNote(kind);
+      expect(n.options.tag).toBe('ring-incoming');
+      expect(n.options.renotify).toBe(false);
+    }
+  });
+});

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -23,6 +23,7 @@ import { ExpirationPlugin } from 'workbox-expiration';
 import {
   previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, previewPosts, previewPostActivity, markConnShown,
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
+  anyClientVisible, quietNote,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
@@ -188,6 +189,28 @@ async function showNotes(notes: SwNote[]): Promise<void> {
   }
 }
 
+/** (spec 1034) Show the content-free QUIET generic — the terminal fallback that
+ *  keeps the Web Push userVisibleOnly contract when the rich path has nothing it
+ *  may display. Skipped only when a Ring window is truly on screen. iOS revokes
+ *  subscriptions that repeatedly consume a wake without showing anything (the
+ *  "zombie" — Apple keeps accepting sends with 201, the device never wakes
+ *  again; observed live), so silence is never an outcome while the app is away. */
+async function showQuietUnlessVisible(kind: 'msg' | 'activity'): Promise<void> {
+  try {
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    if (anyClientVisible(clients)) return; // user is looking at Ring — silence is honest here
+    const n = quietNote(kind);
+    await self.registration.showNotification(n.title, {
+      ...n.options,
+      icon: ICON,
+      badge: BADGE,
+      data: { url: kind === 'msg' ? '/tabs/chats' : '/' },
+    });
+  } catch (e) {
+    console.warn('[sw] quiet generic failed', e);
+  }
+}
+
 /** Close any lingering notifications with a given tag (used to clear the generic
  *  placeholder once a richer preview is ready, since different tags don't auto-replace). */
 async function closeByTag(tag: string): Promise<void> {
@@ -227,10 +250,10 @@ function serializeNotify<T>(fn: () => Promise<T>): Promise<T> {
  * resurrected; if there's no fresh summary, shows nothing (the mute/badge-only outcome). Also closes a
  * stranded generic placeholder, since a real per-chat notification supersedes it.
  */
-async function reassertFromSummary(): Promise<void> {
+async function reassertFromSummary(): Promise<boolean> {
   try {
     const list = await loadShownSummary(); // already TTL-filtered
-    if (!list.length) return; // nothing to re-assert → show nothing (mirrors the badge-only path)
+    if (!list.length) return false; // no fresh summary — the caller shows the quiet generic (spec 1034)
     const n = list.reduce((a, b) => (b.ts > a.ts ? b : a)); // freshest
     // (spec 2020) A re-assert that is VISUALLY IDENTICAL to what the user already
     // sees (same body + cumulative count on this tag) shows nothing at all: iOS
@@ -238,7 +261,11 @@ async function reassertFromSummary(): Promise<void> {
     // Notification Center entry, which read as "the same message notified twice"
     // in a burst. A CHANGED body/count still re-asserts silently below.
     const sigs = await loadShownSigs();
-    if (!shouldReassert(sigs[n.tag], n)) return;
+    // (spec 1034, amending spec 2020) An identical re-assert no longer SKIPS —
+    // skipping consumed the wake invisibly, which is subscription-fatal on iOS.
+    // The caller shows the quiet generic instead: silent, content-free, its own
+    // self-replacing tag — the rich per-chat banner still never repeats.
+    if (!shouldReassert(sigs[n.tag], n)) return false;
     const k = n.ids.length;
     await saveShownSig(n.tag, { body: n.body, count: k, ts: Date.now() });
     await self.registration.showNotification(k > 1 ? `${n.title} (${k})` : n.title, {
@@ -251,8 +278,10 @@ async function reassertFromSummary(): Promise<void> {
       data: { url: n.url },
     });
     await closeByTag(GENERIC_TAG); // a real per-chat notification supersedes any stranded placeholder
+    return true;
   } catch {
     /* ignore — re-assert is best-effort; the badge still updates */
+    return false;
   }
 }
 
@@ -445,6 +474,9 @@ async function tryAuthoritativeDrain(): Promise<boolean> {
       if (r.deferred > 0) return false; // preview flow handles the deferred remainder
       // Fully handled: applied rows are already in unreadCount(), nothing pending.
       await updateAppBadge(0);
+      // (spec 1034) Persisted + acked but produced no notes (every frame was for a
+      // muted/hidden/badge-only chat): the wake still needs a visible ending.
+      if (!r.notes.length) await showQuietUnlessVisible('msg');
       return true;
     });
   } catch (e) {
@@ -480,10 +512,12 @@ async function showMessageNotification(): Promise<void> {
   }
 
   let shownGeneric = false;
+  let shownAny = false; // spec 1034: track whether THIS wake produced anything visible
   if (result.notes.length) {
     await closeByTag(GENERIC_TAG); // clear any earlier generic before the rich note
     await showNotes(result.notes);
     await markShown(allIds(result.notes)); // only mark what we displayed
+    shownAny = true;
   } else if (timedOut || (!result.suppressed && !result.silenced && result.newUnshown)) {
     // Show the generic placeholder ONLY when there's a genuinely-new message we couldn't render: a
     // slow cold-start decrypt still in flight at the deadline (timedOut), a fetched-but-undecryptable
@@ -492,14 +526,20 @@ async function showMessageNotification(): Promise<void> {
     // and `silenced` (mute / web-push-off / badge-only, spec 1015 FR-022/FR-024) show no placeholder.
     await showGeneric(timedOut ? 'timeout' : result.reason);
     shownGeneric = true;
+    shownAny = true;
   } else if (isNothingNew(result)) {
     // (spec 2016/2017) Nothing genuinely new — the relay queue was empty (`no-frames`) or every frame
     // was already shown (a burst wake the first wake beat). A new generic here is pure noise. Re-assert
     // the ONE authoritative coalesced notification from the persisted summary silently (spec 2017), so
     // iOS sees a showNotification call (no own-summary gap) without a new alert; shows nothing only when
     // there's no fresh summary (the mute/badge-only outcome). The badge below still stays accurate.
-    await reassertFromSummary();
+    shownAny = await reassertFromSummary();
   }
+  // (spec 1034) Silence is not an outcome: muted / hidden / badge-only / web-push-
+  // off (`silenced`), the master-toggle race (`suppressed`), and a nothing-new
+  // wake with nothing to re-assert all still consumed a push — end them with the
+  // content-free quiet generic unless Ring is actually on screen.
+  if (!shownAny) await showQuietUnlessVisible('msg');
 
   // Settle the full preview (bounded) so its /relay/pending fetch lands (→ delivery)
   // even after a generic fallback, we learn the accurate backlog for the badge, and
@@ -516,11 +556,12 @@ async function showMessageNotification(): Promise<void> {
       await showNotes(full.notes); // …show the real sender + text…
       await markShown(allIds(full.notes)); // …and don't re-preview them next push
     } else if (shownGeneric && full.silenced) {
-      // A SLOW cold start showed the generic before the decrypt settled; the settled
-      // result says every pending message was per-chat silenced → drop the placeholder
-      // so badge-only / web-push-off / mute is honored even on a slow wake. The badge
-      // below still counts them (pending), since `silenced` never sets `suppressed`.
-      await closeByTag(GENERIC_TAG);
+      // A SLOW cold start showed the loud generic before the decrypt settled; the
+      // settled result says every pending message was per-chat silenced. Spec 1034:
+      // don't vanish it (a wake must stay visible) — downgrade it in place (same
+      // tag) to the QUIET generic, so mute/badge-only keeps its no-buzz spirit
+      // while the notification remains.
+      await showQuietUnlessVisible('msg');
     }
   } catch {
     /* ignore */
@@ -638,6 +679,10 @@ self.addEventListener('push', (event) => {
           // the conn path previously never touched the badge, so a friend request didn't count.
           const pendingIncoming = await showConnNotification();
           await updateAppBadge(pendingIncoming);
+        } else {
+          // (spec 1034) A client EXISTS but may be a frozen background PWA (the norm
+          // on iOS) that will never render the page-side alert — end visibly anyway.
+          await showQuietUnlessVisible('activity');
         }
         return;
       }
@@ -653,6 +698,10 @@ self.addEventListener('push', (event) => {
           // Name the author AND bump the app-icon badge (the post path previously did neither).
           const newCount = await showPostNotification();
           await updateAppBadge(newCount);
+        } else {
+          // (spec 1034) Toggle off, or a (possibly frozen) client exists: the wake
+          // still consumed a push — end it with the content-free quiet generic.
+          await showQuietUnlessVisible('activity');
         }
         return;
       }
@@ -665,10 +714,18 @@ self.addEventListener('push', (event) => {
         // names the actor from the public directory, and opens sealed reaction
         // payloads locally so a REMOVAL shows nothing at all.
         for (const client of clients) client.postMessage({ type: 'ring:posts' });
+        let shownActivity = false;
         if (!clients.length && (await setting('notifications.wall.activity', true))) {
           const notes = await previewPostActivity(post ?? '');
-          if (notes.length) await showConnNotes(notes);
+          if (notes.length) {
+            await showConnNotes(notes);
+            shownActivity = true;
+          }
         }
+        // (spec 1034) Toggle off, frozen client, or a removal that previews to zero
+        // notes: still a consumed push — end visibly (content-free; a removal shows
+        // the neutral "New activity", never who or what).
+        if (!shownActivity) await showQuietUnlessVisible('activity');
         return;
       }
       if (kind === 'version') {
@@ -678,7 +735,12 @@ self.addEventListener('push', (event) => {
         // the app is fully CLOSED — mirroring the post/conn pattern and keeping the
         // userVisibleOnly contract (exactly one visible notification when closed).
         for (const client of clients) client.postMessage({ type: 'ring:checkupdate' });
-        if (!clients.length) await showVersionNotification();
+        if (!clients.length) {
+          await showVersionNotification();
+        } else {
+          // (spec 1034) A frozen background client can't show the update toast.
+          await showQuietUnlessVisible('activity');
+        }
         return;
       }
       // Let a live, unlocked page own the notification (avoids a duplicate); the SW


### PR DESCRIPTION
## Spec 1034 — no silent pushes

User directive after the zombie-subscription incident: **zero push wakes may end without a visible notification** unless the app is visibly open. iOS enforces the `userVisibleOnly` contract by silently revoking subscriptions after repeated invisible wakes — the audit found SEVEN wake outcomes that showed nothing (inventory in the spec):

1. `suppressed` master-toggle race → quiet generic
2. `silenced` (mute / per-chat push off / badge-only / hidden chats) → quiet generic
3. nothing-new, no fresh summary → quiet generic
4. nothing-new, identical signature (spec 2020 skip — deliberately amended) → quiet generic
5. store-on-push drain, all frames silenced → quiet generic
6. conn/post/post-activity/version gated on `clients.length` (a FROZEN background PWA counts — the iOS norm) → visible-client test + quiet generic
7. settle-verdict close of the loud placeholder → downgraded in place to the quiet generic instead of vanishing

The **quiet generic** is content-free (no sender, no preview — the same zero-knowledge class as the push payload), `silent: true` (no buzz — mute and badge-only keep their spirit), self-replacing on the generic tag, and skipped only when a Ring window is truly `visible`.

Pure halves (`anyClientVisible`, `quietNote`) are unit-tested (7 new, red-first); reassert now reports shown/not-shown to its caller. 789 units, build, and all three notification e2e suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE