### PR TITLE
fix(calls): missed calls reach your call log, call alerts name the caller without duplicates, and sunk Armada ships show their true shape

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,3 +97,4 @@ Specs are grouped by category band; status moves
 | [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟢 shipped |
 | [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |
 | [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |
+| [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,4 +97,4 @@ Specs are grouped by category band; status moves
 | [2023](specs/2023-push-wakes-always/spec.md) | Push Wakes Always End Visibly Where Silence Is Unsafe | 🟢 shipped |
 | [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |
 | [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |
-| [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟡 in-progress |
+| [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟢 shipped |

--- a/specs/2026-call-markers-stored/spec.md
+++ b/specs/2026-call-markers-stored/spec.md
@@ -136,6 +136,22 @@ sweep, verify rows gone, unread corrected, preview recomputed.
   downgrading it to the generic, an identical naming is never re-shown, and the
   signature retires with the call's outcome.
 
+### Follow-up fixes ridden on this branch (user-verified rounds)
+
+- **FR-007** (avatar): the missed-group-call row this spec's `logMissedFromMarker` writes
+  MUST use the ad-hoc group people-glyph when no group chat exists — an initials disc
+  built from "<name> & others" embeds a raw ampersand and renders as a broken image.
+  `initials()` skips tokens that don't start with a letter/digit, the SVG text is
+  XML-escaped as defense in depth, and a startup sweep regenerates already-stored rows
+  whose avatar decodes to malformed XML.
+- **FR-008** (Armada, companion hotfix to spec 1038): a `sunk` answer now DECLARES the
+  sunk ship's geometry, stored on the shot record and drawn exactly — the old
+  contiguous-hits guess merged collinear adjacent ships into phantom fleets (two
+  carriers / two destroyers) until the end-of-game reveal. Declarations are optional on
+  the wire (old clients keep the guess as fallback), structurally-invalid ones are
+  stripped rather than fatal (move compatibility across client generations), and a
+  geometry lie is caught by `answersHonest` at the reveal exactly like a result lie.
+
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes

--- a/specs/2026-call-markers-stored/spec.md
+++ b/specs/2026-call-markers-stored/spec.md
@@ -125,6 +125,13 @@ sweep, verify rows gone, unread corrected, preview recomputed.
 - **FR-005**: All existing spec-1040 behaviors (badge units, missed-call replacement
   notification, page-side missed-call trace) MUST be restored by FR-001 with no change to
   the marker wire format.
+- **FR-006**: At most ONE call notification is visible per call at any moment: the named
+  upgrade, a server reminder re-ring, and the missed/cancelled replacement MUST close the
+  previous `ring-call` notification before re-showing. (iOS keeps a separate Notification
+  Center entry per `showNotification` call even on the same tag — the spec-2020 lesson —
+  so same-tag "in-place" re-shows read as stacked doubles there.) The named upgrade is
+  silent (the generic ring already alerted); reminders and the missed replacement still
+  alert.
 
 ## Success Criteria *(mandatory)*
 

--- a/specs/2026-call-markers-stored/spec.md
+++ b/specs/2026-call-markers-stored/spec.md
@@ -1,0 +1,146 @@
+# Feature Specification: Call markers must never surface as messages
+
+**Feature Branch**: `fix/2026-call-markers-stored`
+
+**Created**: 2026-07-12
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Incoming call announcements are still not working: the first
+incoming-call notification bumps the badge by 2, a second generic 'New message' notification
+follows, the missed call never appears in the Calls tab, and the 1:1 chat shows 2 empty
+messages. Group calls behave the same and never mention an incoming group call at all."
+
+## Root cause (regression analysis)
+
+Spec 1040 introduced sealed `callEvent` marker frames (`ring` at dial time, `ended` at
+outcome time) that ride the ordinary queued-message channel. Spec 1032's service-worker
+authoritative drain (`sw.fullPersist`, default ON since the rollout completed) predates
+them: its eligibility classifier has no rule for `callEvent`, so a marker falls through to
+"eligible plain message". The drain then:
+
+- stores the marker as an empty chat message (`kind: 'callevent'`, empty body) → the two
+  empty bubbles, the inflated unread count, and the clobbered chat-list preview;
+- **acks the frame**, so the page never receives it → `handleCallEvent` never runs → no
+  missed-call row in the Calls tab and no in-chat call row;
+- shows nothing for a ring marker (its note is intentionally null) → the wake ends with the
+  generic "New message" placeholder instead of naming the ring;
+- consumes the marker before any later `{"t":"call"}` reminder wake can read it → the
+  "Incoming call" notification is never upgraded with the caller's name (1:1 and group).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Markers are side effects again (Priority: P1)
+
+A callee whose app is closed gets a call. The dial-time and outcome markers the caller
+sends must act only as side effects (notification naming, badge unit, missed-call trace) —
+never as stored chat messages, unread counts, or "New message" notifications.
+
+**Why this priority**: This is the regression itself; everything else follows from it.
+
+**Independent Test**: Unit test on the drain's eligibility classifier; on-device: receive a
+call with the app closed, then open the chat.
+
+**Acceptance Scenarios**:
+
+1. **Given** the SW drain is enabled, **When** a `callEvent` frame is classified,
+   **Then** it is deferred to the page (never persisted, never acked by the SW).
+2. **Given** a missed 1:1 call while the app was closed, **When** the app is next opened,
+   **Then** the chat shows no empty bubbles and the Calls tab shows the missed call with
+   the caller's name, and the in-chat "Missed call" row exists.
+3. **Given** a missed call while the app was closed, **When** the badge settles,
+   **Then** it counts exactly one unit for the call (never two).
+
+### User Story 2 - The ring notification gets named (Priority: P2)
+
+The first "Incoming call" alert is undelayed and generic (the push tickle is content-free);
+once the caller's dial-time marker arrives — which happens on a later *message* wake, since
+the marker send is deliberately deferred off the call-setup hot path — that wake must
+upgrade the ring notification in place with the caller (and group) name instead of adding a
+generic "New message" alert.
+
+**Why this priority**: Spec 1040's headline behavior ("calls show who is calling") is
+currently unreachable on the common path.
+
+**Independent Test**: Unit test the fresh-ring predicate; on-device: call a closed device
+and watch the generic ring upgrade to the named ring within seconds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a msg-push wake whose decrypted frames include a fresh `ring` marker,
+   **When** the wake completes, **Then** the existing `ring-call` notification shows the
+   caller's name (or the group's name with "X is calling") and no extra generic
+   notification is added for the marker.
+2. **Given** the ring marker's call has already ended (an `ended` marker is also queued),
+   **When** the wake completes, **Then** no ring upgrade happens (missed/cancelled shows
+   the missed-call replacement as today).
+
+### User Story 3 - Devices already polluted are repaired (Priority: P3)
+
+Devices that ran the buggy drain have empty `callevent` rows stored, inflated unread
+counters, and stale chat previews. On next app open they must be cleaned up.
+
+**Why this priority**: Without repair the empty bubbles and wrong counts persist forever on
+affected devices (the frames were acked; they will never be redelivered).
+
+**Independent Test**: Seed a chat with junk `callevent` rows + inflated unread, run the
+sweep, verify rows gone, unread corrected, preview recomputed.
+
+**Acceptance Scenarios**:
+
+1. **Given** stored messages with `kind: 'callevent'`, **When** the app starts,
+   **Then** those rows are deleted, each affected chat's unread count is reduced by the
+   number of junk rows removed (floored at 0), and the chat-list preview is recomputed
+   from the newest remaining message.
+
+### Edge Cases
+
+- A marker frame arriving in the same wake as a real text message: the text is drained and
+  notified normally; the marker defers to the page and still names the ring.
+- The old (pre-fix) service worker may stay active until the user accepts the update and
+  can keep storing junk rows; the repair sweep therefore runs on every app open, not once.
+- Hidden chats: an upgraded ring must stay generic and its badge unit withdrawn (existing
+  `previewCallRing` rules apply unchanged).
+- Retroactive traces cannot be reconstructed: junk rows carry no callId/outcome, so calls
+  missed during the buggy window stay absent from the Calls tab (accepted).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SW authoritative drain MUST defer `callEvent` frames to the page: never
+  persist them as messages, never count them as unread, never ack them.
+- **FR-002**: A message-push wake that decrypts a fresh (inside the ring window) `ring`
+  marker MUST attempt the named in-place upgrade of the `ring-call` notification, using
+  the same naming/hidden-chat/badge rules as the call-tickle path (`previewCallRing`).
+- **FR-003**: A wake whose only content is a fresh ring marker MUST count the named ring
+  upgrade as its visible ending (no additional generic notification).
+- **FR-004**: On app start the client MUST remove stored messages with `kind:
+  'callevent'`, correct each affected chat's unread count, and recompute its preview.
+- **FR-005**: All existing spec-1040 behaviors (badge units, missed-call replacement
+  notification, page-side missed-call trace) MUST be restored by FR-001 with no change to
+  the marker wire format.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A missed call to a closed device produces exactly: one ring notification
+  (named once the marker lands), one missed-call replacement notification, one badge unit,
+  one Calls-tab row, one in-chat call row — and zero empty chat messages.
+- **SC-002**: Group calls to a closed device produce a ring notification that names the
+  group/caller once the marker lands, and a missed group call appears in the Calls tab.
+- **SC-003**: Previously polluted devices show no `callevent` bubbles after one app open.
+
+## Assumptions
+
+- The marker send delays (2.5s direct, 8s group) stay as shipped — the hot-path seal rule
+  (spec 1040) is untouched; naming the ring a few seconds after the generic alert is the
+  designed behavior (FR-004 of spec 1040: the first alert is never delayed).
+- No server change is needed: the server already pushes call tickles for 1:1 and group
+  invitees; this is purely a client/service-worker regression.

--- a/specs/2026-call-markers-stored/spec.md
+++ b/specs/2026-call-markers-stored/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-12
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2026-call-markers-stored/spec.md
+++ b/specs/2026-call-markers-stored/spec.md
@@ -131,7 +131,10 @@ sweep, verify rows gone, unread corrected, preview recomputed.
   Center entry per `showNotification` call even on the same tag — the spec-2020 lesson —
   so same-tag "in-place" re-shows read as stacked doubles there.) The named upgrade is
   silent (the generic ring already alerted); reminders and the missed replacement still
-  alert.
+  alert. Shows are kept to the strict minimum via a persisted shown-signature
+  (`sw.ringShown`): a reminder tickle re-asserts the already-named alert instead of
+  downgrading it to the generic, an identical naming is never re-shown, and the
+  signature retires with the call's outcome.
 
 ## Success Criteria *(mandatory)*
 

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -23,7 +23,7 @@ import {
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
 import { kickPendingPosts } from '@/services/pending-posts';
-import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, notifyPostActivity, pruneLocalPost, hydrateGroupMembers, reconcilePendingCallEvents } from '@/db/queries';
+import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, sweepCallEventMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, notifyPostActivity, pruneLocalPost, hydrateGroupMembers, reconcilePendingCallEvents } from '@/db/queries';
 import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
@@ -444,6 +444,10 @@ function start(): void {
   // vanish on both sides shortly after their timer elapses even mid-session.
   void sweepExpiredMessages();
   setInterval(() => void sweepExpiredMessages(), 30_000);
+  // Repair sweep (spec 2026): remove call-event marker rows the pre-fix SW drain
+  // stored as empty messages (and restore the unread counts/previews they broke).
+  // Every open, not once — the old SW can keep writing junk until the update lands.
+  void sweepCallEventMessages();
   // Wall posts (spec 0003): pull any addressed to us, and sweep expired ones on the
   // same cadence as disappearing messages so they vanish shortly after their timer.
   void syncPosts();

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -23,7 +23,7 @@ import {
 } from '@/services/transport';
 import { handleIncomingFrame, drainOutbox } from '@/services/sync';
 import { kickPendingPosts } from '@/services/pending-posts';
-import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, sweepCallEventMessages, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, notifyPostActivity, pruneLocalPost, hydrateGroupMembers, reconcilePendingCallEvents } from '@/db/queries';
+import { getChat, getContact, listChats, listMessages, listMessagesOlder, listContacts, getSetting, drainPendingIncoming, listPendingInvites, resumePendingMediaJobs, refreshContactStatuses, refreshBlocks, sweepExpiredMessages, sweepCallEventMessages, repairBrokenCallAvatars, getPresenceOverrides, collectUnconfirmedOutgoing, markMessagesSeenReported, syncPosts, sweepExpiredPosts, syncEngagement, notifyNewPost, notifyPostActivity, pruneLocalPost, hydrateGroupMembers, reconcilePendingCallEvents } from '@/db/queries';
 import { checkDeliveries, checkSeen } from '@/services/api';
 import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
@@ -444,10 +444,12 @@ function start(): void {
   // vanish on both sides shortly after their timer elapses even mid-session.
   void sweepExpiredMessages();
   setInterval(() => void sweepExpiredMessages(), 30_000);
-  // Repair sweep (spec 2026): remove call-event marker rows the pre-fix SW drain
-  // stored as empty messages (and restore the unread counts/previews they broke).
+  // Repair sweeps (spec 2026): remove call-event marker rows the pre-fix SW drain
+  // stored as empty messages (and restore the unread counts/previews they broke),
+  // and regenerate call-row avatars whose SVG was malformed ("& others" initials).
   // Every open, not once — the old SW can keep writing junk until the update lands.
   void sweepCallEventMessages();
+  void repairBrokenCallAvatars();
   // Wall posts (spec 0003): pull any addressed to us, and sweep expired ones on the
   // same cadence as disappearing messages so they vanish shortly after their timer.
   void syncPosts();

--- a/src/db/avatars.test.ts
+++ b/src/db/avatars.test.ts
@@ -29,3 +29,23 @@ describe('emoji avatars (spec 0008 FR-027)', () => {
     expect(a).toBe(b); // deterministic, byte-stable (profile-change signatures rely on it)
   });
 });
+
+describe('initials avatars survive XML-hostile names (spec 2026)', () => {
+  const decode = (src: string): string => decodeURIComponent(src.replace('data:image/svg+xml;utf8,', ''));
+
+  it('"Macbook & others" yields valid SVG with letter initials (the broken Calls-tab disc)', () => {
+    const svg = decode(initialsAvatar('Macbook & others'));
+    expect(svg).toContain('>MO<'); // the "&" token contributes no initial
+    expect(svg).not.toMatch(/&(?!amp;|lt;|gt;|quot;|apos;|#)/); // no raw ampersand → parseable XML
+  });
+
+  it('a name with no letter-initial tokens still renders the "?" disc', () => {
+    expect(decode(initialsAvatar('& <>'))).toContain('>?<');
+  });
+
+  it('XML-special initials are escaped, not dropped', () => {
+    const svg = decode(initialsAvatar('Alert <script>'));
+    expect(svg).not.toMatch(/&(?!amp;|lt;|gt;|quot;|apos;|#)/);
+    expect(svg).not.toContain('<script');
+  });
+});

--- a/src/db/avatars.ts
+++ b/src/db/avatars.ts
@@ -17,15 +17,22 @@ function hash(s: string): number {
 function initials(name: string): string {
   return name
     .split(/\s+/)
-    .filter(Boolean)
+    // Only words that START with a letter or digit contribute an initial: a
+    // connective token like the "&" in "Macbook & others" would otherwise
+    // become a raw ampersand inside the SVG — invalid XML, broken image.
+    .filter((w) => /^[\p{L}\p{N}]/u.test(w))
     .slice(0, 2)
     .map((w) => w[0]?.toUpperCase() ?? '')
     .join('');
 }
 
+/** Escape a string for an SVG text node / attribute (same rule emojiAvatar
+ *  uses) — defense in depth behind the initials() filter above. */
+const xmlSafe = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+
 export function initialsAvatar(name: string): string {
   const bg = COLORS[hash(name) % COLORS.length];
-  const text = initials(name) || '?';
+  const text = xmlSafe(initials(name) || '?');
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
 <rect width="120" height="120" rx="60" fill="${bg}"/>
 <text x="60" y="60" dy="0.35em" text-anchor="middle" font-family="-apple-system,Helvetica,Arial,sans-serif" font-size="48" font-weight="600" fill="#ffffff">${text}</text>

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3274,7 +3274,7 @@ function postShareLabel(p: Pick<Post, 'kind' | 'game'>): string {
   // A challenge post leads with the urgency: the first to accept plays (spec 0009).
   if (p.game) {
     const gname = GAMES[p.game.gameType]?.displayName ?? 'game';
-    return `started a ${gname} challenge, be quick if you want it 🫵`;
+    return `started a ${gname} challenge, be quick if you want it 🎮`;
   }
   return p.kind === 'image'
     ? 'shared a photo'

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4446,6 +4446,32 @@ export async function sweepExpiredMessages(): Promise<number> {
   return due.length;
 }
 
+/** Repair sweep (spec 2026): group-call rows logged from a missed-call marker
+ *  briefly carried an initials avatar built from "<name> & others" — the raw
+ *  ampersand made the SVG invalid XML, so the Calls tab rendered a broken
+ *  image. Regenerate the glyph for any call row whose stored avatar decodes to
+ *  malformed XML (group rows get the people glyph the live UI uses). */
+export async function repairBrokenCallAvatars(): Promise<number> {
+  const rawAmp = /&(?!amp;|lt;|gt;|quot;|apos;|#)/;
+  let repaired = 0;
+  for (const call of await getAll<Call>('calls')) {
+    const m = (call.avatar ?? '').match(/^data:image\/svg\+xml;utf8,(.*)$/);
+    if (!m) continue;
+    let svg = '';
+    try {
+      svg = decodeURIComponent(m[1]);
+    } catch {
+      /* undecodable counts as broken too */
+    }
+    if (svg && !rawAmp.test(svg)) continue;
+    call.avatar = call.isGroup ? groupAvatar(call.roomId ?? call.contactId) : initialsAvatar(call.name);
+    call.updatedAt = now();
+    await put('calls', call);
+    repaired += 1;
+  }
+  return repaired;
+}
+
 /** Repair sweep (spec 2026): the spec-1032 SW drain briefly persisted spec-1040
  *  call-event marker frames as empty 'callevent' messages — and ACKED them, so
  *  they are never redelivered for the page to reprocess. Remove the junk rows,
@@ -6314,7 +6340,10 @@ async function logMissedFromMarker(p: PendingCallEvent, knownChatId?: string): P
       id: p.callId,
       contactId: p.roomId,
       name,
-      avatar: groupChat?.avatar ?? initialsAvatar(name),
+      // Ad-hoc rooms have no group chat: use the same people-glyph the live
+      // call UI logs for outgoing ad-hoc calls (groupAvatar), not initials —
+      // "Macbook & others" has no sensible initials.
+      avatar: groupChat?.avatar ?? groupAvatar(p.roomId),
       direction: 'incoming',
       missed: true,
       video,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4446,6 +4446,34 @@ export async function sweepExpiredMessages(): Promise<number> {
   return due.length;
 }
 
+/** Repair sweep (spec 2026): the spec-1032 SW drain briefly persisted spec-1040
+ *  call-event marker frames as empty 'callevent' messages — and ACKED them, so
+ *  they are never redelivered for the page to reprocess. Remove the junk rows,
+ *  deflate the unread counts they inflated (the drain bumped `unread` once per
+ *  row; opening the chat since already zeroed it, so clamp at 0), and recompute
+ *  the chat previews they clobbered. Runs on every open rather than once: the
+ *  pre-fix service worker can stay active — and keep storing junk — until the
+ *  user accepts the app update. Cheap when clean (one indexed scan, no writes). */
+export async function sweepCallEventMessages(): Promise<number> {
+  const junk = (await getAll<Message>('messages')).filter((m) => (m.kind as string) === 'callevent');
+  if (!junk.length) return 0;
+  const perChat = new Map<string, number>();
+  for (const m of junk) {
+    await remove('messages', m.id);
+    perChat.set(m.chatId, (perChat.get(m.chatId) ?? 0) + 1);
+  }
+  for (const [chatId, n] of perChat) {
+    const chat = await getChat(chatId);
+    if (chat?.unread) {
+      chat.unread = Math.max(0, chat.unread - n);
+      chat.updatedAt = now();
+      await put('chats', chat);
+    }
+    await refreshChatPreview(chatId);
+  }
+  return junk.length;
+}
+
 /** Mute (or unmute) a chat's alerting until `until` epoch-ms (a far-future value =
  *  always; null/0 = unmute). The message still arrives and counts toward the badge;
  *  only the OS notification / in-app banner / sound are suppressed. Local only. */

--- a/src/games/armada/ArmadaBoard.vue
+++ b/src/games/armada/ArmadaBoard.vue
@@ -535,10 +535,12 @@ const myWreckCells = computed(() => {
 });
 const mySunkCount = computed(() => myShipsView.value.filter((s) => s.sunk).length);
 
-// Enemy ships: each 'sunk' answer closes the straight run of hits through its
-// cell (ships may touch, so a collinear pair can briefly read as one long
-// wreck — the end-of-game reveal corrects any such guess and surfaces the
-// survivors). Same derivation battleship shipped, on the 10-wide board.
+// Enemy ships: a 'sunk' answer from a current client DECLARES the wreck's
+// geometry (spec 2026) — drawn exactly, verified against the reveal at the
+// end. Answers from older clients lack it, so the straight-run-of-hits guess
+// below stays as the fallback (ships may touch, so a collinear pair could
+// read as one long wreck — the phantom-two-carriers bug this declaration
+// fixes; the end-of-game reveal corrects any leftover guess).
 const theirDerivedWrecks = computed<Ship[]>(() => {
   const shots = props.state.shots[me.value];
   const hitCells = new Set<number>();
@@ -548,6 +550,11 @@ const theirDerivedWrecks = computed<Ship[]>(() => {
   for (const rec of shots) {
     if (rec.r !== 'miss') hitCells.add(rec.cell);
     if (rec.r !== 'sunk') continue;
+    if (rec.ship) {
+      wrecks.push(rec.ship);
+      cellsOf(rec.ship).forEach((c) => assigned.add(c));
+      continue;
+    }
     const r0 = Math.floor(rec.cell / 10);
     const c0 = rec.cell % 10;
     let c1 = c0, c2 = c0, r1 = r0, r2 = r0;

--- a/src/games/armada/logic.test.ts
+++ b/src/games/armada/logic.test.ts
@@ -19,6 +19,8 @@ import {
   commitment,
   randomSalt,
   judgeShot,
+  answersHonest,
+  sunkShipValid,
   cellsOf,
   fleetView,
   SIZE,
@@ -296,6 +298,57 @@ describe('verification (the honesty machinery)', () => {
   it('both reveals invalid → a disgraceful draw', () => {
     const s = riggedGame({ layout: L1, salt: S0 }, { layout: L0, salt: S1 }); // both bad salts
     expect(status(s)).toEqual({ state: 'draw' });
+  });
+});
+
+describe('declared sunk-ship geometry (spec 2026)', () => {
+  const DESTROYER = { r: 8, c: 3, len: 2, dir: 'h' } as const; // L1's 2-ship: cells 83, 84
+
+  /** Sink L1's destroyer, with P1 declaring `ship` (or nothing) on the sink. */
+  function sinkDestroyer(ship?: unknown): ArmadaState {
+    let s = committed();
+    s = apply(s, { t: 'shot', cell: 83 }, 0);
+    s = apply(s, { t: 'answer', r: 'hit' }, 1);
+    s = apply(s, { t: 'shot', cell: p1Miss(0) }, 1);
+    s = apply(s, { t: 'answer', r: 'miss' }, 0);
+    s = apply(s, { t: 'shot', cell: 84 }, 0);
+    s = apply(s, { t: 'answer', r: 'sunk', ...(ship !== undefined ? { ship } : {}) } as ArmadaMove, 1);
+    return s;
+  }
+
+  it('a valid declaration is stored on the shot record', () => {
+    expect(sinkDestroyer(DESTROYER).shots[0][1]).toEqual({ cell: 84, r: 'sunk', ship: DESTROYER });
+  });
+
+  it('an undeclared sink stays legal and bare (answers from older clients)', () => {
+    expect(sinkDestroyer().shots[0][1]).toEqual({ cell: 84, r: 'sunk' });
+  });
+
+  it('a malformed declaration is STRIPPED, never fatal (move compatibility)', () => {
+    for (const bad of [
+      { r: 8, c: 3, len: 9, dir: 'h' }, // impossible length
+      { r: 8, c: 9, len: 2, dir: 'h' }, // runs off the board
+      { r: 0, c: 0, len: 2, dir: 'h' }, // does not cover the answered cell
+      { r: 8, c: 3.5, len: 2, dir: 'h' }, // non-integer geometry
+      'destroyer', // not even a ship
+    ]) {
+      expect(sinkDestroyer(bad).shots[0][1]).toEqual({ cell: 84, r: 'sunk' });
+    }
+  });
+
+  it('sunkShipValid demands the answered cell be covered', () => {
+    expect(sunkShipValid(DESTROYER, 84)).toBe(true);
+    expect(sunkShipValid(DESTROYER, 85)).toBe(false);
+  });
+
+  it('a truthful declaration verifies; a geometry lie is cheating', () => {
+    // {r:7,c:4,len:2,dir:'v'} covers the answered cell 84 too (cells 74, 84) —
+    // structurally sane, so it survives applyMove — but it is NOT the destroyer,
+    // and the reveal must expose it exactly like a lied result.
+    const honest = { ...sinkDestroyer(DESTROYER), reveals: [null, { layout: L1, salt: S1 }] } as ArmadaState;
+    expect(answersHonest(1, honest)).toBe(true);
+    const liar = { ...sinkDestroyer({ r: 7, c: 4, len: 2, dir: 'v' }), reveals: [null, { layout: L1, salt: S1 }] } as ArmadaState;
+    expect(answersHonest(1, liar)).toBe(false);
   });
 });
 

--- a/src/games/armada/logic.ts
+++ b/src/games/armada/logic.ts
@@ -54,13 +54,20 @@ export interface Reveal {
 export type ArmadaMove =
   | { t: 'commit'; h: string }
   | { t: 'shot'; cell: number }
-  | { t: 'answer'; r: 'miss' | 'hit' | 'sunk'; reveal?: Reveal }
+  | { t: 'answer'; r: 'miss' | 'hit' | 'sunk'; ship?: Ship; reveal?: Reveal }
   | { t: 'reveal'; layout: Layout; salt: string }
 
 export interface ShotRec {
   cell: number
   /** The defender's declared result (trusted in play, verified at the end). */
   r: 'miss' | 'hit' | 'sunk'
+  /** On 'sunk' (spec 2026): the defender's declared geometry of the ship that
+   *  went down, so the attacker draws the exact wreck instead of guessing it
+   *  from contiguous hit cells (the guess merged collinear ADJACENT ships —
+   *  two phantom carriers — until the end-of-game reveal corrected it).
+   *  Optional on the wire: answers from older clients lack it and fall back
+   *  to the guess. Verified against the reveal like the result itself. */
+  ship?: Ship
 }
 
 export interface ArmadaState {
@@ -193,6 +200,22 @@ export function randomSalt(): string {
   return toB64url(randomBytes(32))
 }
 
+/** Structural sanity for a declared sunk-ship geometry (spec 2026): a single
+ *  in-bounds ship of a fleet-plausible length that covers the answered cell.
+ *  Deliberately NOT a rejection gate in applyMove — old engines accept the
+ *  unknown field silently, so a malformed declaration is stripped, never fatal
+ *  (the two engine generations must stay move-compatible). Honesty against the
+ *  actual layout is answersHonest's job at the reveal. */
+export function sunkShipValid(v: unknown, cell: number): v is Ship {
+  const s = v as Ship
+  if (!s || typeof s !== 'object') return false
+  if (!Number.isInteger(s.r) || !Number.isInteger(s.c) || !Number.isInteger(s.len)) return false
+  if (s.dir !== 'h' && s.dir !== 'v') return false
+  if (s.len < 2 || s.len > 5 || s.r < 0 || s.c < 0) return false
+  if (s.dir === 'h' ? s.c + s.len > SIZE || s.r >= SIZE : s.r + s.len > SIZE || s.c >= SIZE) return false
+  return cellsOf(s).includes(cell)
+}
+
 /** The truthful answer for a shot against `layout`, given every hit cell so
  *  far INCLUDING this one when it hits ('sunk' exactly on a ship's last cell). */
 export function judgeShot(layout: Layout, cell: number, hitsSoFar: number[]): 'miss' | 'hit' | 'sunk' {
@@ -256,7 +279,14 @@ export function applyMove(s: ArmadaState, move: ArmadaMove, player: 0 | 1): Arma
   if (s.pending) {
     if (move.t !== 'answer' || !['miss', 'hit', 'sunk'].includes(move.r)) return null
     const attacker = s.pending.by
-    const rec: ShotRec = { cell: s.pending.cell, r: move.r }
+    // A 'sunk' answer may declare the wreck's geometry (spec 2026). Copied
+    // field-by-field into the record (never the wire object itself) and kept
+    // only when structurally sane — stripped otherwise, see sunkShipValid.
+    const declaredShip =
+      move.r === 'sunk' && sunkShipValid(move.ship, s.pending.cell)
+        ? { r: move.ship.r, c: move.ship.c, len: move.ship.len, dir: move.ship.dir }
+        : undefined
+    const rec: ShotRec = { cell: s.pending.cell, r: move.r, ...(declaredShip ? { ship: declaredShip } : {}) }
     const shots: ArmadaState['shots'] = [attacker === 0 ? [...s.shots[0], rec] : s.shots[0], attacker === 1 ? [...s.shots[1], rec] : s.shots[1]]
     const ends = declaredHits(shots[attacker]) >= FLEET_CELLS
     if (ends) {
@@ -287,6 +317,15 @@ export function answersHonest(side: 0 | 1, s: ArmadaState): boolean {
     const truth = judgeShot(reveal.layout, shot.cell, hits)
     if (truth !== 'miss') hits.push(shot.cell)
     if (shot.r !== truth) return false
+    // A declared wreck must be the real ship (spec 2026): the attacker rendered
+    // their board from it, so a geometry lie is cheating exactly like a result
+    // lie. Same cells ⇒ same ship (len ≥ 2 rules out h/v ambiguity). Absent on
+    // answers from older clients — nothing to check then.
+    if (shot.r === 'sunk' && shot.ship) {
+      const real = reveal.layout.find((sh) => cellsOf(sh).includes(shot.cell))
+      const sig = (sh: Ship): string => cellsOf(sh).sort((a, b) => a - b).join(',')
+      if (!real || sig(real) !== sig(shot.ship)) return false
+    }
   }
   return true
 }

--- a/src/games/duty.test.ts
+++ b/src/games/duty.test.ts
@@ -117,7 +117,23 @@ describe('owed answers (the stall regression)', () => {
     expect(owedMove(s, 1, SEC1)).toEqual({
       t: 'answer',
       r: 'sunk',
+      ship: { r: 8, c: 3, len: 2, dir: 'h' }, // the destroyer went down with the fleet (spec 2026)
       reveal: { layout: L1, salt: S1 },
+    });
+  });
+
+  it('a sinking answer declares the sunk ship geometry (spec 2026)', () => {
+    // Sink L1's destroyer {r:8,c:3,len:2,dir:'h'} (cells 83 → 84).
+    let s = committed();
+    s = apply(s, { t: 'shot', cell: 83 }, 0);
+    s = apply(s, { t: 'answer', r: 'hit' }, 1);
+    s = apply(s, { t: 'shot', cell: 99 }, 1);
+    s = apply(s, { t: 'answer', r: 'miss' }, 0);
+    s = apply(s, { t: 'shot', cell: 84 }, 0);
+    expect(owedMove(s, 1, SEC1)).toEqual({
+      t: 'answer',
+      r: 'sunk',
+      ship: { r: 8, c: 3, len: 2, dir: 'h' },
     });
   });
 });

--- a/src/games/duty.ts
+++ b/src/games/duty.ts
@@ -16,12 +16,14 @@
 
 import {
   FLEET_CELLS,
+  cellsOf,
   judgeShot,
   status,
   type ArmadaMove,
   type ArmadaState,
   type Layout,
   type Reveal,
+  type Ship,
 } from './armada/logic'
 
 export interface DutySecret {
@@ -75,9 +77,15 @@ export function owedMove(
   const incoming = s.shots[p.by].filter((x) => x.r !== 'miss').map((x) => x.cell)
   const r = judgeShot(secret.layout, p.cell, incoming)
   const declared = incoming.length + (r === 'miss' ? 0 : 1)
+  // A sink declares the wreck's geometry (spec 2026) so the attacker draws the
+  // exact ship instead of guessing from contiguous hits (the guess merged
+  // collinear adjacent ships into phantom fleets). Plain-copied like every
+  // emitted move — the reactive-Proxy DataCloneError trap.
+  const sunk = r === 'sunk' ? secret.layout.find((sh) => cellsOf(sh).includes(p.cell)) : undefined
+  const ship: { ship?: Ship } = sunk ? { ship: { r: sunk.r, c: sunk.c, len: sunk.len, dir: sunk.dir } } : {}
   if (declared >= FLEET_CELLS) {
     // The final answer carries the loser's reveal (a bare final answer is illegal).
-    return { t: 'answer', r: 'sunk', reveal: plainReveal(secret) }
+    return { t: 'answer', r: 'sunk', ...ship, reveal: plainReveal(secret) }
   }
-  return { t: 'answer', r }
+  return { t: 'answer', r, ...ship }
 }

--- a/src/services/call-events.test.ts
+++ b/src/services/call-events.test.ts
@@ -205,10 +205,10 @@ describe('hasFreshRing — the msg-wake ring-upgrade gate (spec 2026)', () => {
 });
 
 describe('ring shown-signature — minimal shows on the ring-call tag (spec 2026)', () => {
-  const named: RingShownSig = { callId: 'c1', named: true, title: 'Mac', body: '🎙️ is calling you', ts: NOW };
+  const named: RingShownSig = { callId: 'c1', named: true, title: 'Mac', body: 'is calling you 📞', ts: NOW };
 
   it('reminder re-assert: a fresh NAMED alert re-asserts itself, never downgrades to generic', () => {
-    expect(ringReassert(named, NOW + 10_000)).toEqual({ title: 'Mac', body: '🎙️ is calling you' });
+    expect(ringReassert(named, NOW + 10_000)).toEqual({ title: 'Mac', body: 'is calling you 📞' });
   });
 
   it('reminder re-assert: absent / generic / stale signatures → null (show the generic)', () => {
@@ -218,13 +218,13 @@ describe('ring shown-signature — minimal shows on the ring-call tag (spec 2026
   });
 
   it('already-named: an identical fresh naming is skipped (no extra iOS center entry)', () => {
-    expect(ringAlreadyNamed(named, 'Mac', '🎙️ is calling you', NOW + 5_000)).toBe(true);
+    expect(ringAlreadyNamed(named, 'Mac', 'is calling you 📞', NOW + 5_000)).toBe(true);
   });
 
   it('already-named: different content, generic, or stale signatures re-show', () => {
-    expect(ringAlreadyNamed(named, 'Family', '🎙️ Mac is calling', NOW)).toBe(false); // content changed
-    expect(ringAlreadyNamed({ named: false, ts: NOW }, 'Mac', '🎙️ is calling you', NOW)).toBe(false);
-    expect(ringAlreadyNamed(named, 'Mac', '🎙️ is calling you', NOW + RING_WINDOW_MS + 1)).toBe(false);
-    expect(ringAlreadyNamed(undefined, 'Mac', '🎙️ is calling you', NOW)).toBe(false);
+    expect(ringAlreadyNamed(named, 'Family', 'Mac is calling 📞', NOW)).toBe(false); // content changed
+    expect(ringAlreadyNamed({ named: false, ts: NOW }, 'Mac', 'is calling you 📞', NOW)).toBe(false);
+    expect(ringAlreadyNamed(named, 'Mac', 'is calling you 📞', NOW + RING_WINDOW_MS + 1)).toBe(false);
+    expect(ringAlreadyNamed(undefined, 'Mac', 'is calling you 📞', NOW)).toBe(false);
   });
 });

--- a/src/services/call-events.test.ts
+++ b/src/services/call-events.test.ts
@@ -10,8 +10,11 @@ import {
   applyCallOutcome,
   sweepStaleUnits,
   hasFreshRing,
+  ringReassert,
+  ringAlreadyNamed,
   type PendingCallEvent,
   type CallBadgeUnit,
+  type RingShownSig,
 } from './call-events';
 
 const NOW = 1_800_000_000_000;
@@ -198,5 +201,30 @@ describe('hasFreshRing — the msg-wake ring-upgrade gate (spec 2026)', () => {
 
   it('outcome-only batches → false', () => {
     expect(hasFreshRing([buildEndedEvent('c1', 'audio', 'missed', NOW)], NOW)).toBe(false);
+  });
+});
+
+describe('ring shown-signature — minimal shows on the ring-call tag (spec 2026)', () => {
+  const named: RingShownSig = { callId: 'c1', named: true, title: 'Mac', body: '🎙️ is calling you', ts: NOW };
+
+  it('reminder re-assert: a fresh NAMED alert re-asserts itself, never downgrades to generic', () => {
+    expect(ringReassert(named, NOW + 10_000)).toEqual({ title: 'Mac', body: '🎙️ is calling you' });
+  });
+
+  it('reminder re-assert: absent / generic / stale signatures → null (show the generic)', () => {
+    expect(ringReassert(undefined, NOW)).toBeNull();
+    expect(ringReassert({ named: false, ts: NOW }, NOW)).toBeNull();
+    expect(ringReassert(named, NOW + RING_WINDOW_MS + 1)).toBeNull();
+  });
+
+  it('already-named: an identical fresh naming is skipped (no extra iOS center entry)', () => {
+    expect(ringAlreadyNamed(named, 'Mac', '🎙️ is calling you', NOW + 5_000)).toBe(true);
+  });
+
+  it('already-named: different content, generic, or stale signatures re-show', () => {
+    expect(ringAlreadyNamed(named, 'Family', '🎙️ Mac is calling', NOW)).toBe(false); // content changed
+    expect(ringAlreadyNamed({ named: false, ts: NOW }, 'Mac', '🎙️ is calling you', NOW)).toBe(false);
+    expect(ringAlreadyNamed(named, 'Mac', '🎙️ is calling you', NOW + RING_WINDOW_MS + 1)).toBe(false);
+    expect(ringAlreadyNamed(undefined, 'Mac', '🎙️ is calling you', NOW)).toBe(false);
   });
 });

--- a/src/services/call-events.test.ts
+++ b/src/services/call-events.test.ts
@@ -9,6 +9,7 @@ import {
   applyCallTickle,
   applyCallOutcome,
   sweepStaleUnits,
+  hasFreshRing,
   type PendingCallEvent,
   type CallBadgeUnit,
 } from './call-events';
@@ -162,5 +163,40 @@ describe('badge units — FR-007/FR-008/FR-010', () => {
       { callId: 'new', ts: NOW, state: 'ringing' },
     ];
     expect(sweepStaleUnits(units, NOW)).toEqual([expect.objectContaining({ callId: 'new' })]);
+  });
+});
+
+describe('hasFreshRing — the msg-wake ring-upgrade gate (spec 2026)', () => {
+  it('a fresh ring with no outcome in the batch → true', () => {
+    expect(hasFreshRing([buildRingEvent('c1', 'audio', NOW)], NOW + 5_000)).toBe(true);
+  });
+
+  it('empty / absent batches → false', () => {
+    expect(hasFreshRing(undefined, NOW)).toBe(false);
+    expect(hasFreshRing([], NOW)).toBe(false);
+  });
+
+  it('a ring past the window is stale → false (never name a caller who stopped calling)', () => {
+    expect(hasFreshRing([buildRingEvent('c1', 'audio', NOW)], NOW + RING_WINDOW_MS + 1)).toBe(false);
+  });
+
+  it('a ring whose call also ENDED in the same batch → false (missed/cancelled owns the alert)', () => {
+    const batch = [
+      buildRingEvent('c1', 'audio', NOW),
+      buildEndedEvent('c1', 'audio', 'missed', NOW + 30_000),
+    ];
+    expect(hasFreshRing(batch, NOW + 31_000)).toBe(false);
+  });
+
+  it('an ended marker for a DIFFERENT call does not kill a fresh ring', () => {
+    const batch = [
+      buildEndedEvent('c0', 'audio', 'answered', NOW),
+      buildRingEvent('c1', 'video', NOW + 1_000),
+    ];
+    expect(hasFreshRing(batch, NOW + 2_000)).toBe(true);
+  });
+
+  it('outcome-only batches → false', () => {
+    expect(hasFreshRing([buildEndedEvent('c1', 'audio', 'missed', NOW)], NOW)).toBe(false);
   });
 });

--- a/src/services/call-events.ts
+++ b/src/services/call-events.ts
@@ -167,3 +167,39 @@ export function hasFreshRing(evs: readonly CallEventSignal[] | undefined, now: n
   const ended = new Set(evs.filter((e) => e.phase === 'ended').map((e) => e.callId));
   return evs.some((e) => e.phase === 'ring' && !ended.has(e.callId) && now - e.at <= RING_WINDOW_MS);
 }
+
+/**
+ * What the SW last showed on the 'ring-call' tag (persisted in the settings
+ * store, like the badge units). iOS renders EVERY showNotification call as a
+ * new Notification Center entry — same-tag replacement does not collapse
+ * history (the spec-2020 lesson) — so the ring flow must show the strict
+ * minimum: never downgrade a named alert back to generic on a reminder tickle,
+ * and never re-show a name the alert already carries. Single-slot on purpose:
+ * overlapping rings already fold to one unit/alert elsewhere.
+ */
+export interface RingShownSig {
+  callId?: string;
+  named: boolean;
+  title?: string;
+  body?: string;
+  ts: number; // last show; freshness shares the ring window
+}
+
+/** A reminder tickle re-asserts the NAMED alert (re-alerting is the reminder's
+ *  whole job) instead of downgrading to the generic. Stale/absent/generic → null
+ *  (show the undelayed generic as usual). */
+export function ringReassert(sig: RingShownSig | undefined, now: number): { title: string; body: string } | null {
+  if (!sig?.named || !sig.title || now - sig.ts > RING_WINDOW_MS) return null;
+  return { title: sig.title, body: sig.body ?? '' };
+}
+
+/** Skip a naming re-show when the live alert already says exactly this — every
+ *  extra show is an extra Notification Center entry on iOS. */
+export function ringAlreadyNamed(
+  sig: RingShownSig | undefined,
+  title: string,
+  body: string,
+  now: number,
+): boolean {
+  return !!sig?.named && sig.title === title && sig.body === body && now - sig.ts <= RING_WINDOW_MS;
+}

--- a/src/services/call-events.ts
+++ b/src/services/call-events.ts
@@ -151,3 +151,19 @@ export function applyCallOutcome(
 export function sweepStaleUnits(units: CallBadgeUnit[], now: number): CallBadgeUnit[] {
   return units.filter((u) => now - u.ts <= UNIT_STALE_MS);
 }
+
+/**
+ * Does this batch of decrypted markers carry a call that may STILL be ringing —
+ * a fresh `ring` with no `ended` outcome for the same call in the same batch?
+ * The msg-wake ring upgrade (sw.ts) gates on this before paying previewCallRing's
+ * refetch: the dial-time marker rides the queued message channel (its send is
+ * deferred off the call-setup hot path), so the {"t":"call"} tickle wake usually
+ * ran first and showed the generic ring — the marker's own wake is where the
+ * name becomes available. `at` is the sender's clock: a freshness hint only,
+ * matching previewCallRing's display rule (stale → stay generic).
+ */
+export function hasFreshRing(evs: readonly CallEventSignal[] | undefined, now: number): boolean {
+  if (!evs?.length) return false;
+  const ended = new Set(evs.filter((e) => e.phase === 'ended').map((e) => e.callId));
+  return evs.some((e) => e.phase === 'ring' && !ended.has(e.callId) && now - e.at <= RING_WINDOW_MS);
+}

--- a/src/services/sw-drain.test.ts
+++ b/src/services/sw-drain.test.ts
@@ -207,6 +207,10 @@ describe('classifyPayload: the FR-004 eligibility table (pure)', () => {
     ['erase', { erase: { messageId: 'm', at: 1 } }, 'defer'],
     ['link-preview attach', { linkPreviewSig: { messageId: 'm', preview: { url: 'u', domain: 'd' }, at: 1 } }, 'defer'],
     ['call signal', { call: { callId: 'c', type: 'offer' } }, 'defer'],
+    // Spec 2026 regression pin: a callEvent marker persisted here becomes an empty
+    // "message" AND its ack starves the page of the missed-call trace.
+    ['call-event ring marker', { kind: 'callevent', callEvent: { phase: 'ring', callId: 'c', kind: 'audio', at: 1 } }, 'defer'],
+    ['call-event outcome marker', { kind: 'callevent', callEvent: { phase: 'ended', callId: 'c', kind: 'audio', outcome: 'missed', at: 1 } }, 'defer'],
     ['rekey control', { rekey: true }, 'defer'],
     ['ttl control', { ttl: 60_000 }, 'defer'],
     ['ttl-off control (ttl: null)', { ttl: null }, 'defer'],
@@ -327,6 +331,22 @@ describe('drain: atomic apply + exactly-once + ack discipline (T014)', () => {
     queued = [{ t: 'msg', id: 'm2', from: PEER, ciphertext: N(pay({ body: 'after' })) }];
     const r2 = await drainPersistPending();
     expect(r2.applied).toBe(1);
+  });
+
+  it('spec 2026: a call-event marker frame is deferred whole — no empty row, no unread, no ack', async () => {
+    // The regression: the drain persisted ring/ended markers as empty "messages"
+    // and ACKED them, so the page never got to log the missed call.
+    queued = [
+      { t: 'msg', id: 'cv1', from: PEER, ciphertext: N(pay({ body: '', kind: 'callevent', callEvent: { phase: 'ring', callId: 'c9', kind: 'audio', at: 1234 } })) },
+      { t: 'msg', id: 'cv2', from: PEER, ciphertext: N(pay({ body: '', kind: 'callevent', callEvent: { phase: 'ended', callId: 'c9', kind: 'audio', outcome: 'missed', at: 5678 } })) },
+    ];
+    const r = await drainPersistPending();
+    expect(r.applied).toBe(0);
+    expect(r.deferred).toBe(2);
+    expect(r.ackIds).toEqual([]);
+    expect(msgRows().length).toBe(0);
+    expect(chatRow().unread).toBe(0);
+    expect(ledger()).toEqual([]); // frames stay queued for the page's handleCallEvent
   });
 
   it('ackFrames posts exactly the committed ids to /relay/ack', async () => {

--- a/src/services/sw-drain.ts
+++ b/src/services/sw-drain.ts
@@ -13,7 +13,7 @@
  * stored as `pendingMedia` for the page to download — in an EXISTING chat from an
  * EXISTING connected contact, including group messages into an existing group.
  * First-contact X3DH, contact/group cards, reactions, edits, erases, poll votes,
- * link-preview attaches, call signals, rekey/TTL controls: deferred.
+ * link-preview attaches, call signals, call-event markers, rekey/TTL controls: deferred.
  *
  * Degrade-to-today is the spine (spec FR-008): flag off, no Web Locks, locked
  * device, fetch failure, lock timeout (a frozen page can hold a lock), transaction
@@ -131,6 +131,12 @@ export function classifyPayload(
   if (payload.erase) return { verdict: 'defer', why: 'erase' };
   if (payload.linkPreviewSig) return { verdict: 'defer', why: 'link-preview' };
   if (payload.call) return { verdict: 'defer', why: 'call-signal' };
+  // Call lifecycle markers (spec 1040, added after this classifier shipped): pure
+  // side effects — badge unit, ring naming, missed-call trace — whose handler
+  // (handleCallEvent) lives page-side. Persisting one here would store an empty
+  // "message", inflate unread, and — worse — ACK the frame so the page never logs
+  // the missed call (spec 2026's regression).
+  if (payload.callEvent) return { verdict: 'defer', why: 'call-event' };
   if (payload.rekey) return { verdict: 'defer', why: 'rekey' };
   if (payload.ttl !== undefined) return { verdict: 'defer', why: 'ttl-control' };
   if (payload.groupId) {

--- a/src/services/sw-inbox.calls.test.ts
+++ b/src/services/sw-inbox.calls.test.ts
@@ -61,18 +61,18 @@ describe('noteForPayload — missed-call replacement (US2, FR-012/FR-012a)', () 
     expect(wasMessage).toBe(false);
     expect(note).toMatchObject({
       title: 'Kamran',
-      body: '☎️ Missed call',
+      body: 'Missed call ☎️',
       url: '/chat/chat-1',
       tag: 'ring-call', // replaces the "Incoming call" alert in place
     });
   });
 
   it('a missed video call says so', () => {
-    expect(run(ended({ kind: 'video' }))?.note?.body).toBe('☎️ Missed video call');
+    expect(run(ended({ kind: 'video' }))?.note?.body).toBe('Missed video call ☎️');
   });
 
   it('cancelled (caller hung up before answer) reads as a missed call too', () => {
-    expect(run(ended({ outcome: 'cancelled' }))?.note?.body).toBe('☎️ Missed call');
+    expect(run(ended({ outcome: 'cancelled' }))?.note?.body).toBe('Missed call ☎️');
   });
 
   it('a group call names the group and the caller, deep-linking the group chat', () => {
@@ -80,7 +80,7 @@ describe('noteForPayload — missed-call replacement (US2, FR-012/FR-012a)', () 
     const { note } = run(ended({ roomId: 'room-1' }), { chats: [g] });
     expect(note).toMatchObject({
       title: 'Weekend Trip',
-      body: '☎️ Missed call from Kamran',
+      body: 'Missed call from Kamran ☎️',
       url: '/chat/room-1',
     });
   });

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -44,6 +44,7 @@ import {
   applyCallOutcome,
   sweepStaleUnits,
   type CallBadgeUnit,
+  type RingShownSig,
 } from './call-events';
 
 // Same-origin by default (the dev proxy / prod reverse-proxy route /v1 → backend).
@@ -995,6 +996,26 @@ export async function previewCallRing(): Promise<CallRingPreview> {
     return { kind: 'named', title: chat.name, body: `${emoji} ${caller || 'Someone'} is calling`, callId: ev.callId };
   }
   return { kind: 'named', title: caller as string, body: `${emoji} is calling you`, callId: ev.callId };
+}
+
+/** What the 'ring-call' notification currently says (spec 2026): the ring flow
+ *  reads this to avoid re-shows that would stack Notification Center entries on
+ *  iOS (reminder downgrades to generic, repeat namings). TTL'd by the ring
+ *  window via the pure helpers in call-events.ts. */
+const RING_SHOWN_KEY = 'sw.ringShown';
+
+export async function readRingShown(): Promise<RingShownSig | undefined> {
+  return setting<RingShownSig | undefined>(RING_SHOWN_KEY, undefined);
+}
+
+export async function recordRingShown(sig: RingShownSig): Promise<void> {
+  await put<Setting<RingShownSig>>('settings', { key: RING_SHOWN_KEY, value: sig });
+}
+
+/** The ring is over (outcome arrived / page took over): a later tickle must not
+ *  re-assert the stale name. */
+export async function clearRingShown(): Promise<void> {
+  await recordRingShown({ named: false, ts: 0 });
 }
 
 /** The transient per-call badge units (spec 1040), shared with the page through

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -371,12 +371,12 @@ export function noteForPayload(
     const caller = known || 'Someone';
     const isGroupCall = !!ev.roomId;
     const title = isGroupCall ? cChat?.name || caller : caller;
-    const body = ev.kind === 'video' ? '☎️ Missed video call' : '☎️ Missed call';
+    const what = ev.kind === 'video' ? 'Missed video call' : 'Missed call';
     return {
       note: {
         ids: [f.id as string],
         title,
-        body: isGroupCall && cChat ? `${body} from ${caller}` : body,
+        body: isGroupCall && cChat ? `${what} from ${caller} ☎️` : `${what} ☎️`,
         url: cChat ? `/chat/${cChat.id}` : '/tabs/calls',
         tag: 'ring-call', // replaces the incoming-call alert (FR-012)
       },
@@ -991,11 +991,11 @@ export async function previewCallRing(): Promise<CallRingPreview> {
   if (chat && hidden.has(chat.id)) return { kind: 'generic', callId: ev.callId };
   const caller = contacts.find((c) => c.id === from)?.name;
   if (!caller && !(ev.roomId && chat)) return { kind: 'generic', callId: ev.callId }; // never a raw id (FR-006)
-  const emoji = ev.kind === 'video' ? '📹' : '🎙️';
+  const emoji = ev.kind === 'video' ? '📹' : '📞';
   if (ev.roomId && chat) {
-    return { kind: 'named', title: chat.name, body: `${emoji} ${caller || 'Someone'} is calling`, callId: ev.callId };
+    return { kind: 'named', title: chat.name, body: `${caller || 'Someone'} is calling ${emoji}`, callId: ev.callId };
   }
-  return { kind: 'named', title: caller as string, body: `${emoji} is calling you`, callId: ev.callId };
+  return { kind: 'named', title: caller as string, body: `is calling you ${emoji}`, callId: ev.callId };
 }
 
 /** What the 'ring-call' notification currently says (spec 2026): the ring flow
@@ -1320,7 +1320,7 @@ async function swPostChallengeLine(
     const { payload } = openReceivedPost(bytes, p.wrappedKey, getIdentityKeys().x.privateKey);
     if (!payload.game) return null;
     const gname = GAMES[payload.game.gameType]?.displayName ?? 'game';
-    return `started a ${gname} challenge, be quick if you want it 🫵`;
+    return `started a ${gname} challenge, be quick if you want it 🎮`;
   } catch {
     return null;
   }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -159,18 +159,39 @@ async function showGeneric(reason?: string): Promise<void> {
 }
 
 async function showCall(named?: { title: string; body: string }): Promise<void> {
-  // (spec 1040) The generic ring shows IMMEDIATELY (renotify → the re-alert), then
-  // previewCallRing may upgrade it in place with the caller's name. The upgrade
-  // re-show keeps the tag but not renotify, so naming never buzzes a second time.
-  await self.registration.showNotification(named?.title ?? 'Incoming call', {
-    body: named?.body ?? 'Tap to answer',
-    icon: ICON,
-    badge: BADGE,
-    tag: 'ring-call',
-    renotify: !named, // each repeated ring push re-alerts (a single updating notification)
-    requireInteraction: true, // a ring shouldn't auto-dismiss before it's seen
-    data: { url: '/tabs/chats' },
-  });
+  // (spec 1040) The generic ring shows IMMEDIATELY (the tickle wake never waits on
+  // decryption), then previewCallRing / the marker's own msg wake may upgrade it
+  // with the caller's name.
+  // (spec 2026) Every re-show CLOSES the previous ring alert first: iOS keeps a
+  // separate Notification Center entry per showNotification call even on the same
+  // tag (the spec-2020 lesson), so the old same-tag+renotify:false "in-place"
+  // upgrade actually read as a DOUBLE notification there — generic and named
+  // stacked — and each group reminder push stacked one more generic. Closing
+  // first is safe: this wake's visible ending is the show right below; and if
+  // that show somehow fails after the close, the catch re-asserts a generic ring
+  // so the callee is never left ring-less mid-ring (the rejection still reaches
+  // the caller's visibility accounting).
+  await closeByTag('ring-call');
+  const show = (title: string, body: string, silent: boolean) =>
+    self.registration.showNotification(title, {
+      body,
+      icon: ICON,
+      badge: BADGE,
+      tag: 'ring-call',
+      // Naming is SILENT: the generic ring already alerted for this call, so the
+      // upgrade must not buzz a second time (close-first makes it a fresh
+      // notification, which would otherwise re-alert). A generic (re-)show is a
+      // fresh ring or a server reminder and should keep alerting.
+      silent,
+      requireInteraction: true, // a ring shouldn't auto-dismiss before it's seen
+      data: { url: '/tabs/chats' },
+    });
+  try {
+    await show(named?.title ?? 'Incoming call', named?.body ?? 'Tap to answer', !!named);
+  } catch (e) {
+    if (named) await show('Incoming call', 'Tap to answer', true).catch(() => {});
+    throw e;
+  }
 }
 
 /** (spec 1040) Apply decrypted call-event outcomes: hand the badge unit over
@@ -234,6 +255,11 @@ async function showNotes(notes: SwNote[]): Promise<number> {
   const coalesced = await coalesceForShow(notes, Date.now());
   return countAccepted(coalesced.map((n) => async () => {
     try {
+      // (spec 2026) A missed/cancelled call note REPLACES the ring alert (spec
+      // 1040 FR-012) — but iOS stacks same-tag re-shows as separate Notification
+      // Center entries instead of collapsing them, so close the ring explicitly
+      // before showing its replacement.
+      if (n.tag === 'ring-call') await closeByTag('ring-call');
       await self.registration.showNotification(titleWithCount(n), {
         body: n.body,
         icon: ICON,

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -25,10 +25,11 @@ import {
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
   mayEndWakeSilently, quietNote, stampPushWake, stampedShow, countAccepted,
   previewCallRing, recordCallTickle, recordCallOutcome, withdrawCallBadgeUnit, callBadgeCount,
+  readRingShown, recordRingShown, clearRingShown,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import type { CallEventSignal } from '@/services/crypto/message';
-import { hasFreshRing } from '@/services/call-events';
+import { hasFreshRing, ringReassert, ringAlreadyNamed } from '@/services/call-events';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { resubscribePush } from '@/services/sw-push';
 import { setPendingNav } from '@/services/pending-nav';
@@ -158,7 +159,7 @@ async function showGeneric(reason?: string): Promise<void> {
   });
 }
 
-async function showCall(named?: { title: string; body: string }): Promise<void> {
+async function showCall(named?: { title: string; body: string }, opts?: { realert?: boolean }): Promise<void> {
   // (spec 1040) The generic ring shows IMMEDIATELY (the tickle wake never waits on
   // decryption), then previewCallRing / the marker's own msg wake may upgrade it
   // with the caller's name.
@@ -166,11 +167,13 @@ async function showCall(named?: { title: string; body: string }): Promise<void> 
   // separate Notification Center entry per showNotification call even on the same
   // tag (the spec-2020 lesson), so the old same-tag+renotify:false "in-place"
   // upgrade actually read as a DOUBLE notification there — generic and named
-  // stacked — and each group reminder push stacked one more generic. Closing
-  // first is safe: this wake's visible ending is the show right below; and if
-  // that show somehow fails after the close, the catch re-asserts a generic ring
-  // so the callee is never left ring-less mid-ring (the rejection still reaches
-  // the caller's visibility accounting).
+  // stacked — and each group reminder push stacked one more generic. Callers keep
+  // total shows minimal via the sw.ringShown signature (never downgrade to
+  // generic on a reminder, never repeat an identical naming). Closing first is
+  // safe: this wake's visible ending is the show right below; and if that show
+  // somehow fails after the close, the catch re-asserts a generic ring so the
+  // callee is never left ring-less mid-ring (the rejection still reaches the
+  // caller's visibility accounting).
   await closeByTag('ring-call');
   const show = (title: string, body: string, silent: boolean) =>
     self.registration.showNotification(title, {
@@ -180,14 +183,15 @@ async function showCall(named?: { title: string; body: string }): Promise<void> 
       tag: 'ring-call',
       // Naming is SILENT: the generic ring already alerted for this call, so the
       // upgrade must not buzz a second time (close-first makes it a fresh
-      // notification, which would otherwise re-alert). A generic (re-)show is a
-      // fresh ring or a server reminder and should keep alerting.
+      // notification, which would otherwise re-alert). A generic show, and a
+      // reminder's named re-assert (opts.realert — re-alerting is the reminder's
+      // whole job), should keep alerting.
       silent,
       requireInteraction: true, // a ring shouldn't auto-dismiss before it's seen
       data: { url: '/tabs/chats' },
     });
   try {
-    await show(named?.title ?? 'Incoming call', named?.body ?? 'Tap to answer', !!named);
+    await show(named?.title ?? 'Incoming call', named?.body ?? 'Tap to answer', !!named && !opts?.realert);
   } catch (e) {
     if (named) await show('Incoming call', 'Tap to answer', true).catch(() => {});
     throw e;
@@ -205,6 +209,11 @@ async function applyCallEventEffects(evs?: CallEventSignal[]): Promise<void> {
     try {
       await recordCallOutcome(ev.callId, ev.outcome);
       if (ev.outcome === 'answered') await closeByTag('ring-call');
+      // (spec 2026) The ring is over either way — retire the shown-signature so a
+      // late reminder tickle can't re-assert a stale name. Only for the call the
+      // signature is actually about (a fresh overlapping ring keeps its own).
+      const sig = await readRingShown();
+      if (!sig?.callId || sig.callId === ev.callId) await clearRingShown();
     } catch (e) {
       console.warn('[sw] call-event effect failed', e);
     }
@@ -226,7 +235,12 @@ async function upgradeRingFromMarkers(evs?: CallEventSignal[]): Promise<boolean>
     const ring = await previewCallRing();
     if (ring?.kind === 'named') {
       await recordCallTickle(ring.callId); // claim the tickle's heuristic unit under its real id
+      // Already named identically (a reminder tickle beat this wake to it) → no
+      // re-show; returning false routes this wake to its own quiet/nothing-new
+      // ending, since nothing was made visible here.
+      if (ringAlreadyNamed(await readRingShown(), ring.title, ring.body, Date.now())) return false;
       await showCall({ title: ring.title, body: ring.body });
+      await recordRingShown({ callId: ring.callId, named: true, title: ring.title, body: ring.body, ts: Date.now() });
       return true;
     }
     // Hidden chat: the ring stays generic AND its unit must never badge.
@@ -821,7 +835,14 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         // Show the ring immediately, ack reachability (so the caller's UI flips to
         // "Ringing"), and nudge any device to reconnect so the live call-offer
         // (buffered briefly server-side) flushes and rings in-app.
-        await showCall();
+        // (spec 2026) A reminder tickle for a ring we already NAMED re-asserts the
+        // named alert (re-alerting is the reminder's whole job) — never downgrades
+        // it back to the generic, which on iOS would stack yet another entry and
+        // then need re-naming. A first tickle shows the undelayed generic (FR-004).
+        const sig = await readRingShown();
+        const reassert = ringReassert(sig, Date.now());
+        await showCall(reassert ?? undefined, { realert: true });
+        await recordRingShown(reassert && sig ? { ...sig, ts: Date.now() } : { named: false, ts: Date.now() });
         void ackCall();
         for (const client of clients) client.postMessage({ type: 'ring:drain' });
         // (spec 1040) One badge unit per call while closed. The tickle carries no
@@ -832,12 +853,17 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         // Name the ring from the caller's sealed dial-time marker (the queued
         // callEvent frame) — an in-place upgrade AFTER the generic alert, so the
         // first ring is never delayed (FR-004). Locked/unresolvable stays generic;
-        // a hidden chat's ring stays generic AND never badges.
+        // a hidden chat's ring stays generic AND never badges. Skipped when the
+        // alert already carries exactly this name (every extra show is an extra
+        // Notification Center entry on iOS).
         try {
           const ring = await previewCallRing();
           if (ring?.kind === 'named') {
             await recordCallTickle(ring.callId); // claim the heuristic unit under its real id
-            await showCall({ title: ring.title, body: ring.body });
+            if (!ringAlreadyNamed(await readRingShown(), ring.title, ring.body, Date.now())) {
+              await showCall({ title: ring.title, body: ring.body });
+              await recordRingShown({ callId: ring.callId, named: true, title: ring.title, body: ring.body, ts: Date.now() });
+            }
           } else if (ring?.kind === 'generic') {
             await withdrawCallBadgeUnit(ring.callId);
             await updateAppBadge(0);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -28,6 +28,7 @@ import {
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import type { CallEventSignal } from '@/services/crypto/message';
+import { hasFreshRing } from '@/services/call-events';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { resubscribePush } from '@/services/sw-push';
 import { setPendingNav } from '@/services/pending-nav';
@@ -187,6 +188,32 @@ async function applyCallEventEffects(evs?: CallEventSignal[]): Promise<void> {
       console.warn('[sw] call-event effect failed', e);
     }
   }
+}
+
+/** (spec 2026) A msg wake decrypted a fresh dial-time ring marker: name the ring
+ *  notification in place. The {"t":"call"} tickle wake showed the undelayed
+ *  generic ring, but the marker itself rides the queued message channel a few
+ *  seconds later (its send is deliberately deferred off the call-setup hot
+ *  path), so THIS wake is where the caller's name becomes available —
+ *  previewCallRing applies the same naming / hidden-chat / badge rules as the
+ *  tickle path. Returns true when a named re-show happened (a real
+ *  showNotification: it counts as the wake's visible ending, so a marker-only
+ *  wake adds no "New message" noise). */
+async function upgradeRingFromMarkers(evs?: CallEventSignal[]): Promise<boolean> {
+  if (!hasFreshRing(evs, Date.now())) return false;
+  try {
+    const ring = await previewCallRing();
+    if (ring?.kind === 'named') {
+      await recordCallTickle(ring.callId); // claim the tickle's heuristic unit under its real id
+      await showCall({ title: ring.title, body: ring.body });
+      return true;
+    }
+    // Hidden chat: the ring stays generic AND its unit must never badge.
+    if (ring?.kind === 'generic') await withdrawCallBadgeUnit(ring.callId);
+  } catch (e) {
+    console.warn('[sw] ring upgrade from marker failed (ring stays generic)', e);
+  }
+  return false;
 }
 
 /** Format a note's title with its count, e.g. "Alice (3)". The count is the CUMULATIVE per-chat total
@@ -568,6 +595,10 @@ async function showMessageNotification(): Promise<void> {
   // count — while a queued wake still gets the lock during another wake's sleep gaps and is never
   // starved past iOS's per-push budget. The first wake's straggler catches the burst's late frames;
   // later wakes find everything shown and re-assert silently. Delivery receipts are unaffected.
+  // (spec 2026) Whether a fresh ring marker already upgraded the 'ring-call'
+  // notification with the caller's name this wake — the upgrade is idempotent
+  // but re-running it pays previewCallRing's queue refetch, so once is enough.
+  let ringUpgraded = false;
   await serializeNotify(async () => {
   const preview = previewPending(); // started once; awaited twice (race, then settle)
   let result: Awaited<ReturnType<typeof previewPending>> = { notes: [], pending: 0, badgePending: 0, suppressed: false, silenced: false, newUnshown: false };
@@ -608,6 +639,13 @@ async function showMessageNotification(): Promise<void> {
     // there's no fresh summary (the mute/badge-only outcome). The badge below still stays accurate.
     shownAny = await reassertFromSummary();
   }
+  // (spec 2026) A fresh dial-time ring marker decrypted this pass names the
+  // ongoing ring alert in place. Runs even when notes were shown (a text can
+  // arrive in the same wake as the marker), and its named re-show counts as the
+  // wake's visible ending — a marker-only wake must upgrade the ring, not add a
+  // generic "New message".
+  ringUpgraded = await upgradeRingFromMarkers(result.callEvents);
+  shownAny = shownAny || ringUpgraded;
   // (spec 1034) Silence is not an outcome: muted / hidden / badge-only / web-push-
   // off (`silenced`), the master-toggle race (`suppressed`), and a nothing-new
   // wake with nothing to re-assert all still consumed a push — end them with the
@@ -628,6 +666,9 @@ async function showMessageNotification(): Promise<void> {
     // ring alert closes when the call was answered elsewhere. Runs before the
     // updateAppBadge below so the badge reflects the handover.
     await applyCallEventEffects(full.callEvents);
+    // (spec 2026) The timed-out race above had no callEvents yet — a slow cold
+    // start's ring marker still names the ring once the full preview settles.
+    if (!ringUpgraded) ringUpgraded = await upgradeRingFromMarkers(full.callEvents);
     if (shownGeneric && full.notes.length) {
       // Upgrade the placeholder to the real sender + text. Show FIRST, close the
       // generic only once a rich note was actually ACCEPTED (spec 2023 FR-007):
@@ -674,6 +715,9 @@ async function showMessageNotification(): Promise<void> {
         return true; // fetch failed → stop the straggler loop
       }
       await applyCallEventEffects(more.callEvents); // spec 1040: stragglers can carry outcomes too
+      // (spec 2026) A marker that arrived after the first fetch (the dial-time
+      // send is deferred a few seconds) still names the ring within this wake.
+      if (!ringUpgraded) ringUpgraded = await upgradeRingFromMarkers(more.callEvents);
       if (more.notes.length) {
         await closeByTag(GENERIC_TAG);
         await showNotes(more.notes);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -235,10 +235,12 @@ async function upgradeRingFromMarkers(evs?: CallEventSignal[]): Promise<boolean>
     const ring = await previewCallRing();
     if (ring?.kind === 'named') {
       await recordCallTickle(ring.callId); // claim the tickle's heuristic unit under its real id
-      // Already named identically (a reminder tickle beat this wake to it) → no
-      // re-show; returning false routes this wake to its own quiet/nothing-new
-      // ending, since nothing was made visible here.
-      if (ringAlreadyNamed(await readRingShown(), ring.title, ring.body, Date.now())) return false;
+      // Show even when a tickle wake already named the alert identically: the
+      // re-show is SILENT and replaces on the same tag, and it doubles as this
+      // wake's visible ending — the alternative was the quiet "New message"
+      // generic, which reads as a confusing extra notification during a ring.
+      // (Interleaving with the tickle wake's naming is excluded by the caller's
+      // serializeNotify section, so at most one naming is ever in flight.)
       await showCall({ title: ring.title, body: ring.body });
       await recordRingShown({ callId: ring.callId, named: true, title: ring.title, body: ring.body, ts: Date.now() });
       return true;
@@ -842,7 +844,15 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         const sig = await readRingShown();
         const reassert = ringReassert(sig, Date.now());
         await showCall(reassert ?? undefined, { realert: true });
-        await recordRingShown(reassert && sig ? { ...sig, ts: Date.now() } : { named: false, ts: Date.now() });
+        if (reassert && sig) {
+          await recordRingShown({ ...sig, ts: Date.now() });
+        } else if (!ringReassert(await readRingShown(), Date.now())) {
+          // Re-read before recording "generic": the ring marker's own msg wake can
+          // name the alert concurrently (the tickle and the marker push land
+          // back-to-back), and a stale {named:false} write here would make the
+          // preview below re-show a name the alert already carries.
+          await recordRingShown({ named: false, ts: Date.now() });
+        }
         void ackCall();
         for (const client of clients) client.postMessage({ type: 'ring:drain' });
         // (spec 1040) One badge unit per call while closed. The tickle carries no
@@ -860,10 +870,18 @@ async function dispatchPush(event: PushEvent): Promise<void> {
           const ring = await previewCallRing();
           if (ring?.kind === 'named') {
             await recordCallTickle(ring.callId); // claim the heuristic unit under its real id
-            if (!ringAlreadyNamed(await readRingShown(), ring.title, ring.body, Date.now())) {
-              await showCall({ title: ring.title, body: ring.body });
-              await recordRingShown({ callId: ring.callId, named: true, title: ring.title, body: ring.body, ts: Date.now() });
-            }
+            // The check→show→record must be atomic against the marker msg wake's
+            // upgradeRingFromMarkers (whose enclosing section holds this same
+            // lock): the tickle and marker pushes land back-to-back, and two
+            // unserialized namings each read "not named yet" and BOTH showed —
+            // the double named alert. The slow previewCallRing above stays
+            // outside the lock; only the naming is serialized.
+            await serializeNotify(async () => {
+              if (!ringAlreadyNamed(await readRingShown(), ring.title, ring.body, Date.now())) {
+                await showCall({ title: ring.title, body: ring.body });
+                await recordRingShown({ callId: ring.callId, named: true, title: ring.title, body: ring.body, ts: Date.now() });
+              }
+            });
           } else if (ring?.kind === 'generic') {
             await withdrawCallBadgeUnit(ring.callId);
             await updateAppBadge(0);

--- a/src/utils/notify-preview.test.ts
+++ b/src/utils/notify-preview.test.ts
@@ -38,10 +38,10 @@ describe('notifyPreview', () => {
   // Spec 0008 (US3): game bubbles and move signals get spelled-out lines.
   it('spells out a game invitation, with a generic fallback for unknown games', () => {
     expect(notifyPreview(p({ kind: 'game', game: { gameType: 'tictactoe' } }))).toBe(
-      'Wants to play Tic-tac-toe',
+      'Wants to play Tic-tac-toe 🎮',
     );
     expect(notifyPreview(p({ kind: 'game', game: { gameType: 'from-the-future' } }))).toBe(
-      'Wants to play a game',
+      'Wants to play a game 🎮',
     );
   });
 

--- a/src/utils/notify-preview.ts
+++ b/src/utils/notify-preview.ts
@@ -38,14 +38,14 @@ export function notifyPreview(p: MessagePayload): string {
       return p.contact?.name ? `Contact: ${p.contact.name}` : 'Shared a contact';
     case 'game': {
       const name = GAMES[p.game?.gameType ?? '']?.displayName;
-      return name ? `Wants to play ${name}` : 'Wants to play a game';
+      return name ? `Wants to play ${name} 🎮` : 'Wants to play a game 🎮';
     }
     case 'gamechallenge': {
       // Urgency is the point: the first to accept plays (spec 0009).
       const name = GAMES[p.gameChallenge?.gameType ?? '']?.displayName;
       return name
-        ? `Started a ${name} challenge, be quick if you want it 🫵`
-        : 'Started a game challenge, be quick if you want it 🫵';
+        ? `Started a ${name} challenge, be quick if you want it 🎮`
+        : 'Started a game challenge, be quick if you want it 🎮';
     }
     default:
       return 'New message';


### PR DESCRIPTION
## Summary

Spec 2026 (hotfix): `specs/2026-call-markers-stored/spec.md`

**Root cause (user-reported on device):** the spec-1032 service-worker drain (`sw.fullPersist`, default ON) predates spec 1040's sealed `callEvent` markers and classified them as eligible plain messages — storing each marker as an empty chat bubble, inflating unread/badge, showing a generic "New message", and **acking the frame** so the page-side `handleCallEvent` never ran (no missed-call row in the Calls tab or chat).

- **sw-drain**: `callEvent` frames defer to the page — never persisted, never acked. Restores the missed-call trace, badge units, and the named missed-call replacement notification.
- **sw**: a message wake that decrypts a fresh dial-time ring marker upgrades the "Incoming call" alert in place with the caller's/group's name. Ring shows are kept to the strict minimum via a persisted shown-signature (`sw.ringShown`): naming is serialized against the racing call-tickle wake (the back-to-back double), reminders re-assert the named alert instead of downgrading to generic, and replacements close the previous alert first (iOS keeps per-show Notification Center entries).
- **Copy**: emoji moved to the end of the line — "is calling you 📞/📹", "Missed call ☎️", game invites/challenges end with 🎮.
- **Repair sweeps** (every open, until the old SW is replaced): delete stored `callevent` junk rows, restore unread counts and chat previews, and regenerate call-row avatars whose SVG was malformed.
- **Avatar** (FR-007): ad-hoc missed-group-call rows use the group people-glyph — an initials disc built from "Macbook & others" embedded a raw `&` (invalid XML → broken image). `initials()` skips connective tokens; SVG text is escaped.
- **Armada** (FR-008, companion hotfix to spec 1038): a `sunk` answer now declares the sunk ship's geometry, drawn exactly on the attacker's board — the contiguous-hits guess merged collinear adjacent ships into phantom fleets (two carriers/two destroyers) until the reveal. Optional on the wire (old clients fall back to the guess), malformed declarations stripped (move-compatible across generations), geometry lies flip the verdict in `answersHonest`.

## Test plan

- 981 unit tests pass (11 new: drain eligibility pins + behavioral defer, `hasFreshRing`, ring shown-signature, sunk-ship declaration storage/stripping/honesty, duty declaration, XML-hostile avatar names)
- `npm run build` (vue-tsc) green; `missed-call-trace` e2e green locally
- Verified on-device (iPhone PWA + Mac, dev deployment) across four rounds: missed 1:1/group calls logged, single named ring alert end-to-end, no empty bubbles, no doubles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7