### PR TITLE
fix: back-swipe reply, Wall challenge auto-enter, and no duplicate background notification

### DIFF
--- a/drive/scenarios/reply-deadzone.mjs
+++ b/drive/scenarios/reply-deadzone.mjs
@@ -1,0 +1,59 @@
+// Behavioral check of the incoming-bubble reply dead zone: a swipe-right that
+// STARTS on the left part of an incoming bubble must NOT open a reply (that
+// gesture is the OS back-swipe); a swipe-right starting on the right part MUST.
+// Drives real synthetic TouchEvents on the bubble and reads the composer's
+// reply bar (.reply-bar appears iff replyingTo is set).
+//
+//   node drive/scenarios/reply-deadzone.mjs
+import { createAccount, pair, chatWith, say, waitForMessage, sweep, done } from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob', mobile: true });
+await pair(alice, bob);
+await say(alice, bob.id, 'swipe target message that is fairly wide');
+await waitForMessage(bob, alice.id, 'swipe target');
+
+const bobChat = await chatWith(bob, alice.id);
+await bob.page.goto(`/chat/${bobChat}`);
+await bob.page.waitForSelector('.bubble[data-mid]', { timeout: 15000 });
+await bob.page.waitForTimeout(400);
+
+// Dispatch a horizontal swipe-right on the first incoming bubble, starting at
+// `frac` across its width. Returns whether the reply bar (a reply being composed)
+// appeared as a result.
+async function swipeAt(frac) {
+  return bob.page.evaluate(async (f) => {
+    const clearReply = () => {
+      // Cancel any in-progress reply so each probe starts clean.
+      const cancel = document.querySelector('.reply-bar ion-button');
+      if (cancel) cancel.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    };
+    clearReply();
+    const bubble = document.querySelector('.bubble[data-mid]');
+    if (!bubble) return { error: 'no bubble' };
+    const r = bubble.getBoundingClientRect();
+    const y = r.top + r.height / 2;
+    const startX = r.left + r.width * f;
+    const mk = (type, x) => {
+      const t = new Touch({ identifier: 1, target: bubble, clientX: x, clientY: y });
+      return new TouchEvent(type, { cancelable: true, bubbles: true, touches: type === 'touchend' ? [] : [t], targetTouches: type === 'touchend' ? [] : [t], changedTouches: [t] });
+    };
+    bubble.dispatchEvent(mk('touchstart', startX));
+    for (let dx = 20; dx <= 100; dx += 20) bubble.dispatchEvent(mk('touchmove', startX + dx));
+    bubble.dispatchEvent(mk('touchend', startX + 100));
+    await new Promise((res) => setTimeout(res, 150));
+    const replied = !!document.querySelector('.reply-bar');
+    clearReply();
+    return { replied, startX: Math.round(startX), left: Math.round(r.left), width: Math.round(r.width) };
+  }, frac);
+}
+
+const leftSwipe = await swipeAt(0.15); // left part → should be INERT (back-swipe lane)
+const rightSwipe = await swipeAt(0.85); // right part → should open a reply
+console.log('[left  15%]', JSON.stringify(leftSwipe));
+console.log('[right 85%]', JSON.stringify(rightSwipe));
+const pass = leftSwipe.replied === false && rightSwipe.replied === true;
+console.log(pass ? '[PASS ✓] left inert, right replies' : '[FAIL ✗] dead zone not behaving');
+
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/reply-swipe-gutter.mjs
+++ b/drive/scenarios/reply-swipe-gutter.mjs
@@ -1,0 +1,50 @@
+/**
+ * Verify the WhatsApp-style left gutter on 1:1 incoming bubbles (reply-swipe /
+ * back-swipe separation). Compares a 1:1 chat (should now have a left inset on
+ * incoming bubbles) with a group chat (avatar already provides the inset).
+ *
+ *   HEADED=1 node drive/scenarios/reply-swipe-gutter.mjs
+ */
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import {
+  createAccount, pair, group, chatWith, say, waitForMessage, sweep, done, SHOT_DIR,
+} from '../driver.mjs';
+
+// Navigate to a chat, wait for real bubbles to paint (not the loading spinner),
+// then screenshot. shot()'s fixed 600ms settle can catch the skeleton on a cold
+// direct-nav, so gate on the bubble row instead.
+async function shotChat(client, name, chatId) {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  await client.page.goto(`/chat/${chatId}`);
+  await client.page.waitForSelector('.bubble[data-mid]', { timeout: 15000 });
+  await client.page.waitForTimeout(500);
+  const file = path.join(SHOT_DIR, `${name}.png`);
+  await client.page.screenshot({ path: file });
+  console.log(`[shot] ${file}`);
+}
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob', mobile: true });
+const cara = await createAccount({ name: 'Cara' });
+await pair(alice, bob);
+await pair(alice, cara);
+await pair(bob, cara);
+
+// 1:1 — a few incoming messages so Bob (mobile) sees the left gutter.
+await say(alice, bob.id, 'hey from Alice 👋');
+await say(alice, bob.id, 'swipe me to reply');
+await say(alice, bob.id, 'but the left edge is for going back');
+await waitForMessage(bob, alice.id, 'left edge is for going back');
+const bobDm = await chatWith(bob, alice.id);
+await shotChat(bob, 'gutter-1to1', bobDm);
+
+// Group — avatars should still provide the inset (unchanged).
+const g = await group(alice, 'Trip', [bob, cara]);
+await say(alice, g, 'group hello', { isGroup: true });
+await say(cara, g, 'hi from Cara', { isGroup: true });
+await waitForMessage(bob, g, 'hi from Cara', { isGroup: true });
+await shotChat(bob, 'gutter-group', g);
+
+await sweep([alice, bob, cara]);
+await done();

--- a/drive/scenarios/wall-armada-duel.mjs
+++ b/drive/scenarios/wall-armada-duel.mjs
@@ -1,0 +1,69 @@
+// Full Wall-Armada START: the path with ZERO test coverage (e2e stops at accept).
+// Verifies that once BOTH admirals deploy on the WALL, the duty officer emits the
+// rival's staged commit and the game actually LEAVES deployment into battle.
+//
+//   node drive/scenarios/wall-armada-duel.mjs
+import { createAccount, pair, poll, sweep, done } from '../driver.mjs';
+
+const L0 = [
+  { r: 0, c: 0, len: 5, dir: 'h' }, { r: 2, c: 0, len: 4, dir: 'h' },
+  { r: 4, c: 0, len: 3, dir: 'h' }, { r: 6, c: 0, len: 3, dir: 'h' },
+  { r: 8, c: 0, len: 2, dir: 'h' },
+];
+const L1 = [
+  { r: 0, c: 9, len: 5, dir: 'v' }, { r: 0, c: 7, len: 4, dir: 'v' },
+  { r: 0, c: 5, len: 3, dir: 'v' }, { r: 5, c: 7, len: 3, dir: 'v' },
+  { r: 8, c: 3, len: 2, dir: 'h' },
+];
+
+const commit = (p, arg) => p.page.evaluate((a) => window.__ringTest.armadaCommit(a), arg);
+const info = (p, pid) => p.page.evaluate((id) => window.__ringTest.wallGameInfo(id), pid);
+const syncEng = (p, pid) => p.page.evaluate((id) => window.__ringTest.syncEngagement(id), pid);
+const syncPosts = (p) => p.page.evaluate(() => window.__ringTest.syncPosts());
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob', mobile: true });
+await pair(alice, bob);
+
+const pid = await alice.page.evaluate(() => window.__ringTest.post({ game: { gameType: 'armada' } }));
+console.log('[post] armada wall pid=', pid);
+
+// Bob sees + accepts.
+await poll(() => bob.page.evaluate(async (id) => { await window.__ringTest.syncPosts(); return window.__ringTest.wallGameInfo(id); }, pid), (g) => !!g, { label: 'challenge at bob' });
+await bob.page.evaluate((id) => window.__ringTest.acceptWallChallenge(id), pid);
+await poll(() => info(alice, pid).then(() => syncEng(alice, pid)).then(() => info(alice, pid)), (g) => g?.opponent === bob.id, { label: 'bob seated at alice' });
+console.log('[accepted] alice sees:', JSON.stringify(await info(alice, pid)));
+
+// Bob (seat 1) deploys FIRST → stages device-locally (wire slot not open yet).
+await syncEng(bob, pid);
+await commit(bob, { postId: pid, layout: L1, salt: 'c2FsdDE' });
+console.log('[bob staged] bob sees:', JSON.stringify(await info(bob, pid)));
+
+// Alice (seat 0) deploys → seq 1 goes out. Bob's duty officer must then emit his
+// staged commit (seq 2) on the WALL once Alice's commit syncs to him.
+await commit(alice, { postId: pid, layout: L0, salt: 'c2FsdDA' });
+console.log('[alice committed] alice sees:', JSON.stringify(await info(alice, pid)));
+
+// Poll Bob: after syncing Alice's commit, does the duty officer emit Bob's?
+let started = false;
+try {
+  await poll(
+    () => bob.page.evaluate(async (id) => { await window.__ringTest.syncEngagement(id); return window.__ringTest.wallGameInfo(id); }, pid),
+    (g) => g?.moves >= 2,
+    { label: 'both fleets committed (deployment done)', timeout: 20000 },
+  );
+  started = true;
+  console.log('[STARTED ✓] bob sees moves>=2:', JSON.stringify(await info(bob, pid)));
+} catch {
+  console.log('[STALL ✗] bob stuck:', JSON.stringify(await info(bob, pid)));
+  console.log('[STALL ✗] alice sees:', JSON.stringify(await info(alice, pid)));
+}
+
+// If it started, make sure Alice also observes moves>=2 (battle can begin).
+if (started) {
+  await poll(() => syncEng(alice, pid).then(() => info(alice, pid)), (g) => g?.moves >= 2, { label: 'alice sees battle', timeout: 15000 }).catch(() => {});
+  console.log('[final] alice:', JSON.stringify(await info(alice, pid)));
+}
+
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/wall-author-autoenter.mjs
+++ b/drive/scenarios/wall-author-autoenter.mjs
@@ -1,0 +1,55 @@
+// Verify the author auto-enter fix: when a rival accepts the author's OWN
+// fullscreen Wall challenge and the author's app is visible, the author is
+// dropped straight into the board (parity with 1:1) — so the accepter isn't
+// left waiting. Also checks it does NOT double-enter on a repeat sync.
+//
+//   node drive/scenarios/wall-author-autoenter.mjs
+import { createAccount, pair, poll, sweep, done, SHOT_DIR } from '../driver.mjs';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+const boardVisible = (c, sel) => c.page.locator(sel).isVisible().catch(() => false);
+const vis = (c) => c.page.evaluate(() => document.visibilityState);
+
+for (const [gameType, boardSel] of [['armada', '.armada'], ['chess', '.ch-board']]) {
+  console.log(`\n===== AUTHOR AUTO-ENTER: ${gameType} =====`);
+  const alice = await createAccount({ name: 'Alice' });
+  const bob = await createAccount({ name: 'Bob', mobile: true });
+  await pair(alice, bob);
+
+  const pid = await alice.page.evaluate((gt) => window.__ringTest.post({ game: { gameType: gt } }), gameType);
+
+  // Alice sits on the Wall, watching (visible).
+  await alice.page.goto('/tabs/wall');
+  await alice.page.waitForTimeout(500);
+  console.log('  alice visibilityState =', await vis(alice));
+  console.log('  board before accept:', await boardVisible(alice, boardSel));
+
+  // Bob accepts.
+  await poll(() => bob.page.evaluate(async (id) => { await window.__ringTest.syncPosts(); return window.__ringTest.wallGameInfo(id); }, pid), (g) => !!g, { label: 'card at bob' });
+  await bob.page.evaluate((id) => window.__ringTest.acceptWallChallenge(id), pid);
+
+  // Alice's device syncs the acceptance → notifyWallGameActivity → auto-enter.
+  let entered = false;
+  try {
+    await poll(
+      async () => {
+        await alice.page.evaluate((id) => window.__ringTest.syncEngagement(id), pid);
+        return boardVisible(alice, boardSel);
+      },
+      (v) => v === true,
+      { label: `${gameType} author auto-entered board`, timeout: 15000 },
+    );
+    entered = true;
+  } catch { /* handled below */ }
+  console.log(entered ? `  [AUTO-ENTER ✓] ${gameType}: author board opened on its own` : `  [AUTO-ENTER ✗] ${gameType}: author NOT entered`);
+
+  mkdirSync(SHOT_DIR, { recursive: true });
+  const f = path.join(SHOT_DIR, `autoenter-${gameType}.png`);
+  await alice.page.screenshot({ path: f });
+  console.log('  [shot]', f);
+
+  await sweep([alice, bob]);
+}
+
+await done();

--- a/e2e/games-armada.spec.ts
+++ b/e2e/games-armada.spec.ts
@@ -300,6 +300,12 @@ test('a wall challenge: accept lands in deployment, the race seats exactly one, 
     await expect.poll(async () => (await synced(p))?.opponent, { timeout: 30_000 }).toBe(seated);
   }
 
+  // The AUTHOR is auto-entered into deployment the instant a rival accepts —
+  // parity with starting a game in a 1:1 chat, so the seated opponent isn't left
+  // waiting on a poster who never got pulled in (their page is visible and has
+  // been syncing engagement above, which is what fires the auto-enter).
+  await expect(a.page.locator('.armada')).toBeVisible({ timeout: 15_000 });
+
   // The post face is the challenge CARD on every device; the spectator gets
   // status only (no button once the seats are taken).
   const loser = seated === b.id ? c : b;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -24,6 +24,7 @@ import { isUnlockedNow, getIdentityKeys } from '@/services/crypto/identity';
 import { getSelfUserId, getSelfUsername } from '@/services/auth';
 import { notifyIncoming, isChatActive, pushWakeActive } from '@/services/notify';
 import { isGameActive } from '@/services/game-active';
+import { openGame, overlayOpen } from '@/composables/useGameOverlay';
 import { wallActivityAlert } from '@/services/wall-activity-policy';
 import { compressImage, compressVideo, achievedQuality } from '@/services/media-encode';
 import { setCompressProgress, setUploadProgress, resetJobProgress, clearJobProgress } from '@/services/media-jobs';
@@ -3366,6 +3367,12 @@ export async function notifyPostActivity(postId: string, fresh: FreshEngagement[
   }
 }
 
+// Wall challenges whose author this device has already auto-entered on accept
+// (below). In-memory + one-shot so a burst of engagement syncs can't yank the
+// poster back into a board they deliberately left; it resets on reload, where
+// re-entering an un-played game they still owe a move in is the right call.
+const autoEnteredWallGames = new Set<string>();
+
 /** Alerts for fresh GAME engagement on a challenge post (spec 0009): the seated
  *  player hears their turn / the result; a follower hears moves and results;
  *  everyone else stays quiet — all behind the Settings → Notifications → Games
@@ -3382,6 +3389,29 @@ async function notifyWallGameActivity(post: Post, fresh: FreshEngagement[]): Pro
   const me = playerIndexOf(session, self);
   const latest = others.sort((x, y) => x.at - y.at)[others.length - 1];
   const mover = (await getContact(latest.actor))?.name ?? 'Someone';
+
+  // Author auto-enter (parity with a 1:1 challenge, spec 1038): the instant a
+  // rival accepts THIS device's own FULLSCREEN Wall challenge and the opening
+  // move / fleet deployment is owed to us (seat 0, no moves yet), drop straight
+  // into the board — exactly as starting a game in a 1:1 chat does
+  // (ChatDetailPage.onGamePick). On the Wall the author posts and moves on, so
+  // without this the rival who accepted is left staring at "the other admiral is
+  // still deploying" (chess: "opponent to move") until the poster happens to tap
+  // back in. Gated to a visible app — a background/SW-side sync has no board to
+  // open, and the push notification below carries the nudge there instead.
+  if (
+    me === 0 &&
+    session.moves.length === 0 &&
+    module?.presentation === 'fullscreen' &&
+    challengePhase(session) === 'accepted' &&
+    typeof document !== 'undefined' &&
+    document.visibilityState === 'visible' &&
+    !overlayOpen.value && // already deep in a board (this game's or another's) — don't yank; the toast nudges
+    !autoEnteredWallGames.has(post.id)
+  ) {
+    autoEnteredWallGames.add(post.id);
+    openGame({ surface: 'wall', postId: post.id, gameType: session.gameType });
+  }
 
   // WATCHING the game live — the Wall tab or this very post open, app visible —
   // means the board updates in front of them: no toast, just the move cue for

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1024,6 +1024,7 @@ async function handleGameAccept(from: string, signal: GameAcceptSignal): Promise
     await notifyIncoming({
       kind: 'message',
       chatId: message.chatId,
+      msgId: message.id,
       name,
       body: `${name} accepted your challenge 💪 Your move!`,
       pushWoken: pushWakeActive(),
@@ -1337,6 +1338,7 @@ async function handleGameMove(from: string, signal: GameMoveSignal): Promise<voi
   await notifyIncoming({
     kind: 'message',
     chatId: message.chatId,
+    msgId: message.id,
     name,
     body: text,
     pushWoken: pushWakeActive(),
@@ -5830,6 +5832,7 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
   await notifyIncoming({
     kind: 'message',
     chatId: targetChatId,
+    msgId: message.id,
     name: chat?.isGroup ? chat.name : contact.name,
     // The notification spells out shared location / contact / poll (no icon to lean
     // on), unlike the terser `preview` used for the chats list above.

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -22,7 +22,8 @@ import { personAddOutline } from 'ionicons/icons';
 import router from '@/router';
 import { getSetting, isChatMuted, getChat } from '@/db/queries';
 import { subscribe } from '@/db/idb';
-import { notifyLocal } from '@/services/push';
+import { notifyLocal, pushSubscriptionActive } from '@/services/push';
+import { recordPageShown } from '@/services/sw-inbox';
 import { inAppGloballyEnabled, getChatNotifyPrefs } from '@/services/notify-prefs';
 import { isUnlockedNow } from '@/services/crypto/identity';
 import { ensureHiddenLoaded, isRevealed } from '@/services/hidden-state';
@@ -85,6 +86,7 @@ const DEFAULT_SYSTEM_ICON = personAddOutline;
 export interface IncomingNotice {
   kind: IncomingKind;
   chatId?: string; // for messages → deep-link target
+  msgId?: string; // the message's id — lets a backgrounded-bridge note be re-asserted by the SW (spec: game-move double)
   name: string; // sender / requester display name (or the subject of a system notice)
   body: string; // preview text ("Hi!", "📷 Photo", "wants to connect", "joined Ring")
   avatar?: string; // optional; messages resolve the chat avatar if omitted
@@ -446,7 +448,23 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
         // Preview off hides WHO it's from too, not just the body. A mention is an opt-in
         // escalation and keeps naming the mentioner.
         const title = p.showPreview || isMention ? n.name : 'Ring';
-        void notifyLocal(title, text, targetUrl(n), n.chatId);
+        // A backgrounded recipient (this branch) is marked inactive to the server, so
+        // if we hold a push subscription the server ALREADY pushed this delivery and the
+        // SW owns the ONE OS notification. Showing our own here too is the recently-
+        // backgrounded DOUBLE the user hit (our rich note + the SW's generic on a
+        // different tag — iOS won't collapse them). So: with a live subscription, don't
+        // show anything ourselves; just seed the shown-summary so that push wake renders
+        // the note RICH (via reassertFromSummary) instead of the content-free generic.
+        // With NO subscription the SW is never woken, so the page bridge is the only
+        // background channel and must still fire.
+        if (n.chatId && n.msgId && (await pushSubscriptionActive())) {
+          await recordPageShown(
+            { tag: `ring:${n.chatId}`, title, body: text, url: targetUrl(n), id: n.msgId },
+            Date.now(),
+          );
+        } else {
+          void notifyLocal(title, text, targetUrl(n), n.chatId);
+        }
       }
       return false;
     }

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -304,6 +304,21 @@ export async function notifyLocal(title: string, body: string, url?: string, cha
   }
 }
 
+/** Does this device currently hold an active Web Push subscription? When true, the
+ *  server wakes the SW for a backgrounded delivery, so the PAGE must NOT also show
+ *  its own OS notification for that delivery — doing so is the recently-backgrounded
+ *  DOUBLE (rich from the page + the SW's generic). When false (no permission/endpoint),
+ *  the page's notifyLocal bridge is the ONLY background channel and must still fire. */
+export async function pushSubscriptionActive(): Promise<boolean> {
+  try {
+    if (!('serviceWorker' in navigator)) return false;
+    const reg = await navigator.serviceWorker.ready;
+    return (await reg.pushManager.getSubscription()) !== null;
+  } catch {
+    return false;
+  }
+}
+
 /* ---- preference-driven subscription ---- */
 
 async function settingBool(key: string, fallback: boolean): Promise<boolean> {

--- a/src/services/sw-inbox.pageshown.test.ts
+++ b/src/services/sw-inbox.pageshown.test.ts
@@ -1,0 +1,68 @@
+// The double-notification fix: when the page bridges a hidden delivery via
+// notifyLocal (backgrounded-but-connected), it mirrors the rich note into the
+// shown-summary so a co-arriving push wake re-asserts THAT note (same
+// ring:<chatId> tag) instead of firing the stray "New message" generic. These pin
+// recordPageShown's contract: it seeds the summary the SW reads, merges by tag,
+// and deliberately writes NO shown-sig (so the SW's first re-assert is permitted,
+// not skipped as identical).
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, it, expect } from 'vitest';
+import { put } from '@/db/idb';
+import { recordPageShown, loadShownSummary, loadShownSigs, saveShownSig, shouldReassert, SUMMARY_KEY } from './sw-inbox';
+
+// fake-indexeddb persists across tests in a file; reset the summary + sigs so each
+// case starts clean (these all write the same ring:chat-1 tag).
+beforeEach(async () => {
+  await put('settings', { key: SUMMARY_KEY, value: [] });
+  await put('settings', { key: 'sw.shownSig', value: {} });
+});
+
+const NOW = Date.now(); // loadShownSummary TTL-filters to a 2-min window, so stay near real time
+const note = (over: Partial<{ tag: string; title: string; body: string; url: string; id: string }> = {}) => ({
+  tag: 'ring:chat-1',
+  title: 'Macbook',
+  body: 'made a move, your turn 😏',
+  url: '/chat/chat-1',
+  id: 'm1',
+  ...over,
+});
+
+describe('recordPageShown — page seeds the summary the SW re-asserts from', () => {
+  it('writes a summary entry for the tag that loadShownSummary returns', async () => {
+    await recordPageShown(note(), NOW);
+    const list = await loadShownSummary();
+    const entry = list.find((e) => e.tag === 'ring:chat-1');
+    expect(entry).toBeTruthy();
+    expect(entry!.body).toBe('made a move, your turn 😏');
+    expect(entry!.ids).toEqual(['m1']);
+  });
+
+  it('CLEARS a stale shown-sig so the SW is PERMITTED to re-assert (not skip as identical)', async () => {
+    // A prior move's SW show left an identical-looking sig ("made a move…", count 1).
+    await saveShownSig('ring:chat-1', { body: 'made a move, your turn 😏', count: 1, ts: NOW });
+    await recordPageShown(note({ id: 'm2' }), NOW + 10);
+    const sigs = await loadShownSigs();
+    expect(sigs['ring:chat-1']).toBeUndefined(); // cleared, so the re-assert isn't vetoed
+    // The whole point: reassertFromSummary calls shouldReassert(sig, entry); with no
+    // sig it returns true → the SW re-asserts the rich note instead of the generic —
+    // even though the new move's text is identical to the prior one.
+    const entry = (await loadShownSummary()).find((e) => e.tag === 'ring:chat-1')!;
+    expect(shouldReassert(sigs['ring:chat-1'], entry)).toBe(true);
+  });
+
+  it('merges ids per tag (a second backgrounded delivery grows the cumulative count)', async () => {
+    await recordPageShown(note({ id: 'a' }), NOW + 20);
+    await recordPageShown(note({ id: 'b', body: 'made a move 🎲' }), NOW + 30);
+    const entry = (await loadShownSummary()).find((e) => e.tag === 'ring:chat-1')!;
+    expect(new Set(entry.ids)).toEqual(new Set(['a', 'b']));
+    expect(entry.body).toBe('made a move 🎲'); // latest body wins
+  });
+
+  it('keeps distinct tags separate (another chat is untouched)', async () => {
+    await recordPageShown(note({ id: 'm1' }), NOW + 40);
+    await recordPageShown(note({ tag: 'ring:chat-9', id: 'z', body: 'hi' }), NOW + 41);
+    const list = await loadShownSummary();
+    expect(list.find((e) => e.tag === 'ring:chat-9')!.ids).toEqual(['z']);
+    expect(list.find((e) => e.tag === 'ring:chat-1')!.ids).toEqual(['m1']); // untouched by chat-9
+  });
+});

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -629,6 +629,31 @@ export async function saveShownSig(tag: string, sig: ShownSig): Promise<void> {
   await put<Setting<Record<string, ShownSig>>>('settings', { key: SHOWN_SIG_KEY, value: Object.fromEntries(entries) });
 }
 
+/** A backgrounded, push-subscribed recipient learns of a delivery over its live socket
+ *  (notify.ts) but does NOT show its own OS notification — the server also pushed it (it
+ *  marks a non-foregrounded recipient inactive) and the SW owns the single notification.
+ *  This seeds that note into the same shown-summary the SW's reassertFromSummary reads, so
+ *  the co-arriving push wake — which finds "nothing new" once the page has acked — re-asserts
+ *  THIS rich note (under its ring:<chatId> tag) instead of the content-free "New message"
+ *  generic. Without it the user got the recently-backgrounded DOUBLE. The shown-sig for the
+ *  tag is CLEARED (not written): the page showed no banner, so the SW's re-assert is the FIRST
+ *  visible show and must not be vetoed as an identical duplicate — which it otherwise would be
+ *  for back-to-back game moves that carry the same "made a move, your turn" text. */
+export async function recordPageShown(
+  note: { tag: string; title: string; body: string; url: string; id: string },
+  now: number,
+): Promise<void> {
+  const list = await loadShownSummary();
+  const prev = list.find((e) => e.tag === note.tag);
+  const merged = mergeIntoSummary(prev, { ...note, ids: [note.id] } as SwNote, now);
+  await saveShownSummary([...list.filter((e) => e.tag !== note.tag), merged]);
+  const sigs = await loadShownSigs();
+  if (sigs[note.tag]) {
+    delete sigs[note.tag];
+    await put<Setting<Record<string, ShownSig>>>('settings', { key: SHOWN_SIG_KEY, value: sigs });
+  }
+}
+
 /** (spec 2017) Merge each note into the persisted summary and return the notes to actually SHOW, with
  *  `count` set to the CUMULATIVE per-chat total (so a burst shows one monotonic count, not a bouncing
  *  per-pass slice). Persists the updated summary. Serialized by the caller. */

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -2347,6 +2347,17 @@ async function scrollToMessage(id: string, opts: { instant?: boolean; silent?: b
 // snaps back and does nothing.
 const SWIPE_MAX = 110; // how far the bubble can travel
 const SWIPE_TRIGGER = 70; // release past this fires the action
+// The native standalone-PWA back gesture (iOS swipes the browser history back
+// when the app runs full-screen; Ionic's own swipe-back is off — see main.ts)
+// owns the left of the screen, and iOS fires it from well INSIDE the edge, not
+// just the first few pixels — so a fixed screen-edge guard can't reliably tell a
+// back-swipe from a reply. Instead we make the LEFT PART OF EACH INCOMING BUBBLE
+// inert to the reply drag: a right-swipe that begins on the left of an incoming
+// bubble is almost always "go back", so it must not also arm a reply (which would
+// drop a stray draft as the page navigates away). Only the bubble's right portion
+// starts a reply. Outgoing bubbles hug the right edge, clear of the back-swipe
+// lane, so they stay fully swipeable.
+const REPLY_DEAD_ZONE_FRAC = 0.55; // left 55% of an incoming bubble ignores swipe-right
 const swipeId = ref<string | null>(null); // the message currently being dragged
 const swipeDx = ref(0); // its current x offset
 const swipeReleasing = ref(false); // animate the snap-back
@@ -2365,7 +2376,16 @@ function swipeStyle(id: string): Record<string, string> | undefined {
 function onSwipeStart(e: TouchEvent, m: Message): void {
   if (m.deleted || selecting.value) return;
   if (m.kind === 'game' || m.kind === 'gamechallenge') return; // boards aren't reply-swipeable
-  swipeStartX = e.touches[0].clientX;
+  const startX = e.touches[0].clientX;
+  // Incoming bubbles: the left part is inert to the reply drag — a right-swipe
+  // starting there is the OS back gesture, not a reply (see REPLY_DEAD_ZONE_FRAC).
+  // Measure against the bubble the touch actually landed on, so it scales with
+  // every bubble width and never depends on guessing iOS's back-swipe hot-zone.
+  if (!m.outgoing) {
+    const rect = (e.currentTarget as HTMLElement | null)?.getBoundingClientRect();
+    if (rect && startX - rect.left < rect.width * REPLY_DEAD_ZONE_FRAC) return;
+  }
+  swipeStartX = startX;
   swipeStartY = e.touches[0].clientY;
   swipeDir = null;
   swipeTarget = m;


### PR DESCRIPTION
Three UX fixes from today's session, each its own commit (merge-commit this PR so each keeps its "What's new" line).

### fix(chat): back-swipe no longer opens a stray reply
The iOS standalone-PWA back gesture fires from well inside the left edge, so swiping back to the chat list while your finger was on an incoming bubble also armed swipe-to-reply and left a draft. The left ~55% of each incoming bubble is now inert to swipe-right; a reply only opens from the bubble's right side. Verified with synthetic touch swipes (left → no reply, right → reply).

### feat(games): Wall challenge starts for both players on accept
Posting a fullscreen game (chess/Armada) on the Wall left the accepter waiting, because the poster was never brought into the board to make the first move / deploy. Accepting now auto-enters the poster (parity with a 1:1 challenge). Covered end-to-end for both games; the previously-untested full Wall-Armada duel path is now exercised, plus a regression assertion in `games-armada.spec.ts`.

### fix(notifications): no duplicate alert right after backgrounding
A recipient who just backgrounded the app is still briefly WS-connected, so a message arrived over the socket (rich alert from the page) AND as a push (the SW added a generic "New message"). When a push subscription is active, the page now leaves the single notification to the SW — seeding the shown-summary so it renders with the real content instead of the generic — and only falls back to its own bridge when there's no subscription (so users without push don't lose background alerts).

### Verification
- `npm run build` (typecheck + build) clean
- All 888 unit tests pass, incl. new `sw-inbox.pageshown.test.ts`
- Swipe + Wall flows driven live via `drive/` scenarios; on-device confirmed by the maintainer for the swipe and notification behavior on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7
