### PR TITLE
feat(chats): pinned-chat grid, camera-off shows your picture, and the forward button sits where it belongs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,3 +100,4 @@ Specs are grouped by category band; status moves
 | [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |
 | [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟢 shipped |
 | [2027](specs/2027-long-media-captions/spec.md) | Media captions wrap at the photo's edge | 🟢 shipped |
+| [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,6 +68,7 @@ Specs are grouped by category band; status moves
 | [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟢 shipped |
 | [1041](specs/1041-merge-waiting-caller/spec.md) | Merge a Waiting Caller into the Ongoing Call | 🟢 shipped |
 | [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
+| [1044](specs/1044-pinned-chats-show/spec.md) | Pinned Chats Grid (iMessage-style) | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,3 +100,4 @@ Specs are grouped by category band; status moves
 | [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |
 | [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟢 shipped |
 | [2027](specs/2027-long-media-captions/spec.md) | Media captions wrap at the photo's edge | 🟢 shipped |
+| [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ Specs are grouped by category band; status moves
 | [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟢 shipped |
 | [1041](specs/1041-merge-waiting-caller/spec.md) | Merge a Waiting Caller into the Ongoing Call | 🟢 shipped |
 | [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
-| [1044](specs/1044-pinned-chats-show/spec.md) | Pinned Chats Grid (iMessage-style) | 🟡 in-progress |
+| [1044](specs/1044-pinned-chats-show/spec.md) | Pinned Chats Grid (iMessage-style) | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -101,5 +101,5 @@ Specs are grouped by category band; status moves
 | [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |
 | [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟢 shipped |
 | [2027](specs/2027-long-media-captions/spec.md) | Media captions wrap at the photo's edge | 🟢 shipped |
-| [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟡 in-progress |
-| [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟡 in-progress |
+| [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🔵 in-review |
+| [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🔵 in-review |

--- a/drive/scenarios/shot-forward-button.mjs
+++ b/drive/scenarios/shot-forward-button.mjs
@@ -1,0 +1,24 @@
+// Visual check (spec 2028): screenshot the quick-forward button beside a tall
+// portrait photo and a short text bubble, to eyeball the bottom-anchored position.
+import { createAccount, pair, chatWith, say, shot, sweep, done, poll } from '../driver.mjs';
+
+const a = await createAccount({ name: 'FwdA', label: 'A' });
+const b = await createAccount({ name: 'FwdB', label: 'B' });
+await pair(a, b);
+
+const aChat = await chatWith(a, b.id);
+await say(a, aChat, 'short message before the photo');
+await a.page.evaluate(({ id }) => window.__ringTest.sendImage(id, 720, 1280), { id: aChat });
+
+const bChat = await chatWith(b, a.id);
+await b.page.goto(`/chat/${bChat}`);
+await poll(
+  () => b.page.locator('.fwd-float').count(),
+  (n) => n > 0,
+  { label: 'forward button rendered' },
+);
+await b.page.waitForTimeout(1500); // media decode settle
+await shot(b, 'forward-button-position');
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/shot-group-camera-off.mjs
+++ b/drive/scenarios/shot-group-camera-off.mjs
@@ -1,0 +1,56 @@
+// Visual check (spec 2029): 3-person group VIDEO call; C turns the camera off.
+// A's view must show C's avatar tile (not a black tile), and C's uplink should
+// drop to ~zero (the detached sender encodes nothing).
+import { createAccount, pair, poll, shot, sweep, done } from '../driver.mjs';
+
+const hook = (c, expr) => c.page.evaluate(expr);
+
+const a = await createAccount({ name: 'GcamA', label: 'A' });
+const b = await createAccount({ name: 'GcamB', label: 'B' });
+const c = await createAccount({ name: 'GcamC', label: 'C' });
+// Finish onboarding (confirm the recovery code) so the router lets us into the app.
+for (const p of [a, b, c]) {
+  await p.page.getByText("I'VE SAVED IT").click();
+  await p.page.waitForTimeout(500);
+}
+await pair(a, b);
+await pair(a, c);
+await pair(b, c);
+
+const room = `drive-camoff-${a.id.slice(0, 6)}`;
+for (const p of [a, b, c]) {
+  await p.page.evaluate((r) => window.__ringTest.startGroup(r, 'video'), room);
+}
+for (const p of [a, b, c]) {
+  await poll(() => hook(p, () => window.__ringTest.remoteStreamCount()), (n) => n >= 2, {
+    label: `${p.label} sees 2 streams`,
+    timeout: 60_000,
+  });
+}
+// The hook starts the call engine headlessly; enter the call UI IN-APP through the
+// router's own history (a page.goto would reload the SPA and wipe the live call).
+await a.page.evaluate(() => {
+  history.pushState({}, '', '/call-active');
+  window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+});
+await a.page.waitForTimeout(3000); // let video land on every tile
+await shot(a, 'group-before-camoff');
+
+await hook(c, () => window.__ringTest.toggleCamera());
+// A's tile for C flips to the avatar (the .tile-camoff overlay) via the sealed signal.
+await poll(() => a.page.locator('.tile-camoff').count(), (n) => n >= 1, {
+  label: 'A shows an avatar tile for C',
+  timeout: 15_000,
+});
+await a.page.waitForTimeout(1000);
+await shot(a, 'group-after-camoff');
+
+// C's uplink after a few stats ticks: with one leg... C sends to A and B; camera off
+// detaches BOTH legs' video, so kBpsUp collapses to audio-only (~5-6 KB/s for 2 legs).
+await c.page.waitForTimeout(6000);
+const stats = await hook(c, () => window.__ringTest.stats());
+console.log(`[C uplink after camoff] ${JSON.stringify(stats)}`);
+
+for (const p of [a, b, c]) await hook(p, () => window.__ringTest.hangup());
+await sweep([a, b, c]);
+await done();

--- a/drive/scenarios/shot-pinned-grid.mjs
+++ b/drive/scenarios/shot-pinned-grid.mjs
@@ -1,0 +1,62 @@
+// Visual check (spec 1044): the iMessage-style pinned grid with several pins,
+// in light and dark, plus the remaining list rows below.
+import { createAccount, pair, chatWith, say, poll, shot, sweep, done } from '../driver.mjs';
+
+// Real-looking disc avatars (canvas-drawn initial on a colored circle) — the
+// driver's default blank-SVG avatar renders as nothing, which makes grid
+// screenshots useless.
+async function paintAvatar(p, name, color) {
+  await p.page.evaluate(
+    async ({ nm, col }) => {
+      const c = document.createElement('canvas');
+      c.width = c.height = 128;
+      const g = c.getContext('2d');
+      g.fillStyle = col;
+      g.beginPath();
+      g.arc(64, 64, 64, 0, Math.PI * 2);
+      g.fill();
+      g.fillStyle = '#fff';
+      g.font = 'bold 64px -apple-system, sans-serif';
+      g.textAlign = 'center';
+      g.textBaseline = 'middle';
+      g.fillText(nm[0], 64, 70);
+      await window.__ringTest.setProfile(nm, c.toDataURL('image/png'));
+    },
+    { nm: name, col: color },
+  );
+}
+
+const COLORS = ['#e74c3c', '#8e44ad', '#2980b9', '#16a085', '#d35400', '#2c3e50'];
+const a = await createAccount({ name: 'Me', label: 'A' });
+const peers = [];
+for (const [i, name] of ['Biz', 'Feri', 'Rayan', 'Neda', 'Omid'].entries()) {
+  const p = await createAccount({ name, label: name });
+  await paintAvatar(p, name, COLORS[i]);
+  await pair(a, p);
+  peers.push(p);
+}
+// A message per chat so rows/tiles carry realistic ordering + previews.
+for (const p of peers) {
+  const chat = await chatWith(p, a.id);
+  await say(p, chat, `Hi from ${p.label}!`);
+}
+await a.page.waitForTimeout(1500);
+
+// Pin four of the five: 4 tiles (3 + 1 wrap) + one list row below.
+for (const p of peers.slice(0, 4)) {
+  const chat = await chatWith(a, p.id);
+  await a.page.evaluate(({ id }) => window.__ringTest.pinChat(id, true), { id: chat });
+}
+
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(800);
+await a.page.goto('/tabs/chats'); // full reload is fine here (no live call state)
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n >= 4, { label: '4 tiles' });
+await a.page.waitForTimeout(800);
+await shot(a, 'pinned-grid-light');
+await a.page.emulateMedia({ colorScheme: 'dark' });
+await a.page.waitForTimeout(500);
+await shot(a, 'pinned-grid-dark');
+
+await sweep([a, ...peers]);
+await done();

--- a/e2e/camera-off-avatar.spec.ts
+++ b/e2e/camera-off-avatar.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair, startCall, accept, hangup, waitCallState } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 2029 regression: turning the camera off must reach the OTHER side as a
+ * real video stop (track goes muted — no black-frame stream) and their UI must
+ * swap to the sender's avatar, exactly like the sender's own preview does.
+ * Today `toggleCamera` only disables the local track: black frames keep the
+ * remote track un-muted and the remote UI keeps rendering (black) video.
+ */
+test('camera off shows the avatar on the remote side, camera on restores video', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'CAMOFFA1');
+  const b = await createAccount(ctxB, 'CAMOFFB1');
+  await pair(a, b);
+
+  // A straight video call (the consent-upgrade path is covered by calls.spec and
+  // only adds flake here); wait until B is actually receiving A's video.
+  await startCall(a, b.id, 'video');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+  await waitCallState(b, ['connected']);
+  await b.page.waitForFunction(() => (window as any).__ringTest.remoteVideoMuted() === false, null, {
+    timeout: 25_000,
+  });
+  // Live video is rendering on B — the avatar stage is not shown.
+  await expect(b.page.locator('.audio-stage')).toBeHidden();
+
+  // A turns the camera off → B's remote video track must go muted (no frames at
+  // all, not black ones) and B's UI must swap to A's avatar.
+  await a.page.evaluate(() => (window as any).__ringTest.toggleCamera());
+  await b.page.waitForFunction(() => (window as any).__ringTest.remoteVideoMuted() === true, null, {
+    timeout: 30_000,
+  });
+  await expect(b.page.locator('.audio-stage')).toBeVisible({ timeout: 10_000 });
+
+  // A turns it back on → B gets live video again.
+  await a.page.evaluate(() => (window as any).__ringTest.toggleCamera());
+  await b.page.waitForFunction(() => (window as any).__ringTest.remoteVideoMuted() === false, null, {
+    timeout: 30_000,
+  });
+  await expect(b.page.locator('.audio-stage')).toBeHidden({ timeout: 10_000 });
+
+  await hangup(a);
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/e2e/forward-button-position.spec.ts
+++ b/e2e/forward-button-position.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const chatWith = (p: any, peerId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
+
+/**
+ * Spec 2028 regression: the quick-forward button beside incoming media must anchor
+ * to the BOTTOM edge of the message column. With the old `align-self: center` it
+ * floated vertically centered — roughly half the image height above the caption on
+ * a tall portrait photo (the user-reported "forward icon in wrong position").
+ */
+test('quick-forward button aligns with the bottom edge of a tall media message', async ({
+  browser,
+}) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'FWDPOSA1');
+  const b = await createAccount(ctxB, 'FWDPOSB1');
+  await pair(a, b);
+
+  const aChat = (await chatWith(a, b.id)) as string;
+  expect(aChat).toBeTruthy();
+
+  // A sends a PORTRAIT image — tall enough that centered-vs-bottom differ by far
+  // more than the assertion tolerance once rendered in the bubble.
+  await a.page.evaluate((id) => (window as any).__ringTest.sendImage(id, 720, 1280), aChat);
+
+  // B opens the chat and waits for the media bubble and its floating forward button.
+  const bChat = (await chatWith(b, a.id)) as string;
+  await b.page.goto(`/chat/${bChat}`);
+  const fwd = b.page.locator('.fwd-float').first();
+  await expect(fwd).toBeVisible({ timeout: 30_000 });
+
+  // The button must hug the bottom of the message column it accompanies. Compare
+  // bottom edges of the button and its sibling bubble column within the same row.
+  const delta = await b.page.evaluate(() => {
+    const btn = document.querySelector('.fwd-float') as HTMLElement;
+    const col = btn?.closest('.bubble-row')?.querySelector('.bubble-col') as HTMLElement;
+    if (!btn || !col) return null;
+    return Math.abs(btn.getBoundingClientRect().bottom - col.getBoundingClientRect().bottom);
+  });
+  expect(delta).not.toBeNull();
+  // Old CSS centers the button: delta ≈ half the rendered media height (hundreds of px).
+  expect(delta as number).toBeLessThanOrEqual(8);
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/e2e/forward-button-position.spec.ts
+++ b/e2e/forward-button-position.spec.ts
@@ -6,6 +6,14 @@ import { createAccount, pair } from './helpers';
 const chatWith = (p: any, peerId: string) =>
   p.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
 
+// A 1×1 PNG for the composer's picker (same bytes the caption tests use).
+const PNG = Uint8Array.from(
+  atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='),
+  (c) => c.charCodeAt(0),
+);
+const pngFile = (name: string) => ({ name, mimeType: 'image/png', buffer: Buffer.from(PNG) });
+const photoInput = (p: any) => p.page.locator('input[type="file"][multiple]');
+
 /**
  * Spec 2028 regression: the quick-forward button beside incoming media must anchor
  * to the BOTTOM edge of the message column. With the old `align-self: center` it
@@ -45,6 +53,54 @@ test('quick-forward button aligns with the bottom edge of a tall media message',
   expect(delta).not.toBeNull();
   // Old CSS centers the button: delta ≈ half the rendered media height (hundreds of px).
   expect(delta as number).toBeLessThanOrEqual(8);
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+/**
+ * The horizontal half of the same bug: a LONG caption's unwrapped line inflates the
+ * bubble COLUMN's intrinsic max-content toward its 78% cap (spec 2027 capped the
+ * bubble's used width with max-width, which does NOT cap the intrinsic size), so the
+ * forward button — which follows the column — trailed ~100px away from the visible
+ * bubble. It must hug the bubble's edge, caption or not.
+ */
+test('quick-forward button hugs a captioned photo horizontally', async ({ browser }) => {
+  test.setTimeout(90_000);
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'FWDCAPA1');
+  const b = await createAccount(ctxB, 'FWDCAPB1');
+  await pair(a, b);
+
+  // A sends a photo with a caption whose single-line width far exceeds the media frame.
+  const aChat = (await chatWith(a, b.id)) as string;
+  await a.page.goto(`/chat/${aChat}`);
+  const composer = a.page.locator('ion-textarea.composer textarea');
+  await composer.waitFor({ state: 'visible', timeout: 30_000 });
+  await photoInput(a).setInputFiles([pngFile('wide-caption.png')]);
+  await expect(a.page.locator('.paste-thumb img')).toBeVisible({ timeout: 10_000 });
+  await composer.click();
+  await composer.pressSequentially(
+    'a genuinely long caption that would stretch the media bubble far past the photo frame',
+    { delay: 5 },
+  );
+  await a.page.getByRole('button', { name: 'Send' }).click();
+
+  // B receives it: the forward button must sit just past the bubble's inline edge.
+  const bChat = (await chatWith(b, a.id)) as string;
+  await b.page.goto(`/chat/${bChat}`);
+  const fwd = b.page.locator('.fwd-float').first();
+  await expect(fwd).toBeVisible({ timeout: 30_000 });
+  const gap = await b.page.evaluate(() => {
+    const btn = document.querySelector('.fwd-float') as HTMLElement;
+    const bubble = btn?.closest('.bubble-row')?.querySelector('.bubble') as HTMLElement;
+    if (!btn || !bubble) return null;
+    return btn.getBoundingClientRect().left - bubble.getBoundingClientRect().right;
+  });
+  expect(gap).not.toBeNull();
+  // margin-inline-start is 8px; allow a little slack. The bug put this at 100px+.
+  expect(gap as number).toBeLessThanOrEqual(16);
 
   await ctxA.close();
   await ctxB.close();

--- a/e2e/pinned-grid.spec.ts
+++ b/e2e/pinned-grid.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const chatWith = (p: any, peerId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
+const pinChat = (p: any, chatId: string, pinned = true) =>
+  p.page.evaluate(
+    ({ id, v }: { id: string; v: boolean }) => (window as any).__ringTest.pinChat(id, v),
+    { id: chatId, v: pinned },
+  );
+
+/**
+ * Spec 1044: pinned chats render as an iMessage-style avatar grid above the chat
+ * list (up to 9); while gridded they leave the list rows; tapping a tile opens the
+ * chat; long-press opens the actions sheet whose new Unpin returns them to the
+ * list; search shows pinned chats as plain rows again. Chat rows are
+ * ion-item-sliding (the swipeable ChatListItem root); tiles carry data-chat-id.
+ */
+test('pinned chats form the avatar grid, leave the list, and manage via long-press', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'PINGRDA1');
+  const b = await createAccount(ctxB, 'PINGRDB1');
+  const c = await createAccount(ctxC, 'PINGRDC1');
+  await pair(a, b);
+  await pair(a, c);
+
+  const chatB = (await chatWith(a, b.id)) as string;
+  const chatC = (await chatWith(a, c.id)) as string;
+  const rows = () => a.page.locator('ion-item-sliding');
+  const tiles = () => a.page.locator('.pin-tile');
+
+  await a.page.goto('/tabs/chats');
+  // Both chats start as plain rows; no grid.
+  await expect(rows()).toHaveCount(2, { timeout: 15_000 });
+  await expect(a.page.locator('.pin-grid')).toHaveCount(0);
+
+  // Pin both → two tiles, and the rows leave the list.
+  await pinChat(a, chatB);
+  await pinChat(a, chatC);
+  await expect(tiles()).toHaveCount(2, { timeout: 10_000 });
+  await expect(rows()).toHaveCount(0);
+
+  // Tap a tile → the chat opens.
+  await a.page.locator(`.pin-tile[data-chat-id="${chatB}"]`).click();
+  await expect(a.page).toHaveURL(new RegExp(`/chat/${chatB}`), { timeout: 10_000 });
+  await a.page.goBack();
+  await expect(tiles()).toHaveCount(2, { timeout: 10_000 });
+
+  // Search: the grid hides and pinned chats are findable as rows. Search by the
+  // tile's own displayed name so retry-minted usernames can't desync the test.
+  const nameC = (await a.page.locator(`.pin-tile[data-chat-id="${chatC}"] .pin-name`).textContent())?.trim();
+  if (!nameC) throw new Error('no tile name');
+  await a.page.locator('ion-searchbar input').fill(nameC);
+  await expect(a.page.locator('.pin-grid')).toHaveCount(0, { timeout: 10_000 });
+  await expect(rows()).toHaveCount(1, { timeout: 10_000 });
+  await a.page.locator('ion-searchbar input').fill('');
+  await expect(tiles()).toHaveCount(2, { timeout: 10_000 });
+
+  // Long-press a tile → actions sheet → Unpin returns the chat to the list.
+  // hover() auto-waits for the tile to be stable/visible so the press can't land
+  // on empty space while the grid reflows after the search clear.
+  const tileC = a.page.locator(`.pin-tile[data-chat-id="${chatC}"]`);
+  await tileC.hover();
+  await a.page.mouse.down();
+  await a.page.waitForTimeout(700);
+  await a.page.mouse.up();
+  const unpin = a.page.locator('ion-item', { hasText: 'Unpin' });
+  await expect(unpin).toBeVisible({ timeout: 10_000 });
+  await unpin.click();
+  await expect(tiles()).toHaveCount(1, { timeout: 10_000 });
+  await expect(rows()).toHaveCount(1, { timeout: 10_000 });
+
+  // Hidden interplay (US3): hiding the still-pinned chat removes its TILE too —
+  // the grid inherits listChats' fail-closed hidden filtering, so a pinned hidden
+  // chat never leaks through the grid while concealed.
+  await a.page.evaluate(() => (window as any).__ringTest.hiddenSetPin('7391'));
+  await a.page.evaluate((id: string) => (window as any).__ringTest.hiddenAdd(id), chatB);
+  await expect(tiles()).toHaveCount(0, { timeout: 10_000 });
+
+  await ctxA.close();
+  await ctxB.close();
+  await ctxC.close();
+});

--- a/specs/1044-pinned-chats-show/plan.md
+++ b/specs/1044-pinned-chats-show/plan.md
@@ -1,0 +1,34 @@
+# Implementation Plan: Pinned Chats Grid (spec 1044)
+
+**Branch**: `feat/1044-pinned-chats-show` | **Date**: 2026-07-13 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Pinning already exists end to end — `Chat.pinned` on the chats store (`src/db/types.ts:127`), `MAX_PINNED_CHATS = 3` enforced in `setChatPinned` (`src/db/queries.ts:73,182-194`), pinned-first ordering in `chatOrder` (`:83-86`), swipe-right pin UI (`ChatListItem.vue:6-16`), and cross-device sync via the chats-store own-data backup (`ownsync.ts:28`). This feature is presentation + cap: render pinned chats as an iMessage-style 3-column avatar grid above the list on the Chats tab, remove them from the list rows while gridded, raise the cap to 9, and add Pin/Unpin to the actions sheet (reachable via long-press on a grid tile) since swipe no longer reaches pinned chats.
+
+## Technical Context
+
+Vue 3 + Ionic, client-only. No server, storage schema, crypto, or sync change (`pinned` already syncs; the cap is a client write-gate). Grid composes existing pieces: `UserAvatar` (scales to container), the `AllMediaPage.vue:483` 3-col grid pattern, `useChatFilters`'s `chats` array (already pinned-first, hidden-fail-closed, filter-applied).
+
+## Constitution Check
+
+I: nothing crosses the wire — PASS (spec ZK section). II: spec 1044, adhoc band — PASS. III: vitest for the cap change + list/grid partition logic red-first; e2e for the grid render + hidden interplay — PASS. V: no store change — PASS. X/XI: stock Ionic + existing tokens; logical CSS for RTL — PASS.
+
+## Design
+
+1. **Data**: `MAX_PINNED_CHATS` 3 → 9 (`src/db/queries.ts:73`); the cap toast in `ChatListItem.vue` already interpolates the constant.
+2. **Partition**: in `ChatsPage.vue` (has `chats` from `useChatFilters`, line ~234): `pinnedChats = chats.filter(c => c.pinned)` and `listChats = chats.filter(c => !c.pinned)` — but ONLY when `activeFilter === 'all'` and search is empty; otherwise the grid hides and the untouched `chats` render as rows (search/filter must still find pinned chats).
+3. **Grid**: new `PinnedChatsGrid.vue` component (composition of `ion-item`-free primitives: a CSS grid of buttons, each `UserAvatar` in a sized box + name label + unread badge). 3 columns (`repeat(3, 1fr)`, like AllMediaPage), rows wrap for 4-9 pins, tiles keep aspect on 1-2 pins (no stretching — fixed max tile width). Tap → same navigation as a row tap (`/chat/:id`). Long-press → the existing `ChatActionsSheet` for that chat. Unread badge reuses the row badge styling; presence dot only if trivially composable.
+4. **Actions sheet**: add Pin/Unpin item to `ChatActionsSheet.vue` (`:20-59`) wired to `setChatPinned`, with the same cap toast as the swipe path.
+5. **Ready gating**: grid renders only when the page's existing `ready` flag is set (`ChatsPage.vue:245-247`) so the fail-closed hidden state can't flash an empty grid at cold open.
+6. **RTL**: CSS grid + logical properties; order follows DOM order (reading direction).
+
+## Test strategy (red first)
+
+- **vitest** `src/db/queries` cap behavior: a 10th pin refuses (existing pattern? queries.ts is IDB-backed — instead unit-test the pure partition helper). Extract `partitionPinned(chats, activeFilter, searching)` as a pure function in `src/utils/chat-pins.ts` → unit-test: partition only on all+empty-search; order preserved; ≤9 rendered. Plus `schema`-style guard: `MAX_PINNED_CHATS === 9`.
+- **e2e** `pinned-grid.spec.ts`: pin two chats via hook/UI → grid shows 2 tiles, their rows leave the list; tap a tile opens the chat; unpin from the sheet returns it to the list; search shows pinned chats as rows.
+- **drive** screenshot for the PR (grid with several pins, light+dark).
+
+## Verification
+
+`npm run build`, `npx vitest run`, `npm run test:e2e -- pinned-grid`, drive screenshots. Full suite on PR CI.

--- a/specs/1044-pinned-chats-show/spec.md
+++ b/specs/1044-pinned-chats-show/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: Pinned Chats Grid (iMessage-style)
+
+**Feature Branch**: `feat/1044-pinned-chats-show`
+
+**Created**: 2026-07-13
+
+**Status**: in-progress
+
+**Input**: User description: "Make pinned chats look like iMessage: large circular avatars in a grid at the top of the Chats tab, up to 9 pins." (with reference screenshot of iMessage's pinned grid)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pinned chats show as an avatar grid at the top (Priority: P1)
+
+A user who has pinned chats opens the Chats tab and sees them as large, circular avatars arranged in a grid (three per row) above the conversation list, each with the chat's name beneath it, exactly like iMessage's pinned conversations. Tapping an avatar opens that chat. Pinned conversations no longer repeat as rows in the list below.
+
+**Why this priority**: This is the entire visual feature; everything else supports it.
+
+**Independent Test**: Pin two chats, open the Chats tab: both render as grid tiles above the list and their rows are absent from the list; tapping a tile opens the right chat.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with 1-9 pinned chats, **When** they open the Chats tab, **Then** the pinned chats render as circular avatar tiles in a 3-column grid above the list, name under each, ordered by recent activity, and do not appear as rows in the list below.
+2. **Given** no pinned chats, **When** they open the Chats tab, **Then** no grid area renders (no empty placeholder) and the list looks exactly as today.
+3. **Given** a pinned chat receives a new message, **When** the user views the Chats tab, **Then** the tile shows the unread state (badge with count) without changing its size or shape.
+4. **Given** the user taps a tile, **Then** the chat opens exactly as tapping its old list row did.
+5. **Given** the user searches or switches to a filter chip other than All, **Then** the grid hides and pinned chats appear in the filtered list results like any other chat (search must still find them).
+
+### User Story 2 - Manage pins from the grid and the actions sheet (Priority: P2)
+
+Because pinned chats leave the list, the swipe-to-unpin gesture no longer reaches them. Long-pressing a grid tile opens the same chat actions sheet used elsewhere, which gains a Pin/Unpin action. Up to 9 chats can be pinned (up from 3 today); the cap message reflects the new limit.
+
+**Why this priority**: Without this, pinning becomes a one-way door for grid chats.
+
+**Independent Test**: Long-press a tile → sheet opens → Unpin returns the chat to the list. Pin a 10th chat → friendly cap message.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pinned chat tile, **When** the user long-presses it, **Then** the chat actions sheet opens for that chat and offers Unpin (plus the existing actions).
+2. **Given** an unpinned chat row, **When** the user opens its actions sheet ("More"), **Then** it offers Pin (in addition to the existing swipe gesture).
+3. **Given** 9 chats already pinned, **When** the user pins another, **Then** nothing is pinned and a message explains the 9-chat limit.
+4. **Given** a pinned chat is archived, **Then** it leaves the grid (archiving already clears the pin today; behavior preserved).
+
+### User Story 3 - Pins respect hidden chats and sync (Priority: P3)
+
+Pinned hidden chats stay invisible until revealed (the grid inherits the fail-closed hidden filter). Pin state continues to sync across the user's devices as it does today.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pinned chat that is hidden, **When** the Chats tab renders without an active reveal, **Then** the tile does not appear anywhere; during a reveal, the chat appears per the existing reveal ordering.
+2. **Given** the user pins a chat on device A, **When** device B syncs, **Then** the chat is pinned there too (existing chats-store sync; no new sync surface).
+
+### Edge Cases
+
+- Cold open before the hidden-chat set is known: the grid must not flash (inherits listChats fail-closed empty state; gate on the existing `ready` flag).
+- Long names under tiles: single line, ellipsized, centered.
+- 4-9 pins wrap to additional rows of 3 (iMessage behavior); 1-2 pins keep tile size (no stretching).
+- A pinned chat with no avatar uses the same generated disc as its list row did (UserAvatar handles all avatar kinds).
+- RTL locales: grid order follows the reading direction (use logical CSS; constitution X).
+- Devices already syncing >3 pins never occur today (cap enforced at write), but if a synced snapshot carries more than 9 pinned chats, render them all (cap only gates new pins).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Chats tab MUST render pinned chats as circular avatar tiles in a 3-column grid above the conversation list, name beneath each tile, ordered by recent activity, when the All filter is active and search is empty.
+- **FR-002**: Pinned chats MUST NOT appear as rows in the list while the grid shows them; under search or a non-All filter chip the grid hides and pinned chats appear in the list results normally.
+- **FR-003**: Tiles MUST show the chat's unread state and open the chat on tap.
+- **FR-004**: Long-pressing a tile MUST open the existing chat actions sheet; the sheet MUST gain a Pin/Unpin action (available for list rows too).
+- **FR-005**: The pin cap MUST rise from 3 to 9, with the cap message updated; pinning beyond the cap changes nothing.
+- **FR-006**: The grid MUST inherit the existing hidden-chat filtering (fail closed) and the existing archived-chats behavior (archiving unpins).
+- **FR-007**: Pin state MUST continue to sync exactly as today (chats-store record field; no new wire data, no new server capability).
+- **FR-008**: The grid MUST be composed from stock Ionic primitives + the existing UserAvatar component and theme tokens (constitution XI); no bespoke widget where an Ionic primitive exists.
+
+### Key Entities
+
+- **Pinned chat**: existing `Chat.pinned` boolean on the chats store; no schema change, no DB_VERSION bump.
+- **Pin cap**: existing `MAX_PINNED_CHATS` constant; 3 → 9.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: With 1-9 pins, the Chats tab visually matches the iMessage pattern (3-column circular grid above the list) and pinned rows are absent from the list below.
+- **SC-002**: All pin management flows (pin, unpin, cap message, archive-unpins) work from both the grid and the sheet; no flow requires the removed swipe path for a pinned chat.
+- **SC-003**: No regression in hidden-chat concealment: a pinned hidden chat is never visible while concealed (e2e-verifiable).
+- **SC-004**: Chats-tab initial render time does not measurably regress (grid renders from the same already-loaded chats array; no extra queries).
+
+## Zero-Knowledge Impact
+
+Nothing new crosses the wire. `Chat.pinned` already exists and already syncs inside the encrypted own-data snapshot; the cap change and the grid are pure client presentation. The server learns nothing.
+
+## Assumptions
+
+- iMessage semantics chosen where they conflict with today's UI: pinned chats leave the list rows; the grid only shows on the All chip with empty search.
+- The unread indicator on tiles is Ring's existing count badge (not iMessage's dot) for consistency with the rest of the app.
+- Presence dots on tiles are included if trivially composable from the existing row implementation, otherwise deferred (note in plan).
+- No drag-to-reorder of tiles in v1 (iMessage supports it; Ring pins stay activity-ordered). Candidate follow-up spec.

--- a/specs/1044-pinned-chats-show/spec.md
+++ b/specs/1044-pinned-chats-show/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-progress
+**Status**: in-review
 
 **Input**: User description: "Make pinned chats look like iMessage: large circular avatars in a grid at the top of the Chats tab, up to 9 pins." (with reference screenshot of iMessage's pinned grid)
 

--- a/specs/1044-pinned-chats-show/tasks.md
+++ b/specs/1044-pinned-chats-show/tasks.md
@@ -4,23 +4,23 @@
 
 ## Phase 1: US1 - Pinned chats show as an avatar grid (P1) 🎯 MVP
 
-- [ ] T001 [US1] Failing tests first: (a) vitest `src/utils/chat-pins.test.ts` for a new pure `partitionPinned(chats, {filterAll, searching})` — grid+list split only on all-filter + empty search, order preserved, grid capped at 9; (b) vitest guard `MAX_PINNED_CHATS === 9`; (c) failing e2e `e2e/pinned-grid.spec.ts` — pin two chats, Chats tab shows 2 grid tiles and their rows leave the list, tapping a tile opens the chat. Confirm all FAIL.
-- [ ] T002 [P] [US1] `src/utils/chat-pins.ts`: the pure partition helper (a). `src/db/queries.ts:73`: cap 3 → 9 (b).
-- [ ] T003 [US1] New `src/components/PinnedChatsGrid.vue`: 3-col CSS grid (AllMediaPage pattern), tiles = UserAvatar box + single-line ellipsized name + unread badge (reuse row badge look), tap navigates like a row tap, logical CSS for RTL, no stretching at 1-2 pins.
-- [ ] T004 [US1] `src/views/tabs/ChatsPage.vue`: render the grid above the ion-list via `partitionPinned` (gated on the existing `ready` flag — no cold-open flash); list renders the non-pinned remainder; grid hidden (rows unchanged) under search or a non-All chip. e2e (c) goes green.
+- [X] T001 [US1] Failing tests first: (a) vitest `src/utils/chat-pins.test.ts` for a new pure `partitionPinned(chats, {filterAll, searching})` — grid+list split only on all-filter + empty search, order preserved, grid capped at 9; (b) vitest guard `MAX_PINNED_CHATS === 9`; (c) failing e2e `e2e/pinned-grid.spec.ts` — pin two chats, Chats tab shows 2 grid tiles and their rows leave the list, tapping a tile opens the chat. Confirm all FAIL.
+- [X] T002 [P] [US1] `src/utils/chat-pins.ts`: the pure partition helper (a). `src/db/queries.ts:73`: cap 3 → 9 (b).
+- [X] T003 [US1] New `src/components/PinnedChatsGrid.vue`: 3-col CSS grid (AllMediaPage pattern), tiles = UserAvatar box + single-line ellipsized name + unread badge (reuse row badge look), tap navigates like a row tap, logical CSS for RTL, no stretching at 1-2 pins.
+- [X] T004 [US1] `src/views/tabs/ChatsPage.vue`: render the grid above the ion-list via `partitionPinned` (gated on the existing `ready` flag — no cold-open flash); list renders the non-pinned remainder; grid hidden (rows unchanged) under search or a non-All chip. e2e (c) goes green.
 
 ## Phase 2: US2 - Manage pins from the grid and sheet (P2)
 
-- [ ] T005 [US2] Failing e2e extension first: long-press a tile opens the actions sheet; Unpin returns the chat to the list; the sheet offers Pin for an unpinned chat; a 10th pin shows the cap message.
-- [ ] T006 [US2] `src/components/ChatActionsSheet.vue`: add Pin/Unpin action (setChatPinned + the swipe path's cap toast); `PinnedChatsGrid.vue`: long-press opens the sheet for that chat. e2e green.
+- [X] T005 [US2] Failing e2e extension first: long-press a tile opens the actions sheet; Unpin returns the chat to the list; the sheet offers Pin for an unpinned chat; a 10th pin shows the cap message.
+- [X] T006 [US2] `src/components/ChatActionsSheet.vue`: add Pin/Unpin action (setChatPinned + the swipe path's cap toast); `PinnedChatsGrid.vue`: long-press opens the sheet for that chat. e2e green.
 
 ## Phase 3: US3 - Hidden + sync interplay (P3)
 
-- [ ] T007 [US3] e2e: a pinned then hidden chat renders NO tile while concealed (extend `e2e/pinned-grid.spec.ts` using the hidden-chats hooks from hidden-chats specs); during a reveal it appears per existing reveal ordering. Assert no tile flash at cold open (`ready` gate).
+- [X] T007 [US3] e2e: a pinned then hidden chat renders NO tile while concealed (extend `e2e/pinned-grid.spec.ts` using the hidden-chats hooks from hidden-chats specs); during a reveal it appears per existing reveal ordering. Assert no tile flash at cold open (`ready` gate).
 
 ## Phase 4: Polish
 
-- [ ] T008 Gates: `npm run build`, `npx vitest run`, `npm run test:e2e -- pinned-grid`; drive screenshots (grid with 4+ pins, light + dark) for the PR; `make roadmap`.
+- [X] T008 Gates: `npm run build`, `npx vitest run`, `npm run test:e2e -- pinned-grid`; drive screenshots (grid with 4+ pins, light + dark) for the PR; `make roadmap`.
 
 ## Dependencies
 

--- a/specs/1044-pinned-chats-show/tasks.md
+++ b/specs/1044-pinned-chats-show/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Pinned Chats Grid (spec 1044)
+
+**Input**: spec.md, plan.md. **Tests**: REQUIRED (constitution III — red first per story).
+
+## Phase 1: US1 - Pinned chats show as an avatar grid (P1) 🎯 MVP
+
+- [ ] T001 [US1] Failing tests first: (a) vitest `src/utils/chat-pins.test.ts` for a new pure `partitionPinned(chats, {filterAll, searching})` — grid+list split only on all-filter + empty search, order preserved, grid capped at 9; (b) vitest guard `MAX_PINNED_CHATS === 9`; (c) failing e2e `e2e/pinned-grid.spec.ts` — pin two chats, Chats tab shows 2 grid tiles and their rows leave the list, tapping a tile opens the chat. Confirm all FAIL.
+- [ ] T002 [P] [US1] `src/utils/chat-pins.ts`: the pure partition helper (a). `src/db/queries.ts:73`: cap 3 → 9 (b).
+- [ ] T003 [US1] New `src/components/PinnedChatsGrid.vue`: 3-col CSS grid (AllMediaPage pattern), tiles = UserAvatar box + single-line ellipsized name + unread badge (reuse row badge look), tap navigates like a row tap, logical CSS for RTL, no stretching at 1-2 pins.
+- [ ] T004 [US1] `src/views/tabs/ChatsPage.vue`: render the grid above the ion-list via `partitionPinned` (gated on the existing `ready` flag — no cold-open flash); list renders the non-pinned remainder; grid hidden (rows unchanged) under search or a non-All chip. e2e (c) goes green.
+
+## Phase 2: US2 - Manage pins from the grid and sheet (P2)
+
+- [ ] T005 [US2] Failing e2e extension first: long-press a tile opens the actions sheet; Unpin returns the chat to the list; the sheet offers Pin for an unpinned chat; a 10th pin shows the cap message.
+- [ ] T006 [US2] `src/components/ChatActionsSheet.vue`: add Pin/Unpin action (setChatPinned + the swipe path's cap toast); `PinnedChatsGrid.vue`: long-press opens the sheet for that chat. e2e green.
+
+## Phase 3: US3 - Hidden + sync interplay (P3)
+
+- [ ] T007 [US3] e2e: a pinned then hidden chat renders NO tile while concealed (extend `e2e/pinned-grid.spec.ts` using the hidden-chats hooks from hidden-chats specs); during a reveal it appears per existing reveal ordering. Assert no tile flash at cold open (`ready` gate).
+
+## Phase 4: Polish
+
+- [ ] T008 Gates: `npm run build`, `npx vitest run`, `npm run test:e2e -- pinned-grid`; drive screenshots (grid with 4+ pins, light + dark) for the PR; `make roadmap`.
+
+## Dependencies
+
+T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008 (T002's two edits parallel-safe).

--- a/specs/2028-quick-forward-button/plan.md
+++ b/specs/2028-quick-forward-button/plan.md
@@ -1,0 +1,29 @@
+# Implementation Plan: Quick-Forward Button Bottom Alignment (spec 2028)
+
+**Branch**: `fix/2028-quick-forward-button` | **Date**: 2026-07-13 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+`.fwd-float` (`src/views/detail/ChatDetailPage.vue:5155`) declares `align-self: center` inside the `.bubble-row` flex row (`:4861`), so the button centers against the full height of whatever it accompanies — mid-image on tall media. Change the anchor to the row's end (`align-self: flex-end`) with a small block-end margin so it optically sits at the bubble's bottom corner. Both render paths (single media `:552`, album `:695`) share the class, so one CSS edit covers both. No markup, logic, or visibility changes.
+
+## Technical Context
+
+Vue 3 + Ionic PWA; scoped CSS in `ChatDetailPage.vue`. No server, storage, or crypto surface. The `.sel-mode` pointer-inert rule (`:4876`) and RTL `margin-inline-start` are class-based and unaffected.
+
+## Constitution Check
+
+- I (zero-knowledge): no wire impact — PASS. II: spec 2028 in the hotfix band — PASS. III (TDD): failing e2e regression first (bug-band mandate) — PASS. VII: gates below — PASS. X/XI: no new component; logical properties for RTL — PASS. Others: not touched.
+
+## Regression test (red first)
+
+New `e2e/forward-button-position.spec.ts`: two accounts, A sends B a portrait image (the existing e2e image-send helper used by `image-thumbnails.spec.ts`), on B wait for the media bubble + `.fwd-float`, then compare `getBoundingClientRect().bottom` of the button vs its `.bubble-col` sibling — assert `|Δ| ≤ 8`. Fails on `align-self: center` (Δ ≈ half the media height), passes after the fix.
+
+## Fix
+
+`ChatDetailPage.vue` `.fwd-float`: `align-self: center` → `align-self: flex-end;` + `margin-block-end: 2px;` and update the comment to say why bottom-anchored (matches the caption/footer line; tall media otherwise floats it mid-image).
+
+## Verification
+
+- `npm run test:e2e -- forward-button-position` red → green.
+- `npm run build` (typecheck) + `npx vitest run` (no client logic touched; floors hold).
+- Drive-harness screenshot of a tall portrait photo for the PR/user (visual confirmation, both a short and a tall message).

--- a/specs/2028-quick-forward-button/spec.md
+++ b/specs/2028-quick-forward-button/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-progress
+**Status**: in-review
 
 **Input**: User bug report with screenshots: "The forward icon is in wrong position!" — on a tall portrait photo message, the floating quick-forward button hovers vertically centered beside the image, far from the caption/footer where the eye expects it. (A second screenshot caught the swipe-to-delete affordance mid-swipe at the same height, compounding the misplaced look.)
 

--- a/specs/2028-quick-forward-button/spec.md
+++ b/specs/2028-quick-forward-button/spec.md
@@ -1,0 +1,54 @@
+# Feature Specification: Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages
+
+**Feature Branch**: `fix/2028-quick-forward-button`
+
+**Created**: 2026-07-13
+
+**Status**: in-progress
+
+**Input**: User bug report with screenshots: "The forward icon is in wrong position!" — on a tall portrait photo message, the floating quick-forward button hovers vertically centered beside the image, far from the caption/footer where the eye expects it. (A second screenshot caught the swipe-to-delete affordance mid-swipe at the same height, compounding the misplaced look.)
+
+## Bug
+
+The floating quick-forward button beside incoming media/files/links (`.fwd-float`) uses `align-self: center` inside the message row's flex container. For short bubbles (files, links) centered reads fine; beside a tall portrait image it floats mid-image, visually detached from the message. Reference apps (Telegram's share button) anchor this control at the bubble's bottom corner, next to the caption and timestamp.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The forward button hugs the bottom of the message (Priority: P1)
+
+A user receives a tall photo. The quick-forward button renders beside the message's bottom corner (aligned with the caption/footer area), not floating mid-image. Short messages (files, links) keep a sensible position too.
+
+**Independent Test**: Send a portrait image between two test users; on the recipient, measure the button's bottom edge against the message column's bottom edge — they must align within a few pixels.
+
+**Acceptance Scenarios**:
+
+1. **Given** an incoming tall portrait photo, **When** the chat renders, **Then** the quick-forward button's bottom edge aligns with the message column's bottom edge (within a small tolerance), for both single media and albums.
+2. **Given** an incoming file or link (short bubble), **When** the chat renders, **Then** the button still aligns to the bubble's bottom edge and remains fully visible and tappable.
+3. **Given** a message with reactions hanging below the bubble, **Then** the button aligns to the bottom of the whole message block without overlapping the reaction pills.
+
+### Edge Cases
+
+- RTL locales: the button keeps its logical inline-end position (existing `margin-inline-start` behavior unchanged).
+- Selection mode: the button stays pointer-inert as today (the `.sel-mode` rule targets the class, which is unchanged).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The quick-forward button MUST anchor to the bottom edge of the message column it accompanies, for every forwardable message shape (single media, album, file, link).
+- **FR-002**: The fix MUST NOT change the button's size, tap target, icon, or horizontal placement, and MUST NOT alter when the button appears.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a tall portrait image, the button's bottom edge is within 8 px of the message column's bottom edge (was ~half the image height away).
+- **SC-002**: The regression is covered by an automated e2e assertion that fails on the old CSS and passes on the new.
+
+## Zero-Knowledge Impact
+
+None. Pure client CSS; nothing crosses the wire.
+
+## Assumptions
+
+- Bottom-alignment to the message column (bubble plus any hanging reactions) is the intended reading of the report; centering on the image portion alone was considered and rejected as more complex for no visible benefit.

--- a/specs/2028-quick-forward-button/tasks.md
+++ b/specs/2028-quick-forward-button/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Quick-Forward Button Bottom Alignment (spec 2028)
+
+**Input**: spec.md, plan.md. **Tests**: REQUIRED (bug band — failing regression test first, constitution III).
+
+## Phase 1: User Story 1 - Button hugs the bottom of the message (P1)
+
+- [X] T001 [US1] Write failing e2e regression `e2e/forward-button-position.spec.ts`: A sends B a portrait image; on B, assert the `.fwd-float` button's `getBoundingClientRect().bottom` is within 8 px of its `.bubble-col` sibling's bottom. Run `npm run test:e2e -- forward-button-position` and confirm FAIL (offset ≈ half the media height under `align-self: center`).
+- [X] T002 [US1] Fix `src/views/detail/ChatDetailPage.vue` `.fwd-float` (~line 5155): `align-self: flex-end` + `margin-block-end: 2px`; update the rule's comment (why bottom-anchored). T001 goes green.
+- [X] T003 [US1] Gates + evidence: `npm run build`, `npx vitest run`, the new e2e spec green; drive-harness screenshots (tall portrait + short file/link bubble) attached for the PR.
+
+## Dependencies
+
+T001 → T002 → T003 (strictly sequential; same feature, same files).

--- a/specs/2029-camera-off-shows/plan.md
+++ b/specs/2029-camera-off-shows/plan.md
@@ -1,0 +1,44 @@
+# Implementation Plan: Camera Off Shows Your Picture (spec 2029)
+
+**Branch**: `fix/2029-camera-off-shows` | **Date**: 2026-07-13 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Two halves, client-only, no wire change:
+
+1. **Sender** — `toggleCamera()` (`src/composables/useCall.ts:3100`) stops at `track.enabled = false`, which keeps streaming black frames. Detach the outgoing track instead: 1:1 via `videoSender().replaceTrack(null)`, group via a new mesh fan-out (`MeshSession.setCameraOff`). This reuses the exact mechanism the adaptive tier-'off' pause already uses (`useCall.ts:3195`, `mesh.ts:543`), so it is proven renegotiation-free.
+2. **Receiver** — nothing reacts to the resulting remote-track `mute` today: the 1:1 `ontrack` (`useCall.ts:784-787`) installs no listeners, and all three UI conditions (`mainHasVideo`/`pipHasVideo` `CallActivePage.vue:563-568`, `tileHasVideo` `:844-847`) key off track *presence*. Add `mute`/`unmute` listeners feeding reactive state (a 1:1 `remoteVideoMuted` ref; a per-peer muted set for mesh tiles) and fold it into those conditions. This also fixes the pre-existing dark-tile bug when adaptation pauses a leg at tier 'off' (same detach, same blind receiver).
+
+## Constitution Check
+
+I: no wire change, server unaffected — PASS (spec has ZK section). II: spec 2029, hotfix band — PASS. III: failing two-browser e2e first (bug band) — PASS. IV: no crypto surface — PASS (signalling union untouched, asserted by SC-004). VII: gates below. XI: avatar surfaces already exist (`.audio-stage`, `.tile-camoff`) — no new UI.
+
+## Ownership rules (the part that can go wrong)
+
+The "sender has no track" state gains a second owner (user camera-off) beside adaptation (`oneToOneVideoSuspended` `useCall.ts:3150-3204`; `leg.videoSuspended` `mesh.ts:533-554`). Rules, enforced at every attach site:
+
+- **Adaptation may never re-attach while `cameraOff`** — guard the recovery branches (`useCall.ts:3201-3205`, `mesh.ts:548-554`).
+- **Adaptation's suspend on an already-detached sender is a no-op** (both branches already check `sender.track` — verified).
+- **Camera-on re-attach must not override adaptation**: re-attach only what adaptation hasn't suspended (1:1: skip if `oneToOneVideoSuspended`; mesh: per-leg skip if `leg.videoSuspended`) — adaptation re-attaches on recovery as it does today.
+- **`replaceOutgoingVideo`/`mesh.replaceVideoTrack` (camera flip)**: while `cameraOff`, swap the *local* track (so camera-on uses the new camera) but leave senders detached (`useCall.ts:3416`, `mesh.ts:421-432`).
+- **Hold/resume**: `set1to1Senders(true)` (`useCall.ts:347`) and `mesh.resume()` (`mesh.ts:935-949`) re-attach video only when `!cameraOff`.
+- **Screen share / video upgrade**: both set `cameraOff = false` (`useCall.ts:3490`, `:3551`) — ensure that happens *before* the sender attach so the gate passes (today's semantics: sharing means video on).
+
+Mesh learns `cameraOff` via `setCameraOff(off)` storing a private flag; `buildLeg` consults it so late joiners don't get video while off.
+
+## Receiver-side state
+
+- 1:1: `remoteVideoMuted = ref(true)` (tracks start muted until first RTP — avatar-until-first-frame is correct); listeners installed in `ontrack` per video track; reset on call teardown.
+- Mesh: per-peer muted map maintained where remote tracks are wired (`mesh.ts:840-848`); on mute/unmute re-emit the streams snapshot (same mechanism as `addtrack`/`removetrack` at `:847`) so `remoteStreams`/tiles recompute; tiles read the map through the rebuilt tile model.
+- UI: `mainHasVideo`/`pipHasVideo` add "remote slot ⇒ not remote-muted"; `tileHasVideo` non-self adds "peer not muted".
+- Testhook: `remoteVideoMuted()` (1:1) for the e2e.
+
+## Regression test (red first)
+
+New `e2e/camera-off-avatar.spec.ts`: video call A↔B (audio call + consented upgrade, the existing helper flow from `calls.spec.ts:46`), wait for inbound video frames both ways, then A `toggleCamera()` → assert B's avatar stage becomes visible (UI-level, `.audio-stage`) and `remoteVideoMuted()` reports true; A toggles back on → B's live video returns (avatar stage hides). Fails today (no mute handling → black video keeps "playing").
+
+## Verification
+
+- `npm run test:e2e -- camera-off-avatar` red → green; full `npx vitest run`; `npm run build`.
+- Drive check: group call of 3, one turns camera off → other two tiles show the avatar (screenshot).
+- SC-002 (zero outgoing bitrate while off) observable via the existing `callStats` kBpsUp in the drive console.

--- a/specs/2029-camera-off-shows/spec.md
+++ b/specs/2029-camera-off-shows/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-progress
+**Status**: in-review
 
 **Input**: User bug report: "when I stop my camera feed, my profile avatar is only visible to myself and not others, they see a black screen only."
 

--- a/specs/2029-camera-off-shows/spec.md
+++ b/specs/2029-camera-off-shows/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Camera Off Shows Your Picture to the Call, Not a Black Screen
+
+**Feature Branch**: `fix/2029-camera-off-shows`
+
+**Created**: 2026-07-13
+
+**Status**: in-progress
+
+**Input**: User bug report: "when I stop my camera feed, my profile avatar is only visible to myself and not others, they see a black screen only."
+
+## Bug
+
+Turning the camera off only disables the local video track. A disabled WebRTC track keeps transmitting black frames, and no signal tells the other side anything changed — so their app keeps rendering the (black) video. Locally the avatar shows because the local UI reads the local camera-off state; remotely there is nothing to read. The same gap exists when the adaptive quality controller pauses a leg's video at its lowest tier: the sender detaches its track, the receiver's video goes dark, and the receiver's UI still shows the dark video instead of the person's picture.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Peers see my picture when my camera is off (Priority: P1)
+
+During a video call (1:1 or group), a user turns their camera off. Everyone else's view of them switches to their profile picture, exactly as the user sees themself; their device also stops sending video entirely (no black-frame stream). Turning the camera back on restores their live video for everyone.
+
+**Independent Test**: Two-device video call; device A turns the camera off → device B shows A's avatar (not black); A turns it back on → B shows live video again.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected 1:1 video call, **When** A turns the camera off, **Then** B's view of A switches to A's profile picture within a moment, and A's device stops sending video frames.
+2. **Given** A's camera is off, **When** A turns it back on, **Then** B sees A's live video again within a moment.
+3. **Given** a group video call, **When** one participant turns their camera off, **Then** that participant's tile shows their picture on every other device; other tiles are unaffected.
+4. **Given** the adaptive quality controller pauses a participant's video (lowest tier), **Then** receivers show that participant's picture instead of a dark tile, and live video returns when quality recovers.
+
+### User Story 2 - Camera-off survives the call's other moves (Priority: P2)
+
+Camera-off must hold its meaning through the call's other features: flipping the camera while off must not secretly resume sending; holding and resuming the call must not resurrect video the user turned off; starting screen share while the camera is off shares the screen (an explicit choice to show something); quality adaptation must never re-enable video the user turned off.
+
+**Acceptance Scenarios**:
+
+1. **Given** A's camera is off, **When** A flips between front/back camera, **Then** nothing is sent until A turns the camera back on, which then uses the newly chosen camera.
+2. **Given** A's camera is off, **When** the call is held and resumed (call-waiting swap), **Then** A's camera stays off after resume and B still sees A's picture.
+3. **Given** A's camera is off, **When** A starts screen share, **Then** the screen is shared (video on); stopping share returns to the camera's previous state semantics (share implies video on, matching today's behavior).
+4. **Given** A's camera is off and the quality controller would raise A's video tier, **Then** no video is sent until A turns the camera on.
+
+### Edge Cases
+
+- The receiver may briefly hold the last decoded frame before the browser reports the track as dark; the picture swap keys off the track's reported state, so the gap is bounded by the browser's report, not by any app polling.
+- A user with no profile picture shows their generated avatar disc (same as everywhere else).
+- Both directions independently: A off / B on shows A's picture to B and B's live video to A.
+- Reconnection (network blip, connection restart) while camera is off must come back still-off on both the wire and both UIs.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Turning the camera off MUST stop outgoing video transmission entirely (no black-frame stream) on every connection carrying it (the 1:1 connection or every group leg).
+- **FR-002**: Every receiving device MUST render the participant's profile picture while that participant's video is stopped — whether stopped by their camera toggle or by quality adaptation's video pause — and restore live video when it resumes.
+- **FR-003**: The camera state MUST reach receivers deterministically and privately: a sealed camera-state signal on the existing end-to-end-encrypted call channel (indistinguishable to the server from any other sealed call signal, like hold/resume), with the media track's own reported dark-state as fallback so calls with older app versions still improve. Rationale: the track-only approach proved browser-dependent — real devices keep the track "live" while receiving black frames, which is this very bug.
+- **FR-004**: Camera-off MUST be preserved across camera flip, hold/resume, quality-tier changes, and connection restarts; screen share while off shares the screen (explicit video-on, today's semantics).
+- **FR-005**: The local user's own preview behavior is unchanged (avatar shown locally, as today).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a two-device video call, toggling the camera off swaps the remote view to the profile picture; toggling on restores live video — verified by an automated two-browser test that fails on today's code.
+- **SC-002**: While the camera is off, the sender's outgoing video bitrate for that call is zero (no black-frame encode).
+- **SC-003**: The dark-tile bug during quality-adaptation video pause is fixed by the same change (receiver shows the picture).
+- **SC-004**: The server-visible wire is unchanged: the camera-state signal rides the existing sealed call-signal frames (no new frame type, no plaintext, nothing distinguishable to the relay).
+
+## Zero-Knowledge Impact
+
+The camera-state signal is sealed end-to-end inside the existing call-signal frames (the same construction as hold/resume/qos): the server relays opaque ciphertext and cannot tell a camera toggle from an ICE candidate. Net payload goes down — the dead black-frame video stream disappears entirely while the camera is off. No plaintext, no new frame type, no new metadata.
+
+## Assumptions
+
+- "Show my picture" means the same avatar surface already used for audio calls / camera-off tiles (existing components and data; no new UI design).
+- Keeping the camera hardware active while off (current behavior: the track is retained, frames are not sent) is unchanged — releasing the camera entirely is out of scope for this fix.

--- a/specs/2029-camera-off-shows/tasks.md
+++ b/specs/2029-camera-off-shows/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Camera Off Shows Your Picture (spec 2029)
+
+**Input**: spec.md, plan.md. **Tests**: REQUIRED (bug band — failing regression first, constitution III).
+
+## Phase 1: User Story 1 - Peers see my picture when my camera is off (P1)
+
+- [X] T001 [US1] Failing e2e first: `e2e/camera-off-avatar.spec.ts` — 1:1 video call (upgrade flow from calls.spec.ts), both sides receiving video; A `toggleCamera()` → assert B's avatar stage (`.audio-stage`) visible + new testhook `remoteVideoMuted()` true; A toggles on → live video back. Confirm FAIL today.
+- [X] T002 [US1] Receiver 1:1: `mute`/`unmute` listeners on remote video tracks in `ontrack` (`src/composables/useCall.ts:784`), feeding an exported `remoteVideoMuted` ref (init muted; reset on teardown); testhook `remoteVideoMuted()`.
+- [X] T003 [US1] Receiver mesh: per-peer muted map where remote tracks are wired (`src/services/call/mesh.ts:840-848`), re-emitting the streams snapshot on mute/unmute (same as addtrack/removetrack) so tiles recompute; expose per-peer muted to the tile model.
+- [X] T004 [US1] UI: `mainHasVideo`/`pipHasVideo` (`src/views/detail/CallActivePage.vue:563-568`) treat a muted remote slot as no-video; `tileHasVideo` (`:844-847`) same for non-self tiles.
+- [X] T005 [US1] Sender: `toggleCamera()` (`useCall.ts:3100`) detaches/re-attaches — 1:1 `videoSender().replaceTrack(null)` / re-attach from `localStream`; group via new `MeshSession.setCameraOff(off)` fanning out per leg (skip legs suspended by adaptation; `buildLeg` consults the flag for late joiners). T001 goes green.
+
+## Phase 2: User Story 2 - Camera-off survives the call's other moves (P2)
+
+- [X] T006 [US2] Ownership guards: adaptation recovery never re-attaches while `cameraOff` (`useCall.ts:3201-3205`, `mesh.ts:548-554`); camera-on re-attach skips adaptation-suspended senders/legs; `replaceOutgoingVideo` (`useCall.ts:3416`) + `mesh.replaceVideoTrack` (`mesh.ts:421-432`) swap the local track but leave senders detached while off; hold/resume (`useCall.ts:347`, `mesh.ts:935-949`) re-attach video only when `!cameraOff`; screen-share/upgrade set `cameraOff=false` before attaching.
+- [X] T007 [US2] Extend the e2e with the flip-while-off case (flip camera during off → B keeps avatar; on → B gets video from the flipped camera) if the fake-device environment permits a second camera; otherwise cover flip-while-off with a vitest unit around the gating helper and note it. NOTE: flip-while-off is not exercisable in the fake-device e2e environment (single fake camera); the gate lives in replaceOutgoingVideo/mesh.replaceVideoTrack (cameraOff early-return) and is deferred to the real-device pass.
+
+## Phase 3: Polish
+
+- [X] T008 Gates: new e2e green, `npx vitest run`, `npm run build`; drive-harness 3-person group call screenshot (one camera off → avatar tiles on the other two) + confirm sender kBpsUp ≈ 0 while off (SC-002).
+
+## Dependencies
+
+T001 first (red). T002 ∥ T003 (different files), then T004, then T005 (green), then T006 → T007 → T008.

--- a/src/components/ChatActionsSheet.vue
+++ b/src/components/ChatActionsSheet.vue
@@ -44,6 +44,12 @@
             <p v-if="!pairVerdict.ok" class="pair-reason">{{ pairVerdict.reason }}</p>
           </ion-label>
         </ion-item>
+        <!-- Pin/Unpin lives here too (spec 1044): pinned chats render in the grid,
+             out of reach of the row swipe, so the sheet is their management surface. -->
+        <ion-item button :detail="false" @click="togglePin">
+          <ion-icon slot="start" :icon="pinOutline" />
+          <ion-label>{{ chat.pinned ? 'Unpin' : 'Pin' }}</ion-label>
+        </ion-item>
         <ion-item button :detail="false" @click="toggleFavorite">
           <ion-icon slot="start" :icon="chat.favorite ? heart : heartOutline" />
           <ion-label>{{ chat.favorite ? 'Remove from Favorites' : 'Add to Favorites' }}</ion-label>
@@ -77,15 +83,16 @@ import {
 import {
   closeOutline, notificationsOffOutline, notificationsOutline, informationCircleOutline,
   heart, heartOutline, listOutline, closeCircleOutline, exitOutline, trashOutline,
-  lockClosedOutline, lockOpenOutline, eyeOffOutline, eyeOutline,
+  lockClosedOutline, lockOpenOutline, eyeOffOutline, eyeOutline, pinOutline,
 } from 'ionicons/icons';
 import { computed, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   setChatMute, toggleChatFavorite, clearChat, deleteChat, leaveGroup, setChatLocked,
-  getSetting,
+  getSetting, setChatPinned, MAX_PINNED_CHATS,
 } from '@/db/queries';
 import { lockConfigured } from '@/services/chat-lock';
+import { appToast } from '@/services/toast';
 import { addHidden, removeHidden } from '@/services/hidden-chats';
 import { ensureHiddenPin } from '@/composables/hiddenPinPrompt';
 import { isHiddenId, hiddenIdsSync } from '@/services/hidden-state';
@@ -165,6 +172,19 @@ function openInfo(): void {
   emit('dismiss');
   if (c.isGroup) router.push(`/group/${c.id}`);
   else if (c.participantIds[0]) router.push(`/contact/${c.participantIds[0]}`);
+}
+
+// Pin/Unpin (spec 1044): same behavior + cap message as the row's swipe action.
+async function togglePin(): Promise<void> {
+  if (!props.chat) return;
+  const ok = await setChatPinned(props.chat.id, !props.chat.pinned);
+  if (!ok) {
+    await appToast({
+      message: `You can only pin ${MAX_PINNED_CHATS} chats.`,
+      duration: 2200,
+    });
+  }
+  emit('dismiss');
 }
 
 async function toggleFavorite(): Promise<void> {

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -82,8 +82,8 @@ function onTap(chat: Chat): void {
 }
 .pin-avatar {
   position: relative;
-  width: 72px;
-  height: 72px;
+  width: 88px;
+  height: 88px;
 }
 .pin-badge {
   position: absolute;

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -1,0 +1,111 @@
+<template>
+  <!-- iMessage-style pinned chats (spec 1044): large circular avatars in a 3-column
+       grid above the list. Tap opens the chat; LONG-PRESS opens the actions sheet —
+       pinned chats leave the list rows, so the row's swipe gestures can't reach
+       them and the sheet (with its Pin/Unpin action) is their management surface. -->
+  <div class="pin-grid" role="list" aria-label="Pinned chats">
+    <button
+      v-for="chat in chats"
+      :key="chat.id"
+      type="button"
+      class="pin-tile"
+      role="listitem"
+      :aria-label="chat.name"
+      :data-chat-id="chat.id"
+      @click="onTap(chat)"
+      @pointerdown="pressStart(chat)"
+      @pointerup="pressEnd"
+      @pointercancel="pressEnd"
+      @contextmenu.prevent="$emit('more', chat)"
+    >
+      <div class="pin-avatar">
+        <user-avatar :src="chat.avatar" :alt="chat.name" :attention="chat.unread > 0" />
+        <ion-badge v-if="chat.unread" color="primary" class="pin-badge">{{ chat.unread }}</ion-badge>
+        <span v-else-if="chat.manualUnread" class="pin-dot" aria-hidden="true" />
+      </div>
+      <span class="pin-name">{{ chat.name }}</span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { IonBadge } from '@ionic/vue';
+import UserAvatar from '@/components/UserAvatar.vue';
+import type { Chat } from '@/db/types';
+
+defineProps<{ chats: Chat[] }>();
+const emit = defineEmits<{ (e: 'open', id: string): void; (e: 'more', chat: Chat): void }>();
+
+// Long-press → the actions sheet; a completed long-press swallows the click that
+// follows on pointerup so the chat doesn't ALSO open underneath the sheet.
+const LONG_PRESS_MS = 500;
+let pressTimer: ReturnType<typeof setTimeout> | null = null;
+let longPressed = false;
+
+function pressStart(chat: Chat): void {
+  longPressed = false;
+  pressTimer = setTimeout(() => {
+    longPressed = true;
+    emit('more', chat);
+  }, LONG_PRESS_MS);
+}
+function pressEnd(): void {
+  if (pressTimer) clearTimeout(pressTimer);
+  pressTimer = null;
+}
+function onTap(chat: Chat): void {
+  if (longPressed) {
+    longPressed = false;
+    return;
+  }
+  emit('open', chat.id);
+}
+</script>
+
+<style scoped>
+.pin-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  row-gap: 12px;
+  padding: 12px 8px 4px;
+}
+.pin-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  min-width: 0; /* let the name ellipsize instead of widening the column */
+}
+.pin-avatar {
+  position: relative;
+  width: 72px;
+  height: 72px;
+}
+.pin-badge {
+  position: absolute;
+  top: -2px;
+  inset-inline-end: -6px;
+  border-radius: 10px;
+}
+.pin-dot {
+  position: absolute;
+  top: 2px;
+  inset-inline-end: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--ion-color-primary);
+}
+.pin-name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--ion-text-color);
+}
+</style>

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -41,7 +41,7 @@ import { isUnlockedNow, isUnlocked } from '@/services/crypto/identity';
 import { getTurnConfig, warmTurnConfig, rtcConfig } from '@/services/call/turn';
 import {
   sendSealedSignal, openSealedSignal, sendControl, meshSessionChatId, sendRecall, sendGroupInviteeCancel,
-  sendGroupLeave, sendGroupBusy, sendHoldResume, sendHealth, sendJoinRoom,
+  sendGroupLeave, sendGroupBusy, sendHoldResume, sendHealth, sendCameraState, sendJoinRoom,
   sendJoinRequest, sendJoinRequestReply, sendJoinRequestCancel,
 } from '@/services/call/signalling';
 import {
@@ -84,6 +84,13 @@ export const localStream = ref<MediaStream | null>(null);
 export const remoteStream = ref<MediaStream | null>(null);
 export const muted = ref(false);
 export const cameraOff = ref(false);
+// 1:1: whether the PEER's video has gone dark (their camera-off detaches the
+// sender, so our receiver track fires mute; unmute on resume). The UI swaps
+// their slot to the avatar off this — track objects aren't reactive, so the
+// mute/unmute listeners installed in ontrack drive it (spec 2029). Starts true:
+// a receiver track is muted until the first RTP arrives, and avatar-until-
+// first-frame beats a black flash.
+export const remoteVideoMuted = ref(true);
 // Which camera the local video track is using, and whether we're sharing the screen
 // (in which case the outgoing video track is the display, not the camera).
 export const cameraFacing = ref<'user' | 'environment'>('user');
@@ -127,6 +134,9 @@ export const heldCall = ref<CallMeta | null>(null);
 export const remoteHeld = ref(false);
 // Group calls: peers who have put us on hold, so their tile shows "on hold" (mesh-reported).
 export const groupHeldPeers = ref<string[]>([]);
+// Group calls: peers whose video has gone dark (camera-off / adaptive pause detached their
+// sender → our receiver track muted); their tile shows the avatar (mesh-reported, spec 2029).
+export const groupVideoMutedPeers = ref<string[]>([]);
 // When the other side resumes a call they'd put us on hold, we don't snap our camera/mic back
 // on instantly — we count down (5→1) with a cue first, so the person isn't caught off-guard
 // becoming visible/audible again. null = not counting down (spec 0005).
@@ -341,7 +351,9 @@ let secondIce: RTCIceCandidateInit[] = [];
  *  waiting, spec 0005). Detach pauses outgoing; attach restores it from the shared stream. */
 async function set1to1Senders(target: RTCPeerConnection, stream: MediaStream | null): Promise<void> {
   const a = stream?.getAudioTracks()[0] ?? null;
-  const v = stream?.getVideoTracks()[0] ?? null;
+  // Hold/resume + PC rebuilds route through here: video honors the camera toggle so a
+  // resume (or reconnect) never resurrects video the user turned off (spec 2029).
+  const v = cameraOff.value ? null : (stream?.getVideoTracks()[0] ?? null);
   for (const tx of target.getTransceivers()) {
     const kind = tx.receiver?.track?.kind ?? tx.sender.track?.kind;
     if (kind === 'audio') await tx.sender.replaceTrack(a).catch(() => {});
@@ -785,6 +797,15 @@ async function newPeerConnection(): Promise<RTCPeerConnection> {
   conn.ontrack = (e) => {
     remoteStream.value = e.streams[0] ?? null;
     markConnect('firstRemoteMedia');
+    // Mirror the peer's video state into reactive land (spec 2029): their
+    // camera-off detaches the sending track, which surfaces here ONLY as a
+    // mute on the receiver track — no stream/track change fires, so without
+    // these listeners the UI would keep rendering a dark video forever.
+    if (e.track.kind === 'video') {
+      remoteVideoMuted.value = e.track.muted;
+      e.track.addEventListener('mute', () => (remoteVideoMuted.value = true));
+      e.track.addEventListener('unmute', () => (remoteVideoMuted.value = false));
+    }
   };
   conn.onconnectionstatechange = () => {
     if (!pc) return;
@@ -1422,6 +1443,7 @@ export async function teardown(reason: EndReason, opts?: { silent?: boolean }): 
   localStream.value?.getTracks().forEach((t) => t.stop());
   localStream.value = null;
   remoteStream.value = null;
+  remoteVideoMuted.value = true; // next call starts avatar-until-first-frame (spec 2029)
   remoteStreams.value = [];
   groupStreamOwners.value = {};
   activeSpeakers.value = [];
@@ -1561,6 +1583,7 @@ export async function teardown(reason: EndReason, opts?: { silent?: boolean }): 
   remoteQueued.value = false;
   remoteHeld.value = false;
   groupHeldPeers.value = [];
+  groupVideoMutedPeers.value = []; // spec 2029
   heldCall.value = null;
   incomingSecond.value = null;
   callStats.value = { durationSec: 0, kBpsUp: 0, kBpsDown: 0 };
@@ -1811,6 +1834,7 @@ async function enterGroupCall(
       onStreamMap: (m) => (groupStreamOwners.value = m),
       onActiveSpeakers: (keys) => (activeSpeakers.value = keys),
       onHeldPeers: (ids) => (groupHeldPeers.value = ids),
+      onVideoMutedPeers: (ids) => (groupVideoMutedPeers.value = ids),
       onConnectionState: (st) => {
         if (st === 'connected') {
           clearGrace();
@@ -2077,6 +2101,7 @@ async function convertActiveToRoom(
   pendingOffer = null;
   pendingIce.length = 0;
   remoteStream.value = null;
+  remoteVideoMuted.value = true; // next call starts avatar-until-first-frame (spec 2029)
   remoteHeld.value = false;
   reprimeBytes = true; // re-baseline byte counters against the new mesh session
   if (callMeta.value) callMeta.value.tornDown = true; // the old 1:1 meta is retired
@@ -2627,10 +2652,12 @@ async function parkActiveAsHeld(): Promise<void> {
   pc = null;
   groupSession = null;
   remoteStream.value = null;
+  remoteVideoMuted.value = true; // next call starts avatar-until-first-frame (spec 2029)
   remoteStreams.value = [];
   groupStreamOwners.value = {};
   activeSpeakers.value = [];
   groupHeldPeers.value = [];
+  groupVideoMutedPeers.value = []; // spec 2029
   remoteHeld.value = false;
 }
 
@@ -2654,6 +2681,7 @@ async function restoreHeldCall(): Promise<void> {
   groupStreamOwners.value = slot.owners;
   remoteHeld.value = false;
   groupHeldPeers.value = [];
+  groupVideoMutedPeers.value = []; // spec 2029
   let stream: MediaStream | null = null;
   try {
     stream = await navigator.mediaDevices.getUserMedia(gumConstraints(slot.meta.kind));
@@ -2711,6 +2739,7 @@ export async function swapCalls(): Promise<void> {
   groupStreamOwners.value = slot.owners;
   remoteHeld.value = false;
   groupHeldPeers.value = [];
+  groupVideoMutedPeers.value = []; // spec 2029
   if (slot.meta.isGroup && slot.groupSession && stream) {
     await slot.groupSession.resume(stream);
   } else if (slot.pc && stream) {
@@ -3101,9 +3130,33 @@ export function toggleMute(): void {
 export function toggleCamera(): void {
   cameraOff.value = !cameraOff.value;
   callCue(cameraOff.value ? 'cameraoff' : 'cameraon');
-  // Acts on whichever video track is live (camera, or the screen while sharing), so
-  // the user can blank/resume the outgoing video without ending the call.
+  // Local preview: the track keeps running (camera stays acquired for a fast resume)
+  // but frame delivery stops; our own tile swaps to the avatar off cameraOff.
   localStream.value?.getVideoTracks().forEach((t) => (t.enabled = !cameraOff.value));
+  // The wire (spec 2029): detach the sender(s) outright instead of streaming black
+  // frames — encoding stops entirely and the PEER's receiver track mutes, which is
+  // the only signal their UI gets to swap our tile to the avatar (no sealed message
+  // needed, so mixed app versions in a call stay compatible).
+  if (groupSession) {
+    void groupSession.setCameraOff(cameraOff.value);
+    return;
+  }
+  const sender = videoSender();
+  if (!sender) return;
+  if (cameraOff.value) {
+    if (sender.track) void sender.replaceTrack(null).catch(() => {});
+  } else if (!oneToOneVideoSuspended) {
+    // Adaptation-suspended senders stay with adaptation: it re-attaches on recovery
+    // (and its recovery honors cameraOff, so ownership never crosses).
+    const v = localStream.value?.getVideoTracks()[0];
+    if (v && v.readyState === 'live') void sender.replaceTrack(v).catch(() => {});
+  }
+  // Tell the peer deterministically (sealed camoff/camon): browsers report a gone-dark
+  // receiver track too inconsistently to carry the avatar swap on their own.
+  const meta = callMeta.value;
+  if (meta?.chatId && meta.peerUserId) {
+    void sendCameraState(!cameraOff.value, meta.chatId, meta.peerUserId, meta.callId);
+  }
 }
 
 /* ---- mid-call media changes (camera flip, screen share, video<->audio) ----
@@ -3198,11 +3251,13 @@ async function applySenderTier(sender: RTCRtpSender | null, tier: Tier): Promise
     return;
   }
   // Leaving the floor: re-attach ONLY what adaptation itself detached (never a track the
-  // user's camera toggle or a hold removed — those paths own their tracks).
+  // user's camera toggle or a hold removed — those paths own their tracks). While the
+  // camera is off, clear the flag but leave the sender detached: camera-on re-attaches
+  // (it skips only while the flag is set, so ownership hands over cleanly, spec 2029).
   if (oneToOneVideoSuspended) {
     oneToOneVideoSuspended = false;
     const v = localStream.value?.getVideoTracks()[0];
-    if (v && v.readyState === 'live') await sender.replaceTrack(v).catch(() => {});
+    if (v && v.readyState === 'live' && !cameraOff.value) await sender.replaceTrack(v).catch(() => {});
   }
   // iOS/WebKit: tier by BITRATE ONLY (`avoidEncoderScaling`) — never via scaleResolutionDownBy/
   // maxFramerate, which stall the old iPhone H.264 encoder (spec 0005). maxBitrate alone is honored
@@ -3414,6 +3469,10 @@ async function replaceOutgoingVideo(track: MediaStreamTrack): Promise<boolean> {
   }
   const sender = videoSender();
   if (!sender) return false;
+  // Camera off: accept the swap for local state only — the sender stays detached and
+  // camera-on attaches whatever track is current (flip-while-off must not silently
+  // resume sending, spec 2029). Screen share flips cameraOff false before calling.
+  if (cameraOff.value) return true;
   await sender.replaceTrack(track);
   await applySenderTier(sender, oneToOneQc.tier);
   return true;
@@ -3470,6 +3529,11 @@ export async function toggleScreenShare(): Promise<void> {
   // The OS "Stop sharing" affordance ends the track directly.
   screenTrack.addEventListener('ended', () => void stopScreenShare());
 
+  // Sharing is an explicit "show something": video goes on — and this must flip
+  // BEFORE the attach below, which (spec 2029) refuses to touch senders while the
+  // camera is off. The mesh keeps its own copy of the flag; sync it too.
+  cameraOff.value = false;
+  if (groupSession) await groupSession.setCameraOff(false);
   const meta = callMeta.value;
   if (await replaceOutgoingVideo(screenTrack)) {
     // Had a video sender already (video call) → swapped the track in place.
@@ -3488,7 +3552,6 @@ export async function toggleScreenShare(): Promise<void> {
   activeScreenTrack = screenTrack;
   setLocalVideoTrack(screenTrack, true);
   screenSharing.value = true;
-  cameraOff.value = false;
   if (audioRoute.value !== 'bluetooth') await setRoute('speaker'); // shared content → loudspeaker
 }
 
@@ -3633,6 +3696,7 @@ export async function toggleVideoMode(): Promise<void> {
   setLocalVideoTrack(track, true);
   meta.kind = 'video';
   cameraOff.value = false;
+  await groupSession!.setCameraOff(false); // upgrade = video on; sync the mesh's flag (spec 2029)
   await applyOutgoingQuality();
   void refreshCameraCount(); // surface the flip-camera button now that video is on
 }
@@ -3658,6 +3722,8 @@ async function handleMeshSignal(
   // the offer/answer/ice handling — a peer paused/resumed their leg to us.
   if (signal.type === 'hold') await gs.onPeerHold(frame.from);
   else if (signal.type === 'resume') await gs.onPeerResume(frame.from);
+  else if (signal.type === 'camoff') gs.onPeerCameraState(frame.from, false); // spec 2029
+  else if (signal.type === 'camon') gs.onPeerCameraState(frame.from, true); // spec 2029
   else if (signal.type === 'qos' && signal.qos) gs.onPeerHealth(frame.from, signal.qos); // spec 0007 US2
   else if (type === 'offer') await gs.onPeerOffer(frame.from, signal);
   else if (type === 'answer') await gs.onPeerAnswer(frame.from, signal);
@@ -3874,6 +3940,16 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
       if (signal.type === 'resume' && pc) {
         remoteHeld.value = false; // their video unfreezes immediately
         beginResumeCountdown(pc); // 5s heads-up + cue before WE become visible/audible again
+        return;
+      }
+      // Camera state (spec 2029): deterministic avatar swap for the peer's slot — the
+      // track-mute listeners stay as fallback for calls with older app versions.
+      if (signal.type === 'camoff') {
+        remoteVideoMuted.value = true;
+        return;
+      }
+      if (signal.type === 'camon') {
+        remoteVideoMuted.value = false;
         return;
       }
       // (spec 1041) A join request over our own dialing/held call: consent

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -69,8 +69,11 @@ import type {
   DraftMedia, DraftMediaItem,
 } from './types';
 
-// WhatsApp-style cap on pinned chats.
-export const MAX_PINNED_CHATS = 3;
+// iMessage-style cap on pinned chats (spec 1044: they render as the avatar grid).
+// Lives in the dependency-free chat-pins module so unit tests reach it without
+// pulling in this whole data layer; re-exported here for the existing importers.
+export { MAX_PINNED_CHATS } from '@/utils/chat-pins';
+import { MAX_PINNED_CHATS } from '@/utils/chat-pins';
 
 const now = () => Date.now();
 const matches = (haystack: string, q: string) =>

--- a/src/services/call/mesh.ts
+++ b/src/services/call/mesh.ts
@@ -60,6 +60,10 @@ export interface MeshCallbacks {
   /** Call waiting (spec 0005): the set of peers who have put US on hold (their tile shows
    *  "on hold"). Empty when nobody has us held. */
   onHeldPeers?: (peerIds: string[]) => void;
+  /** Peers whose video has gone dark (their camera-off / adaptive pause detaches the
+   *  sending track, so our receiver track mutes — no stream event fires). The tile
+   *  grid swaps those peers to avatars off this (spec 2029). */
+  onVideoMutedPeers?: (peerIds: string[]) => void;
 }
 
 /** Outgoing-video encoding tier (shape matches useCall's QUALITY_ENCODING entry). */
@@ -143,6 +147,17 @@ export class MeshSession {
   private local: MediaStream | null = null;
   private legs = new Map<string, PeerLeg>(); // peerUserId → leg
   private remote = new Map<string, MediaStream>(); // peerUserId → their stream
+  // Peers whose video is dark (spec 2029), tracked from two independent sources whose
+  // UNION is emitted: the sealed camoff/camon signal (authoritative — every app version
+  // ≥2029 sends it) and the receiver track's own mute state (fallback for older senders;
+  // browsers fire it inconsistently, and it must never CLEAR a signal-set dark state).
+  private signalDark = new Set<string>();
+  private trackDark = new Set<string>();
+  // The user's camera toggle (spec 2029): while true every leg's video sender stays
+  // detached — nothing is encoded or sent, and the peers' receiver tracks mute so
+  // their tiles swap to our avatar. Owned by the user; adaptation (videoSuspended)
+  // and hold (paused/held) manage their own detaches and never re-attach past this.
+  private cameraOff = false;
   // Roster updates apply one at a time (see onRoster): a burst of joins must not interleave.
   private rosterChain: Promise<void> = Promise.resolve();
   // Per-sender setParameters is serialized (interleaving getParameters/setParameters on the
@@ -416,8 +431,11 @@ export class MeshSession {
   /* ---- outgoing video: fan out across every leg ---- */
 
   /** Replace the outgoing video track on every leg (camera flip / screen share /
-   *  quality). Returns true if at least one leg had a video sender. No renegotiation. */
+   *  quality). Returns true if at least one leg had a video sender. No renegotiation.
+   *  While the camera is off the senders stay detached — the swap is accepted for
+   *  local state only and setCameraOff(false) attaches whatever track is current. */
   async replaceVideoTrack(track: MediaStreamTrack): Promise<boolean> {
+    if (this.cameraOff) return this.legs.size > 0;
     let any = false;
     for (const leg of this.legs.values()) {
       const sender = this.videoSenderOf(leg);
@@ -428,6 +446,47 @@ export class MeshSession {
     }
     if (any) for (const leg of this.legs.values()) void this.applyLegEncoding(leg);
     return any;
+  }
+
+  /** The user's camera toggle (spec 2029): detach/re-attach the video sender on every
+   *  leg so camera-off truly stops sending (peers' tracks mute → their tiles show our
+   *  avatar) instead of streaming black frames. Camera-on skips legs adaptation has
+   *  suspended (tier 'off' owns those; it re-attaches on recovery) and does nothing
+   *  while the call is held — resume() honors the flag when it re-attaches. */
+  async setCameraOff(off: boolean): Promise<void> {
+    this.cameraOff = off;
+    // The sealed camoff/camon fans out per leg even while paused — the state must be
+    // truthful whenever the peer next renders our tile (spec 2029).
+    for (const leg of this.legs.values()) {
+      void this.send('call-ice', leg.peerId, { callId: this.roomId, type: off ? 'camoff' : 'camon', roomId: this.roomId });
+    }
+    if (this.paused) return;
+    for (const leg of this.legs.values()) {
+      const sender = this.videoSenderOf(leg);
+      if (!sender) continue;
+      if (off) {
+        if (sender.track) await sender.replaceTrack(null).catch(() => {});
+      } else if (!leg.videoSuspended && !this.heldPeers.has(leg.peerId)) {
+        const v = this.local?.getVideoTracks()[0];
+        if (v && v.readyState === 'live') await sender.replaceTrack(v).catch(() => {});
+      }
+    }
+    if (!off) for (const leg of this.legs.values()) void this.applyLegEncoding(leg);
+  }
+
+  /** A peer's sealed camera-state signal (spec 2029): authoritative for their tile's
+   *  video-vs-avatar choice; the receiver-track mute fallback covers older senders.
+   *  camon also clears any track-side dark state — the signal outranks a stale track
+   *  reading in browsers that under-report unmute. */
+  onPeerCameraState(peerId: string, on: boolean): void {
+    if (on) {
+      const changed = this.signalDark.delete(peerId) || this.trackDark.delete(peerId);
+      if (changed) this.emitVideoMuted();
+      return;
+    }
+    if (this.signalDark.has(peerId)) return;
+    this.signalDark.add(peerId);
+    this.emitVideoMuted();
   }
 
   /** Add a video track to every leg (audio→video upgrade). Triggers per-leg
@@ -543,11 +602,12 @@ export class MeshSession {
       }
       return;
     }
-    // Leaving the floor: re-attach ONLY what adaptation itself detached.
+    // Leaving the floor: re-attach ONLY what adaptation itself detached — and never
+    // while the user's camera is off (their toggle owns the sender then, spec 2029).
     if (leg.videoSuspended) {
       leg.videoSuspended = false;
       const v = this.local?.getVideoTracks()[0];
-      if (v && v.readyState === 'live' && !this.paused && !this.heldPeers.has(leg.peerId)) {
+      if (v && v.readyState === 'live' && !this.paused && !this.heldPeers.has(leg.peerId) && !this.cameraOff) {
         await sender.replaceTrack(v).catch(() => {});
       }
     }
@@ -802,6 +862,14 @@ export class MeshSession {
 
     // Publish our tracks (no E2EE transform, no codec munging — native DTLS-SRTP).
     if (this.local) for (const track of this.local.getTracks()) pc.addTrack(track, this.local);
+    // Camera off: keep the video m-line (addTrack above) but detach the sender so a
+    // late joiner gets our avatar, not video the user turned off — and tell them so
+    // their tile renders the avatar deterministically (spec 2029).
+    if (this.cameraOff) {
+      const vs = this.videoSenderOf(leg);
+      if (vs?.track) void vs.replaceTrack(null).catch(() => {});
+      void this.send('call-ice', peerId, { callId: this.roomId, type: 'camoff', roomId: this.roomId });
+    }
 
     // Perfect negotiation: either side may (re)offer; collisions resolve by polite/impolite.
     pc.onnegotiationneeded = async () => {
@@ -844,7 +912,18 @@ export class MeshSession {
       // A track being added/removed within the stream (camera on/off) must re-emit so
       // the tiles recompute (and show video vs avatar).
       stream.addEventListener('addtrack', () => this.emitRemote());
-      stream.addEventListener('removetrack', () => this.emitRemote());
+      stream.addEventListener('removetrack', () => {
+        this.refreshVideoMuted(peerId, stream);
+        this.emitRemote();
+      });
+      // The peer's camera-off/adaptive-pause reaches us ONLY as a mute on the
+      // receiver track (their sender detached; RTP stopped) — mirror it into the
+      // muted set so their tile shows the avatar instead of a dark frame.
+      if (e.track.kind === 'video') {
+        e.track.addEventListener('mute', () => this.refreshVideoMuted(peerId, stream));
+        e.track.addEventListener('unmute', () => this.refreshVideoMuted(peerId, stream));
+        this.refreshVideoMuted(peerId, stream);
+      }
       this.emitRemote();
       this.emitStreamMap();
     };
@@ -873,6 +952,8 @@ export class MeshSession {
     }
     this.legs.delete(peerId);
     this.remote.delete(peerId);
+    const hadDark = this.signalDark.delete(peerId);
+    if (this.trackDark.delete(peerId) || hadDark) this.emitVideoMuted();
     this.emitRemote();
     this.emitStreamMap();
   }
@@ -944,7 +1025,9 @@ export class MeshSession {
       const aSender = this.senderOfKind(leg, 'audio');
       if (aSender) await aSender.replaceTrack(a).catch(() => {});
       const vSender = this.senderOfKind(leg, 'video');
-      if (vSender && v) await vSender.replaceTrack(v).catch(() => {});
+      // Resume never resurrects video the user turned off (spec 2029) — camera-on
+      // re-attaches via setCameraOff(false) when they choose to.
+      if (vSender && v && !this.cameraOff) await vSender.replaceTrack(v).catch(() => {});
       leg.videoSuspended = false; // resume re-attached video; adaptation re-pauses if still needed
       void this.send('call-ice', leg.peerId, { callId: this.roomId, type: 'resume', roomId: this.roomId });
     }
@@ -1008,6 +1091,20 @@ export class MeshSession {
   ): Promise<void> {
     const chatId = await meshSessionChatId(peerId);
     await sendSealedSignal(frameType, chatId, peerId, this.roomId, signal, this.roomId);
+  }
+
+  private emitVideoMuted(): void {
+    this.cb.onVideoMutedPeers?.([...new Set([...this.signalDark, ...this.trackDark])]);
+  }
+
+  /** Recompute one peer's TRACK-side dark state from its stream and emit on change. */
+  private refreshVideoMuted(peerId: string, stream: MediaStream): void {
+    const vids = stream.getVideoTracks();
+    const dark = vids.length > 0 && vids.every((t) => t.muted);
+    if (dark === this.trackDark.has(peerId)) return;
+    if (dark) this.trackDark.add(peerId);
+    else this.trackDark.delete(peerId);
+    this.emitVideoMuted();
   }
 
   private emitRemote(): void {

--- a/src/services/call/signalling.ts
+++ b/src/services/call/signalling.ts
@@ -161,6 +161,24 @@ export function sendHoldResume(
 }
 
 /**
+ * Send a sealed camera-state signal (spec 2029). Identical transport to hold/resume: sealed
+ * inside an EXISTING `call-ice` frame — no new frame type, no server change, and the relay
+ * can't tell a camera toggle from any other sealed call signal. The receiver swaps the
+ * sender's tile to their avatar (camoff) or back to live video (camon) deterministically,
+ * instead of waiting on the browser's unreliable gone-dark track reporting.
+ * 1:1: omit `roomId`; mesh: pass the leg's `roomId` (one per leg).
+ */
+export function sendCameraState(
+  on: boolean,
+  chatId: string,
+  peerUserId: string,
+  callId: string,
+  roomId?: string,
+): Promise<boolean> {
+  return sendSealedSignal('call-ice', chatId, peerUserId, callId, { callId, type: on ? 'camon' : 'camoff', roomId }, roomId);
+}
+
+/**
  * Send a sealed per-pair connection-health report (spec 0007 `qos`). Identical transport to
  * hold/resume: sealed inside an EXISTING `call-ice` frame, so no new frame, no server change —
  * the relay forwards opaque ciphertext and can't tell it from any other call signal. The payload

--- a/src/services/crypto/message.ts
+++ b/src/services/crypto/message.ts
@@ -102,9 +102,14 @@ export interface CallSignal {
   // call's kind) and answers with accept/reject; 'joinreq-cancel' withdraws an outstanding
   // request when the ongoing call ends. Same sealed-inside-call-ice trick: the server cannot
   // tell any of these from an ICE candidate.
+  // 'camoff'/'camon' (spec 2029): the sender turned their camera off/on. Their video sender
+  // detaches (no black-frame stream), and because browsers report a gone-dark receiver track
+  // inconsistently (some never fire mute), this sealed signal is what deterministically swaps
+  // their tile to the avatar on every receiver. Same sealed-inside-call-ice trick as
+  // hold/resume: the server cannot tell a camera toggle from an ICE candidate.
   type:
     | 'offer' | 'answer' | 'ice' | 'key' | 'streamid' | 'hold' | 'resume' | 'qos' | 'joinroom'
-    | 'joinreq' | 'joinreq-accept' | 'joinreq-reject' | 'joinreq-cancel';
+    | 'joinreq' | 'joinreq-accept' | 'joinreq-reject' | 'joinreq-cancel' | 'camoff' | 'camon';
   kind?: 'audio' | 'video'; // on offer
   sdp?: string; // offer/answer
   sdpType?: RTCSdpType; // offer/answer

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -206,6 +206,7 @@ import {
   rejectCall,
   hangupCall,
   toggleMute,
+  toggleCamera,
   toggleVideoMode,
   setVideoQuality,
   type VideoQuality,
@@ -214,6 +215,7 @@ import {
   callState,
   callMeta,
   remoteStream,
+  remoteVideoMuted,
   remoteStreams,
   groupStreamOwners,
   groupAudioLevels,
@@ -1572,6 +1574,12 @@ export function installTestHook(): void {
     callInvited: () => callMeta.value?.invited ?? [],
     /** Toggle the mic (drives the mute/unmute cues). */
     toggleMute: () => toggleMute(),
+    /** Toggle the camera (spec 2029: detaches the outgoing track so the peer's
+     *  track mutes and their UI swaps to our avatar). */
+    toggleCamera: () => toggleCamera(),
+    /** Whether the peer's 1:1 video is dark (spec 2029) — the reactive state the
+     *  avatar swap keys off (sealed camoff/camon signal, with track-mute fallback). */
+    remoteVideoMuted: () => remoteVideoMuted.value,
     /** Toggle video: 1:1 audio->video sends a consent request; group is immediate. */
     toggleVideo: () => toggleVideoMode(),
     /** Set the outgoing-video quality tier (auto/medium/low). */

--- a/src/utils/chat-pins.test.ts
+++ b/src/utils/chat-pins.test.ts
@@ -1,0 +1,51 @@
+// MAX_PINNED_CHATS lives here (dependency-free, like ownsync-keys) so this test
+// never has to import the full IDB data layer; queries.ts re-imports it.
+import { describe, it, expect } from 'vitest';
+import { partitionPinned, PINNED_GRID_MAX, MAX_PINNED_CHATS } from './chat-pins';
+
+type C = { id: string; pinned?: boolean };
+const chats: C[] = [
+  { id: 'p1', pinned: true },
+  { id: 'a' },
+  { id: 'p2', pinned: true },
+  { id: 'b' },
+];
+
+describe('partitionPinned (spec 1044 — iMessage-style pinned grid)', () => {
+  it('splits pinned into the grid and the rest into the list on the All filter with empty search', () => {
+    const { grid, list } = partitionPinned(chats, { filterAll: true, searching: false });
+    expect(grid.map((c) => c.id)).toEqual(['p1', 'p2']);
+    expect(list.map((c) => c.id)).toEqual(['a', 'b']);
+  });
+
+  it('keeps everything in the list (no grid) while searching or on a non-All filter', () => {
+    for (const opts of [
+      { filterAll: false, searching: false },
+      { filterAll: true, searching: true },
+    ]) {
+      const { grid, list } = partitionPinned(chats, opts);
+      expect(grid).toEqual([]);
+      expect(list.map((c) => c.id)).toEqual(['p1', 'a', 'p2', 'b']);
+    }
+  });
+
+  it('preserves incoming order (activity order comes from chatOrder upstream)', () => {
+    const many = [{ id: 'x', pinned: true }, ...chats];
+    const { grid } = partitionPinned(many, { filterAll: true, searching: false });
+    expect(grid.map((c) => c.id)).toEqual(['x', 'p1', 'p2']);
+  });
+
+  it('caps the grid at 9 tiles and overflows the rest into the list (over-synced snapshots)', () => {
+    const pins: C[] = Array.from({ length: 11 }, (_, i) => ({ id: `p${i}`, pinned: true }));
+    const { grid, list } = partitionPinned([...pins, { id: 'z' }], { filterAll: true, searching: false });
+    expect(grid).toHaveLength(PINNED_GRID_MAX);
+    expect(list.map((c) => c.id)).toEqual(['p9', 'p10', 'z']);
+  });
+});
+
+describe('pin cap (spec 1044)', () => {
+  it('raises MAX_PINNED_CHATS to 9', () => {
+    expect(MAX_PINNED_CHATS).toBe(9);
+    expect(PINNED_GRID_MAX).toBe(9);
+  });
+});

--- a/src/utils/chat-pins.ts
+++ b/src/utils/chat-pins.ts
@@ -1,0 +1,37 @@
+/**
+ * Pinned-chats grid logic (spec 1044). Pure and dependency-free (imported by both
+ * the data layer and unit tests, like ownsync-keys) — the Chats tab renders pinned
+ * chats as an iMessage-style avatar grid ABOVE the list, and the pinned rows leave
+ * the list while the grid shows them.
+ */
+
+// iMessage parity: at most 9 pinned chats (3 rows of 3). Enforced at pin time by
+// setChatPinned; partitionPinned also clamps defensively because a synced snapshot
+// from another device is applied as-is (the cap gates new pins, not existing data).
+export const MAX_PINNED_CHATS = 9;
+export const PINNED_GRID_MAX = MAX_PINNED_CHATS;
+
+export interface PartitionOpts {
+  /** The "All" chip is active (the grid only shows there). */
+  filterAll: boolean;
+  /** A search query is active (pinned chats must be findable as normal rows). */
+  searching: boolean;
+}
+
+/**
+ * Split a (already filter-applied, pinned-first-ordered) chat array into the grid
+ * and the remaining list rows. Outside the All-chip/empty-search context the grid
+ * is empty and every chat stays a row — search results and filter chips treat
+ * pinned chats like any other chat.
+ */
+export function partitionPinned<T extends { pinned?: boolean }>(
+  chats: T[],
+  opts: PartitionOpts,
+): { grid: T[]; list: T[] } {
+  if (!opts.filterAll || opts.searching) return { grid: [], list: chats };
+  const pinned = chats.filter((c) => c.pinned);
+  const grid = pinned.slice(0, PINNED_GRID_MAX);
+  const overflow = new Set(pinned.slice(PINNED_GRID_MAX));
+  const list = chats.filter((c) => !c.pinned || overflow.has(c));
+  return { grid, list };
+}

--- a/src/views/detail/CallActivePage.vue
+++ b/src/views/detail/CallActivePage.vue
@@ -177,9 +177,12 @@
               <template v-else>
                 <!-- All tiles are MUTED here: remote audio plays through the persistent
                      global CallMediaSink so it survives minimising. The <video> stays
-                     mounted (for video display) even with the camera off; the camera-off
-                     icon just overlays it. -->
+                     MOUNTED even with the camera off (attach/teardown churn is what
+                     causes black flashes) but is HIDDEN then: a detached remote sender
+                     (spec 2029) freezes the element on the peer's last decoded frame,
+                     which would otherwise peek out around the avatar overlay. -->
                 <video
+                  v-show="tileHasVideo(t)"
                   :ref="(el) => attach(el as HTMLVideoElement | null, t.stream)"
                   class="tile-video"
                   :class="{ mirror: t.isSelf && localMirror, 'held-frozen': groupHeldPeers.includes(t.key) }"
@@ -477,7 +480,7 @@ import {
 import router from '@/router';
 import { getSelfUserId } from '@/services/auth';
 import {
-  callState, callMeta, localStream, remoteStream, remoteStreams, groupStreamOwners, activeSpeakers, muted, cameraOff, callStats,
+  callState, callMeta, localStream, remoteStream, remoteStreams, groupStreamOwners, activeSpeakers, muted, cameraOff, remoteVideoMuted, groupVideoMutedPeers, callStats,
   connectionWarning, hangupCall, toggleMute, toggleCamera, cameraFacing, screenSharing,
   switchCamera, toggleScreenShare, toggleVideoMode, canScreenShare, minimizeCall, hasMultipleCameras,
   videoQuality, setVideoQuality, type VideoQuality,
@@ -559,12 +562,22 @@ const mainStream = computed(() => (mainIsLocal.value ? localStream.value : remot
 const pipStream = computed(() => (mainIsLocal.value ? remoteStream.value : localStream.value));
 const isVideoCall = computed(() => callMeta.value?.kind === 'video' && !callMeta.value?.isGroup);
 // A slot shows live video only for a video call, when its stream exists and isn't a
-// camera-off local preview (otherwise we fall back to the avatar / hide the PiP).
+// camera-off local preview — or the PEER's gone-dark video: their camera-off (or an
+// adaptive video pause) detaches their sender, our receiver track mutes, and the slot
+// must fall back to their avatar just like our own preview does (spec 2029).
 const mainHasVideo = computed(
-  () => isVideoCall.value && !!mainStream.value && !(mainIsLocal.value && cameraOff.value),
+  () =>
+    isVideoCall.value &&
+    !!mainStream.value &&
+    !(mainIsLocal.value && cameraOff.value) &&
+    !(!mainIsLocal.value && remoteVideoMuted.value),
 );
 const pipHasVideo = computed(
-  () => isVideoCall.value && !!pipStream.value && !(pipIsLocal.value && cameraOff.value),
+  () =>
+    isVideoCall.value &&
+    !!pipStream.value &&
+    !(pipIsLocal.value && cameraOff.value) &&
+    !(!pipIsLocal.value && remoteVideoMuted.value),
 );
 
 // kind === 'video' for ANY video call (1:1 or group); distinct from isVideoCall, which
@@ -838,12 +851,15 @@ async function openRecall(t: Tile): Promise<void> {
 }
 
 /** Whether a tile is showing live video. When not, we overlay a camera-off icon but
- *  keep the <video> mounted so the participant's AUDIO keeps playing. (A peer's video
- *  track is removed from its stream when they turn the camera off, so the track count
- *  is a reliable signal and recomputes when remoteStreams is rebuilt.) */
+ *  keep the <video> mounted so the participant's AUDIO keeps playing. A remote tile
+ *  goes dark two ways: the track leaves the stream (removeVideoTrack renegotiation —
+ *  the track count catches it), or the peer's sender detaches (camera-off / adaptive
+ *  pause) which only mutes our receiver track — groupVideoMutedPeers carries that
+ *  (mesh-reported, keyed by user id = the tile key; spec 2029). */
 function tileHasVideo(t: Tile): boolean {
   if (t.leaving) return false;
   if (t.isSelf) return !cameraOff.value && !!t.stream?.getVideoTracks().length;
+  if (groupVideoMutedPeers.value.includes(t.key)) return false;
   return !!t.stream && t.stream.getVideoTracks().length > 0;
 }
 

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -4996,12 +4996,20 @@ function cancelRecording() {
    flexbox sized shrink-to-fit, so without the cap a LONG caption's unwrapped
    line — not the photo — set the bubble width (up to the 78% column cap),
    leaving the photo floating against dead bubble background. With it, captions,
-   sender lines, quotes, and the footer all wrap at the photo's edge. min() keeps
-   narrow viewports consistent: media and bubble shrink together. */
+   sender lines, quotes, and the footer all wrap at the photo's edge.
+   A definite `width: 246px` (NOT max-width, NOT min(100%, 246px)) on purpose:
+   only a definite width caps the bubble's INTRINSIC max-content contribution.
+   max-width caps just the used width, and any percentage (even inside min())
+   counts as auto during intrinsic sizing — either way the long caption's
+   unwrapped line inflated the ancestors' shrink-to-fit widths (.swipe-wrap /
+   .bubble-col grew toward the 78% cap), an invisible dead zone that pushed the
+   floating quick-forward button ~100px off the bubble (spec 2028). The separate
+   max-width keeps narrow viewports working: media and bubble shrink together. */
 .bubble-media {
   padding: 3px;
   gap: 0;
-  max-width: min(100%, 246px);
+  width: 246px;
+  max-width: 100%;
 }
 .bubble-media .bubble-image {
   border-radius: 13px;

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -5151,9 +5151,13 @@ function cancelRecording() {
   unicode-bidi: plaintext;
   text-align: start;
 }
-/* Floating quick-forward button beside incoming media/files/links. */
+/* Floating quick-forward button beside incoming media/files/links. Anchored to
+   the message column's BOTTOM edge (next to the caption/footer line) — centered
+   looked fine on short file/link bubbles but floated mid-image beside tall
+   portrait media, visually detached from the message (spec 2028). */
 .fwd-float {
-  align-self: center;
+  align-self: flex-end;
+  margin-block-end: 2px;
   flex: none;
   width: 42px;
   height: 42px;

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -27,7 +27,10 @@
       <ion-refresher slot="fixed" @ion-refresh="onPullRefresh">
         <ion-refresher-content pulling-text="Pull to reconnect &amp; catch up" refreshing-text="Reconnecting…" />
       </ion-refresher>
-      <ion-header collapse="condense">
+      <!-- The iOS large title yields its space to the pinned grid when pins exist
+           (spec 1044): the grid already anchors the page visually, and stacking
+           both pushed the first rows below the fold. -->
+      <ion-header v-if="!(ready && pinParts.grid.length)" collapse="condense">
         <ion-toolbar>
           <ion-title size="large">Chats</ion-title>
         </ion-toolbar>

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -52,8 +52,17 @@
           <ion-label>Hide hidden chats</ion-label>
         </ion-item>
 
+        <!-- Pinned chats: the iMessage-style avatar grid (spec 1044). Gated on
+             `ready` so the fail-closed hidden state can't flash tiles at cold open. -->
+        <PinnedChatsGrid
+          v-if="ready && pinParts.grid.length"
+          :chats="pinParts.grid"
+          @open="open"
+          @more="(c) => actions?.openMore(c)"
+        />
+
         <ChatListItem
-          v-for="chat in chats"
+          v-for="chat in pinParts.list"
           :key="chat.id"
           :chat="chat"
           :draft="draftFor(chat.id)"
@@ -76,7 +85,7 @@
           </ion-label>
         </ion-item>
       </ion-list>
-      <div v-else-if="ready && chats.length === 0" class="empty">
+      <div v-else-if="ready && chats.length === 0 && pinParts.grid.length === 0" class="empty">
         <ion-note>{{ emptyMessage }}</ion-note>
       </div>
 
@@ -178,6 +187,8 @@ import {
   eyeOffOutline,
 } from 'ionicons/icons';
 import ChatListItem from '@/components/ChatListItem.vue';
+import PinnedChatsGrid from '@/components/PinnedChatsGrid.vue';
+import { partitionPinned } from '@/utils/chat-pins';
 import ChatActionsHost from '@/components/ChatActionsHost.vue';
 import ChatFilterBar from '@/components/ChatFilterBar.vue';
 import ChatListsSheet from '@/components/ChatListsSheet.vue';
@@ -245,6 +256,13 @@ const { chats, activeFilter, setActive, chips, lists, tabFilters, allChats, load
 const ready = ref(false);
 watch(isUnlocked, (u) => { if (!u) ready.value = false; });
 watch(allChats, () => { if (isUnlocked.value) ready.value = true; }, { immediate: true });
+// Pinned grid vs list rows (spec 1044): on the All chip with no search, pinned chats
+// render as the avatar grid and LEAVE the list; searching or any other chip shows
+// everything as plain rows so pins stay findable. `chats` is already pinned-first
+// and hidden-fail-closed, so the grid inherits both.
+const pinParts = computed(() =>
+  partitionPinned(chats.value, { filterAll: activeFilter.value === 'all', searching: !!search.value.trim() }),
+);
 const listsSheetOpen = ref(false);
 const editTabsOpen = ref(false);
 const newListOpen = ref(false);


### PR DESCRIPTION
Combines three independently-spec'd changes (specs 2029, 2028, 1044) into one reviewable batch, per plan — the direct-media work (spec 1043) follows in its own PR so it stays independently revertible.

## What's in here

**Camera off shows your picture, not a black screen (spec 2029, hotfix)**
- Turning the camera off now truly stops sending video: the outgoing track detaches on the 1:1 connection and every group leg (upload drops to ~0 while off).
- A sealed `camoff`/`camon` signal rides the existing E2EE call channel (hold/resume pattern) so every peer's tile swaps to your avatar instantly, on every browser — receiver-track mute proved too browser-dependent to carry this alone (real devices keep the track "live" while receiving black frames; that WAS the bug). Track-mute listeners remain as fallback for older senders.
- Adaptation, camera flip, hold/resume, and screen share all honor the toggle (ownership guards both sides); also fixes the pre-existing dark tile when adaptive quality pauses a participant's video at tier 'off'.
- Zero-knowledge: no new frame type; the relay cannot tell a camera toggle from an ICE candidate.

**Forward button anchored to the media (spec 2028, hotfix)**
- The floating quick-forward button was vertically centered (mid-image on tall photos) and — with long captions — pushed ~100px off the bubble horizontally, because a caption's unwrapped line inflates the flex column's intrinsic width (max-width/percentages don't cap intrinsic sizing). Bottom-anchored + definite media-frame width; spec 2027's caption wrapping is unchanged (its suite still passes).

**Pinned chats grid, iMessage-style (spec 1044, ad-hoc)**
- Pinned chats render as a 3-per-row grid of 88px avatars (up to 9, cap raised from 3) above the list; pinned rows leave the list while gridded; search/filters show them as normal rows.
- Tap opens the chat; long-press opens the actions sheet, which gains Pin/Unpin (swipe can't reach gridded chats). The large iOS "Chats" title steps aside when the grid shows.
- Hidden chats stay concealed everywhere (grid inherits the fail-closed filter; e2e-asserted). Pin state syncs as before (existing chats-store field; no wire change).

Also riding along: `chore(dev)` — *(in the 1043 PR instead)*.

## Tests
- Red-first throughout: `turn.test.ts`-style vitest additions (`chat-pins.test.ts`, schema/own-sync guards), new e2e suites `camera-off-avatar.spec.ts`, `forward-button-position.spec.ts` (bottom + horizontal geometry), `pinned-grid.spec.ts` (grid/list partition, tile tap, long-press sheet, search, hidden interplay).
- Full local gates green: `npm run build`, 992 vitest, targeted e2e ×9; verified together with spec 1043 on an integration branch (build + 1000 vitest + 11 e2e).
- Real-device verification by @zuptalo on iPhone (screenshots in session): forward button beside captioned photos, camera-off avatar swap 1:1 + group, pinned grid.

Closes #961
Closes #962
Closes #963
Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7