### PR TITLE
docs(spec): spec 1034 shipped in #861; roadmap regenerated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,7 +59,7 @@ Specs are grouped by category band; status moves
 | [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
 | [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟢 shipped |
 | [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🟢 shipped |
-| [1034](specs/1034-every-push-wake/spec.md) | No Silent Pushes — Every Wake Shows a Notification Unless the App Is Visibly Open | 🔵 in-review |
+| [1034](specs/1034-every-push-wake/spec.md) | No Silent Pushes — Every Wake Shows a Notification Unless the App Is Visibly Open | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1034-every-push-wake/spec.md
+++ b/specs/1034-every-push-wake/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-07
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User directive after a live incident: "We should have 0 push


### PR DESCRIPTION
Status flip after #861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE