### PR TITLE
docs(spec): specs 1039 + 2025 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,7 +64,7 @@ Specs are grouped by category band; status moves
 | [1036](specs/1036-wall-game-follows/spec.md) | Followers Get the Result Push; Group Chats Retire Games | 🟢 shipped |
 | [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 | [1038](specs/1038-armada-fullscreen-naval/spec.md) | Armada — Fullscreen Naval Duel Replaces Battleship | 🔵 in-review |
-| [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🔵 in-review |
+| [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -94,4 +94,4 @@ Specs are grouped by category band; status moves
 | [2022](specs/2022-push-failures-name/spec.md) | Bug: Push failures hide their reason, and dead subscriptions are retried forever | 🟢 shipped |
 | [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟢 shipped |
 | [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |
-| [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🔵 in-review |
+| [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |

--- a/specs/1039-simultaneous-mutual-calls/spec.md
+++ b/specs/1039-simultaneous-mutual-calls/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-11
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2025-video-calls-look/spec.md
+++ b/specs/2025-video-calls-look/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-11
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Lifecycle bookkeeping after #940 merged: both specs move to shipped and ROADMAP.md is regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7