### PR TITLE
docs(spec): specs 2023 + 2024 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,5 +91,5 @@ Specs are grouped by category band; status moves
 | [2020](specs/2020-fast-message-bursts/spec.md) | Fast message bursts stop showing duplicate notifications | 🟢 shipped |
 | [2021](specs/2021-remove-save-to-photos/spec.md) | Remove the "Save to Photos" chat setting | 🟢 shipped |
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
-| [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🔵 in-review |
-| [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🔵 in-review |
+| [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟢 shipped |
+| [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |

--- a/specs/2023-push-wakes-always/spec.md
+++ b/specs/2023-push-wakes-always/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-09
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: Review of an externally-proposed fix to the spec-1034 visible-client

--- a/specs/2024-tab-bar-labels/spec.md
+++ b/specs/2024-tab-bar-labels/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-10
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User report: "when opened on desktop as installed chrome app, on


### PR DESCRIPTION
Both fixes have merged to `develop` (#922 push-wakes, #930 tab labels). This moves their spec lifecycle `Status` from `in-review` to `shipped` and regenerates `ROADMAP.md` to match (the roadmap CI guard requires it).

Docs-only; no code, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7