### PR TITLE
fix(notifications): a device that silently stopped receiving pushes heals itself on the next app open

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,7 @@ Specs are grouped by category band; status moves
 | [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟢 shipped |
 | [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🟢 shipped |
 | [1034](specs/1034-every-push-wake/spec.md) | No Silent Pushes — Every Wake Shows a Notification Unless the App Is Visibly Open | 🟢 shipped |
+| [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1037-zombie-push-subscriptions/spec.md
+++ b/specs/1037-zombie-push-subscriptions/spec.md
@@ -1,0 +1,62 @@
+# Feature Specification: Zombie Push Subscriptions Rotate Themselves
+
+**Feature Branch**: `feat/1037-zombie-push-subscriptions`
+
+**Created**: 2026-07-07
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: Follow-up to specs 2022/1034 (the push-death incident). The one
+remaining unhealed failure mode: a ZOMBIE subscription — the push service
+accepts sends (201) but the device never receives, and the browser still
+returns the old subscription object, so re-registering on every open just
+re-registers the corpse. Today recovery needs a manual notifications
+off/on toggle. Users bitten by the old silent-wake bug should instead heal
+automatically the first time they open the app.
+
+## Mechanism
+
+The zombie signature is detectable on-device: *a message that sat queued for
+a long time arrived via the normal drain, and no push wake ever happened
+after it was sent — while we supposedly held a valid subscription.*
+
+- **FR-001 (wake stamp)**: the service worker records `push.lastWakeAt` at the
+  top of EVERY push wake.
+- **FR-002 (stale-drain marker)**: when an inbound message's sender timestamp
+  is older than 10 minutes at receive time, the receive path records
+  `push.staleMsg` = { at: the message's send time, recordedAt: now }.
+- **FR-003 (rotation decision — pure, unit-tested)**: on app open/foreground
+  (inside the existing `ensurePushSubscription`), rotate — unsubscribe and
+  subscribe fresh, yielding a NEW endpoint — exactly when:
+  - a stale-drain marker exists, AND
+  - it was recorded ≥ 60s ago (a racing held-push wake gets a chance to land
+    first), AND
+  - `lastWakeAt` predates the stale message's send time (no wake since —
+    the should-have-woken-but-didn't core of the signature), AND
+  - the last rotation was ≥ 24h ago (thrash cap).
+  Rotation clears the marker and stamps `push.lastRotateAt`.
+
+## Why false positives are harmless
+
+A phone that was simply off/offline matches "stale messages drained" — but on
+reconnect the push service DELIVERS its held wakes (28-day TTL), stamping
+`lastWakeAt` fresh, which invalidates the signature. Only a subscription that
+never wakes again rotates. And even a spurious rotation costs nothing: the new
+endpoint keeps notifications working seamlessly; the old row is replaced.
+
+## Zero-Knowledge Impact
+
+None. All signals are device-local timestamps; the server sees only the same
+subscribe call it already sees on every app open, occasionally with a new
+endpoint.
+
+## Success Criteria
+
+- **SC-001**: Unit tests cover the rotation decision: fires on the zombie
+  signature; declines when a wake followed the stale message, within the
+  60s grace, within the 24h cap, or with no marker.
+- **SC-002**: Existing push registration behavior (key-mismatch re-subscribe,
+  normal reuse) is unchanged.
+- **SC-003**: Client gates green (typecheck/build, unit suite, notification
+  e2e).

--- a/specs/1037-zombie-push-subscriptions/spec.md
+++ b/specs/1037-zombie-push-subscriptions/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-07
 
-**Status**: planned
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: Follow-up to specs 2022/1034 (the push-death incident). The one

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -12,6 +12,7 @@ import { capitalizeFirst } from '@/utils/text';
 import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination';
 import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
 import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, keepAlivePost as apiKeepAlivePost, addPostEnvelopes as apiAddPostEnvelopes, removePostRecipient as apiRemovePostRecipient, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
+import { recordStaleDrain, STALE_MSG_MS } from '@/services/push';
 import { sealForChat, openPacket } from '@/services/messaging';
 import { withInboundLock } from '@/services/cross-lock';
 import { mediaPreview, previewKind, chatListPreview } from '@/services/message-preview';
@@ -5461,6 +5462,12 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
   if (payload.groupId) await ensureGroupChat(payload.groupId, from);
 
   const ts = payload.timestamp || now();
+  // (spec 1037) A message that sat queued past the staleness bar means a push
+  // SHOULD have woken this device while it was away — record the signature so
+  // the next subscription check can detect a zombie and rotate. Harmless for a
+  // merely-offline phone: its held pushes arrive on reconnect and stamp a
+  // fresh wake, which invalidates the marker.
+  if (now() - ts > STALE_MSG_MS) void recordStaleDrain(ts);
   const kind = (payload.kind as MessageKind) || 'text';
 
   // If the message carries media, download + decrypt the ciphertext and store

--- a/src/services/push.rotate.test.ts
+++ b/src/services/push.rotate.test.ts
@@ -1,0 +1,39 @@
+// Spec 1037 — the pure zombie-rotation decision: rotate the push subscription
+// exactly when a long-queued message drained with NO push wake since it was
+// sent (the should-have-woken-but-didn't signature), with a grace window for a
+// racing held-push wake and a 24h thrash cap.
+import { describe, it, expect } from 'vitest';
+import { shouldRotateForStaleness } from './push';
+
+const H = 60 * 60 * 1000;
+const NOW = 1_000_000_000;
+const base = {
+  stale: { at: NOW - 30 * 60 * 1000, recordedAt: NOW - 5 * 60 * 1000 }, // sent 30min ago, seen 5min ago
+  lastWakeAt: NOW - 2 * 24 * H, // no wake in two days
+  lastRotateAt: 0,
+  now: NOW,
+};
+
+describe('spec 1037: shouldRotateForStaleness', () => {
+  it('fires on the zombie signature', () => {
+    expect(shouldRotateForStaleness(base)).toBe(true);
+  });
+  it('no marker → never', () => {
+    expect(shouldRotateForStaleness({ ...base, stale: null })).toBe(false);
+  });
+  it('a wake AFTER the stale message was sent invalidates the signature (offline phone, held pushes arrived)', () => {
+    expect(shouldRotateForStaleness({ ...base, lastWakeAt: base.stale.at + 1000 })).toBe(false);
+  });
+  it('a wake BEFORE the stale message keeps the signature (that wake proves nothing)', () => {
+    expect(shouldRotateForStaleness({ ...base, lastWakeAt: base.stale.at - 1000 })).toBe(true);
+  });
+  it('within the 60s grace (a racing held-push may still land) → wait', () => {
+    expect(shouldRotateForStaleness({ ...base, stale: { ...base.stale, recordedAt: NOW - 30_000 } })).toBe(false);
+  });
+  it('rotated within 24h → capped', () => {
+    expect(shouldRotateForStaleness({ ...base, lastRotateAt: NOW - 23 * H })).toBe(false);
+  });
+  it('rotated over 24h ago → allowed again', () => {
+    expect(shouldRotateForStaleness({ ...base, lastRotateAt: NOW - 25 * H })).toBe(true);
+  });
+});

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -10,7 +10,8 @@
  * handles the prompt); these functions are safe no-ops otherwise.
  */
 import { fetchServerConfig, subscribePush, unsubscribePushServer } from './api';
-import { get } from '@/db/idb';
+import { get, put, remove } from '@/db/idb';
+import type { Setting } from '@/db/types';
 
 function urlBase64ToUint8Array(base64: string): Uint8Array {
   const padding = '='.repeat((4 - (base64.length % 4)) % 4);
@@ -29,6 +30,71 @@ function pushReady(): boolean {
     Notification.permission === 'granted'
   );
 }
+
+/* ---- spec 1037: zombie-subscription self-healing. A push service can accept
+ * sends (201) for a subscription the DEVICE no longer honors (observed live:
+ * iOS revoked it after the old silent-wake bug, but the browser still returns
+ * the object, so re-registering just re-registers the corpse). The signature
+ * is detectable on-device: a message that sat queued a long time drained
+ * normally, and no push wake ever happened after it was SENT. On that
+ * signature, rotate: unsubscribe + fresh subscribe = a new endpoint. A merely
+ * offline phone never matches — its held pushes arrive on reconnect and stamp
+ * a fresh wake first. ---- */
+
+const STALE_MSG_MS = 10 * 60 * 1000; // queued this long = should have woken us
+const ROTATE_GRACE_MS = 60 * 1000; // let a racing held-push wake land first
+const ROTATE_MIN_INTERVAL_MS = 24 * 60 * 60 * 1000; // thrash cap
+
+export interface StaleMarker {
+  at: number; // the stale message's SEND time
+  recordedAt: number; // when the drain observed it
+}
+
+/** The pure rotation decision (unit-tested). */
+export function shouldRotateForStaleness(args: {
+  stale: StaleMarker | null;
+  lastWakeAt: number;
+  lastRotateAt: number;
+  now: number;
+}): boolean {
+  const { stale, lastWakeAt, lastRotateAt, now } = args;
+  if (!stale) return false;
+  if (now - stale.recordedAt < ROTATE_GRACE_MS) return false;
+  if (lastWakeAt >= stale.at) return false; // a wake since it was sent → not a zombie
+  return now - lastRotateAt >= ROTATE_MIN_INTERVAL_MS;
+}
+
+/** Record that the drain received a message queued past the staleness bar —
+ *  called by the receive path (db/queries); read + consumed here. Keeps the
+ *  NEWEST stale send-time (the strongest evidence). */
+export async function recordStaleDrain(sentAt: number): Promise<void> {
+  const prev = await get<Setting<StaleMarker>>('settings', STALE_KEY);
+  if (prev?.value && prev.value.at >= sentAt) return;
+  await put<Setting<StaleMarker>>('settings', { key: STALE_KEY, value: { at: sentAt, recordedAt: Date.now() } });
+}
+
+const STALE_KEY = 'push.staleMsg';
+const WAKE_KEY = 'push.lastWakeAt';
+const ROTATED_KEY = 'push.lastRotateAt';
+
+/** Evaluate the zombie signature; when it holds, clear the marker + stamp the
+ *  rotation and tell the caller to mint a fresh subscription. */
+async function consumeRotationDecision(): Promise<boolean> {
+  try {
+    const stale = (await get<Setting<StaleMarker>>('settings', STALE_KEY))?.value ?? null;
+    if (!stale) return false;
+    const lastWakeAt = (await get<Setting<number>>('settings', WAKE_KEY))?.value ?? 0;
+    const lastRotateAt = (await get<Setting<number>>('settings', ROTATED_KEY))?.value ?? 0;
+    if (!shouldRotateForStaleness({ stale, lastWakeAt, lastRotateAt, now: Date.now() })) return false;
+    await remove('settings', STALE_KEY);
+    await put<Setting<number>>('settings', { key: ROTATED_KEY, value: Date.now() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export { STALE_MSG_MS };
 
 /** Whether an existing subscription was created with the given VAPID key. If not,
  *  the server's key rotated (or differs across envs) and pushes to it would
@@ -61,6 +127,18 @@ export async function ensurePushSubscription(): Promise<boolean> {
     const key = urlBase64ToUint8Array(vapidPublicKey);
     let sub = await reg.pushManager.getSubscription();
     if (sub && !subMatchesKey(sub, key)) {
+      try {
+        await sub.unsubscribe();
+      } catch {
+        /* ignore, we resubscribe below regardless */
+      }
+      sub = null;
+    }
+    // (spec 1037) The zombie signature: long-queued messages drained with no
+    // push wake since they were sent. Rotate to a fresh endpoint — the browser
+    // object is not trustworthy evidence that the push service still delivers.
+    if (sub && (await consumeRotationDecision())) {
+      console.warn('[push] stale-drain signature — rotating the subscription');
       try {
         await sub.unsubscribe();
       } catch {

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -109,6 +109,17 @@ export interface PreviewResult {
 /** Read a settings-store value from the service worker (no keystore needed; settings
  *  are stored in the clear). Exported so the SW push handler can honor notification
  *  toggles like `notifications.wall.show`. */
+/** (spec 1037) Stamp the wall-clock of a push WAKE. The page compares this
+ *  against stale-drained messages: a long-queued message with NO wake after
+ *  its send time is the zombie-subscription signature that triggers rotation. */
+export async function stampPushWake(): Promise<void> {
+  try {
+    await put<Setting<number>>('settings', { key: 'push.lastWakeAt', value: Date.now() });
+  } catch {
+    /* best-effort */
+  }
+}
+
 export async function setting<T>(key: string, fallback: T): Promise<T> {
   const s = await get<Setting<T>>('settings', key);
   return s ? s.value : fallback;

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -23,7 +23,7 @@ import { ExpirationPlugin } from 'workbox-expiration';
 import {
   previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, previewPosts, previewPostActivity, markConnShown,
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
-  anyClientVisible, quietNote,
+  anyClientVisible, quietNote, stampPushWake,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
@@ -656,6 +656,10 @@ async function pageWillNotify(clients: readonly Client[], timeoutMs: number): Pr
 self.addEventListener('push', (event) => {
   event.waitUntil(
     (async () => {
+      // (spec 1037) Every wake stamps its time FIRST — the page-side zombie
+      // detector treats "no wake since a stale message was sent" as the
+      // rotate-the-subscription signature.
+      await stampPushWake();
       const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
       const { kind, post } = pushKind(event);
       if (kind === 'call') {


### PR DESCRIPTION
## Spec 1037 — zombie subscriptions rotate themselves

Completes the push-reliability trilogy (2022 reason-aware pruning, 1034 no-silent-wakes): the remaining unhealed mode is the ZOMBIE — the push service 201s our sends, the device never receives, and the browser still returns the dead subscription object, so the re-register-on-open loop re-registers the corpse. Recovery needed a manual notifications toggle.

Mechanism (all device-local timestamps, nothing new on the wire):
- The SW stamps `push.lastWakeAt` at the top of EVERY wake.
- The receive path marks a stale drain when an inbound message's send time is >10min old on arrival.
- `ensurePushSubscription` rotates (unsubscribe + fresh subscribe → NEW endpoint) on the pure, 7-case-tested signature: stale drain recorded ≥60s ago + NO wake since that message was sent + ≥24h since the last rotation.

Self-validating against false positives: a merely-offline phone's held pushes (28d TTL) arrive on reconnect and stamp a fresh wake, invalidating the marker — only a truly dead subscription rotates. And a spurious rotation is harmless anyway (new endpoint, seamless).

Everyone bitten by the old silent-wake bug heals automatically on their next app open.

Gates: 796 units (7 new, red-first), build, notification e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE