### PR TITLE
fix(ui): tab names no longer disappear as you switch tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/2023-push-wakes-always/plan.md`
+`specs/2024-tab-bar-labels/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,3 +92,4 @@ Specs are grouped by category band; status moves
 | [2021](specs/2021-remove-save-to-photos/spec.md) | Remove the "Save to Photos" chat setting | 🟢 shipped |
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
 | [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🔵 in-review |
+| [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,4 +92,4 @@ Specs are grouped by category band; status moves
 | [2021](specs/2021-remove-save-to-photos/spec.md) | Remove the "Save to Photos" chat setting | 🟢 shipped |
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
 | [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🔵 in-review |
-| [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟡 in-progress |
+| [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🔵 in-review |

--- a/drive/scenarios/tab-labels-vanish.mjs
+++ b/drive/scenarios/tab-labels-vanish.mjs
@@ -1,0 +1,53 @@
+/**
+ * Repro: desktop tab-bar labels reportedly disappear one by one as each tab is
+ * clicked (installed Chrome PWA). Click every tab with real clicks and dump the
+ * ion-tab-button classes + ion-label computed styles before/after each click.
+ *
+ *   node drive/scenarios/tab-labels-vanish.mjs
+ */
+import { createAccount, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'TabProbe' });
+const page = a.page;
+
+const dump = () =>
+  page.evaluate(() =>
+    Array.from(document.querySelectorAll('ion-tab-button')).map((b) => {
+      const label = b.querySelector('ion-label');
+      const cs = label ? getComputedStyle(label) : null;
+      return {
+        tab: b.getAttribute('tab'),
+        dataOn: b.hasAttribute('data-on'), // the active marker (spec 2024) — exactly one true
+        cls: b.className,
+        btnH: b.clientHeight,
+        label: label
+          ? {
+              text: label.textContent,
+              display: cs.display,
+              visibility: cs.visibility,
+              opacity: cs.opacity,
+              h: label.clientHeight,
+              w: label.clientWidth,
+              fontSize: cs.fontSize,
+              transform: cs.transform,
+            }
+          : 'MISSING',
+      };
+    }),
+  );
+
+await shot(a, 'tabs-wherever'); // where did createAccount leave us?
+await page.goto('http://localhost:5173/tabs/chats');
+await page.waitForSelector('ion-tab-bar ion-tab-button', { state: 'attached' });
+console.log('INITIAL', JSON.stringify(await dump()));
+await shot(a, 'tabs-initial');
+
+for (const t of ['Calls', 'Wall', 'Contacts', 'Settings', 'Chats']) {
+  await page.click(`ion-tab-button:has-text("${t}")`);
+  await page.waitForTimeout(600);
+  console.log(`AFTER ${t}:`, JSON.stringify(await dump()));
+  await shot(a, `tabs-after-${t}`);
+}
+
+await sweep([a]);
+await done();

--- a/e2e/tab-labels.spec.ts
+++ b/e2e/tab-labels.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { createAccount } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Tab-bar labels survive tab switching (spec 2024). A dynamic Vue `:class`
+ * binding on `ion-tab-button` used to rewrite the element's whole className
+ * whenever its value changed, erasing the Stencil-managed host classes
+ * (`md`, `tab-has-label`, …) on the two buttons involved in every switch —
+ * collapsing their labels to 0px height, one pair per click, until the whole
+ * bar was bare icons. The fix drives the active-tab highlight with a
+ * `data-on` ATTRIBUTE (Vue patches data-* via setAttribute, never touching
+ * className).
+ *
+ * Assertion order matters for the red-first record (constitution III): the
+ * label-height check runs FIRST so the red run fails on the actual bug (a
+ * collapsed label), not on the then-nonexistent `data-on` attribute.
+ */
+
+const tabBtn = (page: any, label: string) => page.locator('ion-tab-button', { hasText: label });
+
+const ALL_LABELS = ['Calls', 'Chats', 'Wall', 'Contacts', 'Settings'];
+
+/** [{text, h}] for every tab button's label (h = rendered height in px). */
+const labelStates = (page: any) =>
+  page.evaluate(() =>
+    Array.from(document.querySelectorAll('ion-tab-bar ion-tab-button')).map((b: any) => {
+      const l = b.querySelector('ion-label');
+      return { text: l?.textContent ?? '', h: l ? Math.round(l.getBoundingClientRect().height) : -1 };
+    }),
+  );
+
+/** Label texts of the buttons currently carrying the active `data-on` marker. */
+const activeMarkers = (page: any) =>
+  page.evaluate(() =>
+    Array.from(document.querySelectorAll('ion-tab-bar ion-tab-button'))
+      .filter((b: any) => b.hasAttribute('data-on'))
+      .map((b: any) => b.querySelector('ion-label')?.textContent ?? '?'),
+  );
+
+async function expectLabelsIntact(page: any): Promise<void> {
+  const states = await labelStates(page);
+  expect(states.map((s: any) => s.text).sort()).toEqual([...ALL_LABELS].sort());
+  for (const s of states) expect(s.h, `label "${s.text}" collapsed to ${s.h}px`).toBeGreaterThan(0);
+}
+
+const WALK = [
+  ['Calls', 'calls'],
+  ['Wall', 'wall'],
+  ['Contacts', 'contacts'],
+  ['Settings', 'settings'],
+  ['Chats', 'chats'],
+] as const;
+
+test.describe('tab-bar labels (spec 2024)', () => {
+  test('labels keep their height through two full walks, and re-tapping the active tab is a no-op', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const a = await createAccount(ctx, 'TABLBL1');
+
+    await a.page.goto('/tabs/chats');
+    await tabBtn(a.page, 'Calls').waitFor({ state: 'visible', timeout: 30_000 });
+    await expectLabelsIntact(a.page);
+
+    // Two full cycles: the old bug destroyed the labels of the entered AND the
+    // left tab on every click, so one cycle wipes the whole bar and the second
+    // proves nothing degrades further.
+    for (let round = 0; round < 2; round++) {
+      for (const [label, slug] of WALK) {
+        await tabBtn(a.page, label).click();
+        await a.page.waitForURL(`**/tabs/${slug}`);
+        await expectLabelsIntact(a.page);
+      }
+    }
+
+    // Re-tap the active tab: no navigation, nothing degrades (FR-005 / contract row 6).
+    const urlBefore = a.page.url();
+    await tabBtn(a.page, 'Chats').click();
+    await a.page.waitForTimeout(300);
+    expect(a.page.url()).toBe(urlBefore);
+    await expectLabelsIntact(a.page);
+
+    await ctx.close();
+  });
+
+  test('exactly one tab carries the active marker, following the route', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const a = await createAccount(ctx, 'TABLBL2');
+
+    await a.page.goto('/tabs/chats');
+    await tabBtn(a.page, 'Calls').waitFor({ state: 'visible', timeout: 30_000 });
+    expect(await activeMarkers(a.page)).toEqual(['Chats']); // marked from first load
+
+    for (const [label, slug] of WALK) {
+      await tabBtn(a.page, label).click();
+      await a.page.waitForURL(`**/tabs/${slug}`);
+      expect(await activeMarkers(a.page)).toEqual([label]);
+    }
+
+    await ctx.close();
+  });
+});

--- a/specs/2024-tab-bar-labels/checklists/requirements.md
+++ b/specs/2024-tab-bar-labels/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Tab Bar Labels Stay Visible After Switching Tabs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The Why section and FR-003 name the concrete mechanism (Vue class binding
+  vs web-component-managed classes) because the mechanism IS the bug being
+  fixed; FR-001/002/005/006 stay behavior-level.
+- The two adjacent warts found during diagnosis are dispositioned in-spec:
+  US2/FR-004 (a11y selection, investigate-or-defer) and FR-007/Edge Cases
+  (console noise, out of scope by decision).
+- No [NEEDS CLARIFICATION] markers: the root cause is proven by DOM dumps
+  and the fix constraint (FR-003) follows from it; the one open question
+  (safe a11y mechanism) is explicitly delegated to planning with a
+  documented deferral path.

--- a/specs/2024-tab-bar-labels/contracts/tab-bar.md
+++ b/specs/2024-tab-bar-labels/contracts/tab-bar.md
@@ -1,0 +1,26 @@
+# Contract: Tab-Bar Observable Behavior
+
+**Spec**: [spec.md](./spec.md) · **Date**: 2026-07-10
+
+What any observer (user, e2e test, drive scenario) must see, at every settled
+moment while the tab bar is visible:
+
+| # | Observable | Requirement |
+|---|-----------|-------------|
+| 1 | Labels | All five tab buttons render their name (Calls, Chats, Wall, Contacts, Settings) with height > 0, after any number of tab switches |
+| 2 | Active marker | Exactly one button carries the `data-on` attribute, matching the current `/tabs/<name>` route |
+| 3 | Highlight | The `data-on` button's icon shows the circular primary-tint background and filled glyph; the other four show outline glyphs, no tint |
+| 4 | Ionic classes | Every button retains its component-managed classes (mode, `tab-has-label`, `tab-has-icon`, layout, `hydrated`) forever |
+| 5 | Badges | Unread badges keep rendering next to icon+label on their buttons |
+| 6 | Navigation | Tab switches replace history (no back-stack growth); re-tapping the active tab is a no-op |
+| 7 | Remount | After logout→login the bar returns fully intact (fresh components) |
+
+Known accepted noise (FR-007, out of scope): one
+`[ion-tabs] - Tab with id: "undefined" does not exist` console error per tab
+tap.
+
+The e2e regression asserts rows 1–3 after each click of a two-full-cycles tab
+walk, plus row 6's re-tap no-op (active tab re-clicked → URL unchanged,
+labels intact); history-replace in row 6 is pinned by the existing
+e2e/navigation.spec.ts, and rows 4/5/7 are covered by rows 1–3's mechanics
+plus code review.

--- a/specs/2024-tab-bar-labels/data-model.md
+++ b/specs/2024-tab-bar-labels/data-model.md
@@ -1,0 +1,21 @@
+# Data Model: Tab Bar Labels Stay Visible After Switching Tabs
+
+**Spec**: [spec.md](./spec.md) · **Date**: 2026-07-10
+
+No persistent data, no storage, no wire shapes. One piece of derived UI
+state:
+
+## ActiveTabMarker
+
+- **Source**: `activeTab` computed from the current route
+  (`/tabs/<name>` → `<name>`, fallback `chats`) — unchanged by this fix.
+- **DOM projection (changed)**: a `data-on` attribute present on exactly the
+  active tab's `ion-tab-button`, absent on the other four. Never a class.
+- **Invariant**: at any settled moment exactly one of the five buttons
+  carries `data-on`; all five buttons always retain their Ionic-managed
+  classes (`md`/`ios`, `tab-has-label`, `tab-has-icon`,
+  `tab-layout-icon-top`, `hydrated`) because nothing the app binds can
+  rewrite `className`.
+- **Consumers**: scoped CSS (`ion-tab-button[data-on] ion-icon` — circular
+  tint + primary color) and the filled-vs-outline `:icon` swap (existing
+  property binding, unchanged).

--- a/specs/2024-tab-bar-labels/plan.md
+++ b/specs/2024-tab-bar-labels/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: Tab Bar Labels Stay Visible After Switching Tabs
+
+**Branch**: `fix/2024-tab-bar-labels` | **Date**: 2026-07-10 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/2024-tab-bar-labels/spec.md`
+
+## Summary
+
+Vue's class patching rewrites a custom element's whole `className`, so the
+dynamic `:class="{ 'tab-on': … }"` binding on each `ion-tab-button`
+(PR #552's circular highlight) erases the Stencil-managed host classes
+(`md`, `tab-has-label`, `tab-has-icon`, `tab-layout-icon-top`, `hydrated`)
+whenever the binding's value changes — the two buttons involved in every tab
+switch — and Ionic never restores them, collapsing the slotted label to 0px.
+Fix: replace the class binding with a `data-on` **attribute** binding (Vue
+patches `data-*` via `setAttribute`/`removeAttribute`, never touching
+`className`) and key the scoped CSS off `ion-tab-button[data-on]`. Red-first
+e2e regression clicks through all tabs asserting label heights. US2 (truthful
+`aria-selected` at load) is investigated and **deferred with documentation**
+(research D2): the @ionic/vue wrapper imperatively resets the bar's
+`selectedTab` to `""` on mount and every history change, so any value we set
+races a second framework writer unless we adopt `href`-based tab routing —
+which would run the wrapper's navigation alongside `switchTab` and risk the
+deliberately tuned flat-history transitions (out of scope per FR-005/FR-007).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Vue 3 `<script setup>` + Ionic 8.8.8
+(`@ionic/vue` wrappers over Stencil web components)
+
+**Primary Dependencies**: none new; touches one component
+(`src/views/TabsPage.vue`, template + scoped CSS only)
+
+**Storage**: none
+
+**Testing**: new Playwright e2e spec (`e2e/tab-labels.spec.ts`, red-first);
+interactive verification via `drive/scenarios/tab-labels-vanish.mjs`
+(already written during diagnosis); `npm run build` typecheck
+
+**Target Platform**: the PWA everywhere (desktop Chromium PWA where reported;
+mechanism is mode- and platform-independent)
+
+**Project Type**: web client; server untouched
+
+**Performance Goals**: n/a (attribute toggle replaces class toggle)
+
+**Constraints**: no dynamic class bindings on Ionic custom elements (FR-003);
+visual parity with the shipped highlight design; tab navigation semantics
+unchanged (FR-005)
+
+**Scale/Scope**: 2 files of product surface: `src/views/TabsPage.vue`,
+`e2e/tab-labels.spec.ts` (new); plus the tracked drive scenario
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary** — PASS (nothing crosses the wire; spec's
+  Zero-Knowledge Impact: none). `/speckit-checklist` is optional for this
+  spec (no Principle I/IV surface) and is skipped; the spec-quality
+  checklist (`checklists/requirements.md`) passed.
+- **II. Spec-Driven Development** — PASS: spec 2024 (hotfix band), pipeline
+  specify → clarify (no critical ambiguities) → plan (this) → tasks →
+  analyze → taskstoissues → implement.
+- **III. Test-Driven Development** — PASS: `2001+` fix ⇒ the regression test
+  comes first and this bug IS e2e-drivable (unlike the SW push work): a new
+  Playwright spec clicks all tabs and asserts every tab-bar label has
+  non-zero rendered height; it must be observed FAILING against current code
+  before the class → attribute fix lands. No unit-test surface exists (the
+  defect is a framework-interaction behavior of a Vue template; there is no
+  pure function to extract), so e2e is the required coverage — which also
+  satisfies the "changed user-facing behavior MUST add or extend an e2e
+  spec" clause directly.
+- **IV. Crypto Discipline** — PASS (untouched).
+- **V. Offline-First Data Integrity** — PASS (no data).
+- **VI. Stateless Server** — PASS (untouched).
+- **VII. Quality Gates** — PASS: build + unit + e2e; user-facing `fix`
+  commit subject in release-note voice.
+- **VIII. Traceable Delivery** — PASS: taskstoissues; PR lists `Closes #N`.
+- **IX. Privacy** — PASS (no data collection).
+- **X/XI. A11y & Ionic-First** — PASS with one documented deferral: the fix
+  keeps stock Ionic components and existing theme tokens (the CSS moves from
+  a class selector to an attribute selector, values unchanged). The
+  `aria-selected`-at-load gap (US2) is deferred with rationale (research D2);
+  it is a pre-existing limitation, not a regression introduced here.
+
+No violations → Complexity Tracking stays empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/2024-tab-bar-labels/
+├── spec.md              # (done; gains the US2 deferral note in Phase 1)
+├── plan.md              # This file
+├── research.md          # Phase 0: mechanism + alternatives + US2 verdict
+├── data-model.md        # Phase 1: no persistent data; the one UI state
+├── quickstart.md        # Phase 1: red/green + drive verification recipe
+├── contracts/
+│   └── tab-bar.md       # Phase 1: observable tab-bar behavior contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (done)
+└── tasks.md             # Phase 2 (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/views/TabsPage.vue           # :class="{tab-on}" → :data-on attribute;
+                                 # scoped CSS .tab-on → [data-on]; comment
+                                 # block documenting WHY (clobber mechanism,
+                                 # US2 deferral, known console-noise wart)
+e2e/tab-labels.spec.ts           # NEW red-first regression (FR-006)
+drive/scenarios/tab-labels-vanish.mjs  # diagnosis repro — currently
+                                       # untracked; ADDED to git in T006
+drive/scenarios/tab-props-probe.mjs    # one-off diagnosis probe — DELETED
+```
+
+**Structure Decision**: single-component client fix. The active-tab marker
+stays derived from the route in `TabsPage.vue` (unchanged computed); only its
+DOM projection changes from a class to a `data-on` attribute. No composable,
+no new component, no theme-token changes (Principle XI).
+
+## Design (what changes, precisely)
+
+1. **Template** (`TabsPage.vue`): on each of the five `ion-tab-button`s,
+   replace `:class="{ 'tab-on': activeTab === 'x' }"` with
+   `:data-on="activeTab === 'x' || undefined"` — `undefined` removes the
+   attribute entirely, so the CSS selector is a clean presence test. The
+   existing `:selected`, `:icon`, `@click`, `tab` bindings stay exactly as
+   they are (property/listener bindings never touch `className`).
+2. **Scoped CSS**: `ion-tab-button.tab-on ion-icon` →
+   `ion-tab-button[data-on] ion-icon`; everything else (sizes, tint,
+   transition) byte-identical.
+3. **Why-comment** in the template/CSS explaining the FR-003 rule (Vue class
+   patching clobbers Stencil-managed host classes; attribute bindings are
+   the safe channel), the US2 deferral pointer, and the known
+   `[ion-tabs] "undefined"` console wart (FR-007) so neither is
+   re-investigated from scratch.
+4. **e2e regression** (`e2e/tab-labels.spec.ts`): register an account, walk
+   Calls → Wall → Contacts → Settings → Chats (twice around per US1), after
+   each click assert all five tab buttons contain their label text with a
+   rendered height > 0, and assert exactly one button carries the active
+   marker. Observed RED before steps 1-2 land, GREEN after.
+5. **Spec deferral note** (FR-004/SC-004): one paragraph added to spec.md
+   recording the US2 verdict with the wrapper-source evidence (research D2).

--- a/specs/2024-tab-bar-labels/quickstart.md
+++ b/specs/2024-tab-bar-labels/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: verifying spec 2024
+
+**Spec**: [spec.md](./spec.md) · **Date**: 2026-07-10
+
+## Red → Green (the CI gate)
+
+```sh
+# RED: on the un-fixed tree the new spec must fail
+npx playwright test e2e/tab-labels.spec.ts   # needs `make db-up` (or the dev stack's postgres)
+
+# GREEN after the TabsPage.vue fix
+npx playwright test e2e/tab-labels.spec.ts
+npm run build                                 # vue-tsc typecheck + vite build
+npx vitest run                                # full unit suite (unaffected, must stay green)
+```
+
+## Interactive verification (dev stack)
+
+```sh
+make start                                    # if not already running
+node drive/scenarios/tab-labels-vanish.mjs    # walks all tabs, screenshots each state
+```
+
+Read `.tmp/drive/tabs-after-*.png`: every screenshot must show all five
+labels at full size, the circular highlight on exactly the clicked tab, and
+no ghost artifacts near the bar. The stdout DOM dumps must show every button
+keeping `md tab-has-label tab-has-icon tab-layout-icon-top … hydrated`
+classes after every click (plus `data-on` only on the active one).
+
+## Visual parity check
+
+Compare `.tmp/drive/tabs-initial.png` (highlight on Chats) against the same
+screenshot from before the fix — tint circle, icon fill, label size and
+positions must be indistinguishable.

--- a/specs/2024-tab-bar-labels/research.md
+++ b/specs/2024-tab-bar-labels/research.md
@@ -1,0 +1,104 @@
+# Research: Tab Bar Labels Stay Visible After Switching Tabs
+
+**Spec**: [spec.md](./spec.md) · **Date**: 2026-07-10
+
+Phase 0 was performed live before the spec, with the drive harness against
+the running dev stack (`drive/scenarios/tab-labels-vanish.mjs` +
+`tab-props-probe.mjs`); this consolidates the evidence and decisions.
+
+## D1. Root cause: Vue class patching clobbers Stencil-managed host classes
+
+**Decision**: Treat the dynamic `:class` binding on `ion-tab-button` as the
+defect class, not the specific class name. Evidence (DOM dumps): initial
+button `class="md tab-has-label tab-has-icon tab-layout-icon-top
+ion-activatable ion-selectable ion-focusable hydrated"` with label height
+12px; after one tab switch the two buttons whose binding value changed read
+`class="tab-on tab-selected"` / `class=""` with label height 0px (label still
+`display:block; visibility:visible; opacity:1` — the collapse is the loss of
+the component's internal sizing rules keyed on `md`/`tab-has-label`/
+`tab-layout-icon-top`). Vue's `patchClass` assigns `el.className` wholesale;
+Stencil applies host classes through its own vdom diff, so once wiped it
+never re-adds classes it believes are present (only `tab-selected` came back,
+because that specific value changed in Stencil's diff at that moment).
+
+**Rationale for the fix mechanism (`data-on` attribute)**: Vue patches
+`data-*` keys with `setAttribute`/`removeAttribute` — a channel neither Vue's
+class patching nor Stencil's host-class management ever touches. CSS
+attribute selectors (`ion-tab-button[data-on] ion-icon`) have identical
+specificity behavior to the class selector they replace.
+
+**Alternatives considered**:
+- *Wrapper element around the icon to carry the class*: breaks Ionic's
+  shadow `::slotted(ion-icon)` layout (the icon must be a direct slotted
+  child) — rejected.
+- *Ionic's own `.tab-selected` class as the style hook*: requires Ionic's
+  selection machinery to be truthful, which it is not here (see D2) —
+  rejected.
+- *Static class + manual classList manipulation from a watcher*: works but
+  is imperative DOM fiddling Vue may still clobber on unrelated re-renders
+  of the same element's class prop; strictly worse than an attribute —
+  rejected.
+- *Upgrading/patching @ionic/vue or Vue*: out of proportion for a hotfix;
+  the attribute mechanism is the documented community practice for
+  web-component + Vue class coexistence — rejected.
+
+## D2. US2 (truthful selection at load): DEFER, with evidence
+
+**Decision**: Defer. No clobber-safe, race-free mechanism exists with the
+current @ionic/vue wrapper and the app's deliberate no-`href` tab model.
+
+**Evidence** (read from `node_modules/@ionic/vue/dist/index.js`, v8.8.8):
+- `IonTabBar`'s Vue wrapper renders `h("ion-tab-bar", { ref: "ionTabBar" })`
+  and **imperatively** assigns `tabBar.selectedTab` in `tabSwitch()`, called
+  from `mounted()` and from a `registerHistoryChangeListener` callback on
+  every route change.
+- Its active-tab matching (`checkActiveTab` → `matchesTab`) is **`href`
+  based**: `matchesTab(pathname, href)` returns false when `href` is
+  `undefined`. Ring's tab buttons deliberately carry no `href` (flat-history
+  `switchTab` with root/replace, see TabsPage.vue comments), so
+  `activeTab` resolves to `undefined` → `tabSwitch` hits the no-active-child
+  arm → `tabBar.selectedTab = ""`.
+- Core `ion-tab-bar` then emits `ionTabBarChanged` and every core
+  `ion-tab-button` sets `selected = (tab === "")` = false — overwriting the
+  app's `:selected` binding. Probe confirmed: at mount every button reports
+  `selected === false` (including the active one bound `true`); after the
+  first click the Vue binding change propagates and selection becomes
+  correct from then on.
+- Every candidate fix is one of: (a) give buttons `href`s so the wrapper's
+  matching works — but that re-enables the wrapper's own click routing
+  (`ionRouter.changeTab`) alongside `switchTab`, risking the tuned
+  transition semantics (explicitly out of scope, FR-005/FR-007); (b) write
+  `selectedTab`/`selected` ourselves post-mount — a timing race against the
+  wrapper's history listener and the lazy-hydrating core (two writers, no
+  ordering guarantee); (c) bind `aria-selected` directly — Stencil's own
+  render also writes/removes that attribute from its `selected` prop, two
+  writers again.
+
+**Consequence**: `aria-selected` reads false on all tabs from load until the
+first tab switch (pre-existing behavior, unchanged by this fix). Recorded in
+spec.md as the FR-004 deferral; a future spec could revisit by adopting
+href-based tabs wholesale.
+
+## D3. Regression-test strategy: e2e, red-first
+
+**Decision**: New `e2e/tab-labels.spec.ts` (this defect is fully
+Playwright-drivable, so the constitution's e2e clause is satisfied directly,
+and red-first is observed for the hotfix band). Assert after each tab click:
+all five buttons still render their label text with height > 0, and exactly
+one button carries the `data-on` marker. No unit-test surface exists — the
+defect is emergent from Vue↔Stencil interaction on a template; there is no
+pure function to extract (unlike specs 1034/2023).
+
+**Alternatives considered**: drive-scenario-only verification (rejected —
+drive is interactive, not CI); a vitest component test with Ionic stubs
+(rejected — stubbing Ionic's web components removes the exact interaction
+under test).
+
+## D4. Known wart kept out of scope
+
+`[ion-tabs] - Tab with id: "undefined" does not exist` logs on every tab
+tap: the @ionic/vue `IonTabButton` wrapper's internal click handler runs its
+own tab-routing path in parallel with the app's `switchTab`. Pre-existing
+(predates PR #552), console-only. Fixing it means touching the click/routing
+path this hotfix must not destabilize. Recorded in spec Edge Cases (FR-007)
+and in the TabsPage.vue comment so it isn't re-diagnosed.

--- a/specs/2024-tab-bar-labels/spec.md
+++ b/specs/2024-tab-bar-labels/spec.md
@@ -1,0 +1,202 @@
+# Feature Specification: Tab Bar Labels Stay Visible After Switching Tabs
+
+**Feature Branch**: `fix/2024-tab-bar-labels`
+
+**Created**: 2026-07-10
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User report: "when opened on desktop as installed chrome app, on
+first run the name of the main view tabs are shown, but when I click one then
+the name goes away and if I click on another one that name also goes away and
+it is true from all of them!" Reproduced and root-caused with the drive
+harness before this spec was written.
+
+## Why (the bug)
+
+On first load the bottom tab bar shows all five names — Calls, Chats, Wall,
+Contacts, Settings. Switching tabs makes names vanish one by one: every tab
+switch destroys the label of the tab being activated AND the tab being left,
+so after visiting all tabs only bare icons remain, plus stray visual
+artifacts near the bar. It happens on every platform; the reporter noticed it
+in the installed desktop Chrome PWA. Reproduced in plain desktop Chromium
+(`drive/scenarios/tab-labels-vanish.mjs`, before/after screenshots captured).
+
+Root cause, proven with DOM dumps: the tab page binds a dynamic Vue class to
+each tab-button web component to drive the circular active-icon highlight
+(introduced 2026-06-28, PR #552). The tab button manages its **own** classes
+on that same element (`md`, `tab-has-label`, `tab-has-icon`,
+`tab-layout-icon-top`, `hydrated`, …). When the bound class value changes —
+exactly the two buttons involved in each switch — Vue rewrites the element's
+entire class list to only what the template declares, erasing every
+component-managed class, and the component never restores them (its renderer
+believes they are still present). Without its layout classes the component's
+internal styling stops sizing the label, which collapses from 12px to 0px
+height (still technically "visible", just zero-tall). The measured wipe:
+`class="md tab-has-label tab-has-icon tab-layout-icon-top … hydrated"` →
+`class="tab-on tab-selected"` (or `class=""` on the tab being left).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Tab names never disappear (Priority: P1)
+
+A user opens Ring (any platform, notably the installed desktop app) and
+switches between the main tabs freely. Every tab keeps its name below its
+icon at all times; the active tab shows the same circular brand-tint
+highlight and filled icon it does today. No amount of tab switching degrades
+the bar.
+
+**Why this priority**: This is the reported bug. Missing labels make the app
+look broken and hurt navigation for anyone who doesn't know the icons.
+
+**Independent Test**: A browser-driven regression test clicks through every
+tab (twice around) and asserts each tab button still renders its label text
+with a non-zero height. Must FAIL against the current code (red-first,
+constitution III for the hotfix band) and pass with the fix.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh load on the Chats tab, **When** the user clicks Calls,
+   **Then** all five tab names remain visible, and the highlight moves from
+   Chats to Calls.
+2. **Given** the user has visited every tab in sequence, **When** they look
+   at the tab bar, **Then** all five names are still visible at their normal
+   size, with no leftover visual artifacts.
+3. **Given** any theme (light/dark) and either component display mode,
+   **When** tabs are switched repeatedly, **Then** labels and highlight
+   render identically to the design intent throughout.
+
+---
+
+### User Story 2 - Selection is truthful to assistive tech (Priority: P3)
+
+A screen-reader user focuses the tab bar on a fresh load. The currently
+active tab reports itself as selected immediately — not only after the first
+manual tab switch.
+
+**Why this priority**: Correctness for assistive tech, discovered during
+diagnosis: the framework machinery overwrites the app's selection state at
+load, so every tab reads "not selected" until the first click. Small, real,
+and adjacent — but it must not risk the P1 fix, so it is investigated during
+planning and implemented only if a mechanism exists that cannot reintroduce
+the class-erasure bug; otherwise documented and deferred.
+
+**Independent Test**: On a fresh load, the active tab button exposes a
+truthful selected state (and the others expose not-selected) before any user
+interaction; the state follows subsequent tab switches.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh load on the Chats tab, **When** selection state is
+   inspected before any click, **Then** Chats reports selected and the other
+   four report not selected — OR the spec's deferral note documents why this
+   remains unfixed.
+
+> **Deferral note (FR-004, resolved during planning)**: deferred. The UI
+> framework's tab-bar wrapper imperatively resets the bar's selection to
+> empty on mount and on every route change, because its active-tab matching
+> is link-based and this app's tab buttons deliberately carry no links (the
+> flat-history navigation model). Every candidate fix either re-enables the
+> framework's own tab routing alongside the app's (regression risk this spec
+> excludes) or races a second framework writer with no ordering guarantee.
+> Full evidence and the rejected mechanisms: research.md D2. Consequence
+> (pre-existing, unchanged): assistive tech reads no tab as selected between
+> load and the first tab switch. A future spec may revisit by adopting
+> link-based tabs wholesale.
+
+---
+
+### Edge Cases
+
+- **Rapid tab switching**: hammering different tabs quickly must never leave
+  a label collapsed or a highlight on the wrong tab once navigation settles.
+- **Badges**: unread badges on tab buttons keep rendering correctly alongside
+  the label and highlight (they are siblings on the same buttons).
+- **Re-tapping the active tab**: remains a no-op (no navigation, no visual
+  change), as today.
+- **Known issue, explicitly out of scope**: every tab tap logs
+  `[ion-tabs] - Tab with id: "undefined" does not exist` to the console —
+  pre-existing (predates PR #552), cosmetic, caused by the UI framework's
+  built-in tab-click routing running alongside the app's own tab switching.
+  Touching the navigation path risks regressing the deliberately tuned
+  flat-history tab transitions, so it is recorded here and not fixed.
+- **Logout/login transition**: the tab bar unmounts and remounts around auth
+  changes; a remount must restore a fully intact bar (fresh components with
+  fresh labels).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every main tab MUST show its name below its icon at all times
+  while the tab bar is visible, regardless of how many tab switches have
+  occurred, in both light and dark themes and in both component display
+  modes. *(Theme/mode verification is by mechanism-independence plus
+  Chromium coverage — the recorded waiver in Assumptions; the fix carries no
+  theme- or mode-conditional behavior.)*
+- **FR-002**: The active tab MUST show the existing design's highlight —
+  circular brand-tint behind a filled icon, smooth fade, no icon shift — on
+  exactly one tab (the active one); inactive tabs show outline icons with no
+  tint.
+- **FR-003**: The mechanism driving the active-tab visual MUST NOT be a
+  dynamic class binding on the tab-button web components (or any other
+  mechanism that can erase component-managed classes). Property and
+  attribute bindings that never touch the element's class list are the
+  permitted alternatives.
+- **FR-004**: Selection state exposed to assistive technology SHOULD be
+  truthful from first load (User Story 2). If no mechanism exists that is
+  safe with the current framework wrapper, the deferral MUST be documented
+  in this spec with the reason, and the current behavior noted as a known
+  limitation.
+- **FR-005**: Tab navigation semantics MUST be unchanged: switches replace
+  history (no back-stack pileup), transitions stay instant, re-tapping the
+  active tab is a no-op.
+- **FR-006**: A browser-driven end-to-end regression test MUST exist that
+  clicks through all tabs and asserts every tab label is rendered with
+  non-zero height; it MUST be demonstrated failing before the fix (red) and
+  passing after (green).
+- **FR-007**: The console-noise wart (`[ion-tabs] … "undefined"`) is OUT of
+  scope; this spec records it as a known issue (Edge Cases) so it is not
+  re-diagnosed from scratch next time.
+
+### Key Entities
+
+- **Tab bar**: the five main-view tab buttons (Calls, Chats, Wall, Contacts,
+  Settings), each an icon + name + optional unread badge, with a single
+  active-tab highlight.
+- **Active-tab marker**: the app-owned signal saying which tab is active
+  (derived from the current route), rendered as the highlight; its DOM
+  representation must be class-clobber-safe (FR-003).
+
+## Zero-Knowledge Impact
+
+None. This is a purely visual, on-device UI fix: nothing crosses the wire,
+no data is stored, read, or transmitted, and the server is untouched.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The e2e regression (FR-006) fails on the pre-fix code and
+  passes on the fixed code; it keeps passing in CI.
+- **SC-002**: The interactive reproduction (`drive/scenarios/
+  tab-labels-vanish.mjs`) shows all five labels at full height after a
+  complete walk of all tabs — with screenshots demonstrating before/after
+  parity of the highlight design.
+- **SC-003**: `npm run build` (typecheck + build), the full unit suite, and
+  the e2e suite pass.
+- **SC-004**: User Story 2 either verifies (truthful selection at load) or
+  carries a documented deferral in this spec.
+
+## Assumptions
+
+- The visual design of the highlight (PR #552's circular tint + filled icon)
+  is correct as shipped; this fix restores its implementation safety without
+  changing its look.
+- The reproduction and regression assertions run under desktop Chromium
+  (the project's e2e browser); the fix mechanism is platform-independent, so
+  Chromium coverage plus the mode-agnostic mechanism is accepted as covering
+  iOS/Android rendering.
+- The pre-existing console error (Edge Cases) has no user-visible effect
+  beyond console noise.

--- a/specs/2024-tab-bar-labels/spec.md
+++ b/specs/2024-tab-bar-labels/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-10
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User report: "when opened on desktop as installed chrome app, on

--- a/specs/2024-tab-bar-labels/tasks.md
+++ b/specs/2024-tab-bar-labels/tasks.md
@@ -1,0 +1,124 @@
+# Tasks: Tab Bar Labels Stay Visible After Switching Tabs
+
+**Input**: Design documents from `/specs/2024-tab-bar-labels/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md,
+contracts/tab-bar.md, quickstart.md
+
+**Tests**: REQUIRED and red-first — this is a `2001+` hotfix; the regression
+test is a new Playwright e2e spec (the defect is fully e2e-drivable; no unit
+surface exists per plan Constitution Check III / research D3). It MUST be
+observed failing before the fix lands.
+
+**Organization**: US1 (labels never disappear) is the whole fix; US2
+(truthful selection at load) was resolved to a documented deferral during
+planning.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+- [X] T001 Mark spec 2024 `**Status**: in-progress` in
+      specs/2024-tab-bar-labels/spec.md and run `make roadmap` (CI guard)
+
+---
+
+## Phase 2: Foundational
+
+*(none — single-component fix on existing files)*
+
+---
+
+## Phase 3: User Story 1 — Tab names never disappear (P1) 🎯 MVP
+
+**Goal**: Labels survive unlimited tab switching; the circular highlight
+follows the active tab; contract rows 1–3 hold.
+
+**Independent Test**: `npx playwright test e2e/tab-labels.spec.ts` — RED on
+the un-fixed tree, GREEN after; drive scenario screenshots show all five
+labels after a full tab walk.
+
+- [X] T002 [US1] RED: create e2e/tab-labels.spec.ts following the existing
+      e2e conventions (e2e/helpers.ts account setup): register one account,
+      walk the five tabs twice around (Calls → Wall → Contacts → Settings →
+      Chats, ×2) clicking the real ion-tab-button elements; after EACH click
+      assert — in this order, so the red run demonstrably fails on the BUG,
+      not on the not-yet-added mechanism — (a) all five tab buttons render
+      their label text with bounding height > 0, then (b) exactly one button
+      carries the `data-on` attribute matching the current route (contract
+      rows 1–3); finish with a re-tap of the active tab asserting the URL is
+      unchanged and labels intact (FR-005 / contract row 6). Run it and
+      OBSERVE it fail on the collapsed-label assertion (a); record the red
+      output for the PR description
+- [X] T003 [US1] Fix src/views/TabsPage.vue: replace each
+      `:class="{ 'tab-on': activeTab === '<tab>' }"` with
+      `:data-on="activeTab === '<tab>' || undefined"` on all five
+      ion-tab-buttons; change the scoped CSS selector
+      `ion-tab-button.tab-on ion-icon` → `ion-tab-button[data-on] ion-icon`
+      (declarations unchanged); update the selector's why-comment to state
+      the FR-003 rule (Vue class patching rewrites className wholesale and
+      erases Stencil-managed host classes — attribute bindings are the safe
+      channel; cite spec 2024), fold in the US2 deferral pointer
+      (research.md D2) where the old comment discussed `.tab-selected`
+      unreliability, and note the known `[ion-tabs] "undefined"` console
+      wart (FR-007) at the switchTab comment; ALSO correct the tab-bar
+      template comment (~lines 9-12) claiming the `:selected` binding makes
+      "the active tab still report correctly for assistive tech" — research
+      D2 disproved that at load; reword to best-effort-after-first-switch
+      with a pointer to the spec 2024 US2 deferral
+- [X] T004 [US1] GREEN + visual parity: extend the `dump()` in
+      drive/scenarios/tab-labels-vanish.mjs with
+      `dataOn: b.hasAttribute('data-on')` so the stdout check in
+      quickstart.md is observable; `npx playwright test
+      e2e/tab-labels.spec.ts` passes; run
+      `node drive/scenarios/tab-labels-vanish.mjs` against the dev stack and
+      verify per quickstart.md — every screenshot shows five full-size
+      labels, the highlight matches the pre-fix design on the initial shot,
+      DOM dumps show Ionic classes intact after every click and `data-on` on
+      exactly the active tab (SC-002)
+
+**Checkpoint**: the reported bug is fixed and pinned by CI.
+
+---
+
+## Phase 4: User Story 2 — Selection truthful to assistive tech (P3)
+
+**Goal**: Dispositioned per FR-004: deferred with documentation (no safe
+mechanism exists; see research.md D2 and the spec's deferral note).
+
+- [X] T005 [US2] Confirm the deferral documentation is complete and
+      cross-linked: spec.md deferral note under US2 ↔ research.md D2 ↔ the
+      TabsPage.vue comment from T003; no code change (FR-004, SC-004)
+
+---
+
+## Phase 5: Polish & Gates
+
+- [X] T006 [P] Track the repro scenario and drop the one-off probe: both
+      files are currently UNTRACKED — `git add
+      drive/scenarios/tab-labels-vanish.mjs` (the interactive
+      repro/verification per SC-002; drive/ scenarios are tracked by
+      convention) and delete drive/scenarios/tab-props-probe.mjs
+- [X] T007 Run the full gates: `npm run build` (vue-tsc + vite) and
+      `npx vitest run` (full unit suite, must be untouched-green), plus the
+      new e2e spec (SC-003; the full e2e suite runs in CI)
+
+## Dependencies
+
+- T001 → everything (roadmap guard)
+- T002 (RED) → T003 (fix) → T004 (GREEN) — strict order, red observed first
+- T005 after T003 (the comment it cross-checks lands there)
+- T006 [P] anytime; T007 last
+
+## Issue Mapping
+
+T001 #923 · T002 #924 · T003 #925 · T004 #926 · T005 #927 · T006 #928 ·
+T007 #929 — the feature → `develop` PR must list `Closes #N` for each
+(constitution VIII).
+
+## Implementation Strategy
+
+US1 is the MVP and the entire code change (one template/CSS edit + one e2e
+spec). US2 is a documentation-only disposition. Single PR;
+red test → fix → green as ordered commits or one commit with the red run
+recorded in the PR description.

--- a/src/views/TabsPage.vue
+++ b/src/views/TabsPage.vue
@@ -7,31 +7,41 @@
            (auth flips false before the redirect to /auth completes) so a bare bar
            never flashes. It reappears the instant auth state flips back. -->
       <!-- Tabs carry no `href`: tapping is handled by switchTab so the four tab roots
-           are entered as a flat 'root' replace (terminal tabs — see switchTab). We bind
-           `selected` explicitly (normally ion-tabs sets it off the href it navigates)
-           so the active tab still reports correctly for assistive tech. -->
+           are entered as a flat 'root' replace (terminal tabs — see switchTab). The
+           `selected` binding is best-effort AFTER the first switch only: at load the
+           @ionic/vue tab-bar wrapper imperatively resets the bar's selection to ""
+           (its matching is href-based and finds nothing), so assistive tech reads no
+           tab as selected until the first tap — a documented deferral, see spec 2024
+           US2 / research D2.
+           The active-tab highlight rides a `data-on` ATTRIBUTE, never a dynamic
+           class (spec 2024 FR-003): a Vue :class binding on an Ionic custom element
+           rewrites the element's whole className each time its value changes, wiping
+           the Stencil-managed host classes (md/tab-has-label/tab-has-icon/…) that
+           size the label — which is exactly how the tab names used to vanish one by
+           one. Vue patches data-* via setAttribute, which touches nothing of
+           Ionic's. -->
       <ion-tab-bar v-if="isAuthenticated" slot="bottom">
-        <ion-tab-button tab="calls" :class="{ 'tab-on': activeTab === 'calls' }" :selected="activeTab === 'calls'" @click="switchTab('/tabs/calls')">
+        <ion-tab-button tab="calls" :data-on="activeTab === 'calls' || undefined" :selected="activeTab === 'calls'" @click="switchTab('/tabs/calls')">
           <ion-icon :icon="activeTab === 'calls' ? call : callOutline" />
           <ion-label>Calls</ion-label>
           <ion-badge v-if="calls" color="danger">{{ calls }}</ion-badge>
         </ion-tab-button>
-        <ion-tab-button tab="chats" :class="{ 'tab-on': activeTab === 'chats' }" :selected="activeTab === 'chats'" @click="switchTab('/tabs/chats')">
+        <ion-tab-button tab="chats" :data-on="activeTab === 'chats' || undefined" :selected="activeTab === 'chats'" @click="switchTab('/tabs/chats')">
           <ion-icon :icon="activeTab === 'chats' ? chatbubbles : chatbubblesOutline" />
           <ion-label>Chats</ion-label>
           <ion-badge v-if="chats" color="primary">{{ chats }}</ion-badge>
         </ion-tab-button>
-        <ion-tab-button tab="wall" :class="{ 'tab-on': activeTab === 'wall' }" :selected="activeTab === 'wall'" @click="switchTab('/tabs/wall')">
+        <ion-tab-button tab="wall" :data-on="activeTab === 'wall' || undefined" :selected="activeTab === 'wall'" @click="switchTab('/tabs/wall')">
           <ion-icon :icon="activeTab === 'wall' ? sparkles : sparklesOutline" />
           <ion-label>Wall</ion-label>
           <ion-badge v-if="wall" color="primary">{{ wall }}</ion-badge>
         </ion-tab-button>
-        <ion-tab-button tab="contacts" :class="{ 'tab-on': activeTab === 'contacts' }" :selected="activeTab === 'contacts'" @click="switchTab('/tabs/contacts')">
+        <ion-tab-button tab="contacts" :data-on="activeTab === 'contacts' || undefined" :selected="activeTab === 'contacts'" @click="switchTab('/tabs/contacts')">
           <ion-icon :icon="activeTab === 'contacts' ? people : peopleOutline" />
           <ion-label>Contacts</ion-label>
           <ion-badge v-if="contacts" color="primary">{{ contacts }}</ion-badge>
         </ion-tab-button>
-        <ion-tab-button tab="settings" :class="{ 'tab-on': activeTab === 'settings' }" :selected="activeTab === 'settings'" @click="switchTab('/tabs/settings')">
+        <ion-tab-button tab="settings" :data-on="activeTab === 'settings' || undefined" :selected="activeTab === 'settings'" @click="switchTab('/tabs/settings')">
           <ion-icon :icon="activeTab === 'settings' ? settings : settingsOutline" />
           <ion-label>Settings</ion-label>
           <ion-badge v-if="you" color="primary">{{ you }}</ion-badge>
@@ -89,6 +99,11 @@ const ionRouter = useIonRouter();
 // clean root-level commit); the empty animation only suppresses the visual transition,
 // matching how tab switches looked before (and keeping main.ts's navAnimation, which
 // only fast-paths the 'back' direction, from sliding a 'root' tab switch).
+// Known wart (spec 2024 FR-007, out of scope): every tap ALSO runs @ionic/vue's
+// built-in tab-click routing alongside this handler, which logs
+// `[ion-tabs] - Tab with id: "undefined" does not exist` to the console. It is
+// cosmetic; fixing it means touching the framework's click path and risking the
+// transition tuning above.
 function switchTab(path: string): void {
   if (route.path === path) return;
   ionRouter.navigate(path, 'root', 'replace', () => createAnimation());
@@ -144,10 +159,12 @@ ion-tab-button ion-icon {
   background: transparent;
   transition: background-color 0.18s ease, color 0.18s ease;
 }
-/* Drive the highlight off the app's own route-derived active tab (`tab-on`), NOT
-   Ionic's `.tab-selected` — this app manages tab selection manually, so that class
-   isn't reliably present on a fresh load. */
-ion-tab-button.tab-on ion-icon {
+/* Drive the highlight off the app's own route-derived active tab via the `data-on`
+   ATTRIBUTE — never a class, and not Ionic's `.tab-selected`. A dynamic Vue :class
+   here clobbers the Stencil-managed host classes and collapses the labels (spec
+   2024 FR-003), and `.tab-selected` isn't reliably present because the @ionic/vue
+   wrapper resets the bar's selection at load (spec 2024 US2 deferral, research D2). */
+ion-tab-button[data-on] ion-icon {
   background: rgba(var(--ion-color-primary-rgb), 0.18);
   color: var(--ion-color-primary);
 }


### PR DESCRIPTION
## Why

On the installed desktop PWA (and every platform), the bottom tab bar showed all five names on first load, then lost them one by one as you switched tabs — each switch collapsed the label of both the entered and the left tab, until only bare icons plus stray artifacts remained.

Root cause (proven with live DOM dumps): PR #552's Telegram-style highlight drove the active tab with a dynamic Vue `:class` binding on each `ion-tab-button`. Vue's class patching rewrites a custom element's **entire** `className` whenever the bound value changes — the two buttons involved in every switch — erasing the Stencil-managed host classes (`md`, `tab-has-label`, `tab-has-icon`, `tab-layout-icon-top`, `hydrated`) that size the slotted label. Ionic never restores them (its vdom believes they're present), so the label collapsed from 12px to 0px.

## What (spec 2024)

The highlight now rides a `data-on` **attribute** (`:data-on` binding + `ion-tab-button[data-on] ion-icon` CSS). Vue patches `data-*` via `setAttribute`/`removeAttribute` and never touches `className`, so Ionic's classes survive and the visuals are unchanged by design (same circle tint, same filled icon).

One-file product change (`src/views/TabsPage.vue`, template + scoped CSS + comments) plus a red-first e2e regression.

## Verification

- **Red-first** (`e2e/tab-labels.spec.ts`, new): observed failing on the un-fixed tree with `Error: label "Calls" collapsed to 0px` — the actual bug, asserted before the `data-on` marker check. **Green** after the fix (2 passed): labels keep their height through two full tab walks + a re-tap no-op, and exactly one button carries the active marker following the route.
- Interactive repro tracked at `drive/scenarios/tab-labels-vanish.mjs`; dev-stack run confirms every label at full height and Ionic classes intact after each click, with screenshot parity to the pre-fix highlight design.
- `npm run build` (vue-tsc + vite) and 871/871 unit tests green; full e2e suite runs in CI.

## Documented deferrals (in spec + code comments)

- **`aria-selected` at load**: the `@ionic/vue` tab-bar wrapper imperatively resets the bar's selection to `""` on mount and every route change (href-based matching; this app's tabs carry no href by design), so no tab reads selected until the first tap. No race-free fix exists without adopting href-based tabs wholesale — deferred with evidence (research D2), a pre-existing limitation this PR doesn't regress.
- **Console noise**: `[ion-tabs] - Tab with id: "undefined" does not exist` logs per tap from the wrapper's parallel click routing — pre-existing, cosmetic, out of scope (touching it risks the tuned flat-history transitions).

## Zero-knowledge

None: a purely visual, on-device UI fix. Nothing crosses the wire, no data stored/read/transmitted, server untouched.

Closes #923
Closes #924
Closes #925
Closes #926
Closes #927
Closes #928
Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7