### PR TITLE
docs(spec): spec 1037 shipped in #867; roadmap regenerated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,7 @@ Specs are grouped by category band; status moves
 | [1032](specs/1032-store-messages-push/spec.md) | Messages store on push so the app opens warm | 🟢 shipped |
 | [1033](specs/1033-submarine-redesign-battleship/spec.md) | Submarine Redesign of the Battleship Card | 🟢 shipped |
 | [1034](specs/1034-every-push-wake/spec.md) | No Silent Pushes — Every Wake Shows a Notification Unless the App Is Visibly Open | 🟢 shipped |
-| [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🔵 in-review |
+| [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1037-zombie-push-subscriptions/spec.md
+++ b/specs/1037-zombie-push-subscriptions/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-07
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: Follow-up to specs 2022/1034 (the push-death incident). The one


### PR DESCRIPTION
Status flip after #867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg2y8GTZxmxNgioXon69SE