### PR TITLE
Mutual calls connect + video quality restored (specs 1039 + 2025)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/2024-tab-bar-labels/plan.md`
+`specs/1039-simultaneous-mutual-calls/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,4 +94,4 @@ Specs are grouped by category band; status moves
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
 | [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟢 shipped |
 | [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |
-| [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | ⚪ planned |
+| [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,3 +94,4 @@ Specs are grouped by category band; status moves
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
 | [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟢 shipped |
 | [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |
+| [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | ⚪ planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,7 +64,7 @@ Specs are grouped by category band; status moves
 | [1036](specs/1036-wall-game-follows/spec.md) | Followers Get the Result Push; Group Chats Retire Games | 🟢 shipped |
 | [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 | [1038](specs/1038-armada-fullscreen-naval/spec.md) | Armada — Fullscreen Naval Duel Replaces Battleship | 🔵 in-review |
-| [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟡 in-progress |
+| [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -94,4 +94,4 @@ Specs are grouped by category band; status moves
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
 | [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟢 shipped |
 | [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |
-| [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟡 in-progress |
+| [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,7 @@ Specs are grouped by category band; status moves
 | [1036](specs/1036-wall-game-follows/spec.md) | Followers Get the Result Push; Group Chats Retire Games | 🟢 shipped |
 | [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 | [1038](specs/1038-armada-fullscreen-naval/spec.md) | Armada — Fullscreen Naval Duel Replaces Battleship | 🔵 in-review |
+| [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,7 +64,7 @@ Specs are grouped by category band; status moves
 | [1036](specs/1036-wall-game-follows/spec.md) | Followers Get the Result Push; Group Chats Retire Games | 🟢 shipped |
 | [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 | [1038](specs/1038-armada-fullscreen-naval/spec.md) | Armada — Fullscreen Naval Duel Replaces Battleship | 🔵 in-review |
-| [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | ⚪ planned |
+| [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/armada.mjs
+++ b/drive/scenarios/armada.mjs
@@ -65,6 +65,9 @@ await shot(bob, 'armada-7-toast-over-game');
 await bob.page.locator('.nb-main').first().click().catch(() => {});
 await bob.page.waitForTimeout(900);
 await shot(bob, 'armada-8-pill');
+// The pill tucks into just the circular glyph after ~2.5s so it stops covering the chat.
+await bob.page.waitForTimeout(2500);
+await shot(bob, 'armada-8b-pill-collapsed');
 
 // 5 — back in via the pill; then Alice resigns so Bob gets the medal ceremony.
 await bob.page.locator('.fgb').click().catch(() => {});

--- a/drive/scenarios/probe-call-quality.mjs
+++ b/drive/scenarios/probe-call-quality.mjs
@@ -1,0 +1,52 @@
+// Probe (spec 2025): watch the 1:1 adaptive tier on the LIVE dev stack — capture
+// resolution, the high→hd climb (≤6s, SC-001), steady state (no down-steps, SC-002),
+// and the pin-clamp → unpin recovery (SC-003 proxy at the integration level).
+import { createAccount, pair, poll, sweep, done } from '../driver.mjs';
+
+const hook = (c, fn, arg) => c.page.evaluate(fn, arg);
+
+const a = await createAccount({ name: 'QuaA', label: 'A' });
+const b = await createAccount({ name: 'QuaB', label: 'B' });
+await pair(a, b);
+
+await a.page.evaluate((peer) => window.__ringTest.startCall(peer, 'video'), b.id);
+await poll(() => hook(b, () => window.__ringTest.callState()), (s) => s === 'incoming', { label: 'ring' });
+await hook(b, () => window.__ringTest.accept());
+await poll(() => hook(a, () => window.__ringTest.callState()), (s) => s === 'connected', { label: 'connected' });
+const t0 = Date.now();
+
+const gum = await hook(a, () => window.__ringTest.localVideoSettings());
+console.log(`[capture] ${gum?.width}x${gum?.height}@${gum?.frameRate ?? '?'}fps  (expect ≥1280x720 on desktop Chromium)`);
+
+// Sample the tier every second for 20s: expect 'high' immediately, 'hd' within ~6s, and
+// ZERO down-steps once there.
+const TIERS = ['off', 'low', 'medium', 'high', 'hd'];
+const seen = [];
+let hdAtMs = null;
+let downSteps = 0;
+for (let i = 0; i < 20; i++) {
+  const q = await hook(a, () => window.__ringTest.callQuality());
+  seen.push(q.tier);
+  if (q.tier === 'hd' && hdAtMs == null) hdAtMs = Date.now() - t0;
+  if (seen.length > 1 && TIERS.indexOf(q.tier) < TIERS.indexOf(seen[seen.length - 2])) downSteps++;
+  await a.page.waitForTimeout(1000);
+}
+console.log(`[tier] samples: ${seen.join(' ')}`);
+console.log(`[tier] hd reached at +${hdAtMs}ms (SC-001 wants ≤6000)  down-steps=${downSteps} (SC-002 wants 0)`);
+
+// Pin low (clamps immediately), then back to auto — the climb must resume within ~10s.
+await hook(a, () => window.__ringTest.setVideoQuality('low'));
+await poll(() => hook(a, () => window.__ringTest.callQuality()), (q) => q.tier === 'low', { label: 'pin clamps', timeout: 10_000 });
+console.log('[pin] low pin clamped the tier ✓');
+await hook(a, () => window.__ringTest.setVideoQuality('auto'));
+const tUnpin = Date.now();
+await poll(
+  () => hook(a, () => window.__ringTest.callQuality()),
+  (q) => q.tier === 'high' || q.tier === 'hd',
+  { label: 'recovery climb', timeout: 15_000 },
+);
+console.log(`[pin] climbed back to high/hd ${Date.now() - tUnpin}ms after unpin (SC-003 proxy: ≤10s) ✓`);
+
+await hook(a, () => window.__ringTest.hangup());
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/probe-connect-timing.mjs
+++ b/drive/scenarios/probe-connect-timing.mjs
@@ -1,0 +1,72 @@
+// Probe (spec 1039 follow-up): how long from placing/accepting a call until BOTH sides
+// have media flowing — for a normal answered call AND a simultaneous mutual call — with
+// the spec-2008 connect milestones to show where the time goes. Investigating a report
+// of ~15s to first video on ring-dev.
+import { createAccount, pair, poll, sweep, done } from '../driver.mjs';
+
+const t = () => Date.now();
+const hook = (c, expr) => c.page.evaluate(expr);
+
+async function waitState(c, states, timeout = 40_000) {
+  await poll(
+    () => hook(c, () => window.__ringTest.callState()),
+    (s) => states.includes(s),
+    { timeout, label: `state ${states}` },
+  );
+}
+async function waitMedia(c, timeout = 40_000) {
+  await poll(
+    () => hook(c, () => window.__ringTest.remoteTracks()),
+    (n) => n > 0,
+    { timeout, label: 'remote media' },
+  );
+}
+
+const a = await createAccount({ name: 'TimA', label: 'A' });
+const b = await createAccount({ name: 'TimB', label: 'B' });
+await pair(a, b);
+await hook(a, () => window.__ringTest.recordConnect(true));
+await hook(b, () => window.__ringTest.recordConnect(true));
+
+// --- normal answered video call ---
+let t0 = t();
+await a.page.evaluate((peer) => window.__ringTest.startCall(peer, 'video'), b.id);
+await waitState(b, ['incoming']);
+const tRing = t() - t0;
+const tAccept = t();
+await hook(b, () => window.__ringTest.accept());
+await waitState(a, ['connected']);
+await waitState(b, ['connected']);
+const tConn = t() - tAccept;
+await waitMedia(a);
+await waitMedia(b);
+const tMedia = t() - tAccept;
+console.log(`[normal] ring=${tRing}ms  accept→connected=${tConn}ms  accept→both-media=${tMedia}ms`);
+console.log('[normal] A marks:', JSON.stringify(await hook(a, () => window.__ringTest.connectMarks())));
+console.log('[normal] B marks:', JSON.stringify(await hook(b, () => window.__ringTest.connectMarks())));
+await hook(a, () => window.__ringTest.hangup());
+await waitState(a, ['idle'], 15_000);
+await waitState(b, ['idle'], 15_000);
+
+// --- simultaneous mutual video call ---
+await hook(a, () => window.__ringTest.recordConnect(true));
+await hook(b, () => window.__ringTest.recordConnect(true));
+t0 = t();
+await Promise.all([
+  a.page.evaluate((peer) => window.__ringTest.startCall(peer, 'video'), b.id),
+  b.page.evaluate((peer) => window.__ringTest.startCall(peer, 'video'), a.id),
+]);
+await waitState(a, ['connected']);
+await waitState(b, ['connected']);
+const tConn2 = t() - t0;
+await waitMedia(a);
+await waitMedia(b);
+const tMedia2 = t() - t0;
+console.log(`[mutual] tap→connected=${tConn2}ms  tap→both-media=${tMedia2}ms`);
+console.log('[mutual] A marks:', JSON.stringify(await hook(a, () => window.__ringTest.connectMarks())));
+console.log('[mutual] B marks:', JSON.stringify(await hook(b, () => window.__ringTest.connectMarks())));
+await hook(a, () => window.__ringTest.hangup());
+await waitState(a, ['idle'], 15_000);
+
+await sweep([a, b]);
+await done();

--- a/e2e/mutual-call.spec.ts
+++ b/e2e/mutual-call.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startCall, accept, reject, hangup,
+  waitCallState, callState, callLogCount, rejectSecond, hasSecondIncoming,
+  type RingClient,
+} from './helpers';
+
+/**
+ * Mutual simultaneous calls (spec 1039): two contacts placing 1:1 calls at each other at
+ * (nearly) the same time must resolve to ONE connected call — automatically when the kinds
+ * match (neither side ever rings or taps Accept), via a normal ring when the kinds differ
+ * (camera consent). A crossing offer must also never corrupt an outgoing call being placed
+ * (the pre-1039 race stranded both sides on "Calling…").
+ *
+ * The winner of the deterministic tie-break is the SMALLER user id (its offer survives),
+ * so tests that depend on which side yields compute winner/loser from the actual ids.
+ */
+
+/** Record every distinct callState the page passes through (25ms sampler), so a test can
+ *  assert a state — e.g. 'incoming' — was never entered. The auto-accept path never SETS
+ *  'incoming', so any observation of it is a real regression, not sampling luck. */
+async function trackStates(c: RingClient): Promise<void> {
+  await c.page.evaluate(() => {
+    const w = window as any;
+    w.__seenStates = [w.__ringTest.callState()];
+    w.__stateTracker ??= setInterval(() => {
+      const s = w.__ringTest.callState();
+      const arr = w.__seenStates;
+      if (arr[arr.length - 1] !== s) arr.push(s);
+    }, 25);
+  });
+}
+const seenStates = (c: RingClient): Promise<string[]> =>
+  c.page.evaluate(() => (window as any).__seenStates ?? []);
+
+async function settled(c: RingClient): Promise<void> {
+  await waitCallState(c, ['idle', 'ended']);
+}
+
+for (const kind of ['audio', 'video'] as const) {
+  test(`mutual ${kind} calls at the same instant connect both sides, no ring, no manual accept`, async ({ browser }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    const a = await createAccount(ctxA, `GL${kind === 'audio' ? 'A' : 'V'}1A`);
+    const b = await createAccount(ctxB, `GL${kind === 'audio' ? 'A' : 'V'}1B`);
+    await pair(a, b);
+    await trackStates(a);
+    await trackStates(b);
+
+    // Both tap "call" on each other in the same instant — the offers cross mid-flight,
+    // landing inside (or right after) each side's setup window.
+    await Promise.all([startCall(a, b.id, kind), startCall(b, a.id, kind)]);
+
+    // Both sides end up in ONE connected call without anyone accepting (SC-001).
+    await waitCallState(a, ['connected']);
+    await waitCallState(b, ['connected']);
+
+    // Neither side ever rang: the incoming state must never have been entered (FR-003/008).
+    expect(await seenStates(a)).not.toContain('incoming');
+    expect(await seenStates(b)).not.toContain('incoming');
+
+    // The call works and ends cleanly.
+    await hangup(a);
+    await settled(a);
+    await settled(b);
+
+    // Exactly one history entry per side for the encounter, an answered call — the
+    // yielded attempt must not surface as a second/missed entry (FR-007, SC-005).
+    expect(await callLogCount(a, b.id)).toBe(1);
+    expect(await callLogCount(b, a.id)).toBe(1);
+
+    // A follow-up call still works (no leaked state from the resolution). Wait for both
+    // sides to fully settle to idle first: an offer landing inside the short post-call
+    // 'ended' display dwell is answered busy (pre-existing behavior, unrelated to glare).
+    await waitCallState(a, ['idle']);
+    await waitCallState(b, ['idle']);
+    await startCall(a, b.id, 'audio');
+    await waitCallState(b, ['incoming']);
+    await accept(b);
+    await waitCallState(a, ['connected']);
+    await hangup(a);
+
+    await ctxA.close();
+    await ctxB.close();
+  });
+}
+
+test('mismatched kinds: the yielder gets a normal ring (no auto-camera); decline ends both cleanly', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const first = await createAccount(ctxA, 'GLMM1A');
+  const second = await createAccount(ctxB, 'GLMM1B');
+  await pair(first, second);
+  // The SMALLER id wins the tie-break; give the winner an AUDIO call and the yielder a
+  // VIDEO call, so the surviving (audio) offer mismatches the yielder's own intent.
+  const winner = first.id < second.id ? first : second;
+  const loser = winner === first ? second : first;
+  await trackStates(winner);
+
+  await Promise.all([startCall(winner, loser.id, 'audio'), startCall(loser, winner.id, 'video')]);
+
+  // The yielder is presented the surviving AUDIO call as a normal incoming ring (FR-004) —
+  // its own video attempt is withdrawn, and no camera is auto-enabled for an audio call.
+  await waitCallState(loser, ['incoming']);
+  expect((await loser.page.evaluate(() => (window as any).__ringTest.callMeta()))?.kind).toBe('audio');
+  // The winner never rings (its attempt survived).
+  expect(await seenStates(winner)).not.toContain('incoming');
+
+  // Declining settles BOTH sides promptly — no stuck states, no waiting out a timeout (US2).
+  await reject(loser);
+  await settled(winner);
+  await settled(loser);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('mismatched kinds: accepting the surviving call connects it at the surviving kind', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const first = await createAccount(ctxA, 'GLMM2A');
+  const second = await createAccount(ctxB, 'GLMM2B');
+  await pair(first, second);
+  const winner = first.id < second.id ? first : second;
+  const loser = winner === first ? second : first;
+
+  await Promise.all([startCall(winner, loser.id, 'video'), startCall(loser, winner.id, 'audio')]);
+
+  // Surviving offer is VIDEO; the yielder placed audio → ring, not auto-connect (consent).
+  await waitCallState(loser, ['incoming']);
+  await accept(loser);
+  await waitCallState(winner, ['connected']);
+  await waitCallState(loser, ['connected']);
+
+  await hangup(winner);
+  await settled(winner);
+  await settled(loser);
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('a third caller in the same instant cannot corrupt the call being placed', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'GL3P1A');
+  const b = await createAccount(ctxB, 'GL3P1B');
+  const c = await createAccount(ctxC, 'GL3P1C');
+  await pair(a, b);
+  await pair(b, c);
+
+  // B places a call to A while C calls B in the same instant. C's offer lands during (or
+  // right after) B's setup window — before the fix it clobbered B's outgoing call state.
+  await Promise.all([startCall(b, a.id, 'audio'), startCall(c, b.id, 'audio')]);
+
+  // B's call to A proceeds and connects normally (FR-006).
+  await waitCallState(a, ['incoming']);
+  await accept(a);
+  await waitCallState(b, ['connected']);
+  expect((await b.page.evaluate(() => (window as any).__ringTest.callMeta()))?.peerUserId).toBe(a.id);
+
+  // C is never silently connected: it got busy (ended) or is parked in B's call-waiting
+  // prompt (both are the existing "calling a busy person" outcomes).
+  expect(await callState(c)).not.toBe('connected');
+  if (await hasSecondIncoming(b)) await rejectSecond(b);
+  await settled(c);
+
+  await hangup(b);
+  await ctxA.close();
+  await ctxB.close();
+  await ctxC.close();
+});
+
+test('a mutual attempt while already in a call follows busy/call-waiting rules, not glare', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'GLBZ1A');
+  const b = await createAccount(ctxB, 'GLBZ1B');
+  const c = await createAccount(ctxC, 'GLBZ1C');
+  await pair(a, b);
+  await pair(b, c);
+
+  // A and B are connected.
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+  await waitCallState(b, ['connected']);
+
+  // C calls B (who is busy). B's connected call is NOT glare — C lands in the existing
+  // call-waiting prompt; the A↔B call is undisturbed (FR-009, spec edge case).
+  await startCall(c, b.id, 'audio');
+  await b.page.waitForFunction(() => (window as any).__ringTest.hasSecondIncoming() === true, null, { timeout: 15_000 });
+  expect(await callState(a)).toBe('connected');
+  expect(await callState(b)).toBe('connected');
+
+  await rejectSecond(b);
+  await settled(c);
+  await hangup(a);
+  await ctxA.close();
+  await ctxB.close();
+  await ctxC.close();
+});

--- a/specs/1039-simultaneous-mutual-calls/checklists/requirements.md
+++ b/specs/1039-simultaneous-mutual-calls/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Simultaneous mutual calls connect instead of ringing each other
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The mismatched-kind policy (ring instead of degraded auto-connect) and the deterministic
+  tie-break are recorded as Assumptions with rationale, so no [NEEDS CLARIFICATION] markers
+  were required; both are cheap to revisit before implementation if the owner prefers
+  otherwise.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/1039-simultaneous-mutual-calls/contracts/signalling.md
+++ b/specs/1039-simultaneous-mutual-calls/contracts/signalling.md
@@ -1,0 +1,55 @@
+# Signalling contract: Simultaneous mutual calls (spec 1039)
+
+**No wire change.** Every frame below already exists and keeps its exact shape; the
+server relays sealed envelopes blindly as today. This document only fixes the required
+*sequences* so both clients interoperate (including a new client against an old one).
+
+## Frames used (all existing)
+
+| Frame | Direction | Content |
+|---|---|---|
+| `call-offer` | caller → callee (sealed SDP) | the attempt itself |
+| `call-answer` | callee → caller (sealed SDP) | accept |
+| `call-cancel` | caller → callee (control) | caller withdraws an unanswered attempt (reason from existing vocabulary, e.g. `answered-elsewhere`) |
+| `call-ringing` / `call-busy` / `call-end` | control | unchanged usages |
+
+## Sequence — mutual attempt, kinds match
+
+`A < B` (A's attempt survives; B yields). Both taps ~simultaneous.
+
+```
+A → B : call-offer(callA, kind K)          B → A : call-offer(callB, kind K)
+A: offer callB crosses its own attempt → glare decision = ignore (A wins)
+B: offer callA crosses its own attempt → glare decision = auto-accept
+B → A : call-cancel(callB, answered-elsewhere)   (clears relay retention of callB)
+B → A : call-answer(callA)                        (no ring, no manual accept on B)
+A: receives call-answer(callA) → connects (normal answered-call path)
+A: (whenever call-cancel(callB) arrives, before or after: no-op — callB was never
+    presented; also dropped if redelivered later, spec 2012 retention)
+```
+
+## Sequence — mutual attempt, kinds differ
+
+Same as above until B's decision, which is `ring`: B sends `call-cancel(callB, …)`,
+then presents `call-offer(callA)` as a normal incoming call (kind shown). Accept /
+decline proceed exactly as today (`call-answer` / `call-reject`).
+
+## Sequence — different caller during setup window
+
+```
+B: placing call to A (unanswered attempt, any phase)
+C → B : call-offer(callC)
+B: glare decision = none (different peer) → existing busy / call-waiting flow
+   (attempt to A is untouched)
+```
+
+## Compatibility
+
+- **New yielder vs old winner**: old A already ignores a crossing offer once dialing;
+  B's `call-answer` and `call-cancel` are frames old A fully understands. Works.
+- **Old yielder vs new winner**: old B tears down and rings (today's behavior); new A
+  ignores the crossing offer (unchanged). Works — just without auto-connect, and the
+  setup-window race persists only on the old client.
+- The only ordering requirement introduced: the yielding side sends `call-cancel` for
+  its abandoned attempt no later than its `call-answer` send (best-effort; a lost
+  cancel is healed by the existing stale-offer handling on redelivery).

--- a/specs/1039-simultaneous-mutual-calls/data-model.md
+++ b/specs/1039-simultaneous-mutual-calls/data-model.md
@@ -1,0 +1,72 @@
+# Data Model: Simultaneous mutual calls (spec 1039)
+
+No new persisted entities and no schema change. This feature is a state-machine
+refinement over existing in-memory call state plus a call-log integrity rule.
+
+## In-memory entities
+
+### Outgoing attempt (existing, made explicit)
+
+The unit the resolution reasons about. Today it is implicit in `callMeta` +
+`callState`; the fix makes its lifetime crisp.
+
+| Field | Source | Notes |
+|---|---|---|
+| `callId` | `callMeta.callId` | Also serves as the attempt token (R3) |
+| `peerUserId` | `callMeta.peerUserId` | The callee |
+| `kind` | `callMeta.kind` | `audio` \| `video` |
+| `phase` | derived | `setting-up` (callState still `idle`, meta set) → `dialing` → `remote-ringing` → answered/ended |
+
+**Lifecycle**: created synchronously when the user places the call (meta set) →
+`setting-up` while capture/PC/offer-send run → `dialing`/`remote-ringing` → terminal
+(connected, cancelled, yielded, failed, timeout). A yielded attempt MUST stop mutating
+shared state the moment it yields (token check after every await).
+
+### Mutual pair / glare decision (new, pure, not persisted)
+
+Computed independently on each device by `src/services/call/glare.ts` when a 1:1 offer
+arrives from `from` while an outgoing attempt exists:
+
+Inputs: `selfId`, `from`, attempt (`peerUserId`, `kind`, `phase` unanswered), offer `kind`.
+
+| Condition | Decision |
+|---|---|
+| No unanswered outgoing attempt to `from` | `none` (normal incoming / busy / call-waiting flow) |
+| Attempt exists, `selfId < from` | `ignore` — we win; drop the crossing offer silently |
+| Attempt exists, `selfId > from`, kinds match | `auto-accept` — yield our attempt, join theirs with no ring |
+| Attempt exists, `selfId > from`, kinds differ | `ring` — yield our attempt, present theirs as a normal incoming call |
+
+Invariants:
+
+- Deterministic and symmetric: for any pair of crossing attempts, exactly one side
+  computes `ignore` and the other computes `auto-accept`/`ring` (FR-002).
+- Group offers and offers from a different user never reach the glare decision
+  (`none`), preserving busy/call-waiting behavior (FR-006, FR-009).
+
+## Persisted data (existing stores, integrity rules only)
+
+### Call log entry (`calls` store via `src/db/queries.ts`)
+
+- Winner side: keeps its normal outgoing record; it transitions to answered/ended as
+  for any answered call. The crossing (yielded) offer never creates a record.
+- Yielding side: the record `startDirectCall` created for the abandoned attempt is
+  deleted (`deleteCalls([abandonedCallId])`); the auto-accept/ring path creates the
+  single incoming record as usual (FR-007 / SC-005).
+
+## State transitions touched (yielding side, kinds match)
+
+```
+placing call to A (meta set, callState idle, capture in flight)
+        │  offer from A arrives → glare decision = auto-accept
+        ▼
+yield: invalidate attempt token · send call-cancel(abandoned callId)
+       · delete abandoned call record · keep captured stream if resolved
+        ▼
+auto-accept surviving offer (no ring, no incoming UI):
+       set meta incoming(A) · reuse/capture stream · answer sealed
+        ▼
+connected  (callState 'connecting' → 'connected' as any answered call)
+```
+
+All other transitions (decline, hang-up, timeout, busy, call waiting, group) are
+unchanged.

--- a/specs/1039-simultaneous-mutual-calls/plan.md
+++ b/specs/1039-simultaneous-mutual-calls/plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: Simultaneous mutual calls connect instead of ringing each other
+
+**Branch**: `feat/1039-simultaneous-mutual-calls` | **Date**: 2026-07-11 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1039-simultaneous-mutual-calls/spec.md`
+
+## Summary
+
+When two contacts place 1:1 calls at each other at (nearly) the same time, resolve the
+glare deterministically on both devices and connect them into ONE call — automatically
+when the kinds match, via a normal incoming ring when they differ (camera consent).
+Two client-side defects are fixed on the way: (1) the glare branch in `handleOffer`
+keys on `callState !== 'idle'`, but `startDirectCall` only leaves `'idle'` *after*
+getUserMedia + PC build + offer send, so a crossing offer inside that setup window
+skips glare handling, clobbers `callMeta`, and strands BOTH sides on "Calling…"; and
+(2) even detected glare today re-rings the yielding side instead of connecting it.
+Everything is client-only policy over the existing sealed signalling — no server or
+protocol change.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (Vue 3 `<script setup>` + Ionic 8), client-only change
+
+**Primary Dependencies**: WebRTC (`RTCPeerConnection`), existing sealed call signalling
+(`sendSealedSignal`/`openSealedSignal` over the pair's Double Ratchet), existing call
+state machine in `src/composables/useCall.ts`
+
+**Storage**: IndexedDB call log via existing `createCall`/`deleteCalls` in `src/db/queries.ts`
+(no new object store, no `DB_VERSION` bump)
+
+**Testing**: vitest for a new pure decision module; Playwright e2e (two real browsers
+calling each other simultaneously, per-repo harness)
+
+**Target Platform**: installable PWA — Chrome/Android, Safari/iOS (WebKit constraints
+apply, see research R4), desktop browsers
+
+**Project Type**: web app (client of the existing monorepo; `server/` untouched)
+
+**Performance Goals**: mutual attempts connect within the normal single-call
+answer-to-connected time (+≤1s); no added latency to ordinary calls
+
+**Constraints**: zero-knowledge boundary (no new plaintext or metadata to the server);
+no second `getUserMedia` on the yielding WebKit device (mute hazard, bug 179363);
+call-waiting (specs 0005/2009) behavior for genuinely different callers unchanged
+
+**Scale/Scope**: one composable (`useCall.ts`) + one new pure module + tests; ~4 touch
+points (`startDirectCall`, `handleOffer`, accept path, teardown/cancel)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary** — PASS. No new frame types or fields; the resolution
+  re-uses the sealed offer/answer/cancel frames exactly as a human-driven
+  place/accept/hang-up would. Spec carries the required Zero-Knowledge Impact section.
+- **II. Spec-Driven Development** — PASS. Spec 1039 (ad-hoc band), pipeline followed
+  (specify → clarify → plan → tasks → analyze → taskstoissues → implement).
+- **III. Test-Driven Development** — PASS (planned). New pure decision module gets
+  vitest coverage written first; user-facing behavior gets a new e2e spec
+  (`e2e/mutual-call.spec.ts`) with the mutual-timing scenarios. tasks.md orders tests
+  before implementation.
+- **IV. Crypto Discipline** — PASS. No crypto change: sealing/opening of call frames is
+  untouched; `messaging.ts` untouched. `/speckit-checklist` is therefore not mandated by
+  the gate-sequencing rule (no Principle I/IV surface is modified), and is skipped.
+- **V. Offline-First Data Integrity** — PASS. Call-log writes stay behind
+  `src/db/queries.ts`; the abandoned attempt's record is removed via the existing
+  `deleteCalls`. No schema change.
+- **VI. Stateless Server** — PASS (server untouched).
+- **VII. Quality Gates** — PASS (planned): `npm run build`, vitest, e2e for the changed
+  behavior; server gates unaffected but run anyway in CI.
+- **VIII. Traceability** — PASS: branch `feat/1039-…`, issues via taskstoissues, PR
+  lists `Closes #N`.
+- **IX–XI** — PASS. No new data collected; no new UI surface (the change *removes* a
+  ring in one path; any toast/cue reuses existing primitives).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1039-simultaneous-mutual-calls/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── signalling.md    # Phase 1 output — existing-frame sequences (no wire change)
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── composables/
+│   └── useCall.ts                 # startDirectCall (attempt token), handleOffer
+│                                  # (meta-keyed glare gate + routing), auto-accept path,
+│                                  # yield/cancel of the abandoned attempt
+├── services/call/
+│   ├── glare.ts                   # NEW pure decision module (unit-testable)
+│   └── glare.test.ts              # NEW vitest decision-table tests
+└── db/queries.ts                  # (existing deleteCalls; no change expected)
+
+e2e/
+└── mutual-call.spec.ts            # NEW two-browser simultaneous-call e2e
+```
+
+**Structure Decision**: single-project client change inside the existing monorepo
+layout; all new logic that can be pure lives in `src/services/call/glare.ts` following
+the repo's established pattern (`capacity.ts`, `invite-plan.ts`, `merge-kind.ts` — pure
+modules with sibling tests), keeping `useCall.ts` wiring thin.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/1039-simultaneous-mutual-calls/quickstart.md
+++ b/specs/1039-simultaneous-mutual-calls/quickstart.md
@@ -33,6 +33,12 @@ connect, no incoming UI, one history entry each), mismatched kinds (ring on the
 yielder, no camera without accept), different-caller-during-setup (busy/call-waiting,
 outgoing attempt intact).
 
+## Manual cue check (FR-008, not machine-checkable)
+
+During a same-kind mutual attempt, listen on the yielding device: the "calling" tone
+must transition straight into the connected call — the incoming ringtone must never
+play. (E2e asserts the UI level: no incoming screen; tones are verified by ear here.)
+
 ## Full gates before calling it done
 
 ```sh

--- a/specs/1039-simultaneous-mutual-calls/quickstart.md
+++ b/specs/1039-simultaneous-mutual-calls/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart: Simultaneous mutual calls (spec 1039)
+
+## See the bug / the fix in the real app
+
+```sh
+make start                       # dev stack (Vite :5173 → ringd :8080)
+```
+
+Two browser profiles (or a browser + phone on the LAN), two paired test accounts, then
+tap call on each other within ~1 second. Before the fix: both sit on "Calling…" (taps
+< ~1s apart) or one side rings back at its own caller (taps ~1–2s apart). After: the
+call just connects.
+
+A scripted repro can use the `drive/` harness (`drive/README.md`): create two accounts,
+`pair`, then fire `startDirectCall` on both pages in the same tick via the
+`window.__ringTest` hook and screenshot both call screens.
+
+## Unit tests (decision table)
+
+```sh
+npx vitest run src/services/call/glare.test.ts
+```
+
+## E2E (two real browsers, real WebRTC)
+
+```sh
+make db-up                       # once
+npm run test:e2e -- mutual-call  # e2e/mutual-call.spec.ts
+```
+
+Scenarios covered: same-kind audio + video mutual attempts at 0ms/~1s offsets (both
+connect, no incoming UI, one history entry each), mismatched kinds (ring on the
+yielder, no camera without accept), different-caller-during-setup (busy/call-waiting,
+outgoing attempt intact).
+
+## Full gates before calling it done
+
+```sh
+npm run build                    # vue-tsc typecheck + vite build
+npx vitest run                   # unit suites + coverage floors
+npm run test:e2e                 # full e2e
+```

--- a/specs/1039-simultaneous-mutual-calls/research.md
+++ b/specs/1039-simultaneous-mutual-calls/research.md
@@ -1,0 +1,116 @@
+# Research: Simultaneous mutual calls (spec 1039)
+
+All Technical Context items were resolvable from the codebase; no external unknowns
+remained. Decisions below are the load-bearing ones.
+
+## R1 — Winner tie-break: reuse the existing deterministic id ordering
+
+- **Decision**: the attempt whose CALLER has the smaller user id survives; the other
+  side yields. This is the rule the current glare branch already applies
+  (`useCall.ts:1883`, `if (self < from) return`) and matches the mesh's polite/impolite
+  convention (`mesh.ts`: `polite = selfId > peerId`).
+- **Rationale**: both devices can compute it independently from information they already
+  hold (the two user ids), with no extra round-trip and no timing sensitivity — FR-002's
+  symmetric determinism for free. Keeping the same ordering as the mesh avoids two
+  competing conventions in one file.
+- **Alternatives considered**: comparing callIds (random per attempt — both sides know
+  both ids only after the cross, same property but no benefit and it diverges from the
+  established convention); timestamps (not comparable across devices; ties possible);
+  explicit negotiation frames (new protocol surface for zero gain).
+
+## R2 — Where glare must be detected: `callMeta`, not `callState`
+
+- **Decision**: key the glare gate on the synchronously-set `callMeta`
+  (direction `outgoing`, non-group, `peerUserId === from`, call not yet answered)
+  combined with `callState` in `{'idle' (setup window), 'dialing', 'remote-ringing'}`,
+  instead of today's `callState.value !== 'idle'` gate.
+- **Rationale**: `startDirectCall` sets `callMeta` on its first line but only leaves
+  `'idle'` after getUserMedia + PC construction + offer send (0.5–2s+, longer with a
+  permission prompt). Mutual taps land inside that window almost by definition, which is
+  exactly why users see both sides stuck. `callMeta` is the earliest truthful record of
+  "an attempt exists".
+- **Alternatives considered**: setting `callState = 'dialing'` synchronously at the top
+  of `startDirectCall` (rejected: `dialing` drives UI/tones that must not start before
+  capture consent, and other code paths key off the current meaning); a separate
+  `placingCall` flag (rejected: `callMeta` already encodes it — a second source of truth
+  invites the next desync).
+
+## R3 — Cancelling the in-flight `startDirectCall` safely: attempt token
+
+- **Decision**: give each outgoing attempt a monotonically increasing token (or use the
+  callId itself) captured at entry; after every `await` inside `startDirectCall`, bail
+  out if the current attempt token no longer matches (the attempt was yielded/torn
+  down). The yield path stops local tracks only if the auto-accept isn't reusing them.
+- **Rationale**: the chimera state exists because a half-finished `startDirectCall`
+  keeps mutating global state (`setState('dialing')`, tones, navigation) after
+  `handleOffer` has already repurposed the call slot. A generation check after each
+  suspension point is the established minimal pattern for exactly this bug class.
+- **Alternatives considered**: AbortController plumbed through (heavier, same effect);
+  a mutex serializing `startDirectCall` against `handleOffer` (would *delay* the
+  incoming offer instead of resolving it, and risks deadlock with the sealed-signal
+  session mutex).
+
+## R4 — Media for the auto-accepting (yielding) side: reuse the already-captured stream
+
+- **Decision**: when the yielding side has already captured its local stream (its own
+  attempt got as far as getUserMedia) and the kinds match, hand that stream to the
+  accept path instead of a second `getUserMedia`. If capture hadn't resolved yet, let
+  the accept path do the (single) capture as usual.
+- **Rationale**: WebKit mutes tracks when a second concurrent `getUserMedia` runs
+  (documented in `useCall.ts` ~line 629, WebKit bug 179363); the kinds-match rule means
+  the captured stream is exactly what the surviving call needs. This also makes the
+  auto-connect faster (capture is the slow step).
+- **Alternatives considered**: always re-capture (violates the WebKit constraint and
+  slower); keep both captures alive briefly (two live captures is itself the hazard).
+
+## R5 — The abandoned attempt on the wire: reuse `call-cancel`
+
+- **Decision**: the yielding side sends the existing `call-cancel` control for its
+  abandoned callId (reason from the existing vocabulary, e.g. `answered-elsewhere`)
+  before/while auto-accepting the surviving offer.
+- **Rationale**: the relay retains sealed offers for redelivery (spec 2012); without a
+  cancel, the winner (or one of its other devices) could get the yielder's stale offer
+  redelivered after a reload and raise a ghost incoming ring. `call-cancel` is already
+  understood by every receive path (`useCall.ts:3224`) and by the relay's retention
+  logic; no new frame type, zero-knowledge unchanged.
+- **Alternatives considered**: silent abandonment (leaves the retained-offer ghost);
+  a new dedicated reason string (needless vocabulary growth — nothing branches on it).
+
+## R6 — Call-log integrity (FR-007): delete the yielded attempt's record
+
+- **Decision**: `startDirectCall` writes an outgoing call record immediately
+  (`createCall` at `useCall.ts:1294`); on yield, remove that record via the existing
+  `deleteCalls([callId])` and let the auto-accept path write its normal
+  incoming-answered record. Winner side: its outgoing record proceeds normally, and the
+  crossing offer is ignored *before* any record is created for it (current behavior,
+  preserved).
+- **Rationale**: exactly one entry per side, each reflecting what actually happened
+  (an answered call), with no "no answer"/"missed" artifacts — the spec's SC-005.
+- **Alternatives considered**: mutating the outgoing record into an incoming one
+  (more code, lies about direction); leaving both records (fails FR-007).
+
+## R7 — Kind mismatch: ring, never auto-enable a camera
+
+- **Decision**: auto-connect only when `myKind === offerKind`. On mismatch the yielding
+  side cancels its own attempt and presents the surviving offer as a normal incoming
+  ring (today's post-glare behavior), showing the offer's kind.
+- **Rationale**: constitution Principle IX / spec FR-004 — capture consent is explicit.
+  A video offer auto-accepted by someone who placed an audio call would light their
+  camera uninvited; the ring is the established consent surface. (Joining a video call
+  as audio-only, or auto-accepting audio when the yielder wanted video, are viable
+  refinements — deferred by the spec's Assumptions to keep this slice small.)
+- **Alternatives considered**: degrade-to-audio auto-connect (extra states in the accept
+  path and in-call upgrade interplay; deferred); treating mismatch as busy (worst UX —
+  the call simply fails).
+
+## R8 — Per-chat mute vs. the mutual case
+
+- **Decision**: the glare branch runs BEFORE the per-chat mute suppression in
+  `handleOffer`, so a muted chat still resolves/auto-connects a mutual attempt (the
+  muted person themselves just placed a call to that contact — it is not an unsolicited
+  ring). A mismatched-kind fall-through to the ring path keeps ringing even for the
+  muted chat in the mutual case only (the user's own outgoing attempt is the consent).
+- **Rationale**: spec edge case; mute exists to stop unsolicited interruptions, and a
+  mutual attempt is by construction solicited.
+- **Alternatives considered**: honoring mute (the mutual call silently fails on one
+  side — indistinguishable from the current bug).

--- a/specs/1039-simultaneous-mutual-calls/spec.md
+++ b/specs/1039-simultaneous-mutual-calls/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Simultaneous mutual calls connect instead of ringing each other
+
+**Feature Branch**: `feat/1039-simultaneous-mutual-calls`
+
+**Created**: 2026-07-11
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "If 2 contacts try to either audio or video call each other at the same time, they should get connected — they should not end up in call waiting for each other."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Calling each other at the same moment just connects (Priority: P1)
+
+Two contacts decide to talk and both tap the call button on each other at (nearly) the same time — both audio, or both video. Instead of each phone showing "Calling…" forever (or one phone confusingly starting to ring after its owner just placed a call), the two attempts are recognized as one mutual intent and the call simply connects: both people land in a live call with each other, no extra tap needed.
+
+**Why this priority**: This is the requested behavior and fixes the worst current outcome — today near-simultaneous mutual calls can leave BOTH people stuck on "Calling…" until the no-answer timeout, so the call never happens at all. Both people have already expressed exactly the same intent; making either of them answer (or wait) is pure friction.
+
+**Independent Test**: On two devices signed in as mutual contacts, tap "call" on each other within ~0–2 seconds (same kind). Verify both devices enter one connected call without either user tapping Accept, for both audio and video, across several timing offsets (0ms, ~300ms, ~1s, ~2s apart).
+
+**Acceptance Scenarios**:
+
+1. **Given** two contacts both idle, **When** both place an audio call to each other within the setup window of one another (any overlap of the two unanswered attempts), **Then** both devices end up connected in a single audio call together, without either user accepting manually.
+2. **Given** two contacts both idle, **When** both place a video call to each other at the same time, **Then** both devices end up connected in a single video call together, without either user accepting manually.
+3. **Given** the mutual attempt above, **When** the call connects, **Then** neither device is left showing "Calling…", an incoming-call screen, a busy screen, or a call-waiting prompt for the other's attempt.
+4. **Given** the mutual attempt above, **When** either person hangs up during or right after the resolution, **Then** both devices return cleanly to idle (no ghost call, no stuck screen, and a follow-up call between the two works normally).
+
+---
+
+### User Story 2 - Mismatched kinds never switch on a camera uninvited (Priority: P2)
+
+One person places an audio call while, at the same time, the other places a video call to them. The two attempts still resolve deterministically to a single call — but the person who only asked for an audio call must never find their camera live without having agreed to video. In that mismatched case the surviving call is presented as a normal incoming call (showing its kind), and the recipient decides.
+
+**Why this priority**: Consent to the camera is a hard privacy principle (Constitution Principle IX: capture only ever follows an explicit user action). Auto-connecting is only safe when it grants exactly what each person already asked for.
+
+**Independent Test**: Device A places an audio call while device B simultaneously places a video call to A. Verify a single surviving call is presented, no camera turns on on the audio-caller's device without an explicit accept, and no stuck/timeout state occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** A places an audio call and B places a video call to A at the same time, **Then** exactly one of the two attempts survives (deterministically), the other side sees it as a normal incoming call ring with its kind clearly shown, and no camera is captured on any device that didn't explicitly start or accept a video call.
+2. **Given** the mismatched mutual attempt, **When** the ringing side declines the surviving call, **Then** both sides end in idle with clear outcomes (declined / call ended), not a timeout.
+
+---
+
+### User Story 3 - A different caller during call setup doesn't wreck the call being placed (Priority: P3)
+
+While someone is placing a call to contact A (the brief setup moment before it audibly starts "calling"), an unrelated contact C happens to call them. The incoming call from C must not corrupt or replace the call being placed — C gets the same treatment as any caller reaching a busy person (busy, or the call-waiting prompt when available), and the outgoing call to A proceeds normally.
+
+**Why this priority**: The same blind spot that loses mutual calls (an offer arriving during the setup window) also lets ANY incoming call corrupt an outgoing call being placed. Rarer than the mutual case, but the same defect class and the same fix surface.
+
+**Independent Test**: Start an outgoing call from B to A, and within the same instant have C call B. Verify B's outgoing call to A rings and can connect normally, and C receives the existing busy/call-waiting treatment.
+
+**Acceptance Scenarios**:
+
+1. **Given** B is placing a call to A, **When** C's incoming call arrives during B's setup window, **Then** B's outgoing call to A continues unharmed (it can be answered and connect), and C is handled exactly as if B were already in a call (busy, or call-waiting prompt per the existing rules).
+
+---
+
+### Edge Cases
+
+- The two attempts overlap at every possible timing: both offers cross mid-flight, one arrives before the other side's attempt has even finished setting up (camera permission prompt, slow capture), or one arrives while the other is already audibly "calling". All overlaps resolve the same way — one connected call.
+- The yielding side's own (now abandoned) attempt reaches the surviving side late (relay retention / reconnect redelivery): it must be ignored, not raised as a new incoming call, including after the mutual call has already connected or ended.
+- One person cancels (hangs up) their attempt in the same instant the resolution happens: both sides must settle to idle or to a normal single-direction ring — never a stuck hybrid.
+- The mutual attempt happens while one side's app was just opened via the incoming-call push: resolution still applies (the intent is mutual regardless of how the offer arrived).
+- A mutual attempt between people who are ALREADY in other calls follows the existing busy/call-waiting rules; this feature only governs two attempts aimed at each other while neither call is connected yet.
+- Per-chat mute: a muted chat suppresses that contact's incoming ring today — but a mutual attempt is not an unsolicited ring (the muted person themselves just called that contact), so resolution/auto-connect still applies.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When two contacts each have an unanswered outgoing call to the other in progress at the same time (any overlap between the two attempts, from the moment a call is placed until it is answered or ended), the system MUST resolve them to a single call — never two parallel rings, a busy result, or mutual "Calling…" hangs.
+- **FR-002**: Resolution MUST be deterministic and symmetric: both devices, acting independently on the same information, MUST pick the same surviving attempt (and the same yielding attempt) regardless of message timing.
+- **FR-003**: When both attempts are the same kind (both audio, or both video), the yielding side MUST join the surviving call automatically — no incoming ring, no Accept tap — and the surviving side MUST see its outgoing call get answered normally.
+- **FR-004**: Automatic joining MUST NOT capture any media the yielding person did not already consent to by placing their own call. When the kinds differ, the system MUST NOT auto-connect; the surviving attempt is presented to the yielding side as a normal incoming call showing its kind, and the existing accept/decline flow applies.
+- **FR-005**: Resolution MUST cover the entire lifetime of an outgoing attempt — explicitly including the setup window between the user tapping "call" and the attempt audibly ringing (permission prompts, camera warm-up, connection preparation). An offer from the same contact arriving anywhere in that window MUST trigger resolution, not a second incoming call, and MUST NOT corrupt the outgoing attempt's state.
+- **FR-006**: An incoming call from a DIFFERENT person arriving during the setup window MUST leave the outgoing attempt intact and MUST receive the existing treatment for calling a busy person (busy, or the call-waiting prompt when a slot is free).
+- **FR-007**: After resolution, each person's call history MUST show exactly one entry for the mutual attempt — a normal answered call (outgoing on the surviving side, incoming on the yielding side). The yielding side's abandoned attempt MUST NOT surface as a separate missed, declined, or unanswered call on either side.
+- **FR-008**: Audible/visual cues MUST follow the resolution: the yielding side's "calling" tone transitions into the connected call without ever playing an incoming ringtone for the mutual case; connected-call cues then behave as for any answered call.
+- **FR-009**: All existing behaviors for non-mutual situations MUST be preserved: sequential calls, busy handling, call waiting (hold/swap/drop), group calls, and declining/cancelling — none of these change except as required by FR-001–FR-008.
+
+### Key Entities
+
+- **Outgoing attempt**: a call one person has placed that has not yet been answered or ended; carries the callee, the kind (audio/video), and its progress (setting up / ringing).
+- **Mutual pair**: two outgoing attempts, one on each side, each aimed at the other person, overlapping in time; resolves to one surviving attempt and one yielding attempt.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In repeated trials of two devices calling each other within 0–2 seconds of one another (same kind, both audio and both video), 100% of trials end with both devices in one connected call, with no manual accept.
+- **SC-002**: The mutual case connects within the normal answer-to-connected time for a single call (no added waiting attributable to the resolution beyond ~1 second).
+- **SC-003**: Zero occurrences (in those trials) of: both sides stuck on "Calling…", a busy result, a call-waiting prompt for the mutual attempt, or a no-answer timeout.
+- **SC-004**: In mismatched-kind trials, zero occurrences of a camera turning on for a user who neither placed nor accepted a video call.
+- **SC-005**: After each trial, each device's call history shows exactly one entry for the encounter, marked answered (not missed/declined).
+
+## Assumptions
+
+- Scope is 1:1 direct calls between contacts. Group calls resolve join collisions by an existing mechanism and are out of scope.
+- The surviving attempt is chosen by the existing deterministic tie-break already used for glare (a fixed ordering of the two user identities); which side "wins" is arbitrary and invisible to users — both experience "the call connected".
+- On mismatched kinds we prefer a ring over auto-connecting in a reduced form (e.g. joining a video call as audio-only): a ring is the established, well-understood consent surface, and mismatched mutual attempts are expected to be rare. This can be revisited later without breaking this spec.
+- The existing in-call upgrade flow (audio → video with consent) remains the path to add video after any audio connection, including one produced by this resolution.
+- No server/protocol change is assumed to be required: both devices can already observe everything they need (their own outgoing attempt and the peer's crossing offer). If planning finds otherwise, the zero-knowledge boundary still applies — the server must not learn anything new about call content or participants beyond what it relays today.

--- a/specs/1039-simultaneous-mutual-calls/spec.md
+++ b/specs/1039-simultaneous-mutual-calls/spec.md
@@ -99,6 +99,23 @@ While someone is placing a call to contact A (the brief setup moment before it a
 - **SC-004**: In mismatched-kind trials, zero occurrences of a camera turning on for a user who neither placed nor accepted a video call.
 - **SC-005**: After each trial, each device's call history shows exactly one entry for the encounter, marked answered (not missed/declined).
 
+## Zero-Knowledge Impact
+
+- **What crosses the wire**: nothing new. Resolution is decided independently on each
+  device from information it already has — its own outgoing attempt and the peer's
+  crossing (sealed) call offer. Connecting uses the same sealed answer a manual accept
+  would send; abandoning the yielding attempt uses the same sealed cancel/end a manual
+  hang-up during "Calling…" would send.
+- **What is encrypted**: everything content-bearing, exactly as today — offers, answers,
+  cancels, and all call signalling remain sealed over the pair's existing ratchet. No new
+  frame types, no new fields readable by the server.
+- **Unavoidably visible metadata**: unchanged — the server continues to see only that
+  sealed call-signalling envelopes flow between the two users (as for any call today).
+  The resolution does not create additional envelopes beyond a normal placed-then-
+  answered call plus the one cancel of the abandoned attempt.
+- **Why**: the feature is purely a client-side policy change about how two already-
+  visible attempts are presented and answered; the server keeps relaying blindly.
+
 ## Assumptions
 
 - Scope is 1:1 direct calls between contacts. Group calls resolve join collisions by an existing mechanism and are out of scope.

--- a/specs/1039-simultaneous-mutual-calls/spec.md
+++ b/specs/1039-simultaneous-mutual-calls/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-11
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1039-simultaneous-mutual-calls/spec.md
+++ b/specs/1039-simultaneous-mutual-calls/spec.md
@@ -68,7 +68,7 @@ While someone is placing a call to contact A (the brief setup moment before it a
 - One person cancels (hangs up) their attempt in the same instant the resolution happens: both sides must settle to idle or to a normal single-direction ring — never a stuck hybrid.
 - The mutual attempt happens while one side's app was just opened via the incoming-call push: resolution still applies (the intent is mutual regardless of how the offer arrived).
 - A mutual attempt between people who are ALREADY in other calls follows the existing busy/call-waiting rules; this feature only governs two attempts aimed at each other while neither call is connected yet.
-- Per-chat mute: a muted chat suppresses that contact's incoming ring today — but a mutual attempt is not an unsolicited ring (the muted person themselves just called that contact), so resolution/auto-connect still applies.
+- Per-chat mute: a muted chat suppresses that contact's incoming ring today — but a mutual attempt is not an unsolicited ring (the muted person themselves just called that contact), so resolution still applies: same-kind attempts auto-connect, and a mismatched-kind fallback ring is allowed to ring despite the mute (the person's own outgoing attempt is the consent).
 
 ## Requirements *(mandatory)*
 

--- a/specs/1039-simultaneous-mutual-calls/spec.md
+++ b/specs/1039-simultaneous-mutual-calls/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-11
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1039-simultaneous-mutual-calls/tasks.md
+++ b/specs/1039-simultaneous-mutual-calls/tasks.md
@@ -29,9 +29,9 @@ story builds on.
 
 **⚠️ CRITICAL**: complete before any user story phase.
 
-- [ ] T001 Write FAILING decision-table unit tests in `src/services/call/glare.test.ts`: all four decision rows from data-model.md (no attempt → `none`; attempt + `selfId < from` → `ignore`; attempt + `selfId > from` + kinds match → `auto-accept`; kinds differ → `ring`), plus exclusions (group offer, different peer, already-answered attempt → `none`) and a symmetry property (for any id pair exactly one side ignores)
-- [ ] T002 Implement the pure decision module `src/services/call/glare.ts` (inputs: selfId, from, current attempt {peerUserId, kind, isGroup, answered}, offer kind → decision enum) making T001 green; pure function style matching `src/services/call/capacity.ts` et al.
-- [ ] T003 Add the outgoing-attempt token guard in `src/composables/useCall.ts` `startDirectCall`: capture the attempt's callId at entry and bail out after every `await` if the active attempt changed (yielded/torn down), so an abandoned attempt never mutates shared state (`setState('dialing')`, tones, navigation) — research R3
+- [X] T001 Write FAILING decision-table unit tests in `src/services/call/glare.test.ts`: all four decision rows from data-model.md (no attempt → `none`; attempt + `selfId < from` → `ignore`; attempt + `selfId > from` + kinds match → `auto-accept`; kinds differ → `ring`), plus exclusions (group offer, different peer, already-answered attempt → `none`) and a symmetry property (for any id pair exactly one side ignores)
+- [X] T002 Implement the pure decision module `src/services/call/glare.ts` (inputs: selfId, from, current attempt {peerUserId, kind, isGroup, answered}, offer kind → decision enum) making T001 green; pure function style matching `src/services/call/capacity.ts` et al.
+- [X] T003 Add the outgoing-attempt token guard in `src/composables/useCall.ts` `startDirectCall`: capture the attempt's callId at entry and bail out after every `await` if the active attempt changed (yielded/torn down), so an abandoned attempt never mutates shared state (`setState('dialing')`, tones, navigation) — research R3
 
 **Checkpoint**: `npx vitest run src/services/call/glare.test.ts` green; typecheck passes.
 
@@ -47,15 +47,15 @@ and video, 0ms and ~1s offsets) and both land connected with no incoming-call UI
 
 ### Tests for User Story 1 (write first, must FAIL)
 
-- [ ] T004 [P] [US1] Write FAILING e2e `e2e/mutual-call.spec.ts`: same-kind mutual attempts (audio at ~0ms offset, video at ~0ms, audio at ~1s offset) → both sides reach `connected`, neither side ever shows the incoming-call UI or plays the incoming ring, no manual accept, and each side's call history has exactly one answered entry (SC-001/003/005); drive via the `window.__ringTest` hook like the existing call e2e specs
+- [X] T004 [P] [US1] Write FAILING e2e `e2e/mutual-call.spec.ts`: same-kind mutual attempts (audio at ~0ms offset, video at ~0ms, audio at ~1s offset) → both sides reach `connected`, neither side ever shows the incoming-call UI or plays the incoming ring, no manual accept, and each side's call history has exactly one answered entry (SC-001/003/005); drive via the `window.__ringTest` hook like the existing call e2e specs
 
 ### Implementation for User Story 1
 
-- [ ] T005 [US1] Rework the glare gate in `src/composables/useCall.ts` `handleOffer`: replace the `callState !== 'idle'`-scoped check with the `glare.ts` decision keyed on the synchronously-set `callMeta` (covers the setup window, research R2); decision `ignore` (we win) drops the crossing offer before any record/UI is created
-- [ ] T006 [US1] Implement the yield path in `src/composables/useCall.ts`: on `auto-accept`, invalidate the attempt token (T003), send `call-cancel` for the abandoned callId (existing control frame, research R5), delete the abandoned outgoing call record via `deleteCalls` from `src/db/queries.ts` (research R6), stop/hand over local media per R4 (reuse the captured stream if it resolved; never a second concurrent getUserMedia)
-- [ ] T007 [US1] Implement the silent auto-accept in `src/composables/useCall.ts`: factor the 1:1 accept flow so the yield path can join the surviving offer with no `setState('incoming')`, no ring tone, and no incoming UI (FR-008), reusing the yielded stream when available and writing the normal incoming-answered record; ensure the glare branch runs before the per-chat-mute suppression (research R8)
-- [ ] T008 [US1] Guard against late redelivery in `src/composables/useCall.ts`: a crossing/yielded offer arriving after resolution (relay retention, spec 2012) is dropped — extend the existing duplicate/withdrawal guards to cover callIds cancelled by the yield path
-- [ ] T009 [US1] Verify US1: `npx vitest run` green, `npm run build` green, `npm run test:e2e -- mutual-call` US1 scenarios green
+- [X] T005 [US1] Rework the glare gate in `src/composables/useCall.ts` `handleOffer`: replace the `callState !== 'idle'`-scoped check with the `glare.ts` decision keyed on the synchronously-set `callMeta` (covers the setup window, research R2); decision `ignore` (we win) drops the crossing offer before any record/UI is created
+- [X] T006 [US1] Implement the yield path in `src/composables/useCall.ts`: on `auto-accept`, invalidate the attempt token (T003), send `call-cancel` for the abandoned callId (existing control frame, research R5), delete the abandoned outgoing call record via `deleteCalls` from `src/db/queries.ts` (research R6), stop/hand over local media per R4 (reuse the captured stream if it resolved; never a second concurrent getUserMedia)
+- [X] T007 [US1] Implement the silent auto-accept in `src/composables/useCall.ts`: factor the 1:1 accept flow so the yield path can join the surviving offer with no `setState('incoming')`, no ring tone, and no incoming UI (FR-008), reusing the yielded stream when available and writing the normal incoming-answered record; ensure the glare branch runs before the per-chat-mute suppression (research R8)
+- [X] T008 [US1] Guard against late redelivery in `src/composables/useCall.ts`: a crossing/yielded offer arriving after resolution (relay retention, spec 2012) is dropped — extend the existing duplicate/withdrawal guards to cover callIds cancelled by the yield path
+- [X] T009 [US1] Verify US1: `npx vitest run` green, `npm run build` green, `npm run test:e2e -- mutual-call` US1 scenarios green
 
 **Checkpoint**: MVP — mutual same-kind calls connect; ordinary calls unaffected.
 
@@ -71,11 +71,11 @@ single surviving call rings on the yielder showing its kind; decline ends cleanl
 
 ### Tests for User Story 2 (write first, must FAIL)
 
-- [ ] T010 [P] [US2] Extend `e2e/mutual-call.spec.ts` with FAILING mismatched-kind scenarios: audio-caller yields to video offer → normal incoming ring (kind shown), no local camera capture before accept (SC-004); and decline → both sides idle with no timeout (US2 acceptance 2)
+- [X] T010 [P] [US2] Extend `e2e/mutual-call.spec.ts` with FAILING mismatched-kind scenarios: audio-caller yields to video offer → normal incoming ring (kind shown), no local camera capture before accept (SC-004); and decline → both sides idle with no timeout (US2 acceptance 2)
 
 ### Implementation for User Story 2
 
-- [ ] T011 [US2] Route the `ring` decision in `src/composables/useCall.ts`: yield the own attempt (same cancel/record/token steps as T006, releasing any captured media since kinds differ) then fall through to the existing incoming-ring presentation of the surviving offer
+- [X] T011 [US2] Route the `ring` decision in `src/composables/useCall.ts`: yield the own attempt (same cancel/record/token steps as T006, releasing any captured media since kinds differ) then fall through to the existing incoming-ring presentation of the surviving offer
 
 **Checkpoint**: US1 + US2 behaviors verified together.
 
@@ -91,11 +91,11 @@ proceeds and can connect; C sees busy (or the call-waiting prompt per existing r
 
 ### Tests for User Story 3 (write first, must FAIL)
 
-- [ ] T012 [P] [US3] Extend `e2e/mutual-call.spec.ts` with FAILING scenarios: (a) C's offer lands during B's setup window → B's outgoing call to A still rings/connects, and C receives the busy/call-waiting outcome (FR-006); (b) a mutual attempt while one side is already in a connected call follows the existing busy/call-waiting rules, not glare resolution (spec edge case, FR-009)
+- [X] T012 [P] [US3] Extend `e2e/mutual-call.spec.ts` with FAILING scenarios: (a) C's offer lands during B's setup window → B's outgoing call to A still rings/connects, and C receives the busy/call-waiting outcome (FR-006); (b) a mutual attempt while one side is already in a connected call follows the existing busy/call-waiting rules, not glare resolution (spec edge case, FR-009)
 
 ### Implementation for User Story 3
 
-- [ ] T013 [US3] Gate non-glare incoming offers on `callMeta` (not just `callState`) in `src/composables/useCall.ts` `handleOffer`, routing a different-peer offer during the setup window to the existing busy/call-waiting flow instead of the normal-incoming path that clobbers `callMeta`
+- [X] T013 [US3] Gate non-glare incoming offers on `callMeta` (not just `callState`) in `src/composables/useCall.ts` `handleOffer`, routing a different-peer offer during the setup window to the existing busy/call-waiting flow instead of the normal-incoming path that clobbers `callMeta`
 
 **Checkpoint**: all three stories independently green.
 
@@ -104,7 +104,7 @@ proceeds and can connect; C sees busy (or the call-waiting prompt per existing r
 ## Phase 6: Polish & Cross-Cutting
 
 - [ ] T014 Run the full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e` (full suite — confirms no regression to busy, call-waiting spec 0005/2009, group calls, upgrade flow)
-- [ ] T015 Bump `**Status**:` in `specs/1039-simultaneous-mutual-calls/spec.md` to `in-progress` → `in-review` as appropriate and run `make roadmap` so the CI roadmap guard stays green
+- [X] T015 Bump `**Status**:` in `specs/1039-simultaneous-mutual-calls/spec.md` to `in-progress` → `in-review` as appropriate and run `make roadmap` so the CI roadmap guard stays green
 
 ---
 

--- a/specs/1039-simultaneous-mutual-calls/tasks.md
+++ b/specs/1039-simultaneous-mutual-calls/tasks.md
@@ -1,0 +1,131 @@
+# Tasks: Simultaneous mutual calls connect instead of ringing each other
+
+**Input**: Design documents from `/specs/1039-simultaneous-mutual-calls/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/signalling.md
+
+**Tests**: INCLUDED — the constitution's TDD principle (III) mandates failing tests
+before the implementation that satisfies them; this feature changes user-facing call
+behavior, so both unit (pure decision module) and e2e coverage are required.
+
+**Organization**: Grouped by user story; each story is independently implementable and
+testable once the Foundational phase is done.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story the task belongs to (US1, US2, US3)
+
+## Phase 1: Setup
+
+No setup tasks — existing repo, existing toolchain, no new dependencies or scaffolding.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: the pure glare-decision core and the attempt-lifetime guard that every
+story builds on.
+
+**⚠️ CRITICAL**: complete before any user story phase.
+
+- [ ] T001 Write FAILING decision-table unit tests in `src/services/call/glare.test.ts`: all four decision rows from data-model.md (no attempt → `none`; attempt + `selfId < from` → `ignore`; attempt + `selfId > from` + kinds match → `auto-accept`; kinds differ → `ring`), plus exclusions (group offer, different peer, already-answered attempt → `none`) and a symmetry property (for any id pair exactly one side ignores)
+- [ ] T002 Implement the pure decision module `src/services/call/glare.ts` (inputs: selfId, from, current attempt {peerUserId, kind, isGroup, answered}, offer kind → decision enum) making T001 green; pure function style matching `src/services/call/capacity.ts` et al.
+- [ ] T003 Add the outgoing-attempt token guard in `src/composables/useCall.ts` `startDirectCall`: capture the attempt's callId at entry and bail out after every `await` if the active attempt changed (yielded/torn down), so an abandoned attempt never mutates shared state (`setState('dialing')`, tones, navigation) — research R3
+
+**Checkpoint**: `npx vitest run src/services/call/glare.test.ts` green; typecheck passes.
+
+---
+
+## Phase 3: User Story 1 — Calling each other at the same moment just connects (P1) 🎯 MVP
+
+**Goal**: same-kind mutual attempts always resolve into one connected call, no manual
+accept, at any tap offset (including inside the setup window).
+
+**Independent Test**: two e2e browsers place calls at each other simultaneously (audio
+and video, 0ms and ~1s offsets) and both land connected with no incoming-call UI.
+
+### Tests for User Story 1 (write first, must FAIL)
+
+- [ ] T004 [P] [US1] Write FAILING e2e `e2e/mutual-call.spec.ts`: same-kind mutual attempts (audio at ~0ms offset, video at ~0ms, audio at ~1s offset) → both sides reach `connected`, neither side ever shows the incoming-call UI or plays the incoming ring, no manual accept, and each side's call history has exactly one answered entry (SC-001/003/005); drive via the `window.__ringTest` hook like the existing call e2e specs
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] Rework the glare gate in `src/composables/useCall.ts` `handleOffer`: replace the `callState !== 'idle'`-scoped check with the `glare.ts` decision keyed on the synchronously-set `callMeta` (covers the setup window, research R2); decision `ignore` (we win) drops the crossing offer before any record/UI is created
+- [ ] T006 [US1] Implement the yield path in `src/composables/useCall.ts`: on `auto-accept`, invalidate the attempt token (T003), send `call-cancel` for the abandoned callId (existing control frame, research R5), delete the abandoned outgoing call record via `deleteCalls` from `src/db/queries.ts` (research R6), stop/hand over local media per R4 (reuse the captured stream if it resolved; never a second concurrent getUserMedia)
+- [ ] T007 [US1] Implement the silent auto-accept in `src/composables/useCall.ts`: factor the 1:1 accept flow so the yield path can join the surviving offer with no `setState('incoming')`, no ring tone, and no incoming UI (FR-008), reusing the yielded stream when available and writing the normal incoming-answered record; ensure the glare branch runs before the per-chat-mute suppression (research R8)
+- [ ] T008 [US1] Guard against late redelivery in `src/composables/useCall.ts`: a crossing/yielded offer arriving after resolution (relay retention, spec 2012) is dropped — extend the existing duplicate/withdrawal guards to cover callIds cancelled by the yield path
+- [ ] T009 [US1] Verify US1: `npx vitest run` green, `npm run build` green, `npm run test:e2e -- mutual-call` US1 scenarios green
+
+**Checkpoint**: MVP — mutual same-kind calls connect; ordinary calls unaffected.
+
+---
+
+## Phase 4: User Story 2 — Mismatched kinds never switch on a camera uninvited (P2)
+
+**Goal**: audio-vs-video mutual attempts resolve to ONE surviving call presented as a
+normal incoming ring on the yielding side; no camera without explicit accept.
+
+**Independent Test**: e2e where A places audio and B places video simultaneously →
+single surviving call rings on the yielder showing its kind; decline ends cleanly.
+
+### Tests for User Story 2 (write first, must FAIL)
+
+- [ ] T010 [P] [US2] Extend `e2e/mutual-call.spec.ts` with FAILING mismatched-kind scenarios: audio-caller yields to video offer → normal incoming ring (kind shown), no local camera capture before accept (SC-004); and decline → both sides idle with no timeout (US2 acceptance 2)
+
+### Implementation for User Story 2
+
+- [ ] T011 [US2] Route the `ring` decision in `src/composables/useCall.ts`: yield the own attempt (same cancel/record/token steps as T006, releasing any captured media since kinds differ) then fall through to the existing incoming-ring presentation of the surviving offer
+
+**Checkpoint**: US1 + US2 behaviors verified together.
+
+---
+
+## Phase 5: User Story 3 — A different caller during setup doesn't wreck the call being placed (P3)
+
+**Goal**: an unrelated incoming offer during the setup window leaves the outgoing
+attempt intact and gets the existing busy/call-waiting treatment.
+
+**Independent Test**: e2e where C calls B in the instant B places a call to A → B↔A
+proceeds and can connect; C sees busy (or the call-waiting prompt per existing rules).
+
+### Tests for User Story 3 (write first, must FAIL)
+
+- [ ] T012 [P] [US3] Extend `e2e/mutual-call.spec.ts` with a FAILING different-caller scenario: C's offer lands during B's setup window → B's outgoing call to A still rings/connects, and C receives the busy/call-waiting outcome (FR-006)
+
+### Implementation for User Story 3
+
+- [ ] T013 [US3] Gate non-glare incoming offers on `callMeta` (not just `callState`) in `src/composables/useCall.ts` `handleOffer`, routing a different-peer offer during the setup window to the existing busy/call-waiting flow instead of the normal-incoming path that clobbers `callMeta`
+
+**Checkpoint**: all three stories independently green.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T014 Run the full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e` (full suite — confirms no regression to busy, call-waiting spec 0005/2009, group calls, upgrade flow)
+- [ ] T015 Bump `**Status**:` in `specs/1039-simultaneous-mutual-calls/spec.md` to `in-progress` → `in-review` as appropriate and run `make roadmap` so the CI roadmap guard stays green
+
+---
+
+## Dependencies & Execution Order
+
+- **Foundational (Phase 2)**: T001 → T002 (tests then module); T003 independent of T001/T002 → all three block every story
+- **US1 (Phase 3)**: T004 [P] may be written while T005–T008 are pending (it must fail first); T005 → T006 → T007 → T008 → T009
+- **US2 (Phase 4)**: depends on T006 (yield steps reused); T010 [P] before T011
+- **US3 (Phase 5)**: depends on T005 (gate rework); T012 [P] before T013
+- **Polish (Phase 6)**: after all desired stories
+
+### Parallel Opportunities
+
+- T001 and T003 touch different files → parallel
+- T004, T010, T012 are all e2e-spec authoring in one new file — parallel with
+  implementation tasks of *other* stories but serialized with each other
+- US2 and US3 implementation (T011, T013) touch the same composable — serialize
+
+## Implementation Strategy
+
+MVP = Phase 2 + Phase 3 (US1): mutual same-kind calls connect. US2 (consent on
+mismatch) and US3 (setup-window busy routing) are small increments on the same
+gate/yield machinery and land next. Stop at any checkpoint; every phase leaves
+ordinary call behavior intact.

--- a/specs/1039-simultaneous-mutual-calls/tasks.md
+++ b/specs/1039-simultaneous-mutual-calls/tasks.md
@@ -91,7 +91,7 @@ proceeds and can connect; C sees busy (or the call-waiting prompt per existing r
 
 ### Tests for User Story 3 (write first, must FAIL)
 
-- [ ] T012 [P] [US3] Extend `e2e/mutual-call.spec.ts` with a FAILING different-caller scenario: C's offer lands during B's setup window → B's outgoing call to A still rings/connects, and C receives the busy/call-waiting outcome (FR-006)
+- [ ] T012 [P] [US3] Extend `e2e/mutual-call.spec.ts` with FAILING scenarios: (a) C's offer lands during B's setup window → B's outgoing call to A still rings/connects, and C receives the busy/call-waiting outcome (FR-006); (b) a mutual attempt while one side is already in a connected call follows the existing busy/call-waiting rules, not glare resolution (spec edge case, FR-009)
 
 ### Implementation for User Story 3
 

--- a/specs/1039-simultaneous-mutual-calls/tasks.md
+++ b/specs/1039-simultaneous-mutual-calls/tasks.md
@@ -103,7 +103,7 @@ proceeds and can connect; C sees busy (or the call-waiting prompt per existing r
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T014 Run the full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e` (full suite — confirms no regression to busy, call-waiting spec 0005/2009, group calls, upgrade flow)
+- [X] T014 Run the full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e` (full suite — confirms no regression to busy, call-waiting spec 0005/2009, group calls, upgrade flow)
 - [X] T015 Bump `**Status**:` in `specs/1039-simultaneous-mutual-calls/spec.md` to `in-progress` → `in-review` as appropriate and run `make roadmap` so the CI roadmap guard stays green
 
 ---

--- a/specs/2025-video-calls-look/checklists/requirements.md
+++ b/specs/2025-video-calls-look/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Video calls look sharp again and recover from quality dips
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Numeric tuning values (thresholds, minimum window sizes) are deliberately delegated
+  to the plan with their INTENT fixed by FR-004/FR-006; this keeps the spec stable if
+  tuning iterates.
+- "Bandwidth limited" / "send estimate" terminology is the domain language of the
+  existing quality feature (spec 0007) rather than an implementation leak.

--- a/specs/2025-video-calls-look/plan.md
+++ b/specs/2025-video-calls-look/plan.md
@@ -1,0 +1,179 @@
+# Implementation Plan: Video calls look sharp again and recover from quality dips
+
+**Branch**: `feat/1039-simultaneous-mutual-calls` (shared with spec 1039 by owner request — one branch build, one develop build) | **Date**: 2026-07-11 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/2025-video-calls-look/spec.md`
+
+## Summary
+
+Fix the video-quality regression introduced with the adaptive tier controller
+(specs 0004/0007) while keeping its adaptivity: make the congestion signal truthful
+(an encoder "bandwidth limited" reading caused by our own cap is not congestion),
+make the floor recoverable (tier `off` genuinely pauses the video sender instead of
+strangling it to 1 bps, so stats can read healthy and the ladder climbs back), raise
+the ceiling (top tier ≥4 Mbps; 1:1 starts at `high`), request HD capture where safe
+(non-iOS), sample 1:1 adaptation on the designed ~2 s cadence, and de-noise the
+receiver's downlink classification. Client-only; the sealed `qos` frame and all wire
+shapes are unchanged.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (Vue 3 + Ionic PWA), client-only
+
+**Primary Dependencies**: WebRTC RTCRtpSender.setParameters / getStats; the existing
+pure controller `src/services/call/quality.ts` and its two consumers
+(`src/composables/useCall.ts` 1:1 path, `src/services/call/mesh.ts` per-leg path)
+
+**Storage**: none (no persisted data touched)
+
+**Testing**: vitest on the pure controller (regression tests FIRST — hotfix band);
+existing Playwright e2e (`call-adaptive`, `call-quality`, `call-connect-speed`,
+`mutual-call`) as the behavioral gate; a drive probe for capture resolution + steady-tier
+
+**Target Platform**: PWA — Chrome/Android, Safari/iOS (WebKit constraints per R4)
+
+**Project Type**: web app (client of the monorepo; `server/` untouched)
+
+**Performance Goals**: top tier ≤6 s after connect on a clean link; zero tier
+down-steps over 60 s steady-state; floor recovery ≤10 s after conditions clear
+
+**Constraints**: zero-knowledge boundary (no wire change); iPhone-8-class WebKit must
+keep unconstrained capture + bitrate-only tiering; adaptation must not fight
+hold/resume (spec 0005) or the user's camera toggle
+
+**Scale/Scope**: `quality.ts` (+ its test), `useCall.ts` (1:1 adapt/suspend/capture),
+`mesh.ts` (per-leg suspend), no schema/server changes
+
+## Constitution Check
+
+- **I. Zero-Knowledge Boundary** — PASS: no new wire data; `qos` shape untouched; spec
+  carries the Zero-Knowledge Impact section.
+- **II. Spec-Driven Development** — PASS: spec 2025 (hotfix band), full pipeline on the
+  shared branch; every commit references the spec.
+- **III. Test-Driven Development** — PASS (planned): this is a `2001+` fix, so FAILING
+  regression tests reproducing the floor trap and the self-inflicted back-off land
+  before the fix; downlink-classifier noise tests likewise.
+- **IV. Crypto Discipline** — PASS: no crypto surface; `/speckit-checklist` not
+  mandated (no Principle I/IV change).
+- **V. Offline-First Data Integrity** — PASS: no data layer changes.
+- **VI. Stateless Server** — PASS: server untouched.
+- **VII. Quality Gates** — PASS (planned): `npm run build`, vitest, adaptive/call e2e.
+- **VIII. Traceability** — PASS: spec id in commits; GitHub issues deferred together
+  with spec 1039's (issue creation pending owner-approved tooling permission).
+- **IX–XI** — PASS: no new data collection; no UI change (numbers/semantics only).
+
+## Design decisions (research folded in — client-only tuning fix)
+
+### R1 — Congestion truthfulness (FR-004)
+
+`snapshotFromReport` reports `limitedBy: 'bandwidth' | 'cpu' | null` instead of the
+boolean `qualityLimited`. In `nextTier`:
+
+- `bandwidth`-limited counts as congestion **only when corroborated**: receiver loss
+  `fractionLost > 0.02`, or a known send estimate below the current tier's target
+  (the existing `BW_BACKOFF_MARGIN` path already covers the collapse case).
+- `cpu`-limited keeps today's semantics (sustained 2-sample back-off) — it is never
+  caused by our bitrate cap, and in a mesh it is the real N-encoders protection. The
+  brief cpu blip after an encoder reconfigure is filtered by the existing
+  sustained-congestion requirement at the 2 s cadence.
+
+*Rejected*: dropping limitation reasons entirely (loses the only early CPU signal);
+corroborating cpu too (starves the mesh protection the moment loss is clean).
+
+### R2 — Recoverable floor (FR-005)
+
+Tier `off` pauses the video sender for real: the adapter (1:1 `applySenderTier` /
+mesh `setLegTier`) detaches the video track (`replaceTrack(null)`) and remembers *it*
+did so (a per-connection/per-leg suspended flag). With nothing encoded, `outbound-rtp`
+stops reporting `bandwidth` limitation, samples read healthy, and the existing ladder
+climbs `off → low` after `CLIMB_AFTER` healthy samples; leaving `off` re-attaches the
+current local video track and applies the tier's encoding. Guards:
+
+- Resume only re-attaches when adaptation itself suspended — never fights the user's
+  camera toggle or hold/resume, which manage tracks through their own paths.
+- Teardown / hold / camera-off clear the flag (hold and camera-off already detach
+  tracks; adaptation is suspended while held, unchanged).
+
+*Rejected*: flooring the ladder at `low` (perpetuates ~150 kbps of junk video on a
+link that can't afford it — audio suffers, the original spec-0004 intent); keeping
+`maxBitrate: 1` (the trap being fixed).
+
+### R3 — Ceiling + entry point (FR-001/FR-002)
+
+`hd` tier: `maxBitrate` 2.5 → **4 Mbps** (shared table; mesh reaches `hd` only for
+2-person calls via `clampForPeers`, where 4 Mbps is equally appropriate).
+`initialController(start)` gains a start-tier argument: **1:1 starts `high`**, mesh
+legs keep `medium` (N parallel encoders). With `CLIMB_AFTER = 2` at the 2 s cadence,
+`high → hd` lands ≤6 s after connect (SC-001).
+
+*Rejected*: uncapped `hd` (destroys pin/data-saver semantics and mesh budgeting);
+starting 1:1 at `hd` directly (one blind step above the estimate on a genuinely bad
+link before the first sample lands — `high` is the safe sharp start).
+
+### R4 — HD capture where safe (FR-003)
+
+`gumConstraints` (and the camera-flip/re-acquire call sites, via one shared
+`videoConstraints(facing?)` helper) request `width/height ideal 1280×720` **on
+non-iOS only**. iOS stays unconstrained: the iPhone-8/iOS-16.7 WebKit orientation
+flip permanently mutes the camera when ANY size is named (existing comment), and
+unconstrained WebKit opens the sensor in its native format anyway. Chrome (Android/
+desktop) defaults to 640×480 without the request — this is where the sharpness is won.
+`ideal` (not `exact`) so devices without 720p still open.
+
+### R5 — De-noised downlink classification (FR-006)
+
+`downlinkClassFrom` gains a minimum-evidence rule: a window with fewer than
+**50 packets** (received+lost) keeps the previous class unchanged (no hysteresis
+step on noise). The dropped-frame trim requires a ratio **> 0.25** (was 0.1) — real
+decode/render starvation, not UI-animation jitter. Loss thresholds keep their intent
+with mild relaxation: `>0.25 → low`, `>0.12 → medium`, `>0.05 → high`, else `hd`.
+
+### R6 — Cadence (FR-007)
+
+`pollStats` stays at 1 s (byte counters / warning / ⓘ need it) but calls
+`adaptOneToOne` every **second** tick (~2 s), matching the mesh and the constants'
+design. The severe-loss immediate back-off is unaffected (it acts within one decision).
+
+### R7 — What deliberately does NOT change
+
+Manual pin + data-saver clamps, per-peer mesh ceilings, tile-size ceilings, the
+receiver-request (`qos`) wire shape and staleness fallback, severe-loss immediate
+back-off, iOS bitrate-only tiering, and the hold/resume machinery.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/2025-video-calls-look/
+├── spec.md
+├── plan.md              # This file (research folded in — client-only tuning fix)
+├── quickstart.md
+└── tasks.md
+```
+
+No `data-model.md` (no persisted entities) and no `contracts/` (no interface change;
+the `qos` frame is untouched — asserted by FR-008).
+
+### Source Code (repository root)
+
+```text
+src/
+├── services/call/
+│   ├── quality.ts           # limitedBy signal, corroborated congestion, start-tier
+│   │                        # param, hd bitrate, downlink min-evidence + thresholds
+│   ├── quality.test.ts      # FAILING-first regression + decision tests
+│   └── mesh.ts              # per-leg suspend/resume at tier 'off'
+├── composables/useCall.ts   # 1:1 suspend/resume, start 'high', 2s adapt cadence,
+│                            # videoConstraints helper (HD capture on non-iOS)
+drive/scenarios/
+└── probe-call-quality.mjs   # capture size + steady-tier + floor-recovery probe
+```
+
+**Structure Decision**: all policy changes land in the pure `quality.ts` first (unit-
+testable), with the two consumers wired to the new signal; matches the repo's
+pure-core/thin-wiring convention.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/2025-video-calls-look/quickstart.md
+++ b/specs/2025-video-calls-look/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: Video quality hotfix (spec 2025)
+
+## Unit / regression tests (the TDD red → green core)
+
+```sh
+npx vitest run src/services/call/quality.test.ts
+```
+
+Covers: floor-trap recovery (off must climb back on healthy samples and must be a real
+pause), bandwidth-limitation needs corroboration, cpu limitation unchanged, start-tier
+parameter, downlink classifier minimum-evidence + relaxed trims.
+
+## See it on the dev stack
+
+```sh
+make start                          # if not already running
+node drive/scenarios/probe-call-quality.mjs
+```
+
+The probe prints: captured resolution (expect ≥1280×720 on desktop Chromium), the
+outgoing tier over time (expect high → hd within ~6s, then steady), and a floor-
+recovery check.
+
+On phones via ring-dev: `npm run build` (dist is what :8443 serves), update both
+installed PWAs, place a video call and open the ⓘ panel — `tier=hd` should appear
+within seconds on a good link and stay; on a genuinely bad link video may pause
+entirely (audio continues) and MUST come back by itself when the link recovers.
+
+## Gates
+
+```sh
+npm run build
+npx vitest run
+npx playwright test e2e/call-adaptive.spec.ts e2e/call-quality.spec.ts \
+  e2e/call-connect-speed.spec.ts e2e/mutual-call.spec.ts
+```

--- a/specs/2025-video-calls-look/spec.md
+++ b/specs/2025-video-calls-look/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-11
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2025-video-calls-look/spec.md
+++ b/specs/2025-video-calls-look/spec.md
@@ -1,0 +1,222 @@
+# Feature Specification: Video calls look sharp again and recover from quality dips
+
+**Feature Branch**: `feat/1039-simultaneous-mutual-calls` <!-- shared branch by owner request: one branch build, one develop build -->
+
+**Created**: 2026-07-11
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Video quality in Ring has dropped significantly compared to the initial versions. It used to be crisp and sharp; now it is laggy and low quality. Tested against FaceTime on the same devices and connections — FaceTime is now the clear winner; it used to be the opposite or a tie."
+
+## Background (regression)
+
+Until late June, `auto` video quality meant no cap at all: the browser's own bandwidth
+estimator ramped a good connection to whatever it could carry — the "crisp" era. The
+adaptive quality work (specs 0004/0007) introduced a tier ladder with hard caps and
+congestion back-offs whose signals are partly self-inflicted: the ladder's own bitrate
+caps and encoder reconfigurations produce the very "quality limited" readings the
+controller treats as congestion, so quality starts low, climbs slowly, gets knocked
+back down, and in the worst case parks video at a floor tier it can never leave. This
+hotfix keeps the (valuable) adaptivity but makes its signals truthful, its ceiling
+worthy of a good link, and its floor recoverable.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A good connection looks great, quickly (Priority: P1)
+
+Two people on solid connections start a video call. The picture looks sharp within a
+few seconds of connecting and stays at the best quality the link and devices support —
+comparable to native calling apps on the same hardware, not visibly a step below.
+
+**Why this priority**: this is the reported regression — the everyday, good-network
+call is the one people compare against FaceTime.
+
+**Independent Test**: a 1:1 video call on an unconstrained link reaches the top quality
+tier within seconds of connecting (observable in the ⓘ panel / diagnostics) and the
+captured/encoded resolution is HD-class on platforms that support requesting it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a 1:1 video call on an unconstrained connection, **When** it connects,
+   **Then** outgoing video reaches the top tier within ~6 seconds and stays there.
+2. **Given** capable hardware on a platform where a capture size may safely be
+   requested, **When** a video call starts, **Then** the camera captures at HD-class
+   resolution (not the browser's 640×480 default).
+
+---
+
+### User Story 2 - Quality holds steady instead of pumping (Priority: P1)
+
+During a call on a stable connection, the picture quality must not visibly cycle
+(sharp → blocky → sharp) when nothing about the network changed. In particular, the
+app must never interpret the consequences of its own bitrate cap or its own quality
+switches as network congestion.
+
+**Why this priority**: the oscillation is the "laggy" half of the report — every
+down-switch forces an encoder reset and a keyframe, which shows as stutter.
+
+**Independent Test**: controller unit tests — a "bandwidth limited" reading with zero
+packet loss and a healthy send estimate must NOT count as congestion; steady healthy
+samples must never step the tier down.
+
+**Acceptance Scenarios**:
+
+1. **Given** a call sending at a tier's bitrate cap with no packet loss and a healthy
+   send estimate, **When** the encoder reports it is bandwidth-limited (a direct
+   consequence of the cap), **Then** the controller holds or climbs — it does not back
+   off.
+2. **Given** genuine congestion (receiver-reported loss, or the send estimate
+   collapsing), **Then** the controller still backs off as today — adaptivity is kept.
+
+---
+
+### User Story 3 - Video that dipped to protect audio comes back (Priority: P2)
+
+On a really bad stretch the app may reduce video all the way down so audio survives.
+When conditions recover, video must come back on its own within seconds — never stay
+frozen/black for the rest of the call.
+
+**Why this priority**: today the floor tier is a trap: video is strangled to an
+effectively-zero bitrate (not actually paused), which itself keeps the "congested"
+signal on forever — a call that dips once never shows video again.
+
+**Independent Test**: controller/regression test — from the floor tier, healthy
+samples must climb back; and the floor must genuinely pause the outgoing video (no
+zero-bitrate zombie encode) so samples CAN read healthy.
+
+**Acceptance Scenarios**:
+
+1. **Given** a call whose outgoing video was floored during severe congestion,
+   **When** the network recovers, **Then** the peer sees video again within ~10
+   seconds, without anyone touching settings.
+2. **Given** the floor is active, **Then** audio continues unaffected, and the video
+   pause is what actually happens technically (nothing is encoded), not a 1-bps
+   zombie stream.
+
+---
+
+### User Story 4 - A receiver's momentary hiccup doesn't cap the sender (Priority: P3)
+
+A brief blip on the receiving side (a couple of lost packets in a one-second window,
+frames dropped while the phone animates its UI) must not push the sender's quality
+down for many seconds. Only meaningful, sustained receive-side trouble should lower
+what the other side sends.
+
+**Why this priority**: the receiver-reported ceiling is a second, independent path
+that today caps quality on statistical noise; fixing only the sender side would leave
+calls still capped below their potential.
+
+**Independent Test**: unit tests on the downlink classifier — tiny per-window sample
+sizes keep the previous class; the dropped-frame trim requires a high sustained ratio.
+
+**Acceptance Scenarios**:
+
+1. **Given** a receive window with too little traffic to be statistically meaningful,
+   **Then** the reported downlink class does not change.
+2. **Given** an isolated small loss blip in one short window on an otherwise clean
+   link, **Then** the sender is not asked to drop below the top tier.
+
+---
+
+### Edge Cases
+
+- Old-device iOS (iPhone-8 class): capture stays unconstrained (requesting any
+  width/height triggers the WebKit orientation-flip that permanently mutes the camera)
+  and tiering stays bitrate-only. The capture-resolution improvement applies only where
+  it is safe; these devices keep today's behavior.
+- Group (mesh) calls: the per-peer-count ceilings and the CPU protection stay — many
+  parallel encoders on a phone are a real constraint. Genuine CPU limitation still
+  backs off (sustained, as today); only the self-inflicted bandwidth-cap reading is
+  re-classified.
+- Manual quality pin and "use less data" stay exact upper bounds, unchanged.
+- Call hold/resume (call waiting) and the user's own camera-off toggle must not fight
+  the floor's pause/resume: adaptation only re-attaches video it paused itself.
+- The recovered-from-floor climb still respects the ladder (one step at a time) so a
+  flapping network doesn't strobe the video on/off.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A 1:1 video call on an unconstrained connection MUST reach the top
+  quality tier within ~6 seconds of connecting (start higher, climb on the design
+  cadence), instead of starting at half resolution and needing sustained luck to climb.
+- **FR-002**: The top tier's bitrate ceiling MUST be raised to at least 4 Mbps so a
+  good link is visibly sharp (group calls keep their existing per-peer-count ceilings).
+- **FR-003**: Where a capture size can safely be requested (not the affected WebKit
+  devices), video calls MUST request HD-class capture (≈1280×720 ideal) instead of
+  accepting the 640×480 browser default — including when flipping cameras mid-call.
+- **FR-004**: An encoder "bandwidth limited" reading MUST count as congestion only when
+  corroborated by an independent signal (receiver-reported loss, or the send estimate
+  collapsing below the current tier's need). CPU limitation keeps today's sustained
+  back-off. Genuine-congestion behavior (loss spikes, estimate collapse) is unchanged.
+- **FR-005**: The floor tier MUST genuinely pause outgoing video (nothing encoded, so
+  stats can read healthy) and MUST automatically resume and climb when samples recover
+  — in 1:1 calls and per mesh leg. A call must never end with video permanently frozen
+  by the adaptive floor.
+- **FR-006**: The receiver's downlink self-assessment MUST ignore windows with too
+  little traffic to be meaningful and MUST require a substantially higher, non-noise
+  dropped-frame ratio before trimming the requested ceiling.
+- **FR-007**: 1:1 adaptation MUST sample on the cadence the controller was designed
+  for (~2 s between decisions), independent of the 1 s UI stats poll.
+- **FR-008**: All existing quality behaviors not named here are preserved: manual pin,
+  data-saver, per-peer mesh ceilings, tile-size ceilings, severe-loss immediate
+  back-off, and the sealed `qos` report shape on the wire.
+- **FR-009**: As a regression fix, failing tests reproducing the floor trap and the
+  self-inflicted back-off MUST exist before the fix (constitution III).
+
+### Key Entities
+
+- **Quality tier ladder**: off / low / medium / high / hd — unchanged shape; changed
+  numbers (top-tier bitrate), changed floor semantics (real pause), changed entry point
+  (1:1 starts high).
+- **Congestion signal**: the per-sample verdict the controller acts on; re-defined so
+  self-inflicted encoder readings alone are not congestion.
+- **Downlink class / requested ceiling**: the receiver's sealed per-~2s report;
+  unchanged wire shape, recalibrated thresholds.
+
+## Zero-Knowledge Impact
+
+- **What crosses the wire**: nothing new. The sealed `qos` report keeps its exact
+  shape (coarse tier enums + seq); offers/answers/media are untouched. Capture
+  resolution and tier decisions are device-local.
+- **What is encrypted**: everything content-bearing, exactly as today (media via
+  DTLS-SRTP, signalling sealed over the pair's ratchet).
+- **Unavoidably visible metadata**: unchanged — the server relays the same sealed
+  envelopes; a higher media bitrate through the blind TURN relay is the only
+  externally observable difference, identical in kind to today.
+- **Why**: this is a client-local policy/tuning fix inside the existing machinery.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On an unconstrained local link, a 1:1 video call reaches the top tier
+  within 6 seconds of connecting (observable via diagnostics) in 100% of e2e runs.
+- **SC-002**: Over a 60-second steady call on a clean link, the outgoing tier never
+  steps down (no pumping) in e2e/probe runs.
+- **SC-003**: From a forced floor, video resumes within 10 seconds of samples reading
+  healthy (regression test + probe).
+- **SC-004**: On platforms where HD capture is requested, the captured track reports
+  ≥1280×720 (probe assertion).
+- **SC-005**: Connect-speed and existing adaptive e2e suites stay green (no first-media
+  or reliability regression).
+
+## Assumptions
+
+- FaceTime-parity in absolute numbers is not the bar (different codecs/OS access); the
+  bar is "a good link looks sharp and stable, quickly" and "quality dips recover".
+- Raising the top tier to ~4 Mbps is enough for HD-class WebRTC video at 30 fps; going
+  fully uncapped is deliberately avoided so the data-saver/pin semantics and the mesh's
+  per-peer budgeting keep meaning.
+- iOS capture stays unconstrained: on the affected WebKit builds any size request can
+  permanently mute the camera (documented iPhone-8 behavior), and unconstrained WebKit
+  opens the sensor in its native format anyway (i.e., iOS is not stuck at VGA today).
+- The exact recalibrated thresholds (minimum packets per window, dropped-frame ratio,
+  corroboration loss level) are design-time decisions recorded in the plan; the spec
+  fixes their intent (noise must not change class; corroboration must be independent).

--- a/specs/2025-video-calls-look/spec.md
+++ b/specs/2025-video-calls-look/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-11
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2025-video-calls-look/tasks.md
+++ b/specs/2025-video-calls-look/tasks.md
@@ -1,0 +1,103 @@
+# Tasks: Video calls look sharp again and recover from quality dips
+
+**Input**: Design documents from `/specs/2025-video-calls-look/`
+
+**Prerequisites**: plan.md (design decisions R1–R7), spec.md
+
+**Tests**: INCLUDED and MANDATORY-FIRST — hotfix band (constitution III): failing
+regression tests reproducing the defects land before the fixes.
+
+**Organization**: user stories share one pure core (`quality.ts`), so the Foundational
+phase carries the red tests + core changes; the story phases wire the consumers.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+No setup tasks — existing repo and toolchain.
+
+---
+
+## Phase 2: Foundational (red tests + pure-core changes)
+
+**⚠️ CRITICAL**: the failing tests (T001) must be committed/observed failing before
+T002 lands.
+
+- [ ] T001 Extend `src/services/call/quality.test.ts` with FAILING regression + decision tests: (a) floor trap — from `off`, samples that read "bandwidth-limited because nothing but our cap constrains the encoder" must not keep it congested once `off` is a real pause: encode the new contract that a paused sender yields `limitedBy: null` samples and the ladder climbs back (FR-005/SC-003); (b) `limitedBy: 'bandwidth'` with `fractionLost ≤ 0.02` and healthy estimate → NOT congestion (holds/climbs, FR-004); (c) `limitedBy: 'bandwidth'` corroborated by loss > 0.02 → congestion (sustained back-off retained); (d) `limitedBy: 'cpu'` → congestion exactly as today; (e) `initialController('high')` starts at `high` (default stays `medium`); (f) `hd` encoding carries `maxBitrate ≥ 4_000_000`; (g) `downlinkClassFrom` keeps the previous class when the window has < 50 packets; (h) dropped-frame trim requires ratio > 0.25; (i) relaxed loss thresholds map as designed (R5)
+- [ ] T002 Implement the `quality.ts` changes making T001 green: `StatsSnapshot.limitedBy` replaces `qualityLimited` (update `snapshotFromReport`), corroborated-bandwidth congestion rule in `nextTier` (R1), `initialController(start: Tier = 'medium')` (R3), `TIER_ENCODING.hd.maxBitrate = 4_000_000` (R3), `downlinkClassFrom` minimum-evidence + `> 0.25` drop-trim + relaxed thresholds (R5)
+
+**Checkpoint**: `npx vitest run src/services/call/quality.test.ts` green; all other
+vitest suites still green.
+
+---
+
+## Phase 3: User Story 1 — A good connection looks great, quickly (P1)
+
+**Goal**: 1:1 starts `high`, reaches `hd` (now 4 Mbps) ≤6 s; HD capture on non-iOS.
+
+**Independent Test**: drive probe shows tier `high→hd` within ~6 s and ≥1280×720
+capture on desktop Chromium.
+
+- [ ] T003 [US1] In `src/composables/useCall.ts`: initialize and reset the 1:1 controller with `initialController('high')` (call-start + teardown reset), and adapt every second `pollStats` tick (~2 s cadence, R6) while keeping the 1 s byte/warning/ⓘ updates
+- [ ] T004 [US1] In `src/composables/useCall.ts`: add a shared `videoConstraints()` helper — `facingMode` + `frameRate ideal 30` + (non-iOS only) `width/height ideal 1280×720` — and use it in `gumConstraints` AND the camera-flip / camera-restore `getUserMedia` call sites, preserving the iOS-unconstrained rule and its iPhone-8 rationale comment
+- [ ] T005 [P] [US1] Write `drive/scenarios/probe-call-quality.mjs`: two accounts, 1:1 video call on the live dev stack; print captured track settings (expect ≥1280×720), sample the outgoing tier each second for ~20 s (expect `high` at connect, `hd` ≤6 s, no down-steps — SC-001/SC-002 evidence), then `sweep`
+
+**Checkpoint**: probe output shows the climb + steady state; `npm run build` green.
+
+---
+
+## Phase 4: User Story 2 — Quality holds steady (P1)
+
+**Goal**: consumers feed the new `limitedBy` signal; no behavior change needed beyond
+Phase 2's core rule.
+
+- [ ] T006 [US2] Wire `useCall.ts` and `src/services/call/mesh.ts` to the renamed snapshot field (`limitedBy`), keeping the mesh ⓘ limitation readout working; typecheck-driven sweep of all `qualityLimited` references
+
+**Checkpoint**: `npm run build` + full vitest green.
+
+---
+
+## Phase 5: User Story 3 — Video comes back after a dip (P2)
+
+**Goal**: tier `off` is a real, self-clearing pause in both call paths.
+
+- [ ] T007 [US3] 1:1 suspend/resume in `src/composables/useCall.ts`: entering `off` detaches the video sender's track (`replaceTrack(null)`) with an adaptation-owned suspended flag; leaving `off` re-attaches the live local video track + applies the tier encoding; flag cleared on teardown/hold/camera-off so adaptation never re-attaches a track the user (or hold) removed
+- [ ] T008 [US3] Mesh per-leg suspend/resume in `src/services/call/mesh.ts` `setLegTier`: same semantics per leg (detach on `off`, re-attach on leaving it), guarded against the leg-hold path (`paused`/held peers) and camera-off
+- [ ] T009 [P] [US3] Extend the probe (or a targeted vitest where feasible) to force the floor via a `low` pin + severe-loss simulation isn't scriptable from outside — so assert the OBSERVABLE contract in the probe instead: pin `low`, confirm tier clamps; unpin, confirm climb resumes ≤10 s (SC-003 proxy at the integration level; the trap itself is covered by T001a at the unit level)
+
+**Checkpoint**: vitest + probe green.
+
+---
+
+## Phase 6: User Story 4 — Receiver hiccups don't cap the sender (P3)
+
+Covered in the pure core (T001g–i / T002); no consumer wiring needed — `reportLegHealth`
+and `reportHealthToPeer` already pass per-interval deltas into `downlinkClassFrom`.
+
+- [ ] T010 [US4] Verify by inspection + unit tests only: confirm both consumers pass (received+lost) counts such that the < 50-packet windows short-circuit correctly (audio-only intervals, first-window-after-connect), adjusting call sites if the delta plumbing needs the raw counts
+
+**Checkpoint**: full vitest green.
+
+---
+
+## Phase 7: Polish & Gates
+
+- [ ] T011 Run gates: `npm run build`, `npx vitest run`, `npx playwright test e2e/call-adaptive.spec.ts e2e/call-quality.spec.ts e2e/call-connect-speed.spec.ts e2e/mutual-call.spec.ts e2e/call-waiting.spec.ts` (hold/resume interplay)
+- [ ] T012 Bump spec 2025 `**Status**:` (in-progress → in-review) + `make roadmap`
+
+---
+
+## Dependencies & Execution Order
+
+- T001 → T002 (red → green) block everything
+- US1: T003, T004 sequential (same file); T005 [P] parallel to both
+- US2: T006 after T002 (field rename)
+- US3: T007 → T008 (same semantics, two files); T009 [P] after T007
+- US4: T010 after T002
+- Gates last
+
+## Implementation Strategy
+
+Single hotfix increment: the pure core (Phase 2) is the fix; story phases are wiring
++ evidence. Every phase leaves the suite green; the branch is shared with spec 1039,
+so each phase is its own commit referencing spec 2025.

--- a/specs/2025-video-calls-look/tasks.md
+++ b/specs/2025-video-calls-look/tasks.md
@@ -23,8 +23,8 @@ No setup tasks — existing repo and toolchain.
 **⚠️ CRITICAL**: the failing tests (T001) must be committed/observed failing before
 T002 lands.
 
-- [ ] T001 Extend `src/services/call/quality.test.ts` with FAILING regression + decision tests: (a) floor trap — from `off`, samples that read "bandwidth-limited because nothing but our cap constrains the encoder" must not keep it congested once `off` is a real pause: encode the new contract that a paused sender yields `limitedBy: null` samples and the ladder climbs back (FR-005/SC-003); (b) `limitedBy: 'bandwidth'` with `fractionLost ≤ 0.02` and healthy estimate → NOT congestion (holds/climbs, FR-004); (c) `limitedBy: 'bandwidth'` corroborated by loss > 0.02 → congestion (sustained back-off retained); (d) `limitedBy: 'cpu'` → congestion exactly as today; (e) `initialController('high')` starts at `high` (default stays `medium`); (f) `hd` encoding carries `maxBitrate ≥ 4_000_000`; (g) `downlinkClassFrom` keeps the previous class when the window has < 50 packets; (h) dropped-frame trim requires ratio > 0.25; (i) relaxed loss thresholds map as designed (R5)
-- [ ] T002 Implement the `quality.ts` changes making T001 green: `StatsSnapshot.limitedBy` replaces `qualityLimited` (update `snapshotFromReport`), corroborated-bandwidth congestion rule in `nextTier` (R1), `initialController(start: Tier = 'medium')` (R3), `TIER_ENCODING.hd.maxBitrate = 4_000_000` (R3), `downlinkClassFrom` minimum-evidence + `> 0.25` drop-trim + relaxed thresholds (R5)
+- [X] T001 Extend `src/services/call/quality.test.ts` with FAILING regression + decision tests: (a) floor trap — from `off`, samples that read "bandwidth-limited because nothing but our cap constrains the encoder" must not keep it congested once `off` is a real pause: encode the new contract that a paused sender yields `limitedBy: null` samples and the ladder climbs back (FR-005/SC-003); (b) `limitedBy: 'bandwidth'` with `fractionLost ≤ 0.02` and healthy estimate → NOT congestion (holds/climbs, FR-004); (c) `limitedBy: 'bandwidth'` corroborated by loss > 0.02 → congestion (sustained back-off retained); (d) `limitedBy: 'cpu'` → congestion exactly as today; (e) `initialController('high')` starts at `high` (default stays `medium`); (f) `hd` encoding carries `maxBitrate ≥ 4_000_000`; (g) `downlinkClassFrom` keeps the previous class when the window has < 50 packets; (h) dropped-frame trim requires ratio > 0.25; (i) relaxed loss thresholds map as designed (R5)
+- [X] T002 Implement the `quality.ts` changes making T001 green: `StatsSnapshot.limitedBy` replaces `qualityLimited` (update `snapshotFromReport`), corroborated-bandwidth congestion rule in `nextTier` (R1), `initialController(start: Tier = 'medium')` (R3), `TIER_ENCODING.hd.maxBitrate = 4_000_000` (R3), `downlinkClassFrom` minimum-evidence + `> 0.25` drop-trim + relaxed thresholds (R5)
 
 **Checkpoint**: `npx vitest run src/services/call/quality.test.ts` green; all other
 vitest suites still green.
@@ -38,9 +38,9 @@ vitest suites still green.
 **Independent Test**: drive probe shows tier `high→hd` within ~6 s and ≥1280×720
 capture on desktop Chromium.
 
-- [ ] T003 [US1] In `src/composables/useCall.ts`: initialize and reset the 1:1 controller with `initialController('high')` (call-start + teardown reset), and adapt every second `pollStats` tick (~2 s cadence, R6) while keeping the 1 s byte/warning/ⓘ updates
-- [ ] T004 [US1] In `src/composables/useCall.ts`: add a shared `videoConstraints()` helper — `facingMode` + `frameRate ideal 30` + (non-iOS only) `width/height ideal 1280×720` — and use it in `gumConstraints` AND the camera-flip / camera-restore `getUserMedia` call sites, preserving the iOS-unconstrained rule and its iPhone-8 rationale comment
-- [ ] T005 [P] [US1] Write `drive/scenarios/probe-call-quality.mjs`: two accounts, 1:1 video call on the live dev stack; print captured track settings (expect ≥1280×720), sample the outgoing tier each second for ~20 s (expect `high` at connect, `hd` ≤6 s, no down-steps — SC-001/SC-002 evidence), then `sweep`
+- [X] T003 [US1] In `src/composables/useCall.ts`: initialize and reset the 1:1 controller with `initialController('high')` (call-start + teardown reset), and adapt every second `pollStats` tick (~2 s cadence, R6) while keeping the 1 s byte/warning/ⓘ updates
+- [X] T004 [US1] In `src/composables/useCall.ts`: add a shared `videoConstraints()` helper — `facingMode` + `frameRate ideal 30` + (non-iOS only) `width/height ideal 1280×720` — and use it in `gumConstraints` AND the camera-flip / camera-restore `getUserMedia` call sites, preserving the iOS-unconstrained rule and its iPhone-8 rationale comment
+- [X] T005 [P] [US1] Write `drive/scenarios/probe-call-quality.mjs`: two accounts, 1:1 video call on the live dev stack; print captured track settings (expect ≥1280×720), sample the outgoing tier each second for ~20 s (expect `high` at connect, `hd` ≤6 s, no down-steps — SC-001/SC-002 evidence), then `sweep`
 
 **Checkpoint**: probe output shows the climb + steady state; `npm run build` green.
 
@@ -51,7 +51,7 @@ capture on desktop Chromium.
 **Goal**: consumers feed the new `limitedBy` signal; no behavior change needed beyond
 Phase 2's core rule.
 
-- [ ] T006 [US2] Wire `useCall.ts` and `src/services/call/mesh.ts` to the renamed snapshot field (`limitedBy`), keeping the mesh ⓘ limitation readout working; typecheck-driven sweep of all `qualityLimited` references
+- [X] T006 [US2] Wire `useCall.ts` and `src/services/call/mesh.ts` to the renamed snapshot field (`limitedBy`), keeping the mesh ⓘ limitation readout working; typecheck-driven sweep of all `qualityLimited` references
 
 **Checkpoint**: `npm run build` + full vitest green.
 
@@ -61,9 +61,9 @@ Phase 2's core rule.
 
 **Goal**: tier `off` is a real, self-clearing pause in both call paths.
 
-- [ ] T007 [US3] 1:1 suspend/resume in `src/composables/useCall.ts`: entering `off` detaches the video sender's track (`replaceTrack(null)`) with an adaptation-owned suspended flag; leaving `off` re-attaches the live local video track + applies the tier encoding; flag cleared on teardown/hold/camera-off so adaptation never re-attaches a track the user (or hold) removed
-- [ ] T008 [US3] Mesh per-leg suspend/resume in `src/services/call/mesh.ts` `setLegTier`: same semantics per leg (detach on `off`, re-attach on leaving it), guarded against the leg-hold path (`paused`/held peers) and camera-off
-- [ ] T009 [P] [US3] Extend the probe (or a targeted vitest where feasible) to force the floor via a `low` pin + severe-loss simulation isn't scriptable from outside — so assert the OBSERVABLE contract in the probe instead: pin `low`, confirm tier clamps; unpin, confirm climb resumes ≤10 s (SC-003 proxy at the integration level; the trap itself is covered by T001a at the unit level)
+- [X] T007 [US3] 1:1 suspend/resume in `src/composables/useCall.ts`: entering `off` detaches the video sender's track (`replaceTrack(null)`) with an adaptation-owned suspended flag; leaving `off` re-attaches the live local video track + applies the tier encoding; flag cleared on teardown/hold/camera-off so adaptation never re-attaches a track the user (or hold) removed
+- [X] T008 [US3] Mesh per-leg suspend/resume in `src/services/call/mesh.ts` `setLegTier`: same semantics per leg (detach on `off`, re-attach on leaving it), guarded against the leg-hold path (`paused`/held peers) and camera-off
+- [X] T009 [P] [US3] Extend the probe (or a targeted vitest where feasible) to force the floor via a `low` pin + severe-loss simulation isn't scriptable from outside — so assert the OBSERVABLE contract in the probe instead: pin `low`, confirm tier clamps; unpin, confirm climb resumes ≤10 s (SC-003 proxy at the integration level; the trap itself is covered by T001a at the unit level)
 
 **Checkpoint**: vitest + probe green.
 
@@ -74,7 +74,7 @@ Phase 2's core rule.
 Covered in the pure core (T001g–i / T002); no consumer wiring needed — `reportLegHealth`
 and `reportHealthToPeer` already pass per-interval deltas into `downlinkClassFrom`.
 
-- [ ] T010 [US4] Verify by inspection + unit tests only: confirm both consumers pass (received+lost) counts such that the < 50-packet windows short-circuit correctly (audio-only intervals, first-window-after-connect), adjusting call sites if the delta plumbing needs the raw counts
+- [X] T010 [US4] Verify by inspection + unit tests only: confirm both consumers pass (received+lost) counts such that the < 50-packet windows short-circuit correctly (audio-only intervals, first-window-after-connect), adjusting call sites if the delta plumbing needs the raw counts
 
 **Checkpoint**: full vitest green.
 
@@ -82,8 +82,8 @@ and `reportHealthToPeer` already pass per-interval deltas into `downlinkClassFro
 
 ## Phase 7: Polish & Gates
 
-- [ ] T011 Run gates: `npm run build`, `npx vitest run`, `npx playwright test e2e/call-adaptive.spec.ts e2e/call-quality.spec.ts e2e/call-connect-speed.spec.ts e2e/mutual-call.spec.ts e2e/call-waiting.spec.ts` (hold/resume interplay)
-- [ ] T012 Bump spec 2025 `**Status**:` (in-progress → in-review) + `make roadmap`
+- [X] T011 Run gates: `npm run build`, `npx vitest run`, `npx playwright test e2e/call-adaptive.spec.ts e2e/call-quality.spec.ts e2e/call-connect-speed.spec.ts e2e/mutual-call.spec.ts e2e/call-waiting.spec.ts` (hold/resume interplay)
+- [X] T012 Bump spec 2025 `**Status**:` (in-progress → in-review) + `make roadmap`
 
 ---
 

--- a/src/components/FloatingGameButton.vue
+++ b/src/components/FloatingGameButton.vue
@@ -8,6 +8,7 @@
   <div
     v-if="show"
     class="fgb"
+    :class="{ 'fgb-collapsed': collapsed }"
     :style="style"
     role="button"
     :aria-label="label"
@@ -25,7 +26,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onUnmounted, ref, watch } from 'vue';
 import { IonBadge, IonIcon } from '@ionic/vue';
 import { locateOutline } from 'ionicons/icons';
 import { useOngoingGames } from '@/composables/useOngoingGames';
@@ -39,6 +40,28 @@ const label = computed(() =>
     ? `Back to your game, ${awaitingCount.value} awaiting your move`
     : 'Back to your game',
 );
+
+// The pill covers a whole message-card width when it lingers over the chat, so it
+// tucks itself into just the circular glyph after a moment (the label appears long
+// enough to be learnable, then gets out of the way). It re-expands briefly when it
+// (re)appears or when a new "your move" lands, so urgency still catches the eye.
+const collapsed = ref(false);
+let collapseTimer: ReturnType<typeof setTimeout> | null = null;
+function expandBriefly(): void {
+  collapsed.value = false;
+  if (collapseTimer) clearTimeout(collapseTimer);
+  collapseTimer = setTimeout(() => (collapsed.value = true), 2500);
+}
+watch(show, (on) => {
+  if (on) expandBriefly();
+  else if (collapseTimer) clearTimeout(collapseTimer);
+}, { immediate: true });
+watch(awaitingCount, (n, prev) => {
+  if (show.value && n > (prev ?? 0)) expandBriefly();
+});
+onUnmounted(() => {
+  if (collapseTimer) clearTimeout(collapseTimer);
+});
 
 /* ---- free drag (tap = open the most urgent game); MinimizedCall pattern ---- */
 const pos = ref<{ x: number; y: number } | null>(null);
@@ -108,6 +131,22 @@ function onUp(): void {
   cursor: grab;
   touch-action: none;
   max-width: 230px;
+  transition: padding 0.25s ease, gap 0.25s ease;
+}
+/* Tucked away: just the circular glyph, hugging the left edge — the chat stays
+   readable. The badge rides the circle's shoulder so urgency is still visible. */
+.fgb-collapsed {
+  padding: 6px;
+  gap: 0;
+}
+.fgb-collapsed .fgb-text {
+  max-width: 0;
+  opacity: 0;
+}
+.fgb-collapsed .fgb-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
 }
 .fgb-glyph {
   width: 30px;
@@ -126,6 +165,8 @@ function onUp(): void {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 180px;
+  transition: max-width 0.25s ease, opacity 0.2s ease;
 }
 .fgb-badge {
   flex: none;

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -739,20 +739,32 @@ async function toast(message: string): Promise<void> {
   await appToast({ message, duration: 3500 });
 }
 
+/** Camera constraints for every in-call getUserMedia (initial capture, camera flip, and
+ *  the screen-share/hold restores — one helper so they can't drift apart, spec 2025).
+ *
+ *  iOS: DO NOT impose a resolution/orientation. On the A11/iOS-16.7 iPhone 8, naming any
+ *  width/height makes WebKit start at the requested orientation, then flip to the
+ *  perpendicular one and MUTE the track in the same instant — permanently (≈1fps, frozen
+ *  self-view, black tile to the peer). It always flips AWAY from whatever we ask, so there
+ *  is no "right" resolution to request; the only escape is to impose none and let WebKit
+ *  open the sensor in its native format (which is also why iOS is NOT stuck at VGA). We
+ *  still pin a frameRate ideal (cheap, doesn't drive the orientation flip).
+ *
+ *  Everywhere else: ask for 1280×720 `ideal` (spec 2025 FR-003). Chromium's unconstrained
+ *  default is 640×480 — the single biggest reason Ring video read soft next to native
+ *  apps on Android/desktop. `ideal` (never `exact`) so cameras without 720p still open. */
+function videoConstraints(facing: 'user' | 'environment' = 'user'): MediaTrackConstraints {
+  const base: MediaTrackConstraints = { facingMode: { ideal: facing }, frameRate: { ideal: 30 } };
+  if (isIOS()) return base;
+  return { ...base, width: { ideal: 1280 }, height: { ideal: 720 } };
+}
+
 function gumConstraints(kind: CallKind): MediaStreamConstraints {
   // Echo cancellation / noise suppression / AGC matter especially on loudspeaker
   // (the default for video calls), where open-air feedback would otherwise howl.
   return {
     audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
-    // Ask for the front camera but DO NOT impose a resolution/orientation. On the A11/iOS-16.7
-    // iPhone 8, naming any width/height makes WebKit start at the requested orientation, then flip to
-    // the perpendicular one and MUTE the track in the same instant — permanently (≈1fps, frozen
-    // self-view, black tile to the peer). It always flips AWAY from whatever we ask, so there is no
-    // "right" resolution to request; the only escape is to impose none and let WebKit open the sensor
-    // in its native format with nothing to reconfigure away from. We still pin a frameRate ideal (cheap,
-    // doesn't drive the orientation flip) and rely on the per-tier bitrate cap (not resolution) to keep
-    // the encoder sane. Newer phones already coped with an explicit size, so this only helps the iPhone 8.
-    video: kind === 'video' ? { facingMode: { ideal: 'user' }, frameRate: { ideal: 30 } } : false,
+    video: kind === 'video' ? videoConstraints() : false,
   };
 }
 
@@ -987,8 +999,10 @@ async function pollStats(): Promise<void> {
       if (s.type === 'remote-inbound-rtp' && typeof s.roundTripTime === 'number') rtt = s.roundTripTime;
     });
     // 1:1 adaptive outgoing quality (spec 0004 US4): the group path adapts per-leg inside
-    // MeshSession; the 1:1 PC adapts here off the same sample.
-    if (pc) await adaptOneToOne(report);
+    // MeshSession; the 1:1 PC adapts here off the same sample — every SECOND 1s tick, the
+    // ~2s cadence the controller's streak constants were tuned for (spec 2025 FR-007).
+    adaptTick += 1;
+    if (pc && adaptTick % 2 === 0) await adaptOneToOne(report);
   } catch {
     return;
   }
@@ -1159,7 +1173,9 @@ export async function teardown(reason: EndReason, opts?: { silent?: boolean }): 
   hasMultipleCameras.value = false;
   videoQuality.value = 'auto';
   lessDataCalls = false;
-  oneToOneQc = initialController(); // next call starts low again
+  oneToOneQc = initialController('high'); // next 1:1 call starts sharp again (spec 2025)
+  oneToOneVideoSuspended = false; // the paused-by-adaptation flag never outlives its call
+  adaptTick = 0;
   // spec 0007: reset 1:1 connection-health state so the next call starts clean.
   oneToOneDownlink = 'hd';
   oneToOneHealthSeq = 0;
@@ -2122,6 +2138,7 @@ async function yieldToMutualCall(frame: Extract<CallFrame, { t: 'call-offer' }>,
   }
   localStream.value = null;
   pendingIce.length = 0;
+  oneToOneVideoSuspended = false; // the abandoned attempt's PC is gone; flag dies with it
   const reuse = mode === 'auto-accept' && media != null;
   if (!reuse && media) {
     void Promise.resolve(media)
@@ -2725,15 +2742,26 @@ function videoSender(): RTCRtpSender | null {
 }
 
 /* ---- outgoing-video quality (adaptive, spec 0004 US4) ----
- * Both 1:1 and group video START LOW and adapt: each connection runs the pure controller in
- * services/call/quality (AIMD over getStats — climb only with headroom, back off on local or
- * remote-reported congestion). The manual quality pin + "use less data" are an UPPER-BOUND
- * clamp (the controller may still drop below to keep the call alive). Group adaptation is
- * per-receiver inside MeshSession; 1:1 runs here against the single PC's video sender. */
+ * Each connection runs the pure controller in services/call/quality (AIMD over getStats —
+ * climb on health, back off on genuine local or remote-reported congestion). 1:1 starts
+ * HIGH (one cheap encode, spec 2025); mesh legs start MEDIUM (N parallel encoders). The
+ * manual quality pin + "use less data" are an UPPER-BOUND clamp (the controller may still
+ * drop below to keep the call alive). Group adaptation is per-receiver inside MeshSession;
+ * 1:1 runs here against the single PC's video sender. */
 let lessDataCalls = false;
 
-// 1:1 adaptive state, sampled in pollStats; reset per call.
-let oneToOneQc: ControllerState = initialController();
+// 1:1 adaptive state, sampled in pollStats; reset per call. Starts HIGH (spec 2025
+// FR-001): a single encode is cheap and the first sample lands within ~2s to correct a
+// genuinely bad link — starting sharp is the point (mesh legs keep the medium start).
+let oneToOneQc: ControllerState = initialController('high');
+// Spec 2025 FR-005: set when ADAPTATION detached the video track at tier 'off' (a real
+// pause — a 1 bps cap kept the encoder "bandwidth limited" forever, so video never came
+// back). Only the flag's owner re-attaches, so this never fights the user's camera
+// toggle or hold/resume, which manage tracks through their own paths.
+let oneToOneVideoSuspended = false;
+// Spec 2025 FR-007: pollStats ticks every 1s for the byte counters/warning/ⓘ, but the
+// controller's streak constants were designed for ~2s samples — adapt every SECOND tick.
+let adaptTick = 0;
 
 // 1:1 connection-health (spec 0007 US2). We periodically tell the peer the max quality we want from
 // THEM (`requestedTier`, from our downlink + manual pin + view size), and apply the peer's report to
@@ -2768,6 +2796,24 @@ function qualityClamp(): Tier {
  *  every field, and there may be no sender yet on an audio call. */
 async function applySenderTier(sender: RTCRtpSender | null, tier: Tier): Promise<void> {
   if (!sender) return;
+  // Tier 'off' is a REAL pause (spec 2025 FR-005): detach the track so nothing is encoded.
+  // The old 1 bps cap left a zombie encode whose own "bandwidth limited" reading kept the
+  // controller congested forever — video that dipped once never came back. With the track
+  // detached, samples read healthy and the ladder climbs back out on its own.
+  if (tier === 'off') {
+    if (!oneToOneVideoSuspended && sender.track) {
+      oneToOneVideoSuspended = true;
+      await sender.replaceTrack(null).catch(() => {});
+    }
+    return;
+  }
+  // Leaving the floor: re-attach ONLY what adaptation itself detached (never a track the
+  // user's camera toggle or a hold removed — those paths own their tracks).
+  if (oneToOneVideoSuspended) {
+    oneToOneVideoSuspended = false;
+    const v = localStream.value?.getVideoTracks()[0];
+    if (v && v.readyState === 'live') await sender.replaceTrack(v).catch(() => {});
+  }
   // iOS/WebKit: tier by BITRATE ONLY (`avoidEncoderScaling`) — never via scaleResolutionDownBy/
   // maxFramerate, which stall the old iPhone H.264 encoder (spec 0005). maxBitrate alone is honored
   // and safe (the iPhone-8 black-video bug was the camera-mute/​re-acquire, not the bitrate cap), so
@@ -2831,7 +2877,12 @@ async function reportHealthToPeer(report: RTCStatsReport, now: number): Promise<
   inPrevFramesDropped = framesDropped;
   inPrevFramesReceived = framesReceived;
   const fractionLost = dRecv + dLost > 0 ? dLost / (dRecv + dLost) : 0;
-  oneToOneDownlink = downlinkClassFrom({ fractionLost, framesDropped: dDrop, framesReceived: dFrames }, oneToOneDownlink);
+  // packets: the window's evidence size — a near-empty interval must not move the class
+  // (spec 2025 FR-006).
+  oneToOneDownlink = downlinkClassFrom(
+    { fractionLost, framesDropped: dDrop, framesReceived: dFrames, packets: dRecv + dLost },
+    oneToOneDownlink,
+  );
   // requestedTier = min(downlink, manual pin/data-saver, view size). The 1:1 remote is shown
   // (near-)fullscreen, so the tile target is HD here; US4 refines this with the real rendered size.
   const requested = requestedTierOf(oneToOneDownlink, qualityClamp(), 'hd');
@@ -2885,6 +2936,18 @@ function sendHealthNow(): void {
  *  No-op off a group call. */
 export function setGroupTileSize(px: number): void {
   groupSession?.setAllTileTargets(tileTarget(px));
+}
+
+/** Test-only introspection (spec 2025): the 1:1 controller's current tier, whether
+ *  adaptation has the video paused (the recoverable floor), and the peer-requested
+ *  ceiling — so probes/e2e can watch the climb and the floor recovery. */
+export function oneToOneQualityDiag(): { tier: Tier; suspended: boolean; requestedByPeer?: Tier; downlink: Tier } {
+  return {
+    tier: oneToOneQc.tier,
+    suspended: oneToOneVideoSuspended,
+    requestedByPeer: oneToOnePeerReq?.tier,
+    downlink: oneToOneDownlink,
+  };
 }
 
 /** Change the outgoing-video quality tier and apply it immediately. */
@@ -2972,7 +3035,7 @@ export async function switchCamera(): Promise<void> {
   const next = cameraFacing.value === 'user' ? 'environment' : 'user';
   let stream: MediaStream;
   try {
-    stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: { ideal: next } } });
+    stream = await navigator.mediaDevices.getUserMedia({ video: videoConstraints(next) });
   } catch {
     await toast('Could not switch camera');
     return;
@@ -3064,7 +3127,7 @@ async function stopScreenShare(): Promise<void> {
   // Otherwise restore the camera (a fresh capture; the old one was stopped on share).
   let camTrack: MediaStreamTrack | null = null;
   try {
-    const s = await navigator.mediaDevices.getUserMedia({ video: { facingMode: { ideal: cameraFacing.value } } });
+    const s = await navigator.mediaDevices.getUserMedia({ video: videoConstraints(cameraFacing.value) });
     camTrack = s.getVideoTracks()[0] ?? null;
   } catch {
     camTrack = null;
@@ -3084,7 +3147,7 @@ async function addLocalVideo(renegotiateAfter: boolean): Promise<boolean> {
   if (!pc || !meta) return false;
   let s: MediaStream;
   try {
-    s = await navigator.mediaDevices.getUserMedia({ video: { facingMode: { ideal: cameraFacing.value } } });
+    s = await navigator.mediaDevices.getUserMedia({ video: videoConstraints(cameraFacing.value) });
   } catch {
     await toast('Camera unavailable');
     return false;
@@ -3160,7 +3223,7 @@ export async function toggleVideoMode(): Promise<void> {
   // Group: turn on my own video immediately (each peer renegotiates to receive it).
   let s: MediaStream;
   try {
-    s = await navigator.mediaDevices.getUserMedia({ video: { facingMode: { ideal: cameraFacing.value } } });
+    s = await navigator.mediaDevices.getUserMedia({ video: videoConstraints(cameraFacing.value) });
   } catch {
     await toast('Camera unavailable');
     return;

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -23,6 +23,7 @@ import {
   createCall,
   finishCall,
   markCallMissed,
+  deleteCalls,
   recordGroupCall,
   logCallToChat,
   sendMessage,
@@ -43,8 +44,10 @@ import { MeshSession } from '@/services/call/mesh';
 import { syncState } from '@/composables/useSync';
 import { startLoopTone, stopLoopTone, playTone, cue, type ToneName } from '@/services/sound';
 import type { CallState, CallMeta, CallKind, EndReason } from '@/services/call/types';
+import type { CallSignal } from '@/services/crypto/message';
 import { VIDEO_MAX } from '@/services/call/types';
 import { remainingSlots, canAdd } from '@/services/call/capacity';
+import { glareRole, yieldMode } from '@/services/call/glare';
 import { planInvite } from '@/services/call/invite-plan';
 import { newJoiners } from '@/services/call/join-cue';
 import {
@@ -441,6 +444,32 @@ export function groupCallDiag(): Promise<{
 
 let pendingOffer: { sdp: string; sdpType: RTCSdpType } | null = null;
 const pendingIce: RTCIceCandidateInit[] = [];
+
+/* ---- mutual-call (glare) resolution, spec 1039 ----
+ * startDirectCall runs through several awaits (capture, PC build, offer send) before the
+ * call state leaves 'idle'. A crossing offer from the SAME contact landing inside that
+ * window is a mutual attempt and is resolved by handleOffer (services/call/glare) — which
+ * repurposes the call slot. The in-flight startDirectCall must then stop touching shared
+ * state, or it stamps 'dialing' (tones, navigation) over the call that replaced it and
+ * both sides end up stranded on "Calling…". The token identifies the attempt that still
+ * owns the slot; startDirectCall re-checks it after every await. */
+let outgoingAttemptId: string | null = null;
+// The current outgoing attempt's in-flight camera/mic capture. Kept so a glare yield can
+// hand the ALREADY-CAPTURED stream to the auto-accept path instead of running a second
+// concurrent getUserMedia (a documented WebKit mute trigger, bug 179363).
+let pendingCapture: Promise<MediaStream> | null = null;
+// callIds retired by glare resolution — the crossing offer we ignored (winner side) and
+// our own yielded attempt. The relay retains sealed offers for recovery redelivery
+// (spec 2012), so a late copy of these must be dropped, never rung. Session-scoped,
+// size-capped (a stale entry is only ever a re-drop, never a lost call).
+const glareDroppedCallIds = new Set<string>();
+function rememberGlareDrop(callId: string): void {
+  glareDroppedCallIds.add(callId);
+  if (glareDroppedCallIds.size > 32) {
+    const oldest = glareDroppedCallIds.values().next().value;
+    if (oldest) glareDroppedCallIds.delete(oldest);
+  }
+}
 
 /* ---- connect-milestone instrumentation (spec 2008, dev/test-only) -------------------------
  * Records ephemeral timestamps for the 1:1 connect path so the Playwright harness can assert the
@@ -1085,6 +1114,15 @@ export async function teardown(reason: EndReason, opts?: { silent?: boolean }): 
   stopTimers();
   stopLoopTone();
 
+  // (spec 1039) Retire the outgoing-attempt token so an in-flight startDirectCall stops
+  // mutating shared state, and release an unclaimed in-flight capture (the camera would
+  // otherwise stay live if teardown won the race against getUserMedia resolving).
+  outgoingAttemptId = null;
+  if (pendingCapture) {
+    void pendingCapture.then((s) => s.getTracks().forEach((t) => t.stop())).catch(() => {});
+    pendingCapture = null;
+  }
+
   const meta = callMeta.value;
   const wasConnected = callState.value === 'connected';
   // Total bytes moved this call (sent + received), from the last stats sample.
@@ -1291,8 +1329,15 @@ export async function startDirectCall(contactId: string, kind: CallKind): Promis
     name: contact.name,
     avatar: contact.avatar,
   };
+  // (spec 1039) This attempt owns the call slot until it's answered, torn down, or a
+  // mutual-call resolution yields it. Everything below re-checks after each await.
+  outgoingAttemptId = callId;
+  const attemptAlive = (): boolean =>
+    outgoingAttemptId === callId && callMeta.value?.callId === callId && !callMeta.value?.tornDown;
+
   await createCall({ callId, contactId, direction: 'outgoing', video: kind === 'video' });
   await loadCallPrefs(); // data-saver floor + call-sounds pref, read once for this call
+  if (!attemptAlive()) return; // yielded to a mutual call while we set up (spec 1039)
 
   // Fast-connect (spec 2008): warm the TURN credential cache OFF the critical path before we
   // await getUserMedia, so the fetch overlaps camera/mic capture and `newPeerConnection` finds it
@@ -1303,11 +1348,15 @@ export async function startDirectCall(contactId: string, kind: CallKind): Promis
   warmTurnConfig();
 
   let stream: MediaStream;
+  const capture = navigator.mediaDevices.getUserMedia(gumConstraints(kind));
+  pendingCapture = capture;
   try {
     markConnect('gumStart');
-    stream = await navigator.mediaDevices.getUserMedia(gumConstraints(kind));
+    stream = await capture;
     markConnect('gumResolved');
   } catch (err) {
+    if (pendingCapture === capture) pendingCapture = null;
+    if (!attemptAlive()) return; // slot already repurposed; nothing of ours to tear down
     // The call can't start without local media. Tell the caller WHY (blocked permission,
     // no device, in use) rather than the bare "Couldn't connect the call" — the usual
     // Android cause is the app's mic (or camera) permission being off at the OS level. Pass
@@ -1316,10 +1365,29 @@ export async function startDirectCall(contactId: string, kind: CallKind): Promis
     await teardown('failed', { silent: true });
     return;
   }
+  if (!attemptAlive()) {
+    // The slot was repurposed while we were capturing. A glare yield CLAIMS the capture
+    // (sets pendingCapture to null / its own) to reuse it for the auto-accept; if it's
+    // still ours, nothing claimed it — release the camera/mic instead of leaking it live.
+    if (pendingCapture === capture) {
+      pendingCapture = null;
+      stream.getTracks().forEach((t) => t.stop());
+    }
+    return;
+  }
   localStream.value = stream;
 
   try {
-    pc = await newPeerConnection();
+    const conn = await newPeerConnection();
+    if (!attemptAlive()) {
+      try {
+        conn.close();
+      } catch {
+        /* already closed */
+      }
+      return;
+    }
+    pc = conn;
     wireIce(pc);
     addLocalTracks(pc, stream);
     const offer = await pc.createOffer();
@@ -1332,12 +1400,14 @@ export async function startDirectCall(contactId: string, kind: CallKind): Promis
       sdpType: offer.type,
     });
     markConnect('offerSent');
+    if (!attemptAlive()) return; // our offer may still cross; the winner ignores it (glare)
     if (!sent) {
       console.warn('[call] offer not sent (no session or offline)');
       await teardown('unavailable');
       return;
     }
   } catch (e) {
+    if (!attemptAlive()) return;
     console.warn('[call] startDirectCall failed', e);
     await teardown('failed');
     return;
@@ -1823,6 +1893,11 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
   // ringing for this same callId, don't raise a second incoming screen.
   if (callState.value === 'incoming' && callMeta.value?.callId === frame.callId) return;
 
+  // (spec 1039) An offer already retired by mutual-call resolution (the crossing offer we
+  // ignored as winner, or our own yielded attempt) may be redelivered late by the same
+  // retention path — drop it; it must never raise a ring.
+  if (glareDroppedCallIds.has(frame.callId)) return;
+
   // Renegotiation of an in-progress call (e.g. the peer's ICE restart): same
   // call + peer and we're already connected/connecting → apply as offer/answer,
   // don't raise a new incoming call.
@@ -1875,23 +1950,40 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
     return;
   }
 
-  if (callState.value !== 'idle') {
-    const meta = callMeta.value;
-    const glareWithPeer = meta?.direction === 'outgoing' && meta.peerUserId === from;
-    if (glareWithPeer) {
-      const self = getSelfUserId() ?? '';
-      if (self < from) return; // we win, keep our outgoing offer, ignore theirs
-      await teardown('answered-elsewhere', { silent: true }); // we yield, accept theirs
-    } else if (canRaiseSecondIncoming()) {
+  // Mutual call — glare (spec 1039): they called us while we have an UNANSWERED outgoing
+  // attempt at them. Detected via callMeta, which startDirectCall sets synchronously — NOT
+  // via callState, which only leaves 'idle' after capture + PC build + offer send. Mutual
+  // taps usually land inside that setup window, and missing them here is what used to
+  // clobber the slot and strand BOTH sides on "Calling…". Runs before the per-chat-mute
+  // gate below: a mutual attempt is not an unsolicited ring — this user just placed a
+  // call at that very contact.
+  const unanswered =
+    callState.value === 'idle' || callState.value === 'dialing' || callState.value === 'remote-ringing';
+  const role = glareRole(getSelfUserId() ?? '', from, callMeta.value, unanswered);
+  if (role === 'win') {
+    // Our attempt survives (deterministic id tie-break, same on both sides). Their
+    // crossing offer dies here — they auto-answer OURS instead.
+    rememberGlareDrop(frame.callId);
+    return;
+  }
+  if (role === 'yield') {
+    await yieldToMutualCall(frame, from);
+    return;
+  }
+
+  // Busy gate: `callMeta` (not just callState) so an offer from a THIRD party landing in
+  // an outgoing call's setup window gets the normal busy/call-waiting treatment instead of
+  // falling through and corrupting the call being placed (spec 1039 FR-006).
+  if (callState.value !== 'idle' || callMeta.value) {
+    if (canRaiseSecondIncoming()) {
       // Call waiting (spec 0005): a held slot is free AND no one is already waiting → offer
       // Accept & hold instead of busy. The waiting-slot check (spec 2009) stops a later caller
       // from stealing the place of one already in the prompt.
       await presentSecondDirect(frame, from);
       return;
-    } else {
-      void sendControl('call-busy', from, frame.callId);
-      return;
     }
+    void sendControl('call-busy', from, frame.callId);
+    return;
   }
 
   let contact = await getContact(from);
@@ -1919,9 +2011,22 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
     return;
   }
 
+  await ringForOffer(frame.callId, from, contact, chatId, signal);
+}
+
+/** Stage an incoming 1:1 offer into the (free) call slot and ring for it. Shared by the
+ *  normal incoming path above and the mismatched-kind mutual-call fallback (spec 1039),
+ *  which must ring WITHOUT re-running the per-chat-mute gate. */
+async function ringForOffer(
+  callId: string,
+  from: string,
+  contact: { name: string; avatar: string },
+  chatId: string,
+  signal: CallSignal,
+): Promise<void> {
   const kind: CallKind = signal.kind ?? 'audio';
   callMeta.value = {
-    callId: frame.callId,
+    callId,
     isGroup: false,
     kind,
     direction: 'incoming',
@@ -1933,8 +2038,8 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
     name: contact.name,
     avatar: contact.avatar,
   };
-  pendingOffer = { sdp: signal.sdp, sdpType: signal.sdpType ?? 'offer' };
-  await createCall({ callId: frame.callId, contactId: from, direction: 'incoming', video: kind === 'video' });
+  pendingOffer = { sdp: signal.sdp!, sdpType: signal.sdpType ?? 'offer' };
+  await createCall({ callId, contactId: from, direction: 'incoming', video: kind === 'video' });
 
   // Fast-connect (spec 2008): warm the TURN cache NOW, during the ring, so accepting doesn't pay a
   // cold fetch. Network/SDP prep only — NO camera/mic capture before the user accepts (Principle
@@ -1947,23 +2052,132 @@ async function handleOffer(frame: Extract<CallFrame, { t: 'call-offer' }>): Prom
   setState('incoming');
   presentIncoming(); // full-screen if the app is being opened for this call; else the banner
   startLoopTone('beacon', 2000);
-  void sendControl('call-ringing', from, frame.callId);
+  void sendControl('call-ringing', from, callId);
 
   clearRingTimeout();
   noAnswerTimer = setTimeout(() => {
-    void sendControl('call-end', from, frame.callId, { reason: 'timeout' });
+    void sendControl('call-end', from, callId, { reason: 'timeout' });
     void teardown('timeout');
   }, RING_TIMEOUT_MS);
 }
 
-/** Accept the current incoming call (branches to the group path for a group ring). */
+/** Mutual-call resolution, yielding side (spec 1039): we placed a call at `from` and their
+ *  offer crossed ours — the id tie-break says THEIR attempt survives. Abandon ours
+ *  surgically (no teardown: the slot is reused in the same breath) and join theirs —
+ *  automatically when the kinds match (both people already asked for exactly this call),
+ *  via a normal ring when they differ (never auto-enable media this user didn't ask for,
+ *  FR-004). */
+async function yieldToMutualCall(frame: Extract<CallFrame, { t: 'call-offer' }>, from: string): Promise<void> {
+  const mine = callMeta.value;
+  if (!mine || mine.tornDown) return;
+
+  // Resolve + open the surviving offer FIRST — its kind picks auto-accept vs ring, and if
+  // it can't be opened we keep our own attempt (losing both calls would be worse).
+  let contact = await getContact(from);
+  if (!contact) {
+    await addContactWithId(from, '');
+    contact = await getContact(from);
+  }
+  if (!contact) return;
+  const chatId = await sessionChatIdForPeer(contact); // may be a hidden 1:1 (knock-knock, spec 1027)
+  const signal = await openSealedSignal(chatId, frame.ciphertext);
+  if (!signal || signal.type !== 'offer' || !signal.sdp) return;
+  // The slot may have moved on while we awaited (our attempt answered, torn down, or an
+  // earlier copy of this offer already resolved the glare) — re-check before acting on it.
+  if (callMeta.value !== mine || mine.tornDown) return;
+  const offerKind: CallKind = signal.kind ?? 'audio';
+  const mode = yieldMode(mine.kind, offerKind);
+
+  // Abandon OUR attempt. No teardown(): it would stop shared media, log the call, cue
+  // "ended", and settle the state we're about to reuse. Surgical steps instead:
+  const abandonedId = mine.callId;
+  outgoingAttemptId = null; // the in-flight startDirectCall stops at its next token check
+  mine.tornDown = true; // and any racing teardown of the old attempt becomes a no-op
+  rememberGlareDrop(abandonedId); // a late redelivery of our own offer must not ring
+  clearDialTimer();
+  clearRingTimeout();
+  stopLoopTone();
+  // Withdraw our offer so the relay drops its retained copy and any of the winner's other
+  // devices stop ringing for it (same control a dial-timeout give-up sends).
+  void sendControl('call-cancel', from, abandonedId, { reason: 'answered-elsewhere' });
+  // FR-007: the abandoned attempt must not surface as a separate unanswered call — the
+  // encounter is logged once, by the surviving call's incoming record below.
+  void deleteCalls([abandonedId]);
+
+  // Claim our attempt's media (captured or still capturing) before dismantling: same-kind
+  // auto-accept reuses it — a second concurrent getUserMedia is a WebKit mute trigger
+  // (bug 179363) — and on a mismatch it must be released, not leaked live.
+  const media: Promise<MediaStream> | MediaStream | null = pendingCapture ?? localStream.value;
+  pendingCapture = null;
+  if (pc) {
+    pc.onicecandidate = null;
+    pc.ontrack = null;
+    pc.onconnectionstatechange = null;
+    try {
+      pc.close();
+    } catch {
+      /* already closed */
+    }
+    pc = null;
+  }
+  localStream.value = null;
+  pendingIce.length = 0;
+  const reuse = mode === 'auto-accept' && media != null;
+  if (!reuse && media) {
+    void Promise.resolve(media)
+      .then((s) => s.getTracks().forEach((t) => t.stop()))
+      .catch(() => {});
+  }
+
+  if (mode === 'ring') {
+    // Kinds differ: present the surviving call as a normal incoming ring (the established
+    // consent surface). Deliberately NOT re-running the per-chat-mute gate: a mutual
+    // attempt is solicited — this user just called that contact themselves.
+    await ringForOffer(frame.callId, from, contact, chatId, signal);
+    return;
+  }
+
+  // Same kind: connect without ringing. The state flows dialing → connecting → connected,
+  // so the caller's "calling" cue transitions straight into the call (FR-008) — the
+  // incoming ringtone never plays and no incoming UI is raised.
+  callMeta.value = {
+    callId: frame.callId,
+    isGroup: false,
+    kind: offerKind,
+    direction: 'incoming',
+    peerUserId: from,
+    chatId,
+    roster: [from],
+    name: contact.name,
+    avatar: contact.avatar,
+  };
+  pendingOffer = { sdp: signal.sdp, sdpType: signal.sdpType ?? 'offer' };
+  await createCall({ callId: frame.callId, contactId: from, direction: 'incoming', video: offerKind === 'video' });
+  resetConnectMarks();
+  markConnect('ringStart');
+  markConnect('turnWarmStart');
+  warmTurnConfig();
+  await acceptIncoming({ media: media ?? undefined, auto: true });
+}
+
+/** Accept the current incoming call (branches to the group path for a group ring).
+ *  Parameterless on purpose — it's bound straight to @click handlers. */
 export async function acceptCall(): Promise<void> {
+  return acceptIncoming();
+}
+
+/** The accept flow. `opts` is the mutual-call auto-accept path (spec 1039): `auto` joins
+ *  without the slot ever having rung (callState never reached 'incoming'), and `media`
+ *  hands over the yielded attempt's already-captured stream so no second concurrent
+ *  getUserMedia runs (WebKit mute hazard, bug 179363). */
+async function acceptIncoming(opts?: { media?: Promise<MediaStream> | MediaStream; auto?: boolean }): Promise<void> {
   if (callMeta.value?.isGroup) {
     await acceptGroupCall();
     return;
   }
   const meta = callMeta.value;
-  if (callState.value !== 'incoming' || !meta?.chatId || !meta.peerUserId || !pendingOffer) return;
+  const stateOk = callState.value === 'incoming' || opts?.auto === true;
+  if (!stateOk || !meta?.chatId || !meta.peerUserId || !pendingOffer) return;
   clearRingTimeout();
   stopLoopTone();
   await loadCallPrefs(); // data-saver floor + call-sounds pref, read once for this call
@@ -1974,12 +2188,13 @@ export async function acceptCall(): Promise<void> {
   // ICE doesn't need the captured stream — so overlapping them removes the serial gap. TURN was
   // already warmed during the ring, so newPeerConnection doesn't pay a cold fetch here.
   markConnect('gumStart');
-  const gumPromise = navigator.mediaDevices
-    .getUserMedia(gumConstraints(meta.kind))
-    .then((s) => {
-      markConnect('gumResolved');
-      return s;
-    });
+  const gumPromise = (opts?.media != null
+    ? Promise.resolve(opts.media)
+    : navigator.mediaDevices.getUserMedia(gumConstraints(meta.kind))
+  ).then((s) => {
+    markConnect('gumResolved');
+    return s;
+  });
   gumPromise.catch(() => {}); // tame the unhandled-rejection while the PC sets up in parallel
 
   try {

--- a/src/services/call/glare.test.ts
+++ b/src/services/call/glare.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { glareRole, yieldMode, glareDecision, type GlareAttempt } from './glare';
+
+// Ids chosen so ordering is obvious: ALICE < BOB lexicographically.
+const ALICE = 'aaaa1111';
+const BOB = 'bbbb2222';
+const CARO = 'cccc3333';
+
+const attempt = (over: Partial<GlareAttempt> = {}): GlareAttempt => ({
+  direction: 'outgoing',
+  isGroup: false,
+  kind: 'audio',
+  peerUserId: BOB,
+  ...over,
+});
+
+describe('glareRole (spec 1039): who wins a mutual 1:1 call', () => {
+  it('no outgoing attempt → none (normal incoming flow)', () => {
+    expect(glareRole(ALICE, BOB, null, true)).toBe('none');
+    expect(glareRole(ALICE, BOB, undefined, true)).toBe('none');
+  });
+
+  it('attempt at a DIFFERENT peer → none (busy/call-waiting flow, FR-006)', () => {
+    expect(glareRole(ALICE, CARO, attempt({ peerUserId: BOB }), true)).toBe('none');
+  });
+
+  it('incoming (not outgoing) meta → none', () => {
+    expect(glareRole(ALICE, BOB, attempt({ direction: 'incoming' }), true)).toBe('none');
+  });
+
+  it('group attempt → none (out of scope)', () => {
+    expect(glareRole(ALICE, BOB, attempt({ isGroup: true }), true)).toBe('none');
+  });
+
+  it('attempt already answered (connected/connecting) → none — busy rules apply', () => {
+    expect(glareRole(ALICE, BOB, attempt(), false)).toBe('none');
+  });
+
+  it('smaller self id wins (keeps its own offer)', () => {
+    expect(glareRole(ALICE, BOB, attempt({ peerUserId: BOB }), true)).toBe('win');
+  });
+
+  it('larger self id yields', () => {
+    expect(glareRole(BOB, ALICE, attempt({ peerUserId: ALICE }), true)).toBe('yield');
+  });
+
+  it('missing ids → none (never resolve on unknown identity)', () => {
+    expect(glareRole('', BOB, attempt(), true)).toBe('none');
+    expect(glareRole(ALICE, '', attempt(), true)).toBe('none');
+  });
+
+  it('is symmetric: for any id pair, exactly one side wins and the other yields (FR-002)', () => {
+    const ids = ['0001', '9zzz', 'aaaa1111', 'aaab', 'zzzz9999'];
+    for (const a of ids) {
+      for (const b of ids) {
+        if (a === b) continue;
+        const roleA = glareRole(a, b, attempt({ peerUserId: b }), true);
+        const roleB = glareRole(b, a, attempt({ peerUserId: a }), true);
+        expect([roleA, roleB].sort()).toEqual(['win', 'yield']);
+      }
+    }
+  });
+});
+
+describe('yieldMode (spec 1039): consent decides auto-accept vs ring', () => {
+  it('same kind → auto-accept (both already asked for exactly this call, FR-003)', () => {
+    expect(yieldMode('audio', 'audio')).toBe('auto-accept');
+    expect(yieldMode('video', 'video')).toBe('auto-accept');
+  });
+
+  it('different kinds → ring (never auto-enable a camera uninvited, FR-004)', () => {
+    expect(yieldMode('audio', 'video')).toBe('ring');
+    expect(yieldMode('video', 'audio')).toBe('ring');
+  });
+});
+
+describe('glareDecision (composed decision table from data-model.md)', () => {
+  it('no attempt → none', () => {
+    expect(glareDecision(ALICE, BOB, null, true, 'audio')).toBe('none');
+  });
+
+  it('attempt + smaller self id → ignore', () => {
+    expect(glareDecision(ALICE, BOB, attempt(), true, 'audio')).toBe('ignore');
+  });
+
+  it('attempt + larger self id + kinds match → auto-accept', () => {
+    expect(glareDecision(BOB, ALICE, attempt({ peerUserId: ALICE, kind: 'video' }), true, 'video')).toBe('auto-accept');
+  });
+
+  it('attempt + larger self id + kinds differ → ring', () => {
+    expect(glareDecision(BOB, ALICE, attempt({ peerUserId: ALICE, kind: 'audio' }), true, 'video')).toBe('ring');
+  });
+});

--- a/src/services/call/glare.ts
+++ b/src/services/call/glare.ts
@@ -1,0 +1,68 @@
+/**
+ * Mutual-call ("glare") resolution for 1:1 calls (spec 1039) — PURE functions so the
+ * policy is unit-testable without WebRTC or the call store.
+ *
+ * When two contacts place calls at each other at (nearly) the same time, each device
+ * sees the peer's offer cross its own unanswered outgoing attempt. Both devices must
+ * independently reach the SAME resolution with no extra round-trip, so the tie-break is
+ * a fixed ordering of the two user ids — the attempt whose CALLER has the smaller id
+ * survives. (Same convention as the mesh's polite/impolite rule and the pre-1039 glare
+ * branch, so one ordering governs all call collisions.)
+ *
+ * The yielding side then either joins the surviving call automatically (kinds match —
+ * both people already asked for exactly this call, so ringing is pure friction) or
+ * falls back to a normal incoming ring (kinds differ — auto-accepting a video offer
+ * after placing an AUDIO call would light a camera nobody consented to; the ring is the
+ * established consent surface, constitution Principle IX).
+ */
+import type { CallKind } from '@/services/call/types';
+
+/** The shape of the current call slot the decision needs — structurally satisfied by
+ *  CallMeta, so useCall can pass `callMeta.value` straight in. */
+export interface GlareAttempt {
+  direction: 'incoming' | 'outgoing';
+  isGroup: boolean;
+  kind: CallKind;
+  peerUserId?: string;
+}
+
+export type GlareRole = 'none' | 'win' | 'yield';
+export type GlareDecision = 'none' | 'ignore' | 'auto-accept' | 'ring';
+
+/**
+ * Which side of a mutual attempt we are, given an incoming 1:1 offer from `from`.
+ * `unanswered` is whether our own attempt is still awaiting an answer (idle-while-
+ * setting-up, dialing, or remote-ringing) — a connected/connecting call is NOT glare;
+ * it follows the ordinary busy/call-waiting rules.
+ */
+export function glareRole(
+  selfId: string,
+  from: string,
+  attempt: GlareAttempt | null | undefined,
+  unanswered: boolean,
+): GlareRole {
+  if (!selfId || !from || !attempt || !unanswered) return 'none';
+  if (attempt.isGroup || attempt.direction !== 'outgoing') return 'none';
+  if (attempt.peerUserId !== from) return 'none';
+  return selfId < from ? 'win' : 'yield';
+}
+
+/** How the yielding side joins the surviving call: automatically when it grants exactly
+ *  what this user already asked for (same kind), a normal ring otherwise (consent). */
+export function yieldMode(attemptKind: CallKind, offerKind: CallKind): 'auto-accept' | 'ring' {
+  return attemptKind === offerKind ? 'auto-accept' : 'ring';
+}
+
+/** The composed decision table (data-model.md): what to do with a crossing 1:1 offer. */
+export function glareDecision(
+  selfId: string,
+  from: string,
+  attempt: GlareAttempt | null | undefined,
+  unanswered: boolean,
+  offerKind: CallKind,
+): GlareDecision {
+  const role = glareRole(selfId, from, attempt, unanswered);
+  if (role === 'none') return 'none';
+  if (role === 'win') return 'ignore';
+  return yieldMode((attempt as GlareAttempt).kind, offerKind);
+}

--- a/src/services/call/mesh.ts
+++ b/src/services/call/mesh.ts
@@ -102,6 +102,11 @@ interface PeerLeg {
   // independently from this leg's own getStats, so one call can send different qualities to
   // different peers based on each link. Starts low; climbs/backs off via quality.nextTier.
   qc: ControllerState;
+  // Spec 2025 FR-005: true when ADAPTATION detached this leg's video track at tier 'off'
+  // (a real pause — the old 1 bps cap kept the encoder "bandwidth limited" forever and
+  // video never came back). Only adaptation re-attaches what it detached, so this never
+  // fights hold/resume or the camera toggle, which manage tracks through their own paths.
+  videoSuspended: boolean;
   // Per-receiver connection health (spec 0007 US2).
   health: LegHealth;
 }
@@ -527,6 +532,25 @@ export class MeshSession {
   private async setLegTier(leg: PeerLeg, retry = true): Promise<void> {
     const sender = this.videoSenderOf(leg);
     if (!sender) return;
+    // Tier 'off' is a REAL pause for this leg (spec 2025 FR-005): detach the track so
+    // nothing is encoded — the old 1 bps cap left a zombie encode whose own "bandwidth
+    // limited" reading kept the leg congested forever. Held legs are left alone: hold
+    // owns the detached state (and adaptation is suspended while WE are held).
+    if (leg.qc.tier === 'off') {
+      if (!leg.videoSuspended && sender.track && !this.paused && !this.heldPeers.has(leg.peerId)) {
+        leg.videoSuspended = true;
+        await sender.replaceTrack(null).catch(() => {});
+      }
+      return;
+    }
+    // Leaving the floor: re-attach ONLY what adaptation itself detached.
+    if (leg.videoSuspended) {
+      leg.videoSuspended = false;
+      const v = this.local?.getVideoTracks()[0];
+      if (v && v.readyState === 'live' && !this.paused && !this.heldPeers.has(leg.peerId)) {
+        await sender.replaceTrack(v).catch(() => {});
+      }
+    }
     // iOS/WebKit: tier by BITRATE ONLY (`avoidEncoderScaling`) — never scaleResolutionDownBy/
     // maxFramerate, which stall the old iPhone H.264 encoder (spec 0005). maxBitrate alone is honored
     // and safe, so per-receiver + manual quality caps (spec 0007) still apply on iOS. Non-iOS gets the
@@ -596,7 +620,12 @@ export class MeshSession {
     h.inPrevDrop = drop;
     h.inPrevFrames = frames;
     const fractionLost = dRecv + dLost > 0 ? dLost / (dRecv + dLost) : 0;
-    h.downlink = downlinkClassFrom({ fractionLost, framesDropped: dDrop, framesReceived: dFrames }, h.downlink);
+    // packets: the window's evidence size — a near-empty interval must not move the class
+    // (spec 2025 FR-006; 1 lost of 3 packets reads as 33% "loss").
+    h.downlink = downlinkClassFrom(
+      { fractionLost, framesDropped: dDrop, framesReceived: dFrames, packets: dRecv + dLost },
+      h.downlink,
+    );
     // requestedTier = downlink ∧ manual clamp ∧ tile target — sent (if changed/cadence) by pushLegHealth.
     this.pushLegHealth(leg, now);
   }
@@ -765,7 +794,8 @@ export class MeshSession {
       pendingLocalIce: [],
       negotiated: false,
       offerAttempts: 0,
-      qc: initialController(), // starts sending low; the controller climbs from there
+      qc: initialController(), // mesh legs start medium (N parallel encoders); the controller climbs
+      videoSuspended: false, // spec 2025 FR-005
       health: freshLegHealth(), // spec 0007 US2
     };
     this.legs.set(peerId, leg);
@@ -915,6 +945,7 @@ export class MeshSession {
       if (aSender) await aSender.replaceTrack(a).catch(() => {});
       const vSender = this.senderOfKind(leg, 'video');
       if (vSender && v) await vSender.replaceTrack(v).catch(() => {});
+      leg.videoSuspended = false; // resume re-attached video; adaptation re-pauses if still needed
       void this.send('call-ice', leg.peerId, { callId: this.roomId, type: 'resume', roomId: this.roomId });
     }
     this.startDiag();
@@ -944,6 +975,7 @@ export class MeshSession {
     if (aSender) await aSender.replaceTrack(a).catch(() => {});
     const vSender = this.senderOfKind(leg, 'video');
     if (vSender && v) await vSender.replaceTrack(v).catch(() => {});
+    leg.videoSuspended = false; // their resume re-attached our video; adaptation re-pauses if needed
     this.heldPeers.delete(from);
     this.cb.onHeldPeers?.([...this.heldPeers]);
   }

--- a/src/services/call/quality.test.ts
+++ b/src/services/call/quality.test.ts
@@ -15,9 +15,9 @@ import {
 } from './quality';
 
 // A healthy sample with plenty of headroom.
-const healthy: StatsSnapshot = { qualityLimited: false, availableOutgoingBitrate: 5_000_000, fractionLost: 0 };
+const healthy: StatsSnapshot = { limitedBy: null, availableOutgoingBitrate: 5_000_000, fractionLost: 0 };
 // Healthy on a browser that doesn't report bitrate/limitation (Safari-style).
-const healthyNoBw: StatsSnapshot = { qualityLimited: false, fractionLost: 0 };
+const healthyNoBw: StatsSnapshot = { limitedBy: null, fractionLost: 0 };
 
 function run(start: ControllerState, snap: StatsSnapshot, clamp: Tier = 'hd', n = 1): ControllerState {
   let s = start;
@@ -55,13 +55,13 @@ describe('nextTier (adaptive quality controller) — spec 0007', () => {
 
   it('does NOT back off on a single mild-congestion sample (no flap)', () => {
     // Regression fix: one noisy bad sample used to drop a tier. Mild congestion must be SUSTAINED.
-    const lossy: StatsSnapshot = { qualityLimited: false, availableOutgoingBitrate: 5_000_000, fractionLost: 0.1 };
+    const lossy: StatsSnapshot = { limitedBy: null, availableOutgoingBitrate: 5_000_000, fractionLost: 0.1 };
     const s = nextTier({ tier: 'high', healthyStreak: 0, unhealthyStreak: 0 }, lossy, 'hd');
     expect(s.tier).toBe('high'); // held after one mild sample
   });
 
   it('backs off after SUSTAINED mild congestion (two consecutive bad samples)', () => {
-    const lossy: StatsSnapshot = { qualityLimited: false, availableOutgoingBitrate: 5_000_000, fractionLost: 0.1 };
+    const lossy: StatsSnapshot = { limitedBy: null, availableOutgoingBitrate: 5_000_000, fractionLost: 0.1 };
     let s: ControllerState = { tier: 'high', healthyStreak: 0, unhealthyStreak: 0 };
     s = nextTier(s, lossy, 'hd'); // 1st bad — hold
     s = nextTier(s, lossy, 'hd'); // 2nd bad — back off
@@ -69,13 +69,13 @@ describe('nextTier (adaptive quality controller) — spec 0007', () => {
   });
 
   it('backs off IMMEDIATELY on a severe loss spike (no waiting for sustained)', () => {
-    const severe: StatsSnapshot = { qualityLimited: false, availableOutgoingBitrate: 5_000_000, fractionLost: 0.3 };
+    const severe: StatsSnapshot = { limitedBy: null, availableOutgoingBitrate: 5_000_000, fractionLost: 0.3 };
     const s = nextTier({ tier: 'high', healthyStreak: 0, unhealthyStreak: 0 }, severe, 'hd');
     expect(s.tier).toBe('medium');
   });
 
-  it('backs off after sustained CPU/bandwidth limitation (mesh: N parallel encoders)', () => {
-    const limited: StatsSnapshot = { qualityLimited: true, availableOutgoingBitrate: 5_000_000, fractionLost: 0 };
+  it('backs off after sustained CPU limitation (mesh: N parallel encoders)', () => {
+    const limited: StatsSnapshot = { limitedBy: 'cpu', availableOutgoingBitrate: 5_000_000, fractionLost: 0 };
     let s: ControllerState = { tier: 'high', healthyStreak: 0, unhealthyStreak: 0 };
     s = nextTier(s, limited, 'hd');
     s = nextTier(s, limited, 'hd');
@@ -83,7 +83,7 @@ describe('nextTier (adaptive quality controller) — spec 0007', () => {
   });
 
   it('reaches the floor (off → suspend video) under severe congestion, protecting audio', () => {
-    const dead: StatsSnapshot = { qualityLimited: true, fractionLost: 0.5 };
+    const dead: StatsSnapshot = { limitedBy: 'bandwidth', fractionLost: 0.5 };
     const s = nextTier({ tier: 'low', healthyStreak: 0, unhealthyStreak: 0 }, dead, 'hd');
     expect(s.tier).toBe('off');
   });
@@ -95,7 +95,7 @@ describe('nextTier (adaptive quality controller) — spec 0007', () => {
   });
 
   it('lets congestion drop BELOW the clamp to keep the call alive', () => {
-    const severe: StatsSnapshot = { qualityLimited: true, fractionLost: 0.3 };
+    const severe: StatsSnapshot = { limitedBy: 'cpu', fractionLost: 0.3 };
     const s = nextTier({ tier: 'medium', healthyStreak: 0, unhealthyStreak: 0 }, severe, 'high');
     expect(s.tier).toBe('low');
   });
@@ -128,7 +128,7 @@ describe('nextTier with a peer-requested ceiling (spec 0007 US2)', () => {
 
   it('still backs off BELOW the requested ceiling to keep the call alive', () => {
     // A requested ceiling is an UPPER bound, not a floor: severe congestion still drops below it.
-    const severe: StatsSnapshot = { qualityLimited: true, fractionLost: 0.3 };
+    const severe: StatsSnapshot = { limitedBy: 'cpu', fractionLost: 0.3 };
     const s2 = nextTier({ tier: 'high', healthyStreak: 0, unhealthyStreak: 0 }, severe, 'hd', 'high');
     expect(s2.tier).toBe('medium');
   });
@@ -147,7 +147,7 @@ describe('downlinkClassFrom (receiver self-assessed downlink, spec 0007 US2)', (
   });
 
   it('steps the class DOWN under sustained loss (one step per sample = hysteresis)', () => {
-    const lossy = { fractionLost: 0.25 }; // target low
+    const lossy = { fractionLost: 0.3 }; // target low (spec 2025: low needs > 0.25)
     let c: Tier = 'hd';
     c = downlinkClassFrom(lossy, c); // hd → high
     expect(c).toBe('high');
@@ -158,8 +158,99 @@ describe('downlinkClassFrom (receiver self-assessed downlink, spec 0007 US2)', (
   });
 
   it('trims an extra step when many frames are dropped (render/decode behind)', () => {
-    // 3% loss alone → high; heavy frame drops pull it to medium.
-    expect(downlinkClassFrom({ fractionLost: 0.04, framesReceived: 50, framesDropped: 50 }, 'medium')).toBe('medium');
+    // ~6% loss alone → high; heavy frame drops (50%) pull it one more step to medium.
+    expect(downlinkClassFrom({ fractionLost: 0.06, framesReceived: 50, framesDropped: 50 }, 'medium')).toBe('medium');
+  });
+});
+
+describe('quality regressions (spec 2025): truthful congestion, recoverable floor, de-noised downlink', () => {
+  // The encoder saying "bandwidth limited" while LOSS IS ZERO and the send estimate is
+  // healthy is the signature of our OWN maxBitrate cap (or a post-reconfigure blip) — the
+  // old controller counted it as congestion and rode the ladder down (the reported
+  // sharp→blocky pumping). It must hold, and keep climbing.
+  it('uncorroborated bandwidth limitation is NOT congestion: holds at hd', () => {
+    const capLimited: StatsSnapshot = { limitedBy: 'bandwidth', availableOutgoingBitrate: 5_000_000, fractionLost: 0 };
+    let s: ControllerState = { tier: 'hd', healthyStreak: 0, unhealthyStreak: 0 };
+    for (let i = 0; i < 10; i++) s = nextTier(s, capLimited, 'hd');
+    expect(s.tier).toBe('hd'); // never stepped down by its own cap
+  });
+
+  it('uncorroborated bandwidth limitation still CLIMBS toward the clamp', () => {
+    const capLimited: StatsSnapshot = { limitedBy: 'bandwidth', availableOutgoingBitrate: 5_000_000, fractionLost: 0 };
+    let s = initialController(); // medium
+    for (let i = 0; i < 6; i++) s = nextTier(s, capLimited, 'hd');
+    expect(s.tier).toBe('hd');
+  });
+
+  it('bandwidth limitation CORROBORATED by receiver loss is congestion (sustained back-off kept)', () => {
+    const genuine: StatsSnapshot = { limitedBy: 'bandwidth', availableOutgoingBitrate: 5_000_000, fractionLost: 0.03 };
+    let s: ControllerState = { tier: 'hd', healthyStreak: 0, unhealthyStreak: 0 };
+    s = nextTier(s, genuine, 'hd'); // 1st — hold (no flap)
+    expect(s.tier).toBe('hd');
+    s = nextTier(s, genuine, 'hd'); // 2nd — back off
+    expect(s.tier).toBe('high');
+  });
+
+  it('bandwidth limitation corroborated by a collapsed send estimate is congestion', () => {
+    // hd wants 4 Mbps; a 1 Mbps estimate is well under the margin → genuine pressure.
+    const collapsed: StatsSnapshot = { limitedBy: 'bandwidth', availableOutgoingBitrate: 1_000_000, fractionLost: 0 };
+    let s: ControllerState = { tier: 'hd', healthyStreak: 0, unhealthyStreak: 0 };
+    s = nextTier(s, collapsed, 'hd');
+    s = nextTier(s, collapsed, 'hd');
+    expect(s.tier).toBe('high');
+  });
+
+  // The floor trap: `off` used to strangle the encoder to 1 bps (still "sending"), which
+  // itself kept the bandwidth-limited reading on → congested forever → video never came
+  // back. With `off` as a REAL pause the sender emits nothing, samples read healthy, and
+  // the ladder must climb back out.
+  it('recovers from the floor: healthy samples climb off → low (video comes back)', () => {
+    let s: ControllerState = { tier: 'off', healthyStreak: 0, unhealthyStreak: 0 };
+    s = nextTier(s, healthyNoBw, 'hd');
+    s = nextTier(s, healthyNoBw, 'hd');
+    expect(s.tier).toBe('low');
+  });
+
+  it('a paused sender that still reads bandwidth-limited with zero loss must ALSO escape the floor', () => {
+    // Belt-and-braces for browsers that keep reporting the stale limitation reason on a
+    // track-less sender: uncorroborated bandwidth limitation is not congestion, so the
+    // climb happens regardless.
+    const stale: StatsSnapshot = { limitedBy: 'bandwidth', fractionLost: 0 };
+    let s: ControllerState = { tier: 'off', healthyStreak: 0, unhealthyStreak: 0 };
+    for (let i = 0; i < 4; i++) s = nextTier(s, stale, 'hd');
+    expect(s.tier).not.toBe('off');
+  });
+
+  it('the 1:1 entry point starts high (sharp within one climb of the top); default stays medium', () => {
+    expect(initialController('high').tier).toBe('high');
+    expect(initialController().tier).toBe('medium'); // mesh legs keep the N-encoders start
+  });
+
+  it('the top tier is worth a good link: hd carries at least 4 Mbps', () => {
+    expect(tierEncoding('hd', false).maxBitrate).toBeGreaterThanOrEqual(4_000_000);
+    expect(tierEncoding('hd', true).maxBitrate).toBeGreaterThanOrEqual(4_000_000); // iOS too
+  });
+
+  // Downlink classifier de-noising (FR-006): a statistically meaningless window must not
+  // move the class, and the dropped-frame trim needs real starvation, not UI jitter.
+  it('keeps the previous class when the window has too few packets to mean anything', () => {
+    // 1 lost of 3 packets is 33% "loss" — but 3 packets is noise, not evidence.
+    expect(downlinkClassFrom({ fractionLost: 0.33, packets: 3 }, 'hd')).toBe('hd');
+    // The same ratio over a real window IS evidence and steps down.
+    expect(downlinkClassFrom({ fractionLost: 0.33, packets: 200 }, 'hd')).toBe('high');
+  });
+
+  it('ignores a moderate dropped-frame ratio (UI jitter) but trims on real starvation', () => {
+    // 15% dropped with zero loss: no trim (was trimming at >10%).
+    expect(downlinkClassFrom({ fractionLost: 0, framesReceived: 85, framesDropped: 15, packets: 500 }, 'hd')).toBe('hd');
+    // 40% dropped: genuine starvation → one-step trim below the loss target.
+    expect(downlinkClassFrom({ fractionLost: 0, framesReceived: 60, framesDropped: 40, packets: 500 }, 'hd')).toBe('high');
+  });
+
+  it('a small isolated loss blip no longer caps the sender below the top tier', () => {
+    // 3% in one window used to map below hd; the relaxed thresholds keep hd (> 0.05 → high).
+    expect(downlinkClassFrom({ fractionLost: 0.03, packets: 500 }, 'hd')).toBe('hd');
+    expect(downlinkClassFrom({ fractionLost: 0.06, packets: 500 }, 'hd')).toBe('high');
   });
 });
 

--- a/src/services/call/quality.ts
+++ b/src/services/call/quality.ts
@@ -26,14 +26,17 @@ export interface TierEncoding {
   maxFramerate?: number;
 }
 
-// Concrete sender encodings per tier. `off` is handled by suspending the track, not by
-// these numbers, but is kept here for completeness.
+// Concrete sender encodings per tier. `off` is handled by REALLY suspending the track
+// (spec 2025: the consumers replaceTrack(null) — never these numbers; a 1 bps cap kept
+// the encoder "bandwidth limited" forever and video could never come back). The entry
+// is kept only so the table stays total; hd carries 4 Mbps so a good link is actually
+// sharp (spec 2025 FR-002 — the old 2.5 Mbps read as a visible step below native apps).
 export const TIER_ENCODING: Record<Tier, TierEncoding> = {
   off: { maxBitrate: 1, scaleResolutionDownBy: 4, maxFramerate: 1 },
   low: { maxBitrate: 150_000, scaleResolutionDownBy: 4, maxFramerate: 15 },
   medium: { maxBitrate: 500_000, scaleResolutionDownBy: 2, maxFramerate: 24 },
   high: { maxBitrate: 1_200_000, scaleResolutionDownBy: 1, maxFramerate: 30 },
-  hd: { maxBitrate: 2_500_000, scaleResolutionDownBy: 1, maxFramerate: 30 },
+  hd: { maxBitrate: 4_000_000, scaleResolutionDownBy: 1, maxFramerate: 30 },
 };
 
 /** The encoding to actually push to a sender for a tier. On WebKit/iOS (`avoidEncoderScaling`)
@@ -54,7 +57,7 @@ const TIER_TARGET: Record<Tier, number> = {
   low: 150_000,
   medium: 500_000,
   high: 1_200_000,
-  hd: 2_500_000,
+  hd: 4_000_000,
 };
 
 // Spec 0007: converge fast but stay stable. Climb one step after a SHORT healthy streak (≈ a
@@ -68,15 +71,24 @@ const LOSS_SEVERE = 0.15; // a big loss spike → back off immediately, don't wa
 // Only back off on the bandwidth estimate when it's WELL below what the current tier wants
 // (a margin), since each mesh leg estimates bandwidth independently and the numbers are noisy.
 const BW_BACKOFF_MARGIN = 0.7;
+// Spec 2025 (FR-004): a "bandwidth limited" encoder reading is CONFOUNDED — our own
+// maxBitrate cap produces it on a perfectly healthy link (the encoder is degraded
+// relative to the source *because we asked it to be*). It only counts as congestion when
+// an INDEPENDENT signal corroborates it: receiver-reported loss above this (deliberately
+// below LOSS_HIGH — the limitation reading plus even mild real loss is meaningful), or
+// the send estimate collapsing under the current tier (the BW_BACKOFF_MARGIN path).
+const LOSS_CORROBORATE = 0.02;
 
 /** A single getStats sample, reduced to the signals the controller needs. Fields are
  *  optional because Safari/WebKit doesn't expose them all (the controller degrades to the
  *  cross-browser receiver-loss/RTT signal when bitrate/limitation info is missing). */
 export interface StatsSnapshot {
-  // The browser is limited by bandwidth OR cpu (qualityLimitationReason). CPU matters a lot in
-  // a mesh: each peer is a separate encoder, so N peers = N parallel encodes — a phone/iPad
-  // saturates and silently degrades unless we back off, which is why we treat cpu as congestion.
-  qualityLimited: boolean;
+  // What qualityLimitationReason says is degrading the encode, if anything. CPU matters a
+  // lot in a mesh: each peer is a separate encoder, so N peers = N parallel encodes — a
+  // phone/iPad saturates and silently degrades unless we back off, so cpu is always
+  // congestion (sustained). 'bandwidth' is only congestion when corroborated (spec 2025):
+  // it is routinely self-inflicted by the tier's own maxBitrate cap.
+  limitedBy: 'bandwidth' | 'cpu' | null;
   availableOutgoingBitrate?: number; // candidate-pair (often absent on Safari; noisy in a mesh)
   fractionLost: number; // remote-inbound-rtp.fractionLost, 0..1 (the receiver's downlink view)
   rtt?: number; // remote-inbound-rtp.roundTripTime, seconds
@@ -88,11 +100,13 @@ export interface ControllerState {
   unhealthyStreak: number; // consecutive congested samples (sustained-congestion back-off, spec 0007)
 }
 
-/** Initial state: start at a sensible MID tier (spec 0007) so a good picture appears fast, then
- *  climb to the ceiling on sustained health (or back off if the link can't sustain it) — instead
- *  of starting at the bottom and crawling up, which left calls looking low for many seconds. */
-export function initialController(): ControllerState {
-  return { tier: 'medium', healthyStreak: 0, unhealthyStreak: 0 };
+/** Initial state. The default MID start (spec 0007) makes a good picture appear fast and
+ *  climbs from there — right for mesh legs, where every peer is another parallel encoder.
+ *  The 1:1 path starts a step higher (spec 2025 FR-001): a single encode is cheap, the
+ *  first sample lands within ~2s to correct a genuinely bad link, and starting sharp is
+ *  the whole point of the regression fix. */
+export function initialController(start: Tier = 'medium'): ControllerState {
+  return { tier: start, healthyStreak: 0, unhealthyStreak: 0 };
 }
 
 const idxOf = (t: Tier): number => TIERS.indexOf(t);
@@ -144,13 +158,18 @@ export function nextTier(
   // survival beats any pin/clamp).
   if (snap.fractionLost > LOSS_SEVERE) return down();
 
-  // Mild congestion (browser bandwidth/cpu limitation, >5% loss, or the send estimate collapsing
-  // well below the current tier) must be SUSTAINED before we drop a tier — one noisy sample must
-  // not cause a flap.
+  // Mild congestion must be SUSTAINED before we drop a tier — one noisy sample must not
+  // cause a flap. Signals: cpu limitation (always real — never caused by our own cap),
+  // bandwidth limitation only when corroborated by receiver loss (spec 2025 FR-004 — the
+  // uncorroborated reading is the signature of our own maxBitrate cap and used to ride
+  // the ladder down on perfectly healthy links), >5% loss on its own, or the send
+  // estimate collapsing well below the current tier.
+  const bwCollapsed = knownBw && (snap.availableOutgoingBitrate as number) < TIER_TARGET[state.tier] * BW_BACKOFF_MARGIN;
   const congested =
-    snap.qualityLimited ||
+    snap.limitedBy === 'cpu' ||
+    (snap.limitedBy === 'bandwidth' && snap.fractionLost > LOSS_CORROBORATE) ||
     snap.fractionLost > LOSS_HIGH ||
-    (knownBw && (snap.availableOutgoingBitrate as number) < TIER_TARGET[state.tier] * BW_BACKOFF_MARGIN);
+    bwCollapsed;
   if (congested) {
     const unhealthy = state.unhealthyStreak + 1;
     if (unhealthy >= CONGEST_AFTER) return down();
@@ -179,18 +198,19 @@ export function nextTier(
  *  expose them all) are left undefined; nextTier copes. Shared by the mesh (per-leg) and the
  *  1:1 path. */
 export function snapshotFromReport(report: RTCStatsReport): StatsSnapshot {
-  let qualityLimited = false;
+  let limitedBy: 'bandwidth' | 'cpu' | null = null;
   let availableOutgoingBitrate: number | undefined;
   let fractionLost = 0;
   let rtt: number | undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   report.forEach((st: any) => {
     if (st.type === 'outbound-rtp' && st.kind === 'video') {
-      // bandwidth OR cpu: in a mesh, N peers = N parallel encoders, so cpu limitation is common
-      // on phones/tablets and must trigger a back-off just like bandwidth does.
-      if (st.qualityLimitationReason === 'bandwidth' || st.qualityLimitationReason === 'cpu') {
-        qualityLimited = true;
-      }
+      // Keep WHICH reason (spec 2025): cpu is always congestion (in a mesh, N peers = N
+      // parallel encoders and phones saturate); bandwidth needs corroboration in nextTier
+      // because our own maxBitrate cap produces it on healthy links. cpu wins if both
+      // ssrcs somehow disagree — it's the stronger (never self-inflicted) signal.
+      if (st.qualityLimitationReason === 'cpu') limitedBy = 'cpu';
+      else if (st.qualityLimitationReason === 'bandwidth' && limitedBy == null) limitedBy = 'bandwidth';
     } else if (st.type === 'candidate-pair' && typeof st.availableOutgoingBitrate === 'number') {
       if (st.nominated || st.selected || availableOutgoingBitrate == null) {
         availableOutgoingBitrate = st.availableOutgoingBitrate;
@@ -200,7 +220,7 @@ export function snapshotFromReport(report: RTCStatsReport): StatsSnapshot {
       if (typeof st.roundTripTime === 'number') rtt = st.roundTripTime;
     }
   });
-  return { qualityLimited, availableOutgoingBitrate, fractionLost, rtt };
+  return { limitedBy, availableOutgoingBitrate, fractionLost, rtt };
 }
 
 /** Map the manual pin ('auto'|'medium'|'low') + data-saver to the controller's clamp tier.
@@ -230,17 +250,28 @@ export interface InboundSnapshot {
   fractionLost: number; // 0..1, this peer's inbound video loss
   framesDropped?: number; // frames dropped in the interval (decode/render couldn't keep up)
   framesReceived?: number; // frames received in the interval (denominator for the drop ratio)
+  // Packets observed in the interval (received + lost). A couple of packets make the loss
+  // ratio pure noise (1 lost of 3 reads as 33%!) — below MIN_WINDOW_PACKETS the class is
+  // held (spec 2025 FR-006). Optional so senders that can't count packets still classify.
+  packets?: number;
 }
+// Fewer packets than this in a window is statistically meaningless — hold the class.
+const MIN_WINDOW_PACKETS = 50;
 export function downlinkClassFrom(snap: InboundSnapshot, prev: Tier = 'hd'): Tier {
+  // Too little evidence to say anything (a near-idle window right after connect, or an
+  // audio-mostly interval) — don't let a 1-in-3 "loss ratio" walk the class down.
+  if (snap.packets != null && snap.packets < MIN_WINDOW_PACKETS) return prev;
   let target: Tier;
-  if (snap.fractionLost > 0.2) target = 'low';
-  else if (snap.fractionLost > 0.1) target = 'medium';
-  else if (snap.fractionLost > 0.03) target = 'high';
+  if (snap.fractionLost > 0.25) target = 'low';
+  else if (snap.fractionLost > 0.12) target = 'medium';
+  else if (snap.fractionLost > 0.05) target = 'high';
   else target = 'hd';
-  // A high dropped-frame ratio (render/decode can't keep up) trims one more step.
+  // A heavy dropped-frame ratio (render/decode genuinely starving) trims one more step.
+  // The bar is deliberately high (spec 2025): phones drop 10–20% of frames during plain
+  // UI animation, and that noise used to cap the SENDER a tier below what the link takes.
   const recv = snap.framesReceived ?? 0;
   const dropped = snap.framesDropped ?? 0;
-  if (recv > 0 && dropped / (recv + dropped) > 0.1) target = TIERS[Math.max(1, idxOf(target) - 1)];
+  if (recv > 0 && dropped / (recv + dropped) > 0.25) target = TIERS[Math.max(1, idxOf(target) - 1)];
   return stepToward(prev, target);
 }
 

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -221,6 +221,7 @@ import {
   callStats,
   videoTransceiverCount,
   inboundVideoFrames,
+  oneToOneQualityDiag,
   acceptAndHold,
   swapCalls,
   endActive,
@@ -1552,6 +1553,10 @@ export function installTestHook(): void {
     /** Call introspection for assertions. */
     callState: () => callState.value,
     callMeta: () => callMeta.value,
+    /** 1:1 adaptive quality: current tier / floor-pause / peer ceiling (spec 2025). */
+    callQuality: () => oneToOneQualityDiag(),
+    /** The local camera track's actual settings (capture resolution assertions, spec 2025). */
+    localVideoSettings: () => localStream.value?.getVideoTracks()[0]?.getSettings() ?? null,
     stats: () => callStats.value,
     remoteTracks: () =>
       (remoteStream.value?.getTracks().length ?? 0) +


### PR DESCRIPTION
## What this delivers

**Spec 1039 — simultaneous mutual calls connect** (`feat(calls)`): two contacts calling each other at (nearly) the same time now land in ONE connected call automatically — no manual accept, no more both sides stranded on "Calling…" (the crossing offer used to bypass glare handling during the outgoing call's setup window and corrupt the slot). Deterministic tie-break, silent auto-accept reusing the already-captured stream (WebKit bug 179363), mismatched kinds ring instead of auto-enabling a camera (Principle IX), third-party offers during setup get busy/call-waiting, late redeliveries (spec 2012 retention) are dropped.

**Spec 2025 — video quality hotfix** (`fix(calls)`): the adaptive controller no longer treats its own bitrate cap as congestion (bandwidth limitation needs corroborating loss or a collapsed send estimate), tier `off` genuinely pauses the sender and recovers automatically instead of being a permanent 1-bps trap, 1:1 starts at `high` with a 4 Mbps top tier, capture requests 1280×720 on non-iOS (Chromium defaulted to 640×480), adaptation runs on the designed ~2s cadence, and receiver downlink reports ignore statistically meaningless windows. Verified on the live stack: 720p capture, `hd` at +4.0s, zero down-steps over 20s, 8.1s pin-release recovery.

**Spec 1038 polish** (`fix(games)`): the back-to-the-game pill collapses to its circular glyph after ~2.5s so it stops covering chat content; re-expands on new your-move.

## Verification

- 914 vitest unit tests green (incl. red-first regression tests for the glare decision table and the quality controller trap/corroboration rules — constitution III hotfix requirement)
- New two-browser e2e `mutual-call.spec.ts` (6 scenarios) green
- Call-surface e2e green: busy, call-waiting (+slot), calls, connect, hidden-call, history, cues, connect-speed, churn, summary, adaptive, quality, games-armada
- `npm run build` (vue-tsc + vite) green; on-device verification on ring-dev by the owner

## Zero-knowledge

No wire change anywhere: resolution reuses the existing sealed offer/answer/cancel frames; the `qos` report keeps its exact shape; all tuning is device-local. Both specs carry Zero-Knowledge Impact sections.

Closes #935
Closes #936
Closes #937
Closes #938
Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7