### PR TITLE
feat(notifications): calls show who is calling, missed calls are never lost, and friend request updates tell the truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1039-simultaneous-mutual-calls/plan.md`
+`specs/1040-incoming-call-notifications/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,6 +65,7 @@ Specs are grouped by category band; status moves
 | [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 | [1038](specs/1038-armada-fullscreen-naval/spec.md) | Armada — Fullscreen Naval Duel Replaces Battleship | 🔵 in-review |
 | [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟢 shipped |
+| [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call Notifications — Caller Identity, Badge, and Missed-Call Trace | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,7 @@ Specs are grouped by category band; status moves
 | [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 | [1038](specs/1038-armada-fullscreen-naval/spec.md) | Armada — Fullscreen Naval Duel Replaces Battleship | 🔵 in-review |
 | [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟢 shipped |
-| [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call Notifications — Caller Identity, Badge, and Missed-Call Trace | ⚪ planned |
+| [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,7 @@ Specs are grouped by category band; status moves
 | [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 | [1038](specs/1038-armada-fullscreen-naval/spec.md) | Armada — Fullscreen Naval Duel Replaces Battleship | 🔵 in-review |
 | [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟢 shipped |
-| [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | ⚪ planned |
+| [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,7 @@ Specs are grouped by category band; status moves
 | [1037](specs/1037-zombie-push-subscriptions/spec.md) | Zombie Push Subscriptions Rotate Themselves | 🟢 shipped |
 | [1038](specs/1038-armada-fullscreen-naval/spec.md) | Armada — Fullscreen Naval Duel Replaces Battleship | 🔵 in-review |
 | [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟢 shipped |
-| [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟡 in-progress |
+| [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/missed-call-trace.spec.ts
+++ b/e2e/missed-call-trace.spec.ts
@@ -32,22 +32,30 @@ test('a call attempted while the callee was unreachable leaves a missed trace on
 
   // A dials, gets no reachability sign, and gives up (cancel-before-answer —
   // the clarification says that still logs as a missed call for the callee).
+  // The fast hangup lands before the delayed ring marker fires, so teardown
+  // sends the ring+ended pair together — no timing luck involved.
   await startCall(a, b.id, 'audio');
   await waitCallState(a, ['dialing', 'remote-ringing']);
-  await a.page.waitForTimeout(1500); // let the dial-time ring marker reach the relay queue
+  await a.page.waitForTimeout(500);
   await hangup(a);
   await waitCallState(a, ['idle', 'ended']);
 
-  // B comes back: the queued markers drain and materialize the trace.
+  // B comes back: the queued markers drain and materialize the trace. One
+  // atomic poll reads chat + row + callLog together, so no transient between
+  // separate reads can misjudge it.
   await goOnline(b);
-  await waitCallLog(b, a.id, 15_000);
-
-  // The in-chat row is a MISSED call for B.
   const bChat = await chatWith(b, a.id);
-  const row = (await messages(b, bChat)).find((m) => m.kind === 'call') as
-    | { callLog?: { missed?: boolean } }
-    | undefined;
-  expect(row?.callLog?.missed, 'callee trace is a missed call').toBe(true);
+  await expect
+    .poll(
+      async () => {
+        const row = (await messages(b, bChat)).find((m) => m.kind === 'call') as
+          | { callLog?: { missed?: boolean } }
+          | undefined;
+        return row ? (row.callLog?.missed ?? 'row-without-calllog') : 'no-row';
+      },
+      { timeout: 15_000, message: 'callee trace is a missed call' },
+    )
+    .toBe(true);
 
   // ...and the Calls tab row exists, missed and unseen (feeds the badge until viewed).
   await expect

--- a/e2e/missed-call-trace.spec.ts
+++ b/e2e/missed-call-trace.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startCall, reject, hangup, accept,
+  waitCallState, waitCallLog, callLogCount, chatWith, messages,
+  goOffline, goOnline,
+} from './helpers';
+import type { RingClient } from './helpers';
+
+/**
+ * Spec 1040 US2: every missed call leaves a trace — even when the callee's app
+ * never witnessed the ring. The caller sends sealed callEvent markers (`ring` at
+ * dial, `ended` at outcome) over the messaging relay, so a callee who was
+ * offline/closed for the whole attempt still finds the missed-call entry in the
+ * 1:1 chat and the Calls tab on next open (FR-013/014/015), while a callee who
+ * handled the ring live never gets a duplicate (FR-018).
+ */
+
+const callRows = (
+  c: RingClient,
+): Promise<Array<{ id: string; contactId: string; missed: boolean; seen?: boolean; direction: string }>> =>
+  c.page.evaluate(() => (window as any).__ringTest.callRows());
+
+test('a call attempted while the callee was unreachable leaves a missed trace on reconnect', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'MISS1A');
+  const b = await createAccount(ctxB, 'MISS1B');
+  await pair(a, b);
+
+  // B drops off the network — the closed-app stand-in: the relay queues frames.
+  await goOffline(b);
+
+  // A dials, gets no reachability sign, and gives up (cancel-before-answer —
+  // the clarification says that still logs as a missed call for the callee).
+  await startCall(a, b.id, 'audio');
+  await waitCallState(a, ['dialing', 'remote-ringing']);
+  await a.page.waitForTimeout(1500); // let the dial-time ring marker reach the relay queue
+  await hangup(a);
+  await waitCallState(a, ['idle', 'ended']);
+
+  // B comes back: the queued markers drain and materialize the trace.
+  await goOnline(b);
+  await waitCallLog(b, a.id, 15_000);
+
+  // The in-chat row is a MISSED call for B.
+  const bChat = await chatWith(b, a.id);
+  const row = (await messages(b, bChat)).find((m) => m.kind === 'call') as
+    | { callLog?: { missed?: boolean } }
+    | undefined;
+  expect(row?.callLog?.missed, 'callee trace is a missed call').toBe(true);
+
+  // ...and the Calls tab row exists, missed and unseen (feeds the badge until viewed).
+  await expect
+    .poll(async () => (await callRows(b)).filter((c) => c.contactId === a.id && c.missed && c.seen === false).length, {
+      timeout: 10_000,
+    })
+    .toBe(1);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('a ring the callee declined live never gains a duplicate from the markers', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'MISS2A');
+  const b = await createAccount(ctxB, 'MISS2B');
+  await pair(a, b);
+
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await reject(b);
+  await waitCallState(a, ['idle', 'ended']);
+  await waitCallState(b, ['idle', 'ended']);
+
+  await waitCallLog(b, a.id);
+  // Give the outcome marker time to arrive and (correctly) do nothing.
+  await b.page.waitForTimeout(2500);
+  expect(await callLogCount(b, a.id), 'exactly one chat trace on the callee').toBe(1);
+  const rows = (await callRows(b)).filter((c) => c.contactId === a.id);
+  expect(rows.length, 'exactly one Calls-tab row on the callee').toBe(1);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+test('a call answered normally leaves no missed artifacts from the markers', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'MISS3A');
+  const b = await createAccount(ctxB, 'MISS3B');
+  await pair(a, b);
+
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+  await hangup(a);
+  await waitCallState(b, ['idle', 'ended']);
+
+  await waitCallLog(b, a.id);
+  await b.page.waitForTimeout(2500); // let the answered marker settle (it must clear, not log)
+  const rows = (await callRows(b)).filter((c) => c.contactId === a.id);
+  expect(rows.length, 'one row total').toBe(1);
+  expect(rows[0].missed, 'the answered call is not missed').toBe(false);
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/server/internal/api/connections_handlers.go
+++ b/server/internal/api/connections_handlers.go
@@ -198,7 +198,15 @@ func (h *Handlers) listConnections(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusInternalServerError, "could not list connections")
 		return
 	}
-	outgoing, err := h.Connections.OutgoingRequests(r.Context(), uid)
+	// Default outgoing = UNRESOLVED requests only (pending/rejected) — clients
+	// treat a request leaving this list as answered. `?include=accepted` (spec
+	// 1040) additionally returns rows accepted within 24h, for the service
+	// worker's "accepted your friend request" reconcile.
+	list := h.Connections.OutgoingRequests
+	if r.URL.Query().Get("include") == "accepted" {
+		list = h.Connections.OutgoingWithRecentAccepts
+	}
+	outgoing, err := list(r.Context(), uid)
 	if err != nil {
 		httpx.Error(w, http.StatusInternalServerError, "could not list connections")
 		return

--- a/server/internal/api/connections_handlers_test.go
+++ b/server/internal/api/connections_handlers_test.go
@@ -80,9 +80,21 @@ func (c *fakeConn) IncomingRequests(_ context.Context, _ string) ([]store.Connec
 	return nil, nil
 }
 func (c *fakeConn) OutgoingRequests(_ context.Context, _ string) ([]store.ConnectionReq, error) {
-	// Models the real store's contract (spec 1040): pending + rejected always,
-	// accepted only while fresh (updated within 24h) — the SW's accepted-note
-	// window. Tests inject rows via `outgoing`.
+	// The default list means UNRESOLVED: pending/rejected only (spec 1040 kept
+	// accepted rows out of it — clients treat leaving this list as "answered").
+	out := make([]store.ConnectionReq, 0, len(c.outgoing))
+	for _, r := range c.outgoing {
+		if r.State != "accepted" {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (c *fakeConn) OutgoingWithRecentAccepts(_ context.Context, _ string) ([]store.ConnectionReq, error) {
+	// Models the real store's ?include=accepted contract (spec 1040): pending +
+	// rejected + accepted-within-24h (the window is SQL-side; the fake returns
+	// everything injected via `outgoing`).
 	return c.outgoing, nil
 }
 
@@ -251,14 +263,14 @@ func registerLookup(t *testing.T, srv http.Handler, token string) string {
 	return me.UserID
 }
 
-// TestListConnectionsPassesAcceptedOutcomeThrough (spec 1040 US3): the outgoing
-// list carries accepted/rejected states verbatim to the requester — the service
-// worker's "accepted your friend request" note is built from exactly this
-// payload, and a handler-side filter would silently revive the "New friend
-// request" mis-copy bug. (The store-side recency window — accepted rows only
-// while updated within 24h — lives in the SQL and is covered by the e2e stack's
-// real database.)
-func TestListConnectionsPassesAcceptedOutcomeThrough(t *testing.T) {
+// TestListConnectionsAcceptedRowsAreOptIn (spec 1040 US3): the DEFAULT outgoing
+// list means "unresolved" — an answered (accepted) request must leave it, or
+// the friendship UI/tests break. With `?include=accepted` the handler serves
+// the recently-accepted rows the service worker's "accepted your friend
+// request" note is built from, states passed through verbatim. (The store-side
+// 24h recency window lives in the SQL and is covered by the e2e stack's real
+// database.)
+func TestListConnectionsAcceptedRowsAreOptIn(t *testing.T) {
 	conn := newFakeConn()
 	srv, _ := newConnTestServer(conn)
 	tok, uid, _ := registerNamed(t, srv, "alice")
@@ -269,30 +281,50 @@ func TestListConnectionsPassesAcceptedOutcomeThrough(t *testing.T) {
 		{Requester: uid, Target: "friend-3", State: "pending", UpdatedMs: 800},
 	}
 
+	states := func(rr interface{ Result() *http.Response }, raw string) map[string]string {
+		t.Helper()
+		var resp struct {
+			Outgoing []struct {
+				Target string `json:"target"`
+				State  string `json:"state"`
+			} `json:"outgoing"`
+		}
+		if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		got := map[string]string{}
+		for _, o := range resp.Outgoing {
+			got[o.Target] = o.State
+		}
+		return got
+	}
+
+	// Default: unresolved only — the accepted row is ABSENT.
 	rr := do(t, srv, http.MethodGet, "/v1/connections", tok, "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want 200; body=%s", rr.Code, rr.Body.String())
 	}
-	var resp struct {
-		Outgoing []struct {
-			Target string `json:"target"`
-			State  string `json:"state"`
-		} `json:"outgoing"`
+	got := states(rr, rr.Body.String())
+	if _, present := got["friend-1"]; present {
+		t.Errorf("default outgoing must NOT contain the accepted row, got %v", got)
 	}
-	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
+	if got["friend-2"] != "rejected" || got["friend-3"] != "pending" {
+		t.Errorf("default outgoing lost pending/rejected rows: %v", got)
 	}
-	got := map[string]string{}
-	for _, o := range resp.Outgoing {
-		got[o.Target] = o.State
+
+	// Opt-in: accepted rows pass through with their state intact.
+	rr = do(t, srv, http.MethodGet, "/v1/connections?include=accepted", tok, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list(include=accepted) status = %d, want 200; body=%s", rr.Code, rr.Body.String())
 	}
+	got = states(rr, rr.Body.String())
 	want := map[string]string{"friend-1": "accepted", "friend-2": "rejected", "friend-3": "pending"}
 	for target, state := range want {
 		if got[target] != state {
-			t.Errorf("outgoing[%s] state = %q, want %q (full: %v)", target, got[target], state, got)
+			t.Errorf("include=accepted outgoing[%s] state = %q, want %q (full: %v)", target, got[target], state, got)
 		}
 	}
-	if strings.Contains(rr.Body.String(), "friend-1") && got["friend-1"] != "accepted" {
-		t.Errorf("accepted row must pass through with its state intact")
+	if !strings.Contains(rr.Body.String(), "friend-1") {
+		t.Errorf("accepted row missing from include=accepted response")
 	}
 }

--- a/server/internal/api/connections_handlers_test.go
+++ b/server/internal/api/connections_handlers_test.go
@@ -48,6 +48,7 @@ func (f *fakeConnNotifier) wokeCount(userID string) int {
 type fakeConn struct {
 	withdrawn map[[2]string]bool // (requester,target) -> true
 	rejected  map[[2]string]bool // (requester,target) declined → suppressed (FR-007)
+	outgoing  []store.ConnectionReq // what OutgoingRequests returns (spec 1040)
 }
 
 func newFakeConn() *fakeConn {
@@ -79,7 +80,10 @@ func (c *fakeConn) IncomingRequests(_ context.Context, _ string) ([]store.Connec
 	return nil, nil
 }
 func (c *fakeConn) OutgoingRequests(_ context.Context, _ string) ([]store.ConnectionReq, error) {
-	return nil, nil
+	// Models the real store's contract (spec 1040): pending + rejected always,
+	// accepted only while fresh (updated within 24h) — the SW's accepted-note
+	// window. Tests inject rows via `outgoing`.
+	return c.outgoing, nil
 }
 
 // newConnTestServer builds the router with a real fake store (for register/auth)
@@ -245,4 +249,50 @@ func registerLookup(t *testing.T, srv http.Handler, token string) string {
 		t.Fatalf("decode me: %v", err)
 	}
 	return me.UserID
+}
+
+// TestListConnectionsPassesAcceptedOutcomeThrough (spec 1040 US3): the outgoing
+// list carries accepted/rejected states verbatim to the requester — the service
+// worker's "accepted your friend request" note is built from exactly this
+// payload, and a handler-side filter would silently revive the "New friend
+// request" mis-copy bug. (The store-side recency window — accepted rows only
+// while updated within 24h — lives in the SQL and is covered by the e2e stack's
+// real database.)
+func TestListConnectionsPassesAcceptedOutcomeThrough(t *testing.T) {
+	conn := newFakeConn()
+	srv, _ := newConnTestServer(conn)
+	tok, uid, _ := registerNamed(t, srv, "alice")
+
+	conn.outgoing = []store.ConnectionReq{
+		{Requester: uid, Target: "friend-1", State: "accepted", UpdatedMs: 1000},
+		{Requester: uid, Target: "friend-2", State: "rejected", UpdatedMs: 900},
+		{Requester: uid, Target: "friend-3", State: "pending", UpdatedMs: 800},
+	}
+
+	rr := do(t, srv, http.MethodGet, "/v1/connections", tok, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Outgoing []struct {
+			Target string `json:"target"`
+			State  string `json:"state"`
+		} `json:"outgoing"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := map[string]string{}
+	for _, o := range resp.Outgoing {
+		got[o.Target] = o.State
+	}
+	want := map[string]string{"friend-1": "accepted", "friend-2": "rejected", "friend-3": "pending"}
+	for target, state := range want {
+		if got[target] != state {
+			t.Errorf("outgoing[%s] state = %q, want %q (full: %v)", target, got[target], state, got)
+		}
+	}
+	if strings.Contains(rr.Body.String(), "friend-1") && got["friend-1"] != "accepted" {
+		t.Errorf("accepted row must pass through with its state intact")
+	}
 }

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -100,6 +100,9 @@ func (c *fakePostConn) IncomingRequests(context.Context, string) ([]store.Connec
 func (c *fakePostConn) OutgoingRequests(context.Context, string) ([]store.ConnectionReq, error) {
 	return nil, nil
 }
+func (c *fakePostConn) OutgoingWithRecentAccepts(context.Context, string) ([]store.ConnectionReq, error) {
+	return nil, nil
+}
 
 // fakePostStore is an in-memory PostStore for handler tests.
 type fakePostStore struct {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -51,6 +51,9 @@ type ConnectionStore interface {
 	WithdrawConnection(ctx context.Context, requester, target string) error
 	IncomingRequests(ctx context.Context, user string) ([]store.ConnectionReq, error)
 	OutgoingRequests(ctx context.Context, user string) ([]store.ConnectionReq, error)
+	// Spec 1040: OutgoingRequests + accepted rows updated within 24h, served only
+	// for GET /v1/connections?include=accepted (the SW's accepted-note reconcile).
+	OutgoingWithRecentAccepts(ctx context.Context, user string) ([]store.ConnectionReq, error)
 }
 
 // BlockStore is the per-user block-list persistence. *store.Store satisfies it.

--- a/server/internal/store/connections.go
+++ b/server/internal/store/connections.go
@@ -145,17 +145,29 @@ func (s *Store) IncomingRequests(ctx context.Context, user string) ([]Connection
 }
 
 // OutgoingRequests returns the requests user SENT that are still pending or were
-// rejected (so the UI can show "requested" / "rejected"), newest first — plus
-// RECENTLY accepted ones (spec 1040): the service worker's closed-app reconcile
-// builds its "accepted your friend request" notification from this list, and
-// without accepted rows that code path could never fire (acceptances showed the
-// misleading "New friend request" placeholder instead). The 24h window bounds
-// the response (accepted rows would otherwise accumulate forever) and sits
-// strictly inside the client's 48h shown-ledger TTL, so every acceptance is
-// announced exactly once and can never re-announce after its ledger entry
+// rejected (so the UI can show "requested" / "rejected"), newest first. This
+// set deliberately means "UNRESOLVED": the UI and the e2e suite treat a request
+// leaving this list as answered, so resolved-accepted rows never appear here —
+// they are served only on explicit request (OutgoingWithRecentAccepts below).
+func (s *Store) OutgoingRequests(ctx context.Context, user string) ([]ConnectionReq, error) {
+	return s.listRequests(ctx,
+		`SELECT requester::text, target::text, state, (extract(epoch from updated_at)*1000)::bigint
+		   FROM connections WHERE requester::text = $1 AND state IN ('pending','rejected')
+		   ORDER BY updated_at DESC`, user)
+}
+
+// OutgoingWithRecentAccepts is OutgoingRequests plus RECENTLY accepted rows
+// (spec 1040), served only when a client explicitly asks
+// (GET /v1/connections?include=accepted): the service worker's closed-app
+// reconcile builds its "accepted your friend request" notification from these,
+// and without accepted rows that code path could never fire (acceptances showed
+// the misleading "New friend request" placeholder instead). The 24h window
+// bounds the response (accepted rows would otherwise accumulate forever) and
+// sits strictly inside the client's 48h shown-ledger TTL, so every acceptance
+// is announced exactly once and can never re-announce after its ledger entry
 // expires. Nothing new is revealed: this echoes the requester's own request
 // state back to them.
-func (s *Store) OutgoingRequests(ctx context.Context, user string) ([]ConnectionReq, error) {
+func (s *Store) OutgoingWithRecentAccepts(ctx context.Context, user string) ([]ConnectionReq, error) {
 	return s.listRequests(ctx,
 		`SELECT requester::text, target::text, state, (extract(epoch from updated_at)*1000)::bigint
 		   FROM connections WHERE requester::text = $1

--- a/server/internal/store/connections.go
+++ b/server/internal/store/connections.go
@@ -145,11 +145,22 @@ func (s *Store) IncomingRequests(ctx context.Context, user string) ([]Connection
 }
 
 // OutgoingRequests returns the requests user SENT that are still pending or were
-// rejected (so the UI can show "requested" / "rejected"), newest first.
+// rejected (so the UI can show "requested" / "rejected"), newest first — plus
+// RECENTLY accepted ones (spec 1040): the service worker's closed-app reconcile
+// builds its "accepted your friend request" notification from this list, and
+// without accepted rows that code path could never fire (acceptances showed the
+// misleading "New friend request" placeholder instead). The 24h window bounds
+// the response (accepted rows would otherwise accumulate forever) and sits
+// strictly inside the client's 48h shown-ledger TTL, so every acceptance is
+// announced exactly once and can never re-announce after its ledger entry
+// expires. Nothing new is revealed: this echoes the requester's own request
+// state back to them.
 func (s *Store) OutgoingRequests(ctx context.Context, user string) ([]ConnectionReq, error) {
 	return s.listRequests(ctx,
 		`SELECT requester::text, target::text, state, (extract(epoch from updated_at)*1000)::bigint
-		   FROM connections WHERE requester::text = $1 AND state IN ('pending','rejected')
+		   FROM connections WHERE requester::text = $1
+		    AND ( state IN ('pending','rejected')
+		       OR (state = 'accepted' AND updated_at > now() - interval '24 hours') )
 		   ORDER BY updated_at DESC`, user)
 }
 

--- a/specs/1040-incoming-call-notifications/checklists/requirements.md
+++ b/specs/1040-incoming-call-notifications/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Incoming Call Notifications — Caller Identity, Badge, and Missed-Call Trace
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Ambiguities were resolved with documented defaults instead of
+  [NEEDS CLARIFICATION] markers: hidden-chat callers stay generic (consistent
+  with the hidden-chats feature), unresolvable identity falls back to the
+  current generic alert, and the existing call-log outcome taxonomy is reused.
+  These live in the Assumptions section and in FR-004/FR-005/FR-016; revisit
+  during `/speckit-clarify` if any default is wrong.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/1040-incoming-call-notifications/checklists/requirements.md
+++ b/specs/1040-incoming-call-notifications/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: Incoming Call Notifications — Caller Identity, Badge, and Missed-Call Trace
+# Specification Quality Checklist: Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-07-12
@@ -37,4 +37,8 @@
   current generic alert, and the existing call-log outcome taxonomy is reused.
   These live in the Assumptions section and in FR-004/FR-005/FR-016; revisit
   during `/speckit-clarify` if any default is wrong.
+- Scope amended same-day at the user's request: User Story 3 + FR-019..023 add
+  truthful friend-request outcome notifications ("X accepted your friend
+  request" instead of the misleading "New friend request" fallback). Checklist
+  re-validated against the amended spec; all items still pass.
 - Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/1040-incoming-call-notifications/checklists/security.md
+++ b/specs/1040-incoming-call-notifications/checklists/security.md
@@ -1,0 +1,48 @@
+# Zero-Knowledge & Crypto-Discipline Checklist: sealed callEvent frame + push/notification surfaces (spec 1040)
+
+**Purpose**: Validate the requirements themselves (spec/plan/contracts) for the
+constitution's Principle I/IV surfaces before implementation — mandated by the
+plan's Constitution Check (new E2EE frame kind).
+**Created**: 2026-07-12
+**Feature**: [spec.md](../spec.md) · [contracts/call-event.md](../contracts/call-event.md) · [contracts/connections-api.md](../contracts/connections-api.md)
+
+## Zero-Knowledge Boundary
+
+- [x] CHK001 - Does the spec enumerate what crosses the wire for every new flow (ring marker, ended marker, accepted-row echo), what is encrypted, and what metadata stays visible? [Completeness, Spec §Zero-Knowledge Impact]
+- [x] CHK002 - Is the push-payload constraint stated measurably (no names, user ids, group ids in plaintext; type-only tickles) with a success criterion? [Measurability, Spec §FR-003, §SC-005]
+- [x] CHK003 - Is it explicit that the server-side friend-request change echoes only state the server already stores, to its own requester? [Clarity, contracts/connections-api.md]
+- [x] CHK004 - Are requirements explicit that identity is resolved exclusively on-device or from E2EE material the device can decrypt? [Completeness, Spec §FR-003, §FR-023]
+- [x] CHK005 - Is the fallback on unresolvable identity specified as degrade-to-generic, never delay/suppress the alert? [Clarity, Spec §FR-004]
+
+## Identity Exposure Surfaces
+
+- [x] CHK006 - Is hidden-chat precedence defined for every notification surface the feature touches — ring AND missed replacement AND badge/trace exclusions? [Coverage, Spec §FR-005, §FR-017] *(FR-005 tightened during this checklist run to name both ring and missed surfaces explicitly)*
+- [x] CHK007 - Is the raw-internal-identifier prohibition scoped to all notification surfaces, not only the ring? [Coverage, Spec §FR-006] *(FR-006 broadened during this run: "in any notification")*
+- [x] CHK008 - Are lock-screen exposure requirements consistent between the named ring, the missed replacement, and friend-request outcome notes (named only when the relationship already knows the identity)? [Consistency, Spec §FR-001/§FR-012a/§FR-019, §Assumptions]
+
+## Sealed Frame Discipline (Principle IV)
+
+- [x] CHK009 - Do the requirements confine the new frame to an optional field inside the EXISTING sealed payload, sealed/opened by unchanged code (no new primitive, key exchange, or channel)? [Completeness, contracts/call-event.md §Envelope, plan.md §Constitution IV]
+- [x] CHK010 - Are duplication/replay semantics defined and testable (idempotent by callId; existing row always wins; markers never overwrite)? [Measurability, Spec §FR-018, contracts/call-event.md §Receiver]
+- [x] CHK011 - Are out-of-order arrivals specified (ended before ring; ring after ended; stale ring reconciliation) without contradictory outcomes? [Edge Case, data-model.md §Pending call events]
+- [x] CHK012 - Is the sender trust model documented (markers ride the authenticated pairwise ratchet, so a peer can only assert calls under their own identity; a fabricated marker is nuisance-equivalent to a real cancelled call)? [Assumption, Spec §Assumptions] *(assumption added during this run)*
+- [x] CHK013 - Is the SW's read-only constraint (never persist, never ack from preview — spec 1032 single-writer invariant) carried into the requirements artifacts? [Consistency, contracts/call-event.md §Receiver, plan.md §Constraints]
+
+## Degradation & Platform Constraints
+
+- [x] CHK014 - Are locked-device behaviors specified for each surface (generic ring, generic missed copy, badge undercount-never-overcount)? [Coverage, Spec §FR-004, §FR-008]
+- [x] CHK015 - Is the iOS visible-wake constraint accounted for on every new wake outcome, including the nothing-to-show `answered` path? [Coverage, plan.md §Constraints, quickstart.md §Gotchas]
+- [x] CHK016 - Are retention/cleanup rules defined for the new client-side state (pending call events, badge units) so nothing accumulates unbounded? [Completeness, data-model.md §SW call-badge units]
+
+## Friend-Request Outcome Surface
+
+- [x] CHK017 - Is at-most-once announcement measurable, with the server visibility window explicitly inside the client dedup-ledger TTL (24h < 48h)? [Measurability, Spec §FR-022, contracts/connections-api.md]
+- [x] CHK018 - Is the fallback copy requirement stated as event-neutral (never claims a new incoming request) rather than as a specific string? [Clarity, Spec §FR-021]
+- [x] CHK019 - Are the consumers of the widened outgoing set enumerated with their expected non-impact (UI filters pending; badge counts incoming only)? [Coverage, contracts/connections-api.md §Consumers]
+
+## Notes
+
+- All 19 items PASS after three tightening edits made during this run:
+  FR-005 now names both the ring and missed-call notifications, FR-006 covers
+  every notification surface, and the Assumptions section documents the
+  marker sender trust model. No open findings; implement may proceed.

--- a/specs/1040-incoming-call-notifications/contracts/call-event.md
+++ b/specs/1040-incoming-call-notifications/contracts/call-event.md
@@ -1,0 +1,59 @@
+# Contract: sealed `callEvent` system frame (spec 1040)
+
+Scope: client↔client only. The server relays this as an opaque sealed
+envelope on the existing messaging channel; it has no server-side schema.
+
+## Envelope
+
+- Carried as a new OPTIONAL field on `MessagePayload`
+  (`src/services/crypto/message.ts`), sealed/opened by the unchanged Double
+  Ratchet code path — same class as `reaction`, `gameMove`, `rekey`.
+- MUST be sent on the pairwise 1:1 channel, including for group calls (the
+  initiator fans out pairwise to each invitee).
+- MUST NOT create a visible chat message on receive; it is a silent
+  side-effect frame (`receiveIncomingInner` returns without storing a row).
+
+## Shape
+
+```ts
+callEvent?: {
+  phase: 'ring' | 'ended';
+  callId: string;              // dedup key everywhere
+  kind: 'audio' | 'video';
+  outcome?: 'missed' | 'cancelled' | 'answered'; // required when phase='ended'
+  roomId?: string;             // group calls only
+  at: number;                  // sender ms clock; hint only
+}
+```
+
+## Sender obligations (caller / group initiator)
+
+| Moment | Frame |
+|---|---|
+| Dial (1:1) / group ring start | `{ phase:'ring', callId, kind, roomId? }` to the (each) callee |
+| Caller no-answer timeout fires | `{ phase:'ended', outcome:'missed', … }` |
+| Caller cancels before answer | `{ phase:'ended', outcome:'cancelled', … }` |
+| Call answered (any callee device) | `{ phase:'ended', outcome:'answered', … }` |
+
+Fire-and-forget; senders MUST NOT block or fail call setup on marker send.
+
+## Receiver obligations
+
+- Idempotent by `callId`; an existing `calls` row for `callId` wins — markers
+  never overwrite or duplicate (FR-018).
+- `ended/missed|cancelled` with no existing row → missed `calls` row +
+  `logCallToChat` (1:1 chat; group chat via `roomId`; Calls tab only when no
+  chat resolves).
+- `ended/answered` → clear pending only.
+- Stale `ring` (older than ring window, no outcome, no row) → reconcile to
+  missed.
+- SW preview path: read-only (never persists, never acks — spec 1032
+  invariant); builds the named ring / missed-replacement notification, honors
+  hidden-chat gating, and updates `sw.callBadge` units only.
+
+## Compatibility
+
+- Old receivers ignore unknown optional payload fields (existing behavior for
+  every past field addition) — no version gate needed.
+- Old senders simply never send markers: receivers see today's behavior
+  (generic ring, live-only logging). No handshake.

--- a/specs/1040-incoming-call-notifications/contracts/connections-api.md
+++ b/specs/1040-incoming-call-notifications/contracts/connections-api.md
@@ -1,5 +1,13 @@
 # Contract: `GET /v1/connections` outgoing set change (spec 1040)
 
+> **Amended during implementation**: the widened set is served ONLY for
+> `GET /v1/connections?include=accepted`. The default response keeps its
+> existing meaning (UNRESOLVED requests, pending/rejected) because clients and
+> the e2e suite treat a request leaving that list as answered
+> (`e2e/friendship.spec.ts:54` pins it; CI caught the regression). The SW's
+> `previewConnections` is the only `include=accepted` caller; the store method
+> behind it is `OutgoingWithRecentAccepts`.
+
 ## Today
 
 `Store.OutgoingRequests` (`server/internal/store/connections.go:149-153`)

--- a/specs/1040-incoming-call-notifications/contracts/connections-api.md
+++ b/specs/1040-incoming-call-notifications/contracts/connections-api.md
@@ -1,0 +1,38 @@
+# Contract: `GET /v1/connections` outgoing set change (spec 1040)
+
+## Today
+
+`Store.OutgoingRequests` (`server/internal/store/connections.go:149-153`)
+returns the caller's sent requests with `state IN ('pending','rejected')`.
+Accepted requests are never echoed back, so the client SW's accepted-note
+builder (`sw-inbox.ts:1020`) is dead code and acceptances fall through to the
+misleading "New friend request" placeholder.
+
+## Change
+
+```sql
+WHERE requester::text = $1
+  AND ( state IN ('pending','rejected')
+     OR (state = 'accepted' AND updated_at > now() - interval '24 hours') )
+ORDER BY updated_at DESC
+```
+
+- Response DTO shape unchanged: `{requester, target, state, updatedMs}`.
+- `accepted` rows appear only while fresh (24h), bounding response size and
+  guaranteeing at-most-once announcement: the SW conn ledger dedups for 48h,
+  strictly longer than the visibility window (FR-022).
+- No new information: the server already stores `connections.state`; this
+  echoes a requester's own request state back to them.
+
+## Consumers (verified)
+
+- `src/services/connections.ts:61-68` — passes `state` through verbatim.
+- `ContactsPage.vue:289` — renders only `state === 'pending'`; accepted rows
+  invisible to the list. Badge counts use incoming only (`useBadges.ts:45`).
+- `sw-inbox.ts:1018-1022` — the intended consumer: accepted → "accepted your
+  friend request", rejected → "declined your friend request".
+
+## Tests
+
+- Fake store + handler test: accepted-within-24h present, accepted-older
+  absent, pending/rejected unchanged, DTO state passthrough.

--- a/specs/1040-incoming-call-notifications/data-model.md
+++ b/specs/1040-incoming-call-notifications/data-model.md
@@ -1,0 +1,81 @@
+# Data Model: Incoming call & friend-request notifications (spec 1040)
+
+No new object store and no `DB_VERSION` bump. One new sealed payload field,
+two namespaced `settings`-store keys (the established SW↔page channel), and
+integrity rules over the existing `calls` store.
+
+## Sealed payload: `callEvent` (new optional field on `MessagePayload`)
+
+Rides the existing pairwise Double Ratchet envelope exactly like
+`reaction`/`gameMove`; never rendered as a chat bubble.
+
+| Field | Type | Notes |
+|---|---|---|
+| `phase` | `'ring' \| 'ended'` | dial-time vs outcome-time marker |
+| `callId` | string | the live call's id — dedup key across markers, live logging, and re-sends |
+| `kind` | `'audio' \| 'video'` | drives the emoji/cue and the log's `video` flag |
+| `outcome` | `'missed' \| 'cancelled' \| 'answered'` | `ended` only. `cancelled` = caller hung up before answer (logs as missed per clarification); `answered` = answered on some device (clears pending, logs nothing) |
+| `roomId?` | string | group calls: the room; used to resolve the group chat + name locally |
+| `at` | number (ms) | sender clock; staleness/ordering hint only, never trusted for identity |
+
+Sender duties (`useCall.ts`):
+
+- 1:1 dial → `ring` to the callee; group dial → `ring` pairwise to each invitee.
+- Caller no-answer timeout → `ended/missed`; caller cancel → `ended/cancelled`;
+  answer (any callee device) → caller sends `ended/answered`.
+- Markers are fire-and-forget; loss degrades per the reconcile rules below.
+
+## Pending call events (receiver side, `settings` store key)
+
+`callEvents.pending`: `{ [callId]: { from, kind, roomId?, receivedAt } }` —
+written by the `receiveIncomingInner` `callEvent` branch on `ring`, consumed
+by `ended` or by reconciliation.
+
+| Transition | Effect |
+|---|---|
+| `ring` arrives | record pending (idempotent; never duplicates) |
+| `ended/missed` or `ended/cancelled` | if no `calls` row for `callId`: `createCall`-shaped missed row (`missed: true, seen: false`) + `logCallToChat` into the 1:1 chat (or group chat via `roomId`; Calls tab only when no chat resolves) — then clear pending |
+| `ended/answered` | clear pending, write nothing (answered-elsewhere is not missed — FR-016) |
+| pending older than ring window + no outcome + no `calls` row for `callId` | reconcile to missed (caller crashed mid-ring) |
+| pending but a `calls` row for `callId` exists | clear pending, write nothing (live path already logged — FR-018) |
+
+## SW call-badge units (`settings` store key `sw.callBadge`)
+
+`Array<{ callId?: string; ts: number; state: 'ringing' | 'missed' }>` — the
+transient badge contribution while the app is closed.
+
+| Event | Rule |
+|---|---|
+| call tickle, no fresh `ringing` unit (and marker `callId` unknown) | append `ringing` unit → badge +1 (FR-007) |
+| call tickle while a `ringing` unit is fresh (ring window) or `callId` matches | no change (FR-008); distinct decryptable `callId`s each get a unit |
+| missed/cancelled marker previewed by SW | flip that unit `ringing → missed` (same unit — FR-010) |
+| answered marker previewed by SW | remove the unit |
+| page foreground/open | page clears ALL units (`useAppBadge` sweep): ringing increments vanish (FR-009); missed calls are represented in the `calls` store by then and counted by `countMissedUnseen` |
+| unit older than a stale bound (e.g. 24h) | dropped on next SW pass (hygiene) |
+
+Badge totals: SW total (`updateAppBadge`) = existing `unreadCount() + newCount`
+**+ units.length**; page total (`useBadges`) unchanged (already includes
+missed-unseen calls).
+
+## Existing entities touched (rules only, no shape change)
+
+- **`calls` store row** (`Call`, keyed `callId`): marker-created rows use
+  `direction: 'incoming'`, `missed: true`, `seen: false`, `video` from `kind`,
+  `isGroup`/`roomId` when group. Never overwrite an existing row for the same
+  `callId`.
+- **Chat `kind: 'call'` message row** (`logCallToChat`): same local-only shape
+  as live logging; hidden-chat exclusions (`hiddenCallKeys`) apply unchanged.
+- **`GET /v1/connections` outgoing DTO**: unchanged shape; the set now
+  includes `state: 'accepted'` rows with `updated_at` within 24h. UI consumers
+  filter `state === 'pending'` (`ContactsPage.vue:289`) and are unaffected;
+  the SW's existing accepted/rejected note builder becomes live.
+
+## Notification surfaces (composed on-device, not persisted)
+
+| Surface | Copy shape | Tag / target |
+|---|---|---|
+| Named ring | "📹/🎙️ \<Name\> is calling you" · group "\<Name\> is calling in \<Group\>" | `ring-call`, `/tabs/chats` |
+| Generic ring (fallback: locked, unresolvable, hidden chat) | today's "Incoming call / Tap to answer" | `ring-call` |
+| Missed replacement | "☎️ Missed call from \<Name\>" (generic "Missed call" when unresolvable/hidden) | `ring-call` (replaces), deep-link chat else `/tabs/calls` |
+| Friend-request accepted | "\<Name\> · accepted your friend request" (existing builder) | `ring:conn:acc:<id>` |
+| Conn fallback placeholder | neutral "Contact updates / Tap to review" (was "New friend request") | `ring:conn:req`, `/tabs/contacts` |

--- a/specs/1040-incoming-call-notifications/plan.md
+++ b/specs/1040-incoming-call-notifications/plan.md
@@ -1,0 +1,163 @@
+# Implementation Plan: Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace
+
+**Branch**: `feat/1040-incoming-call-notifications` | **Date**: 2026-07-12 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1040-incoming-call-notifications/spec.md`
+
+## Summary
+
+Make the closed-app call experience truthful end to end: the ring notification
+names the caller and call type, a ringing call adds exactly one app-badge unit
+that hands over (never double-counts) to the missed state, opening the app
+sweeps the notification and the unit, an unanswered ring is replaced by a
+"Missed call from <name>" notification, and every unanswered call leaves the
+existing call-log trace (chat row + Calls tab) even when the app never ran
+during the ring. Vehicle: a new sealed `callEvent` system frame from the
+caller over the existing pairwise Double Ratchet (`ring` at dial, `ended` at
+outcome), which the service worker can already fetch and preview from
+`GET /v1/relay/pending` — the push tickles stay content-free, the server
+learns nothing new, and no new push type is needed (the outcome marker's own
+msg tickle is the wake that retires the ring). Separately, the friend-request
+acceptance bug is fixed at its root: the server's outgoing-connections query
+never returns `accepted` rows, so the SW's existing "accepted your friend
+request" renderer is dead code — return recently-accepted rows (24h window
+inside the 48h dedup ledger) and neutralize the misleading placeholder copy.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (Vue 3 `<script setup>` + Ionic 8) client;
+Go 1.26 stdlib server (one small query change)
+
+**Primary Dependencies**: existing E2EE messaging core
+(`src/services/crypto/message.ts` `MessagePayload`, Double Ratchet via
+`previewPacket`), SW inbox (`src/services/sw-inbox.ts`, `src/sw.ts`), call
+orchestration (`src/composables/useCall.ts`), call log
+(`src/db/queries.ts` `createCall`/`logCallToChat`), Web Push relay
+(`server/internal/ws/hub.go` ring loops — read-only reference, unchanged)
+
+**Storage**: IndexedDB — existing `calls` store and chat `kind:'call'` rows
+(no new object store, no `DB_VERSION` bump); `settings` store gains two
+namespaced keys (`sw.callBadge`, pending call events) following the existing
+SW↔page shared-key pattern (`badge.lastCount`, `swShownSummary`)
+
+**Testing**: vitest for the pure marker/reconcile/badge-unit logic and
+`noteForPayload` additions; Go table tests against the fake store for the
+connections query; e2e/drive verification of the friend-accept copy and call
+log trace (SW push paths verified at unit level — headless push delivery is
+not CI-testable)
+
+**Target Platform**: installable PWA — Safari/iOS (SW visible-ending
+three-strike rule applies), Chrome/Android, desktop browsers
+
+**Project Type**: web app (client-heavy; one server query + tests)
+
+**Performance Goals**: first ring alert latency unchanged (identity never
+blocks it); missed-call replacement within one msg-tickle debounce of ring
+end; SW pending-preview stays inside the existing 8s fetch bound
+
+**Constraints**: zero-knowledge boundary (spec's ZK Impact section; tickles
+stay content-free, identity rides E2EE); iOS rule that every SW wake ends
+visibly; spec 1032 single-writer invariant (SW preview path never persists or
+acks); hidden-chats exclusions fail closed
+
+**Scale/Scope**: ~6 client files (message payload type, useCall send sites,
+queries receive branch, sw-inbox notes/badge, sw.ts call+conn paths, badge
+composables), 1 server file + test, new vitest modules, spec artifacts
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary** — PASS. Spec carries the required
+  Zero-Knowledge Impact section. All identity crosses as sealed `callEvent`
+  frames on the existing ratchet channel; push payloads remain type-only
+  tickles; the server-side change returns rows whose state the server already
+  stores (`connections.state`) to their own requester. No new plaintext, no
+  new metadata field.
+- **II. Spec-Driven Development** — PASS. Spec 1040 (ad-hoc band), pipeline
+  followed: specify → clarify (1 Q integrated) → plan → tasks → analyze →
+  taskstoissues → implement.
+- **III. Test-Driven Development** — PASS (planned). New pure logic (marker
+  reconcile, badge units, note builders) lands as vitest-first; the Go query
+  change lands test-first against the fake store; tasks.md orders red before
+  green.
+- **IV. Crypto Discipline** — PASS with review flag. No new primitive and no
+  ratchet change: `callEvent` is one more optional field inside the existing
+  sealed `MessagePayload`, sealed/opened by unchanged code (the same pattern
+  as `reaction`/`gameMove`). Because a Principle I surface is touched (a new
+  E2EE frame kind), `/speckit-checklist` **is** mandated and will be run
+  before implement.
+- **V. Offline-First Data Integrity** — PASS. No schema change; writes go
+  through `queries.ts` on the page/drain side only; the SW preview path stays
+  read-only (spec 1032 invariant); marker processing is idempotent (keyed by
+  `callId`) and never overwrites an existing record.
+- **VI. Stateless Server & Forward-Only Migrations** — PASS. No migration; a
+  `SELECT` predicate change only. Handlers stay stdlib; fake-store test
+  updated alongside.
+- **VII. Quality Gates** — PASS (planned): `npm run build`, vitest,
+  `go build/vet/test`, e2e where behavior changed; release-note-style commit
+  subjects.
+- **VIII. Traceability** — PASS: branch `feat/1040-…`, issues via
+  taskstoissues, PR lists `Closes #N`.
+- **IX. Privacy & Data Minimization** — PASS. Markers carry the minimum
+  (callId, kind, phase, optional roomId); nothing new is collected or stored
+  server-side.
+- **X–XI. A11y/i18n & Ionic-First** — PASS. No new UI surface: notification
+  strings only (plain-language, emoji cues supplement text, not replace it);
+  copy follows the app's voice (no em-dashes or semicolons in user copy).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1040-incoming-call-notifications/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Phase 0 (R1–R8)
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+├── contracts/
+│   ├── call-event.md    # sealed callEvent frame contract
+│   └── connections-api.md # GET /v1/connections outgoing change
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── services/
+│   ├── crypto/message.ts        # MessagePayload.callEvent (type + docs)
+│   ├── call-events.ts           # NEW pure module: marker build/reconcile/badge-unit logic
+│   ├── sw-inbox.ts              # noteForPayload callEvent notes; call badge units; neutral conn placeholder data
+│   └── notify.ts                # (reference only — hand-off unchanged)
+├── composables/
+│   ├── useCall.ts               # send ring/ended markers at dial, timeout, cancel, answer
+│   ├── useAppBadge.ts           # foreground sweep also clears sw.callBadge units
+│   └── useBadges.ts             # (reference — page badge already counts missed)
+├── db/
+│   └── queries.ts               # receiveIncomingInner callEvent branch + reconcile
+└── sw.ts                        # call wake: marker preview → named ring; missed replace; badge units; neutral placeholder copy
+
+server/internal/
+├── store/connections.go         # OutgoingRequests: + accepted within 24h
+└── api/connections_handlers_test.go  # fake-store + handler coverage
+
+src/services/call-events.test.ts # vitest (pure logic)
+src/services/sw-inbox.calls.test.ts # vitest (note building, badge units)
+```
+
+**Structure Decision**: single web-app monorepo as-is; one new pure client
+module (`call-events.ts`) so the marker/reconcile/badge logic is testable
+without IndexedDB or a SW, mirroring the crypto-core purity convention.
+
+## Complexity Tracking
+
+No constitution violations to justify. One scope note: SW-delivered push
+behavior (named ring, missed replacement) cannot run in headless CI e2e —
+covered by vitest at the note-builder/unit level plus manual device
+verification via the quickstart; this mirrors how existing SW push behavior
+(specs 1015/1032/1034/2023) is covered.

--- a/specs/1040-incoming-call-notifications/quickstart.md
+++ b/specs/1040-incoming-call-notifications/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: Incoming call & friend-request notifications (spec 1040)
+
+## Where the logic lives
+
+- `src/services/call-events.ts` — NEW pure module: marker shapes, reconcile
+  decisions, badge-unit transitions. Start here; it is vitest-covered and has
+  no IndexedDB/SW dependency.
+- `src/composables/useCall.ts` — marker send sites (dial, no-answer timeout,
+  cancel, answer). Search `callEvent`.
+- `src/db/queries.ts` — `receiveIncomingInner`'s `callEvent` branch (silent
+  side-effect pattern, like `reaction`) + stale-ring reconciliation.
+- `src/services/sw-inbox.ts` / `src/sw.ts` — SW side: named ring preview,
+  missed replacement (tag `ring-call`), `sw.callBadge` units, neutral conn
+  placeholder.
+- `server/internal/store/connections.go` — the one server change
+  (accepted-within-24h in `OutgoingRequests`).
+
+## Fast verification loop
+
+```sh
+npx vitest run src/services/call-events.test.ts src/services/sw-inbox.calls.test.ts
+cd server && go test ./internal/api/ ./internal/store/...   # connections change
+npm run build                                               # typecheck gate
+```
+
+## Seeing it on a device (dev stack)
+
+1. `make start`, install the PWA from a phone pointed at the dev host, allow
+   notifications, then CLOSE the app.
+2. From a second account (browser profile), call the phone's account —
+   lock screen should show "📹 <Name> is calling you", badge +1, re-rings do
+   not increase it.
+3. Let it ring out — notification becomes "☎️ Missed call from <Name>";
+   opening it lands in the 1:1 chat with the missed-call row; Calls tab shows
+   the entry; badge unit persists until the calls list is viewed.
+4. Open the app mid-ring instead — notification and the +1 vanish, in-app
+   ring takes over.
+5. Friend accept: send a request from the phone account to a third account,
+   close the app, accept on the third account → phone shows
+   "<Name> · accepted your friend request" (never "New friend request").
+
+Multi-user drive scenarios (`drive/`) cover the data-layer effects (missed
+rows, dedup against live logging); SW push visuals need the real device pass
+above.
+
+## Gotchas
+
+- SW preview is READ-ONLY (spec 1032): never persist or ack from the preview
+  path; the page/drain owns writes.
+- Every SW wake must end visibly on iOS (three-strike revocation): the
+  `answered` marker path closes the ring notification and must still end via
+  the quiet terminal.
+- Marker processing is idempotent by `callId`; an existing `calls` row always
+  wins.
+- Hidden chats: gate BEFORE naming anything; fail closed to generic copy.
+- Copy voice: warm, plain, "you"; no em-dashes or semicolons in user copy.

--- a/specs/1040-incoming-call-notifications/research.md
+++ b/specs/1040-incoming-call-notifications/research.md
@@ -1,0 +1,155 @@
+# Research: Incoming call & friend-request notifications (spec 1040)
+
+All unknowns were resolvable from the codebase. The load-bearing decisions:
+
+## R1 — Identity transport: a sealed `callEvent` marker over the existing pairwise ratchet
+
+- **Decision**: the caller (or group-call initiator) sends a small sealed system
+  frame — a new optional `callEvent` field on `MessagePayload`
+  (`src/services/crypto/message.ts:268`) — through the existing 1:1 Double
+  Ratchet channel to the callee, alongside the live call signalling. Two phases:
+  `ring` (sent at dial time: `callId`, `kind`, optional `roomId`) and `ended`
+  (sent at outcome time: `outcome: 'missed' | 'cancelled' | 'answered'`). For a
+  group call the initiator sends the same pairwise marker to each invitee
+  (bounded by group size — the server already sends per-member invites).
+- **Rationale**: the 1:1 call offer itself is never queued on the relay ("the
+  tickle is the signal", `src/sw.ts:717`), so the SW cannot fetch it. But
+  `callEvent` markers land in `GET /v1/relay/pending`, which the SW already
+  fetches and decrypts read-only (`previewPending` → `previewPacket`,
+  `sw-inbox.ts:722-868`) — the exact machinery rich message previews use. The
+  push payload stays a content-free tickle; identity crosses only E2EE.
+- **Alternatives considered**: putting a caller id in the push tickle (leaks
+  social graph to APNs/FCC — violates FR-003, rejected); server-buffered
+  offer exposed over HTTP for the SW (new server surface, still undecryptable
+  while locked, and duplicates relay retention); sender-key group markers
+  (SW preview only walks the pairwise ratchet — pairwise markers keep the SW
+  path uniform).
+
+## R2 — Ring notification: preview the marker, fall back generic, upgrade on re-ring
+
+- **Decision**: on a `{"t":"call"}` wake, the SW (after the existing
+  nudge/ack) runs a bounded pending-preview looking for a fresh (`ring`-phase,
+  < ring-window old) `callEvent`; if decryptable it shows
+  "📹/🎙️ <Name> is calling you" (group: "… is calling in <Group>") under the
+  existing `tag: 'ring-call'`; otherwise today's generic ring. Reminder pushes
+  (1:1 re-pushes up to 6× every 10s — `hub.go:210-211,346-364`; group
+  `hub.go:556-572`) re-run the preview, so a marker that raced behind the first
+  tickle upgrades the same notification in place (`renotify` behavior kept).
+- **Rationale**: FR-004 (never delay the first alert) plus the reminder cadence
+  gives a free upgrade path. PIN-locked devices (`attemptDeviceUnlock` fails →
+  `reason: 'locked'`, `sw-inbox.ts:776-786`) simply stay generic.
+- **Alternatives considered**: blocking the ring on decrypt (violates FR-004);
+  a separate identity endpoint (new plaintext surface, rejected).
+
+## R3 — Missed-call trace: outcome markers are primary, stale-ring reconciliation is the net
+
+- **Decision**: `receiveIncomingInner` (`src/db/queries.ts:5566-5728`) gains a
+  `callEvent` branch following the established silent-side-effect pattern
+  (reaction/gameMove/etc.): `ring` records a pending call event; `ended` with
+  `outcome: 'missed'` creates the missed `calls` row (`createCall`-shaped,
+  keyed by `callId` → natural dedup, FR-018) and the in-chat `kind: 'call'`
+  row via `logCallToChat`; `cancelled` does the same (caller hung up before
+  answer = missed per clarification); `answered` (answered on another device
+  or this one) just clears the pending event. A pending `ring` older than the
+  ring window with no outcome marker and no existing `calls` row for that
+  `callId` reconciles to missed on next processing (caller crashed mid-ring).
+  Existing live-ring logging is untouched; the marker branch never overwrites
+  an existing record for the same `callId`.
+- **Rationale**: the caller is online at dial time by definition, so the
+  dial-time `ring` marker is durably queued even if the caller dies later —
+  that makes SC-004's "100% trace" reachable. The outcome marker settles
+  accuracy (answered-elsewhere never logs missed, FR-016).
+- **Alternatives considered**: SW-side tickle ledger only (no identity → no
+  chat placement, breaks FR-014); server-recorded missed calls (server must
+  not know outcomes' meaning — rejected on Principle I).
+
+## R4 — Missed-call notification: the outcome marker's own push is the wake
+
+- **Decision**: no new push type. The caller's `ended` marker arrives as a
+  normal `{"t":"msg"}` tickle; the SW preview recognizes `callEvent` in
+  `noteForPayload` (`sw-inbox.ts:341-349` pattern) and, for `missed`/
+  `cancelled`, shows "☎️ Missed call from <Name>" reusing the `ring-call` tag
+  (which REPLACES the stale incoming-call alert — FR-012/FR-012a), deep-linking
+  to the 1:1/group chat (or `/tabs/calls`). For `answered` it closes the
+  `ring-call` notification and ends the wake with the established quiet
+  terminal (`showQuietUnlessVisible`, `sw.ts:232-241`) so the iOS
+  visible-ending rule (three-strike zombie revocation, `sw-inbox.ts:495-506`)
+  is never violated.
+- **Rationale**: the marker is both the data and the wake — one mechanism, no
+  server change for calls at all. Message-tickle debounce delays it by at most
+  the debounce window, well inside SC-006's ring-window bound.
+- **Alternatives considered**: a server `call-end` push (the server does know
+  ring end — `hub.go:1484-1510` — but a new tickle type is more surface for
+  zero gain); leaving the stale ring until user interaction (rejected in
+  clarification).
+
+## R5 — Badge: per-call units in SW-shared storage, cleared by the page on open
+
+- **Decision**: a `sw.callBadge` entry in the idb `settings` store (already
+  the SW↔page shared channel: `badge.lastCount`, `swShownSummary`) holds a
+  small list of `{callId?, ts, state: 'ringing' | 'missed'}` units. The SW
+  badge total (`updateAppBadge`, `sw.ts:326-342`) adds `units.length`. First
+  call tickle for an unknown call appends one `ringing` unit (identified by
+  marker `callId` when decryptable, else a ring-window heuristic — a call
+  tickle while a `ringing` unit is fresh joins it, FR-007/FR-008); the
+  missed outcome flips the SAME unit to `missed` (FR-010, no double count).
+  On page open/foreground, the page clears all units (`useAppBadge`'s existing
+  foreground hook) — ringing units simply vanish (FR-009); missed ones are by
+  then represented in the `calls` store, which the page badge already counts
+  (`countMissedUnseen`, `useBadges.ts:39`).
+- **Rationale**: reuses the existing split (SW approximates while closed, page
+  is authoritative on open — `sw.ts:321-334`) and the existing foreground
+  clearing hooks (`useAppBadge.ts:16-28`). The heuristic degrades exactly to
+  the spec's stated platform-degradation assumption.
+- **Alternatives considered**: teaching the SW to read/write the `calls`
+  store (write path belongs to `queries.ts`/drain — spec 1032's single-writer
+  invariants say don't); server-counted badges (server can't know, Principle I).
+
+## R6 — Stop-on-open: existing server foreground suppression + page notification sweep
+
+- **Decision**: no new suppression mechanism. The server already skips pushes
+  once the device is foregrounded and socket-fresh (`isActiveFresh` gates in
+  both ring loops, `hub.go:353`, `hub.go:568`) and stops ringing on
+  answer/decline (`stopCallRing`, `hub.go:1484-1487`). The page already closes
+  ALL notifications on foreground (`useAppBadge.ts:16-17`), which sweeps
+  `ring-call`. The only addition: the foreground hook also clears
+  `sw.callBadge` ringing units (R5) so the badge drops with the notification.
+- **Rationale**: FR-011's behavior is 90% shipped; discovering that avoided a
+  redundant client-suppression layer.
+- **Alternatives considered**: SW-side "page is open" gating (already exists
+  as `pageWillNotify`/`ring:drain` hand-off, `sw.ts:690-704` — nothing to add).
+
+## R7 — Friend-request accepted: return recent accepted rows; ledger stays the dedup
+
+- **Decision**: `Store.OutgoingRequests`
+  (`server/internal/store/connections.go:149-153`) adds
+  `OR (state = 'accepted' AND updated_at > now() - interval '24 hours')`. The
+  SW already renders accepted outgoing rows ("accepted your friend request",
+  `sw-inbox.ts:1020`) and dedups via the 48h `swNotifiedIds`-style conn ledger
+  (`CONN_SHOWN`, TTL 48h) — a 24h server visibility window inside the 48h
+  ledger TTL guarantees at-most-once announcement (FR-022) with zero client
+  reconcile changes.
+- **Rationale**: the accept branch on the client is dead code today only
+  because the server never returns accepted rows; the minimal, windowed server
+  change revives it without unbounded response growth and without re-announce
+  loops after ledger expiry. `ContactsPage.vue:289` filters
+  `state === 'pending'`, so the UI list is unaffected.
+- **Alternatives considered**: unwindowed `IN ('pending','rejected','accepted')`
+  (response grows with every friendship forever, and rows re-announce every
+  ledger-TTL); a new push payload type for accepts (more surface; the conn
+  tickle + reconcile pattern already exists).
+
+## R8 — Neutral fallback copy + hidden-chat guard
+
+- **Decision**: the unconditional placeholder at `sw.ts:476` changes from
+  "New friend request / Tap to review" to neutral copy ("Contact updates" /
+  "Tap to review" — matching the warm plain UI voice, no em-dashes), keeping
+  tag/url. For calls, every named note (ring and missed) passes the same
+  hidden-chat gate the message previews use: a hidden peer/group renders the
+  generic variant, and missed-call rows stay excluded from Calls tab and badges
+  by the existing `hiddenCallKeys` consumers (`queries.ts:2606`, `4851`).
+- **Rationale**: FR-021 (the fallback must not misstate the event) and
+  FR-005/FR-017 (hidden chats leak nothing, exclusions still hold).
+- **Alternatives considered**: guessing the event type in the fallback
+  (exactly the reported bug); skipping the placeholder (violates the iOS
+  visible-ending contract).

--- a/specs/1040-incoming-call-notifications/spec.md
+++ b/specs/1040-incoming-call-notifications/spec.md
@@ -266,10 +266,10 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   call" text. The first ring alert MUST NOT be delayed or suppressed while
   waiting for identity resolution.
 - **FR-005**: Calls originating from chats the user has hidden (hidden-chats
-  feature) MUST always use the generic notification with no identifying
-  detail.
+  feature) MUST always use generic notifications with no identifying detail —
+  the incoming-call alert and the missed-call replacement alike.
 - **FR-006**: A raw internal identifier (user id, room id) MUST never be shown
-  as a caller name; unresolvable identity falls back to generic text.
+  in any notification; unresolvable identity falls back to generic text.
 
 **Badge lifecycle for a ringing call (US4, US5)**
 
@@ -446,3 +446,7 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   new: incoming-request notifications already name the requester from their
   public directory profile, and both parties to a request already know each
   other's identity.
+- Call-event trust model: call metadata arrives over the authenticated,
+  end-to-end-encrypted pairwise channel, so a peer can only assert calls under
+  their own identity. A fabricated "missed call" claim is nuisance-equivalent
+  to actually calling and hanging up — no identity confusion is possible.

--- a/specs/1040-incoming-call-notifications/spec.md
+++ b/specs/1040-incoming-call-notifications/spec.md
@@ -392,6 +392,31 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   "New friend request" copy, verified by end-to-end test of the
   request→accept flow with the requester's app closed.
 
+## Zero-Knowledge Impact
+
+- **What crosses the wire**: (a) The existing content-free push tickles
+  (`{"t":"call"}`, `{"t":"msg"}`, `{"t":"conn"}`) continue to cross the push
+  services untouched; if a new tickle type is needed to end a ring visibly
+  (e.g. a call-ended wake), it carries a frame-type discriminator only — no
+  names, user ids, call ids, or group ids. (b) Any caller→callee call
+  metadata needed for identity or missed-call traces rides the existing
+  end-to-end-encrypted messaging/signalling channels as sealed envelopes.
+- **What is encrypted**: All identity and call context (who called, call
+  type, group/room association, outcome) is either already on the callee's
+  device or arrives E2EE; the notification text is composed on-device.
+- **What metadata is unavoidably visible**: The server already knows it
+  relayed a call tickle and sealed frames between two account ids (routing
+  metadata that relaying physically requires); this feature adds no new
+  server-visible fields. The platform push services (APNs/FCM) see only
+  frame-type tickles, exactly as today.
+- **Why**: Caller identity display, badge accounting, and missed-call
+  logging are all client-side concerns resolved from on-device data plus
+  sealed payloads; the server remains unable to read who called whom about
+  what. The friend-request fix changes only which already-server-visible
+  connection states (`accepted`) are echoed back to their own requester —
+  the server learns nothing new; names are still resolved on-device from
+  the public directory profile.
+
 ## Assumptions
 
 - The existing ~60-second ring window and repeated re-alert behavior for

--- a/specs/1040-incoming-call-notifications/spec.md
+++ b/specs/1040-incoming-call-notifications/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-12
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1040-incoming-call-notifications/spec.md
+++ b/specs/1040-incoming-call-notifications/spec.md
@@ -1,4 +1,4 @@
-# Feature Specification: Incoming Call Notifications — Caller Identity, Badge, and Missed-Call Trace
+# Feature Specification: Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace
 
 **Feature Branch**: `feat/1040-incoming-call-notifications`
 
@@ -11,7 +11,7 @@
      are derived from the directory number (0001+ planned, 1001+ ad-hoc,
      2001+ hotfix), so do not restate them by hand. -->
 
-**Input**: User description: "Incoming call notification improvements. (1) When a call comes in while the app is closed or backgrounded, the app icon badge count should increase by one because the incoming call is new activity — but only once for the first call notification of that call; subsequent/repeated notifications for the same ringing call must not increment the badge again. (2) If the user opens the app (by tapping the call notification or opening it directly), further push notifications for that call should stop, and the call's badge increment should be removed so only unread message counts remain on the app badge. (3) When a call is missed — either the user never opened the app, or opened it but chose not to answer — it must be logged as a missed call with a visible trace: in the 1:1 chat with the caller for direct calls, in the group chat the call was started from for group calls, and in the Calls tab for group ad-hoc calls. The point is there must always be a trace of missed calls. (4) The OS notification for an incoming call currently shows no detail about who is calling; it should show caller identity, e.g. 'Kamran is calling you' with a video emoji or audio emoji depending on call type, so the user knows what's happening directly from the notification."
+**Input**: User description: "Incoming call notification improvements. (1) When a call comes in while the app is closed or backgrounded, the app icon badge count should increase by one because the incoming call is new activity — but only once for the first call notification of that call; subsequent/repeated notifications for the same ringing call must not increment the badge again. (2) If the user opens the app (by tapping the call notification or opening it directly), further push notifications for that call should stop, and the call's badge increment should be removed so only unread message counts remain on the app badge. (3) When a call is missed — either the user never opened the app, or opened it but chose not to answer — it must be logged as a missed call with a visible trace: in the 1:1 chat with the caller for direct calls, in the group chat the call was started from for group calls, and in the Calls tab for group ad-hoc calls. The point is there must always be a trace of missed calls. (4) The OS notification for an incoming call currently shows no detail about who is calling; it should show caller identity, e.g. 'Kamran is calling you' with a video emoji or audio emoji depending on call type, so the user knows what's happening directly from the notification." — Follow-up in the same session: "also when someone accepts my friend request, instead of 'X has accepted your friend request' in a web push notification, I get that a friend request has come in! let's address this as part of the same fix as well."
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -96,7 +96,43 @@ for an ad-hoc group call.
 
 ---
 
-### User Story 3 - A ringing call badges the app icon once (Priority: P3)
+### User Story 3 - Friend-request outcomes are announced truthfully (Priority: P3)
+
+Sara sent Kamran a friend request yesterday. Today Kamran accepts it while
+Sara's app is closed. Sara's notification reads "Kamran accepted your friend
+request" — not today's misleading "New friend request — Tap to review", which
+tells her the opposite of what happened (that someone new is asking *her*).
+
+**Why this priority**: This is a plain correctness bug in an existing
+notification: the copy misstates the event. It confuses users into looking for
+a pending request that does not exist, and it hides the good news that a
+connection was established.
+
+**Independent Test**: From account A (app closed on A's device), send a friend
+request to account B; accept it on B. Verify A's notification names B and says
+the request was accepted. Repeat for decline.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has an outgoing friend request and their app is closed
+   or backgrounded, **When** the other person accepts it, **Then** the
+   notification says that person accepted the friend request (e.g. "Kamran ·
+   accepted your friend request"), naming them when their public profile is
+   resolvable on-device.
+2. **Given** the same state, **When** the other person declines, **Then** the
+   notification reflects the decline (existing declined copy), never "New
+   friend request".
+3. **Given** the event type cannot be determined (device offline, state
+   cannot be reconciled in time), **Then** a fallback notification MAY be
+   shown to satisfy platform visibility rules, but its copy MUST be neutral
+   about the event type (e.g. contact activity to review) rather than
+   claiming a new incoming request.
+4. **Given** an actual new incoming friend request arrives, **Then** the
+   existing "wants to be friends" notification behavior is unchanged.
+
+---
+
+### User Story 4 - A ringing call badges the app icon once (Priority: P4)
 
 Kamran calls Sara while Ring is closed. Her app icon badge, which read "2" for
 two unread messages, now reads "3" — the ringing call is new activity. The ring
@@ -128,7 +164,7 @@ by exactly 1 over the whole ring.
 
 ---
 
-### User Story 4 - Opening the app clears the ring's notification footprint (Priority: P4)
+### User Story 5 - Opening the app clears the ring's notification footprint (Priority: P5)
 
 Sara hears the ring and opens Ring — by tapping the call notification or just
 launching the app. The in-app incoming-call screen takes over: the OS
@@ -136,7 +172,7 @@ notification for that call is dismissed, no further notifications for that call
 appear, and the badge increment the ringing call added is removed, leaving only
 the unread counts that were already standing.
 
-**Why this priority**: Follow-through on stories 1 and 3 — stale call
+**Why this priority**: Follow-through on stories 1 and 4 — stale call
 notifications and a leftover badge after the app is already handling the call
 read as bugs, but this only matters once those stories exist.
 
@@ -187,6 +223,12 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   behavior; notifications and missed-call traces are unaffected.
 - Repeated ring notifications must keep re-alerting audibly (current behavior)
   even though they no longer re-increment the badge.
+- A friend-request acceptance happens while the device is offline → the
+  outcome is still announced correctly (or at worst neutrally) when the device
+  next reconciles, and only once.
+- The user opens the app and sees the acceptance in-app before any
+  notification is shown → no stale "accepted" notification needs to fire
+  afterwards.
 
 ## Requirements *(mandatory)*
 
@@ -216,7 +258,7 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
 - **FR-006**: A raw internal identifier (user id, room id) MUST never be shown
   as a caller name; unresolvable identity falls back to generic text.
 
-**Badge lifecycle for a ringing call (US3, US4)**
+**Badge lifecycle for a ringing call (US4, US5)**
 
 - **FR-007**: The first notification shown for an incoming call while the app
   is closed or backgrounded MUST increase the app icon badge count by exactly
@@ -230,7 +272,7 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   moment across its lifecycle (ringing → missed-unseen); transitioning from
   "ringing" to "missed, unseen" must not double-count.
 
-**Notification lifecycle on open (US4)**
+**Notification lifecycle on open (US5)**
 
 - **FR-011**: Opening the app while a call is ringing MUST dismiss the OS
   notification for that call and suppress further OS notifications for it
@@ -263,6 +305,27 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   about the same call arrive (e.g. the device later reconnects and also learns
   about the call through normal sync).
 
+**Friend-request outcome notifications (US3)**
+
+- **FR-019**: When another user accepts the user's outgoing friend request,
+  the resulting notification MUST state that the request was accepted, naming
+  the accepter when their public profile is resolvable on-device — never copy
+  implying a new incoming request.
+- **FR-020**: When another user declines the outgoing request, the
+  notification MUST reflect the decline; existing incoming-request ("wants to
+  be friends") notifications are unchanged.
+- **FR-021**: When the event type behind a contact-activity wake cannot be
+  determined in time, any fallback notification shown to satisfy platform
+  visibility rules MUST use copy that is neutral about the event type, not
+  "New friend request".
+- **FR-022**: A given friend-request outcome (accept/decline of a specific
+  request) MUST be announced at most once; later wakes or reconciles must not
+  repeat it.
+- **FR-023**: Names in friend-request notifications MUST continue to be
+  resolved on-device from the public directory profile, exactly as the
+  existing incoming-request notification does; the push payload itself stays
+  content-free.
+
 ### Key Entities
 
 - **Incoming-call notification**: The OS-level alert for a ringing call.
@@ -275,6 +338,9 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
 - **Missed-call record**: The durable trace of an unanswered call (already
   exists as the call-log entry with missed/outcome/seen semantics); this
   feature extends its coverage to calls the app never witnessed live.
+- **Friend-request outcome notification**: The alert announcing what happened
+  to the user's outgoing friend request (accepted/declined). Must always match
+  the actual event, or be neutral when the event is unknown.
 
 ## Success Criteria *(mandatory)*
 
@@ -298,6 +364,10 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
 - **SC-006**: No stale incoming-call notification remains on the lock screen
   more than a ring-window's length after the call ended (answered, cancelled,
   or expired), on platforms that permit notification withdrawal.
+- **SC-007**: 100% of friend-request acceptances that reach a closed app as a
+  push produce an "accepted" notification (named or neutral), and 0% produce
+  "New friend request" copy, verified by end-to-end test of the
+  request→accept flow with the requester's app closed.
 
 ## Assumptions
 
@@ -319,3 +389,7 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
 - Notification-preference settings (mute, badge-only, web-push off) continue
   to gate whether any alert or badge change happens at all; this spec only
   shapes alerts that are already allowed to show.
+- Naming the accepter in a friend-request-outcome notification exposes nothing
+  new: incoming-request notifications already name the requester from their
+  public directory profile, and both parties to a request already know each
+  other's identity.

--- a/specs/1040-incoming-call-notifications/spec.md
+++ b/specs/1040-incoming-call-notifications/spec.md
@@ -1,0 +1,321 @@
+# Feature Specification: Incoming Call Notifications — Caller Identity, Badge, and Missed-Call Trace
+
+**Feature Branch**: `feat/1040-incoming-call-notifications`
+
+**Created**: 2026-07-12
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Incoming call notification improvements. (1) When a call comes in while the app is closed or backgrounded, the app icon badge count should increase by one because the incoming call is new activity — but only once for the first call notification of that call; subsequent/repeated notifications for the same ringing call must not increment the badge again. (2) If the user opens the app (by tapping the call notification or opening it directly), further push notifications for that call should stop, and the call's badge increment should be removed so only unread message counts remain on the app badge. (3) When a call is missed — either the user never opened the app, or opened it but chose not to answer — it must be logged as a missed call with a visible trace: in the 1:1 chat with the caller for direct calls, in the group chat the call was started from for group calls, and in the Calls tab for group ad-hoc calls. The point is there must always be a trace of missed calls. (4) The OS notification for an incoming call currently shows no detail about who is calling; it should show caller identity, e.g. 'Kamran is calling you' with a video emoji or audio emoji depending on call type, so the user knows what's happening directly from the notification."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Know who is calling from the notification (Priority: P1)
+
+Sara's phone is in her pocket with Ring closed. Kamran video-calls her. The
+notification that appears on her lock screen reads "📹 Kamran is calling you"
+instead of today's anonymous "Incoming call — Tap to answer". For a group call
+started from the "Weekend Trip" group, the notification names the group and,
+when known, who started it (e.g. "🎙️ Kamran is calling in Weekend Trip"). Sara
+can decide whether to grab the phone without unlocking anything.
+
+**Why this priority**: This is the moment-of-truth interaction of a calling
+app. An anonymous ring forces the user to open the app just to find out who
+wants them, and makes the notification indistinguishable from spam. It is also
+the piece users notice on every single call.
+
+**Independent Test**: Close the app on device B, call it from device A as a
+named contact (audio, then video, then from a group). Inspect the OS
+notification text on B in all three cases.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is closed or backgrounded and the caller is a saved
+   contact, **When** an audio call arrives, **Then** the notification shows the
+   caller's display name and an audio indicator (e.g. "🎙️ Kamran is calling
+   you").
+2. **Given** the same state, **When** a video call arrives, **Then** the
+   notification shows the caller's name and a video indicator (e.g. "📹 Kamran
+   is calling you").
+3. **Given** a group call started from a group the user is a member of,
+   **When** the ring arrives, **Then** the notification names the group (and
+   the initiator when known) plus the call-type indicator.
+4. **Given** the caller's identity cannot be determined on the device in time
+   (unknown sender, identity not yet resolvable), **When** the ring arrives,
+   **Then** the notification falls back to today's generic "Incoming call" —
+   the ring alert itself is never delayed or dropped waiting for identity.
+5. **Given** the call comes from a chat the user has hidden behind their
+   hidden-chats PIN, **When** the ring arrives, **Then** the notification stays
+   generic and does not name the caller or group.
+
+---
+
+### User Story 2 - Every missed call leaves a trace (Priority: P2)
+
+Kamran calls Sara while her phone sits silent in a drawer with Ring closed all
+day. When she opens Ring that evening, she finds a "Missed call" entry in her
+1:1 chat with Kamran and in the Calls tab — even though the app never ran while
+the call was ringing. The same holds when she saw the ring and chose not to
+answer, and for group calls (trace in the group chat) and ad-hoc group calls
+with no originating group chat (trace in the Calls tab).
+
+**Why this priority**: Today a call that rings only as a notification while the
+app stays closed can vanish without a record, so the callee never learns anyone
+tried to reach them. A messenger that silently loses missed calls breaks trust;
+this closes the gap for every path a call can go unanswered.
+
+**Independent Test**: With the app on device B fully closed, call it from
+device A and let the ring expire. Open B afterwards and verify the missed-call
+entry appears in the 1:1 chat and the Calls tab. Repeat for a group call and
+for an ad-hoc group call.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app was closed for the entire ring and the call was never
+   answered, **When** the user next opens the app, **Then** a missed-call entry
+   for that call appears in the 1:1 chat with the caller and in the Calls tab.
+2. **Given** the user saw the incoming-call screen in the app and declined or
+   ignored it until it timed out, **Then** the call is recorded with the
+   appropriate existing outcome ("Missed call" / "Declined") in the same
+   places.
+3. **Given** a group call started from a group chat goes unanswered, **Then**
+   the trace appears in that group chat and in the Calls tab.
+4. **Given** an ad-hoc group call with no originating group chat goes
+   unanswered, **Then** the trace appears at least in the Calls tab.
+5. **Given** the call was answered on another of the user's devices or the
+   caller cancelled before the ring window ended, **Then** it is not recorded
+   as missed on this device beyond the existing behavior for those outcomes.
+6. **Given** a new missed-call entry exists and has not been seen, **Then** it
+   counts toward the existing Calls-tab missed badge until viewed, exactly as
+   live-logged missed calls do today.
+
+---
+
+### User Story 3 - A ringing call badges the app icon once (Priority: P3)
+
+Kamran calls Sara while Ring is closed. Her app icon badge, which read "2" for
+two unread messages, now reads "3" — the ringing call is new activity. The ring
+re-alerts a few times while unanswered, but the badge stays at "3"; repeated
+notifications for the same call never inflate the count.
+
+**Why this priority**: The badge is the at-a-glance "something happened"
+signal. Without the call contribution, a user who misses the transient
+notification sees no evidence anything occurred; but a badge that climbs with
+every re-ring would overstate one call as many events.
+
+**Independent Test**: Note the badge count on device B with the app closed.
+Call from device A, let it re-alert at least twice, and confirm the badge rose
+by exactly 1 over the whole ring.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is closed or backgrounded with N standing badge items,
+   **When** the first notification for an incoming call arrives, **Then** the
+   app icon badge shows N+1.
+2. **Given** the same call re-alerts (repeated ring notifications for the same
+   call), **Then** the badge remains N+1 — no further increments.
+3. **Given** two distinct incoming calls ring while the app stays closed,
+   **Then** each contributes one increment (N+2).
+4. **Given** the ring ends unanswered while the app stays closed, **Then** the
+   badge does not double-count the same call as both "ringing" and "missed":
+   the total call-related contribution for that call is one until the user
+   sees it.
+
+---
+
+### User Story 4 - Opening the app clears the ring's notification footprint (Priority: P4)
+
+Sara hears the ring and opens Ring — by tapping the call notification or just
+launching the app. The in-app incoming-call screen takes over: the OS
+notification for that call is dismissed, no further notifications for that call
+appear, and the badge increment the ringing call added is removed, leaving only
+the unread counts that were already standing.
+
+**Why this priority**: Follow-through on stories 1 and 3 — stale call
+notifications and a leftover badge after the app is already handling the call
+read as bugs, but this only matters once those stories exist.
+
+**Independent Test**: With a call ringing and the badge incremented, open the
+app. Verify the OS call notification is gone, no new ones appear while the
+in-app ring continues, and the badge reverts to the pre-call unread count.
+
+**Acceptance Scenarios**:
+
+1. **Given** a call notification is showing and the badge is incremented,
+   **When** the user opens the app (via the notification or directly),
+   **Then** the OS call notification for that call is dismissed and no further
+   OS notifications for that call are shown while the app is handling it.
+2. **Given** the app has been opened during the ring, **Then** the badge drops
+   the ringing-call increment and reflects only the standing unread/missed
+   counts.
+3. **Given** the user opened the app during the ring but let the call go
+   unanswered anyway, **Then** the missed-call trace (User Story 2) is still
+   recorded and the existing unseen-missed-call badge behavior applies from
+   that point.
+
+---
+
+### Edge Cases
+
+- Caller is not a saved contact and no display identity is resolvable on the
+  device → generic notification (US1 scenario 4); never show a raw user id.
+- Call from a hidden chat (hidden-chats PIN feature) → generic notification, no
+  identity leak on the lock screen; hidden-call exclusions from the Calls tab
+  and badges continue to apply to the missed-call trace.
+- Identity resolution is slower than the ring alert → show generic immediately
+  or upgrade the same notification when identity resolves; never delay the
+  first alert.
+- Two calls ring in overlapping windows → each is tracked separately for badge
+  (one increment each) and missed-call traces (one entry each).
+- The caller hangs up (cancel) before the callee ever opens the app → the call
+  notification is withdrawn if the platform allows; the call still surfaces as
+  a missed call, and the badge contribution follows the missed-call rules
+  rather than lingering as "ringing".
+- Call answered on the user's other device → this device's notification and
+  badge contribution clear; no missed-call entry is created for an
+  answered-elsewhere call.
+- The user has notifications muted for the relevant chat or has badge-only
+  settings → existing notification-preference semantics win; this feature never
+  makes a silenced context louder.
+- The device's platform does not support app-icon badging from the background
+  → badge catches up the next time the app opens, matching existing badge
+  behavior; notifications and missed-call traces are unaffected.
+- Repeated ring notifications must keep re-alerting audibly (current behavior)
+  even though they no longer re-increment the badge.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Caller identity in the notification (US1)**
+
+- **FR-001**: The incoming-call notification MUST display the caller's local
+  display name and the call type (audio vs video, with a matching emoji or
+  equivalent visual cue) for 1:1 calls when the caller is resolvable on the
+  device, e.g. "📹 Kamran is calling you".
+- **FR-002**: For group calls, the notification MUST name the group when the
+  ring can be associated with a group the user knows, and SHOULD name the
+  initiator when known, with the call-type cue.
+- **FR-003**: Caller/group identity MUST be resolved exclusively from data
+  already on the device or from end-to-end-encrypted material the device can
+  decrypt. The push payload the notification service carries MUST remain
+  content-free (no names, no user ids, no group ids in plaintext) — the
+  zero-knowledge boundary is unchanged.
+- **FR-004**: If identity cannot be resolved by the time the ring must be
+  shown, the notification MUST fall back to the current generic "Incoming
+  call" text. The first ring alert MUST NOT be delayed or suppressed while
+  waiting for identity resolution.
+- **FR-005**: Calls originating from chats the user has hidden (hidden-chats
+  feature) MUST always use the generic notification with no identifying
+  detail.
+- **FR-006**: A raw internal identifier (user id, room id) MUST never be shown
+  as a caller name; unresolvable identity falls back to generic text.
+
+**Badge lifecycle for a ringing call (US3, US4)**
+
+- **FR-007**: The first notification shown for an incoming call while the app
+  is closed or backgrounded MUST increase the app icon badge count by exactly
+  one.
+- **FR-008**: Subsequent/repeated notifications for the same ringing call MUST
+  NOT increase the badge further; distinct concurrent calls each count once.
+- **FR-009**: When the user opens the app during the ring (via the
+  notification or directly), the ringing-call badge contribution MUST be
+  removed so the badge reflects only standing unread/missed counts.
+- **FR-010**: A single call MUST contribute at most one badge unit at any
+  moment across its lifecycle (ringing → missed-unseen); transitioning from
+  "ringing" to "missed, unseen" must not double-count.
+
+**Notification lifecycle on open (US4)**
+
+- **FR-011**: Opening the app while a call is ringing MUST dismiss the OS
+  notification for that call and suppress further OS notifications for it
+  while the app is foreground and handling the ring in-app.
+- **FR-012**: If the caller cancels or the ring window expires while the app
+  stays closed, the call notification MUST stop re-alerting and, where the
+  platform allows, be updated or withdrawn so a stale "incoming call" alert
+  does not outlive the actual ring.
+
+**Missed-call trace (US2)**
+
+- **FR-013**: Every incoming call that ends unanswered on this account —
+  whether the app was open, backgrounded, or fully closed for the entire ring
+  — MUST produce a missed-call record visible to the user.
+- **FR-014**: The missed-call record MUST appear in the 1:1 chat with the
+  caller for direct calls, in the originating group chat for group calls, and
+  in the Calls tab in all cases; an ad-hoc group call with no originating
+  group chat MUST at minimum appear in the Calls tab.
+- **FR-015**: Calls the user never saw in-app (app closed throughout the ring)
+  MUST surface their missed-call record no later than the next time the app is
+  opened.
+- **FR-016**: Existing outcome distinctions (missed vs declined vs busy vs
+  answered-elsewhere) MUST be preserved; answered-elsewhere and
+  caller-cancelled-before-ring calls follow their existing recording behavior
+  and are not newly classified as missed.
+- **FR-017**: Missed-call records created by this feature MUST participate in
+  the existing unseen-missed-call badge and "seen" clearing semantics, and
+  MUST respect existing exclusions (e.g. hidden chats).
+- **FR-018**: Missed-call records MUST NOT be duplicated when multiple signals
+  about the same call arrive (e.g. the device later reconnects and also learns
+  about the call through normal sync).
+
+### Key Entities
+
+- **Incoming-call notification**: The OS-level alert for a ringing call.
+  Gains: caller/group identity text, call-type cue, a lifecycle (shown →
+  re-alerted → dismissed on open / withdrawn on cancel or expiry).
+- **Ringing-call badge contribution**: A transient, per-call unit added to the
+  app icon badge; created on first notification, removed on app open, and
+  handed over (not added) to the missed-unseen contribution when the call is
+  missed.
+- **Missed-call record**: The durable trace of an unanswered call (already
+  exists as the call-log entry with missed/outcome/seen semantics); this
+  feature extends its coverage to calls the app never witnessed live.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For calls from saved contacts with the app closed, 100% of
+  incoming-call notifications name the caller and call type (verified across
+  1:1 audio, 1:1 video, and group calls in end-to-end tests / manual device
+  checks).
+- **SC-002**: A user can tell who is calling and whether it is audio or video
+  from the lock screen alone, without unlocking or opening the app.
+- **SC-003**: Across a full unanswered ring with repeated alerts, the app icon
+  badge rises by exactly 1, and returns to the pre-call count within 5 seconds
+  of the app being opened during the ring.
+- **SC-004**: 100% of unanswered incoming calls leave a visible missed-call
+  trace — including calls whose entire ring happened while the app was closed
+  — discoverable in the expected chat and/or Calls tab by the next app open.
+- **SC-005**: Zero plaintext identity (names, user ids, group ids) is present
+  in any payload handed to the platform push service, verified by inspecting
+  the wire payloads in tests.
+- **SC-006**: No stale incoming-call notification remains on the lock screen
+  more than a ring-window's length after the call ended (answered, cancelled,
+  or expired), on platforms that permit notification withdrawal.
+
+## Assumptions
+
+- The existing ~60-second ring window and repeated re-alert behavior for
+  unanswered calls stay as they are; this feature changes what the alerts say
+  and count, not when they fire.
+- Caller/group display names come from the user's own on-device data
+  (contacts, group membership); there is no server-side directory lookup, and
+  the server continues to see only content-free call tickles.
+- The existing call-log data model (missed / outcome / seen, chat call rows,
+  Calls tab) is reused and extended in coverage — no parallel "missed call"
+  concept is introduced.
+- Hidden-chat exclusions (Calls tab, badges, generic notifications) defined by
+  the hidden-chats feature take precedence over every behavior in this spec.
+- "App icon badge" behavior is subject to platform capability (e.g. badging
+  from the background is unavailable on some older platforms); where the
+  platform cannot badge in the background, the badge reconciles on next app
+  open, which is the existing accepted degradation.
+- Notification-preference settings (mute, badge-only, web-push off) continue
+  to gate whether any alert or badge change happens at all; this spec only
+  shapes alerts that are already allowed to show.

--- a/specs/1040-incoming-call-notifications/spec.md
+++ b/specs/1040-incoming-call-notifications/spec.md
@@ -165,8 +165,10 @@ by exactly 1 over the whole ring.
    app icon badge shows N+1.
 2. **Given** the same call re-alerts (repeated ring notifications for the same
    call), **Then** the badge remains N+1 — no further increments.
-3. **Given** two distinct incoming calls ring while the app stays closed,
-   **Then** each contributes one increment (N+2).
+3. **Given** two distinct incoming calls ring while the app stays closed and
+   the device can tell them apart, **Then** each contributes one increment
+   (N+2); an undistinguishable overlap (locked device) folds into one
+   increment rather than overcounting.
 4. **Given** the ring ends unanswered while the app stays closed, **Then** the
    badge does not double-count the same call as both "ringing" and "missed":
    the total call-related contribution for that call is one until the user
@@ -275,7 +277,10 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   is closed or backgrounded MUST increase the app icon badge count by exactly
   one.
 - **FR-008**: Subsequent/repeated notifications for the same ringing call MUST
-  NOT increase the badge further; distinct concurrent calls each count once.
+  NOT increase the badge further; distinct concurrent calls each count once
+  when the device can tell the calls apart (identity resolvable). When it
+  cannot (e.g. locked device), overlapping rings MAY fold into one unit —
+  undercounting is the accepted degradation, never overcounting.
 - **FR-009**: When the user opens the app during the ring (via the
   notification or directly), the ringing-call badge contribution MUST be
   removed so the badge reflects only standing unread/missed counts.

--- a/specs/1040-incoming-call-notifications/spec.md
+++ b/specs/1040-incoming-call-notifications/spec.md
@@ -13,6 +13,16 @@
 
 **Input**: User description: "Incoming call notification improvements. (1) When a call comes in while the app is closed or backgrounded, the app icon badge count should increase by one because the incoming call is new activity — but only once for the first call notification of that call; subsequent/repeated notifications for the same ringing call must not increment the badge again. (2) If the user opens the app (by tapping the call notification or opening it directly), further push notifications for that call should stop, and the call's badge increment should be removed so only unread message counts remain on the app badge. (3) When a call is missed — either the user never opened the app, or opened it but chose not to answer — it must be logged as a missed call with a visible trace: in the 1:1 chat with the caller for direct calls, in the group chat the call was started from for group calls, and in the Calls tab for group ad-hoc calls. The point is there must always be a trace of missed calls. (4) The OS notification for an incoming call currently shows no detail about who is calling; it should show caller identity, e.g. 'Kamran is calling you' with a video emoji or audio emoji depending on call type, so the user knows what's happening directly from the notification." — Follow-up in the same session: "also when someone accepts my friend request, instead of 'X has accepted your friend request' in a web push notification, I get that a friend request has come in! let's address this as part of the same fix as well."
 
+## Clarifications
+
+### Session 2026-07-12
+
+- Q: What happens to the OS call notification once the ring ends unanswered
+  (app still closed)? → A: Replace it with a missed-call notification
+  ("Missed call from \<name\>" — named when resolvable, generic otherwise);
+  tapping it opens the relevant chat / Calls tab. It represents the same
+  single badge unit the ringing call held (no double-count).
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Know who is calling from the notification (Priority: P1)
@@ -208,10 +218,11 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   first alert.
 - Two calls ring in overlapping windows → each is tracked separately for badge
   (one increment each) and missed-call traces (one entry each).
-- The caller hangs up (cancel) before the callee ever opens the app → the call
-  notification is withdrawn if the platform allows; the call still surfaces as
-  a missed call, and the badge contribution follows the missed-call rules
-  rather than lingering as "ringing".
+- The caller hangs up (cancel) before the callee ever opens the app → the ring
+  notification is replaced by the missed-call notification (platform
+  permitting); the call still surfaces as a missed call in-app, and the badge
+  contribution follows the missed-call rules rather than lingering as
+  "ringing".
 - Call answered on the user's other device → this device's notification and
   badge contribution clear; no missed-call entry is created for an
   answered-elsewhere call.
@@ -279,8 +290,14 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   while the app is foreground and handling the ring in-app.
 - **FR-012**: If the caller cancels or the ring window expires while the app
   stays closed, the call notification MUST stop re-alerting and, where the
-  platform allows, be updated or withdrawn so a stale "incoming call" alert
-  does not outlive the actual ring.
+  platform allows, be REPLACED by a missed-call notification so a stale
+  "incoming call" alert never outlives the actual ring.
+- **FR-012a**: The missed-call notification MUST read "Missed call from
+  \<name\>" (or the group equivalent) when identity is resolvable on-device,
+  falling back to a generic "Missed call" otherwise; tapping it MUST open the
+  relevant 1:1/group chat, or the Calls tab when no chat applies. It carries
+  the same single badge unit the ringing call held (FR-010) and clears under
+  the existing unseen-missed-call semantics (FR-017).
 
 **Missed-call trace (US2)**
 
@@ -330,7 +347,12 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
 
 - **Incoming-call notification**: The OS-level alert for a ringing call.
   Gains: caller/group identity text, call-type cue, a lifecycle (shown →
-  re-alerted → dismissed on open / withdrawn on cancel or expiry).
+  re-alerted → dismissed on open / replaced by a missed-call notification on
+  cancel or expiry).
+- **Missed-call notification**: The OS-level alert that replaces an unanswered
+  ring ("Missed call from \<name\>", generic when unresolvable). Opens the
+  relevant chat or the Calls tab; holds the call's single badge unit until
+  seen.
 - **Ringing-call badge contribution**: A transient, per-call unit added to the
   app icon badge; created on first notification, removed on app open, and
   handed over (not added) to the missed-unseen contribution when the call is
@@ -363,7 +385,8 @@ in-app ring continues, and the badge reverts to the pre-call unread count.
   the wire payloads in tests.
 - **SC-006**: No stale incoming-call notification remains on the lock screen
   more than a ring-window's length after the call ended (answered, cancelled,
-  or expired), on platforms that permit notification withdrawal.
+  or expired), on platforms that permit notification withdrawal; an unanswered
+  ring is replaced by a missed-call notification on those platforms.
 - **SC-007**: 100% of friend-request acceptances that reach a closed app as a
   push produce an "accepted" notification (named or neutral), and 0% produce
   "New friend request" copy, verified by end-to-end test of the

--- a/specs/1040-incoming-call-notifications/spec.md
+++ b/specs/1040-incoming-call-notifications/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-12
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1040-incoming-call-notifications/tasks.md
+++ b/specs/1040-incoming-call-notifications/tasks.md
@@ -15,7 +15,7 @@ fully independent of it.
 
 ## Phase 1: Setup
 
-- [ ] T001 Create the pure module skeleton `src/services/call-events.ts` (exported types for `CallEventPayload`, badge units, reconcile decisions; no logic yet) and empty test file `src/services/call-events.test.ts` wired into vitest
+- [x] T001 Create the pure module skeleton `src/services/call-events.ts` (exported types for `CallEventPayload`, badge units, reconcile decisions; no logic yet) and empty test file `src/services/call-events.test.ts` wired into vitest
 
 ---
 
@@ -24,10 +24,10 @@ fully independent of it.
 **Purpose**: the marker type, its pure logic, and the sender sites; nothing
 user-visible yet.
 
-- [ ] T002 [P] Write failing vitest specs in `src/services/call-events.test.ts` for marker construction/validation (ring + ended shapes per contracts/call-event.md), freshness/staleness against the ring window, and the reconcile decision table from data-model.md (ended/missed creates, ended/answered clears, stale ring → missed, existing-row wins)
-- [ ] T003 Add the optional `callEvent` field (typed, documented) to `MessagePayload` in `src/services/crypto/message.ts` per contracts/call-event.md — types + doc comment only, no behavior
-- [ ] T004 Implement `src/services/call-events.ts` pure logic to green T002: `buildRingEvent`/`buildEndedEvent`, `isRingStale`, `reconcileCallEvent(pending, existingRow, outcome)`, and badge-unit transition helpers (`applyCallTickle`, `applyOutcome`, `clearUnits`, stale sweep)
-- [ ] T005 Wire fire-and-forget marker sends in `src/composables/useCall.ts`: `ring` at 1:1 dial and per-invitee at group ring start; `ended/missed` at the caller no-answer timeout; `ended/cancelled` on caller cancel; `ended/answered` on answer — reusing the existing sealed payload-only send path (same class as reactions), never blocking call setup
+- [x] T002 [P] Write failing vitest specs in `src/services/call-events.test.ts` for marker construction/validation (ring + ended shapes per contracts/call-event.md), freshness/staleness against the ring window, and the reconcile decision table from data-model.md (ended/missed creates, ended/answered clears, stale ring → missed, existing-row wins)
+- [x] T003 Add the optional `callEvent` field (typed, documented) to `MessagePayload` in `src/services/crypto/message.ts` per contracts/call-event.md — types + doc comment only, no behavior
+- [x] T004 Implement `src/services/call-events.ts` pure logic to green T002: `buildRingEvent`/`buildEndedEvent`, `isRingStale`, `reconcileCallEvent(pending, existingRow, outcome)`, and badge-unit transition helpers (`applyCallTickle`, `applyOutcome`, `clearUnits`, stale sweep)
+- [x] T005 Wire fire-and-forget marker sends in `src/composables/useCall.ts`: `ring` at 1:1 dial and per-invitee at group ring start; `ended/missed` at the caller no-answer timeout; `ended/cancelled` on caller cancel; `ended/answered` on answer — reusing the existing sealed payload-only send path (same class as reactions), never blocking call setup
 
 **Checkpoint**: `npx vitest run src/services/call-events.test.ts` green;
 `npm run build` green; wire behavior unchanged for old receivers.
@@ -42,9 +42,9 @@ calling in \<Group\>"); generic fallback when locked/unresolvable/hidden.
 **Independent test**: quickstart step 2 on a real device; vitest for every
 note variant.
 
-- [ ] T006 [P] [US1] Write failing vitest specs in `src/services/sw-inbox.calls.test.ts` for the call-note builder: 1:1 audio/video named copy, group copy with group-name resolution via `roomId`, hidden-chat → generic, unresolvable identity → generic, raw-id never shown (FR-006)
-- [ ] T007 [US1] Implement the call-note builder in `src/services/sw-inbox.ts`: recognize `callEvent` ring frames in the preview path (`noteForPayload`/a dedicated `previewCallRing`), resolve caller/group names from local stores, apply the hidden-chat gate before naming, return the note or null
-- [ ] T008 [US1] Update the `{"t":"call"}` wake path in `src/sw.ts`: run a bounded pending preview for a fresh ring marker; show the named ring (same `tag: 'ring-call'`, `renotify`, `requireInteraction`) or today's generic; re-ring wakes re-run the preview so identity upgrades in place (research R2); never delay the first alert (FR-004). NOTE: the `swNotifiedIds` shown-ledger dedups message notes — ring notes must stay re-buildable from the same pending marker across reminder wakes
+- [x] T006 [P] [US1] Write failing vitest specs in `src/services/sw-inbox.calls.test.ts` for the call-note builder: 1:1 audio/video named copy, group copy with group-name resolution via `roomId`, hidden-chat → generic, unresolvable identity → generic, raw-id never shown (FR-006)
+- [x] T007 [US1] Implement the call-note builder in `src/services/sw-inbox.ts`: recognize `callEvent` ring frames in the preview path (`noteForPayload`/a dedicated `previewCallRing`), resolve caller/group names from local stores, apply the hidden-chat gate before naming, return the note or null
+- [x] T008 [US1] Update the `{"t":"call"}` wake path in `src/sw.ts`: run a bounded pending preview for a fresh ring marker; show the named ring (same `tag: 'ring-call'`, `renotify`, `requireInteraction`) or today's generic; re-ring wakes re-run the preview so identity upgrades in place (research R2); never delay the first alert (FR-004). NOTE: the `swNotifiedIds` shown-ledger dedups message notes — ring notes must stay re-buildable from the same pending marker across reminder wakes
 - [ ] T009 [US1] Verify on the dev stack per quickstart.md step 2 (named audio, named video, group, and locked-device generic fallback); record results in the PR description
 
 **Checkpoint**: US1 delivers standalone value (named rings) with zero
@@ -61,11 +61,11 @@ rings are replaced by a "Missed call from \<name\>" notification.
 **Independent test**: e2e spec drives an unanswered 1:1 call and asserts the
 trace; device pass per quickstart step 3.
 
-- [ ] T010 [P] [US2] Extend `src/services/call-events.test.ts` with failing specs for receive-side integration decisions: dedup against a live-logged `calls` row (FR-018), group placement via `roomId` (group chat vs Calls-tab-only), declined/answered-elsewhere never logged as missed (FR-016)
-- [ ] T011 [P] [US2] Write failing e2e spec `e2e/missed-call-trace.spec.ts`: account A calls account B (B never answers), A's no-answer timeout ends the attempt, then B (app open, or reopened) shows the missed-call row in the 1:1 chat and the Calls tab entry with the missed badge until viewed (FR-013/014/017)
-- [ ] T012 [US2] Implement the `callEvent` receive branch in `src/db/queries.ts` `receiveIncomingInner` (silent side-effect pattern, no chat bubble): pending-ring bookkeeping, `ended/missed|cancelled` → missed `calls` row + `logCallToChat` placement per data-model.md, `ended/answered` → clear pending, plus stale-ring reconciliation on drain/open; idempotent by `callId`, never overwrites, hidden-chat exclusions intact
-- [ ] T013 [US2] Implement the missed-replacement in `src/services/sw-inbox.ts` + `src/sw.ts`: preview of `ended/missed|cancelled` shows "☎️ Missed call from \<Name\>" reusing the `ring-call` tag (FR-012/FR-012a) with chat deep-link (Calls tab when no chat resolves); `ended/answered` closes the ring notification and ends the wake via the quiet terminal (iOS visible-ending rule)
-- [ ] T014 [US2] Run the new e2e spec green (`npm run test:e2e -- missed-call-trace`) and the quickstart step-3 device pass; verify no duplicate rows when B was open the whole ring
+- [x] T010 [P] [US2] Extend `src/services/call-events.test.ts` with failing specs for receive-side integration decisions: dedup against a live-logged `calls` row (FR-018), group placement via `roomId` (group chat vs Calls-tab-only), declined/answered-elsewhere never logged as missed (FR-016)
+- [x] T011 [P] [US2] Write failing e2e spec `e2e/missed-call-trace.spec.ts`: account A calls account B (B never answers), A's no-answer timeout ends the attempt, then B (app open, or reopened) shows the missed-call row in the 1:1 chat and the Calls tab entry with the missed badge until viewed (FR-013/014/017)
+- [x] T012 [US2] Implement the `callEvent` receive branch in `src/db/queries.ts` `receiveIncomingInner` (silent side-effect pattern, no chat bubble): pending-ring bookkeeping, `ended/missed|cancelled` → missed `calls` row + `logCallToChat` placement per data-model.md, `ended/answered` → clear pending, plus stale-ring reconciliation on drain/open; idempotent by `callId`, never overwrites, hidden-chat exclusions intact
+- [x] T013 [US2] Implement the missed-replacement in `src/services/sw-inbox.ts` + `src/sw.ts`: preview of `ended/missed|cancelled` shows "☎️ Missed call from \<Name\>" reusing the `ring-call` tag (FR-012/FR-012a) with chat deep-link (Calls tab when no chat resolves); `ended/answered` closes the ring notification and ends the wake via the quiet terminal (iOS visible-ending rule)
+- [x] T014 [US2] Run the new e2e spec green (`npm run test:e2e -- missed-call-trace`) and the quickstart step-3 device pass; verify no duplicate rows when B was open the whole ring
 
 **Checkpoint**: missed calls are never lost; ring notifications never go stale.
 
@@ -80,10 +80,10 @@ friend request"; fallback copy is event-neutral. Fully independent of Phases
 **Independent test**: Go handler test + vitest for the SW path + quickstart
 step 5.
 
-- [ ] T015 [P] [US3] Write failing Go tests (fake store + handler) in `server/internal/api/connections_handlers_test.go` and the store fake: outgoing set includes `accepted` rows updated within 24h, excludes older accepted rows, keeps pending/rejected unchanged, DTO passes state through (contracts/connections-api.md)
-- [ ] T016 [US3] Change `OutgoingRequests` in `server/internal/store/connections.go` to include `state = 'accepted' AND updated_at > now() - interval '24 hours'`; update the in-memory fake store to match; `go build ./... && go vet ./... && go test ./...` green
-- [ ] T017 [P] [US3] Write failing vitest specs (mocked fetch) in `src/services/sw-inbox.calls.test.ts` or a sibling file for `previewConnections`: accepted outgoing row → "accepted your friend request" note named via public profile, dedup ledger announces at most once (FR-022), rejected unchanged
-- [ ] T018 [US3] Neutralize the fallback placeholder in `src/sw.ts` (`showConnNotification`): title/body copy that does not claim a new incoming request (e.g. "Contact updates" / "Tap to review" — app voice, no em-dashes), same tag/url; confirm the incoming-request path still says "wants to be friends" (FR-020/FR-021)
+- [x] T015 [P] [US3] Write failing Go tests (fake store + handler) in `server/internal/api/connections_handlers_test.go` and the store fake: outgoing set includes `accepted` rows updated within 24h, excludes older accepted rows, keeps pending/rejected unchanged, DTO passes state through (contracts/connections-api.md)
+- [x] T016 [US3] Change `OutgoingRequests` in `server/internal/store/connections.go` to include `state = 'accepted' AND updated_at > now() - interval '24 hours'`; update the in-memory fake store to match; `go build ./... && go vet ./... && go test ./...` green
+- [x] T017 [P] [US3] Write failing vitest specs (mocked fetch) in `src/services/sw-inbox.calls.test.ts` or a sibling file for `previewConnections`: accepted outgoing row → "accepted your friend request" note named via public profile, dedup ledger announces at most once (FR-022), rejected unchanged
+- [x] T018 [US3] Neutralize the fallback placeholder in `src/sw.ts` (`showConnNotification`): title/body copy that does not claim a new incoming request (e.g. "Contact updates" / "Tap to review" — app voice, no em-dashes), same tag/url; confirm the incoming-request path still says "wants to be friends" (FR-020/FR-021)
 - [ ] T019 [US3] Verify end-to-end per quickstart step 5 on the dev stack (request → accept with requester's app closed → named accepted notification; decline path shows declined copy)
 
 **Checkpoint**: the reported bug is dead: 0% of acceptances can render "New
@@ -99,8 +99,8 @@ add more; ringing→missed hands over the same unit.
 **Independent test**: vitest transition table; device badge observation per
 quickstart step 2/3.
 
-- [ ] T020 [P] [US4] Extend `src/services/call-events.test.ts` with failing badge-unit specs: first tickle appends (FR-007), fresh-window/`callId` dedup on re-ring (FR-008), two distinct calls → two units, ringing→missed flip keeps one unit (FR-010), answered removes, stale sweep drops
-- [ ] T021 [US4] Implement `sw.callBadge` units in the SW: persist units in the idb `settings` store (shared-key pattern), include `units.length` in `updateAppBadge`'s total in `src/sw.ts`, append on call wake (marker `callId` when decryptable, ring-window heuristic otherwise), flip/remove on outcome preview (uses T004 helpers)
+- [x] T020 [P] [US4] Extend `src/services/call-events.test.ts` with failing badge-unit specs: first tickle appends (FR-007), fresh-window/`callId` dedup on re-ring (FR-008), two distinct calls → two units, ringing→missed flip keeps one unit (FR-010), answered removes, stale sweep drops
+- [x] T021 [US4] Implement `sw.callBadge` units in the SW: persist units in the idb `settings` store (shared-key pattern), include `units.length` in `updateAppBadge`'s total in `src/sw.ts`, append on call wake (marker `callId` when decryptable, ring-window heuristic otherwise), flip/remove on outcome preview (uses T004 helpers)
 - [ ] T022 [US4] Device verification: badge N → N+1 across a full re-ringing unanswered call, N+2 for two distinct calls (quickstart steps 2–3); note results in the PR
 
 **Checkpoint**: badge is truthful while the app is closed.
@@ -115,7 +115,7 @@ OS notifications while the app handles the ring.
 **Independent test**: quickstart step 4; unit coverage of the clearing helper
 already in T020.
 
-- [ ] T023 [US5] Extend the foreground sweep in `src/composables/useAppBadge.ts` to clear `sw.callBadge` units (ringing AND missed — the `calls` store owns missed from that moment), alongside the existing notification close-all and summary clear (FR-009/FR-011); confirm server-side push suppression on foreground needs no change (research R6)
+- [x] T023 [US5] Extend the foreground sweep in `src/composables/useAppBadge.ts` to clear `sw.callBadge` units (ringing AND missed — the `calls` store owns missed from that moment), alongside the existing notification close-all and summary clear (FR-009/FR-011); confirm server-side push suppression on foreground needs no change (research R6)
 - [ ] T024 [US5] Verify open-during-ring on the dev stack per quickstart step 4: notification gone, badge back to pre-call count within 5s (SC-003), in-app ring unaffected, missed trace still recorded if left unanswered (US5 scenario 3)
 
 **Checkpoint**: all five stories independently verified.
@@ -124,9 +124,9 @@ already in T020.
 
 ## Phase 8: Polish & gates
 
-- [ ] T025 [P] Sweep copy against the app voice (no em-dashes/semicolons, "you" phrasing) across all new notification strings in `src/sw.ts` / `src/services/sw-inbox.ts`
-- [ ] T026 Run the full gate set: `npm run build`, `npx vitest run`, `cd server && go build ./... && go vet ./... && go test ./...`, `npm run test:e2e` (needs `make db-up`); fix anything red
-- [ ] T027 Bump spec Status to `in-review`, run `make roadmap`, and prepare the PR body listing `Closes #N` for every task issue (constitution VIII)
+- [x] T025 [P] Sweep copy against the app voice (no em-dashes/semicolons, "you" phrasing) across all new notification strings in `src/sw.ts` / `src/services/sw-inbox.ts`
+- [x] T026 Run the full gate set: `npm run build`, `npx vitest run`, `cd server && go build ./... && go vet ./... && go test ./...`, `npm run test:e2e` (needs `make db-up`); fix anything red
+- [x] T027 Bump spec Status to `in-review`, run `make roadmap`, and prepare the PR body listing `Closes #N` for every task issue (constitution VIII)
 
 ---
 
@@ -153,3 +153,16 @@ MVP = Phase 2 + US1 (named rings) — immediately demonstrable value.
 Then US2 (the data-integrity core), US3 (independent quick win, can land any
 time), US4 → US5 (badge lifecycle). Each checkpoint is a working, testable
 increment; nothing after Phase 2 changes the wire format again.
+
+---
+
+## Implementation notes (2026-07-12)
+
+- T009/T019/T022/T024 (real-device lock-screen passes) remain open as MANUAL
+  verification: OS notification visuals and app-icon badges cannot be observed
+  in headless CI (plan.md Complexity Tracking). Everything they verify is
+  covered at the unit level (note builders, badge-unit transitions, conn
+  classification) and at the data layer by `e2e/missed-call-trace.spec.ts`.
+  Follow quickstart.md steps 2–5 on an installed PWA to close them.
+- T014's e2e half is green (3/3 in `missed-call-trace.spec.ts`); its device
+  half folds into the manual pass above.

--- a/specs/1040-incoming-call-notifications/tasks.md
+++ b/specs/1040-incoming-call-notifications/tasks.md
@@ -1,0 +1,155 @@
+# Tasks: Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace
+
+**Input**: Design documents from `/specs/1040-incoming-call-notifications/`
+
+**Prerequisites**: plan.md, spec.md, research.md (R1–R8), data-model.md, contracts/
+
+**Tests**: REQUIRED (constitution Principle III) — every phase orders failing
+tests before the implementation that satisfies them.
+
+**Organization**: grouped by user story; stories are independently testable
+increments. US1/US2/US4/US5 share the `callEvent` foundation (Phase 2); US3 is
+fully independent of it.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+- [ ] T001 Create the pure module skeleton `src/services/call-events.ts` (exported types for `CallEventPayload`, badge units, reconcile decisions; no logic yet) and empty test file `src/services/call-events.test.ts` wired into vitest
+
+---
+
+## Phase 2: Foundational — sealed `callEvent` frame (blocks US1, US2, US4, US5)
+
+**Purpose**: the marker type, its pure logic, and the sender sites; nothing
+user-visible yet.
+
+- [ ] T002 [P] Write failing vitest specs in `src/services/call-events.test.ts` for marker construction/validation (ring + ended shapes per contracts/call-event.md), freshness/staleness against the ring window, and the reconcile decision table from data-model.md (ended/missed creates, ended/answered clears, stale ring → missed, existing-row wins)
+- [ ] T003 Add the optional `callEvent` field (typed, documented) to `MessagePayload` in `src/services/crypto/message.ts` per contracts/call-event.md — types + doc comment only, no behavior
+- [ ] T004 Implement `src/services/call-events.ts` pure logic to green T002: `buildRingEvent`/`buildEndedEvent`, `isRingStale`, `reconcileCallEvent(pending, existingRow, outcome)`, and badge-unit transition helpers (`applyCallTickle`, `applyOutcome`, `clearUnits`, stale sweep)
+- [ ] T005 Wire fire-and-forget marker sends in `src/composables/useCall.ts`: `ring` at 1:1 dial and per-invitee at group ring start; `ended/missed` at the caller no-answer timeout; `ended/cancelled` on caller cancel; `ended/answered` on answer — reusing the existing sealed payload-only send path (same class as reactions), never blocking call setup
+
+**Checkpoint**: `npx vitest run src/services/call-events.test.ts` green;
+`npm run build` green; wire behavior unchanged for old receivers.
+
+---
+
+## Phase 3: User Story 1 — Know who is calling from the notification (P1) 🎯 MVP
+
+**Goal**: closed-app ring shows "📹/🎙️ \<Name\> is calling you" (group: "…is
+calling in \<Group\>"); generic fallback when locked/unresolvable/hidden.
+
+**Independent test**: quickstart step 2 on a real device; vitest for every
+note variant.
+
+- [ ] T006 [P] [US1] Write failing vitest specs in `src/services/sw-inbox.calls.test.ts` for the call-note builder: 1:1 audio/video named copy, group copy with group-name resolution via `roomId`, hidden-chat → generic, unresolvable identity → generic, raw-id never shown (FR-006)
+- [ ] T007 [US1] Implement the call-note builder in `src/services/sw-inbox.ts`: recognize `callEvent` ring frames in the preview path (`noteForPayload`/a dedicated `previewCallRing`), resolve caller/group names from local stores, apply the hidden-chat gate before naming, return the note or null
+- [ ] T008 [US1] Update the `{"t":"call"}` wake path in `src/sw.ts`: run a bounded pending preview for a fresh ring marker; show the named ring (same `tag: 'ring-call'`, `renotify`, `requireInteraction`) or today's generic; re-ring wakes re-run the preview so identity upgrades in place (research R2); never delay the first alert (FR-004)
+- [ ] T009 [US1] Verify on the dev stack per quickstart.md step 2 (named audio, named video, group, and locked-device generic fallback); record results in the PR description
+
+**Checkpoint**: US1 delivers standalone value (named rings) with zero
+missed-call/badge behavior yet.
+
+---
+
+## Phase 4: User Story 2 — Every missed call leaves a trace (P2)
+
+**Goal**: unanswered calls always produce the existing call-log trace (chat
+row + Calls tab), even when the app never ran during the ring; unanswered
+rings are replaced by a "Missed call from \<name\>" notification.
+
+**Independent test**: e2e spec drives an unanswered 1:1 call and asserts the
+trace; device pass per quickstart step 3.
+
+- [ ] T010 [P] [US2] Extend `src/services/call-events.test.ts` with failing specs for receive-side integration decisions: dedup against a live-logged `calls` row (FR-018), group placement via `roomId` (group chat vs Calls-tab-only), declined/answered-elsewhere never logged as missed (FR-016)
+- [ ] T011 [P] [US2] Write failing e2e spec `e2e/missed-call-trace.spec.ts`: account A calls account B (B never answers), A's no-answer timeout ends the attempt, then B (app open, or reopened) shows the missed-call row in the 1:1 chat and the Calls tab entry with the missed badge until viewed (FR-013/014/017)
+- [ ] T012 [US2] Implement the `callEvent` receive branch in `src/db/queries.ts` `receiveIncomingInner` (silent side-effect pattern, no chat bubble): pending-ring bookkeeping, `ended/missed|cancelled` → missed `calls` row + `logCallToChat` placement per data-model.md, `ended/answered` → clear pending, plus stale-ring reconciliation on drain/open; idempotent by `callId`, never overwrites, hidden-chat exclusions intact
+- [ ] T013 [US2] Implement the missed-replacement in `src/services/sw-inbox.ts` + `src/sw.ts`: preview of `ended/missed|cancelled` shows "☎️ Missed call from \<Name\>" reusing the `ring-call` tag (FR-012/FR-012a) with chat deep-link (Calls tab when no chat resolves); `ended/answered` closes the ring notification and ends the wake via the quiet terminal (iOS visible-ending rule)
+- [ ] T014 [US2] Run the new e2e spec green (`npm run test:e2e -- missed-call-trace`) and the quickstart step-3 device pass; verify no duplicate rows when B was open the whole ring
+
+**Checkpoint**: missed calls are never lost; ring notifications never go stale.
+
+---
+
+## Phase 5: User Story 3 — Friend-request outcomes are announced truthfully (P3)
+
+**Goal**: acceptance shows "\<Name\> accepted your friend request", never "New
+friend request"; fallback copy is event-neutral. Fully independent of Phases
+2–4.
+
+**Independent test**: Go handler test + vitest for the SW path + quickstart
+step 5.
+
+- [ ] T015 [P] [US3] Write failing Go tests (fake store + handler) in `server/internal/api/connections_handlers_test.go` and the store fake: outgoing set includes `accepted` rows updated within 24h, excludes older accepted rows, keeps pending/rejected unchanged, DTO passes state through (contracts/connections-api.md)
+- [ ] T016 [US3] Change `OutgoingRequests` in `server/internal/store/connections.go` to include `state = 'accepted' AND updated_at > now() - interval '24 hours'`; update the in-memory fake store to match; `go build ./... && go vet ./... && go test ./...` green
+- [ ] T017 [P] [US3] Write failing vitest specs (mocked fetch) in `src/services/sw-inbox.calls.test.ts` or a sibling file for `previewConnections`: accepted outgoing row → "accepted your friend request" note named via public profile, dedup ledger announces at most once (FR-022), rejected unchanged
+- [ ] T018 [US3] Neutralize the fallback placeholder in `src/sw.ts` (`showConnNotification`): title/body copy that does not claim a new incoming request (e.g. "Contact updates" / "Tap to review" — app voice, no em-dashes), same tag/url; confirm the incoming-request path still says "wants to be friends" (FR-020/FR-021)
+- [ ] T019 [US3] Verify end-to-end per quickstart step 5 on the dev stack (request → accept with requester's app closed → named accepted notification; decline path shows declined copy)
+
+**Checkpoint**: the reported bug is dead: 0% of acceptances can render "New
+friend request" copy.
+
+---
+
+## Phase 6: User Story 4 — A ringing call badges the app icon once (P4)
+
+**Goal**: first ring notification adds exactly one badge unit; re-rings never
+add more; ringing→missed hands over the same unit.
+
+**Independent test**: vitest transition table; device badge observation per
+quickstart step 2/3.
+
+- [ ] T020 [P] [US4] Extend `src/services/call-events.test.ts` with failing badge-unit specs: first tickle appends (FR-007), fresh-window/`callId` dedup on re-ring (FR-008), two distinct calls → two units, ringing→missed flip keeps one unit (FR-010), answered removes, stale sweep drops
+- [ ] T021 [US4] Implement `sw.callBadge` units in the SW: persist units in the idb `settings` store (shared-key pattern), include `units.length` in `updateAppBadge`'s total in `src/sw.ts`, append on call wake (marker `callId` when decryptable, ring-window heuristic otherwise), flip/remove on outcome preview (uses T004 helpers)
+- [ ] T022 [US4] Device verification: badge N → N+1 across a full re-ringing unanswered call, N+2 for two distinct calls (quickstart steps 2–3); note results in the PR
+
+**Checkpoint**: badge is truthful while the app is closed.
+
+---
+
+## Phase 7: User Story 5 — Opening the app clears the ring's footprint (P5)
+
+**Goal**: open during ring → notification swept, badge unit gone, no further
+OS notifications while the app handles the ring.
+
+**Independent test**: quickstart step 4; unit coverage of the clearing helper
+already in T020.
+
+- [ ] T023 [US5] Extend the foreground sweep in `src/composables/useAppBadge.ts` to clear `sw.callBadge` units (ringing AND missed — the `calls` store owns missed from that moment), alongside the existing notification close-all and summary clear (FR-009/FR-011); confirm server-side push suppression on foreground needs no change (research R6)
+- [ ] T024 [US5] Verify open-during-ring on the dev stack per quickstart step 4: notification gone, badge back to pre-call count within 5s (SC-003), in-app ring unaffected, missed trace still recorded if left unanswered (US5 scenario 3)
+
+**Checkpoint**: all five stories independently verified.
+
+---
+
+## Phase 8: Polish & gates
+
+- [ ] T025 [P] Sweep copy against the app voice (no em-dashes/semicolons, "you" phrasing) across all new notification strings in `src/sw.ts` / `src/services/sw-inbox.ts`
+- [ ] T026 Run the full gate set: `npm run build`, `npx vitest run`, `cd server && go build ./... && go vet ./... && go test ./...`, `npm run test:e2e` (needs `make db-up`); fix anything red
+- [ ] T027 Bump spec Status to `in-review`, run `make roadmap`, and prepare the PR body listing `Closes #N` for every task issue (constitution VIII)
+
+---
+
+## Dependencies
+
+- Phase 2 (foundation) blocks US1 (T007–T009), US2 (T012–T014), US4 (T021)
+- US2's T013 builds on US1's T007/T008 (same preview surface) — implement in
+  order US1 → US2
+- US3 (T015–T019) is fully independent — can run in parallel with any phase
+- US4 (T020–T022) depends on Phase 2 helpers only; US5 (T023–T024) depends on
+  US4's units existing
+- Polish (T025–T027) last
+
+## Parallel opportunities
+
+- T002 ∥ T003 (test file vs type file)
+- After Phase 2: the US3 server track (T015–T016) ∥ US1 client track
+  (T006–T008); T006 ∥ T010 ∥ T011 ∥ T017 ∥ T020 (distinct test files)
+- T025 ∥ final verification tasks
+
+## Implementation strategy
+
+MVP = Phase 2 + US1 (named rings) — immediately demonstrable value.
+Then US2 (the data-integrity core), US3 (independent quick win, can land any
+time), US4 → US5 (badge lifecycle). Each checkpoint is a working, testable
+increment; nothing after Phase 2 changes the wire format again.

--- a/specs/1040-incoming-call-notifications/tasks.md
+++ b/specs/1040-incoming-call-notifications/tasks.md
@@ -44,7 +44,7 @@ note variant.
 
 - [ ] T006 [P] [US1] Write failing vitest specs in `src/services/sw-inbox.calls.test.ts` for the call-note builder: 1:1 audio/video named copy, group copy with group-name resolution via `roomId`, hidden-chat → generic, unresolvable identity → generic, raw-id never shown (FR-006)
 - [ ] T007 [US1] Implement the call-note builder in `src/services/sw-inbox.ts`: recognize `callEvent` ring frames in the preview path (`noteForPayload`/a dedicated `previewCallRing`), resolve caller/group names from local stores, apply the hidden-chat gate before naming, return the note or null
-- [ ] T008 [US1] Update the `{"t":"call"}` wake path in `src/sw.ts`: run a bounded pending preview for a fresh ring marker; show the named ring (same `tag: 'ring-call'`, `renotify`, `requireInteraction`) or today's generic; re-ring wakes re-run the preview so identity upgrades in place (research R2); never delay the first alert (FR-004)
+- [ ] T008 [US1] Update the `{"t":"call"}` wake path in `src/sw.ts`: run a bounded pending preview for a fresh ring marker; show the named ring (same `tag: 'ring-call'`, `renotify`, `requireInteraction`) or today's generic; re-ring wakes re-run the preview so identity upgrades in place (research R2); never delay the first alert (FR-004). NOTE: the `swNotifiedIds` shown-ledger dedups message notes — ring notes must stay re-buildable from the same pending marker across reminder wakes
 - [ ] T009 [US1] Verify on the dev stack per quickstart.md step 2 (named audio, named video, group, and locked-device generic fallback); record results in the PR description
 
 **Checkpoint**: US1 delivers standalone value (named rings) with zero

--- a/src/composables/useAppBadge.ts
+++ b/src/composables/useAppBadge.ts
@@ -21,6 +21,11 @@ export function useAppBadge(): void {
     // summary so a stray push within its TTL can't silently re-assert a notification for a chat that's
     // just been read (or re-assert a now-stale cumulative count).
     void setSetting(SUMMARY_KEY, []);
+    // (spec 1040 FR-009) Retire the SW's per-call badge units: a still-ringing
+    // call is now handled by the open app (its increment goes away), and a missed
+    // call is represented in the calls store by now, which useBadges counts —
+    // keeping the unit too would double-badge it.
+    void setSetting('sw.callBadge', []);
     void getSetting<string>('notifications.badge', 'open').then((mode) => {
       if (mode !== 'open') return; // "When viewed" → leave the unread-count badge
       const nav = navigator as Navigator & { clearAppBadge?: () => Promise<void> };

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -925,42 +925,99 @@ function clearDialTimer(): void {
  * The caller/initiator sends sealed markers over the messaging ratchet so a
  * callee whose app is closed for the whole ring still gets a NAMED notification
  * (the SW previews the queued marker; the push tickle stays content-free) and a
- * missed-call trace on next open. `ring` goes out at dial time; `ended` settles
- * the outcome exactly once per callee. Everything is fire-and-forget — markers
- * must never block or fail call setup. */
+ * missed-call trace on next open. `ring` goes out during the ring; `ended`
+ * settles the outcome exactly once per callee. Everything is fire-and-forget —
+ * markers must never block or fail call setup.
+ *
+ * OFF THE HOT PATH: a marker seal shares the per-chat session lock with the
+ * live call signalling (offer/answer/trickle-ICE all open under the same
+ * withSessionLock), so sending one during connection setup serializes with the
+ * ICE burst — harmless on a fast machine, connect-breaking on a starved CI
+ * runner. Ring markers therefore fire on a DELAYED timer (2.5s — far inside
+ * the 60s ring window the closed-device preview needs), and outcomes settle
+ * either after the call is over (teardown/yield) or a beat after answer. An
+ * attempt that ends before its timer sends the ring+ended pair AT settle time
+ * instead (the call is over; there is no hot path left to disturb). */
 
-// 1:1: which callIds sent a ring marker, and which already got their outcome.
+const RING_MARKER_DELAY_MS = 2_500;
+
+// 1:1: pending delayed ring sends, which callIds actually sent one, and which
+// already settled their outcome.
+const ringMarkerTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const callEventRingSent = new Set<string>();
 const callEventOutcomeSent = new Set<string>();
 // Group: the per-instance marker id (the roomId is REUSED across calls, so it
-// can't dedup one call) plus the per-member outcome ledger. Created lazily by
+// can't dedup one call) plus per-member rung/outcome ledgers. Created lazily by
 // whoever rings members (initiator, or a participant adding someone later).
-const groupCallEvents = new Map<string, { instanceId: string; kind: CallKind; outcome: Set<string> }>();
+const groupCallEvents = new Map<string, { instanceId: string; kind: CallKind; rung: Set<string>; outcome: Set<string> }>();
 
-/** Settle the 1:1 marker for an outgoing attempt (at most once per call). */
+/** Schedule the 1:1 dial-time ring marker: fires only while the attempt is
+ *  still unanswered (a call that connected fast needs no ring marker — the
+ *  callee answered it live; their other devices retire via the answered
+ *  settle). */
+function scheduleRingMarker(meta: CallMeta): void {
+  const { callId, kind, peerUserId } = meta;
+  if (!peerUserId) return;
+  const timer = setTimeout(() => {
+    ringMarkerTimers.delete(callId);
+    const cur = callMeta.value;
+    const stillRinging =
+      cur?.callId === callId && !cur.tornDown && callState.value !== 'connected' && callState.value !== 'connecting';
+    if (!stillRinging || callEventOutcomeSent.has(callId)) return;
+    callEventRingSent.add(callId);
+    void sendCallEvent(peerUserId, buildRingEvent(callId, kind, Date.now()));
+  }, RING_MARKER_DELAY_MS);
+  ringMarkerTimers.set(callId, timer);
+}
+
+/** Settle the 1:1 marker for an outgoing attempt (at most once per call). If
+ *  the delayed ring marker never fired but the callee's devices were pushed
+ *  the ring anyway (a fast cancel), sends the ring+ended pair now — the call
+ *  is over, so there is no hot path to protect. */
 function settleDirectCallEvent(meta: CallMeta, outcome: 'missed' | 'cancelled' | 'answered'): void {
   if (meta.isGroup || meta.direction !== 'outgoing' || !meta.peerUserId) return;
-  if (!callEventRingSent.has(meta.callId) || callEventOutcomeSent.has(meta.callId)) return;
+  if (callEventOutcomeSent.has(meta.callId)) return;
+  const timer = ringMarkerTimers.get(meta.callId);
+  if (timer) {
+    clearTimeout(timer);
+    ringMarkerTimers.delete(meta.callId);
+  }
   callEventOutcomeSent.add(meta.callId);
+  const rung = callEventRingSent.has(meta.callId);
+  if (!rung && (outcome === 'missed' || outcome === 'cancelled')) {
+    // The server pushed the callee's devices the moment we dialed; give their
+    // closed devices the trace even though the delayed ring marker never fired.
+    callEventRingSent.add(meta.callId);
+    void sendCallEvent(meta.peerUserId, buildRingEvent(meta.callId, meta.kind, Date.now()));
+  }
+  // 'answered' without a prior ring marker still sends the bare ended frame:
+  // it retires the stale ring notification + badge unit on closed devices.
   void sendCallEvent(meta.peerUserId, buildEndedEvent(meta.callId, meta.kind, outcome, Date.now()));
 }
 
 /** The marker state for a room we're ringing people into (created on demand). */
-function groupCallEventState(roomId: string, kind: CallKind): { instanceId: string; kind: CallKind; outcome: Set<string> } {
+function groupCallEventState(roomId: string, kind: CallKind): { instanceId: string; kind: CallKind; rung: Set<string>; outcome: Set<string> } {
   let g = groupCallEvents.get(roomId);
   if (!g) {
-    g = { instanceId: uid(), kind, outcome: new Set() };
+    g = { instanceId: uid(), kind, rung: new Set(), outcome: new Set() };
     groupCallEvents.set(roomId, g);
   }
   return g;
 }
 
-/** Ring-marker one group invitee (initial ring, recall, or mid-call add). A
- *  recall clears any earlier outcome so the fresh ring can settle again. */
+/** Ring-marker one group invitee (initial ring, recall, or mid-call add) — on
+ *  the same delayed timer as the 1:1 marker, and only while they haven't
+ *  joined. A recall clears any earlier outcome so the fresh ring settles again. */
 function ringGroupCallEvent(roomId: string, kind: CallKind, memberId: string): void {
   const g = groupCallEventState(roomId, kind);
   g.outcome.delete(memberId);
-  void sendCallEvent(memberId, buildRingEvent(g.instanceId, g.kind, Date.now(), roomId));
+  setTimeout(() => {
+    const meta = callMeta.value;
+    const live = meta?.isGroup && (meta.roomId ?? meta.callId) === roomId && !meta.tornDown;
+    if (!live || g.outcome.has(memberId) || meta.roster.includes(memberId)) return;
+    g.rung.add(memberId);
+    void sendCallEvent(memberId, buildRingEvent(g.instanceId, g.kind, Date.now(), roomId));
+  }, RING_MARKER_DELAY_MS);
 }
 
 /** Settle one group invitee's marker (at most once per member per ring). */
@@ -968,6 +1025,11 @@ function settleGroupCallEvent(roomId: string, memberId: string, outcome: 'missed
   const g = groupCallEvents.get(roomId);
   if (!g || g.outcome.has(memberId)) return;
   g.outcome.add(memberId);
+  const rung = g.rung.has(memberId);
+  if (!rung && (outcome === 'missed' || outcome === 'cancelled')) {
+    g.rung.add(memberId);
+    void sendCallEvent(memberId, buildRingEvent(g.instanceId, g.kind, Date.now(), roomId));
+  }
   void sendCallEvent(memberId, buildEndedEvent(g.instanceId, g.kind, outcome, Date.now(), roomId));
 }
 
@@ -1505,9 +1567,9 @@ export async function startDirectCall(contactId: string, kind: CallKind): Promis
   setState('dialing');
   startLoopTone('calling', 2800); // "calling" ringback (not yet ringing)
   // (spec 1040) Dial-time marker: lets the callee's closed device NAME this ring
-  // and guarantees a missed-call trace even if we die mid-ring. Fire-and-forget.
-  callEventRingSent.add(callId);
-  void sendCallEvent(contactId, buildRingEvent(callId, kind, Date.now()));
+  // and guarantees a missed-call trace even if we die mid-ring. Scheduled off
+  // the connect-critical window (see the marker section above).
+  if (callMeta.value) scheduleRingMarker(callMeta.value);
   // Caller-side timeout: the server may be buffering the offer for an offline
   // (push-woken) callee, so we can't rely on a fast "unavailable", give up
   // ourselves if nobody answers.
@@ -2204,6 +2266,15 @@ async function yieldToMutualCall(frame: Extract<CallFrame, { t: 'call-offer' }>,
   // Withdraw our offer so the relay drops its retained copy and any of the winner's other
   // devices stop ringing for it (same control a dial-timeout give-up sends).
   void sendControl('call-cancel', from, abandonedId, { reason: 'answered-elsewhere' });
+  // (spec 1040) Settle the abandoned attempt's call-event marker as handled: the yield
+  // skips teardown (the settle choke point), and an unsettled ring marker would
+  // reconcile on the WINNER's device into a phantom missed call ~a ring window after
+  // every mutual call. Deferred past the auto-accept's answer seal (same session lock).
+  setTimeout(() => {
+    settleDirectCallEvent(mine, 'answered');
+    callEventRingSent.delete(abandonedId);
+    callEventOutcomeSent.delete(abandonedId);
+  }, RING_MARKER_DELAY_MS);
   // FR-007: the abandoned attempt must not surface as a separate unanswered call — the
   // encounter is logged once, by the surviving call's incoming record below.
   void deleteCalls([abandonedId]);
@@ -3504,9 +3575,14 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
         if (meta.peerUserId) {
           void sendControl('call-cancel', meta.peerUserId, meta.callId, { reason: 'answered-elsewhere' });
         }
-        // (spec 1040) Settle the marker NOW (not at teardown): the callee's other
-        // devices may be closed, and their stale ring notification retires on this.
-        settleDirectCallEvent(meta, 'answered');
+        // (spec 1040) Settle the marker soon (not at teardown — a long call would
+        // leave the callee's closed other devices showing a stale ring), but a
+        // beat AFTER the answer: the settle seal shares the session lock with the
+        // trickle-ICE opens happening right now, and injecting it mid-burst can
+        // stall connection setup on a slow machine.
+        setTimeout(() => {
+          if (callMeta.value?.callId === meta.callId) settleDirectCallEvent(meta, 'answered');
+        }, RING_MARKER_DELAY_MS);
       }
       return;
     }

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -28,7 +28,10 @@ import {
   logCallToChat,
   sendMessage,
   getSetting,
+  sendCallEvent,
+  markGroupRingSeenLive,
 } from '@/db/queries';
+import { buildRingEvent, buildEndedEvent } from '@/services/call-events';
 import { groupAvatar } from '@/db/avatars';
 
 // Pre-answer identity for a call whose conversation is hidden (spec 1019, FR-019):
@@ -917,6 +920,57 @@ function clearDialTimer(): void {
   dialTimer = null;
 }
 
+/* ---- call-event markers (spec 1040) ----
+ *
+ * The caller/initiator sends sealed markers over the messaging ratchet so a
+ * callee whose app is closed for the whole ring still gets a NAMED notification
+ * (the SW previews the queued marker; the push tickle stays content-free) and a
+ * missed-call trace on next open. `ring` goes out at dial time; `ended` settles
+ * the outcome exactly once per callee. Everything is fire-and-forget — markers
+ * must never block or fail call setup. */
+
+// 1:1: which callIds sent a ring marker, and which already got their outcome.
+const callEventRingSent = new Set<string>();
+const callEventOutcomeSent = new Set<string>();
+// Group: the per-instance marker id (the roomId is REUSED across calls, so it
+// can't dedup one call) plus the per-member outcome ledger. Created lazily by
+// whoever rings members (initiator, or a participant adding someone later).
+const groupCallEvents = new Map<string, { instanceId: string; kind: CallKind; outcome: Set<string> }>();
+
+/** Settle the 1:1 marker for an outgoing attempt (at most once per call). */
+function settleDirectCallEvent(meta: CallMeta, outcome: 'missed' | 'cancelled' | 'answered'): void {
+  if (meta.isGroup || meta.direction !== 'outgoing' || !meta.peerUserId) return;
+  if (!callEventRingSent.has(meta.callId) || callEventOutcomeSent.has(meta.callId)) return;
+  callEventOutcomeSent.add(meta.callId);
+  void sendCallEvent(meta.peerUserId, buildEndedEvent(meta.callId, meta.kind, outcome, Date.now()));
+}
+
+/** The marker state for a room we're ringing people into (created on demand). */
+function groupCallEventState(roomId: string, kind: CallKind): { instanceId: string; kind: CallKind; outcome: Set<string> } {
+  let g = groupCallEvents.get(roomId);
+  if (!g) {
+    g = { instanceId: uid(), kind, outcome: new Set() };
+    groupCallEvents.set(roomId, g);
+  }
+  return g;
+}
+
+/** Ring-marker one group invitee (initial ring, recall, or mid-call add). A
+ *  recall clears any earlier outcome so the fresh ring can settle again. */
+function ringGroupCallEvent(roomId: string, kind: CallKind, memberId: string): void {
+  const g = groupCallEventState(roomId, kind);
+  g.outcome.delete(memberId);
+  void sendCallEvent(memberId, buildRingEvent(g.instanceId, g.kind, Date.now(), roomId));
+}
+
+/** Settle one group invitee's marker (at most once per member per ring). */
+function settleGroupCallEvent(roomId: string, memberId: string, outcome: 'missed' | 'cancelled' | 'answered'): void {
+  const g = groupCallEvents.get(roomId);
+  if (!g || g.outcome.has(memberId)) return;
+  g.outcome.add(memberId);
+  void sendCallEvent(memberId, buildEndedEvent(g.instanceId, g.kind, outcome, Date.now(), roomId));
+}
+
 /** Caller-side give-up: after `ms` with no answer, play the no-answer cue, tell the
  *  callee to stop ringing, and end. Armed short while only dialing, then re-armed to a
  *  longer window once the callee proves reachable (call-ringing). */
@@ -1254,6 +1308,25 @@ export async function teardown(reason: EndReason, opts?: { silent?: boolean }): 
         });
       }
     }
+    // (spec 1040) Settle the outgoing markers. 1:1: rang out → missed, we gave up
+    // before an answer → cancelled, everything else (answered, declined, busy,
+    // glare, answered-elsewhere) → handled, so the callee gets no false missed
+    // trace. Group: invitees whose ring we never saw settle (join/no-answer) get
+    // "cancelled" — the call ended before they ever picked up.
+    if (!meta.isGroup) {
+      settleDirectCallEvent(
+        meta,
+        wasConnected ? 'answered' : reason === 'timeout' ? 'missed' : reason === 'hangup' ? 'cancelled' : 'answered',
+      );
+      callEventRingSent.delete(meta.callId);
+      callEventOutcomeSent.delete(meta.callId);
+    } else {
+      const gRoomId = meta.roomId ?? meta.callId;
+      if (groupCallEvents.has(gRoomId)) {
+        for (const id of meta.invited ?? []) settleGroupCallEvent(gRoomId, id, 'cancelled');
+        groupCallEvents.delete(gRoomId);
+      }
+    }
     meta.endedReason = reason;
   }
   groupJoined.clear();
@@ -1431,6 +1504,10 @@ export async function startDirectCall(contactId: string, kind: CallKind): Promis
 
   setState('dialing');
   startLoopTone('calling', 2800); // "calling" ringback (not yet ringing)
+  // (spec 1040) Dial-time marker: lets the callee's closed device NAME this ring
+  // and guarantees a missed-call trace even if we die mid-ring. Fire-and-forget.
+  callEventRingSent.add(callId);
+  void sendCallEvent(contactId, buildRingEvent(callId, kind, Date.now()));
   // Caller-side timeout: the server may be buffering the offer for an offline
   // (push-woken) callee, so we can't rely on a fast "unavailable", give up
   // ourselves if nobody answers.
@@ -1550,6 +1627,10 @@ async function enterGroupCall(
     await teardown('failed');
     return;
   }
+  // (spec 1040) Ring markers for the invitees, under a fresh per-instance id
+  // (the roomId is reused across calls). Their closed devices name the ring
+  // from these; outcomes settle per member as the call progresses.
+  if (direction === 'outgoing') for (const m of members) ringGroupCallEvent(roomId, kind, m);
   armGroupIdleTimeout(); // end the call if nobody joins within the grace window
   navigateToCall();
 }
@@ -1578,6 +1659,10 @@ async function deriveGroupCallTitle(ids: string[]): Promise<string> {
 async function handleGroupInvite(frame: Extract<CallFrame, { t: 'call-group-invite' }>): Promise<void> {
   const roomId = frame.roomId;
   if (!roomId || !frame.from) return;
+  // (spec 1040) This device is handling the ring live (full ring, second-call
+  // prompt, or busy auto-decline below) — the live flows own the call trace, so
+  // any queued call-event marker for this room must stay silent.
+  void markGroupRingSeenLive(roomId);
   // Already ringing/connected for this room → ignore duplicate invites.
   if (callMeta.value?.roomId === roomId) return;
   // Already prompting for this room in the waiting slot → a server re-ring; keep the prompt.
@@ -1707,6 +1792,7 @@ export async function mergeGroupInvite(): Promise<void> {
       markNotJoining(id, false);
       armMemberRingTimer(id);
       await sendRecall(id, m.roomId, m.kind, m.invited);
+      ringGroupCallEvent(m.roomId, m.kind, id); // spec 1040: named ring + trace for their closed devices
     }
   });
   // Leave the invite's own room: we fold people into OUR call, we don't join theirs
@@ -1732,6 +1818,7 @@ export async function recallMember(memberId: string): Promise<void> {
   markNotJoining(memberId, false);
   armMemberRingTimer(memberId);
   await sendRecall(memberId, meta.roomId, meta.kind, meta.invited ?? []);
+  ringGroupCallEvent(meta.roomId, meta.kind, memberId); // spec 1040: fresh ring marker on recall
 }
 
 /** Free participant slots left in the ACTIVE call for its kind (spec 1028) — 0 when
@@ -1832,6 +1919,7 @@ export async function addPeople(ids: string[]): Promise<void> {
       markNotJoining(id, false);
       armMemberRingTimer(id);
       await sendRecall(id, meta.roomId, meta.kind, meta.invited);
+      ringGroupCallEvent(meta.roomId, meta.kind, id); // spec 1040: named ring + trace for their closed devices
     }
     return plan.dropped;
   });
@@ -3416,6 +3504,9 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
         if (meta.peerUserId) {
           void sendControl('call-cancel', meta.peerUserId, meta.callId, { reason: 'answered-elsewhere' });
         }
+        // (spec 1040) Settle the marker NOW (not at teardown): the callee's other
+        // devices may be closed, and their stale ring notification retires on this.
+        settleDirectCallEvent(meta, 'answered');
       }
       return;
     }
@@ -3562,6 +3653,9 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
         clearMemberRingTimer(id);
         markNotJoining(id, false);
         markMemberBusy(id, false); // a free device joined → no longer "unavailable" (US2)
+        // (spec 1040) They joined → settle their marker so no closed device of
+        // theirs logs a false missed call (and its stale ring retires).
+        settleGroupCallEvent(frame.roomId, id, 'answered');
       }
       // (spec 1030 US2) "{name} joined the call": the first roster of a call seeds
       // silently (whoever is already in the room was here before us, or is us);
@@ -3619,6 +3713,8 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
       if (frame.status === 'noanswer') {
         clearMemberRingTimer(id);
         markNotJoining(id, true);
+        // (spec 1040) Their reminder window ran out → the missed-call marker.
+        settleGroupCallEvent(frame.roomId, id, 'missed');
       } else if (frame.status === 'ringing') {
         markNotJoining(id, false);
         markMemberBusy(id, false);

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -23,7 +23,7 @@ import {
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
 import { kickPendingPosts } from '@/services/pending-posts';
-import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, notifyPostActivity, pruneLocalPost, hydrateGroupMembers } from '@/db/queries';
+import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, notifyPostActivity, pruneLocalPost, hydrateGroupMembers, reconcilePendingCallEvents } from '@/db/queries';
 import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
@@ -297,6 +297,11 @@ function start(): void {
       if (typeof document === 'undefined' || document.visibilityState === 'visible') {
         checkForUpdate(true);
       }
+      // (spec 1040) Settle any pending call-event markers: rings the live UI (or a
+      // marker outcome) already resolved clear silently; stale rings with no outcome
+      // become the missed-call trace. Runs after the drain paths above so a queued
+      // outcome marker lands before the stale judgement.
+      if (isUnlocked.value) void reconcilePendingCallEvents();
       void applyPushPreference(true); // (re)register or drop push per the notification prefs
       void sendPresencePrefs(); // upload our sharing booleans
       void sendPresenceSub(); // watch our contacts' presence

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -40,7 +40,9 @@ import { computeUnreadTotal, type HiddenBadgeMode } from '@/db/badge-count';
 import type {
   MessagePayload, ContactCard, GroupCard, GroupMember, ReactionSignal, PollVoteSignal, MediaRef,
   EditSignal, EraseSignal, LinkPreviewSignal, GameMoveSignal, GameAcceptSignal, GameCancelSignal,
+  CallEventSignal,
 } from '@/services/crypto/message';
+import { RING_WINDOW_MS, reconcilePending, type PendingCallEvent } from '@/services/call-events';
 import { GAMES } from '@/games/registry';
 import {
   applySignal as applyGameSignal,
@@ -5726,6 +5728,12 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     if (remoteId) await markInboundSeen(remoteId);
     return;
   }
+  // Call lifecycle markers (spec 1040) → missed-call trace bookkeeping, never stored.
+  if (payload.callEvent) {
+    await handleCallEvent(from, chatId, payload.callEvent);
+    if (remoteId) await markInboundSeen(remoteId);
+    return;
+  }
 
   // A group message arrives over a 1:1 session but belongs to the group chat.
   const isGroupMsg = !!payload.groupId;
@@ -6187,6 +6195,175 @@ export async function logCallToChat(chatId: string, log: CallLog): Promise<void>
   chat.lastMessageTime = ts;
   chat.updatedAt = ts;
   await put('chats', chat);
+}
+
+/* ---- call-event markers (spec 1040) ----
+ *
+ * The caller sends sealed `callEvent` frames over the pairwise ratchet: `ring`
+ * at dial time, `ended` at outcome time. They exist so a callee whose app never
+ * ran during the ring still (a) sees the caller named in the OS notification
+ * (SW preview) and (b) gets the missed-call trace on next open. All decisions
+ * are the pure rules in services/call-events.ts; this section is the stateful
+ * glue: the pending ledger (settings store), the send helper, and the
+ * trace-writing reconciler. Idempotent by callId — a row the live call UI
+ * already logged always wins (FR-018). */
+
+const CALL_EVENTS_PENDING_KEY = 'callEvents.pending';
+
+const readPendingCallEvents = (): Promise<Record<string, PendingCallEvent>> =>
+  getSetting<Record<string, PendingCallEvent>>(CALL_EVENTS_PENDING_KEY, {});
+const writePendingCallEvents = (map: Record<string, PendingCallEvent>): Promise<void> =>
+  setSetting(CALL_EVENTS_PENDING_KEY, map);
+
+/** Send one call-event marker to one user (1:1 callee, or each group invitee).
+ *  Fire-and-forget: a marker must never block or fail call setup. Reuses the
+ *  member-session machinery so group co-members without a visible chat work. */
+export async function sendCallEvent(toUserId: string, ev: CallEventSignal): Promise<void> {
+  try {
+    if ((await isContactGhosted(toUserId)) || (await isPeerBlocked(toUserId))) return;
+    const chatId = await memberSessionChat(toUserId);
+    if (!chatId) return;
+    const sealed = await sealForChat(chatId, toUserId, false, {
+      body: '',
+      kind: 'callevent',
+      timestamp: ev.at,
+      callEvent: ev,
+    });
+    if (sealed) await enqueue({ t: 'msg', id: uid(), to: sealed.to, ciphertext: sealed.packet });
+  } catch (e) {
+    console.warn('[call-events] marker send failed', e);
+  }
+}
+
+/** Rooms whose ring THIS device handled live (ring UI, second-call prompt, or
+ *  busy auto-decline). The live flows own the trace, so a marker for such a
+ *  room must not create a second one — including a marker that arrives AFTER
+ *  the live invite (markers ride the queued message channel; invites ride the
+ *  live socket, so either order happens). Entries expire with the ring window.
+ *  (A 1:1 ring needs none of this — its live offer path creates the calls-store
+ *  row keyed by the same callId, which is the dedup signal.) */
+const CALL_EVENTS_SEEN_LIVE_KEY = 'callEvents.seenLiveRooms';
+
+async function roomSeenLive(roomId: string | undefined): Promise<boolean> {
+  if (!roomId) return false;
+  const map = await getSetting<Record<string, number>>(CALL_EVENTS_SEEN_LIVE_KEY, {});
+  const ts = map[roomId];
+  return typeof ts === 'number' && now() - ts <= RING_WINDOW_MS;
+}
+
+/** The live UI is handling the group ring for this room: drop any pending
+ *  markers and remember the room so a late-arriving marker stays silent too. */
+export async function markGroupRingSeenLive(roomId: string): Promise<void> {
+  const map = await readPendingCallEvents();
+  let changed = false;
+  for (const [id, p] of Object.entries(map)) {
+    if (p.roomId === roomId) {
+      delete map[id];
+      changed = true;
+    }
+  }
+  if (changed) await writePendingCallEvents(map);
+  const seen = await getSetting<Record<string, number>>(CALL_EVENTS_SEEN_LIVE_KEY, {});
+  const cutoff = now() - RING_WINDOW_MS;
+  const fresh = Object.fromEntries(Object.entries(seen).filter(([, ts]) => ts >= cutoff));
+  fresh[roomId] = now();
+  await setSetting(CALL_EVENTS_SEEN_LIVE_KEY, fresh);
+}
+
+/** Write the missed-call trace a marker (or stale-ring reconcile) decided on:
+ *  the Calls-tab row (keyed by the marker callId → idempotent) and the in-chat
+ *  call row when a chat resolves. Hidden chats need no special casing here —
+ *  the Calls tab, badges, and chat list already exclude them downstream. */
+async function logMissedFromMarker(p: PendingCallEvent, knownChatId?: string): Promise<void> {
+  if (await get<Call>('calls', p.callId)) return; // live path logged it — never duplicate
+  const video = p.kind === 'video';
+  if (p.roomId) {
+    const groupChat = await getChat(p.roomId);
+    const initiator = await getContact(p.from);
+    const name = groupChat?.name ?? (initiator?.name ? `${initiator.name} & others` : 'Group call');
+    const ts = now();
+    await put<Call>('calls', {
+      id: p.callId,
+      contactId: p.roomId,
+      name,
+      avatar: groupChat?.avatar ?? initialsAvatar(name),
+      direction: 'incoming',
+      missed: true,
+      video,
+      seen: false,
+      timestamp: ts,
+      updatedAt: ts,
+      isGroup: true,
+      roomId: p.roomId,
+      participants: initiator?.name ? [initiator.name] : undefined,
+    });
+    if (groupChat) await logCallToChat(p.roomId, { direction: 'incoming', video, missed: true });
+    return;
+  }
+  await createCall({ callId: p.callId, contactId: p.from, direction: 'incoming', video });
+  const chatId =
+    knownChatId ??
+    (await getAll<Chat>('chats')).find(
+      (c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === p.from,
+    )?.id;
+  if (chatId) await logCallToChat(chatId, { direction: 'incoming', video, missed: true });
+}
+
+/** Apply one inbound marker (side effect, never a stored message). */
+async function handleCallEvent(from: string, chatId: string, ev: CallEventSignal): Promise<void> {
+  const map = await readPendingCallEvents();
+  if (ev.phase === 'ring') {
+    if (await roomSeenLive(ev.roomId)) return; // the live ring UI owns this room's trace
+    if (!map[ev.callId] && !(await get<Call>('calls', ev.callId))) {
+      map[ev.callId] = {
+        callId: ev.callId,
+        from,
+        kind: ev.kind,
+        ...(ev.roomId ? { roomId: ev.roomId } : {}),
+        receivedAt: now(),
+      };
+      await writePendingCallEvents(map);
+      // If no outcome ever arrives (caller died mid-ring), reconcile after the
+      // window instead of waiting for the next app open.
+      setTimeout(() => void reconcilePendingCallEvents(), RING_WINDOW_MS + 5_000);
+    }
+    return;
+  }
+  if (!ev.outcome) return;
+  const p: PendingCallEvent = map[ev.callId] ?? {
+    callId: ev.callId,
+    from,
+    kind: ev.kind,
+    ...(ev.roomId ? { roomId: ev.roomId } : {}),
+    receivedAt: now(),
+  };
+  const hasRow = !!(await get<Call>('calls', ev.callId));
+  const sawLive = await roomSeenLive(ev.roomId ?? p.roomId);
+  const decision = reconcilePending(p, { hasRow, sawLive, now: now(), outcome: ev.outcome });
+  if (decision === 'log-missed') await logMissedFromMarker(p, p.roomId ? undefined : chatId);
+  if (map[ev.callId]) {
+    delete map[ev.callId];
+    await writePendingCallEvents(map);
+  }
+}
+
+/** Sweep the pending ledger: rows the live UI logged clear silently; stale
+ *  rings with no outcome become missed-call traces (the caller crashed
+ *  mid-ring). Called on connect/open and after the ring window. */
+export async function reconcilePendingCallEvents(): Promise<void> {
+  const map = await readPendingCallEvents();
+  const entries = Object.values(map);
+  if (!entries.length) return;
+  let changed = false;
+  for (const p of entries) {
+    const hasRow = !!(await get<Call>('calls', p.callId));
+    const decision = reconcilePending(p, { hasRow, sawLive: await roomSeenLive(p.roomId), now: now() });
+    if (decision === 'keep') continue;
+    if (decision === 'log-missed') await logMissedFromMarker(p);
+    delete map[p.callId];
+    changed = true;
+  }
+  if (changed) await writePendingCallEvents(map);
 }
 
 /* ---- invitations (pending placeholders + auto-accept) ---- */

--- a/src/services/call-events.test.ts
+++ b/src/services/call-events.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RING_WINDOW_MS,
+  UNIT_STALE_MS,
+  buildRingEvent,
+  buildEndedEvent,
+  isRingStale,
+  reconcilePending,
+  applyCallTickle,
+  applyCallOutcome,
+  sweepStaleUnits,
+  type PendingCallEvent,
+  type CallBadgeUnit,
+} from './call-events';
+
+const NOW = 1_800_000_000_000;
+
+const pending = (over: Partial<PendingCallEvent> = {}): PendingCallEvent => ({
+  callId: 'c1',
+  from: 'alice',
+  kind: 'audio',
+  receivedAt: NOW,
+  ...over,
+});
+
+describe('marker construction', () => {
+  it('builds a ring event with the dial-time facts', () => {
+    expect(buildRingEvent('c1', 'video', NOW)).toEqual({
+      phase: 'ring', callId: 'c1', kind: 'video', at: NOW,
+    });
+    expect(buildRingEvent('c2', 'audio', NOW, 'room-9')).toEqual({
+      phase: 'ring', callId: 'c2', kind: 'audio', roomId: 'room-9', at: NOW,
+    });
+  });
+
+  it('builds an ended event carrying the outcome', () => {
+    expect(buildEndedEvent('c1', 'audio', 'missed', NOW)).toEqual({
+      phase: 'ended', callId: 'c1', kind: 'audio', outcome: 'missed', at: NOW,
+    });
+    expect(buildEndedEvent('c1', 'video', 'answered', NOW, 'room-9').roomId).toBe('room-9');
+  });
+});
+
+describe('ring staleness', () => {
+  it('a ring inside the window is not stale', () => {
+    expect(isRingStale(pending(), NOW + RING_WINDOW_MS - 1)).toBe(false);
+  });
+  it('a ring past the window is stale', () => {
+    expect(isRingStale(pending(), NOW + RING_WINDOW_MS + 1)).toBe(true);
+  });
+});
+
+describe('reconcilePending — the missed-trace decision table', () => {
+  it('an existing call-log row always wins: clear, never log (FR-018)', () => {
+    expect(reconcilePending(pending(), { hasRow: true, sawLive: false, now: NOW + RING_WINDOW_MS * 2 })).toBe('clear');
+  });
+  it('a ring the device handled live is owned by the live path: clear', () => {
+    expect(reconcilePending(pending(), { hasRow: false, sawLive: true, now: NOW + RING_WINDOW_MS * 2 })).toBe('clear');
+  });
+  it('an explicit missed outcome logs the trace', () => {
+    expect(reconcilePending(pending(), { hasRow: false, sawLive: false, now: NOW, outcome: 'missed' })).toBe('log-missed');
+  });
+  it('cancelled (caller hung up before answer) logs as missed per the clarification', () => {
+    expect(reconcilePending(pending(), { hasRow: false, sawLive: false, now: NOW, outcome: 'cancelled' })).toBe('log-missed');
+  });
+  it('answered (any device) clears without logging (FR-016)', () => {
+    expect(reconcilePending(pending(), { hasRow: false, sawLive: false, now: NOW, outcome: 'answered' })).toBe('clear');
+  });
+  it('a stale ring with no outcome and no row reconciles to missed (caller crashed)', () => {
+    expect(reconcilePending(pending(), { hasRow: false, sawLive: false, now: NOW + RING_WINDOW_MS + 1 })).toBe('log-missed');
+  });
+  it('a fresh ring with no outcome is kept (still ringing)', () => {
+    expect(reconcilePending(pending(), { hasRow: false, sawLive: false, now: NOW + 1000 })).toBe('keep');
+  });
+});
+
+describe('badge units — FR-007/FR-008/FR-010', () => {
+  it('first tickle appends exactly one ringing unit', () => {
+    const units = applyCallTickle([], undefined, NOW);
+    expect(units).toHaveLength(1);
+    expect(units[0].state).toBe('ringing');
+  });
+
+  it('re-ring tickles inside the window never add more (FR-008)', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, undefined, NOW);
+    units = applyCallTickle(units, undefined, NOW + 10_000);
+    units = applyCallTickle(units, undefined, NOW + 20_000);
+    expect(units).toHaveLength(1);
+  });
+
+  it('a known callId dedups by id, and claims an anonymous fresh unit instead of double-counting', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, undefined, NOW); // first tickle undecryptable
+    units = applyCallTickle(units, 'c1', NOW + 10_000); // second tickle resolved the marker
+    expect(units).toHaveLength(1);
+    expect(units[0].callId).toBe('c1');
+    units = applyCallTickle(units, 'c1', NOW + 20_000);
+    expect(units).toHaveLength(1);
+  });
+
+  it('two distinguishable calls each count once (FR-008)', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, 'c1', NOW);
+    units = applyCallTickle(units, 'c2', NOW + 5_000);
+    expect(units).toHaveLength(2);
+  });
+
+  it('an undistinguishable overlap folds into one unit — undercount, never overcount', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, undefined, NOW);
+    units = applyCallTickle(units, undefined, NOW + 5_000); // actually a 2nd call; can't tell
+    expect(units).toHaveLength(1);
+  });
+
+  it('a tickle after the previous ring expired counts as a new call', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, undefined, NOW);
+    units = applyCallTickle(units, undefined, NOW + RING_WINDOW_MS + 1_000);
+    expect(units).toHaveLength(2);
+  });
+
+  it('missed flips the SAME unit — never a second one (FR-010)', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, 'c1', NOW);
+    units = applyCallOutcome(units, 'c1', 'missed', NOW + 30_000);
+    expect(units).toHaveLength(1);
+    expect(units[0].state).toBe('missed');
+  });
+
+  it('missed with no prior unit (marker arrived, tickle lost) still adds one', () => {
+    const units = applyCallOutcome([], 'c1', 'missed', NOW);
+    expect(units).toHaveLength(1);
+    expect(units[0].state).toBe('missed');
+  });
+
+  it('missed flips the newest anonymous ringing unit when the callId is unknown', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, undefined, NOW);
+    units = applyCallOutcome(units, 'c1', 'missed', NOW + 30_000);
+    expect(units).toHaveLength(1);
+    expect(units[0].state).toBe('missed');
+  });
+
+  it('answered removes the unit', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, 'c1', NOW);
+    units = applyCallOutcome(units, 'c1', 'answered', NOW + 5_000);
+    expect(units).toHaveLength(0);
+  });
+
+  it('cancelled counts as missed for the badge (there will be a trace to see)', () => {
+    let units: CallBadgeUnit[] = [];
+    units = applyCallTickle(units, 'c1', NOW);
+    units = applyCallOutcome(units, 'c1', 'cancelled', NOW + 5_000);
+    expect(units).toEqual([expect.objectContaining({ state: 'missed' })]);
+  });
+
+  it('stale units are swept', () => {
+    const units: CallBadgeUnit[] = [
+      { callId: 'old', ts: NOW - UNIT_STALE_MS - 1, state: 'missed' },
+      { callId: 'new', ts: NOW, state: 'ringing' },
+    ];
+    expect(sweepStaleUnits(units, NOW)).toEqual([expect.objectContaining({ callId: 'new' })]);
+  });
+});

--- a/src/services/call-events.ts
+++ b/src/services/call-events.ts
@@ -1,0 +1,153 @@
+/**
+ * Call-event markers (spec 1040) — the PURE logic behind caller identity in
+ * notifications, the missed-call trace, and the ringing-call badge unit.
+ *
+ * The caller (or group-call initiator) sends a sealed `callEvent` frame over
+ * the existing pairwise ratchet: `ring` at dial time, `ended` at outcome time
+ * (see `CallEventSignal` in crypto/message.ts and contracts/call-event.md).
+ * This module holds every decision those markers drive, with no IndexedDB,
+ * service-worker, or crypto dependency, so the rules stay unit-testable:
+ *
+ *  - freshness/staleness of a pending ring against the ring window;
+ *  - the reconcile decision table (when a marker becomes a missed-call log,
+ *    when it clears silently, when it waits);
+ *  - the app-badge unit transitions (one unit per call across its whole
+ *    ringing → missed-unseen lifecycle — never two).
+ *
+ * The stateful glue lives in db/queries.ts (receive branch), composables/
+ * useCall.ts (send sites), and sw-inbox.ts / sw.ts (notifications + badge).
+ */
+import type { CallEventSignal } from './crypto/message';
+
+/** How long a ring can plausibly still be ringing: the 60s ring window used by
+ *  caller timeout, relay offer buffering, and push TTL, plus delivery slack.
+ *  Past this, a pending ring with no outcome means the caller died mid-ring. */
+export const RING_WINDOW_MS = 75_000;
+
+/** Badge units older than this are bookkeeping leaks (the page clears units on
+ *  every open; a device closed for days shouldn't accumulate ghosts). */
+export const UNIT_STALE_MS = 24 * 60 * 60 * 1000;
+
+export function buildRingEvent(
+  callId: string,
+  kind: 'audio' | 'video',
+  at: number,
+  roomId?: string,
+): CallEventSignal {
+  return { phase: 'ring', callId, kind, ...(roomId ? { roomId } : {}), at };
+}
+
+export function buildEndedEvent(
+  callId: string,
+  kind: 'audio' | 'video',
+  outcome: 'missed' | 'cancelled' | 'answered',
+  at: number,
+  roomId?: string,
+): CallEventSignal {
+  return { phase: 'ended', callId, kind, outcome, ...(roomId ? { roomId } : {}), at };
+}
+
+/** A ring marker awaiting its outcome on the receiver. */
+export interface PendingCallEvent {
+  callId: string;
+  from: string; // the caller/initiator user id (the authenticated frame sender)
+  kind: 'audio' | 'video';
+  roomId?: string;
+  receivedAt: number; // receiver clock — staleness is judged locally, never off `at`
+}
+
+export function isRingStale(p: PendingCallEvent, now: number): boolean {
+  return now - p.receivedAt > RING_WINDOW_MS;
+}
+
+export type ReconcileDecision = 'log-missed' | 'clear' | 'keep';
+
+/**
+ * The missed-trace decision for one pending ring (data-model.md table):
+ *  - an existing call-log row for this callId always wins (the live path
+ *    logged it — never duplicate, never overwrite, FR-018);
+ *  - a ring this device handled live is owned by the live UI's own logging
+ *    (answer/decline/timeout all write their row) — clear;
+ *  - explicit `missed`/`cancelled` outcome → log the missed trace (a cancel
+ *    before answer is a missed call per the spec clarification);
+ *  - explicit `answered` (on any of the callee's devices) → clear, log
+ *    nothing (FR-016);
+ *  - no outcome yet: stale → the caller died mid-ring, log missed; fresh →
+ *    keep waiting (the call may still be ringing).
+ */
+export function reconcilePending(
+  p: PendingCallEvent,
+  ctx: { hasRow: boolean; sawLive: boolean; now: number; outcome?: 'missed' | 'cancelled' | 'answered' },
+): ReconcileDecision {
+  if (ctx.hasRow || ctx.sawLive) return 'clear';
+  if (ctx.outcome === 'answered') return 'clear';
+  if (ctx.outcome === 'missed' || ctx.outcome === 'cancelled') return 'log-missed';
+  return isRingStale(p, ctx.now) ? 'log-missed' : 'keep';
+}
+
+/**
+ * One app-badge unit per call while the app is closed (FR-007/008/010). The
+ * service worker holds these in the shared settings store; the page clears
+ * them all on foreground (FR-009 — by then the calls store is authoritative).
+ */
+export interface CallBadgeUnit {
+  callId?: string; // known when a marker decrypted; absent on the heuristic path
+  ts: number; // when the unit was created (ring freshness / staleness)
+  state: 'ringing' | 'missed';
+}
+
+const freshRinging = (units: CallBadgeUnit[], now: number): CallBadgeUnit | undefined =>
+  [...units].reverse().find((u) => u.state === 'ringing' && now - u.ts <= RING_WINDOW_MS);
+
+/**
+ * A `{"t":"call"}` push arrived. Exactly one unit per distinguishable call:
+ *  - a unit with this callId already exists → no change (re-ring);
+ *  - callId known but only an ANONYMOUS fresh ringing unit exists → claim it
+ *    (the first tickle couldn't decrypt the marker; don't double-count);
+ *  - callId unknown and any fresh ringing unit exists → same call re-ringing
+ *    (the fold-to-one degradation: undercount, never overcount);
+ *  - otherwise → a new call, append one ringing unit.
+ */
+export function applyCallTickle(
+  units: CallBadgeUnit[],
+  callId: string | undefined,
+  now: number,
+): CallBadgeUnit[] {
+  if (callId && units.some((u) => u.callId === callId)) return units;
+  const anon = freshRinging(units, now);
+  if (callId && anon && !anon.callId) {
+    return units.map((u) => (u === anon ? { ...u, callId } : u));
+  }
+  if (!callId && anon) return units;
+  return [...units, { ...(callId ? { callId } : {}), ts: now, state: 'ringing' }];
+}
+
+/**
+ * An outcome marker was decrypted (SW preview) — hand the SAME unit over:
+ *  - `missed`/`cancelled` flips ringing → missed (or creates the unit if the
+ *    tickle never arrived: the trace exists, it deserves its badge);
+ *  - `answered` removes the unit (handled on some device, nothing pending).
+ * Matching prefers the callId, falling back to the newest fresh anonymous
+ * ringing unit (its tickle predated the marker's decryptability).
+ */
+export function applyCallOutcome(
+  units: CallBadgeUnit[],
+  callId: string | undefined,
+  outcome: 'missed' | 'cancelled' | 'answered',
+  now: number,
+): CallBadgeUnit[] {
+  const target =
+    (callId ? units.find((u) => u.callId === callId) : undefined) ?? freshRinging(units, now);
+  if (outcome === 'answered') {
+    return target ? units.filter((u) => u !== target) : units;
+  }
+  if (target) {
+    return units.map((u) => (u === target ? { ...u, callId: u.callId ?? callId, state: 'missed' as const } : u));
+  }
+  return [...units, { ...(callId ? { callId } : {}), ts: now, state: 'missed' }];
+}
+
+/** Drop units old enough to be bookkeeping leaks. */
+export function sweepStaleUnits(units: CallBadgeUnit[], now: number): CallBadgeUnit[] {
+  return units.filter((u) => now - u.ts <= UNIT_STALE_MS);
+}

--- a/src/services/crypto/message.ts
+++ b/src/services/crypto/message.ts
@@ -265,6 +265,30 @@ export interface GameCancelSignal {
   at: number;
 }
 
+/**
+ * Call lifecycle marker (spec 1040), carried E2EE inside a payload (like `card`)
+ * and applied as a side effect, never shown as a chat message. The caller (or
+ * group-call initiator) sends `ring` at dial time and `ended` at outcome time so
+ * the callee — even a device that was closed for the whole ring — can (a) name
+ * the caller in the OS notification (the push tickle itself stays content-free)
+ * and (b) log the missed-call trace. Fire-and-forget: call setup never blocks on
+ * it, and receivers treat it idempotently by `callId` (an existing call-log row
+ * always wins). Trust model: it rides the authenticated pairwise ratchet, so a
+ * peer can only assert calls under their own identity — a fabricated "missed
+ * call" is nuisance-equivalent to actually calling and hanging up.
+ */
+export interface CallEventSignal {
+  phase: 'ring' | 'ended';
+  // 1:1: the live callId (matches the calls-store row id, which is the dedup
+  // key). Group: a per-instance id minted by the initiator (the roomId is
+  // reused across calls, so it can't dedup a single call).
+  callId: string;
+  kind: 'audio' | 'video';
+  outcome?: 'missed' | 'cancelled' | 'answered'; // required when phase='ended'
+  roomId?: string; // group calls: resolve the group chat + name locally
+  at: number; // sender ms clock; staleness/ordering hint only, never trusted for identity
+}
+
 export interface MessagePayload {
   body: string;
   kind: string;
@@ -313,6 +337,8 @@ export interface MessagePayload {
   // @everyone) is mentioned, and escalates the notification locally.
   mentions?: string[];
   mentionsEveryone?: boolean;
+  // Call lifecycle marker (spec 1040) — side effect, never a stored message.
+  callEvent?: CallEventSignal;
 }
 
 export interface WireMessage {

--- a/src/services/sw-inbox.calls.test.ts
+++ b/src/services/sw-inbox.calls.test.ts
@@ -1,0 +1,145 @@
+// Spec 1040: the closed-app (service worker) side of call + friend-request
+// notifications. These tests pin the pure cores: the callEvent branch of
+// noteForPayload (missed-call replacement note, hidden-chat silence) and
+// classifyConnEvents (truthful friend-request outcome copy + at-most-once
+// dedup). The IO wrappers (previewPending / previewCallRing /
+// previewConnections) only feed them fetch/IDB/ledger state.
+import { describe, it, expect } from 'vitest';
+import { noteForPayload, classifyConnEvents } from './sw-inbox';
+import type { MessagePayload, CallEventSignal } from './crypto/message';
+import type { Chat, Contact } from '@/db/types';
+
+const NOW = 1_800_000_000_000;
+
+const chat = (over: Partial<Chat>): Chat =>
+  ({
+    id: 'chat-1',
+    name: 'Kamran',
+    avatar: '',
+    isGroup: false,
+    participantIds: ['kamran'],
+    lastMessage: '',
+    lastMessageTime: NOW,
+    unread: 0,
+    updatedAt: NOW,
+    ...over,
+  }) as Chat;
+
+const contact = (id: string, name: string): Contact => ({ id, name, avatar: '' }) as Contact;
+
+const frame = { t: 'msg', id: 'f1', from: 'kamran', ciphertext: 'SEALED' } as Parameters<typeof noteForPayload>[0];
+
+const payloadWith = (ev: CallEventSignal): MessagePayload =>
+  ({ body: '', kind: 'callevent', timestamp: NOW, callEvent: ev }) as MessagePayload;
+
+const ended = (over: Partial<CallEventSignal> = {}): CallEventSignal => ({
+  phase: 'ended',
+  callId: 'c1',
+  kind: 'audio',
+  outcome: 'missed',
+  at: NOW,
+  ...over,
+});
+
+const run = (
+  ev: CallEventSignal,
+  opts: { chats?: Chat[]; contacts?: Contact[]; hidden?: Set<string> } = {},
+): ReturnType<typeof noteForPayload> =>
+  noteForPayload(
+    frame,
+    payloadWith(ev),
+    opts.chats ?? [chat({})],
+    opts.contacts ?? [contact('kamran', 'Kamran')],
+    true,
+    true,
+    opts.hidden ?? new Set(),
+  );
+
+describe('noteForPayload — missed-call replacement (US2, FR-012/FR-012a)', () => {
+  it('a missed 1:1 audio call names the caller and deep-links the chat', () => {
+    const { note, wasMessage } = run(ended());
+    expect(wasMessage).toBe(false);
+    expect(note).toMatchObject({
+      title: 'Kamran',
+      body: '☎️ Missed call',
+      url: '/chat/chat-1',
+      tag: 'ring-call', // replaces the "Incoming call" alert in place
+    });
+  });
+
+  it('a missed video call says so', () => {
+    expect(run(ended({ kind: 'video' }))?.note?.body).toBe('☎️ Missed video call');
+  });
+
+  it('cancelled (caller hung up before answer) reads as a missed call too', () => {
+    expect(run(ended({ outcome: 'cancelled' }))?.note?.body).toBe('☎️ Missed call');
+  });
+
+  it('a group call names the group and the caller, deep-linking the group chat', () => {
+    const g = chat({ id: 'room-1', name: 'Weekend Trip', isGroup: true, participantIds: ['kamran', 'sara'] });
+    const { note } = run(ended({ roomId: 'room-1' }), { chats: [g] });
+    expect(note).toMatchObject({
+      title: 'Weekend Trip',
+      body: '☎️ Missed call from Kamran',
+      url: '/chat/room-1',
+    });
+  });
+
+  it('an ad-hoc group call (no group chat) falls back to the Calls tab', () => {
+    const { note } = run(ended({ roomId: 'room-x' }), { chats: [] });
+    expect(note).toMatchObject({ title: 'Kamran', url: '/tabs/calls' });
+  });
+
+  it('an unknown caller never shows a raw id (FR-006)', () => {
+    const { note } = run(ended(), { chats: [], contacts: [] });
+    expect(note?.title).toBe('Someone');
+    expect(JSON.stringify(note)).not.toContain('kamran');
+  });
+
+  it('a hidden chat shows NOTHING — even a nameless alert would leak hidden activity (FR-005)', () => {
+    expect(run(ended(), { hidden: new Set(['chat-1']) }).note).toBeNull();
+  });
+
+  it('ring markers are silent here (the call tickle owns the ring alert)', () => {
+    expect(run({ phase: 'ring', callId: 'c1', kind: 'audio', at: NOW }).note).toBeNull();
+  });
+
+  it('an answered outcome is silent (sw.ts closes the ring alert instead)', () => {
+    expect(run(ended({ outcome: 'answered' })).note).toBeNull();
+  });
+});
+
+describe('classifyConnEvents — truthful friend-request outcomes (US3)', () => {
+  it('an accepted outgoing request announces the acceptance, never "new friend request" (FR-019)', () => {
+    const { events } = classifyConnEvents({ outgoing: [{ target: 'kamran', state: 'accepted' }] }, new Set());
+    expect(events).toEqual([
+      { key: 'acc:kamran', userId: 'kamran', body: 'accepted your friend request', tag: 'ring:conn:acc:kamran' },
+    ]);
+  });
+
+  it('a declined outgoing request announces the decline (FR-020)', () => {
+    const { events } = classifyConnEvents({ outgoing: [{ target: 'kamran', state: 'rejected' }] }, new Set());
+    expect(events[0]?.body).toBe('declined your friend request');
+  });
+
+  it('an incoming pending request keeps the existing copy and count', () => {
+    const { events, pendingIncoming } = classifyConnEvents(
+      { incoming: [{ requester: 'sara', state: 'pending' }] },
+      new Set(),
+    );
+    expect(pendingIncoming).toBe(1);
+    expect(events[0]?.body).toBe('wants to be friends');
+  });
+
+  it('the dedup ledger announces each outcome at most once (FR-022)', () => {
+    const { events } = classifyConnEvents(
+      { outgoing: [{ target: 'kamran', state: 'accepted' }] },
+      new Set(['acc:kamran']),
+    );
+    expect(events).toEqual([]);
+  });
+
+  it('a pending outgoing request announces nothing', () => {
+    expect(classifyConnEvents({ outgoing: [{ target: 'k', state: 'pending' }] }, new Set()).events).toEqual([]);
+  });
+});

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -37,7 +37,14 @@ import { GAMES } from '@/games/registry';
 import { applySignal as applyGameSignal, deriveStatus as deriveGameStatus } from '@/games/session';
 import { playerIndexOf, lockOpponent, buildWallSession, challengePhase, type WallGameRow } from '@/games/challenge';
 import type { Chat, Contact, Message, Setting } from '@/db/types';
-import type { MessagePayload } from './crypto/message';
+import type { MessagePayload, CallEventSignal } from './crypto/message';
+import {
+  RING_WINDOW_MS,
+  applyCallTickle,
+  applyCallOutcome,
+  sweepStaleUnits,
+  type CallBadgeUnit,
+} from './call-events';
 
 // Same-origin by default (the dev proxy / prod reverse-proxy route /v1 → backend).
 // VITE_API_URL is baked in only when targeting a different backend host.
@@ -75,6 +82,11 @@ export interface SwNote {
 export interface PreviewResult {
   notes: SwNote[];
   pending: number;
+  // Call-event markers decrypted this pass (spec 1040): the caller (sw.ts)
+  // applies their badge-unit transitions and, on an 'answered' outcome, closes
+  // the stale ring notification. The missed/cancelled NOTIFICATION itself rides
+  // `notes` like any other (tag 'ring-call' so it REPLACES the ring alert).
+  callEvents?: CallEventSignal[];
   // The pending count the app-icon BADGE may use (spec 1027, B4): equal to
   // `pending` under badge mode 'always'; under 'never'/'revealed' only frames
   // that decrypted AND resolved to a provably NON-hidden chat. A frame we can't
@@ -333,6 +345,39 @@ export function noteForPayload(
         body: gshowText ? gline : 'New message',
         url: gchat ? `/chat/${gchat.id}` : '/tabs/chats',
         tag: gchat ? `ring:${gchat.id}` : `ring:from:${from}`,
+      },
+      wasMessage: false,
+    };
+  }
+
+  // Call lifecycle markers (spec 1040). Only a missed/cancelled outcome shows —
+  // it REPLACES the stale "Incoming call" alert via the shared 'ring-call' tag.
+  // A ring marker is silent here (the {"t":"call"} wake names the actual ring via
+  // previewCallRing) and an 'answered' outcome is silent (sw.ts closes the ring
+  // notification from the collected callEvents instead).
+  if (payload.callEvent) {
+    const ev = payload.callEvent;
+    if (ev.phase !== 'ended' || (ev.outcome !== 'missed' && ev.outcome !== 'cancelled')) {
+      return { note: null, wasMessage: false };
+    }
+    const cChat = ev.roomId
+      ? chats.find((c) => c.id === ev.roomId && c.isGroup)
+      : chats.find((c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === from);
+    // Hidden chats: calls are excluded from every at-rest surface (Calls tab,
+    // missed badge), so a hidden conversation's missed call shows NOTHING here —
+    // even a nameless "Missed call" alert would leak that hidden activity exists.
+    if (cChat && hidden.has(cChat.id)) return { note: null, wasMessage: false };
+    const caller = known || 'Someone';
+    const isGroupCall = !!ev.roomId;
+    const title = isGroupCall ? cChat?.name || caller : caller;
+    const body = ev.kind === 'video' ? '☎️ Missed video call' : '☎️ Missed call';
+    return {
+      note: {
+        ids: [f.id as string],
+        title,
+        body: isGroupCall && cChat ? `${body} from ${caller}` : body,
+        url: cChat ? `/chat/${cChat.id}` : '/tabs/calls',
+        tag: 'ring-call', // replaces the incoming-call alert (FR-012)
       },
       wasMessage: false,
     };
@@ -796,6 +841,8 @@ export async function previewPending(): Promise<PreviewResult> {
   const seen = new Set(shown);
 
   const raw: SwNote[] = [];
+  const callEvents: CallEventSignal[] = []; // spec 1040: markers for sw.ts's badge/close effects
+  let callEventFrames = 0; // markers are side effects, not backlog — keep them out of the badge count
   let badgeable = 0; // frames provably in a NON-hidden chat (badge modes never/revealed)
   let withheldMessage = false;
   let silencedMessage = false; // a message intentionally silenced by per-chat prefs
@@ -811,6 +858,10 @@ export async function previewPending(): Promise<PreviewResult> {
       continue; // can't decrypt this one (session not reachable yet) → leave it for the page
     }
     seen.add(f.id);
+    if (payload.callEvent) {
+      callEvents.push(payload.callEvent);
+      callEventFrames += 1;
+    }
     // Classify for the badge (spec 1027): the frame counts only when its chat
     // resolves AND is provably not hidden. Same resolution noteForPayload uses.
     if (!badgeAll) {
@@ -864,7 +915,113 @@ export async function previewPending(): Promise<PreviewResult> {
   // When every fetched frame was already shown (all-seen), decryptFailed === 0 and notes is empty →
   // newUnshown is false → the caller shows NO new placeholder (kills the burst extra-generic).
   const newUnshown = decryptFailed > 0;
-  return { notes, pending, badgePending: badgeAll ? pending : badgeable, suppressed, silenced, newUnshown, reason };
+  // Spec 1040: call-event markers are side effects, never unread backlog — a call
+  // would otherwise inflate the badge by its two markers on top of its own unit.
+  const backlog = Math.max(0, pending - callEventFrames);
+  return {
+    notes,
+    pending: backlog,
+    badgePending: badgeAll ? backlog : badgeable,
+    suppressed,
+    silenced,
+    newUnshown,
+    reason,
+    ...(callEvents.length ? { callEvents } : {}),
+  };
+}
+
+/* ---- call-event support for the SW (spec 1040) ---- */
+
+/** What the {"t":"call"} wake shows once a fresh ring marker decrypts. */
+export type CallRingPreview =
+  | { kind: 'named'; title: string; body: string; callId: string }
+  | { kind: 'generic'; callId?: string } // marker found but identity must not show (hidden chat) or resolves to nothing
+  | null; // nothing usable — stay on today's generic ring
+
+/**
+ * Bounded, read-only scan of the pending queue for the freshest still-ringing
+ * call marker — the call wake names its notification from this. Never touches
+ * the shown ledger and never acks, so reminder wakes re-run it and upgrade the
+ * same notification in place (research R2). PIN-locked or undecryptable → null
+ * (the generic ring already showed; FR-004 keeps the first alert undelayed).
+ */
+export async function previewCallRing(): Promise<CallRingPreview> {
+  const token = await readSessionToken();
+  if (!token) return null;
+  const unlockReady = attemptDeviceUnlock().catch(() => false);
+  const fetched = await fetchPendingFrames(token);
+  if ('failure' in fetched || !fetched.frames.length) return null;
+  if (!(await unlockReady)) return null;
+  const [chats, contacts, hidden, committedIds] = await Promise.all([
+    getAll<Chat>('chats'),
+    getAll<Contact>('contacts'),
+    readHiddenSet(),
+    setting<string[]>('inboundSeenIds', []),
+  ]);
+  const committed = new Set(committedIds);
+  let best: { ev: CallEventSignal; from: string } | null = null;
+  const endedIds = new Set<string>();
+  for (const f of fetched.frames) {
+    if (f.t !== 'msg' || !f.from || !f.id || committed.has(f.id)) continue;
+    let payload: MessagePayload;
+    try {
+      payload = await previewPacket(sessionKeyForPeer(chats, f.from as string), f.ciphertext);
+    } catch {
+      continue;
+    }
+    const ev = payload.callEvent;
+    if (!ev) continue;
+    if (ev.phase === 'ended') {
+      endedIds.add(ev.callId);
+      continue;
+    }
+    // `at` is the sender's clock — a display-freshness hint only. A stale ring
+    // stays generic rather than naming a caller who is no longer calling.
+    if (Date.now() - ev.at > RING_WINDOW_MS) continue;
+    if (!best || ev.at > best.ev.at) best = { ev, from: f.from as string };
+  }
+  if (!best || endedIds.has(best.ev.callId)) return null;
+  const { ev, from } = best;
+  const chat = ev.roomId
+    ? chats.find((c) => c.id === ev.roomId && c.isGroup)
+    : chats.find((c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === from);
+  // Hidden chat → the ring must stay generic AND its badge unit is withdrawn by
+  // the caller (hidden calls never badge).
+  if (chat && hidden.has(chat.id)) return { kind: 'generic', callId: ev.callId };
+  const caller = contacts.find((c) => c.id === from)?.name;
+  if (!caller && !(ev.roomId && chat)) return { kind: 'generic', callId: ev.callId }; // never a raw id (FR-006)
+  const emoji = ev.kind === 'video' ? '📹' : '🎙️';
+  if (ev.roomId && chat) {
+    return { kind: 'named', title: chat.name, body: `${emoji} ${caller || 'Someone'} is calling`, callId: ev.callId };
+  }
+  return { kind: 'named', title: caller as string, body: `${emoji} is calling you`, callId: ev.callId };
+}
+
+/** The transient per-call badge units (spec 1040), shared with the page through
+ *  the settings store; the page clears them wholesale on foreground (FR-009). */
+const CALL_BADGE_KEY = 'sw.callBadge';
+
+export async function callBadgeCount(): Promise<number> {
+  const units = await setting<CallBadgeUnit[]>(CALL_BADGE_KEY, []);
+  return sweepStaleUnits(units, Date.now()).length;
+}
+
+/** A call tickle arrived: ensure exactly one ringing unit for it (callId when a
+ *  marker already resolved, else the ring-window heuristic — see call-events.ts). */
+export async function recordCallTickle(callId?: string): Promise<void> {
+  const units = sweepStaleUnits(await setting<CallBadgeUnit[]>(CALL_BADGE_KEY, []), Date.now());
+  await put<Setting<CallBadgeUnit[]>>('settings', { key: CALL_BADGE_KEY, value: applyCallTickle(units, callId, Date.now()) });
+}
+
+/** An outcome marker decrypted: hand the unit over (missed) or retire it (answered). */
+export async function recordCallOutcome(callId: string | undefined, outcome: 'missed' | 'cancelled' | 'answered'): Promise<void> {
+  const units = sweepStaleUnits(await setting<CallBadgeUnit[]>(CALL_BADGE_KEY, []), Date.now());
+  await put<Setting<CallBadgeUnit[]>>('settings', { key: CALL_BADGE_KEY, value: applyCallOutcome(units, callId, outcome, Date.now()) });
+}
+
+/** Withdraw one unit entirely (a hidden chat's call must never badge). */
+export async function withdrawCallBadgeUnit(callId: string | undefined): Promise<void> {
+  await recordCallOutcome(callId, 'answered');
 }
 
 /**
@@ -980,6 +1137,48 @@ async function connName(userId: string, token: string): Promise<string> {
   return 'Someone';
 }
 
+/** One announceable friend-request lifecycle event (pure classification). */
+export interface ConnEvent {
+  key: string; // dedup-ledger key
+  userId: string; // whose name the note carries (resolved by the IO wrapper)
+  body: string;
+  tag: string;
+}
+
+/**
+ * Classify the server's connection state into NEW events (pure core, unit-
+ * tested; spec 1040 US3). Incoming pending → "wants to be friends"; OUR
+ * outgoing accepted/rejected → the truthful outcome copy. The dedup ledger
+ * (`seen`) keeps each event announced at most once (FR-022) — the server's
+ * 24h accepted-row window sits inside the ledger's 48h TTL, so an accepted
+ * row can never re-announce after its ledger entry expires.
+ */
+export function classifyConnEvents(
+  data: { incoming?: ConnReq[]; outgoing?: ConnReq[] },
+  seen: ReadonlySet<string>,
+): { events: ConnEvent[]; pendingIncoming: number } {
+  const events: ConnEvent[] = [];
+  const taken = new Set(seen);
+  const add = (key: string, userId: string, body: string, tag: string): void => {
+    if (taken.has(key)) return;
+    taken.add(key);
+    events.push({ key, userId, body, tag });
+  };
+  let pendingIncoming = 0;
+  for (const r of data.incoming ?? []) {
+    if (r.state === 'pending' && r.requester) {
+      pendingIncoming++;
+      add(`req:${r.requester}`, r.requester, 'wants to be friends', 'ring:conn:req');
+    }
+  }
+  for (const r of data.outgoing ?? []) {
+    if (!r.target) continue;
+    if (r.state === 'accepted') add(`acc:${r.target}`, r.target, 'accepted your friend request', `ring:conn:acc:${r.target}`);
+    else if (r.state === 'rejected') add(`rej:${r.target}`, r.target, 'declined your friend request', `ring:conn:rej:${r.target}`);
+  }
+  return { events, pendingIncoming };
+}
+
 export async function previewConnections(): Promise<{ notes: ConnNote[]; pendingIncoming: number }> {
   const token = await readSessionToken();
   if (!token) return { notes: [], pendingIncoming: 0 };
@@ -999,26 +1198,13 @@ export async function previewConnections(): Promise<{ notes: ConnNote[]; pending
     return { notes: [], pendingIncoming: 0 };
   }
   const seen = new Set((await loadConnShownEntries()).map((e) => e.id));
-  const notes: ConnNote[] = [];
   // Title = WHO, body = the action — so iOS renders "<name>: wants to be friends". The app
   // name ("Ring") is already the notification's source line, so the old "Ring / New friend
   // request" was doubly redundant.
-  const add = (key: string, title: string, body: string, tag: string): void => {
-    if (seen.has(key)) return;
-    seen.add(key);
-    notes.push({ keys: [key], title, body, url: '/tabs/contacts', tag });
-  };
-  let pendingIncoming = 0;
-  for (const r of data.incoming ?? []) {
-    if (r.state === 'pending' && r.requester) {
-      pendingIncoming++;
-      add(`req:${r.requester}`, await connName(r.requester, token), 'wants to be friends', 'ring:conn:req');
-    }
-  }
-  for (const r of data.outgoing ?? []) {
-    if (!r.target) continue;
-    if (r.state === 'accepted') add(`acc:${r.target}`, await connName(r.target, token), 'accepted your friend request', `ring:conn:acc:${r.target}`);
-    else if (r.state === 'rejected') add(`rej:${r.target}`, await connName(r.target, token), 'declined your friend request', `ring:conn:rej:${r.target}`);
+  const { events, pendingIncoming } = classifyConnEvents(data, seen);
+  const notes: ConnNote[] = [];
+  for (const ev of events) {
+    notes.push({ keys: [ev.key], title: await connName(ev.userId, token), body: ev.body, url: '/tabs/contacts', tag: ev.tag });
   }
   return { notes, pendingIncoming };
 }

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -1188,7 +1188,11 @@ export async function previewConnections(): Promise<{ notes: ConnNote[]; pending
     const timer = setTimeout(() => ctrl.abort(), PENDING_FETCH_TIMEOUT_MS);
     let res: Response;
     try {
-      res = await fetch(`${API}/connections`, { headers: { Authorization: `Bearer ${token}` }, signal: ctrl.signal });
+      // ?include=accepted (spec 1040): the DEFAULT list means unresolved
+      // requests (the UI's contract — an answered request leaves it); only this
+      // reconcile also wants the recently-accepted rows its "accepted your
+      // friend request" note is built from.
+      res = await fetch(`${API}/connections?include=accepted`, { headers: { Authorization: `Bearer ${token}` }, signal: ctrl.signal });
     } finally {
       clearTimeout(timer);
     }

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -530,6 +530,7 @@ export function installTestHook(): void {
         poll: m.poll ?? null,
         contact: m.contact ?? null,
         audio: m.audio ?? null,
+        callLog: m.callLog ?? null, // spec 1040: missed-trace assertions
       })),
     /* ---- media blob lifecycle (server cleanup tests) ---- */
     /** A message's media state: whether the bytes are on-device (mediaId), still pending,
@@ -1038,6 +1039,19 @@ export function installTestHook(): void {
         updatedAt: opts.ts,
       });
     },
+
+    /** Spec 1040: the raw calls-store rows (the Calls tab's source), so the e2e
+     *  missed-call-trace tests can assert a marker-created row (missed, unseen)
+     *  and the no-duplicate rule without scraping the UI. */
+    callRows: async (): Promise<Array<{ id: string; contactId: string; missed: boolean; seen?: boolean; direction: string; isGroup?: boolean }>> =>
+      (await getAll<Call>('calls')).map((c) => ({
+        id: c.id,
+        contactId: c.contactId,
+        missed: c.missed,
+        seen: c.seen,
+        direction: c.direction,
+        isGroup: c.isGroup,
+      })),
 
     /* ---- media storage cleanup ---- */
     /** Seed a fake media blob + a message linking it (for storage tests). */

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -24,8 +24,10 @@ import {
   previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, previewPosts, previewPostActivity, markConnShown,
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
   mayEndWakeSilently, quietNote, stampPushWake, stampedShow, countAccepted,
+  previewCallRing, recordCallTickle, recordCallOutcome, withdrawCallBadgeUnit, callBadgeCount,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
+import type { CallEventSignal } from '@/services/crypto/message';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { resubscribePush } from '@/services/sw-push';
 import { setPendingNav } from '@/services/pending-nav';
@@ -155,16 +157,36 @@ async function showGeneric(reason?: string): Promise<void> {
   });
 }
 
-async function showCall(): Promise<void> {
-  await self.registration.showNotification('Incoming call', {
-    body: 'Tap to answer',
+async function showCall(named?: { title: string; body: string }): Promise<void> {
+  // (spec 1040) The generic ring shows IMMEDIATELY (renotify → the re-alert), then
+  // previewCallRing may upgrade it in place with the caller's name. The upgrade
+  // re-show keeps the tag but not renotify, so naming never buzzes a second time.
+  await self.registration.showNotification(named?.title ?? 'Incoming call', {
+    body: named?.body ?? 'Tap to answer',
     icon: ICON,
     badge: BADGE,
     tag: 'ring-call',
-    renotify: true, // each repeated ring push re-alerts (a single updating notification)
+    renotify: !named, // each repeated ring push re-alerts (a single updating notification)
     requireInteraction: true, // a ring shouldn't auto-dismiss before it's seen
     data: { url: '/tabs/chats' },
   });
+}
+
+/** (spec 1040) Apply decrypted call-event outcomes: hand the badge unit over
+ *  (missed) or retire it, and close the stale ring alert when the call was
+ *  answered on another device (the missed/cancelled case needs no close — its
+ *  own note REPLACES the ring via the shared 'ring-call' tag). Idempotent:
+ *  outcome frames can be previewed again on later wakes until the page drains. */
+async function applyCallEventEffects(evs?: CallEventSignal[]): Promise<void> {
+  for (const ev of evs ?? []) {
+    if (ev.phase !== 'ended' || !ev.outcome) continue;
+    try {
+      await recordCallOutcome(ev.callId, ev.outcome);
+      if (ev.outcome === 'answered') await closeByTag('ring-call');
+    } catch (e) {
+      console.warn('[sw] call-event effect failed', e);
+    }
+  }
 }
 
 /** Format a note's title with its count, e.g. "Alice (3)". The count is the CUMULATIVE per-chat total
@@ -333,7 +355,10 @@ async function updateAppBadge(newCount: number): Promise<void> {
       console.warn('[sw] setAppBadge unavailable in SW (older iOS?), page will badge on open');
       return;
     }
-    const total = (await unreadCount()) + newCount;
+    // (spec 1040) + the per-call units: one per ringing/missed-unseen call while
+    // the app is closed. The page clears them on foreground (the calls store is
+    // authoritative from then on), so they never double-count a stored missed call.
+    const total = (await unreadCount()) + newCount + (await callBadgeCount());
     if (total > 0) await nav.setAppBadge(total);
     console.info('[sw] setAppBadge', total);
   } catch (e) {
@@ -472,8 +497,11 @@ async function showConnNotification(): Promise<number> {
     if (accepted > 0) return pendingIncoming;
   }
   // Couldn't reconcile (offline / already-seen) but a tickle implies activity →
-  // a single generic placeholder keeps the userVisibleOnly contract.
-  await self.registration.showNotification('New friend request', {
+  // a single generic placeholder keeps the userVisibleOnly contract. The copy is
+  // EVENT-NEUTRAL (spec 1040 FR-021): this wake may be a new request, an accept,
+  // or a decline — claiming "New friend request" told acceptees the opposite of
+  // what happened.
+  await self.registration.showNotification('Contact updates', {
     body: 'Tap to review',
     icon: ICON,
     badge: BADGE,
@@ -596,6 +624,10 @@ async function showMessageNotification(): Promise<void> {
       new Promise<typeof result>((resolve) => setTimeout(() => resolve(result), SETTLE_MAX_MS)),
     ]);
     pending = full.pending || pending;
+    // (spec 1040) Call outcomes decrypted this pass: badge-unit handover, and the
+    // ring alert closes when the call was answered elsewhere. Runs before the
+    // updateAppBadge below so the badge reflects the handover.
+    await applyCallEventEffects(full.callEvents);
     if (shownGeneric && full.notes.length) {
       // Upgrade the placeholder to the real sender + text. Show FIRST, close the
       // generic only once a rich note was actually ACCEPTED (spec 2023 FR-007):
@@ -641,6 +673,7 @@ async function showMessageNotification(): Promise<void> {
       } catch {
         return true; // fetch failed → stop the straggler loop
       }
+      await applyCallEventEffects(more.callEvents); // spec 1040: stragglers can carry outcomes too
       if (more.notes.length) {
         await closeByTag(GENERIC_TAG);
         await showNotes(more.notes);
@@ -721,6 +754,27 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         await showCall();
         void ackCall();
         for (const client of clients) client.postMessage({ type: 'ring:drain' });
+        // (spec 1040) One badge unit per call while closed. The tickle carries no
+        // callId (content-free), so this pass uses the ring-window heuristic; the
+        // marker preview below claims/keys the unit once it decrypts.
+        await recordCallTickle();
+        await updateAppBadge(0);
+        // Name the ring from the caller's sealed dial-time marker (the queued
+        // callEvent frame) — an in-place upgrade AFTER the generic alert, so the
+        // first ring is never delayed (FR-004). Locked/unresolvable stays generic;
+        // a hidden chat's ring stays generic AND never badges.
+        try {
+          const ring = await previewCallRing();
+          if (ring?.kind === 'named') {
+            await recordCallTickle(ring.callId); // claim the heuristic unit under its real id
+            await showCall({ title: ring.title, body: ring.body });
+          } else if (ring?.kind === 'generic') {
+            await withdrawCallBadgeUnit(ring.callId);
+            await updateAppBadge(0);
+          }
+        } catch (e) {
+          console.warn('[sw] call-ring preview failed (ring stays generic)', e);
+        }
         return;
       }
       if (kind === 'conn') {


### PR DESCRIPTION
## Spec 1040 — Incoming Call & Friend-Request Notifications

Closes #942
Closes #943
Closes #944
Closes #945
Closes #946

### What changed

**Named incoming-call notifications (US1).** The caller (or group initiator) now sends a sealed `callEvent` marker over the existing pairwise Double Ratchet at dial time. The service worker previews it from the relay queue and upgrades the generic "Incoming call" alert in place to "Kamran: 📹 is calling you" (group: "Weekend Trip: 📹 Kamran is calling"). The push tickle stays the content-free `{"t":"call"}` — zero-knowledge boundary untouched (see the spec's Zero-Knowledge Impact section and `contracts/call-event.md`). Locked devices, unresolvable identity, and hidden chats stay generic; the first alert is never delayed.

**Missed calls always leave a trace (US2).** Outcome markers (`missed`/`cancelled`/`answered`) settle every attempt: a callee whose app was closed for the whole ring finds the missed-call row in the 1:1 chat (or group chat) and the Calls tab on next open, with the existing unseen-missed badge semantics. Stale rings with no outcome reconcile to missed on connect (caller died mid-ring). Idempotent by callId — a live-logged call never duplicates. The stale "Incoming call" notification is REPLACED by "☎️ Missed call" (deep-links the chat); answered-elsewhere closes it via the quiet terminal (iOS visible-wake rule respected).

**Truthful friend-request outcomes (US3).** Root cause fixed: `OutgoingRequests` never returned `accepted` rows, so the SW's "accepted your friend request" renderer was dead code and acceptances fell through to the misleading "New friend request" placeholder. The store now returns accepted rows updated within 24h (window strictly inside the SW's 48h dedup ledger → announced exactly once), and the fallback placeholder is event-neutral ("Contact updates"). UI lists filter `state === 'pending'` and are unaffected.

**One badge unit per call (US4/US5).** A ringing call adds exactly one app-icon badge unit (re-rings never add more; two distinguishable calls add two; an undistinguishable overlap folds to one — undercount, never overcount). The unit hands over to "missed" without double-counting and the page clears all units on foreground, leaving the calls store authoritative.

### Verification

- `npm run build` (vue-tsc + vite) ✓
- `npx vitest run` — 951 tests, coverage floors held ✓ (37 new: `call-events.test.ts`, `sw-inbox.calls.test.ts`)
- `go build ./... && go vet ./... && go test ./...` ✓ (new handler test pins the accepted-state passthrough)
- e2e: new `missed-call-trace.spec.ts` 3/3 ✓, plus a 77-spec local subset covering every call spec, friendship, connect, notifications, and sw-decrypt ✓
- Zero-knowledge checklist: `specs/1040-incoming-call-notifications/checklists/security.md`, 19/19 ✓

**Manual device pass still open** (headless CI cannot observe lock-screen notifications/badges): quickstart.md steps 2–5 on an installed PWA — named ring, missed replacement, badge ±1, accept notification. Data-layer equivalents are e2e-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7