### PR TITLE
fix(notifications): game moves only notify the players, spectators just hear who won

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,7 @@ Specs are grouped by category band; status moves
 | [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟢 shipped |
 | [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🟢 shipped |
 | [1034](specs/1034-every-push-wake/spec.md) | No Silent Pushes — Every Wake Shows a Notification Unless the App Is Visibly Open | 🟢 shipped |
+| [1035](specs/1035-game-activity-notifies/spec.md) | Game Activity Notifies Players, Not the Whole Audience | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/server/internal/api/posts_handlers.go
+++ b/server/internal/api/posts_handlers.go
@@ -328,18 +328,22 @@ func (h *Handlers) submitEngagement(w http.ResponseWriter, r *http.Request) {
 	// A failed author lookup skips the push rather than failing the write — the
 	// engagement is stored and the WS frames above already went out.
 	//
-	// EXCEPTION — kind "game" (spec 0009): a game riding a post must reach its
-	// players and followers while their app is CLOSED (a turn-based game whose
-	// player never learns it is their turn defeats the feature), so the same
-	// content-free push fans to the WHOLE audience plus the author, except the
-	// actor — including when the actor IS the author, whose move is the other
-	// player's turn. Each woken device pulls, decrypts under K_post, and decides
-	// locally (turn/follow settings) whether to show anything.
+	// EXCEPTION — kind "game" (spec 0009, narrowed by spec 1035): a game riding
+	// a post must reach its PLAYERS while their app is CLOSED (a turn-based game
+	// whose player never learns it is their turn defeats the feature) — but only
+	// its players. The participants are the post author plus everyone who has
+	// previously written a `game` engagement here (the accept and every move are
+	// all kind "game", and the CURRENT row is already stored, so the accepter is
+	// a participant from their own accept onward). The passive audience is never
+	// woken per move — their one game push stays the challenge post itself; a
+	// spectator device learns of results on its next ordinary wake or open.
+	// Routing uses only kind + actor, which the server already stores; each
+	// woken device still pulls, decrypts under K_post, and decides locally.
 	if h.Notifier != nil && !tombstone {
 		if req.Kind == "game" {
 			targets := map[string]bool{}
-			if aud, err := h.Posts.PostAudience(r.Context(), postID); err == nil {
-				for _, u := range aud {
+			if players, err := h.Posts.GameParticipants(r.Context(), postID); err == nil {
+				for _, u := range players {
 					targets[u] = true
 				}
 			}

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -120,6 +120,17 @@ func newFakePostStore() *fakePostStore {
 func (f *fakePostStore) PostAuthor(_ context.Context, postID string) (string, error) {
 	return f.posts[postID].Author, nil
 }
+func (f *fakePostStore) GameParticipants(_ context.Context, postID string) ([]string, error) {
+	seen := map[string]bool{}
+	var out []string
+	for _, e := range f.eng[postID] {
+		if e.Kind == "game" && !seen[e.Actor] {
+			seen[e.Actor] = true
+			out = append(out, e.Actor)
+		}
+	}
+	return out, nil
+}
 func (f *fakePostStore) EngagementActor(_ context.Context, postID, engID string) (string, error) {
 	for _, e := range f.eng[postID] {
 		if e.ID == engID {
@@ -832,12 +843,12 @@ func TestEngagementPushesOwnerOnly(t *testing.T) {
 	}
 }
 
-// Spec 0009: game engagement (an accept or move on a game-challenge post) must
-// reach players and followers even when their app is closed — so unlike
-// reactions/comments (author-only, spec 1031), kind "game" fans the CONTENT-FREE
-// activity push to the whole audience except the actor, author included even
-// when the author is the actor's opponent. The payload stays sealed; each woken
-// device pulls, decrypts under K_post, and decides locally whether to alert.
+// Spec 1035 (amending 0009): game engagement pushes reach the PARTICIPANTS
+// only — the post author plus everyone who has previously written a game
+// engagement on the post — never the passive audience. A spectator's one
+// game-related push stays the challenge post itself; a Battleship game no
+// longer wakes every audience device per move. Routing uses only metadata the
+// server already holds (kind + actor); payloads stay sealed.
 func TestGameEngagementPushesAudience(t *testing.T) {
 	conn := newFakePostConn()
 	notif := &recordingNotifier{}
@@ -856,33 +867,45 @@ func TestGameEngagementPushesAudience(t *testing.T) {
 	notif.reset()
 
 	// Bob accepts the challenge (kind "game") → the kind is valid, stored
-	// opaquely, and the push fans to alice (author) AND carol (audience) — not bob.
+	// opaquely, and the push goes to alice (the author) ONLY — carol is a
+	// spectator and must not be woken (spec 1035).
 	acceptEng := `{"id":"77777777-7777-7777-7777-777777777777","kind":"game","payload":"SEALED"}`
 	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokB, acceptEng); rr.Code != http.StatusCreated {
 		t.Fatalf("game engagement status = %d; body=%s (kind must be accepted)", rr.Code, rr.Body.String())
 	}
-	if !notif.activityPushedTo(aliceID, postID) || !notif.activityPushedTo(carolID, postID) {
-		t.Errorf("game engagement must push the whole audience (alice + carol)")
+	if !notif.activityPushedTo(aliceID, postID) {
+		t.Errorf("game engagement must push the author (alice)")
+	}
+	if notif.activityPushedTo(carolID, postID) {
+		t.Errorf("game engagement must NOT push a passive spectator (carol), spec 1035")
 	}
 	if notif.activityPushedTo(bobID, postID) {
 		t.Errorf("game engagement must never push the actor (bob)")
 	}
-	if n := notif.activityPushCount(); n != 2 {
-		t.Errorf("game engagement fired %d activity pushes; want exactly 2", n)
+	if n := notif.activityPushCount(); n != 1 {
+		t.Errorf("game engagement fired %d activity pushes; want exactly 1 (the author)", n)
 	}
 	notif.reset()
 
 	// The AUTHOR moves (alice is player 0): unlike self-reactions, her game
-	// engagement still wakes the others — it is bob's turn now.
+	// engagement still wakes her OPPONENT — it is bob's turn now. Bob is a
+	// participant because he has a prior game engagement on the post; carol
+	// still is not.
 	moveEng := `{"id":"88888888-8888-8888-8888-888888888888","kind":"game","payload":"SEALED2"}`
 	if rr := do(t, srv, http.MethodPost, "/v1/posts/"+postID+"/engagement", tokA, moveEng); rr.Code != http.StatusCreated {
 		t.Fatalf("author game engagement status = %d; body=%s", rr.Code, rr.Body.String())
 	}
-	if !notif.activityPushedTo(bobID, postID) || !notif.activityPushedTo(carolID, postID) {
-		t.Errorf("the author's game engagement must push bob + carol")
+	if !notif.activityPushedTo(bobID, postID) {
+		t.Errorf("the author's game engagement must push her opponent (bob)")
+	}
+	if notif.activityPushedTo(carolID, postID) {
+		t.Errorf("a move must NOT push the spectator (carol), spec 1035")
 	}
 	if notif.activityPushedTo(aliceID, postID) {
 		t.Errorf("the author's own game engagement must not push the author")
+	}
+	if n := notif.activityPushCount(); n != 1 {
+		t.Errorf("move fired %d activity pushes; want exactly 1 (the opponent)", n)
 	}
 	notif.reset()
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -126,6 +126,7 @@ type PostStore interface {
 	RecentCommentCount(ctx context.Context, postID, actor string, withinSec int) (int, error)
 	CanSeePost(ctx context.Context, postID, user string) (bool, error)
 	PostAudience(ctx context.Context, postID string) ([]string, error)
+	GameParticipants(ctx context.Context, postID string) ([]string, error)
 	PostAuthor(ctx context.Context, postID string) (string, error)
 	SubmitEngagement(ctx context.Context, postID, id, actor, kind, payload string) error
 	EngagementActor(ctx context.Context, postID, engID string) (string, error)

--- a/server/internal/store/posts.go
+++ b/server/internal/store/posts.go
@@ -376,6 +376,28 @@ type PostEngagementRow struct {
 	CreatedMs int64
 }
 
+// GameParticipants returns the distinct actors of the post's `game`
+// engagements — together with the author, these are a challenge's players
+// (spec 1035): the accepter's accept and every subsequent move are all kind
+// "game", so anyone who ever wrote one holds a seat (or raced for it). Uses
+// only metadata the server already stores; payloads stay sealed.
+func (s *Store) GameParticipants(ctx context.Context, postID string) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `SELECT DISTINCT actor FROM post_engagement WHERE post_id=$1 AND kind='game'`, postID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var u string
+		if err := rows.Scan(&u); err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
 // PostAuthor returns a post's author id (or "" if the post is gone).
 func (s *Store) PostAuthor(ctx context.Context, postID string) (string, error) {
 	var author string

--- a/specs/1035-game-activity-notifies/spec.md
+++ b/specs/1035-game-activity-notifies/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: Game Activity Notifies Players, Not the Whole Audience
+
+**Feature Branch**: `feat/1035-game-activity-notifies`
+
+**Created**: 2026-07-07
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User: "are we maybe sending too many notifications around games
+played in groups or on the wall to people who are not participating? Audience
+should get only the first invitation push if offline, no other game pushes
+whatsoever, and only the final result as an in-app notification. Players should
+always get a push when it's their turn if offline, and in-app notifications
+that take them directly to the game when online."
+
+## Today's behavior (audited)
+
+- **Wall, server**: EVERY game engagement (each accept, each move) fans a
+  content-free push to the ENTIRE post audience. A full Battleship game =
+  dozens of wakes per spectator device — and since spec 1034, every one of
+  those wakes surfaces at least the quiet generic. This is the noise.
+- **Wall, client**: the classifier is already selective about what it SAYS
+  (players: accept/turn/result; followers: moves/results behind switches;
+  everyone else: quiet) — but a quiet classification no longer means an
+  invisible wake, and a non-follower spectator never hears the result at all.
+- **Groups**: moves are sealed messages, indistinguishable from chat on the
+  server — fan-out is inherent. Observers are already told nothing per move
+  in-app; offline they receive collapsed, silent quiet-generics.
+- The initial challenge invitation is the POST-creation push — a separate
+  path, already audience-wide and urgent-copy. Unchanged.
+
+## Requirements
+
+- **FR-001 (server)**: A `game` engagement pushes ONLY the participants —
+  post author ∪ distinct actors of prior `game` engagements on that post —
+  minus the current actor. Uses exclusively metadata the server already holds
+  (engagement kind + actor); nothing new crosses the zero-knowledge boundary.
+  Non-participant audience devices get ZERO game wakes; their one game-related
+  push remains the challenge-post invitation itself.
+- **FR-002 (players)**: unchanged semantics, now precise: the seated opponent
+  is woken per activity and told "your turn" (or accept/result) with the note
+  deep-linking to `/wall/post/<id>` — both the system notification and the
+  in-app banner already navigate on tap.
+- **FR-003 (audience, in-app)**: spectators (followed or not) get the FINAL
+  RESULT as an in-app notification ("X won the game 🏆" / draw), behind the
+  existing results switch, deduped per engagement as today. Followers keep
+  their opt-in per-move notes. The switch is relabeled "Game results" since it
+  no longer only covers followed games.
+- **FR-004 (SW parity)**: the wake classifier mirrors FR-003 (a result can
+  ride a wake caused by other activity), so page and SW tell the same story.
+- **FR-005 (groups)**: explicitly unchanged — sealed moves cannot be
+  selectively pushed without teaching the server who plays (a metadata leak),
+  observers already get no per-move alerts, and the game-end state is visible
+  in the chat itself. Accepted and documented.
+
+## Zero-Knowledge Impact
+
+Server routing uses only `kind` + `actor` on engagements it already stores;
+identical information class to spec 0009's justified `game` kind. No payload
+inspection, no new columns, no group changes.
+
+## Success Criteria
+
+- **SC-001**: Handler test proves: for a `game` engagement, pushes go to
+  exactly (author ∪ prior game actors) − actor; a plain audience member is NOT
+  pushed; the author is pushed on the opponent's accept.
+- **SC-002**: Unit coverage for the classifier's new non-follower result note.
+- **SC-003**: Full client + server gates green (`build`, vitest, `go test`,
+  wall-activity e2e).

--- a/specs/1035-game-activity-notifies/spec.md
+++ b/specs/1035-game-activity-notifies/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-07
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User: "are we maybe sending too many notifications around games

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3298,6 +3298,15 @@ async function notifyWallGameActivity(post: Post, fresh: FreshEngagement[]): Pro
         body = `${await gameNameOf(session.players?.[status.winner])} won the game \u{1F3C6}`;
       }
     }
+  } else if (status.state !== 'ongoing') {
+    // A plain spectator (spec 1035): the FINAL RESULT only — no per-move noise,
+    // behind the same results switch.
+    if (await getSetting<boolean>('notifications.games.followResults', true)) {
+      if (status.state === 'draw') body = "It's a draw \u{1F91D}";
+      else if (status.state === 'won' || status.state === 'resigned') {
+        body = `${await gameNameOf(session.players?.[status.winner])} won the game \u{1F3C6}`;
+      }
+    }
   }
   for (const i of others) notifiedEngagementIds.add(i.id);
   if (!body) return;

--- a/src/services/sw-inbox.games.test.ts
+++ b/src/services/sw-inbox.games.test.ts
@@ -231,6 +231,34 @@ describe('classifyWallGameActivity — wall games on push wake (spec 0009 US3)',
     expect(loud?.note?.body).toBe('Alice made a move 🎲');
   });
 
+  it('a plain spectator hears the FINAL RESULT (spec 1035), behind the results switch', () => {
+    // bob (P1, accepter) beats alice (P0, author): 0,3,1,4,2 wins for... play a
+    // straight top-row win by the AUTHOR to keep the seats simple.
+    const rows = [
+      row('e1', 'bob', { t: 'accept', at: 1 }),
+      row('e2', 'alice', { t: 'move', seq: 1, action: 'move', move: { cell: 0 }, at: 2, opponent: 'bob' }),
+      row('e3', 'bob', { t: 'move', seq: 2, action: 'move', move: { cell: 3 }, at: 3 }),
+      row('e4', 'alice', { t: 'move', seq: 3, action: 'move', move: { cell: 1 }, at: 4 }),
+      row('e5', 'bob', { t: 'move', seq: 4, action: 'move', move: { cell: 4 }, at: 5 }),
+      row('e6', 'alice', { t: 'move', seq: 5, action: 'move', move: { cell: 2 }, at: 6 }),
+    ];
+    const r = classifyWallGameActivity({
+      post: gpost, self: 'me', rows, seen: new Set(['e1', 'e2', 'e3', 'e4', 'e5']), prefs, followed: false, openGame, names,
+    });
+    expect(r?.note?.body).toBe('Alice won the game 🏆');
+    // Mid-game the same spectator stays quiet (only the result speaks).
+    const mid = classifyWallGameActivity({
+      post: gpost, self: 'me', rows: rows.slice(0, 3), seen: new Set(['e1', 'e2']), prefs, followed: false, openGame, names,
+    });
+    expect(mid?.note).toBeNull();
+    // The results switch silences it.
+    const off = classifyWallGameActivity({
+      post: gpost, self: 'me', rows, seen: new Set(['e1', 'e2', 'e3', 'e4', 'e5']),
+      prefs: { ...prefs, followResults: false }, followed: false, openGame, names,
+    });
+    expect(off?.note).toBeNull();
+  });
+
   it('the challenger hears the accept; the prefs switch silences it', () => {
     const own = { ...gpost, author: 'me', outgoing: true };
     const rows = [row('e1', 'bob', { t: 'accept', at: 1 })];

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -1140,8 +1140,16 @@ export function classifyWallGameActivity(args: {
       if (!prefs.followResults) return quiet;
       body = "It's a draw 🤝";
     }
+  } else if (status.state !== 'ongoing') {
+    // A plain spectator (spec 1035): the FINAL RESULT only, behind the results
+    // switch — mirrors the in-app rule so page and SW tell the same story.
+    if (!prefs.followResults) return quiet;
+    if (status.state === 'draw') body = "It's a draw 🤝";
+    else if (status.state === 'won' || status.state === 'resigned') {
+      body = `${nameOf(session.players?.[status.winner])} won the game 🏆`;
+    }
   } else {
-    return quiet; // a quiet observer — ledger the keys, say nothing
+    return quiet; // a quiet observer mid-game — ledger the keys, say nothing
   }
   if (!body) return quiet;
   return { keys, note: { title: mover, body } };

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -541,7 +541,7 @@ export const SETTINGS: Record<string, SettingNode> = {
           { type: 'toggle', title: 'Your turn', key: 'notifications.games.turn', default: true },
           { type: 'toggle', title: 'New challenges', key: 'notifications.games.challenges', default: true },
           { type: 'toggle', title: 'Followed games, moves', key: 'notifications.games.followMoves', default: true },
-          { type: 'toggle', title: 'Followed games, results', key: 'notifications.games.followResults', default: true },
+          { type: 'toggle', title: 'Game results', key: 'notifications.games.followResults', default: true },
           { type: 'toggle', title: 'Game sounds', key: 'notifications.gameSounds', default: true },
         ],
         footer:


### PR DESCRIPTION
## Spec 1035 — game activity notifies players, not the audience

Audited: every wall-game engagement (each accept, EVERY move) fanned a push to the ENTIRE post audience — dozens of wakes per spectator per Battleship game, each now surfacing at least the spec-1034 quiet generic. 

- **Server**: `game` engagements push ONLY the participants (post author ∪ distinct prior game-engagement actors − actor). Uses only kind + actor, which the server already stores — same metadata class spec 0009 justified. Spectators' one game push remains the challenge post itself. Handler test rewritten: spectator NOT pushed on accept or move; author pushed on accept; opponent pushed on the author's move; exact push counts asserted.
- **Players**: unchanged and verified — turn/accept/result notes with deep links to the game, offline (SW) and online (in-app banner).
- **Spectators, in-app + SW parity**: the FINAL RESULT ("X won the game 🏆" / draw) now reaches plain spectators too (previously only followers heard it), behind the results switch — relabeled "Game results" since it covers everyone. Mid-game they stay quiet. New classifier unit coverage (result / mid-game quiet / switch off).
- **Groups**: explicitly unchanged (documented): moves are sealed and indistinguishable from chat, so selective push would teach the server who plays; observers already get no per-move alerts and see results in the chat.

Gates: server 9/9 packages, 790 client units, build, wall-activity + games e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE