### PR TITLE
fix: group member names, invite redemption, and Android push reliability

### DIFF
--- a/drive/scenarios/group-member-hydrate.mjs
+++ b/drive/scenarios/group-member-hydrate.mjs
@@ -1,0 +1,54 @@
+// Repro + verify: a group member added via the accept-first invite flow, whom
+// nobody in the group personally knows, must still resolve to a real name/photo
+// from the directory instead of rendering as a raw id-slice ("88155153").
+//
+//   Alice creates a group with Bob (paired). Alice then INVITES Carol — a real
+//   registered account with a published profile — whom neither Alice nor Bob has
+//   as a contact. Carol accepts. Before the directory-hydrate fix, Carol rode in
+//   as her raw id on both devices (accept branch adds her to participantIds with
+//   no contact; the roster card carries only her raw id-slice name). After the
+//   fix, handleGroupCard + the accept branch pull her profile from the directory.
+//
+// Run against the live `make start` stack:  node drive/scenarios/group-member-hydrate.mjs
+import { createAccount, pair, poll, shot, done } from '../driver.mjs';
+
+const members = (c, gid) =>
+  c.page.evaluate((g) => window.__ringTest.groupChats().then((gs) => gs.find((x) => x.id === g)?.members ?? []), gid);
+const nameOf = (c, id) => c.page.evaluate((i) => window.__ringTest.contactName(i), id);
+
+const A = await createAccount({ name: 'Alice' });
+const B = await createAccount({ name: 'Bob' });
+const C = await createAccount({ name: 'Carol' });
+
+// Only Alice↔Bob are paired. Nobody pairs with Carol → she is unknown to the group.
+await pair(A, B);
+
+// Alice creates the group with Bob, then invites Carol (accept-first: Alice has no
+// contact for Carol, so addMemberToGroup would route to inviteToGroup anyway).
+const gid = await A.page.evaluate(([n, m]) => window.__ringTest.createGroup(n, m), ['Trip', [B.id]]);
+await poll(() => members(B, gid), (m) => m.includes(B.id) || true, { label: 'Bob has the group' });
+await A.page.evaluate(([g, id]) => window.__ringTest.inviteToGroup(g, id), [gid, C.id]);
+
+// Carol sees the invite and accepts.
+await poll(() => C.page.evaluate((g) => window.__ringTest.groupInviteIds().then((ids) => ids.includes(g)), gid), Boolean, {
+  label: 'Carol sees the group invite',
+});
+await C.page.evaluate((g) => window.__ringTest.acceptGroupInvite(g), gid);
+
+// Carol becomes a member on both devices.
+await poll(() => members(A, gid), (m) => m.includes(C.id), { label: 'Alice sees Carol as member' });
+await poll(() => members(B, gid), (m) => m.includes(C.id), { label: 'Bob sees Carol as member' });
+
+// The fix: Carol resolves to her real name (from the directory), NOT her raw id.
+const raw = C.id.slice(0, 8);
+await poll(() => nameOf(A, C.id), (n) => n === 'Carol', { label: 'Alice resolves Carol → name', timeout: 15_000 });
+await poll(() => nameOf(B, C.id), (n) => n === 'Carol', { label: 'Bob resolves Carol → name', timeout: 15_000 });
+
+const [onA, onB] = [await nameOf(A, C.id), await nameOf(B, C.id)];
+console.log(`\n  Carol.id.slice(0,8) = "${raw}"`);
+console.log(`  name on Alice = "${onA}"   name on Bob = "${onB}"`);
+if (onA === raw || onB === raw) throw new Error('REGRESSION: Carol still shows as a raw id');
+console.log('  ✅ member resolved to a real name on both devices (not a raw id)\n');
+
+await shot(A, 'group-member-hydrate-alice', { route: `/group/${gid}` });
+await done();

--- a/drive/scenarios/invite-mark-used.mjs
+++ b/drive/scenarios/invite-mark-used.mjs
@@ -1,0 +1,45 @@
+// Verify: an invite code that someone redeems is cleared from the "Invited"
+// (waiting) list even if the invitee never finishes setting up their profile.
+// Previously the placeholder was held until the invitee published a photo, so a
+// registered-but-unfinished invitee left the code stuck as "Waiting to join"
+// forever and you had to remove it by hand.
+//
+//   Alice creates an invite, Bob registers with it but sets NO profile (no photo),
+//   Alice sweeps → the code must leave her waiting list.
+//
+// Run against the live `make start` stack:  node drive/scenarios/invite-mark-used.mjs
+import { createAccount, newClient, poll, done } from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice' });
+const code = await alice.page.evaluate(() => window.__ringTest.createInvite('Mom'));
+console.log('invite code:', code);
+
+const before = await alice.page.evaluate(() => window.__ringTest.pendingInviteCodes());
+if (!before.includes(code)) throw new Error('setup: code not in waiting list after createInvite');
+console.log('waiting list before redeem:', before);
+
+// Bob registers with Alice's code but deliberately never sets a profile → no
+// directory avatar, i.e. the "unfinished invitee" the old code got stuck on.
+const bob = await newClient({ label: 'Bob' });
+await bob.page.goto('/');
+await bob.page.waitForFunction(() => !!window.__ringTest, null, { timeout: 30_000 });
+await bob.page.evaluate(async (c) => {
+  const t = window.__ringTest;
+  await t.register(c);
+  await t.createAuto();
+}, code);
+await poll(() => bob.page.evaluate(() => window.__ringTest.isUnlocked()), (v) => v === true, { label: 'Bob unlocked' });
+console.log('Bob registered with the code (no profile set)');
+
+// Alice sweeps redemptions: the redeemed code must clear from the waiting list.
+await poll(
+  async () => {
+    await alice.page.evaluate(() => window.__ringTest.syncInvites());
+    return alice.page.evaluate(() => window.__ringTest.pendingInviteCodes());
+  },
+  (codes) => !codes.includes(code),
+  { label: 'Alice clears the redeemed invite', timeout: 20_000 },
+);
+
+console.log('\n  ✅ redeemed invite cleared from the waiting list even though the invitee has no profile\n');
+await done();

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -23,7 +23,7 @@ import {
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
 import { kickPendingPosts } from '@/services/pending-posts';
-import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, notifyPostActivity, pruneLocalPost } from '@/db/queries';
+import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, notifyPostActivity, pruneLocalPost, hydrateGroupMembers } from '@/db/queries';
 import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
@@ -284,6 +284,11 @@ function start(): void {
         // Refresh contacts' name/photo/About from the directory (replaces the old
         // peer-to-peer "share my name & photo").
         void refreshContactProfiles();
+        // Heal group members still showing as a raw id: every group participant
+        // gets a contact + directory profile, so members added via accept /
+        // ensureGroupChat (which never created a contact) stop rendering as
+        // "88155153" / a "?" disc once they've published a profile.
+        void hydrateGroupMembers();
       }
       void refreshConnections(); // reconcile incoming/outgoing connect requests
       // A reconnect can mean the server was just redeployed; check for a new build

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -6178,6 +6178,13 @@ export interface PendingInvite {
   code: string;
   label: string; // your note for who you sent it to (replaced by their profile on join)
   createdAt: number;
+  // Set once the server reports the code redeemed. The row then drops out of the
+  // "Invited" (waiting) list immediately — the invitee has an account — but the
+  // record itself lingers (keeping your label) until the invitee FINISHES their
+  // profile and the one-time "X joined Ring" announcement fires, at which point it
+  // is removed for good. Kept out of listPendingInvites' semantics so the sweep gate
+  // (useSync) still runs the announcement; only the UI + test hook hide joined ones.
+  joined?: boolean;
 }
 
 /** Record a sent invite code with your label (shows under Contacts → Invited). */
@@ -6199,6 +6206,15 @@ export async function listPendingInvites(): Promise<PendingInvite[]> {
 
 export async function removePendingInvite(code: string): Promise<void> {
   await remove('settings', `${PENDING_INVITE_PREFIX}${code}`);
+}
+
+/** Mark a sent invite as redeemed: it leaves the "Invited" waiting list right away
+ *  (the invitee has registered), but the record survives — keeping your label — so
+ *  the later "X joined Ring" announcement can still use it. No-op if already gone. */
+export async function markInviteJoined(code: string): Promise<void> {
+  const pending = await getPendingInvite(code);
+  if (!pending || pending.joined) return;
+  await setSetting<PendingInvite>(`${PENDING_INVITE_PREFIX}${code}`, { ...pending, joined: true });
 }
 
 /** Cancel a sent invite for real: delete it server-side so it can no longer be

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -5,7 +5,7 @@
  */
 import { bulkPut, clearStore, get, getAll, getByIndex, put, remove } from './idb';
 import { enqueue, removeOutboxByFrameId } from './outbox';
-import { recordTombstone, isTombstoned, clearTombstone, clearHiddenPeerBlock } from './tombstones';
+import { recordTombstone, isTombstoned, hasTombstone, clearTombstone, clearHiddenPeerBlock } from './tombstones';
 import { callLogPreview } from './calllog';
 import { uid } from '@/utils/uid';
 import { sliceOlder, sliceNewer, compareByTimeId } from '@/utils/chat-pagination';
@@ -5233,6 +5233,41 @@ export async function hydrateContactFromDirectory(id: string): Promise<void> {
   }
 }
 
+/** Heal group members that render as a raw id ("88155153" / a "?" disc). Every
+ *  group participant should resolve to a real name / @username / photo from the
+ *  directory, but two paths leave one unresolved: a participant added via the
+ *  accept or ensureGroupChat paths has no contact row at all (so the connect-time
+ *  refreshContactProfiles, which only walks EXISTING contacts, skips them), and a
+ *  member whose one-shot first-frame hydrate ran before they'd published a profile
+ *  never retries. This connect-time sweep gives every group participant a contact
+ *  and (re)pulls their directory profile, so an existing broken group self-heals
+ *  without waiting for a roster change. Best-effort; respects deletion tombstones
+ *  so a member the user deleted is never resurrected. */
+export async function hydrateGroupMembers(): Promise<void> {
+  const self = getSelfUserId();
+  if (!self) return;
+  let chats;
+  try {
+    chats = await getAll<Chat>('chats');
+  } catch {
+    return;
+  }
+  const ids = new Set<string>();
+  for (const ch of chats) {
+    if (!ch.isGroup) continue;
+    for (const id of ch.participantIds) if (id && id !== self) ids.add(id);
+  }
+  for (const id of ids) {
+    const c = await getContact(id);
+    // Already resolved (has an @username and a real name, not the raw id-slice
+    // fallback) → nothing to do. Skips the network round-trip for known members.
+    if (c && c.username && c.name && c.name !== id.slice(0, 8)) continue;
+    if (await hasTombstone('contacts', id)) continue; // never resurrect a deleted contact
+    if (!c) await addContactWithId(id, '');
+    await hydrateContactFromDirectory(id);
+  }
+}
+
 // Messages that arrive while the keystore is locked are stashed here (still
 // encrypted) under `pendingIncoming:<id>` and decrypted on unlock. This lets the
 // sync layer still ack them (so the sender gets "delivered" as soon as the device
@@ -5314,6 +5349,17 @@ async function handleGroupCard(from: string, card: GroupCard): Promise<void> {
     const ts = card.at || now();
     existing.invitedIds = (existing.invitedIds ?? []).filter((id) => id !== from);
     existing.participantIds = [...existing.participantIds, from];
+    // The accepter becomes a member on OUR device here. We author (never receive)
+    // this group's roster, so the handleGroupCard hydrate above never runs for us —
+    // if we don't personally know them they'd sit in the roster as a raw id-slice.
+    // A placeholder contact may already exist from setting up the invite session, so
+    // hydrate whenever they're unresolved (no @username), not only when absent, so
+    // they render as a name/photo instead of "88155153".
+    const accepter = await getContact(from);
+    if (!accepter?.username && !(await hasTombstone('contacts', from))) {
+      if (!accepter) await addContactWithId(from, '');
+      void hydrateContactFromDirectory(from);
+    }
     const roster = await buildRoster([self, ...existing.participantIds]);
     applyAutoName(existing, roster, self);
     existing.rosterAt = ts;
@@ -5360,7 +5406,13 @@ async function handleGroupCard(from: string, card: GroupCard): Promise<void> {
     return;
   }
 
-  // Upsert co-member contacts so their names render in the group view.
+  // Upsert co-member contacts so their names render in the group view. The roster
+  // only carries {id, name} (name filled from the card author's own contacts, with
+  // a raw-id fallback) — never an @username or photo — so ALSO pull each member's
+  // real profile from the directory. Without this a member the card author didn't
+  // personally know rides in as a raw id-slice and stays that way: the one-shot
+  // first-frame hydrate (receiveIncoming) is skipped once this placeholder exists,
+  // and the connect-time refreshContactProfiles only walks contacts that resolve.
   for (const m of card.members) {
     if (!m.id || m.id === self) continue;
     const c = await getContact(m.id);
@@ -5372,6 +5424,9 @@ async function handleGroupCard(from: string, card: GroupCard): Promise<void> {
       c.updatedAt = now();
       await put('contacts', c);
     }
+    // Fire-and-forget: fills the real name/@username/photo when the member has
+    // published a profile; a no-op (kept as-is) for one who hasn't yet.
+    if (!c?.username) void hydrateContactFromDirectory(m.id);
   }
 
   const participantIds = card.members.map((m) => m.id).filter((id) => id !== self);

--- a/src/services/invites.ts
+++ b/src/services/invites.ts
@@ -18,6 +18,7 @@ import {
   acceptRequest,
   markAutoAccept,
   removePendingInvite,
+  markInviteJoined,
   isLinkedOrRequested,
   getPendingInvite,
   isInviteHandled,
@@ -86,16 +87,28 @@ async function processSentInvitations(): Promise<void> {
     await markAutoAccept(inv.usedBy); // auto-accept their request if/when it arrives
     await acceptRequest(inv.usedBy); // accept now if their card already arrived (else no-op)
 
+    // The code is genuinely redeemed the instant the server reports `usedBy` (set
+    // when the invitee picks a username). Drop it from the "Invited" waiting list NOW,
+    // decoupled from whether they've finished their profile — previously the row was
+    // held until a published avatar, so an invitee who registered but never set a
+    // photo left it stuck as "Waiting to join" forever (you had to remove it by hand).
+    // markInviteJoined only hides it from the list; the record (and your label)
+    // survive so the announcement below can still name them by your label.
+    await markInviteJoined(inv.code);
+
+    // Hold the one-time "X joined Ring" announcement until they've actually FINISHED
+    // setting up: a photo is required to finish and is published to the directory on
+    // completion, so a non-empty directory avatar is our "they tapped Start" signal.
     let profile;
     try {
       profile = await fetchDirectoryUser(inv.usedBy);
     } catch {
-      continue; // transient: re-check next sweep
+      continue; // transient: re-check next sweep (already dropped from the list)
     }
     if (!profile?.avatar) continue; // profile not finished yet → don't announce
 
-    const pending = await getPendingInvite(inv.code); // our label, before we clear it
-    await removePendingInvite(inv.code); // the placeholder becomes a real contact
+    const pending = await getPendingInvite(inv.code); // your label survives markInviteJoined
+    await removePendingInvite(inv.code); // fully clean up now that we're announcing
     await markInviteHandled(inv.code); // announce exactly once
 
     // "Mom joined Ring": prefer our label, then their published/synced name. Shown as a

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -27,6 +27,7 @@ import {
   requestFriend as dbRequestFriend,
   acceptRequest as dbAcceptRequest,
   addPendingInvite,
+  listPendingInvites,
   listContacts,
   createGroup as dbCreateGroup,
   addToGroup as dbAddToGroup,
@@ -375,6 +376,11 @@ export function installTestHook(): void {
     },
     /** Force an invitation auto-connect sweep (poll redemptions / connect inviter). */
     syncInvites: () => runInviteSync(),
+    /** Codes still shown in the "Invited" (waiting) list — for asserting a redeemed
+     *  code is cleared even when the invitee never finishes their profile. Mirrors the
+     *  UI: a joined (redeemed) invite has dropped out even though its record lingers. */
+    pendingInviteCodes: async (): Promise<string[]> =>
+      (await listPendingInvites()).filter((i) => !i.joined).map((i) => i.code),
     /** Current in-app notification banners (kind/name/body) for asserting alerting. */
     notices: (): { kind: string; name: string; body: string }[] =>
       notifyBanners.value.map((b) => ({ kind: b.kind, name: b.name, body: b.body })),

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -23,7 +23,7 @@ import { ExpirationPlugin } from 'workbox-expiration';
 import {
   previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, previewPosts, previewPostActivity, markConnShown,
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
-  mayEndWakeSilently, platformTrustsSilence, quietNote, stampPushWake, stampedShow, countAccepted,
+  mayEndWakeSilently, quietNote, stampPushWake, stampedShow, countAccepted,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
@@ -807,15 +807,28 @@ async function dispatchPush(event: PushEvent): Promise<void> {
       // never acks) still falls through to the SW promptly enough.
       if (clients.length && (await pageWillNotify(clients, 2200))) {
         // (spec 2023 FR-003) The page owns the RICH alert, but an in-app banner is
-        // invisible to webpushd: on platforms where silence is unsafe, a claimed
-        // wake still counts a strike unless the SW shows something. And one claim
-        // arm shows nothing anywhere — a message for a locked hidden chat on a
-        // visible page (notify.ts, the spec-1027 FR-012 zero-trace claim) — so the
-        // quiet note is the wake's only visible ending there. Platform-gated ONLY
-        // (never visibility-gated): the Chromium claim outcome stays exactly as
-        // before, and the quiet note's content-free body keeps the hidden-chat
-        // trade bounded to what any message push already reveals.
-        if (!platformTrustsSilence(self.navigator.userAgent)) await showQuietNote('msg');
+        // invisible to the OS push service: a claimed wake that shows no OS
+        // notification is a SILENT push, and every userVisibleOnly push service
+        // revokes the subscription after a few of those — not just WebKit's webpushd.
+        // Chromium does too, exempting ONLY a push handled while a window is open AND
+        // focused (its documented "site is visible" carve-out). This skip used to gate
+        // on the platform ALONE, trusting Chromium unconditionally — but the page acks
+        // when it CAN render a banner, and Chromium samples window visibility at event
+        // RESOLUTION, so a page that was visible when it acked and then backgrounded
+        // during the up-to-2200ms wait produced a silent push Chromium counted. Enough
+        // of those and Android's subscription got revoked "after several messages".
+        //
+        // So re-sample the clients HERE (start-of-wake `clients` is now stale) and end
+        // silently only when `mayEndWakeSilently` holds: the platform tolerates silence
+        // AND a window is focused+visible right now. Otherwise show the content-free
+        // quiet note — which is also the only visible ending for the one claim arm that
+        // shows nothing anywhere (a locked hidden chat on a visible page: notify.ts, the
+        // spec-1027 FR-012 zero-trace claim). iOS is unaffected: platformTrustsSilence is
+        // already false there, so this always showed the quiet note and still does; and a
+        // Chrome window that stays focused+visible still skips exactly as before (the user
+        // saw the in-app banner, so no OS duplicate).
+        const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+        if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) await showQuietNote('msg');
         return;
       }
       // Spec 1032: with sw.fullPersist on (and no page claiming the wake), persist

--- a/src/views/tabs/ContactsPage.vue
+++ b/src/views/tabs/ContactsPage.vue
@@ -299,9 +299,11 @@ const acceptInvite = (groupId?: string) => groupId && acceptGroupInvite(groupId)
 const declineInvite = (groupId?: string) => groupId && declineGroupInvite(groupId);
 
 // Pending invitations (codes you've sent, awaiting the person to join). The label
-// is local; the expiry/redemption state comes from the server (fetched below).
+// is local; the expiry/redemption state comes from the server (fetched below). A
+// redeemed invite (joined) drops out of this waiting list — the person has an
+// account — even though the record lingers until their "joined Ring" announcement.
 const invited = useLiveQuery(
-  () => listPendingInvites(),
+  () => listPendingInvites().then((list) => list.filter((i) => !i.joined)),
   ['settings'],
   [] as PendingInvite[],
 );
@@ -332,6 +334,11 @@ function isExpired(code: string): boolean {
 }
 // Status line under each invite's name.
 function inviteStatus(code: string): string {
+  // Redeemed: the server reports who used the code. Show "Joined" right away rather
+  // than a stale "Waiting to join" — the local placeholder is cleared separately by
+  // the invite sweep (processSentInvitations), which needs the network, so this
+  // keeps the row honest in the interim and while offline.
+  if (serverInvites.value.get(code)?.usedBy) return 'Joined';
   const exp = expiresAt(code);
   if (exp === undefined) return 'Waiting to join'; // offline / legacy never-expiring
   const left = exp - now.value;


### PR DESCRIPTION
Three independent, user-reported reliability fixes. Kept as three commits so each
keeps its own end-user "What's new" line — please **merge** (not squash).

### 1. Group members show their real name and photo, not a raw id
A member added to a group that you or the owner didn't personally know could show
as a raw id-slice with a blank avatar (their messages rendered under that
placeholder). Group rosters only carry a name — never a photo or `@username` — and
a member added by accepting an invite was never looked up in the directory. Now
every member's real name/`@username`/photo is pulled from the directory when they
join and refreshed on reconnect, so existing groups heal themselves.
Verified live via `drive/scenarios/group-member-hydrate.mjs`.

### 2. An invite disappears once it's used
An invite you sent stayed as "Waiting to join" long after someone joined with it —
it only cleared once the invitee finished their profile with a photo. Now it
clears as soon as the server reports it redeemed, and shows "Joined" in the
meantime; the "joined Ring" welcome still waits for a finished profile.
Verified live via `drive/scenarios/invite-mark-used.mjs`.

### 3. Android notifications no longer stop after a while
Chromium revokes a push subscription on repeated silent wakes (its only exemption
is a window open **and** focused). The message-claim skip trusted the platform
alone, so a page visible when it acked that then backgrounded during the wake
produced a silent push Android counted → revocation "after several messages". Now
window visibility is re-checked at the decision point (reusing the tested
`mayEndWakeSilently` gate). **iOS behavior is byte-for-byte unchanged.**
Typecheck + full build + 20 push unit tests pass; needs a real-Android-device
confirmation once deployed (FCM revocation can't be reproduced in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)