### PR TITLE
fix(notifications): iPhone notifications keep working when messages arrive while Ring is open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1038-armada-fullscreen-naval/plan.md`
+`specs/2023-push-wakes-always/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,4 +91,4 @@ Specs are grouped by category band; status moves
 | [2020](specs/2020-fast-message-bursts/spec.md) | Fast message bursts stop showing duplicate notifications | 🟢 shipped |
 | [2021](specs/2021-remove-save-to-photos/spec.md) | Remove the "Save to Photos" chat setting | 🟢 shipped |
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
-| [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟡 in-progress |
+| [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,3 +91,4 @@ Specs are grouped by category band; status moves
 | [2020](specs/2020-fast-message-bursts/spec.md) | Fast message bursts stop showing duplicate notifications | 🟢 shipped |
 | [2021](specs/2021-remove-save-to-photos/spec.md) | Remove the "Save to Photos" chat setting | 🟢 shipped |
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
+| [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟡 in-progress |

--- a/specs/1027-harden-hidden-chats/spec.md
+++ b/specs/1027-harden-hidden-chats/spec.md
@@ -347,6 +347,14 @@ correct from the first frame.
   - **Every path the platform does not force** — app in the foreground, or
     backgrounded but still connected without a push wake — MUST be fully silent
     (no banner, no sound); only the badge updates per preference.
+  - *Amended by [spec 2023](../2023-push-wakes-always/spec.md)*: when a push
+    wake IS involved and the foreground page claims it, the fully-silent
+    outcome above holds only on platforms where consuming a push silently is
+    documented-safe (Chromium engine). On silence-unsafe platforms (all of
+    WebKit, Firefox, unknown engines) the service worker follows the claim
+    with the content-free quiet note — the same generic any message produces,
+    revealing no chat, sender, or content — because the alternative is the
+    exact subscription revocation the push-woken bullet above guards against.
 - **FR-013**: A live incoming call from a hidden-chat peer MUST ring with full
   caller identity (name + avatar) and be answerable normally (the "knock-knock
   call"). Calls are never suppressed by hiding.

--- a/specs/1034-every-push-wake/spec.md
+++ b/specs/1034-every-push-wake/spec.md
@@ -58,6 +58,14 @@ visible notification), on the generic tag (self-replacing, never a pile).
   (the existing generic copy).
 - Other kinds: "Ring" / "New activity".
 
+> **Amended by [spec 2023](../2023-push-wakes-always/spec.md)**: the
+> visible-client license above is now platform-gated. Silence requires BOTH a
+> Chromium-engine browser (whose push service documents the focused-page
+> exemption) AND a window client that is focused AND visible; on WebKit —
+> whose push daemon counts a cumulative, never-reset three-strike silent-push
+> quota with NO on-screen exemption — plus Firefox and unknown engines, every
+> wake ends visibly, and a page-claimed wake is followed by the quiet generic.
+
 ## Requirements
 
 - **FR-002**: The seven paths above (minus #7) each terminate in: rich note,

--- a/specs/2023-push-wakes-always/checklists/privacy.md
+++ b/specs/2023-push-wakes-always/checklists/privacy.md
@@ -1,0 +1,83 @@
+# Checklist: Zero-Knowledge & Notification Privacy — Requirements Quality
+
+**Purpose**: Validate that spec 2023's requirements bound every privacy-relevant
+behavior (quiet-note content, hidden-chat disclosure, wire silence, gate
+fail-direction) completely, clearly, and measurably before implementation.
+**Created**: 2026-07-09
+**Feature**: [spec.md](../spec.md) · Principle-I-adjacent (constitution gate)
+
+## Quiet-Note Content Bounds
+
+- [x] CHK001 - Is the quiet note's information content explicitly bounded as a
+      requirement (no sender, no chat identity, no message content) in every
+      NEW situation it appears, not just described narratively?
+      [Clarity, Spec §FR-003, §Key Entities]
+- [x] CHK002 - Is the bound stated relative to an existing reference class
+      ("exactly the information the push tickle itself reveals") so it can be
+      objectively compared? [Measurability, Spec §Zero-Knowledge Impact]
+- [x] CHK003 - Is it explicit that this spec changes WHERE the quiet note
+      appears but never WHAT it contains? [Consistency, Spec §Key Entities]
+
+## Hidden-Chat Disclosure
+
+- [x] CHK004 - Is the disclosure delta on silence-unsafe platforms enumerated
+      (observer learns: a generic "New message" occurred) AND is what must NOT
+      be learnable stated (which chat, from whom, that hidden chats exist at
+      all)? [Completeness, Spec §Edge Cases]
+- [x] CHK005 - Is the trade explicitly scoped to silence-unsafe platforms
+      only, with zero-trace preserved elsewhere? [Consistency, Spec §Edge
+      Cases, §FR-003]
+- [x] CHK006 - Is the superseded spec-1027 FR-012 zero-trace requirement
+      cross-referenced from BOTH sides (2023 → 1027 and 1027 → 2023), the way
+      FR-008 already mandates for spec 1034? [Traceability, Gap]
+- [x] CHK007 - Is the justification for the trade recorded with its
+      alternative ("permanent notification loss") so a future reader cannot
+      re-relax it as an oversight? [Completeness, Spec §Edge Cases, §Why]
+
+## Wire & Protocol Silence
+
+- [x] CHK008 - Does a requirement-level statement cover that NOTHING new
+      crosses the wire: no server change, no push-payload change, and no new
+      page↔SW message types or fields? [Completeness, Spec §Zero-Knowledge
+      Impact, Gap — protocol constraint currently lives only in plan.md]
+- [x] CHK009 - Is "no new data collection" (telemetry/logging of UA
+      classification results) addressed or excluded? [Coverage, Gap]
+
+## Platform-Gate Fail Direction
+
+- [x] CHK010 - Is the safe direction defined for EVERY misclassification mode
+      (unknown UA, spoofed UA, future browser, empty string), not just listed
+      as examples? [Coverage, Spec §FR-002, §Edge Cases]
+- [x] CHK011 - Can "confidently Chromium-engine" be objectively verified from
+      the requirements (explicit token allow-list plus explicit iOS-skin
+      deny-list)? [Measurability, Spec §FR-002, data-model.md]
+- [x] CHK012 - Is the asymmetric cost of each error direction stated (false
+      "unsafe" = one extra silent note; false "safe" = permanent subscription
+      loss), so reviewers can weigh future gate edits? [Clarity, Spec
+      §Clarifications, research.md D2]
+
+## Timing & Exception Flows
+
+- [x] CHK013 - Is the deadline for the post-claim quiet note specified
+      (within the same wake, before the push event settles — inside the
+      platform's silent-push window)? [Clarity, Spec §FR-003, Gap]
+- [x] CHK014 - Are requirements defined for the quiet note itself failing
+      (propagation to the guarded fallback) and for the fallback also failing
+      (permission revoked — nothing further possible, no path reports
+      success)? [Exception Flow, Spec §FR-005, §Edge Cases]
+- [x] CHK015 - Is notification-center residue bounded (silent, self-replacing
+      tag, cleared by existing foreground cleanup; at most one entry)?
+      [Clarity, Spec §Edge Cases, §Assumptions]
+
+## Consistency & Traceability
+
+- [x] CHK016 - Do FR-001's licensed-silence conditions and the wake-outcomes
+      contract's master rule express the same policy with no wake kind
+      falling outside both? [Consistency, Spec §FR-001,
+      contracts/wake-outcomes.md]
+- [x] CHK017 - Is the spec-1034 amendment one-directional and explicit (2023
+      supersedes 1034 FR-001; 1034 gains a pointer)? [Traceability, Spec
+      §FR-001, §FR-008]
+- [x] CHK018 - Is the UA-sniffing assumption validated by stating what
+      happens when it is wrong (misclassification lands in the safe
+      direction)? [Assumption, Spec §Assumptions, §Edge Cases]

--- a/specs/2023-push-wakes-always/checklists/requirements.md
+++ b/specs/2023-push-wakes-always/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Push Wakes Always End Visibly Where Silence Is Unsafe
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The Why section names concrete platform mechanisms (webpushd, strike
+  counter) because they ARE the incident being fixed; the requirements
+  themselves stay behavior-level. Function/file references from the
+  triggering review are deliberately kept out of the FRs.
+- The hidden-chat stealth trade (spec 1027 FR-012) and the spec 1034 FR-001
+  amendment are called out explicitly so `/speckit-analyze` can check
+  cross-spec consistency.
+- No [NEEDS CLARIFICATION] markers: the one genuine product decision
+  (hidden-chat stealth vs subscription survival on Apple) was explicitly
+  approved by the user before this spec was written.

--- a/specs/2023-push-wakes-always/contracts/wake-outcomes.md
+++ b/specs/2023-push-wakes-always/contracts/wake-outcomes.md
@@ -1,0 +1,58 @@
+# Contract: Push-Wake Terminal Outcomes
+
+**Spec**: [spec.md](./spec.md) · **Date**: 2026-07-09
+
+The behavioral contract `src/sw.ts` must satisfy after this fix. "Quiet note"
+= the existing spec-1034 content-free notification (silent, self-replacing
+tag, no sender/chat/content). "Trusted" = `platformTrustsSilence(ua)` (Chromium
+engine, non-iOS); "unsafe" = everything else (all WebKit, Firefox, unknown).
+
+**Master rule (FR-001)**: on unsafe platforms, EVERY row below ends in a
+`showNotification` call. Licensed silence exists only on trusted platforms
+with a focused AND visible client, or after a page claim on a trusted
+platform.
+
+| # | Wake kind | Situation | Trusted platform | Unsafe platform |
+|---|-----------|-----------|------------------|-----------------|
+| 1 | call | always | ring notification | ring notification |
+| 2 | msg | live page claims within window (rendered banner, or the locked-hidden-chat claim) | silent (claim honored) | quiet note after the ack |
+| 3 | msg | authoritative drain, notes shown (count > 0) | rich note(s) | rich note(s) |
+| 4 | msg | authoritative drain, zero notes OR zero accepted shows | quiet note unless focused+visible client | quiet note, always |
+| 5 | msg | preview path, rich notes (count > 0) | rich note(s) | rich note(s) |
+| 6 | msg | preview path, generic arm (timeout / undecryptable / locked) | loud generic | loud generic |
+| 7 | msg | nothing-new, fresh summary changed | silent re-assert (a show call) | silent re-assert (a show call) |
+| 8 | msg | nothing-new, no summary / identical signature / silenced / suppressed / zero accepted shows | quiet note unless focused+visible client | quiet note, always |
+| 9 | msg | slow-decrypt generic later found silenced (settle downgrade) | quiet note unless focused+visible (loud generic already visible) | quiet note (loud generic already visible) |
+| 10 | conn | app fully closed | conn note(s), or placeholder if none/zero accepted | same |
+| 11 | conn | any client exists | quiet note unless focused+visible | quiet note, always |
+| 12 | post | app closed + Wall toggle on | post note(s) / placeholder | same |
+| 13 | post | toggle off, or any client exists | quiet note unless focused+visible | quiet note, always |
+| 14 | post-activity | app closed + activity toggle on, notes preview (count > 0) | activity note(s) | same |
+| 15 | post-activity | toggle off / clients exist / removal previews to zero / zero accepted | quiet note unless focused+visible | quiet note, always |
+| 16 | version | app fully closed | what's-new notification | same |
+| 17 | version | any client exists | quiet note unless focused+visible | quiet note, always |
+| 18 | any | dispatch throws or exceeds deadline, nothing accepted this event | guardedPush fallback generic | same |
+| 19 | any | quiet-note show itself fails where it is the wake's only remaining visible ending | failure propagates → row 18 | same |
+
+Failure semantics:
+
+- "Accepted" means the `showNotification` promise fulfilled. A rejected or
+  hung show is not accepted, is never recorded in the guard stamp, and never
+  counts toward a show count (rows 3/5/10/12/14 fall to their zero-accepted
+  row).
+- Row 18's guard record (`lastNotificationAt`) is written on fulfillment
+  only; a wake whose only show attempt rejected always reaches the fallback.
+- Row 2's quiet note failing → propagates (row 19). The page↔SW message
+  protocol is unchanged: same `ring:drain` / `ring:handled` messages, no new
+  fields.
+- Row 19 carve-outs (FR-005): the settle downgrade (row 9 — a loud generic is
+  already accepted and showing) and the authoritative-drain degrade (row 4's
+  catch reroutes to the preview flow, whose own quiet terminal propagates)
+  MAY contain a quiet-note failure locally; every other quiet call site lets
+  it propagate.
+- The upgrade arm (row 5 during settle) closes the already-accepted generic
+  only AFTER the upgrade shows report accepted > 0 — a failed upgrade never
+  destroys the wake's existing visible ending.
+
+Out of scope (unchanged): notification click routing, badge counts, straggler
+re-fetch loop, server push-sending policy, page-side rendering decisions.

--- a/specs/2023-push-wakes-always/data-model.md
+++ b/specs/2023-push-wakes-always/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: Push Wakes Always End Visibly Where Silence Is Unsafe
+
+**Spec**: [spec.md](./spec.md) · **Date**: 2026-07-09
+
+No persistent data changes: no IndexedDB store, no `DB_VERSION` bump, no
+server schema, no settings key. The "model" is three pure decision shapes.
+
+## PlatformGate (new, pure)
+
+```
+platformTrustsSilence(ua: string) → boolean
+```
+
+| Input class (user agent)                          | Result | Why |
+|---------------------------------------------------|--------|-----|
+| iOS skins: `CriOS` / `EdgiOS` / `FxiOS`           | false  | WebKit underneath, webpushd strikes |
+| Any `iPhone` / `iPad` / `iPod` token              | false  | all iOS browsers are WebKit |
+| Chromium engine: `Chrome/`, `Chromium/`, `HeadlessChrome/`, `Edg/` (and not an iOS skin) | true | Chromium push service; documented focused-page exemption; includes Chrome/Edge on macOS, Samsung Internet, Opera, Brave |
+| Safari (no Chromium token), incl. iPadOS desktop-mode masquerade | false | webpushd |
+| Firefox (`Firefox/`, no Chromium token)           | false  | own quota system, no documented exemption; over-notify is safe |
+| Empty / unrecognized / spoofed                    | false  | fail to the safe direction |
+
+Invariant: false is always safe on every platform (an extra silent
+notification); true is only ever returned for engines documented to tolerate
+silence.
+
+## SilenceLicense (new, pure; composition)
+
+```
+mayEndWakeSilently(ua, clients) = platformTrustsSilence(ua) && anyClientVisible(clients)
+```
+
+`anyClientVisible(clients)`: some client has `focused === true` AND
+`visibilityState === 'visible'`. Missing fields count as false (older
+platforms fail closed). Unchanged truth table from the applied tightening,
+now with the `{visibilityState:'visible'}`-with-`focused`-absent case pinned.
+
+## ShowOutcome (changed semantics, `sw.ts` wiring)
+
+- `showNotes(notes)` / `showConnNotes(notes)` → `number` (count of shows the
+  platform ACCEPTED — fulfillment, not attempts).
+- Callers: `count > 0` ⇒ wake visibly ended; `count === 0` ⇒ fall through to
+  the quiet/fallback terminal. The authoritative drain's frame acks are
+  independent of the count (data is committed either way).
+- `lastNotificationAt` (guard record): written only on `showNotification`
+  fulfillment. `lastNotificationAt < startedAt` ⇒ the last-resort fallback
+  fires.
+
+## State transitions
+
+A push wake's terminal states, in priority order (see
+[contracts/wake-outcomes.md](./contracts/wake-outcomes.md) for the full
+per-kind table):
+
+1. rich note(s) accepted (count > 0)
+2. generic placeholder accepted
+3. quiet note accepted
+4. page claimed the wake → on trusted platforms: terminal; on unsafe
+   platforms: quiet note (1 show) is the terminal
+5. licensed silence — ONLY `mayEndWakeSilently(ua, clients)` (trusted
+   platform + focused & visible client)
+6. everything else → failure propagates → guardedPush fallback generic

--- a/specs/2023-push-wakes-always/inventory.md
+++ b/specs/2023-push-wakes-always/inventory.md
@@ -1,0 +1,40 @@
+# SC-001 Wake-Path Inventory — spec 2023
+
+Row-by-row mapping of [contracts/wake-outcomes.md](./contracts/wake-outcomes.md)
+to the implemented code (line numbers from the final `src/sw.ts` /
+`src/services/sw-inbox.ts` on `fix/2023-push-wakes-always`). "Quiet terminal" =
+`showQuietUnlessVisible` (sw.ts:239-243), whose only silence license is
+`mayEndWakeSilently(ua, clients)` (sw-inbox.ts) = `platformTrustsSilence(ua) &&
+anyClientVisible(clients)` — false on every WebKit/Firefox/unknown UA, so on
+silence-unsafe platforms every row below ends in a `showNotification` call.
+
+| Row | Code path | Verified ending |
+|-----|-----------|-----------------|
+| 1 call | dispatchPush → `showCall()` (unconditional) | ring notification; a rejection propagates to guardedPush (nothing stamped → fallback) |
+| 2 msg, page claims | sw.ts:817-819: after `pageWillNotify` ack, `!platformTrustsSilence(ua)` → `showQuietNote('msg')` (no catch → row 19) | trusted: silent (unchanged); unsafe: quiet note in the same wake |
+| 3 msg, drain notes accepted | sw.ts:505 `accepted = await showNotes(...)` | rich note(s) |
+| 4 msg, drain zero notes OR zero accepted | sw.ts:522 `!r.notes.length \|\| accepted === 0` → quiet terminal; drain's catch (sw.ts:526-529) degrades a quiet failure to the preview flow (FR-005 carve-out) | quiet note unless licensed |
+| 5 msg, preview notes | sw.ts:561 `accepted = await showNotes(...)`; `shownAny = accepted > 0` (sw.ts:565) | rich note(s); all-rejected → row 8 via `shownAny === false` |
+| 6 msg, generic arm | sw.ts:568-573 `showGeneric(...)` | loud generic; rejection propagates (serializeNotify rethrows) → guardedPush |
+| 7 msg, nothing-new, summary changed | `reassertFromSummary()` returns true only after its show resolved (sw.ts:298-331) | silent re-assert (a show call) |
+| 8 msg, nothing-new residue / silenced / suppressed / zero-accepted | sw.ts:587 `if (!shownAny)` → quiet terminal (propagates) | quiet note unless licensed |
+| 9 msg, settle downgrade | sw.ts:613-615 inside the settle `try/catch` (FR-005 carve-out: the loud generic from row 6 is already accepted and on screen) | quiet note replaces the loud generic in place (same tag), or the generic stays |
+| 5↑ msg, settle upgrade | sw.ts:600-607: `upgraded = await showNotes(...)`; `if (upgraded > 0) closeByTag(GENERIC_TAG)` | the accepted generic is never destroyed for a failed upgrade |
+| 10 conn, closed | `showConnNotification` (sw.ts:459-482): preview errors caught → placeholder always attempted; zero-accepted conn notes (sw.ts:467-472) fall to the placeholder; placeholder rejection propagates | conn note(s) or placeholder |
+| 11 conn, clients exist | sw.ts:740 quiet terminal | quiet note unless licensed |
+| 12 post, closed + toggle on | `showPostNotification` (sw.ts:404-424): zero-accepted (sw.ts:416) falls to the 'Ring / New activity on your Wall' show | post note(s) or placeholder |
+| 13 post, toggle off / clients | sw.ts:759 quiet terminal | quiet note unless licensed |
+| 14 post-activity, closed + toggle on, notes | sw.ts:777 `shownActivity = (await showConnNotes(notes)) > 0` | activity note(s); zero-accepted → row 15 |
+| 15 post-activity residue | sw.ts:783 `if (!shownActivity)` quiet terminal | quiet note unless licensed |
+| 16 version, closed | `showVersionNotification()` (sw.ts:370-397); config fetch failure caught, show always attempted; rejection propagates | what's-new notification |
+| 17 version, clients exist | sw.ts:797 quiet terminal | quiet note unless licensed |
+| 18 guarded fallback | sw.ts:870-887: fallback fires when `lastNotificationAt < startedAt`; the stamp is written ONLY on show fulfillment (`stampedShow`, sw.ts:850-861 / sw-inbox.ts) so a rejected or hung show can no longer suppress it | fallback generic |
+| 19 quiet-note failure | `showQuietNote` has no catch (sw.ts:222-230); callers at 522*/587/740/759/783/797/818 propagate to guardedPush → row 18 (*row-4 carve-out degrades to the preview flow first, whose row-8 terminal propagates) | fallback generic |
+
+Straggler loop (sw.ts:637-652) is post-terminal catch-up (out of contract
+scope): its `showNotes` count is deliberately unused — the wake already ended
+visibly before the loop starts.
+
+Licensed-silence outcomes remaining (trusted platform + focused & visible
+window only): rows 2 (claim, trusted), 4/8/11/13/15/17 (quiet-terminal skip,
+trusted). On WebKit/Firefox/unknown: none.

--- a/specs/2023-push-wakes-always/plan.md
+++ b/specs/2023-push-wakes-always/plan.md
@@ -1,0 +1,183 @@
+# Implementation Plan: Push Wakes Always End Visibly Where Silence Is Unsafe
+
+**Branch**: `fix/2023-push-wakes-always` | **Date**: 2026-07-09 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/2023-push-wakes-always/spec.md`
+
+## Summary
+
+Apple's push daemon counts every service-worker push wake that ends without a
+`showNotification` call as a silent push — cumulatively, three strikes for the
+life of the subscription, no reset, no "user is looking at the app" exemption
+(all verified in WebKit source). Ring's SW still has two *licensed* silent
+endings (the spec-1034 visible-client skip and the page-claim handshake,
+including one claim arm that renders nothing at all) plus three latent
+error-path silences. The fix: a pure, user-agent-keyed **platform gate** —
+silence may only ever be licensed on Chromium-engine browsers (whose push
+service documents the focused-page exemption); on WebKit/Firefox/unknown
+engines every wake ends with a show call, at worst the existing content-free
+quiet note. The page-claim handshake keeps its dedupe role, but on
+silence-unsafe platforms the SW follows the ack with the quiet note. Error
+paths are hardened so a failed show can never be recorded as a successful one.
+Client-only change; no wire, storage, or page-protocol changes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (ES modules), Vue 3 PWA; custom service
+worker built by vite-plugin-pwa `injectManifest` (`src/sw.ts`)
+
+**Primary Dependencies**: none new. Touches `src/sw.ts` (wiring) and
+`src/services/sw-inbox.ts` (pure halves); libsodium/workbox untouched
+
+**Storage**: none. No IndexedDB schema change, no `DB_VERSION` bump
+
+**Testing**: vitest for the pure decisions (`src/services/sw-quiet.test.ts`);
+`npm run build` (vue-tsc) as the typecheck gate; wake-path inventory documented
+in the PR per SC-001; real-device validation recipe in quickstart.md
+
+**Target Platform**: service-worker context across WebKit (iOS 16.4+ PWA,
+macOS Safari), Chromium (desktop incl. macOS, Android), Firefox; the gate must
+be correct from `navigator.userAgent` alone inside the SW
+
+**Project Type**: web (PWA client); server untouched
+
+**Performance Goals**: negligible — one regex classification per push wake
+
+**Constraints**: SW context (no DOM, no `document`); notification content must
+stay exactly as content-free as the push tickle (zero-knowledge class);
+page↔SW message protocol must not change (no new message types)
+
+**Scale/Scope**: ~6 files: `src/services/sw-inbox.ts`,
+`src/services/sw-quiet.test.ts`, `src/sw.ts`, amendment pointers in
+`specs/1034-every-push-wake/spec.md` and
+`specs/1027-harden-hidden-chats/spec.md` (FR-012), plus the SC-001 inventory
+artifact `specs/2023-push-wakes-always/inventory.md`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary** — PASS. Nothing new crosses the wire; the
+  server is untouched. The quiet note's content is unchanged and carries no
+  sender/chat/content. The hidden-chat trade on Apple discloses only the
+  generic "New message" any message produces (spec's Zero-Knowledge Impact
+  section covers this). Because the change touches Principle-I-adjacent
+  surface (notification behavior around hidden chats), `/speckit-checklist`
+  is REQUIRED and will run after `/speckit-tasks`.
+- **II. Spec-Driven Development** — PASS. Spec 2023 (hotfix band), pipeline
+  specify → clarify → plan (this) → tasks → checklist → analyze →
+  taskstoissues → implement.
+- **III. Test-Driven Development** — PASS with explicit ordering: this is a
+  `2001+` fix, so tasks.md MUST begin with failing regression tests that
+  reproduce the bug class in the pure halves — BOTH bug classes: (a) the
+  licensed-silence class (platform gate absent → silence licensed on a WebKit
+  UA with a focused+visible client), and (b) the error-path class via two new
+  pure injectable helpers in `sw-inbox.ts` (`stampedShow`: a show is recorded
+  only on fulfillment; `countAccepted`: a batch's outcome is its accepted
+  count) so a rejecting show can be simulated under vitest. The remaining
+  wiring in `sw.ts` is not directly unit-testable (workbox imports, SW
+  globals) — the established pattern (specs 1034/2016/2017/2020) is
+  pure-decision tests plus a reviewed wake-path inventory; this plan keeps
+  that pattern and the inventory is SC-001. **e2e clause deviation
+  (documented)**: no NEW e2e spec is added or extended because the Playwright
+  harness cannot deliver Web Push events to the service worker (no push
+  service in the loop); behavioral coverage is the pure-decision unit suite,
+  the SC-001 inventory, SC-004's real-device validation, and the existing
+  notification e2e suites staying green in the gates task — the same
+  documented pattern as the predecessor SW hotfixes (1034/2016/2017/2020).
+- **IV. Crypto Discipline** — PASS (not touched).
+- **V. Offline-First Data Integrity** — PASS (no idb change).
+- **VI. Stateless Server & Forward-Only Migrations** — PASS (no server change).
+- **VII. Quality Gates** — PASS. `npm run build` + full vitest suite are the
+  gates; e2e notification suites must stay green. Commit subject will be
+  plain-language release-note copy (this is a user-facing `fix`).
+- **VIII. Traceable Delivery** — PASS. `taskstoissues` will open issues; the
+  PR lists `Closes #N`.
+- **IX–XI** — PASS (no new data collection; no UI change).
+
+No violations → Complexity Tracking stays empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/2023-push-wakes-always/
+├── spec.md              # Feature specification (done)
+├── plan.md              # This file
+├── research.md          # Phase 0: decisions + rejected alternatives
+├── data-model.md        # Phase 1: pure-decision shapes (no persistent data)
+├── quickstart.md        # Phase 1: verification recipe (unit + device)
+├── contracts/
+│   └── wake-outcomes.md # Phase 1: per-kind × per-platform terminal-outcome table
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (done)
+└── tasks.md             # Phase 2 (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── sw.ts                          # wiring: quiet-note split, post-claim show,
+│                                  # stamp-on-fulfillment, show counts, comments
+└── services/
+    ├── sw-inbox.ts                # pure halves: platform gate, silence license,
+    │                              # predicate comment/style
+    └── sw-quiet.test.ts           # regression tests FIRST, then new coverage
+
+specs/1034-every-push-wake/spec.md       # amendment pointer (FR-008a)
+specs/1027-harden-hidden-chats/spec.md   # amendment pointer at FR-012 (FR-008b)
+```
+
+**Structure Decision**: single-project client change following the existing
+pure-core / thin-wiring split: every decision that can be a pure function
+lives in `sw-inbox.ts` beside `anyClientVisible`/`quietNote` (unit-tested),
+and `sw.ts` only wires them (covered by the reviewed inventory). No page-side
+(`notify.ts`, `App.vue`) changes: the ack contract keeps meaning "the page
+owns the *rich* alert", and the SW alone owns the webpushd contract.
+
+## Design (what changes, precisely)
+
+1. **Platform gate** (`sw-inbox.ts`, pure): `platformTrustsSilence(ua)` —
+   true only for confident Chromium-engine UAs (`Chrome/`, `Chromium/`,
+   `HeadlessChrome/`, or `Edg/` token) that are NOT iOS skins
+   (`CriOS|EdgiOS|FxiOS|iPhone|iPad|iPod`). Safari (any OS), Firefox, and
+   unknowns → false. iPadOS "desktop mode" masquerades as macOS Safari →
+   false, the safe direction.
+2. **Silence license** (`sw-inbox.ts`, pure): `mayEndWakeSilently(ua,
+   clients)` = `platformTrustsSilence(ua) && anyClientVisible(clients)`.
+   `anyClientVisible` keeps the focused+visible predicate, gains its
+   why-comment back (both halves: frozen-snapshot distrust AND Chromium's
+   "open and focused" wording), switches to house-style `=== true`, and pins
+   the missing test case.
+3. **Quiet-note split** (`sw.ts`): extract `showQuietNote(kind)` (the bare
+   show, no catch) from `showQuietUnlessVisible(kind)` (matchAll + license
+   check + `showQuietNote`). The swallowing try/catch is removed so failures
+   propagate to `guardedPush` (FR-005). Two carve-outs contain the failure
+   locally per FR-005: the settle-window downgrade call site keeps its outer
+   catch (a loud generic is already accepted and showing there), and the
+   authoritative-drain call site keeps the drain's own catch (a failure there
+   degrades to the preview flow, whose own quiet terminal propagates).
+4. **Post-claim show** (`sw.ts` dispatch): after a successful page claim,
+   `if (!platformTrustsSilence(ua)) await showQuietNote('msg')` — platform-
+   gated only, NOT visibility-gated, so Chromium keeps today's fully-silent
+   claim and WebKit always ends visibly (FR-003).
+5. **Stamp on fulfillment** (`sw-inbox.ts` + `sw.ts`): a pure injectable
+   helper `stampedShow(raw, stamp)` (unit-tested with resolving/rejecting
+   fakes) wraps the platform show so `stamp` runs only on fulfillment and a
+   rejection still surfaces to the caller; `sw.ts` uses it to record
+   `lastNotificationAt` (FR-006).
+6. **Show counts** (`sw-inbox.ts` + `sw.ts`): a pure helper
+   `countAccepted(shows)` (unit-tested) runs show thunks, tolerates
+   individual rejections, and returns the accepted count;
+   `showNotes`/`showConnNotes` are rebuilt on it and return that count.
+   Callers treat 0 as "not visibly ended" and fall through to their
+   quiet/fallback terminal (FR-007). Ordering guard in the settle upgrade
+   arm: the already-accepted generic is closed only AFTER the upgrade shows
+   report accepted > 0 — never destroy the wake's accepted visible ending for
+   a failed upgrade. The authoritative drain still acks its committed frames
+   but ends the wake visibly when the count is 0.
+7. **Docs**: update the stale spec-1034 comment block in `sw-inbox.ts` and
+   the `showQuietUnlessVisible` docs in `sw.ts`; add the amendment pointer to
+   spec 1034 (FR-008).

--- a/specs/2023-push-wakes-always/quickstart.md
+++ b/specs/2023-push-wakes-always/quickstart.md
@@ -1,0 +1,60 @@
+# Quickstart: verifying spec 2023
+
+**Spec**: [spec.md](./spec.md) · **Date**: 2026-07-09
+
+## Unit + typecheck (the CI gates)
+
+```sh
+npx vitest run src/services/sw-quiet.test.ts   # gate + predicate + license tests
+npx vitest run                                  # full suite (871+ tests)
+npm run build                                   # vue-tsc typecheck + vite build
+```
+
+What the tests must pin (see tasks.md for the red-first ordering):
+
+- `platformTrustsSilence`: iOS Safari / CriOS / EdgiOS / FxiOS / macOS Safari
+  / Firefox / empty / garbage → false; desktop+Android Chrome, Chrome-on-macOS,
+  Edge, Samsung Internet → true.
+- `mayEndWakeSilently`: WebKit UA + focused&visible client → false (the
+  regression that motivates this spec); Chromium UA + focused&visible → true;
+  Chromium UA + visible-unfocused → false.
+- `anyClientVisible`: the previously-missing `{visibilityState:'visible'}`
+  (focused absent) → false.
+- `stampedShow`: stamp fires only on fulfillment; a rejecting show never
+  stamps and still rejects for the caller.
+- `countAccepted`: all-reject → 0, mixed → exact count, empty → 0.
+
+## Wake-path inventory (SC-001)
+
+Walk every `return` inside `dispatchPush`/`guardedPush` in `src/sw.ts` against
+[contracts/wake-outcomes.md](./contracts/wake-outcomes.md) and record the
+mapping in the PR description. Every row on the unsafe column must end in a
+`showNotification` call or propagate to the guarded fallback.
+
+## On-device (SC-004, dev iPhone)
+
+1. Deploy the branch build to the dev host (`npm run build`, serve `dist/`
+   via the laptop ringd — see the dev-deployment notes; the installed PWA
+   needs the built client, HMR doesn't reach it).
+2. On the iPhone PWA: open Ring, leave it FOREGROUND, then cut its socket
+   (toggle Wi-Fi off/on quickly, or `make stop` + restart ringd) so the
+   server sees no fresh connection.
+3. From another account, send 5+ messages (each queues a push). Also exercise
+   a Wall post and a friend request (socket-ungated tickles).
+4. Expect: every push yields a visible outcome on the phone — rich note,
+   or the silent "New message"/"New activity" quiet note (check Notification
+   Center; quiet notes don't buzz). No wake may end with nothing.
+5. Afterward the subscription must still be alive: background the app, send
+   another message, the notification arrives. On the dev host the SW
+   surfaces fallback reasons in the notification body (spec 2014) if
+   something failed.
+6. Server-side: `grep "push:" .tmp/ring-dev.log` — sends should stay 201 and
+   the subscription must not get pruned.
+
+## Desktop Chromium regression check
+
+With the app open and focused in Chrome (any OS): send a message from another
+account with the socket severed — no new notification-center entry should
+appear (licensed silence, unchanged). With the window visible but another app
+focused: the silent quiet note is expected (the already-applied predicate
+tightening).

--- a/specs/2023-push-wakes-always/research.md
+++ b/specs/2023-push-wakes-always/research.md
@@ -1,0 +1,118 @@
+# Research: Push Wakes Always End Visibly Where Silence Is Unsafe
+
+**Spec**: [spec.md](./spec.md) · **Date**: 2026-07-09
+
+Phase 0 for this hotfix was performed *before* the spec, as a 20-agent
+adversarially-verified review (platform research against WebKit source, a diff
+review of an externally-proposed fix, an exhaustive silent-path sweep of
+`src/sw.ts`, and a page-ack audit). This file consolidates the decisions.
+
+## D1. Root cause: licensed silences, not a stale-visibility bug
+
+**Decision**: Treat the *licensed* silent endings as the bug. Apple's
+enforcement (verified in WebKit main): webpushd starts a ~30s timer per
+delivered push waiting for `showNotification`; on expiry it increments
+`silentPushCount` (the only write is `+ 1`; no reset API exists); at
+`maxSilentPushCount = 3` ALL of the origin's subscriptions are removed. The
+only exemptions are Web Inspector and declarative web push — there is NO
+visible/focused-page exemption. Chrome, by contrast, documents "the one
+exception is when the user has your site open and focused" and never revokes
+(it shows its own generic fallback instead).
+
+**Rationale**: This mechanism alone explains the persisting revocations
+without any platform bug: pushes arrive while a window is genuinely visible
+(stale-socket foreground for messages; conn/post/post-activity/version tickles
+are not socket-gated at all), the SW legally skips, and three such wakes over
+the subscription's lifetime kill it.
+
+**Alternatives considered**: The externally-proposed diagnosis (frozen iOS
+clients reporting a stale `visibilityState === 'visible'`) is architecturally
+possible (focused/visible travel in one cached ServiceWorkerClientData
+snapshot) but undocumented in the web-push era; the documented modern matchAll
+failure on iOS is an EMPTY list (WebKit bug 268797), which fails in the safe
+direction. The tightened focused+visible predicate is kept (it strictly
+narrows silence and matches Chrome's wording) but is not relied on as the fix.
+
+## D2. Gate by browser engine, not operating system
+
+**Decision**: `platformTrustsSilence(ua)` returns true only for confident
+Chromium-engine UAs (`Chrome/`, `Chromium/`, `HeadlessChrome/`, `Edg/`
+tokens), and false for iOS skins (`CriOS`, `EdgiOS`, `FxiOS`, or any
+`iPhone|iPad|iPod` token), Safari everywhere, Firefox, and anything
+unrecognized.
+
+**Rationale**: The strike counter lives in Apple's push daemon, which only
+WebKit-engine browsers use. Chrome/Edge on macOS run Chromium's engine and
+Chromium's push service, with the documented focused exemption — treating them
+as unsafe would spam the platform the user most likely works on all day, for
+zero safety gain. Every iOS browser is WebKit underneath, so iOS skins gate as
+unsafe. Firefox has its own push quota system with no documented on-page
+exemption → unsafe (over-notifying is harmless there; the note is silent).
+iPadOS "desktop mode" masquerades as macOS Safari → no Chromium token →
+unsafe, the safe direction. Samsung Internet/Opera/Brave carry the `Chrome/`
+token and are genuinely Chromium → safe.
+
+**Alternatives considered**: OS-keyed gating (rejected — misclassifies
+Chrome-on-macOS, see spec Clarifications); feature detection (rejected — no SW
+API distinguishes push-service backends); assuming everything unsafe
+(rejected — needless permanent behavior change for the majority-safe Chromium
+fleet and it erases the documented, deliberate spec-1034 UX on desktop).
+
+## D3. Keep the page-claim handshake; follow it with the quiet note on unsafe platforms
+
+**Decision**: The `pageWillNotify` ack keeps suppressing the SW's *rich*
+notification everywhere. On silence-unsafe platforms the SW additionally shows
+the content-free quiet note after the ack — gated ONLY on the platform, not on
+client visibility, so Chromium's claim outcome stays byte-identical.
+
+**Rationale**: The claim exists to prevent a loud duplicate of the in-app
+banner. Removing it on Apple would replace one silent strike with a loud
+double-announce on every foreground message. The quiet note (silent:true,
+self-replacing tag, no content) satisfies webpushd while staying nearly
+invisible to the user; the app's existing foreground cleanup clears it. This
+also closes the zero-render hidden-chat claim arm by construction, with no
+page-side change and no new page↔SW message.
+
+**Alternatives considered**: Extending the ack protocol with a
+`rendered: boolean` so the SW could show the quiet note only for zero-render
+acks (rejected — on Apple even rendered-banner acks strike, so the
+distinction buys nothing there and adds protocol surface); making the page
+show its own OS notification when claiming (rejected — duplicates SW logic,
+needs Notification permission plumbing in a second place, and the page can be
+killed mid-show).
+
+## D4. Error-path hardening: a failed show is never a shown wake
+
+**Decision**: (a) remove the swallowing catch inside the quiet-note terminal
+so failures propagate to `guardedPush`; (b) stamp `lastNotificationAt` on
+fulfillment of `showNotification`, not at call time; (c) `showNotes` /
+`showConnNotes` return accepted-show counts and a zero count falls through to
+the quiet/fallback terminal (the authoritative drain still acks frames whose
+data is durably committed — the invariant that matters is the wake ending
+visibly, not un-acking committed data).
+
+**Rationale**: All three were confirmed by the review as ways a wake whose
+show attempt FAILED still resolves as "visibly ended", which both ends the
+wake silently and (b) actively suppresses the last-resort fallback whose only
+job is this incident class. They only fire on platform-level show errors
+(mostly permission-revoked, where nothing could show anyway), which is why
+they are hardening rather than the headline fix.
+
+**Alternatives considered**: Un-acking / re-queueing frames on show failure
+(rejected — the frames are durably committed locally; re-delivery would
+double-apply and the preview path would misread consumed ratchet keys as
+decrypt failures — the existing markShown ledger comment documents this).
+
+## D5. Test strategy: pure halves + reviewed inventory
+
+**Decision**: Failing regression tests first (constitution III, hotfix band)
+against the pure decisions in `sw-inbox.ts`: platform gate classification
+table, `mayEndWakeSilently` composition, the previously-unpinned predicate
+case (`{visibilityState:'visible'}`, `focused` absent → false). The `sw.ts`
+wiring is covered by the per-kind × per-platform terminal-outcome contract
+([contracts/wake-outcomes.md](./contracts/wake-outcomes.md)) reviewed as the
+SC-001 inventory, plus the real-device recipe in quickstart.md.
+
+**Rationale**: `sw.ts` imports workbox and SW globals and is not importable
+under vitest; this is the established pattern of specs 1034/2016/2017/2020,
+whose pure halves all live in `sw-inbox.ts` today.

--- a/specs/2023-push-wakes-always/spec.md
+++ b/specs/2023-push-wakes-always/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-09
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: Review of an externally-proposed fix to the spec-1034 visible-client

--- a/specs/2023-push-wakes-always/spec.md
+++ b/specs/2023-push-wakes-always/spec.md
@@ -1,0 +1,286 @@
+# Feature Specification: Push Wakes Always End Visibly Where Silence Is Unsafe
+
+**Feature Branch**: `fix/2023-push-wakes-always`
+
+**Created**: 2026-07-09
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: Review of an externally-proposed fix to the spec-1034 visible-client
+gate, escalated after push deliveries kept dying on iPhones. The review
+verified WebKit's enforcement in source and found the licensed silences —
+not a stale-visibility bug — are what keep revoking subscriptions.
+
+## Why (the persisting incident)
+
+Spec 1034 made every push wake end visibly **unless a Ring window client looks
+visible**, and kept the page-claim handshake (a live page acks that it rendered
+the alert, the service worker stays silent). Both licenses are fatal on Apple
+platforms, and we now know this from WebKit's own source rather than inference:
+
+- Apple grants **no exemption** for "the user is looking at the app". Chrome
+  documents that a focused page may skip the notification; Apple documents the
+  opposite ("Safari doesn't support invisible push notifications… If you
+  don't [show one], Safari revokes"), and webpushd starts a ~30s timer per
+  delivered push waiting for a `showNotification` call.
+- The strike counter is **cumulative for the life of the subscription**:
+  `silentPushCount` is only ever incremented (no reset API exists), and at
+  `maxSilentPushCount = 3` ALL subscriptions for the origin are removed. Three
+  licensed silences, ever, kill the device's notifications until it
+  re-registers.
+- An in-app banner is invisible to webpushd. The page-claim path therefore
+  accrues a strike on every foreground-claimed message wake — and one claim arm
+  (a message for a locked hidden chat while the page is visible) acks having
+  rendered nothing anywhere at all.
+
+The server pushes precisely when the device has no fresh socket — which on
+iPhones routinely includes "app on screen, socket dropped after resume" — and
+the conn/post/post-activity/version tickles are not socket-gated at all, so
+foreground pushes are a designed-in, recurring event, not a corner case.
+
+The review also confirmed three latent error paths where a wake whose
+notification attempt FAILED is still counted as visibly ended, defeating the
+last-resort fallback that exists for exactly that case.
+
+## Clarifications
+
+### Session 2026-07-09
+
+- Q: Is the silence-safe gate decided by operating system (treat everything on
+  Apple hardware as unsafe) or by browser engine (treat every Chromium-engine
+  browser as safe)? → A: By engine. The strike counter lives in Apple's push
+  daemon, which only WebKit-engine browsers use; Chrome/Edge on macOS run
+  Chromium and Chromium's push service on every OS, with Chromium's documented
+  focused-page exemption. So Chrome on macOS keeps the exemption, Safari on
+  macOS does not, and every iOS browser (all WebKit skins, including
+  CriOS/EdgiOS/FxiOS) is unsafe. Resolved from the platform documentation
+  cited in Why; recorded here because the original FR wording said
+  "non-Apple platforms", which reads as OS-based.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - iPhone notifications survive foreground pushes (Priority: P1)
+
+An iPhone user keeps Ring open (or recently open) while messages, friend
+requests, Wall activity, and version announcements arrive. Today each such
+wake can legally end with no visible notification and silently burns one of
+the three lifetime strikes; after the third, the phone never gets another
+notification. After this fix, on Apple platforms every single push wake ends
+with a visible notification — at worst the existing content-free quiet note
+(silent, no sound, self-replacing, no sender or content) — so the strike
+counter never moves.
+
+**Why this priority**: This is the whole incident. Losing push permanently,
+invisibly, with no server-side signal, is the worst notification failure the
+app can have.
+
+**Independent Test**: Unit-test the pure silence-license decisions (platform
+gate and the combined license) with an Apple user agent and a visible, focused
+client — the license must be denied; verify every wake kind's terminal against
+the wake-outcomes contract inventory. On a dev iPhone with the app foregrounded
+and its socket severed, send repeated pushes and confirm notifications keep
+arriving afterward (no revocation).
+
+**Acceptance Scenarios**:
+
+1. **Given** an Apple device with a Ring window visible and focused, **When**
+   a message push arrives and the page claims the alert with an in-app banner,
+   **Then** the service worker still shows the quiet content-free note, and
+   the wake ends visibly.
+2. **Given** an Apple device with a message arriving for a locked hidden chat
+   while the app is visible, **When** the page claims the wake having rendered
+   nothing, **Then** the service worker shows the same content-free quiet note
+   any message produces (no sender, no chat identity, no content).
+3. **Given** an Apple device with the app visibly open, **When** a
+   conn/post/post-activity/version wake has nothing rich to show, **Then** the
+   quiet note is shown rather than skipped.
+
+---
+
+### User Story 2 - Desktop Chromium stays calm (Priority: P2)
+
+A desktop Chromium user actively using Ring does not start seeing redundant
+notification-center entries. Chromium documents that a focused page may skip
+the notification, so on Chromium-engine browsers (desktop including macOS,
+and Android) the existing skip remains —
+gated on a window client that is both **focused and visible** (keeping the
+externally-contributed tightened predicate, now with its rationale documented
+and its missing test pinned).
+
+**Why this priority**: The fix must not trade the iOS incident for a
+notification-spam regression on the platforms that were never at risk.
+
+**Independent Test**: Unit-test the platform gate and predicate: Chromium user
+agents license silence only with a focused+visible client; Apple, iOS-WebKit
+skins (all iOS browsers), Firefox, and unrecognized user agents never license
+silence.
+
+**Acceptance Scenarios**:
+
+1. **Given** a desktop Chromium user agent and a focused, visible Ring window,
+   **When** a wake has nothing rich to show, **Then** the service worker may
+   stay silent (unchanged behavior).
+2. **Given** a desktop Chromium user agent and a Ring window that is visible
+   but NOT focused, **When** such a wake occurs, **Then** the quiet note shows
+   (tightened predicate).
+3. **Given** a Firefox or unrecognized user agent, **When** such a wake
+   occurs, **Then** the quiet note shows (safe default).
+
+---
+
+### User Story 3 - A failed notification can never masquerade as a shown one (Priority: P3)
+
+When the platform rejects or hangs a notification call, the wake must not be
+recorded as visibly ended: the failure propagates so the last-resort generic
+fallback actually fires, and the "a notification was shown during this event"
+record is only made once the platform accepts the show.
+
+**Why this priority**: These are rare error paths, but they sit in the exact
+guard whose only job is preventing the revocation class this spec exists for.
+
+**Independent Test**: Unit-test the show-tracking and show-counting decisions;
+simulate a rejecting notification call and assert the wake either shows the
+fallback or propagates an error (never resolves silently).
+
+**Acceptance Scenarios**:
+
+1. **Given** the quiet-note show itself fails, **When** the wake completes,
+   **Then** the failure reaches the outer guard and the generic fallback is
+   attempted (not swallowed).
+2. **Given** a wake whose every rich-note show was rejected, **When** the wake
+   completes, **Then** it is not counted as visibly ended and terminates via
+   the quiet/fallback path.
+3. **Given** the last-resort guard's record of "shown this event", **When** a
+   show call is made but rejected by the platform, **Then** no record is made
+   and the fallback still fires.
+
+---
+
+### Edge Cases
+
+- **Hidden-chat stealth on silence-unsafe platforms (deliberate trade against
+  spec 1027's FR-012 zero-trace)**: the foreground claim becomes the same content-free
+  "New message" quiet note any message produces — on every silence-unsafe
+  platform (all of WebKit, Firefox, unknowns), not only Apple. It reveals
+  nothing about which chat, from whom, or that hidden chats exist; the
+  alternative on Apple is permanently losing all notifications for the
+  device. Silence-safe (Chromium-engine) platforms keep full zero-trace.
+- **Quiet note while the user is in the app on Apple**: appears silently
+  (no sound/vibration), self-replaces on its tag, and the app's existing
+  foreground cleanup clears it on the next visibility transition. At most one
+  entry lingers; accepted.
+- **Unknown/spoofed user agents**: anything not confidently Chromium-engine
+  is treated like WebKit (always show) — over-notifying is safe on every
+  platform, silence is fatal on some.
+- **Call wakes**: already show unconditionally; unaffected.
+- **Page ack arriving after the wait window**: no claim, service worker shows
+  its own notification — existing behavior, unchanged.
+- **Notification permission revoked at the OS level**: every show call fails;
+  the wake propagates to the outer guard whose fallback also fails — nothing
+  more is possible, and no path reports success.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001** *(amends spec 1034 FR-001)*: A push wake MAY end without a
+  visible notification ONLY when BOTH hold: (a) the platform gate says silence
+  is documented-safe (a Chromium-engine browser, which uses Chromium's push
+  service on every OS it runs on), and (b) a Ring window client is focused AND
+  visible, or a live page claimed the wake. On WebKit-engine platforms (all of
+  iOS, Safari on macOS) and any unrecognized platform, EVERY push wake MUST
+  end with a notification-show call.
+- **FR-002**: The platform gate MUST be a pure, unit-tested decision on the
+  service worker's user agent, keyed on browser engine and defaulting to
+  "silence unsafe" for anything not confidently Chromium-engine: iOS browser
+  skins (CriOS/EdgiOS/FxiOS — WebKit underneath), Safari anywhere, Firefox,
+  and unknowns all count as unsafe; Chrome/Edge on macOS count as safe.
+- **FR-003**: On silence-unsafe platforms, after a page claims a message wake
+  the service worker MUST still show the content-free quiet note (silent,
+  self-replacing tag, no sender/content) within the same wake, before the
+  push event settles — comfortably inside the platform's silent-push timer.
+  This covers the zero-render hidden-chat claim arm by construction. On
+  silence-safe platforms the claim keeps its current fully-silent outcome.
+- **FR-004**: The visible-client predicate remains "focused AND visible",
+  carries a why-comment explaining both conditions, uses the codebase's
+  strict-equality house style, and pins the previously-missing test case
+  (visibility 'visible' with the focused field absent → not visible).
+- **FR-005**: A failure to show the quiet note MUST propagate to the outer
+  push guard whenever the quiet note is the wake's only remaining visible
+  ending, so the last-resort generic fallback runs. Two call sites MAY contain
+  the failure locally because the wake is already visibly ended or re-routed:
+  the settle downgrade of an already-accepted loud generic, and the
+  authoritative-drain degrade (which falls back to the preview flow, whose own
+  quiet terminal propagates).
+- **FR-006**: The outer guard's "a notification was shown during this event"
+  record MUST be made only when the platform accepts the show (on
+  fulfillment), never at call time.
+- **FR-007**: Rich-note and conn-note batch shows MUST report how many
+  notifications were actually accepted; a wake whose count is zero MUST NOT be
+  counted as visibly ended and MUST terminate via the quiet/fallback path. The
+  authoritative drain may still ack its committed frames, but the wake must
+  end visibly.
+- **FR-008**: The superseded requirements gain pointers to this amendment so
+  the documents cannot be read as contradicting: spec 1034's policy section
+  (visible-client license now platform-gated) and spec 1027's FR-012
+  zero-trace behavior (the foreground hidden-chat claim now ends visibly on
+  silence-unsafe platforms).
+
+### Key Entities
+
+- **Platform gate**: pure classification of the service worker's user agent
+  into "silence may be licensed" (Chromium-engine browsers, on any OS) vs
+  "always end visibly" (WebKit, Firefox, and everything unrecognized).
+- **Quiet note**: the existing spec-1034 content-free notification (title/body
+  carry no sender, chat, or content; silent; self-replacing tag). Its content
+  is unchanged by this spec.
+
+## Zero-Knowledge Impact
+
+None on the wire, and none on notification content. The quiet note already
+carries exactly the information the push tickle itself reveals (that
+*something* happened); this spec only shows it in more situations. No server
+changes, no push-payload changes, and no new page↔service-worker message
+types or fields. The platform classification is computed locally per wake and
+is never logged, stored, or transmitted. The hidden-chat trade on
+silence-unsafe platforms discloses no chat identity, sender, or content —
+only the same generic "New message" any message produces.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A code inventory (documented in the PR) shows zero wake
+  terminations on silence-unsafe platforms that do not call notification-show:
+  every dispatch path ends in a rich note, a generic, or the quiet note.
+- **SC-002**: On silence-safe platforms, non-failure behavior is unchanged
+  apart from the already-applied focused+visible tightening; the error-path
+  hardening (a failed show never counts as shown) applies on every platform.
+  Checked by the artifacts the tasks produce: the wake-outcomes inventory's
+  trusted-platform column row-by-row, plus the Chromium rows of the gate
+  truth-table tests.
+- **SC-003**: All pure decisions (platform gate, visible predicate, quiet-note
+  content, show-count handling) are unit-tested, including the previously
+  missing predicate case; `npm run build` and the full unit suite pass.
+- **SC-004**: A dev iPhone with the app foregrounded and a severed socket
+  receiving 5+ pushes still receives notifications afterward (no revocation);
+  validation recipe documented in the PR.
+
+## Assumptions
+
+- The hidden-chat stealth reduction on silence-unsafe platforms (edge case
+  above) is an accepted product decision; it was explicitly approved when this
+  fix was requested.
+- User-agent sniffing inside the service worker is an acceptable and stable
+  platform signal: on iOS every browser is WebKit and uses webpushd, and
+  Chromium ships its engine token on every OS, so the gate only needs to be
+  right about "confidently Chromium-engine vs everything else".
+- Existing foreground cleanup (clearing notifications when the app becomes
+  visible) is sufficient housekeeping for the new quiet notes; no new
+  cleanup mechanism is in scope.
+- Chromium's tolerance of skipped notifications (its own "site updated in the
+  background" fallback, no revocation) continues to hold per its documented
+  push policy.
+- No server-side changes are needed; the server's push-sending policy
+  (socket-gated messages, ungated activity tickles) is out of scope.

--- a/specs/2023-push-wakes-always/tasks.md
+++ b/specs/2023-push-wakes-always/tasks.md
@@ -1,0 +1,204 @@
+# Tasks: Push Wakes Always End Visibly Where Silence Is Unsafe
+
+**Input**: Design documents from `/specs/2023-push-wakes-always/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md,
+contracts/wake-outcomes.md, quickstart.md
+
+**Tests**: REQUIRED and ordered red-first — this is a `2001+` hotfix, so the
+constitution (Principle III) mandates failing regression tests that reproduce
+the bug before the fix lands. The `src/sw.ts` wiring is not importable under
+vitest (workbox + SW globals); per research.md D5 it is covered by the
+[wake-outcomes contract](./contracts/wake-outcomes.md) inventory instead, and
+every pure decision gets red-first unit tests.
+
+**Organization**: Grouped by user story. US1 (always-visible on unsafe
+platforms) is the MVP; US2 (Chromium unchanged) and US3 (failure hardening)
+are independently verifiable increments.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+- [X] T001 Mark spec 2023 `**Status**: in-progress` in
+      specs/2023-push-wakes-always/spec.md and run `make roadmap` (CI guard
+      requires ROADMAP.md to match)
+
+---
+
+## Phase 2: Foundational
+
+*(none — no scaffolding needed; the feature edits existing files only)*
+
+---
+
+## Phase 3: User Story 1 — iPhone notifications survive foreground pushes (P1) 🎯 MVP
+
+**Goal**: On WebKit/unknown platforms every push wake ends with a
+showNotification call; the visible-client skip and the page-claim silence are
+licensed only through the new platform gate.
+
+**Independent Test**: `npx vitest run src/services/sw-quiet.test.ts` — the
+T002 regression cases pass; wake-outcomes contract rows 2/4/8/9/11/13/15/17
+(unsafe column) verified by code inventory.
+
+- [X] T002 [US1] RED: add failing regression tests to
+      src/services/sw-quiet.test.ts importing `platformTrustsSilence` and
+      `mayEndWakeSilently` from `@/services/sw-inbox` (they do not exist yet —
+      the suite must fail): full gate truth table from data-model.md (iOS
+      Safari PWA UA, CriOS, EdgiOS, FxiOS, macOS Safari, Firefox, empty and
+      garbage strings → false; desktop/Android/macOS Chrome, Edge, Samsung
+      Internet → true) and the core regression `mayEndWakeSilently(iOS UA,
+      [{visibilityState:'visible', focused:true}]) === false` plus
+      `mayEndWakeSilently(Chrome UA, same) === true`
+- [X] T003 [US1] GREEN: implement `platformTrustsSilence(ua)` and
+      `mayEndWakeSilently(ua, clients)` as pure exports in
+      src/services/sw-inbox.ts with why-comments (webpushd cumulative 3-strike
+      counter, no reset, no visible-page exemption; engine-keyed per spec
+      Clarifications), and rewrite the stale spec-1034 block comment
+      ("unless a Ring window is actually ON SCREEN") to state the new
+      platform-gated license; T002 tests now pass
+- [X] T004 [US1] Rewire src/sw.ts quiet terminal: split bare
+      `showQuietNote(kind)` out of `showQuietUnlessVisible(kind)`; license the
+      skip via `mayEndWakeSilently(self.navigator.userAgent, clients)`; remove
+      the swallowing try/catch so a failed quiet show propagates to
+      guardedPush (FR-005); update the function doc comment and the
+      "user is looking at Ring — silence is honest here" inline comment to the
+      platform-gated semantics
+- [X] T005 [US1] Add the post-claim visible ending in src/sw.ts dispatchPush:
+      after `pageWillNotify` returns true, on
+      `!platformTrustsSilence(self.navigator.userAgent)` show the quiet note
+      unconditionally (platform-gated ONLY, not visibility-gated, per FR-003 —
+      Chromium claim outcome stays byte-identical); comment why this also
+      closes the zero-render hidden-chat claim arm (notify.ts:386, the spec
+      1027 FR-012 zero-trace trade documented in spec 2023 edge cases)
+
+**Checkpoint**: US1 alone fixes the live incident class on iPhones.
+
+---
+
+## Phase 4: User Story 2 — Desktop Chromium stays calm (P2)
+
+**Goal**: Chromium-engine behavior unchanged except the already-applied
+focused+visible tightening, which gets its rationale, house style, and
+missing test pinned (FR-004).
+
+**Independent Test**: gate truth-table Chromium rows from T002 pass;
+`anyClientVisible` truth table fully pinned; wake-outcomes rows 2–17
+(trusted column) verified by inventory — non-failure behavior unchanged; the
+zero-accepted variants are the US3 hardening and apply on every platform.
+
+- [X] T006 [P] [US2] Pin the missing predicate case in
+      src/services/sw-quiet.test.ts: `anyClientVisible([{visibilityState:
+      'visible'}])` (focused ABSENT) → false — kills the `?? true` mutant that
+      passes today's suite — and `anyClientVisible([{visibilityState:'hidden',
+      focused:true}])` → false; retitle the misnamed test ("a hidden/frozen
+      background client…") so the visible-but-unfocused case is named by a
+      test of its own
+- [X] T007 [P] [US2] Restore the deleted why-comment on `anyClientVisible` in
+      src/services/sw-inbox.ts covering BOTH halves (frozen-snapshot distrust
+      of matchAll attributes AND Chromium's documented "open and focused"
+      exemption wording) and switch `(c.focused ?? false)` to house-style
+      `c.focused === true` (behavior-identical; verified by the truth-table
+      tests)
+
+**Checkpoint**: externally-contributed predicate is fully adopted: rationale,
+style, tests.
+
+---
+
+## Phase 5: User Story 3 — A failed notification can never masquerade as a shown one (P3)
+
+**Goal**: A rejected/hung showNotification is never recorded as a show, and a
+wake whose every show failed still ends visibly or reaches the guarded
+fallback (FR-006, FR-007).
+
+**Independent Test**: wake-outcomes contract rows 18–19 and the
+zero-accepted variants of rows 3/5/10/12/14 verified by inventory; full
+vitest suite + `npm run build` green.
+
+- [X] T008 [US3] RED: add failing unit tests to
+      src/services/sw-quiet.test.ts for two pure helpers imported from
+      `@/services/sw-inbox` that do not exist yet (the suite must fail):
+      `stampedShow(raw, stamp)` — returns a show function where `stamp` runs
+      ONLY when `raw`'s promise fulfills (rejecting raw → stamp NOT called
+      and the rejection still reaches the caller; resolving raw → stamped),
+      and `countAccepted(shows)` — runs an array of async show thunks,
+      tolerates individual rejections, returns the number that fulfilled
+      (all-reject → 0, mixed → exact count, empty → 0)
+- [X] T009 [US3] GREEN: implement `stampedShow` and `countAccepted` as pure
+      exports in src/services/sw-inbox.ts with why-comments (FR-006: a show
+      is only "shown" once the platform accepts it — a rejected show must not
+      suppress the last-resort fallback; FR-007: a batch's visible outcome is
+      its ACCEPTED count); T008 tests pass
+- [X] T010 [US3] Wire src/sw.ts: replace the call-time `lastNotificationAt`
+      assignment with `stampedShow(rawShow, stamp)` preserving the
+      reassignment-blocked fallback comment (FR-006); rebuild `showNotes` and
+      `showConnNotes` on `countAccepted` so both return the accepted count
+      (per-tag sig saves stay best-effort after each accepted show); update
+      callers per the wake-outcomes failure semantics: the initial arm of
+      `showMessageNotification` sets `shownAny` from count > 0; the settle
+      UPGRADE arm closes the already-accepted generic only AFTER the upgrade
+      shows report accepted > 0 (never destroy the wake's accepted visible
+      ending for a failed upgrade — do NOT touch `shownAny` there, it is only
+      read before the settle block); `tryAuthoritativeDrain` ends via the
+      quiet terminal when `!r.notes.length || accepted === 0` (still acks
+      committed frames per research D4); post-activity sets `shownActivity`
+      from count > 0; `showConnNotification`/`showPostNotification` fall
+      through to their generic placeholder when notes existed but zero were
+      accepted (FR-007)
+
+**Checkpoint**: all three latent error-class silent paths from the review are
+closed, each pinned by a unit test on its pure half.
+
+---
+
+## Phase 6: Polish & Gates
+
+- [X] T011 [P] Append the FR-008 amendment pointers, both linking to
+      specs/2023-push-wakes-always/spec.md: (a) in
+      specs/1034-every-push-wake/spec.md "Policy (FR-001)" section, one short
+      paragraph noting spec 2023 supersedes the visible-client license
+      (platform-gated silence; focused AND visible; page-claim followed by
+      the quiet note on silence-unsafe platforms); (b) in
+      specs/1027-harden-hidden-chats/spec.md at FR-012 (the foreground
+      zero-trace claim — the arm at notify.ts:386 whose comment cites 1027
+      FR-012), a note that on silence-unsafe platforms the claim now ends
+      with the content-free quiet note per spec 2023
+- [X] T012 Walk every terminal in src/sw.ts dispatchPush/guardedPush against
+      contracts/wake-outcomes.md and record the row-by-row inventory (SC-001)
+      in specs/2023-push-wakes-always/inventory.md for the PR description
+- [X] T013 Run the full gates: `npx vitest run` (all suites) and
+      `npm run build` (vue-tsc + vite) — both green (SC-003). No NEW e2e spec
+      per the plan's documented Principle-III deviation (Playwright cannot
+      deliver Web Push to the SW); the existing notification e2e suites run
+      in CI on push and must stay green
+- [ ] T014 Real-device validation per quickstart.md on the dev iPhone
+      (SC-004): foreground + severed socket, 5+ pushes, every wake visible,
+      subscription alive afterward — MANUAL, requires the physical device;
+      may complete after the PR opens
+
+## Dependencies
+
+- T001 → everything (roadmap guard)
+- T002 (RED) → T003 (GREEN) → T004 → T005 (same files, strict order)
+- T006/T007 [P] after T003 (same test/source files as US1 but distinct
+  regions; parallel with each other, sequential with T004/T005 edits to
+  sw-inbox.ts only via T007)
+- T008 (RED) → T009 (GREEN) → T010; T010 after T004/T005 (edits src/sw.ts —
+  sequential with US1 wiring)
+- T011 [P] anytime; T012 after T010; T013 after all code tasks; T014 last
+
+## Issue Mapping
+
+T001 #908 · T002 #909 · T003 #910 · T004 #911 · T005 #912 · T006 #913 ·
+T007 #914 · T008 #915 · T009 #916 · T010 #917 · T011 #918 · T012 #919 ·
+T013 #920 · T014 #921 — the feature → `develop` PR must list `Closes #N`
+for each (constitution VIII).
+
+## Implementation Strategy
+
+US1 is the MVP and the incident fix; it is deliverable alone. US2 is mostly
+adoption polish of the already-applied predicate. US3 is defense-in-depth in
+the same wiring. Single PR: the phases land as ordered commits on
+`fix/2023-push-wakes-always`, red tests first within each story.

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -492,17 +492,54 @@ export function mergeIntoSummary(prev: ShownSummary | undefined, note: SwNote, n
  * whenever the coalesced content hasn't changed. The signature records what the user
  * last SAW per tag (body + cumulative count); an identical re-assert is skipped —
  * the same iOS-tolerated outcome class as the mute/badge-only paths. ---- */
-/* ---- spec 1034: the no-silent-pushes policy's pure halves. iOS revokes a push
- * subscription whose service worker repeatedly consumes a wake without showing a
- * notification (the "zombie": the push service keeps accepting sends, the device
- * never wakes again — observed live on a dev iPhone). So EVERY wake must end
- * visibly unless a Ring window is actually ON SCREEN. ---- */
+/* ---- spec 1034 + 2023: the no-silent-pushes policy's pure halves. iOS revokes a
+ * push subscription whose service worker repeatedly consumes a wake without
+ * showing a notification (the "zombie": the push service keeps accepting sends,
+ * the device never wakes again — observed live on a dev iPhone). WebKit's
+ * enforcement is unforgiving: webpushd counts every no-notification wake into a
+ * CUMULATIVE per-subscription strike counter (three strikes for the life of the
+ * subscription, no reset ever, and NO exemption for a page being on screen —
+ * verified in WebKit source). Chromium is the opposite: it documents that a
+ * focused page may skip the notification and never revokes. So a silent outcome
+ * must be licensed TWICE — by the platform (spec 2023) and by the client state
+ * (spec 1034) — and everywhere the platform is untrusted, every wake ends
+ * visibly, at worst with the content-free quiet note below. ---- */
 
-/** Does any window client license a silent outcome? Only a truly VISIBLE one —
- *  a frozen/background PWA still appears in matchAll() (the norm on iOS) but
- *  shows the user nothing, which is exactly the state that accrues strikes. */
-export function anyClientVisible(clients: readonly { visibilityState?: string }[]): boolean {
-  return clients.some((c) => c.visibilityState === 'visible');
+/** May this browser EVER end a push wake silently? Keyed on the browser ENGINE,
+ *  not the OS: the strike counter lives in Apple's push daemon, which only
+ *  WebKit-engine browsers use, while Chromium runs its own push service on every
+ *  OS it ships on (including macOS) with the documented "site open and focused"
+ *  exemption. iOS browser skins (CriOS/EdgiOS/FxiOS) are WebKit underneath, so
+ *  they gate as unsafe despite their Chromium-ish names. Anything unrecognized is
+ *  unsafe too — the costs are asymmetric: a false "unsafe" shows one extra silent
+ *  notification, a false "safe" can permanently kill the subscription. */
+export function platformTrustsSilence(ua: string): boolean {
+  if (/\b(?:CriOS|EdgiOS|FxiOS)\//.test(ua)) return false; // iOS skins carry Chromium-ish tokens but run WebKit
+  if (/\b(?:iPhone|iPad|iPod)\b/.test(ua)) return false; // every iOS browser is WebKit → webpushd
+  return /\b(?:Chrome|Chromium|HeadlessChrome|Edg)\/\d/.test(ua);
+}
+
+/** Does any window client's state license a silent outcome? Only one that is
+ *  BOTH focused AND visible: a frozen/background PWA still appears in matchAll()
+ *  with cached attribute snapshots (the norm on iOS) while showing the user
+ *  nothing — exactly the state that accrues strikes — and Chromium's documented
+ *  exemption wording is "open and focused", not merely visible. Missing fields
+ *  fail closed (an absent `focused` must never fall back to the old
+ *  visibility-only license). Client state alone is HALF the license — the
+ *  platform gate above is the other half (see mayEndWakeSilently). */
+export function anyClientVisible(clients: readonly { visibilityState?: string; focused?: boolean }[]): boolean {
+  return clients.some((c) => c.focused === true && c.visibilityState === 'visible');
+}
+
+/** The ONE license to end a push wake silently (spec 2023, amending 1034 FR-001):
+ *  the platform must tolerate silence AND a Ring window must be focused+visible.
+ *  On WebKit, Firefox, and unknown engines this is always false — every wake ends
+ *  visibly there, no matter what the client list claims. */
+export function mayEndWakeSilently(
+  ua: string,
+  clients: readonly { visibilityState?: string; focused?: boolean }[],
+): boolean {
+  return platformTrustsSilence(ua) && anyClientVisible(clients);
 }
 
 /** The content-free notification shown when the rich path has nothing it may
@@ -517,6 +554,45 @@ export function quietNote(kind: 'msg' | 'activity'): {
   return kind === 'msg'
     ? { title: 'New message', options: { body: 'You have a new message.', tag: 'ring-incoming', silent: true, renotify: false } }
     : { title: 'Ring', options: { body: 'New activity', tag: 'ring-incoming', silent: true, renotify: false } };
+}
+
+/** (spec 2023 FR-006) Wrap the platform's show call so `stamp` records it only
+ *  once the platform ACCEPTS it. The guarded last-resort fallback's whole job is
+ *  showing something when a wake's show FAILED — a stamp at call time records a
+ *  rejected (or hung) show as shown and suppresses that fallback, inverting its
+ *  "on any doubt, show" intent. The rejection still reaches the caller unchanged;
+ *  only the stamp is withheld. */
+export function stampedShow<A extends unknown[]>(
+  raw: (...args: A) => Promise<void>,
+  stamp: () => void,
+): (...args: A) => Promise<void> {
+  return (...args: A) => {
+    const p = raw(...args);
+    // Stamp on fulfillment only; the noop rejection handler keeps this DERIVED
+    // promise from surfacing an unhandled rejection — the caller still observes
+    // the original `p` reject.
+    p.then(stamp, () => {});
+    return p;
+  };
+}
+
+/** (spec 2023 FR-007) Run a batch of show attempts, tolerating individual
+ *  failures; the batch's visible outcome is how many the platform ACCEPTED.
+ *  Callers treat 0 as "this wake has not ended visibly" and fall through to
+ *  their quiet/fallback terminal instead of reporting a shown wake that never
+ *  was (the pre-2023 bug: per-note catches made an all-rejected batch count as
+ *  a visible ending, and the drain then acked frames nothing ever displayed). */
+export async function countAccepted(shows: ReadonlyArray<() => Promise<unknown>>): Promise<number> {
+  let accepted = 0;
+  for (const show of shows) {
+    try {
+      await show();
+      accepted++;
+    } catch {
+      /* one rejection must not kill the rest of the batch */
+    }
+  }
+  return accepted;
 }
 
 export interface ShownSig {

--- a/src/services/sw-quiet.test.ts
+++ b/src/services/sw-quiet.test.ts
@@ -1,21 +1,84 @@
-// Spec 1034 — the pure halves of the no-silent-pushes policy: the visible-client
-// test that licenses a silent outcome, and the content-free quiet note shown when
-// the rich path has nothing it may display.
+// Spec 1034 + 2023 — the pure halves of the no-silent-pushes policy: the platform
+// gate and visible-client test that together license a silent outcome, and the
+// content-free quiet note shown when the rich path has nothing it may display.
 import { describe, it, expect } from 'vitest';
-import { anyClientVisible, quietNote } from './sw-inbox';
+import { anyClientVisible, quietNote, platformTrustsSilence, mayEndWakeSilently, stampedShow, countAccepted } from './sw-inbox';
+
+// Real-world user agents for the platform gate's truth table (spec 2023 FR-002).
+const UA = {
+  iphonePwa: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+  iphoneSafari: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+  ipad: 'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+  chromeIos: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+  edgeIos: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/125.0.2535.72 Version/17.0 Mobile/15E148 Safari/604.1',
+  firefoxIos: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/126.0 Mobile/15E148 Safari/605.1.15',
+  macSafari: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+  macChrome: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+  winChrome: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+  winEdge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0',
+  androidChrome: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.113 Mobile Safari/537.36',
+  androidSamsung: 'Mozilla/5.0 (Linux; Android 14; SAMSUNG SM-S921B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/24.0 Chrome/117.0.0.0 Mobile Safari/537.36',
+  headlessChrome: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/125.0.0.0 Safari/537.36',
+  firefoxDesktop: 'Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0',
+};
+
+describe('spec 2023: platformTrustsSilence', () => {
+  it('every WebKit consumer of webpushd is unsafe: iOS in all its skins, and Safari on macOS', () => {
+    // The strike counter (3 cumulative silent pushes, no reset, no visible-page
+    // exemption) lives in Apple's push daemon — silence is never safe there.
+    for (const ua of [UA.iphonePwa, UA.iphoneSafari, UA.ipad, UA.chromeIos, UA.edgeIos, UA.firefoxIos, UA.macSafari]) {
+      expect(platformTrustsSilence(ua)).toBe(false);
+    }
+  });
+  it('Chromium engine is trusted on every OS it runs on, including macOS', () => {
+    // Chromium uses its own push service everywhere and documents the
+    // "site open and focused" exemption.
+    for (const ua of [UA.macChrome, UA.winChrome, UA.winEdge, UA.androidChrome, UA.androidSamsung, UA.headlessChrome]) {
+      expect(platformTrustsSilence(ua)).toBe(true);
+    }
+  });
+  it('Firefox, empty, and unrecognized user agents fail to the safe direction', () => {
+    for (const ua of [UA.firefoxDesktop, '', 'Some Future Browser/1.0']) {
+      expect(platformTrustsSilence(ua)).toBe(false);
+    }
+  });
+});
+
+describe('spec 2023: mayEndWakeSilently', () => {
+  const focusedVisible = [{ visibilityState: 'visible', focused: true }];
+  it('an iPhone with a focused, visible Ring window still may NOT end a wake silently (the regression this spec exists for)', () => {
+    expect(mayEndWakeSilently(UA.iphonePwa, focusedVisible)).toBe(false);
+  });
+  it('a Chromium browser with a focused, visible window keeps the documented exemption', () => {
+    expect(mayEndWakeSilently(UA.winChrome, focusedVisible)).toBe(true);
+  });
+  it('a Chromium browser with a visible but unfocused window does not license silence', () => {
+    expect(mayEndWakeSilently(UA.winChrome, [{ visibilityState: 'visible', focused: false }])).toBe(false);
+  });
+});
 
 describe('spec 1034: anyClientVisible', () => {
   it('no clients → not visible (fully closed app must always show)', () => {
     expect(anyClientVisible([])).toBe(false);
   });
   it('a hidden/frozen background client does NOT license silence', () => {
-    expect(anyClientVisible([{ visibilityState: 'hidden' }])).toBe(false);
+    expect(anyClientVisible([{ visibilityState: 'hidden', focused: false }])).toBe(false);
+    expect(anyClientVisible([{ visibilityState: 'hidden', focused: true }])).toBe(false); // focus alone is not on-screen
   });
-  it('a visible client licenses a silent outcome', () => {
-    expect(anyClientVisible([{ visibilityState: 'hidden' }, { visibilityState: 'visible' }])).toBe(true);
+  it('a visible but UNFOCUSED window does NOT license silence', () => {
+    // The stale-snapshot case the focused-AND-visible tightening exists for, and
+    // Chromium's exemption wording is "open and focused", not merely visible.
+    expect(anyClientVisible([{ visibilityState: 'visible', focused: false }])).toBe(false);
   });
-  it('clients without a visibilityState (older platforms) count as not visible', () => {
+  it('a visible and focused client licenses a silent outcome', () => {
+    expect(anyClientVisible([{ visibilityState: 'hidden', focused: false }, { visibilityState: 'visible', focused: true }])).toBe(true);
+  });
+  it('clients missing either field (older platforms) fail closed', () => {
     expect(anyClientVisible([{}])).toBe(false);
+    expect(anyClientVisible([{ focused: true }])).toBe(false);
+    // visibilityState present but `focused` absent must NOT fall back to the old
+    // visibility-only license — this pins the fail-closed default.
+    expect(anyClientVisible([{ visibilityState: 'visible' }])).toBe(false);
   });
 });
 
@@ -38,5 +101,47 @@ describe('spec 1034: quietNote', () => {
       expect(n.options.tag).toBe('ring-incoming');
       expect(n.options.renotify).toBe(false);
     }
+  });
+});
+
+describe('spec 2023: stampedShow (a show is only "shown" once the platform accepts it)', () => {
+  it('stamps exactly once when the platform accepts the show', async () => {
+    let stamps = 0;
+    const show = stampedShow(() => Promise.resolve(), () => { stamps++; });
+    await show();
+    expect(stamps).toBe(1);
+  });
+  it('a REJECTED show never stamps, and the rejection still reaches the caller', async () => {
+    let stamps = 0;
+    const show = stampedShow(() => Promise.reject(new Error('permission revoked')), () => { stamps++; });
+    await expect(show()).rejects.toThrow('permission revoked');
+    expect(stamps).toBe(0);
+  });
+  it('passes its arguments through to the raw show', async () => {
+    const seen: unknown[] = [];
+    const show = stampedShow((...args: unknown[]) => { seen.push(args); return Promise.resolve(); }, () => {});
+    await show('Title', { tag: 't' });
+    expect(seen).toEqual([['Title', { tag: 't' }]]);
+  });
+});
+
+describe('spec 2023: countAccepted (a batch\'s visible outcome is its accepted count)', () => {
+  it('empty batch → 0', async () => {
+    expect(await countAccepted([])).toBe(0);
+  });
+  it('every show rejected → 0 (the wake has NOT ended visibly)', async () => {
+    expect(await countAccepted([
+      () => Promise.reject(new Error('a')),
+      () => Promise.reject(new Error('b')),
+    ])).toBe(0);
+  });
+  it('a mixed batch counts only the accepted shows, and one rejection never kills the rest', async () => {
+    const order: string[] = [];
+    expect(await countAccepted([
+      () => { order.push('one'); return Promise.resolve(); },
+      () => { order.push('two'); return Promise.reject(new Error('mid-batch')); },
+      () => { order.push('three'); return Promise.resolve(); },
+    ])).toBe(2);
+    expect(order).toEqual(['one', 'two', 'three']);
   });
 });

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -23,7 +23,7 @@ import { ExpirationPlugin } from 'workbox-expiration';
 import {
   previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, previewPosts, previewPostActivity, markConnShown,
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
-  anyClientVisible, quietNote, stampPushWake,
+  mayEndWakeSilently, platformTrustsSilence, quietNote, stampPushWake, stampedShow, countAccepted,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
@@ -177,10 +177,13 @@ const titleWithCount = (n: SwNote): string => {
 /** Show the decrypted rich notes (one updating notification per conversation). Coalesces each note
  *  against the persisted per-chat summary first (spec 2017) so the title count is the cumulative
  *  backlog and overlapping burst wakes converge on ONE notification instead of a jumpy/duplicate pile.
- *  Callers run this inside the serialize lock so the summary read→write can't interleave. */
-async function showNotes(notes: SwNote[]): Promise<void> {
+ *  Callers run this inside the serialize lock so the summary read→write can't interleave.
+ *  Returns how many shows the platform ACCEPTED (spec 2023 FR-007): a wake whose every
+ *  show was rejected has NOT ended visibly — the caller must fall through to its
+ *  quiet/fallback terminal instead of counting this batch as a visible ending. */
+async function showNotes(notes: SwNote[]): Promise<number> {
   const coalesced = await coalesceForShow(notes, Date.now());
-  for (const n of coalesced) {
+  return countAccepted(coalesced.map((n) => async () => {
     try {
       await self.registration.showNotification(titleWithCount(n), {
         body: n.body,
@@ -191,35 +194,52 @@ async function showNotes(notes: SwNote[]): Promise<void> {
         // for "nothing new" uses reassertFromSummary below, which sets renotify:false)
         data: { url: n.url },
       });
-      // Record what the user SAW on this tag (spec 2020), so a later nothing-new
-      // wake can tell "identical re-assert" (skip) from "content changed" (show).
-      await saveShownSig(n.tag, { body: n.body, count: n.count ?? n.ids.length, ts: Date.now() });
     } catch (e) {
       console.warn('[sw] showNotification failed', e);
+      throw e; // rethrow so countAccepted doesn't count a rejected show
     }
-  }
+    // Record what the user SAW on this tag (spec 2020), so a later nothing-new
+    // wake can tell "identical re-assert" (skip) from "content changed" (show).
+    // Best-effort AFTER the accepted show: a sig bookkeeping failure must not
+    // make an on-screen notification count as not-shown.
+    try {
+      await saveShownSig(n.tag, { body: n.body, count: n.count ?? n.ids.length, ts: Date.now() });
+    } catch {
+      /* sig is bookkeeping only */
+    }
+  }));
 }
 
-/** (spec 1034) Show the content-free QUIET generic — the terminal fallback that
+/** (spec 1034/2023) The content-free QUIET generic — the terminal fallback that
  *  keeps the Web Push userVisibleOnly contract when the rich path has nothing it
- *  may display. Skipped only when a Ring window is truly on screen. iOS revokes
- *  subscriptions that repeatedly consume a wake without showing anything (the
- *  "zombie" — Apple keeps accepting sends with 201, the device never wakes
- *  again; observed live), so silence is never an outcome while the app is away. */
+ *  may display. Deliberately NO catch here (spec 2023 FR-005): when this is the
+ *  wake's only visible ending, a failure must reach guardedPush so the
+ *  last-resort generic runs — a swallowed failure here IS a silent push, and
+ *  guardedPush cannot see a failure that never propagates. The two call sites
+ *  where the wake is already visibly ended or re-routed (the settle downgrade of
+ *  an accepted loud generic; the authoritative-drain degrade) contain it locally
+ *  via their own existing catches. */
+async function showQuietNote(kind: 'msg' | 'activity'): Promise<void> {
+  const n = quietNote(kind);
+  await self.registration.showNotification(n.title, {
+    ...n.options,
+    icon: ICON,
+    badge: BADGE,
+    data: { url: kind === 'msg' ? '/tabs/chats' : '/' },
+  });
+}
+
+/** (spec 2023, amending 1034) Show the quiet generic unless silence is LICENSED,
+ *  which now takes the platform AND the client state: only a Chromium-engine
+ *  browser (whose push service documents the focused-page exemption and never
+ *  revokes) may skip, and only when a Ring window is focused AND visible. On
+ *  WebKit — where webpushd's cumulative three-strike counter has NO on-screen
+ *  exemption — plus Firefox and anything unrecognized, every wake ends visibly
+ *  no matter what the client list claims. */
 async function showQuietUnlessVisible(kind: 'msg' | 'activity'): Promise<void> {
-  try {
-    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
-    if (anyClientVisible(clients)) return; // user is looking at Ring — silence is honest here
-    const n = quietNote(kind);
-    await self.registration.showNotification(n.title, {
-      ...n.options,
-      icon: ICON,
-      badge: BADGE,
-      data: { url: kind === 'msg' ? '/tabs/chats' : '/' },
-    });
-  } catch (e) {
-    console.warn('[sw] quiet generic failed', e);
-  }
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+  if (mayEndWakeSilently(self.navigator.userAgent, clients)) return; // licensed: trusted platform + focused & visible window
+  await showQuietNote(kind);
 }
 
 /** Close any lingering notifications with a given tag (used to clear the generic
@@ -391,9 +411,9 @@ async function showPostNotification(): Promise<number> {
   if (notes.length) {
     // notes carry "<author> · posted on their Wall" (or the urgent challenge
     // line when the SW could unseal a game post, spec 0009); reuse the
-    // conn-note renderer (same shape).
-    await showConnNotes(notes);
-    return newCount;
+    // conn-note renderer (same shape). Zero ACCEPTED shows (spec 2023 FR-007)
+    // falls through to the generic placeholder below.
+    if ((await showConnNotes(notes)) > 0) return newCount;
   }
   await self.registration.showNotification('Ring', {
     body: 'New activity on your Wall',
@@ -405,9 +425,11 @@ async function showPostNotification(): Promise<number> {
   return newCount;
 }
 
-/** Show the generic friend-request notifications (identity-safe; no decryption). */
-async function showConnNotes(notes: ConnNote[]): Promise<void> {
-  for (const n of notes) {
+/** Show the generic friend-request notifications (identity-safe; no decryption).
+ *  Returns the ACCEPTED show count (spec 2023 FR-007) — callers fall through to
+ *  their placeholder/quiet terminal when it is zero. */
+async function showConnNotes(notes: ConnNote[]): Promise<number> {
+  return countAccepted(notes.map((n) => async () => {
     try {
       await self.registration.showNotification(n.title, {
         body: n.body,
@@ -419,8 +441,9 @@ async function showConnNotes(notes: ConnNote[]): Promise<void> {
       });
     } catch (e) {
       console.warn('[sw] conn showNotification failed', e);
+      throw e; // rethrow so countAccepted doesn't count a rejected show
     }
-  }
+  }));
 }
 
 /**
@@ -441,9 +464,12 @@ async function showConnNotification(): Promise<number> {
     /* fall through to the placeholder below */
   }
   if (notes.length) {
-    await showConnNotes(notes);
+    const accepted = await showConnNotes(notes);
     await markConnShown(notes.flatMap((n) => n.keys));
-    return pendingIncoming;
+    // Zero ACCEPTED shows (spec 2023 FR-007) → the wake has not ended visibly;
+    // fall through to the generic placeholder below (the reconcile state stays
+    // marked — it is bookkeeping, not visibility).
+    if (accepted > 0) return pendingIncoming;
   }
   // Couldn't reconcile (offline / already-seen) but a tickle implies activity →
   // a single generic placeholder keeps the userVisibleOnly contract.
@@ -473,9 +499,10 @@ async function tryAuthoritativeDrain(): Promise<boolean> {
       const r = await drainPersistPending();
       if (r.mode === 'degrade') return false; // includes 'no-frames' — the preview
       // path owns the nothing-new / re-assert behavior (spec 2016/2017).
+      let accepted = 0;
       if (r.notes.length) {
         await closeByTag(GENERIC_TAG);
-        await showNotes(r.notes);
+        accepted = await showNotes(r.notes);
       }
       // Mark applied frames in the preview ledger too: if the ack below fails they
       // linger in the queue, and the preview path must not re-decrypt them (their
@@ -485,9 +512,14 @@ async function tryAuthoritativeDrain(): Promise<boolean> {
       if (r.deferred > 0) return false; // preview flow handles the deferred remainder
       // Fully handled: applied rows are already in unreadCount(), nothing pending.
       await updateAppBadge(0);
-      // (spec 1034) Persisted + acked but produced no notes (every frame was for a
-      // muted/hidden/badge-only chat): the wake still needs a visible ending.
-      if (!r.notes.length) await showQuietUnlessVisible('msg');
+      // (spec 1034/2023) Persisted + acked but nothing made it on screen — every
+      // frame was for a muted/hidden/badge-only chat, or every show was REJECTED
+      // (FR-007): either way the wake still needs a visible ending. The frames
+      // stay acked (they are durably committed locally); only the visibility is
+      // owed. A failure of the quiet note itself is contained by this function's
+      // catch, which degrades to the preview flow — whose own quiet terminal
+      // propagates (FR-005 carve-out).
+      if (!r.notes.length || accepted === 0) await showQuietUnlessVisible('msg');
       return true;
     });
   } catch (e) {
@@ -526,9 +558,11 @@ async function showMessageNotification(): Promise<void> {
   let shownAny = false; // spec 1034: track whether THIS wake produced anything visible
   if (result.notes.length) {
     await closeByTag(GENERIC_TAG); // clear any earlier generic before the rich note
-    await showNotes(result.notes);
+    const accepted = await showNotes(result.notes);
     await markShown(allIds(result.notes)); // only mark what we displayed
-    shownAny = true;
+    // (spec 2023 FR-007) an all-rejected batch is NOT a visible ending — leaving
+    // shownAny false routes this wake to the quiet terminal below.
+    shownAny = accepted > 0;
   } else if (timedOut || (!result.suppressed && !result.silenced && result.newUnshown)) {
     // Show the generic placeholder ONLY when there's a genuinely-new message we couldn't render: a
     // slow cold-start decrypt still in flight at the deadline (timedOut), a fetched-but-undecryptable
@@ -563,9 +597,14 @@ async function showMessageNotification(): Promise<void> {
     ]);
     pending = full.pending || pending;
     if (shownGeneric && full.notes.length) {
-      await closeByTag(GENERIC_TAG); // upgrade: drop the placeholder…
-      await showNotes(full.notes); // …show the real sender + text…
-      await markShown(allIds(full.notes)); // …and don't re-preview them next push
+      // Upgrade the placeholder to the real sender + text. Show FIRST, close the
+      // generic only once a rich note was actually ACCEPTED (spec 2023 FR-007):
+      // closing first and then failing every show would destroy the wake's only
+      // accepted visible ending. The brief rich+generic overlap is harmless —
+      // different tags, and the generic is closed the next instant.
+      const upgraded = await showNotes(full.notes);
+      if (upgraded > 0) await closeByTag(GENERIC_TAG);
+      await markShown(allIds(full.notes)); // don't re-preview them next push
     } else if (shownGeneric && full.silenced) {
       // A SLOW cold start showed the loud generic before the decrypt settled; the
       // settled result says every pending message was per-chat silenced. Spec 1034:
@@ -734,8 +773,8 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         if (!clients.length && (await setting('notifications.wall.activity', true))) {
           const notes = await previewPostActivity(post ?? '');
           if (notes.length) {
-            await showConnNotes(notes);
-            shownActivity = true;
+            // (spec 2023 FR-007) only ACCEPTED shows end the wake visibly.
+            shownActivity = (await showConnNotes(notes)) > 0;
           }
         }
         // (spec 1034) Toggle off, frozen client, or a removal that previews to zero
@@ -766,7 +805,19 @@ async function dispatchPush(event: PushEvent): Promise<void> {
       // 1200ms — comfortably above the page's own DRAIN_ACK_WINDOW so a page that will
       // show a banner reliably claims it, while a hidden/locked/frozen page (which
       // never acks) still falls through to the SW promptly enough.
-      if (clients.length && (await pageWillNotify(clients, 2200))) return;
+      if (clients.length && (await pageWillNotify(clients, 2200))) {
+        // (spec 2023 FR-003) The page owns the RICH alert, but an in-app banner is
+        // invisible to webpushd: on platforms where silence is unsafe, a claimed
+        // wake still counts a strike unless the SW shows something. And one claim
+        // arm shows nothing anywhere — a message for a locked hidden chat on a
+        // visible page (notify.ts, the spec-1027 FR-012 zero-trace claim) — so the
+        // quiet note is the wake's only visible ending there. Platform-gated ONLY
+        // (never visibility-gated): the Chromium claim outcome stays exactly as
+        // before, and the quiet note's content-free body keeps the hidden-chat
+        // trade bounded to what any message push already reveals.
+        if (!platformTrustsSilence(self.navigator.userAgent)) await showQuietNote('msg');
+        return;
+      }
       // Spec 1032: with sw.fullPersist on (and no page claiming the wake), persist
       // + ack eligible frames right now so the app opens warm. Any degrade — and
       // any deferred remainder — falls through to today's preview flow.
@@ -799,9 +850,11 @@ const PUSH_DEADLINE_MS = 20000; // under iOS's ~30s SW-event budget, over our ow
 let lastNotificationAt = 0;
 try {
   const rawShow = self.registration.showNotification.bind(self.registration);
-  self.registration.showNotification = ((title: string, options?: NotificationOptions) => {
+  // (spec 2023 FR-006) Stamp on FULFILLMENT, never at call time: a show the OS
+  // rejects (or hangs) was never shown, and stamping it early would suppress the
+  // guarded fallback below — the exact silent wake it exists to prevent.
+  self.registration.showNotification = stampedShow(rawShow, () => {
     lastNotificationAt = Date.now();
-    return rawShow(title, options);
   }) as ServiceWorkerRegistration['showNotification'];
 } catch {
   /* reassignment blocked — fallback stays maximally safe (always shows on failure) */


### PR DESCRIPTION
## Why

Apple's push daemon revokes a web-push subscription after **three** service-worker push wakes that end without a visible notification — counted **cumulatively for the life of the subscription, with no reset and no exemption for the app being on screen** (verified in WebKit source: `WebPushDaemon.mm` silent-push timer → `incrementSilentPushCount`, `maxSilentPushCount = 3`, `PushDatabase` has no reset API). Chromium documents the opposite: a focused page may skip, and it never revokes.

Ring's SW still had licensed silent endings that burned strikes while working exactly as designed — the spec-1034 visible-client skip (7 call sites) and the page-claim handshake (including one arm that acks having rendered nothing: a locked hidden chat on a visible page) — plus three latent error paths where a **failed** show still counted as a visible ending. This is what kept killing iPhone deliveries after #861/#867 (spec 2022/1034), and it survived the externally-proposed `focused && visible` tightening, which this PR adopts and completes.

## What (spec 2023, amends 1034 FR-001 and 1027 FR-012)

- **Platform gate** (`platformTrustsSilence`, pure, engine-keyed): silence may only ever be licensed on Chromium-engine browsers (any OS — Chrome on macOS included). All of WebKit (every iOS browser, macOS Safari), Firefox, and unknown UAs end **every** wake with a `showNotification` call — at worst the existing content-free quiet note (silent, self-replacing tag, no sender/chat/content).
- **Silence license** = platform gate **AND** a focused+visible window client (`mayEndWakeSilently`).
- **Page-claimed message wakes** on silence-unsafe platforms are followed by the quiet note — an in-app banner is invisible to webpushd. This also gives the hidden-chat zero-render claim a visible ending (documented stealth trade; both superseded specs carry amendment pointers).
- **Failure hardening**: the last-resort guard's stamp records show *fulfillment* only (`stampedShow`); `showNotes`/`showConnNotes` report **accepted** counts (`countAccepted`) and zero-accepted wakes fall through to quiet/placeholder terminals; the settle upgrade never closes the accepted generic for an upgrade that failed to show; quiet-note failures propagate to the guarded fallback (two documented carve-outs).

## Verification

- Red-first TDD (hotfix band): two observed red→green cycles; 20 unit tests in `sw-quiet.test.ts` pin the gate truth table (14 real-world UAs), the license, the predicate (incl. the previously-unpinned `focused`-absent case), and both helpers.
- Full unit suite **884/884**, `npm run build` (vue-tsc + vite) green.
- Row-by-row wake-path inventory (SC-001): [`specs/2023-push-wakes-always/inventory.md`](https://github.com/zuptalo/ring/blob/fix/2023-push-wakes-always/specs/2023-push-wakes-always/inventory.md) — on silence-unsafe platforms, zero terminals without a show call.
- Pre-merge adversarial review of the diff: zero confirmed findings.
- No new e2e spec (documented Principle-III deviation: Playwright cannot deliver Web Push to the SW); existing notification e2e suites run in CI.
- **Outstanding**: real-device validation on the dev iPhone (#921) — foreground + severed socket, 5+ pushes, subscription alive afterward (recipe in `quickstart.md`). Intentionally *not* auto-closed by this PR.

## Zero-knowledge

Nothing new crosses the wire; no server changes; no new page↔SW message fields; the quiet note's content is unchanged and as content-free as the push tickle itself; the UA classification is computed per wake and never logged, stored, or transmitted.

Closes #908
Closes #909
Closes #910
Closes #911
Closes #912
Closes #913
Closes #914
Closes #915
Closes #916
Closes #917
Closes #918
Closes #919
Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7