### PR TITLE
docs(spec): thirty delivered specs marked shipped; the roadmap tells the truth

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,9 +16,9 @@ Specs are grouped by category band; status moves
 | [0001](specs/0001-show-what-changed/spec.md) | Show what changed in the update toast (release-note delta) | 🟢 shipped |
 | [0002](specs/0002-connections-and-friendship/spec.md) | Connections & Friendship | 🟢 shipped |
 | [0003](specs/0003-zero-knowledge-social/spec.md) | Zero-Knowledge Social Wall | 🟢 shipped |
-| [0004](specs/0004-group-call-reliability/spec.md) | Group call reliability, adaptive quality, caps, audio cues & busy signalling | 🔵 in-review |
-| [0005](specs/0005-call-waiting-hold/spec.md) | Call waiting — hold, swap & drop between two concurrent calls | 🔵 in-review |
-| [0007](specs/0007-adaptive-call-quality/spec.md) | Adaptive call quality — per-receiver, network- and screen-aware, with peer-reported health | 🔵 in-review |
+| [0004](specs/0004-group-call-reliability/spec.md) | Group call reliability, adaptive quality, caps, audio cues & busy signalling | 🟢 shipped |
+| [0005](specs/0005-call-waiting-hold/spec.md) | Call waiting — hold, swap & drop between two concurrent calls | 🟢 shipped |
+| [0007](specs/0007-adaptive-call-quality/spec.md) | Adaptive call quality — per-receiver, network- and screen-aware, with peer-reported health | 🟢 shipped |
 | [0008](specs/0008-chat-turn-based/spec.md) | In-Chat Turn-Based Games | 🟢 shipped |
 | [0009](specs/0009-game-challenges-groups/spec.md) | Game Challenges in Groups and on the Wall | 🟢 shipped |
 | [0010](specs/0010-connect-four-second/spec.md) | Connect Four, the Second Built-in Game | 🟢 shipped |
@@ -44,18 +44,18 @@ Specs are grouped by category band; status moves
 | [1014](specs/1014-image-thumbnails-album/spec.md) | Multi-Size Image Thumbnails + Album-View Overhaul | 🟢 shipped |
 | [1015](specs/1015-reliable-push-notifications/spec.md) | Reliable Push & Redesigned In-App Notifications | 🟢 shipped |
 | [1016](specs/1016-9-am-local/spec.md) | 9-AM-Local Version-Announcement Push (Per-Device, Behind-Only) | 🟢 shipped |
-| [1017](specs/1017-cache-reusable-assets/spec.md) | Cache reusable assets (animated emoji + avatars) so they aren't refetched | 🔵 in-review |
-| [1018](specs/1018-media-sharing-and/spec.md) | Media Sharing & Viewer Improvements | 🔵 in-review |
-| [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | 🔵 in-review |
-| [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | 🔵 in-review |
-| [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🔵 in-review |
-| [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🔵 in-review |
-| [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🔵 in-review |
-| [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🔵 in-review |
-| [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🔵 in-review |
-| [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🔵 in-review |
-| [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🔵 in-review |
-| [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🔵 in-review |
+| [1017](specs/1017-cache-reusable-assets/spec.md) | Cache reusable assets (animated emoji + avatars) so they aren't refetched | 🟢 shipped |
+| [1018](specs/1018-media-sharing-and/spec.md) | Media Sharing & Viewer Improvements | 🟢 shipped |
+| [1019](specs/1019-hidden-chats-pin/spec.md) | Hidden Chats Locked Behind a PIN | 🟢 shipped |
+| [1020](specs/1020-mentions-group-chats/spec.md) | @mentions in group chats | 🟢 shipped |
+| [1021](specs/1021-support-contributions/spec.md) | Support the project (pay-what-you-want contributions) | 🟢 shipped |
+| [1024](specs/1024-resilient-posting-and-storage/spec.md) | Resilient posting & on-device storage management | 🟢 shipped |
+| [1025](specs/1025-app-ux-polish/spec.md) | App-wide UX polish and fixes | 🟢 shipped |
+| [1026](specs/1026-friends-only-and-settings-refinements/spec.md) | Friends-only messaging with privacy, settings and help refinements | 🟢 shipped |
+| [1027](specs/1027-harden-hidden-chats/spec.md) | Harden Hidden Chats + One-Hidden-One-Visible Per Person | 🟢 shipped |
+| [1028](specs/1028-robust-audio-and/spec.md) | Robust Calls + Add-to-Call (Merge Incoming, Add People) | 🟢 shipped |
+| [1029](specs/1029-tap-phone-and-email/spec.md) | Tap a Phone Number or Email in Messages & Posts | 🟢 shipped |
+| [1030](specs/1030-finish-call-kind/spec.md) | Finish Add-to-Call — Kind Upgrade, Join Cue, Group Merge, Robustness | 🟢 shipped |
 | [1031](specs/1031-wall-notifications-only/spec.md) | Wall notifications go to the owner only | 🟢 shipped |
 | [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟢 shipped |
 | [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🟢 shipped |
@@ -71,19 +71,19 @@ Specs are grouped by category band; status moves
 | [2004](specs/2004-unify-app-notifications/spec.md) | Unify in-app notifications/toasts + user-friendly "What's new" | 🟢 shipped |
 | [2005](specs/2005-pause-resume-during/spec.md) | Video-message recording — stop & review before sending, clean start, right-sized, out of the gallery | 🟢 shipped |
 | [2006](specs/2006-install-page-guidance/spec.md) | Install-page guidance for a Play Protect "older Android" block | 🟢 shipped |
-| [2007](specs/2007-video-hd-sd/spec.md) | HD/SD video sends are transcoded for real on device | 🔵 in-review |
-| [2008](specs/2008-fast-first-call-connect/spec.md) | Make the first call connect as fast as a call-waiting second call | 🔵 in-review |
-| [2009](specs/2009-single-call-waiting-slot/spec.md) | Only one caller may wait in call-waiting; further callers get busy | 🔵 in-review |
-| [2010](specs/2010-nav-notification-robustness/spec.md) | Navigation & notification robustness | 🔵 in-review |
-| [2011](specs/2011-hold-ui-and-1to1-diag/spec.md) | Call on-hold visualization & 1:1 diagnostics | 🔵 in-review |
-| [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | 🔵 in-review |
-| [2013](specs/2013-peer-resume-countdown/spec.md) | Mirror the resume countdown for the swapper | 🔵 in-review |
-| [2014](specs/2014-notif-title-and-auth/spec.md) | Notification title tidy & generic-fallback diagnosis | 🔵 in-review |
-| [2015](specs/2015-sw-preview-ratchet/spec.md) | Background notifications decrypt queued messages reliably | 🔵 in-review |
-| [2016](specs/2016-sw-no-spurious-generic/spec.md) | Stop background notifications showing a generic placeholder when there's nothing new | 🔵 in-review |
-| [2017](specs/2017-sw-burst-coalesce/spec.md) | Coalesce burst notifications into one clean per-chat notification | 🔵 in-review |
-| [2018](specs/2018-notification-tap-opens/spec.md) | Notification tap opens the chat, not a stuck chat list | 🟡 in-progress |
-| [2019](specs/2019-typing-works-again/spec.md) | Typing works again after sending pasted media, and captions reach every attachment | 🟡 in-progress |
-| [2020](specs/2020-fast-message-bursts/spec.md) | Fast message bursts stop showing duplicate notifications | 🟡 in-progress |
-| [2021](specs/2021-remove-save-to-photos/spec.md) | Remove the "Save to Photos" chat setting | 🟡 in-progress |
+| [2007](specs/2007-video-hd-sd/spec.md) | HD/SD video sends are transcoded for real on device | 🟢 shipped |
+| [2008](specs/2008-fast-first-call-connect/spec.md) | Make the first call connect as fast as a call-waiting second call | 🟢 shipped |
+| [2009](specs/2009-single-call-waiting-slot/spec.md) | Only one caller may wait in call-waiting; further callers get busy | 🟢 shipped |
+| [2010](specs/2010-nav-notification-robustness/spec.md) | Navigation & notification robustness | 🟢 shipped |
+| [2011](specs/2011-hold-ui-and-1to1-diag/spec.md) | Call on-hold visualization & 1:1 diagnostics | 🟢 shipped |
+| [2012](specs/2012-call-invite-recovery/spec.md) | Call invite recovery & honest ringing | 🟢 shipped |
+| [2013](specs/2013-peer-resume-countdown/spec.md) | Mirror the resume countdown for the swapper | 🟢 shipped |
+| [2014](specs/2014-notif-title-and-auth/spec.md) | Notification title tidy & generic-fallback diagnosis | 🟢 shipped |
+| [2015](specs/2015-sw-preview-ratchet/spec.md) | Background notifications decrypt queued messages reliably | 🟢 shipped |
+| [2016](specs/2016-sw-no-spurious-generic/spec.md) | Stop background notifications showing a generic placeholder when there's nothing new | 🟢 shipped |
+| [2017](specs/2017-sw-burst-coalesce/spec.md) | Coalesce burst notifications into one clean per-chat notification | 🟢 shipped |
+| [2018](specs/2018-notification-tap-opens/spec.md) | Notification tap opens the chat, not a stuck chat list | 🟢 shipped |
+| [2019](specs/2019-typing-works-again/spec.md) | Typing works again after sending pasted media, and captions reach every attachment | 🟢 shipped |
+| [2020](specs/2020-fast-message-bursts/spec.md) | Fast message bursts stop showing duplicate notifications | 🟢 shipped |
+| [2021](specs/2021-remove-save-to-photos/spec.md) | Remove the "Save to Photos" chat setting | 🟢 shipped |
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |

--- a/specs/0004-group-call-reliability/spec.md
+++ b/specs/0004-group-call-reliability/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-23
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/0005-call-waiting-hold/spec.md
+++ b/specs/0005-call-waiting-hold/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-23
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/0007-adaptive-call-quality/spec.md
+++ b/specs/0007-adaptive-call-quality/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-24
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1017-cache-reusable-assets/spec.md
+++ b/specs/1017-cache-reusable-assets/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-24
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1018-media-sharing-and/spec.md
+++ b/specs/1018-media-sharing-and/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-26
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1019-hidden-chats-pin/spec.md
+++ b/specs/1019-hidden-chats-pin/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-26
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1020-mentions-group-chats/spec.md
+++ b/specs/1020-mentions-group-chats/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-27
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1021-support-contributions/spec.md
+++ b/specs/1021-support-contributions/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-27
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1024-resilient-posting-and-storage/spec.md
+++ b/specs/1024-resilient-posting-and-storage/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-30
 
-**Status**: in-review
+**Status**: shipped
 
 **Input**: User description: "When sharing media to the Wall (and selecting media in chat), make
 posting resilient: tapping Share should dismiss the composer immediately and show a pending

--- a/specs/1025-app-ux-polish/spec.md
+++ b/specs/1025-app-ux-polish/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-01
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1026-friends-only-and-settings-refinements/spec.md
+++ b/specs/1026-friends-only-and-settings-refinements/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1027-harden-hidden-chats/spec.md
+++ b/specs/1027-harden-hidden-chats/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1028-robust-audio-and/spec.md
+++ b/specs/1028-robust-audio-and/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: in-review
+**Status**: shipped
 <!-- The four deferred items (kind upgrade on merge, join cue, group-invite merge,
      churn robustness) are completed by spec 1030 (feat/1030-finish-call-kind);
      both specs ship with that branch's PR into develop. -->

--- a/specs/1029-tap-phone-and-email/spec.md
+++ b/specs/1029-tap-phone-and-email/spec.md
@@ -6,7 +6,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1030-finish-call-kind/spec.md
+++ b/specs/1030-finish-call-kind/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-02
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2007-video-hd-sd/spec.md
+++ b/specs/2007-video-hd-sd/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-22
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2008-fast-first-call-connect/spec.md
+++ b/specs/2008-fast-first-call-connect/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-24
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2009-single-call-waiting-slot/spec.md
+++ b/specs/2009-single-call-waiting-slot/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-24
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2010-nav-notification-robustness/spec.md
+++ b/specs/2010-nav-notification-robustness/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2011-hold-ui-and-1to1-diag/spec.md
+++ b/specs/2011-hold-ui-and-1to1-diag/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2012-call-invite-recovery/spec.md
+++ b/specs/2012-call-invite-recovery/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2013-peer-resume-countdown/spec.md
+++ b/specs/2013-peer-resume-countdown/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2014-notif-title-and-auth/spec.md
+++ b/specs/2014-notif-title-and-auth/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2015-sw-preview-ratchet/spec.md
+++ b/specs/2015-sw-preview-ratchet/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2016-sw-no-spurious-generic/spec.md
+++ b/specs/2016-sw-no-spurious-generic/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2017-sw-burst-coalesce/spec.md
+++ b/specs/2017-sw-burst-coalesce/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2018-notification-tap-opens/spec.md
+++ b/specs/2018-notification-tap-opens/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-04
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2019-typing-works-again/spec.md
+++ b/specs/2019-typing-works-again/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-04
 
-**Status**: in-progress
+**Status**: shipped
 
 **Input**: Bug report (iOS installed PWA): "after pasting an image the composer still works and
 I can type captions — but after I press SEND, I can't type in the composer anymore until I

--- a/specs/2020-fast-message-bursts/spec.md
+++ b/specs/2020-fast-message-bursts/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-04
 
-**Status**: in-progress
+**Status**: shipped
 
 **Input**: Bug report (iOS installed PWA): sending 1..10 quickly produced banners "2", then
 a count summary, then "10" — but Notification Center held ~10 entries including the same

--- a/specs/2021-remove-save-to-photos/spec.md
+++ b/specs/2021-remove-save-to-photos/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-04
 
-**Status**: in-progress
+**Status**: shipped
 
 **Input**: Bug report (iOS installed PWA): with "Save to Photos" on, every incoming photo/video
 popped a Safari/QuickLook preview ("Open in…", Done, Refresh, Back, Share, compass) that broke


### PR DESCRIPTION
Roadmap audit: 30 specs whose features merged long ago (verified per-spec against git history) still carried planned/in-progress/in-review statuses. Flipped to shipped + roadmap regenerated. 1035/1036 are excluded — they ride PRs #864/#865 and get flipped by their merge watchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE