### PR TITLE
fix: Android UX batch — emoji, groups, games, mic errors, notifications, intro, install freshness

### DIFF
--- a/drive/scenarios/emoji-avatar-rest.mjs
+++ b/drive/scenarios/emoji-avatar-rest.mjs
@@ -1,0 +1,35 @@
+// Verify: an animated emoji avatar (a fly-in/out Noto emoji like the running shoe)
+// rests on the fully-formed native glyph after its play-cap, NOT on a blank Lottie
+// frame. Repro of the "empty purple disc once the animation ends" bug.
+//
+//   node drive/scenarios/emoji-avatar-rest.mjs
+//
+// Bob sets the running-shoe emoji avatar; Alice pairs with him and views her chat
+// list, where Bob's avatar animates twice (the default cap) then parks. We wait past
+// the animation and screenshot — the disc must show the shoe, not an empty circle.
+import { createAccount, pair, chatWith, shot, sweep } from '../driver.mjs';
+
+const alice = await createAccount({ mobile: true, name: 'Alice', label: 'alice' });
+const bob = await createAccount({ mobile: true, name: 'Bob', label: 'bob' });
+
+// Bob picks the running-shoe emoji avatar (1f45f) — its Lottie flies the shoe in
+// AND out of frame, so both the first and last frames are blank. The old code
+// parked on frame 0 → an empty disc. publishOwnProfile() lands it in the directory.
+await bob.page.evaluate(() => window.__ringTest.setEmojiAvatar('\u{1F45F}'));
+
+await pair(alice, bob);
+// Confirm Alice actually received Bob's shoe avatar before the render check is meaningful.
+await bob.page.waitForTimeout(300);
+await alice.page.evaluate((id) => window.__ringTest.importDirectoryUser(id), bob.id);
+const got = await alice.page.evaluate((id) => window.__ringTest.contactAvatarEmoji(id), bob.id);
+console.log(`[check] Alice sees Bob avatar emoji: ${JSON.stringify(got)} (expect "👟")`);
+
+// Full-load the chat list (re-runs the auth gate past the onboarding recovery step),
+// then let Bob's avatar animate its two loops and rest. Lottie load (server proxy →
+// gstatic) + 2 loops (~2s each) + margin.
+await alice.page.goto('/tabs/chats');
+await alice.page.waitForTimeout(10_000);
+await shot(alice, 'emoji-avatar-rest');
+
+console.log('Screenshot .tmp/drive/emoji-avatar-rest.png: Bob’s disc must show the shoe, not an empty circle.');
+await sweep([alice, bob]);

--- a/drive/scenarios/group-pending-member-name.mjs
+++ b/drive/scenarios/group-pending-member-name.mjs
@@ -1,0 +1,44 @@
+// Verify: a group co-member the viewer shares NO direct 1:1 with still renders with
+// their real name + avatar in the group — not a raw id. Repro of "some users show as
+// 88155153 with a blank avatar" (Azin).
+//
+//   node drive/scenarios/group-pending-member-name.mjs
+//
+// Root cause: sending into a group creates a HIDDEN pending 1:1 "session carrier" for
+// every co-member you haven't DM'd (memberSessionChat). listContacts() drops pending
+// peers, so the group view — which used to resolve senders through listContacts() —
+// lost that member's contact and fell back to the id. Bob owns a group with Alice and
+// Carol; Alice and Carol never pair, so on Alice's device Carol is a pending carrier.
+import { createAccount, pair, group, say, waitForMessage, shot, sweep } from '../driver.mjs';
+
+const alice = await createAccount({ mobile: true, name: 'Alice', label: 'alice' });
+const bob = await createAccount({ name: 'Bob', label: 'bob' });
+const carol = await createAccount({ name: 'Carol', label: 'carol' });
+
+// Bob (owner) knows both; Alice and Carol are strangers to each other.
+await pair(bob, alice);
+await pair(bob, carol);
+
+const gid = await group(bob, 'Trip', [alice, carol]);
+
+// Alice sends first → creates the hidden pending session-carrier chats for Bob AND
+// Carol on her device, which is what makes listContacts() hide Carol.
+await say(alice, gid, 'hi team', { isGroup: true });
+await say(carol, gid, 'hey from Carol', { isGroup: true });
+await waitForMessage(alice, gid, 'hey from Carol', { isGroup: true });
+
+// Prove the bug CONDITION is present on Alice's device: Carol's contact exists and is
+// named (unfiltered read), yet listContacts() hides her (pending session carrier).
+await alice.page.waitForTimeout(500);
+const carolName = await alice.page.evaluate((id) => window.__ringTest.contactName(id), carol.id);
+const filteredIds = await alice.page.evaluate(() => window.__ringTest.contactIds());
+console.log(`[check] Alice's contactName(Carol) = ${JSON.stringify(carolName)} (expect "Carol")`);
+console.log(`[check] listContacts() includes Carol? ${filteredIds.includes(carol.id)} (expect false — she's a hidden pending carrier)`);
+
+// Open the group on Alice and screenshot: Carol's message must show "Carol", not her id.
+await alice.page.goto(`/chat/${gid}`);
+await alice.page.waitForTimeout(2500);
+await shot(alice, 'group-pending-member-name');
+
+console.log('Screenshot .tmp/drive/group-pending-member-name.png: Carol’s message must be headed "Carol" with an avatar, not a raw id.');
+await sweep([alice, bob, carol]);

--- a/drive/scenarios/launch-reveal-hook.mjs
+++ b/drive/scenarios/launch-reveal-hook.mjs
@@ -1,0 +1,11 @@
+// Verify the ?launch-reveal replay hook works even under automation (forced overrides the
+// webdriver suppression), proving main.ts captures the query before the router strips it.
+import { newClient, done } from '../driver.mjs';
+const c = await newClient({ mobile: true, label: 'reveal' });
+await c.page.goto('/?launch-reveal');
+await c.page.waitForTimeout(700);
+const shown = await c.page.evaluate(() => !!document.querySelector('.launch-reveal') && !!document.querySelector('.rv-skip'));
+const flag = await c.page.evaluate(() => window.__ringLaunchReveal);
+console.log(`[check] __ringLaunchReveal captured: ${flag} (expect true)`);
+console.log(`[check] reveal shown via ?launch-reveal under automation: ${shown} (expect true)`);
+await done();

--- a/drive/scenarios/launch-reveal.mjs
+++ b/drive/scenarios/launch-reveal.mjs
@@ -1,0 +1,38 @@
+// Inspect the cold-start reveal: the normalized montage icons + the new discreet Skip
+// button, and that tapping Skip actually dismisses it. Uses the ?launch-reveal force hook
+// (no account needed — the reveal overlays everything from App.vue).
+//
+//   HEADED=1 node drive/scenarios/launch-reveal.mjs
+import { newClient, shot, done } from '../driver.mjs';
+
+const c = await newClient({ mobile: true, label: 'reveal' });
+// The reveal is suppressed under automation (navigator.webdriver) and the ?launch-reveal
+// query is dropped by the auth-gate redirect before the component reads it. A fresh
+// context has empty localStorage (so isNewVersion is true) — spoof webdriver=false and it
+// plays naturally, exactly as on a real first install.
+await c.page.addInitScript(() => {
+  Object.defineProperty(navigator, 'webdriver', { configurable: true, get: () => false });
+});
+await c.page.goto('/');
+
+// ~0.6s in: "Messaging" bubble hold. Skip button is in the DOM from the start.
+await c.page.waitForTimeout(600);
+const hasSkip = await c.page.evaluate(() => !!document.querySelector('.rv-skip'));
+console.log(`[check] Skip button present: ${hasSkip} (expect true)`);
+await shot(c, 'reveal-1-bubble');
+
+// ~4.0s: "Video calls" camera hold.
+await c.page.waitForTimeout(3400);
+await shot(c, 'reveal-2-camera');
+
+// ~7.4s: "Wall & games" controller hold (with gamepad detail riding the normalized body).
+await c.page.waitForTimeout(3400);
+await shot(c, 'reveal-3-controller');
+
+// Tap Skip → it should fade out and unmount.
+await c.page.click('.rv-skip');
+await c.page.waitForTimeout(700);
+const gone = await c.page.evaluate(() => !document.querySelector('.launch-reveal'));
+console.log(`[check] reveal dismissed after Skip: ${gone} (expect true)`);
+
+await done();

--- a/drive/scenarios/push-nudge-fresh-open.mjs
+++ b/drive/scenarios/push-nudge-fresh-open.mjs
@@ -1,0 +1,45 @@
+// Verify: on a fresh cold start of a RETURNING (already-authenticated) user whose Web
+// Push permission is still undecided, the app asks "Turn on notifications?" — but it does
+// NOT ask during the initial onboarding load (that flow owns the first ask).
+//
+//   node drive/scenarios/push-nudge-fresh-open.mjs
+import { createAccount, shot, sweep } from '../driver.mjs';
+
+const alice = await createAccount({ mobile: true, name: 'Alice', label: 'alice' });
+
+// This first load went through /auth (registration), so the nudge must stay silent.
+await alice.page.waitForTimeout(1500);
+const onFirstLoad = await alice.page.evaluate(() =>
+  !!document.querySelector('ion-alert') &&
+  /Turn on notifications/.test(document.querySelector('ion-alert')?.textContent ?? ''),
+);
+console.log(`[check] nudge shown during onboarding load? ${onFirstLoad} (expect false)`);
+
+// Headless Chromium reports Notification.permission as "denied" (no real device to
+// prompt on), which the nudge correctly SKIPS. To exercise the real-device "default"
+// path (a reinstall), stub the getter to "default" before the reload and no-op the
+// native prompt so it doesn't hang the run.
+await alice.page.addInitScript(() => {
+  try {
+    Object.defineProperty(Notification, 'permission', { configurable: true, get: () => 'default' });
+    Notification.requestPermission = async () => 'default';
+  } catch { /* ignore */ }
+});
+
+// Simulate a returning cold start: reload the same (authenticated) context. The auth gate
+// routes straight to /tabs (never /auth), so the nudge should fire.
+await alice.page.reload({ waitUntil: 'domcontentloaded' });
+await alice.page.waitForFunction(
+  () => /Turn on notifications/.test(document.querySelector('ion-alert')?.textContent ?? ''),
+  null,
+  { timeout: 15_000 },
+).catch(() => {});
+
+const shown = await alice.page.evaluate(() => {
+  const a = document.querySelector('ion-alert');
+  return a ? (a.textContent ?? '').replace(/\s+/g, ' ').trim() : null;
+});
+console.log(`[check] nudge on returning cold start: ${JSON.stringify(shown)} (expect the "Turn on notifications?" ask)`);
+
+await shot(alice, 'push-nudge-fresh-open');
+await sweep([alice]);

--- a/drive/scenarios/update-init-smoke.mjs
+++ b/drive/scenarios/update-init-smoke.mjs
@@ -1,0 +1,19 @@
+// Smoke test: after wiring useInstallGuard into useAppUpdate, the app still boots
+// cleanly (no init error from the update composable) and reaches Chats. The install-gate
+// AUTO-UPDATE path itself can't run here — it needs a production SW, the public origin
+// (localhost is exempt from the gate), and a second deploy — so this only guards startup.
+import { createAccount, shot, sweep } from '../driver.mjs';
+
+const a = await createAccount({ mobile: true, name: 'Alice', label: 'alice' });
+const errors = [];
+a.page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+a.page.on('pageerror', (e) => errors.push('pageerror: ' + e.message));
+
+await a.page.reload({ waitUntil: 'domcontentloaded' });
+await a.page.waitForTimeout(2500);
+const path = await a.page.evaluate(() => location.pathname);
+const relevant = errors.filter((e) => /update|install|serviceworker|registerSW|InstallGuard|useAppUpdate/i.test(e));
+console.log(`[check] landed on: ${path} (expect /tabs/chats)`);
+console.log(`[check] update/install-related console errors: ${relevant.length} ${JSON.stringify(relevant.slice(0, 3))}`);
+await shot(a, 'update-init-smoke');
+await sweep([a]);

--- a/src/App.vue
+++ b/src/App.vue
@@ -64,6 +64,7 @@ import { useGameDuty } from '@/composables/useGameDuty';
 import { callState } from '@/composables/useCall';
 import { stopAudio } from '@/composables/useAudioPlayer';
 import { useSync, nudgeReconnect } from '@/composables/useSync';
+import { useNotificationNudge } from '@/composables/useNotificationNudge';
 import { useAppUpdate, checkForUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
 import { takePendingNav } from '@/services/pending-nav';
@@ -80,6 +81,11 @@ useSync();
 // duty officer that emits owed answers/reveals/staged commits app-wide.
 useGameOverlay();
 useGameDuty();
+
+// On a fresh open, ask for notification permission if it's still undecided (a reinstall
+// resets it and only a tap can re-grant it). Onboarding owns the first ask; this covers
+// later cold starts. See useNotificationNudge.
+useNotificationNudge();
 
 // Registers the service worker and prompts (with the version) when a new deploy is
 // ready, instead of silently reloading. See useAppUpdate + vite.config 'prompt'.

--- a/src/components/AnimatedEmoji.vue
+++ b/src/components/AnimatedEmoji.vue
@@ -1,7 +1,7 @@
 <template>
   <span ref="rootEl" class="aemoji" :class="{ large }">
-    <span ref="anchor" class="aemoji-anim" aria-hidden="true" />
-    <span v-if="showNative" class="aemoji-native">{{ emoji }}</span>
+    <span ref="anchor" class="aemoji-anim" v-show="!atRest" aria-hidden="true" />
+    <span v-if="showNative || atRest" class="aemoji-native">{{ emoji }}</span>
   </span>
 </template>
 
@@ -20,8 +20,11 @@ import { loadEmojiLottie } from '@/services/emoji-cache';
  * `plays` caps how many loops run (spec 0008 FR-027/FR-028: emoji avatars play
  * a configured number of times). Unset = loop forever while visible (the
  * pre-existing behaviour for every caller that doesn't pass it). Once the cap
- * is reached the animation RESTS ON ITS FIRST FRAME — the Lottie art, not the
- * native glyph, so the picture never visibly changes style. Raising/clearing
+ * is reached the animation RESTS ON THE NATIVE GLYPH — the fully-formed emoji.
+ * (It used to park on the Lottie's first frame, but many Noto emoji fly their
+ * art IN and OUT of the canvas — the running-shoe's first AND last frames sit
+ * off-screen — so no single Lottie frame is a safe resting pose; parking there
+ * left a blank disc. The native glyph always shows the emoji.) Raising/clearing
  * `plays` later (an unread chat re-demanding attention) resumes the loop.
  */
 const props = withDefaults(
@@ -32,6 +35,7 @@ const props = withDefaults(
 const rootEl = ref<HTMLElement>();
 const anchor = ref<HTMLElement>();
 const showNative = ref(true); // native glyph shows until (and unless) Lottie loads
+const atRest = ref(false); // play cap reached → rest on the native glyph (see loopComplete)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let anim: any = null;
@@ -65,15 +69,17 @@ async function ensureLoaded(): Promise<void> {
       animationData: data,
     });
     // Bounded playback (spec 0008 FR-027/FR-028): after `plays` full loops,
-    // rest on the FIRST FRAME of the animation (kept loaded), so the picture
-    // stays in the Lottie's art style instead of swapping to the native glyph.
+    // rest on the native glyph. The Lottie stays loaded (so raising `plays`
+    // resumes instantly) but is hidden via `atRest`, because its frames are not
+    // a reliable resting pose — a fly-in/out emoji is off-canvas at both ends.
     // Registered unconditionally: `plays` can appear/clear later (an unread
     // chat re-demanding attention), and the counter must not miss loops.
     anim.addEventListener('loopComplete', () => {
       loopsDone += 1;
       if (props.plays !== undefined && loopsDone >= props.plays) {
         finished = true;
-        anim?.goToAndStop?.(0, true);
+        atRest.value = true;
+        anim?.pause?.();
       }
     });
     showNative.value = false;
@@ -89,7 +95,7 @@ function setVisible(on: boolean): void {
   visible = on;
   if (on) {
     void ensureLoaded();
-    if (!finished) anim?.play(); // at rest → stay on the first frame
+    if (!finished) anim?.play(); // at rest → stay parked on the native glyph
   } else {
     anim?.pause();
   }
@@ -97,13 +103,14 @@ function setVisible(on: boolean): void {
 
 // A raised/cleared cap re-earns playback: an unread chat flips `plays` to
 // unlimited and the resting avatar starts moving again (FR-028); read → the
-// cap returns and the NEXT loopComplete parks it back on the first frame.
+// cap returns and the NEXT loopComplete parks it back on the native glyph.
 watch(
   () => props.plays,
   (next) => {
     if (!finished) return;
     if (next === undefined || loopsDone < next) {
       finished = false;
+      atRest.value = false; // un-hide the Lottie; it takes over from the native glyph again
       if (visible) {
         void ensureLoaded();
         anim?.play();

--- a/src/components/LaunchReveal.vue
+++ b/src/components/LaunchReveal.vue
@@ -14,6 +14,12 @@
        src/vite-env.d.ts:  declare module 'flubber'; -->
   <ion-page v-if="visible" class="launch-reveal" :class="{ leaving }">
     <ion-content :fullscreen="true">
+      <!-- Discreet escape hatch: a returning user who's seen the reveal can dismiss it.
+           Kept low-key (muted, corner, fades in after a beat) so it never competes with
+           the montage; runs the same fade-and-hand-off as a natural finish. -->
+      <button v-if="!leaving" type="button" class="rv-skip" @click="beginExit" aria-label="Skip intro">
+        Skip
+      </button>
       <div class="rv-content" aria-hidden="true">
         <!-- ambient glow -->
         <div class="rv-glow" :style="{ opacity: 0.5 + 0.5 * glowPulse }"></div>
@@ -23,8 +29,10 @@
           <svg :width="MARK" :height="MARK" viewBox="0 0 100 100" style="display:block; overflow:visible">
             <path :d="f.d" fill="#fff" />
 
-            <!-- gamepad detail: visible only while the controller is held -->
-            <g v-if="f.detailOp > 0" :style="{ opacity: f.detailOp }">
+            <!-- gamepad detail: visible only while the controller is held. Rides the
+                 controller's normalize transform so the buttons stay on the (re-centred,
+                 re-scaled) body instead of the raw coordinates they were drawn for. -->
+            <g v-if="f.detailOp > 0" :transform="CONTROLLER_TF" :style="{ opacity: f.detailOp }">
               <rect x="17" y="53.5" width="19" height="7" rx="2.2" :fill="PRIMARY" />
               <rect x="23" y="47.5" width="7" height="19" rx="2.2" :fill="PRIMARY" />
               <circle cx="72" cy="50" r="3.1" :fill="PRIMARY" />
@@ -76,19 +84,86 @@ import { interpolate, separate, combine } from 'flubber';
 const PRIMARY = 'var(--ion-color-primary)';
 const MARK = 84; // px, the morphing symbol inside the 128px tile
 
-// ── single-outline silhouettes (viewBox 100, no arcs so flubber parses cleanly) ──
-const BUBBLE = 'M28 22 L72 22 C77.5 22 82 26.5 82 32 L82 58 C82 63.5 77.5 68 72 68 L44 68 L30 82 L30 68 L28 68 C22.5 68 18 63.5 18 58 L18 32 C18 26.5 22.5 22 28 22 Z';
-const HANDSET = 'M32 20 C40 18 46 24 48 32 L50 44 C48 47 45 49 42 50 C48 60 54 66 64 72 C65 69 67 66 70 64 L82 66 C90 68 94 76 90 84 C84 94 70 95 60 90 C38 80 22 60 16 36 C14 27 22 20 32 20 Z';
-const CAMERA = 'M24 36 L56 36 C60.4 36 64 39.6 64 44 L64 47 L84 35 L84 77 L64 65 L64 68 C64 72.4 60.4 76 56 76 L24 76 C19.6 76 16 72.4 16 68 L16 44 C16 39.6 19.6 36 24 36 Z';
-const CONTROLLER = 'M34 38 L66 38 C78 38 87 47 90 59 L93 73 C95 82 86 87 79 83 L71 75 L29 75 L21 83 C14 87 5 82 7 73 L10 59 C13 47 22 38 34 38 Z';
+// ── normalize each montage silhouette to the final mark's footprint ───────────
+// The hand-drawn silhouettes were authored at inconsistent boxes: the camera is
+// wide and squat and sits low, the controller runs 90 units wide and is pushed
+// down, while the resolved shield is ~62×70 centred at (50,50). So mid-montage the
+// symbols looked cramped and off-centre next to the final icon. Recentre + UNIFORM-
+// scale every intermediate shape to one shared box (same centre, same max extent),
+// so the whole sequence reads at the SAME size/position as the resolved Ring mark.
+// Uniform scale keeps each symbol's own aspect (a phone stays tall, a controller
+// stays wide) — only its size and placement are normalized. The SHIELD/ring finale
+// is deliberately left as-is: it already matches the real app icon.
+const NCENTER = { x: 50, y: 49 };
+const NSIZE = 66; // target max( width, height ) in the 0–100 viewBox
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+function pathBox(d: string): { cx: number; cy: number; w: number; h: number } {
+  const n = (d.match(/-?\d*\.?\d+/g) ?? []).map(Number);
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (let i = 0; i + 1 < n.length; i += 2) {
+    minX = Math.min(minX, n[i]); maxX = Math.max(maxX, n[i]);
+    minY = Math.min(minY, n[i + 1]); maxY = Math.max(maxY, n[i + 1]);
+  }
+  return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2, w: maxX - minX, h: maxY - minY };
+}
+// Walk the path, keeping command letters and transforming every (x,y) number pair.
+// Safe because these silhouettes use only M/L/C/Z — all coordinate pairs, no arcs.
+function mapPath(d: string, fn: (x: number, y: number) => [number, number]): string {
+  const toks = d.match(/[a-zA-Z]|-?\d*\.?\d+/g) ?? [];
+  let out = '', i = 0;
+  while (i < toks.length) {
+    if (/[a-zA-Z]/.test(toks[i])) {
+      out += (out ? ' ' : '') + toks[i++];
+      const nums: number[] = [];
+      while (i < toks.length && !/[a-zA-Z]/.test(toks[i])) nums.push(parseFloat(toks[i++]));
+      for (let j = 0; j + 1 < nums.length; j += 2) {
+        const [x, y] = fn(nums[j], nums[j + 1]);
+        out += ` ${round2(x)} ${round2(y)}`;
+      }
+    } else i++;
+  }
+  return out;
+}
+function normScale(d: string): number {
+  const b = pathBox(d);
+  return NSIZE / Math.max(b.w, b.h);
+}
+function normalize(d: string): string {
+  const b = pathBox(d), s = normScale(d);
+  return mapPath(d, (x, y) => [(x - b.cx) * s + NCENTER.x, (y - b.cy) * s + NCENTER.y]);
+}
+// The SVG-transform equivalent of normalize(), for an overlay (the gamepad detail)
+// that must ride its shape's normalized position instead of the raw coordinates.
+function normTransform(d: string): string {
+  const b = pathBox(d);
+  return `translate(${NCENTER.x} ${NCENTER.y}) scale(${round2(normScale(d))}) translate(${round2(-b.cx)} ${round2(-b.cy)})`;
+}
+
+// ── single-outline silhouettes (viewBox 100, no arcs so flubber parses cleanly),
+//    each normalized above so the montage reads at the final icon's size ──
+const BUBBLE = normalize('M28 22 L72 22 C77.5 22 82 26.5 82 32 L82 58 C82 63.5 77.5 68 72 68 L44 68 L30 82 L30 68 L28 68 C22.5 68 18 63.5 18 58 L18 32 C18 26.5 22.5 22 28 22 Z');
+const HANDSET = normalize('M32 20 C40 18 46 24 48 32 L50 44 C48 47 45 49 42 50 C48 60 54 66 64 72 C65 69 67 66 70 64 L82 66 C90 68 94 76 90 84 C84 94 70 95 60 90 C38 80 22 60 16 36 C14 27 22 20 32 20 Z');
+const CAMERA = normalize('M24 36 L56 36 C60.4 36 64 39.6 64 44 L64 47 L84 35 L84 77 L64 65 L64 68 C64 72.4 60.4 76 56 76 L24 76 C19.6 76 16 72.4 16 68 L16 44 C16 39.6 19.6 36 24 36 Z');
+const CONTROLLER_RAW = 'M34 38 L66 38 C78 38 87 47 90 59 L93 73 C95 82 86 87 79 83 L71 75 L29 75 L21 83 C14 87 5 82 7 73 L10 59 C13 47 22 38 34 38 Z';
+const CONTROLLER = normalize(CONTROLLER_RAW);
+const CONTROLLER_TF = normTransform(CONTROLLER_RAW); // the gamepad detail rides the normalized body
 // Shield pre-transformed to the favicon's inner placement (translate 8.98,8.16 · scale 0.82).
+// Left UNCHANGED — this is the resolved app icon the montage settles into.
 const SHIELD = 'M49.98 14.72 L81.14 25.38 L81.14 50.8 C81.14 67.2 68.02 79.5 49.98 85.24 C31.94 79.5 18.82 67.2 18.82 50.8 L18.82 25.38 Z';
 const RING = { cx: 49.98, cy: 48.34, r: 14.76, sw: 5.74 };
 
 function circlePts(cx: number, cy: number, r: number, n = 34): [number, number][] {
   return Array.from({ length: n }, (_, i) => { const a = (i / n) * Math.PI * 2; return [cx + Math.cos(a) * r, cy + Math.sin(a) * r] as [number, number]; });
 }
-const CIRCLES = [circlePts(32, 39, 12), circlePts(68, 39, 12), circlePts(32, 71, 12), circlePts(68, 71, 12)];
+// Group-of-four, recentred to NCENTER and uniformly scaled to NSIZE like the other
+// marks (raw grid was centred at y≈55 → it sat low; its 60-unit extent scales to 66).
+const G = NSIZE / 60, G_DX = 18 * G, G_DY = 16 * G, G_R = 12 * G;
+const CIRCLES = [
+  circlePts(NCENTER.x - G_DX, NCENTER.y - G_DY, G_R),
+  circlePts(NCENTER.x + G_DX, NCENTER.y - G_DY, G_R),
+  circlePts(NCENTER.x - G_DX, NCENTER.y + G_DY, G_R),
+  circlePts(NCENTER.x + G_DX, NCENTER.y + G_DY, G_R),
+];
 
 // ── flubber interpolators (built once) ───────────────────────────────────────
 const O = { maxSegmentLength: 3 };
@@ -192,7 +267,11 @@ const f = computed(() => {
 // ── show-once-per-version wiring (identical to the previous LaunchReveal) ─────
 const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 const automated = (navigator as unknown as { webdriver?: boolean }).webdriver === true;
-const forced = window.location.search.includes('launch-reveal');
+// main.ts stashes this from the ENTRY url before the router redirect strips the query;
+// fall back to a live read (covers a direct in-app navigation that kept the param).
+const forced =
+  (window as unknown as { __ringLaunchReveal?: boolean }).__ringLaunchReveal === true ||
+  window.location.search.includes('launch-reveal');
 
 const version = __APP_VERSION__;
 const REVEAL_SEEN_KEY = 'ring.revealSeenVersion';
@@ -210,6 +289,7 @@ let done = false;
 function beginExit(): void {
   if (done) return;
   done = true;
+  if (raf) { cancelAnimationFrame(raf); raf = undefined; } // stop the loop at once on a skip
   window.setTimeout(() => { leaving.value = true; }, 0);
   window.setTimeout(() => { visible.value = false; }, 350);
 }
@@ -254,6 +334,33 @@ onUnmounted(() => {
 .launch-reveal.leaving {
   opacity: 0;
   pointer-events: none;
+}
+.rv-skip {
+  position: absolute;
+  top: calc(env(safe-area-inset-top, 0px) + 12px);
+  right: calc(env(safe-area-inset-right, 0px) + 14px);
+  z-index: 2;
+  padding: 8px 14px;
+  border: none;
+  border-radius: 999px;
+  background: none;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--app-text-muted);
+  opacity: 0.55;
+  cursor: pointer;
+  /* Fade in a beat after the montage starts so it's there when wanted, never a
+     distraction up front. */
+  animation: rv-skip-in 0.5s ease 0.9s both;
+}
+.rv-skip:hover,
+.rv-skip:active {
+  opacity: 0.9;
+}
+@keyframes rv-skip-in {
+  from { opacity: 0; }
+  to { opacity: 0.55; }
 }
 .rv-content {
   position: absolute;

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -27,6 +27,7 @@ import { computeDelta, userFacing, displayVersion, type ReleaseNote } from '@/se
 import WhatsNewSheet from '@/components/WhatsNewSheet.vue';
 import router from '@/router';
 import { callState } from '@/composables/useCall';
+import { useInstallGuard } from '@/composables/useInstallGuard';
 
 /** True while a call is in any live phase (ringing through connected). Applying an
  *  update reloads the page, which tears down the in-memory WebRTC state — so we must
@@ -55,6 +56,8 @@ let started = false;
 let swReg: ServiceWorkerRegistration | null = null;
 let lastCheck = 0;
 const CHECK_THROTTLE_MS = 10_000;
+// One silent install-gate auto-update per tab session (loop guard — see maybePrompt).
+const GATE_UPDATED_KEY = 'ring.installGateAutoUpdated';
 
 /**
  * Ask the service worker to check for a newer deployed build. Safe to call on app
@@ -138,6 +141,11 @@ export function useAppUpdate(): void {
   if (started) return; // singleton: one registration + prompt driver per app
   started = true;
 
+  // A visitor still behind the install gate (a plain browser tab on the public origin)
+  // is blocked from the app and about to install. They must land on the LATEST build,
+  // never a previous deploy's cached shell — see the auto-apply branch in maybePrompt.
+  const { mustInstall } = useInstallGuard();
+
   const { needRefresh, updateServiceWorker } = useRegisterSW({
     onRegisteredSW(_swUrl, reg) {
       if (!reg) return;
@@ -163,6 +171,20 @@ export function useAppUpdate(): void {
   // for someone who never fully closes the app — it comes back next time they reopen it.
   async function maybePrompt(): Promise<void> {
     if (!needRefresh.value || prompting) return;
+    // Install-gate visitor: don't offer a card they'd have to tap — a browser-gated
+    // visitor must never install a stale cached build. Silently pull the waiting update
+    // (skipWaiting + reload) so the guide they read and the shell they install are the
+    // latest. sessionStorage caps it to one auto-apply per tab: if an update somehow
+    // fails to take, we stop rather than reload-loop. No call/session to protect here.
+    if (mustInstall.value) {
+      let already = false;
+      try { already = sessionStorage.getItem(GATE_UPDATED_KEY) === '1'; } catch { /* ignore */ }
+      if (already) return;
+      try { sessionStorage.setItem(GATE_UPDATED_KEY, '1'); } catch { /* ignore */ }
+      prompting = true;
+      await applyUpdate(updateServiceWorker);
+      return;
+    }
     // Defer entirely while a call is live: a stray tap on the update banner mid-ring
     // would reload the page and kill the call. The watch on callState below re-fires
     // this the moment the call ends, and every foreground re-checks too, so the
@@ -227,6 +249,11 @@ export function useAppUpdate(): void {
   // Fire when a new worker first appears; immediate covers an update that was
   // already waiting when the app mounted.
   watch(needRefresh, () => void maybePrompt(), { immediate: true });
+
+  // While the install gate is up, actively check for a newer build so the auto-apply
+  // in maybePrompt has something to pull — a gated visitor has no in-app path to the
+  // latest, and registerSW's one-shot open check could predate a just-shipped deploy.
+  watch(mustInstall, (must) => { if (must) checkForUpdate(true); }, { immediate: true });
 
   // A pending update deferred during a call (maybePrompt bails while isInCall) should
   // resurface the instant the call settles, not only on the next foreground.

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -12,6 +12,7 @@
  */
 import { ref, computed, watch } from 'vue';
 import { appToast } from '@/services/toast';
+import { describeMediaError } from '@/services/media-errors';
 import router from '@/router';
 import { uid } from '@/utils/uid';
 import {
@@ -1306,8 +1307,13 @@ export async function startDirectCall(contactId: string, kind: CallKind): Promis
     markConnect('gumStart');
     stream = await navigator.mediaDevices.getUserMedia(gumConstraints(kind));
     markConnect('gumResolved');
-  } catch {
-    await teardown('failed');
+  } catch (err) {
+    // The call can't start without local media. Tell the caller WHY (blocked permission,
+    // no device, in use) rather than the bare "Couldn't connect the call" — the usual
+    // Android cause is the app's mic (or camera) permission being off at the OS level. Pass
+    // silent so teardown doesn't ALSO fire its generic notice over this specific one.
+    await appToast({ message: describeMediaError(err, kind === 'video' ? 'media' : 'microphone'), duration: 4000 });
+    await teardown('failed', { silent: true });
     return;
   }
   localStream.value = stream;
@@ -1992,9 +1998,12 @@ export async function acceptCall(): Promise<void> {
   let stream: MediaStream;
   try {
     stream = await gumPromise; // capture overlapped the setup above; usually already resolved
-  } catch {
+  } catch (err) {
+    // We can't answer without our own mic/camera. Surface the real reason (usually a
+    // blocked OS permission on Android) instead of the generic teardown notice.
+    await appToast({ message: describeMediaError(err, meta.kind === 'video' ? 'media' : 'microphone'), duration: 4000 });
     void sendControl('call-reject', meta.peerUserId, meta.callId, { reason: 'failed' });
-    await teardown('failed');
+    await teardown('failed', { silent: true });
     return;
   }
   localStream.value = stream;

--- a/src/composables/useNotificationNudge.ts
+++ b/src/composables/useNotificationNudge.ts
@@ -1,0 +1,74 @@
+/**
+ * Ask for Web Push permission on a FRESH app open when it's still undecided.
+ *
+ * Why this exists: a reinstall (and, on iOS, an OS-level reset) puts the browser's
+ * notification permission back to `default` and drops the push subscription. Web Push
+ * can only be (re)granted from a user gesture, so nothing can re-subscribe silently —
+ * without a nudge the user is left with no alerts and no obvious prompt until they dig
+ * into Settings. This surfaces a single in-app ask on cold start; tapping "Turn on"
+ * fires the real prompt (and push.ts then subscribes + registers with the server).
+ *
+ * Deliberately narrow:
+ *  - Only NOTIFICATIONS get an up-front ask. Camera/mic/media stay request-at-use —
+ *    they have a natural moment (you tap record / call), notifications don't (they fire
+ *    when the app is closed).
+ *  - We stay silent during the sign-in/onboarding flow (`/auth`): its own push step owns
+ *    the first ask, so we don't double-prompt. If the user skips it there, the nudge
+ *    picks up on the NEXT cold start.
+ *  - Once the choice is made we stop: `granted` needs nothing here (push.ts subscribes on
+ *    connect), and `denied` can't be re-prompted from the page anyway (nagging it would
+ *    only annoy). We also respect the user having turned notifications OFF.
+ */
+import { watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { alertController } from '@ionic/vue';
+import { isUnlocked } from '@/services/crypto/identity';
+import { isAuthenticated } from '@/services/auth';
+import { isPushSupported, pushPermission } from '@/services/permissions';
+import { requestPushPermission } from '@/services/notifications';
+import { getSetting } from '@/db/queries';
+
+export function useNotificationNudge(): void {
+  const router = useRouter();
+  let done = false;
+  // If this load ever passes through the auth/onboarding flow, let onboarding own the
+  // push ask for THIS load; the nudge then applies on the next cold start.
+  let sawAuth = false;
+
+  const stop = watch(
+    () => [isUnlocked.value, isAuthenticated.value, router.currentRoute.value.path] as const,
+    async ([unlocked, authed, path]) => {
+      if (path.startsWith('/auth')) {
+        sawAuth = true;
+        return;
+      }
+      if (done || sawAuth || !unlocked || !authed) return;
+      done = true;
+      stop();
+      if (!isPushSupported() || pushPermission() !== 'default') return; // decided/unsupported → nothing to ask
+      if (!(await getSetting<boolean>('notifications.push', true))) return; // user turned notifications off
+      await promptEnablePush();
+    },
+    { immediate: true },
+  );
+}
+
+async function promptEnablePush(): Promise<void> {
+  const alert = await alertController.create({
+    header: 'Turn on notifications?',
+    message: 'Get alerts for new messages and calls, even when Ring is closed.',
+    buttons: [
+      { text: 'Not now', role: 'cancel' },
+      {
+        text: 'Turn on',
+        handler: () => {
+          // Fire the native prompt straight from this tap — a user gesture is required
+          // (iOS especially). On a grant, notifications.ts → applyPushPreference subscribes
+          // and registers the endpoint with the server.
+          void requestPushPermission();
+        },
+      },
+    ],
+  });
+  await alert.present();
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4899,6 +4899,17 @@ export async function listContacts(q = ''): Promise<Contact[]> {
   return filtered.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** Every contact, UNFILTERED — for resolving a co-member's identity (name / photo
+ *  / colour) inside a chat. Unlike listContacts(), it keeps pending and ghosted
+ *  contacts: a group member is still that person whether or not your 1:1 with them
+ *  is accepted, so their messages must render with their real name + avatar
+ *  regardless. Resolving group senders through the FILTERED listContacts() is what
+ *  made a pending/ghosted co-member render as a raw id ("88155153") with a blank
+ *  avatar even though their contact existed and was named. */
+export async function listAllContacts(): Promise<Contact[]> {
+  return getAll<Contact>('contacts');
+}
+
 /* ---- media ---- */
 
 export async function getMediaUrl(id: string): Promise<string | null> {
@@ -5216,7 +5227,17 @@ export async function hydrateContactFromDirectory(id: string): Promise<void> {
   if (u.avatar) c.remoteAvatar = u.avatar;
   if (!c.localProfile) {
     if (name) c.name = name;
-    if (u.avatar) c.avatar = u.avatar;
+    if (u.avatar) {
+      c.avatar = u.avatar;
+    } else if (c.name && c.name !== id.slice(0, 8) && c.avatar === initialsAvatar(id.slice(0, 8))) {
+      // The peer has no published photo and we're still showing the placeholder
+      // initials disc generated from their raw id (a "8" from "88155153"). Now that
+      // we have their real name, regenerate the disc so the initial matches it (an
+      // "A" for "Azin") instead of a leftover id digit — the disc self-heals on the
+      // next connect-time hydrate. A user-set photo or emoji avatar never equals the
+      // id-slice initials, so this only ever replaces the auto-generated placeholder.
+      c.avatar = initialsAvatar(c.name);
+    }
   }
   c.updatedAt = now();
   await put('contacts', c);

--- a/src/games/armada/ArmadaBoard.vue
+++ b/src/games/armada/ArmadaBoard.vue
@@ -1449,4 +1449,39 @@ const citation = computed(() => {
 :root:not(.ion-palette-dark) .armada .ar-pips i { background: rgba(16, 120, 90, 0.3); }
 :root:not(.ion-palette-dark) .armada .ar-log-row,
 :root:not(.ion-palette-dark) .armada .ar-log-empty { color: rgba(16, 40, 28, 0.72); }
+
+/* The end-of-war result ceremony is authored dark (see .ar-result* above); like the
+   board, flip it to the bright naval-chart palette in light mode. Without these it
+   stayed a dark card on a light device, and its two OUTLINE buttons — .ar-btn uses
+   --g-text (near-black in light) on --g-border-accent — became near-black text on a
+   dark card, i.e. invisible. A light card restores their contrast. */
+:root:not(.ion-palette-dark) .armada .ar-result { background: rgba(16, 40, 28, 0.4); }
+:root:not(.ion-palette-dark) .armada .ar-result-card {
+  background: linear-gradient(180deg, #ffffff, #eef3f0);
+  border-color: rgba(197, 56, 74, 0.28);
+  box-shadow: 0 30px 80px rgba(16, 40, 28, 0.28);
+}
+:root:not(.ion-palette-dark) .armada .ar-result-card.won { border-color: rgba(184, 134, 11, 0.4); }
+:root:not(.ion-palette-dark) .armada .ar-eyebrow { color: rgba(10, 125, 89, 0.8); }
+:root:not(.ion-palette-dark) .armada .ar-verdict { color: #c5384a; }
+:root:not(.ion-palette-dark) .armada .ar-verdict.won { color: #b8860b; }
+:root:not(.ion-palette-dark) .armada .ar-rank { color: #c5384a; }
+:root:not(.ion-palette-dark) .armada .ar-rank.won { color: #b8860b; }
+:root:not(.ion-palette-dark) .armada .ar-citation { color: rgba(16, 40, 28, 0.7); }
+:root:not(.ion-palette-dark) .armada .ar-stats {
+  background: rgba(16, 40, 28, 0.04);
+  border-color: rgba(16, 40, 28, 0.08);
+}
+:root:not(.ion-palette-dark) .armada .ar-stat b { color: rgba(16, 40, 28, 0.92); }
+:root:not(.ion-palette-dark) .armada .ar-stat b.acc,
+:root:not(.ion-palette-dark) .armada .ar-stat b.good { color: #0a7d59; }
+:root:not(.ion-palette-dark) .armada .ar-stat b.bad { color: #c5384a; }
+:root:not(.ion-palette-dark) .armada .ar-stat span { color: rgba(16, 40, 28, 0.5); }
+/* Give the two outline buttons a readable emerald tint on the light card (the shared
+   --g-surface wash is nearly white on white). The filled "New battle" is unaffected. */
+:root:not(.ion-palette-dark) .armada .ar-result-btns .ar-btn:not(.primary) {
+  background: rgba(16, 120, 90, 0.08);
+  border-color: rgba(16, 120, 90, 0.4);
+  color: #0a5f45;
+}
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,14 @@ import '@ionic/vue/css/palettes/dark.class.css';
 /* Theme variables */
 import './theme/variables.css';
 
+// Capture ?launch-reveal NOW, before anything else runs. LaunchReveal mounts only after
+// router.isReady() (see the mount block below), by which point the auth-gate redirect has
+// already rewritten the URL and stripped the query — so the component can't read it there.
+// This top-level statement runs while window.location is still the original entry URL, so
+// the manual "replay the intro" hook (visit /?launch-reveal) works on any device.
+(window as unknown as { __ringLaunchReveal?: boolean }).__ringLaunchReveal =
+  window.location.search.includes('launch-reveal');
+
 // scrollAssist is disabled: we keep focused inputs visible by sizing the app
 // to the visual viewport (see useViewportHeight). Leaving scrollAssist on makes
 // it scroll the window on every focus change (e.g. each OTP box as focus

--- a/src/services/media-errors.ts
+++ b/src/services/media-errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Turn a getUserMedia / MediaRecorder failure into a plain-language sentence the user
+ * can act on.
+ *
+ * Every mic/camera acquisition in the app used to swallow the DOMException in a bare
+ * `catch {}` and show a flat "Microphone unavailable", which hid the one thing the user
+ * actually needs to know: WHY. On Android especially, the common cause is that the
+ * installed app's microphone permission is switched off at the OS level — the web layer
+ * can't grant that; only the user can, in device/browser settings. A generic "unavailable"
+ * gives them nowhere to go. This branches on the standard DOMException `name`
+ * (see MDN: MediaDevices.getUserMedia exceptions) to name the fix.
+ */
+export type MediaKind = 'microphone' | 'camera' | 'media';
+
+function errName(err: unknown): string {
+  if (err instanceof DOMException) return err.name;
+  if (err && typeof err === 'object' && 'name' in err) return String((err as { name: unknown }).name);
+  return '';
+}
+
+export function describeMediaError(err: unknown, kind: MediaKind = 'microphone'): string {
+  // Capitalised subject for sentence starts, lowercase for mid-sentence.
+  const Subject = kind === 'camera' ? 'Camera' : kind === 'media' ? 'Camera or microphone' : 'Microphone';
+  const subject = kind === 'camera' ? 'camera' : kind === 'media' ? 'camera and microphone' : 'microphone';
+  switch (errName(err)) {
+    case 'NotAllowedError':
+    case 'SecurityError':
+      // Permission denied. On an installed Android PWA this is usually the app's OS-level
+      // mic/camera permission being off — not something the page can re-request silently.
+      return `${Subject} access is blocked. Allow ${subject} for Ring in your device and browser settings, then try again.`;
+    case 'NotFoundError':
+    case 'OverconstrainedError':
+      return `No ${subject === 'camera and microphone' ? 'camera or microphone' : subject} was found on this device.`;
+    case 'NotReadableError':
+    case 'AbortError':
+      // The device exists but another app (or a stuck tab) is holding it.
+      return `Your ${subject === 'camera and microphone' ? 'camera or microphone' : subject} is in use by another app. Close it and try again.`;
+    default:
+      return `${Subject} unavailable. Check that Ring has permission to use it.`;
+  }
+}

--- a/src/views/detail/CallActivePage.vue
+++ b/src/views/detail/CallActivePage.vue
@@ -457,7 +457,7 @@ import { useCallParticipants } from '@/composables/useCallParticipants';
 import { getQuickDeclines } from '@/services/quick-declines';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { callDiagLines, callDiagSnapshot, callDiagOpen, clearDiag } from '@/services/call/diag';
-import { listContacts } from '@/db/queries';
+import { listContacts, listAllContacts } from '@/db/queries';
 import { useSelfProfile } from '@/composables/useSelfProfile';
 import { initialsAvatar } from '@/db/avatars';
 import type { Contact } from '@/db/types';
@@ -660,7 +660,12 @@ interface Tile {
 // Reactive contacts, keyed by userId, so a tile can resolve its owner's name + avatar
 // synchronously (mirrors ChatDetailPage). Updates live if a contact card changes.
 const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
-const contactsMap = computed(() => new Map(contacts.value.map((c) => [c.id, c])));
+// Tiles resolve their owner from the UNFILTERED set: a call participant is that
+// person whether or not your 1:1 with them is accepted, so listContacts()'s
+// pending/ghosted filter must not blank their name/avatar on a tile. The filtered
+// `contacts` above still backs the "add people" picker (real contacts only).
+const tileContacts = useLiveQuery(() => listAllContacts(), ['contacts'], [] as Contact[]);
+const contactsMap = computed(() => new Map(tileContacts.value.map((c) => [c.id, c])));
 
 // Add people to the call (spec 1028, US2). Available on a CONNECTED call — 1:1 or
 // group — with room left under its kind's cap; adding on a 1:1 promotes it into a

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1150,7 +1150,7 @@ import {
   chevronDownOutline, chatbubbleEllipses, albumsOutline, imagesOutline, createOutline, timerOutline,
 } from 'ionicons/icons';
 import {
-  getChat, getContact, listContacts, markChatRead, sendMediaMessage, sendMessage,
+  getChat, getContact, listAllContacts, markChatRead, sendMediaMessage, sendMessage,
   reactToMessage, deleteMessage, softDeleteMessage, deleteMessageForEveryone, editMessage,
   toggleFavorite, setCaption, forwardMessage,
   quickReactEmojis,
@@ -1995,7 +1995,12 @@ function confirmDeleteSelected(): void {
 }
 
 /* ---- reply ---- */
-const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+// Resolve co-member identity (sender name/avatar/colour, @-mentions, game seats)
+// from the UNFILTERED contact set: a group member is that person regardless of
+// whether your 1:1 with them is accepted, so listContacts()'s pending/ghosted
+// filter must not hide them here (that filter is for the address book) — doing so
+// made a pending/ghosted member render as a raw id with a blank avatar.
+const contacts = useLiveQuery(() => listAllContacts(), ['contacts'], [] as Contact[]);
 const contactsMap = computed(() => new Map(contacts.value.map((c) => [c.id, c])));
 const replyingTo = ref<ReplyRef | null>(null);
 const composerEl = ref<{ $el: HTMLIonTextareaElement } | null>(null);

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1164,6 +1164,7 @@ import {
   backfillThumbTiers, getDraft, saveDraft, clearDraft, getDraftMedia, saveDraftMedia, clearDraftMedia,
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
+import { describeMediaError } from '@/services/media-errors';
 import { hasRoomFor } from '@/services/storage-estimate';
 import { groupProgress } from '@/services/message-status';
 import { getSelfUserId, getSelfUsername } from '@/services/auth';
@@ -4363,8 +4364,11 @@ async function startRecording() {
     recTimer = window.setInterval(tickElapsed, 200);
     startSampler();
     startActivity('recording-audio'); // tell the peer we're recording a voice message (spec 1009)
-  } catch {
-    await appToast({ message: 'Microphone unavailable', duration: 1500 });
+  } catch (err) {
+    // Say WHY (permission blocked vs. no mic vs. in use) instead of a dead-end "unavailable",
+    // and give it long enough to read the fix — the usual cause on Android is the app's mic
+    // permission being off at the OS level, which only the user can turn back on.
+    await appToast({ message: describeMediaError(err, 'microphone'), duration: 4000 });
   }
 }
 

--- a/src/views/detail/GroupInfoPage.vue
+++ b/src/views/detail/GroupInfoPage.vue
@@ -168,7 +168,7 @@ import {
   chatbubbleOutline, documentTextOutline, videocamOutline,
 } from 'ionicons/icons';
 import {
-  getChat, listContacts, addMemberToGroup, removeMember, leaveGroup,
+  getChat, listContacts, listAllContacts, addMemberToGroup, removeMember, leaveGroup,
   renameGroup, setGroupAvatar, clearGroupAvatar, setChatMute, setChatTtl, setChatSendQuality,
   setChatNotifyPrefs, type ChatNotifyContent,
 } from '@/db/queries';
@@ -182,7 +182,16 @@ const router = useRouter();
 const chatId = route.params.id as string;
 
 const chat = useLiveQuery<Chat | undefined>(() => getChat(chatId), ['chats'], undefined);
+// Filtered (address-book) contacts — for the "add member" picker, which should
+// only offer real, accepted contacts.
 const allContacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+// Unfiltered contacts — for resolving the member/invited rosters to a name + photo.
+// A group member is that person whether or not your 1:1 with them is accepted, so
+// listContacts()'s pending/ghosted filter must not turn them into a raw id here.
+const memberContacts = useLiveQuery(() => listAllContacts(), ['contacts'], [] as Contact[]);
+const memberContactMap = computed(
+  () => new Map(memberContacts.value.map((c) => [c.id, c])),
+);
 
 const muted = computed(() => !!chat.value?.mutedUntil && chat.value.mutedUntil > Date.now());
 const muteLabel = computed(() => {
@@ -306,7 +315,7 @@ const { name: selfName, avatar: selfAvatar } = useSelfProfile();
 // Member profiles (resolve participant ids → contacts).
 const members = computed(() =>
   (chat.value?.participantIds ?? []).map((id) => {
-    const c = allContacts.value.find((x) => x.id === id);
+    const c = memberContactMap.value.get(id);
     return { id, name: c?.name ?? id.slice(0, 8), avatar: c?.avatar ?? initialsAvatar(c?.name ?? '?') };
   }),
 );
@@ -381,7 +390,7 @@ async function addMember(): Promise<void> {
 // Invited-but-not-joined members (pending acceptance).
 const invited = computed(() =>
   (chat.value?.invitedIds ?? []).map((id) => {
-    const c = allContacts.value.find((x) => x.id === id);
+    const c = memberContactMap.value.get(id);
     return { id, name: c?.name ?? id.slice(0, 8), avatar: c?.avatar ?? initialsAvatar(c?.name ?? '?') };
   }),
 );

--- a/src/views/detail/MessageInfoPage.vue
+++ b/src/views/detail/MessageInfoPage.vue
@@ -224,7 +224,7 @@ import {
   IonNote, IonIcon,
 } from '@ionic/vue';
 import { checkmark, checkmarkDone, timeOutline, informationCircleOutline } from 'ionicons/icons';
-import { getMessage, getChat, listContacts, getSetting } from '@/db/queries';
+import { getMessage, getChat, listAllContacts, getSetting } from '@/db/queries';
 import { get } from '@/db/idb';
 import { initialsAvatar } from '@/db/avatars';
 import type { Chat, Contact, Media, Message, MessageStatus } from '@/db/types';
@@ -248,7 +248,9 @@ const message = useLiveQuery<Message | undefined>(
   undefined,
 );
 const chat = useLiveQuery<Chat | undefined>(() => getChat(chatId), ['chats'], undefined);
-const contacts = useLiveQuery(() => listContacts(), ['contacts'], [] as Contact[]);
+// Unfiltered: a group receipt row must resolve to the member's real name/photo even
+// when your 1:1 with them is pending/ghosted (listContacts()'s address-book filter).
+const contacts = useLiveQuery(() => listAllContacts(), ['contacts'], [] as Contact[]);
 
 // Live countdown for a disappearing message (ticks each second while this page is open).
 const nowMs = ref(Date.now());

--- a/src/views/detail/PostComposerPage.vue
+++ b/src/views/detail/PostComposerPage.vue
@@ -159,6 +159,7 @@ import { hasRoomFor } from '@/services/storage-estimate';
 import { generateVideoPoster } from '@/utils/media-meta';
 import { playAudio, stopIfPlaying } from '@/composables/useAudioPlayer';
 import { appToast } from '@/services/toast';
+import { describeMediaError } from '@/services/media-errors';
 
 const router = useRouter();
 const route = useRoute();
@@ -473,10 +474,12 @@ async function startRecording(): Promise<void> {
       const s = Math.floor((Date.now() - recStart) / 1000);
       recElapsed.value = `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
     }, 250);
-  } catch {
+  } catch (err) {
     const a = await alertController.create({
       header: 'Microphone unavailable',
-      message: 'Allow microphone access to record a voice post.',
+      // Name the actual cause (blocked permission / no mic / in use) so the fix is clear —
+      // the flat "allow access" line was a dead-end when the OS had the permission off.
+      message: describeMediaError(err, 'microphone'),
       buttons: ['OK'],
     });
     await a.present();


### PR DESCRIPTION
A batch of user-facing fixes from real-device (Android/iOS) reports. Each is a separate commit so it surfaces as its own line in the update "What's new".

## What's in it
- **fix(chats):** animated emoji profile photos no longer go blank after the animation ends (fly-in/out emoji were parking on an empty frame → now rest on the glyph).
- **fix(groups):** a group member you haven't messaged now shows their name + photo instead of a raw id. Root cause: group-sender resolution went through the address-book list, which hides pending "session-carrier" contacts. Now resolves from the full contact set (new `listAllContacts`), across chat / group-info / message-info / call surfaces. Also heals the stale initials avatar on hydrate.
- **fix(games):** the Armada end-of-game results screen (and its outline buttons) is readable in light mode.
- **fix(calls):** microphone/camera failures now say *why* (blocked permission / no device / in use) instead of a dead-end "unavailable" (new `describeMediaError`), across voice messages, voice posts and calls.
- **feat(notifications):** a discreet "Turn on notifications?" nudge on a fresh open when permission is undecided (a reinstall resets it and only a tap can re-grant). Silent during onboarding and once decided.
- **feat(app):** the cold-start intro animation gets a discreet **Skip**, its morph icons are normalized to the final app-icon's size/centering, and the `?launch-reveal` replay hook works again.
- **fix(app):** the in-browser install guide auto-applies a waiting update so you never install a stale cached shell. Installed users' cold-start (cache-first) behavior is untouched.

## Verification
`npm run build` green. Fixes exercised via `drive/` scenarios (included) + screenshots: emoji rest frame, group pending-member name resolution, Armada light card, push nudge (shows on returning cold start / silent in onboarding), intro montage + skip, launch-reveal hook. The install-gate auto-update and mic OS-permission paths can't be reproduced in the local harness (need a production SW + public origin + a second deploy); verified by construction + build + a startup smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)