### PR TITLE
feat(chats): media captions wrap neatly under the photo, and the app tells you when it loses its connection

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,3 +98,4 @@ Specs are grouped by category band; status moves
 | [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |
 | [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |
 | [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟢 shipped |
+| [2027](specs/2027-long-media-captions/spec.md) | Media captions wrap at the photo's edge | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,7 @@ Specs are grouped by category band; status moves
 | [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟢 shipped |
 | [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟢 shipped |
 | [1041](specs/1041-merge-waiting-caller/spec.md) | Merge a Waiting Caller into the Ongoing Call | 🟢 shipped |
-| [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟡 in-progress |
+| [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -99,4 +99,4 @@ Specs are grouped by category band; status moves
 | [2024](specs/2024-tab-bar-labels/spec.md) | Tab Bar Labels Stay Visible After Switching Tabs | 🟢 shipped |
 | [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |
 | [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟢 shipped |
-| [2027](specs/2027-long-media-captions/spec.md) | Media captions wrap at the photo's edge | 🟡 in-progress |
+| [2027](specs/2027-long-media-captions/spec.md) | Media captions wrap at the photo's edge | 🟢 shipped |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,6 +67,7 @@ Specs are grouped by category band; status moves
 | [1039](specs/1039-simultaneous-mutual-calls/spec.md) | Simultaneous mutual calls connect instead of ringing each other | 🟢 shipped |
 | [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟢 shipped |
 | [1041](specs/1041-merge-waiting-caller/spec.md) | Merge a Waiting Caller into the Ongoing Call | 🟢 shipped |
+| [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/chat-media-captions.spec.ts
+++ b/e2e/chat-media-captions.spec.ts
@@ -73,6 +73,47 @@ test('media picked from the library can be captioned before sending (not just pa
   await ctxB.close();
 });
 
+test('a long caption wraps at the photo edge instead of stretching the bubble (spec 2027)', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'LONGCAP1');
+  const b = await createAccount(ctxB, 'LONGCAP2');
+  await pair(a, b);
+
+  const aChat = (await chatWith(a, b.id)) as string;
+  await a.page.goto(`/chat/${aChat}`);
+  const composer = a.page.locator('ion-textarea.composer textarea');
+  await composer.waitFor({ state: 'visible', timeout: 30_000 });
+
+  // One photo with a caption long enough that its UNWRAPPED line far exceeds the
+  // 240px media frame — the regression made the bubble grow to the caption's
+  // line (toward the 78% column cap), leaving the photo floating in dead space.
+  await photoInput(a).setInputFiles([pngFile('long.png')]);
+  await expect(a.page.locator('.paste-thumb img')).toBeVisible({ timeout: 10_000 });
+  await composer.click();
+  await composer.pressSequentially('a genuinely long caption that would stretch the media bubble far past the photo', { delay: 5 });
+  await a.page.getByRole('button', { name: 'Send' }).click();
+
+  const bubble = a.page.locator('.bubble.bubble-media').last();
+  await expect(bubble.locator('.bubble-image')).toBeVisible({ timeout: 30_000 });
+  await expect(bubble.locator('.text')).toBeVisible();
+
+  // The media frame defines the bubble: at most the 2×3px inset + border wider
+  // than the photo, and the caption stays inside the bubble's width.
+  const bubbleBox = (await bubble.boundingBox())!;
+  const mediaBox = (await bubble.locator('.media-wrap').boundingBox())!;
+  const textBox = (await bubble.locator('.text').boundingBox())!;
+  expect(bubbleBox.width - mediaBox.width).toBeGreaterThanOrEqual(0);
+  expect(bubbleBox.width - mediaBox.width).toBeLessThanOrEqual(10);
+  expect(textBox.width).toBeLessThanOrEqual(bubbleBox.width);
+  // And the caption actually WRAPPED (more than one line high) rather than
+  // being clipped or overflowing.
+  expect(textBox.height).toBeGreaterThan(30);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
 test('multiple picked photos can be sent individually, each carrying the shared caption', async ({ browser }) => {
   const ctxA = await browser.newContext();
   const ctxB = await browser.newContext();

--- a/specs/1042-connection-indicator/spec.md
+++ b/specs/1042-connection-indicator/spec.md
@@ -1,0 +1,67 @@
+# Feature Specification: Show when the app has lost its server connection
+
+**Feature Branch**: `fix/2027-long-media-captions`
+<!-- Rides the 2027 hotfix branch by explicit request (one CI run); the spec
+     number is ad-hoc band. -->
+
+**Created**: 2026-07-12
+
+**Status**: in-progress
+
+**Input**: User description: "I think we probably should have some sort of indicator when
+the connection to server is down!" (screenshot: sent messages sitting on the pending
+clock with no hint that the app is offline).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The app says it is disconnected (Priority: P1)
+
+When the server link is down for more than a moment, a small floating pill appears
+telling the user the app is reconnecting, and whether the problem is their own network
+or the server. It disappears the instant the link is back.
+
+**Independent Test**: Stop the dev server with the app open. Within a few seconds the
+pill appears. Start the server, the pill disappears on reconnect.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in user with the app open, **When** the socket stays non-online
+   continuously past a short grace window, **Then** a "Connecting" pill appears above
+   the content on every screen.
+2. **Given** the device itself has no network, **When** the pill is visible, **Then** it
+   reads "Waiting for network" instead, so the user looks at their connectivity rather
+   than blaming the app.
+3. **Given** the link comes back, **When** the socket reports online, **Then** the pill
+   disappears immediately.
+4. **Given** a cold app start or a sub-second reconnect blip, **When** the socket cycles
+   states briefly, **Then** no pill flashes (grace window).
+5. **Given** a signed-out device (onboarding), **Then** the pill never shows.
+
+### Edge Cases
+
+- The retry loop flaps offline↔connecting while disconnected: the grace window runs
+  once across flaps, not per flap, so the pill still appears.
+- The pill is non-interactive (taps pass through) and sits below the in-app
+  notification banners and call overlays in stacking order.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A signed-in app whose sync socket is continuously non-online for a grace
+  window (~3s) MUST show a floating connection pill on every screen.
+- **FR-002**: The pill copy MUST distinguish device-offline ("Waiting for network") from
+  server-unreachable ("Connecting").
+- **FR-003**: The pill MUST hide immediately on reconnect and never show before sign-in.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With the server stopped, every screen shows the indicator within ~5s; with
+  the server restored, it clears without user action.
+
+## Assumptions
+
+- The existing reactive `syncState` (offline/connecting/online) is the single source of
+  truth; no new transport plumbing is needed.

--- a/specs/1042-connection-indicator/spec.md
+++ b/specs/1042-connection-indicator/spec.md
@@ -6,7 +6,7 @@
 
 **Created**: 2026-07-12
 
-**Status**: in-progress
+**Status**: shipped
 
 **Input**: User description: "I think we probably should have some sort of indicator when
 the connection to server is down!" (screenshot: sent messages sitting on the pending

--- a/specs/2027-long-media-captions/spec.md
+++ b/specs/2027-long-media-captions/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: Media captions wrap at the photo's edge
+
+**Feature Branch**: `fix/2027-long-media-captions`
+
+**Created**: 2026-07-12
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "If media has a long caption it looks odd!" (screenshot: a
+photo bubble whose long caption stretches the bubble wider than the photo, leaving the
+photo floating against dead bubble background).
+
+## Root cause
+
+A media bubble is a column flexbox whose width is its content's shrink-to-fit width. The
+photo/video frame is a fixed 240px square (`.media-wrap`/`.video-poster`), but a long
+caption's intrinsic width is the full unwrapped line — so the caption, not the media,
+sizes the bubble (up to the 78% message-column cap), and the photo sits narrower than its
+own bubble.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Long captions look like captions (Priority: P1)
+
+A photo or video sent with a long caption renders as one tight unit: the media defines
+the bubble's width and the caption wraps beneath it at the media's edge — the way every
+mainstream messenger treats captions.
+
+**Independent Test**: Send a photo with a one-line-plus caption; the bubble hugs the
+photo and the caption wraps at the photo's width. Short captions are unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** an image or video message with a caption longer than the media is wide,
+   **When** it renders (incoming or outgoing, LTR or RTL text), **Then** the bubble is no
+   wider than the media frame plus its 3px inset and the caption wraps within it.
+2. **Given** a short caption, **When** it renders, **Then** nothing changes (the bubble
+   already hugged the media).
+
+### Edge Cases
+
+- Narrow viewports where the 240px frame itself shrinks (`max-width: 100%`): the cap
+  follows `min(100%, …)`, so bubble and media stay aligned.
+- Albums are untouched (`.album-bubble` never carries `.bubble-media`).
+- Video-note / voice / audio / file bubbles are untouched (not `.bubble-media`).
+- RTL captions (dir="auto" + `unicode-bidi: plaintext`) wrap identically — the cap is a
+  width, not a text-direction rule.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A `.bubble-media` bubble MUST be capped at the media frame width plus its
+  own padding, so captions, sender lines, reply quotes, and the footer wrap at the
+  photo's edge instead of stretching the bubble.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A photo with a long caption shows no bubble background beside the photo —
+  media and caption share one width, on any screen size, either message direction.
+
+## Assumptions
+
+- The 240px media frame (spec 1011's fixed-square scroll-anchor rule) stays as is; the
+  cap references it (240 + 2×3px inset = 246px) rather than restructuring the frame.

--- a/specs/2027-long-media-captions/spec.md
+++ b/specs/2027-long-media-captions/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-12
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/App.vue
+++ b/src/App.vue
@@ -30,6 +30,9 @@
     <floating-game-button />
     <!-- In-app notification banners (green, with avatar + name): over any route. -->
     <notification-banners />
+    <!-- Connection-state pill (spec 1042): says the server link is down instead
+         of letting sends sit on the pending clock unexplained. -->
+    <connection-banner />
   </ion-app>
 </template>
 
@@ -57,6 +60,7 @@ import MinimizedCall from '@/components/MinimizedCall.vue';
 import MinimizedAudio from '@/components/MinimizedAudio.vue';
 import CallMediaSink from '@/components/CallMediaSink.vue';
 import NotificationBanners from '@/components/NotificationBanners.vue';
+import ConnectionBanner from '@/components/ConnectionBanner.vue';
 import GameOverlay from '@/components/GameOverlay.vue';
 import FloatingGameButton from '@/components/FloatingGameButton.vue';
 import { useGameOverlay } from '@/composables/useGameOverlay';

--- a/src/components/ConnectionBanner.vue
+++ b/src/components/ConnectionBanner.vue
@@ -72,10 +72,12 @@ const label = computed(() => (netUp.value ? 'Connecting…' : 'Waiting for netwo
 <style scoped>
 .connbar {
   position: fixed;
-  /* Below the header bar (like the notification banners' offset) so it never
-     covers the title/back control, centered, and narrow enough to read as a
-     status pill rather than a banner. */
-  top: calc(env(safe-area-inset-top, 0px) + 62px);
+  /* Bottom-center, in the floating-widget band above the tab bar / composer
+     (MinimizedCall docks bottom-right, FloatingGameButton bottom-left, both at
+     +66px). A top placement collided with the tab pages' search bar — their
+     large-title layout has no toolbar, so content starts where a header-hugging
+     pill would sit. Down here nothing important ever lives, on any screen. */
+  bottom: calc(max(12px, env(safe-area-inset-bottom)) + 70px);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -109,6 +111,6 @@ const label = computed(() => (netUp.value ? 'Connecting…' : 'Waiting for netwo
 .connbar-fade-enter-from,
 .connbar-fade-leave-to {
   opacity: 0;
-  transform: translateX(-50%) translateY(-6px);
+  transform: translateX(-50%) translateY(6px);
 }
 </style>

--- a/src/components/ConnectionBanner.vue
+++ b/src/components/ConnectionBanner.vue
@@ -16,32 +16,30 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { IonSpinner } from '@ionic/vue';
 import { syncState } from '@/composables/useSync';
 import { isAuthenticated } from '@/services/auth';
+import { CONN_GRACE_MS, indicatorLabel, indicatorVisible, nextDownSince } from '@/services/connection-indicator';
 
-// How long the link must be CONTINUOUSLY non-online before the pill shows: long
-// enough to swallow a cold start's connect handshake and transient blips, short
-// enough that a dead server is called out while the stuck clock-icon message is
-// still on screen.
-const GRACE_MS = 3000;
-
-const lapsed = ref(false);
+// All decisions are the pure rules in services/connection-indicator.ts (unit
+// tested there); this component only feeds them state changes and schedules
+// the ONE timer that re-evaluates when the grace window elapses.
+const downSince = ref<number | null>(null);
+const now = ref(Date.now());
 let timer: ReturnType<typeof setTimeout> | null = null;
 watch(
   syncState,
   (s) => {
-    if (s === 'online') {
+    downSince.value = nextDownSince(downSince.value, s, Date.now());
+    now.value = Date.now();
+    if (downSince.value === null) {
       if (timer) {
         clearTimeout(timer);
         timer = null;
       }
-      lapsed.value = false;
-    } else if (!timer && !lapsed.value) {
-      // One window across offline↔connecting flaps: the retry loop cycles the
-      // state while disconnected, and restarting the clock per flap would keep
-      // the pill from ever appearing.
+    } else if (!timer) {
+      const wait = Math.max(0, downSince.value + CONN_GRACE_MS - Date.now());
       timer = setTimeout(() => {
-        lapsed.value = true;
         timer = null;
-      }, GRACE_MS);
+        now.value = Date.now(); // re-evaluate visibility once the window lapses
+      }, wait);
     }
   },
   { immediate: true },
@@ -63,10 +61,8 @@ onBeforeUnmount(() => {
   if (timer) clearTimeout(timer);
 });
 
-// Signed-out devices (onboarding) never show it: syncState sits at 'offline'
-// there by design, not because anything is wrong.
-const visible = computed(() => isAuthenticated.value && lapsed.value && syncState.value !== 'online');
-const label = computed(() => (netUp.value ? 'Connecting…' : 'Waiting for network…'));
+const visible = computed(() => indicatorVisible(downSince.value, isAuthenticated.value, now.value));
+const label = computed(() => indicatorLabel(netUp.value));
 </script>
 
 <style scoped>

--- a/src/components/ConnectionBanner.vue
+++ b/src/components/ConnectionBanner.vue
@@ -1,0 +1,114 @@
+<template>
+  <!-- Connection-state pill (spec 1042): a signed-in app whose server link has
+       been down past the grace window says so, instead of letting messages sit
+       on the pending clock with no explanation. Non-interactive (taps pass
+       through) and it clears the moment the socket is back. -->
+  <transition name="connbar-fade">
+    <div v-if="visible" class="connbar" role="status" aria-live="polite">
+      <ion-spinner class="connbar-spin" name="crescent" aria-hidden="true" />
+      <span>{{ label }}</span>
+    </div>
+  </transition>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { IonSpinner } from '@ionic/vue';
+import { syncState } from '@/composables/useSync';
+import { isAuthenticated } from '@/services/auth';
+
+// How long the link must be CONTINUOUSLY non-online before the pill shows: long
+// enough to swallow a cold start's connect handshake and transient blips, short
+// enough that a dead server is called out while the stuck clock-icon message is
+// still on screen.
+const GRACE_MS = 3000;
+
+const lapsed = ref(false);
+let timer: ReturnType<typeof setTimeout> | null = null;
+watch(
+  syncState,
+  (s) => {
+    if (s === 'online') {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      lapsed.value = false;
+    } else if (!timer && !lapsed.value) {
+      // One window across offline↔connecting flaps: the retry loop cycles the
+      // state while disconnected, and restarting the clock per flap would keep
+      // the pill from ever appearing.
+      timer = setTimeout(() => {
+        lapsed.value = true;
+        timer = null;
+      }, GRACE_MS);
+    }
+  },
+  { immediate: true },
+);
+
+// Reactive navigator.onLine, so the copy can tell "your device has no network"
+// from "the server is unreachable" (FR-002).
+const netUp = ref(typeof navigator === 'undefined' ? true : navigator.onLine);
+const onNet = (): void => {
+  netUp.value = navigator.onLine;
+};
+onMounted(() => {
+  window.addEventListener('online', onNet);
+  window.addEventListener('offline', onNet);
+});
+onBeforeUnmount(() => {
+  window.removeEventListener('online', onNet);
+  window.removeEventListener('offline', onNet);
+  if (timer) clearTimeout(timer);
+});
+
+// Signed-out devices (onboarding) never show it: syncState sits at 'offline'
+// there by design, not because anything is wrong.
+const visible = computed(() => isAuthenticated.value && lapsed.value && syncState.value !== 'online');
+const label = computed(() => (netUp.value ? 'Connecting…' : 'Waiting for network…'));
+</script>
+
+<style scoped>
+.connbar {
+  position: fixed;
+  /* Below the header bar (like the notification banners' offset) so it never
+     covers the title/back control, centered, and narrow enough to read as a
+     status pill rather than a banner. */
+  top: calc(env(safe-area-inset-top, 0px) + 62px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(20, 24, 22, 0.82);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  /* Status only: never intercept taps meant for what's underneath. */
+  pointer-events: none;
+  /* Above page content, below the in-app notification banners (19000) and the
+     incoming-call overlay (20000) so real alerts always win. */
+  z-index: 15000;
+}
+.connbar-spin {
+  width: 15px;
+  height: 15px;
+  --color: #9fe8c7;
+}
+.connbar-fade-enter-active,
+.connbar-fade-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+.connbar-fade-enter-from,
+.connbar-fade-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(-6px);
+}
+</style>

--- a/src/services/connection-indicator.test.ts
+++ b/src/services/connection-indicator.test.ts
@@ -1,0 +1,50 @@
+// Spec 1042 — the connection pill's pure decision rules. The component
+// (ConnectionBanner.vue) only schedules a timer off these; every behavior the
+// spec pins lives here: the flap-proof grace latch, the signed-in gate, and
+// the device-offline vs server-unreachable copy.
+import { describe, it, expect } from 'vitest';
+import { CONN_GRACE_MS, nextDownSince, indicatorVisible, indicatorLabel } from './connection-indicator';
+
+const T0 = 1_800_000_000_000;
+
+describe('grace latch (nextDownSince)', () => {
+  it('starts the window on the first non-online state', () => {
+    expect(nextDownSince(null, 'connecting', T0)).toBe(T0);
+    expect(nextDownSince(null, 'offline', T0)).toBe(T0);
+  });
+
+  it('keeps the ORIGINAL timestamp across offline↔connecting flaps (one continuous window)', () => {
+    let since = nextDownSince(null, 'connecting', T0);
+    since = nextDownSince(since, 'offline', T0 + 500);
+    since = nextDownSince(since, 'connecting', T0 + 1_200);
+    since = nextDownSince(since, 'offline', T0 + 2_900);
+    expect(since).toBe(T0); // a per-flap restart would keep the pill from ever showing
+  });
+
+  it('resets on online, and a later drop starts a FRESH window', () => {
+    let since = nextDownSince(null, 'offline', T0);
+    since = nextDownSince(since, 'online', T0 + 1_000);
+    expect(since).toBeNull();
+    since = nextDownSince(since, 'connecting', T0 + 60_000);
+    expect(since).toBe(T0 + 60_000);
+  });
+});
+
+describe('visibility (indicatorVisible)', () => {
+  it('shows only once the window outlasts the grace period', () => {
+    expect(indicatorVisible(T0, true, T0 + CONN_GRACE_MS - 1)).toBe(false);
+    expect(indicatorVisible(T0, true, T0 + CONN_GRACE_MS)).toBe(true);
+  });
+
+  it('never shows while online (null latch) or signed out', () => {
+    expect(indicatorVisible(null, true, T0 + 60_000)).toBe(false);
+    expect(indicatorVisible(T0, false, T0 + 60_000)).toBe(false); // onboarding idles at offline by design
+  });
+});
+
+describe('copy (indicatorLabel)', () => {
+  it('tells the device-offline case apart from the server-unreachable case', () => {
+    expect(indicatorLabel(true)).toBe('Connecting…');
+    expect(indicatorLabel(false)).toBe('Waiting for network…');
+  });
+});

--- a/src/services/connection-indicator.ts
+++ b/src/services/connection-indicator.ts
@@ -1,0 +1,42 @@
+/**
+ * Connection-state pill decisions (spec 1042) — the PURE half of
+ * components/ConnectionBanner.vue, kept free of Vue and timers so the rules
+ * stay unit-testable:
+ *  - the grace latch: ONE continuous non-online window across the retry loop's
+ *    offline↔connecting flaps (restarting the clock per flap would keep the
+ *    pill from ever showing while disconnected);
+ *  - visibility: signed-in AND the window outlasted the grace period (a
+ *    signed-out device idles at 'offline' by design — nothing is wrong);
+ *  - copy: the device being offline reads differently from the server being
+ *    unreachable, so the user knows whether to check their own connectivity.
+ */
+import type { TransportState } from '@/services/transport';
+
+/** How long the link must be CONTINUOUSLY non-online before the pill shows:
+ *  long enough to swallow a cold start's connect handshake and transient
+ *  blips, short enough that a dead server is called out while the stuck
+ *  clock-icon message is still on screen. */
+export const CONN_GRACE_MS = 3000;
+
+/** The grace latch: when the CURRENT non-online stretch began (null = online).
+ *  Feed it every state change; it keeps the ORIGINAL timestamp across
+ *  offline↔connecting flaps and resets only on 'online'. */
+export function nextDownSince(prev: number | null, state: TransportState, now: number): number | null {
+  if (state === 'online') return null;
+  return prev ?? now;
+}
+
+/** Should the pill be visible right now? */
+export function indicatorVisible(
+  downSince: number | null,
+  authed: boolean,
+  now: number,
+  graceMs: number = CONN_GRACE_MS,
+): boolean {
+  return authed && downSince !== null && now - downSince >= graceMs;
+}
+
+/** The pill's copy: device-offline vs server-unreachable. */
+export function indicatorLabel(netUp: boolean): string {
+  return netUp ? 'Connecting…' : 'Waiting for network…';
+}

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -4991,10 +4991,17 @@ function cancelRecording() {
   background: var(--app-bubble-out);
 }
 /* Media bubbles: a thin (3px) frame hugging the photo/video; caption, sender and
-   timestamp keep a small inset so they don't touch the edge. */
+   timestamp keep a small inset so they don't touch the edge. Capped at the media
+   frame's width (240px + the 2×3px inset — spec 2027): the bubble is a column
+   flexbox sized shrink-to-fit, so without the cap a LONG caption's unwrapped
+   line — not the photo — set the bubble width (up to the 78% column cap),
+   leaving the photo floating against dead bubble background. With it, captions,
+   sender lines, quotes, and the footer all wrap at the photo's edge. min() keeps
+   narrow viewports consistent: media and bubble shrink together. */
 .bubble-media {
   padding: 3px;
   gap: 0;
+  max-width: min(100%, 246px);
 }
 .bubble-media .bubble-image {
   border-radius: 13px;


### PR DESCRIPTION
## Summary

Two specs ride this branch (single CI run by request):

**Spec 2027 (hotfix)** — `specs/2027-long-media-captions/spec.md`
A media bubble sized itself to its caption's unwrapped line, so a long caption stretched the bubble toward the 78% column cap and the photo floated against dead bubble background. The media bubble is now capped at its fixed frame width (240px + the 3px inset), so captions, sender lines, quotes, and the footer wrap at the photo's edge. Albums and non-frame bubbles (voice/audio/file/video-note) untouched; RTL unaffected.

**Spec 1042 (ad-hoc)** — `specs/1042-connection-indicator/spec.md`
Sent messages could sit on the pending clock with no explanation. A floating pill now appears bottom-center (the floating-widget band above the tab bar/composer) once the server link has been down continuously for ~3s: "Connecting…" while reconnecting, "Waiting for network…" when the device itself is offline. Clears instantly on reconnect, never flashes on cold starts or sub-second blips, never shows during onboarding, taps pass through. Decision rules live in a pure module (`services/connection-indicator.ts`): the flap-proof grace latch (one continuous window across the retry loop's offline↔connecting cycling), the signed-in gate, and the copy split.

## Test plan

- New e2e in `chat-media-captions.spec.ts`: sends a photo with a long caption and asserts the bubble hugs the 240px media frame (≤10px wider) with the caption wrapping inside it — fails on the pre-fix geometry. Full caption spec: 5/5 locally.
- New unit suite `connection-indicator.test.ts`: grace latch keeps its origin across flaps / resets on online / restarts fresh, visibility gates on grace + signed-in, label split. 987 unit tests pass (the two Argon2id-timeout flakes under full-suite contention pass in isolation).
- `npm run build` (vue-tsc) green.
- Verified on-device (iPhone PWA, dev deployment): long Persian caption wraps under the photo; airplane mode shows "Waiting for network…" bottom-center on every tab and clears on reconnect (screenshots in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7