### PR TITLE
feat(calls): calls connect directly when possible for lower delay and better quality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1041-merge-waiting-caller/plan.md`
+`specs/1043-direct-peer-peer/plan.md`
 <!-- SPECKIT END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ One repo, two parts, shipped as a single container.
     `usePresence`, `useTheme`, `useLiveQuery`, etc.). Reactive app state lives here.
   - `src/services/` — non-UI logic: `api.ts` (HTTP), `messaging.ts` (1:1 E2EE
     orchestration), `crypto/` (X3DH + Double Ratchet + sender keys, libsodium),
-    `call/` (WebRTC: signalling, SFU, TURN, insertable-streams E2EE), media
+    `call/` (WebRTC: signalling, mesh, TURN, adaptive quality), media
     encode/transfer, push/notifications, sync.
   - `src/db/` — IndexedDB layer. `idb.ts` is a tiny promise wrapper with a
     change-notification bus; `queries.ts` is the data-layer orchestration that
@@ -41,16 +41,17 @@ One repo, two parts, shipped as a single container.
   - `src/router/index.ts` — routes + the auth gate.
 - **Server** (`server/`) — `ringd`, a Go 1.26 service on stdlib `net/http`
   (no web framework), PostgreSQL via `pgx` v5, embedded SQL migrations, an
-  embedded TURN relay + SFU for calls, and VAPID Web Push.
+  embedded TURN relay for calls (media goes peer-to-peer direct when networks
+  allow, relayed otherwise — no SFU), and VAPID Web Push.
   - `cmd/ringd/main.go` — entrypoint: config → pool → migrate → secrets → ACME
-    → TURN/SFU → router → listeners → graceful shutdown.
+    → TURN → router → listeners → graceful shutdown.
   - `internal/api/` — routing (`router.go`) + handlers (one file per area,
     each with a `_test.go`).
   - `internal/store/` — PostgreSQL repositories (one file per domain).
   - `internal/db/migrations/` — embedded, numbered SQL migrations (`NNNN_*.sql`).
   - `internal/{auth,config,httpx,push,secrets,ws,turn,sfu,call,acme}/` — auth
     tokens, env config, HTTP middleware, push, encrypted-at-rest secrets,
-    WebSocket hub, TURN, SFU, call registry, ACME cache.
+    WebSocket hub, TURN, call registry, ACME cache.
 - **`e2e/`** — Playwright multi-browser tests (real WebRTC between accounts).
 - **`server/docs/CALLING.md`** — the full calling/TLS deployment recipe.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ Specs are grouped by category band; status moves
 | [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟢 shipped |
 | [1041](specs/1041-merge-waiting-caller/spec.md) | Merge a Waiting Caller into the Ongoing Call | 🟢 shipped |
 | [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
-| [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | ⚪ planned |
+| [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,6 +68,7 @@ Specs are grouped by category band; status moves
 | [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟢 shipped |
 | [1041](specs/1041-merge-waiting-caller/spec.md) | Merge a Waiting Caller into the Ongoing Call | 🟢 shipped |
 | [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
+| [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ Specs are grouped by category band; status moves
 | [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟢 shipped |
 | [1041](specs/1041-merge-waiting-caller/spec.md) | Merge a Waiting Caller into the Ongoing Call | 🟢 shipped |
 | [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
-| [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | 🟡 in-progress |
+| [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/probe-call-path.mjs
+++ b/drive/scenarios/probe-call-path.mjs
@@ -1,0 +1,110 @@
+// Probe (spec 1043): which ICE path a 1:1 call actually selects.
+// Two same-machine users should connect DIRECT (host↔host) now that the client
+// gathers with iceTransportPolicy 'all'; flipping privacy.relayCalls on one side
+// must force that user's leg back onto the TURN relay. RTCPeerConnection is
+// wrapped before app load so the scenario can read getStats() — the app itself
+// deliberately exposes no candidate detail (data minimization).
+import { newClient, pair, poll, sweep, done } from '../driver.mjs';
+
+const hook = (c, expr) => c.page.evaluate(expr);
+
+// createAccount, but with the PC-capture init script installed pre-navigation.
+async function accountWithPcCapture(name, label) {
+  const c = await newClient({ label });
+  await c.ctx.addInitScript(() => {
+    const Native = window.RTCPeerConnection;
+    window.__pcs = [];
+    window.RTCPeerConnection = class extends Native {
+      constructor(...args) {
+        super(...args);
+        window.__pcs.push(this);
+      }
+    };
+  });
+  await c.page.goto('/');
+  await c.page.waitForFunction(() => !!window.__ringTest, null, { timeout: 30_000 });
+  await c.page.evaluate(async (nm) => {
+    const t = window.__ringTest;
+    const code = await t.freshCode();
+    await t.register(code);
+    await t.createAuto();
+    if (nm) await t.setProfile(nm, 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>');
+  }, name);
+  await poll(() => c.page.evaluate(() => window.__ringTest.isUnlocked()), (v) => v === true, { label: `${label} unlocked` });
+  c.id = await c.page.evaluate(() => window.__ringTest.selfId());
+  console.log(`[${label}] registered ${c.id}`);
+  return c;
+}
+
+async function waitState(c, states, timeout = 40_000) {
+  await poll(
+    () => hook(c, () => window.__ringTest.callState()),
+    (s) => states.includes(s),
+    { timeout, label: `state ${states}` },
+  );
+}
+
+// The selected candidate pair of the newest PC: {policy, local, remote} types.
+const selectedPair = (c) =>
+  c.page.evaluate(async () => {
+    const pc = window.__pcs.at(-1);
+    if (!pc) return null;
+    const stats = await pc.getStats();
+    let pair = null;
+    stats.forEach((s) => {
+      if (s.type === 'transport' && s.selectedCandidatePairId) pair = stats.get(s.selectedCandidatePairId);
+    });
+    if (!pair) stats.forEach((s) => {
+      if (s.type === 'candidate-pair' && s.state === 'succeeded' && s.nominated) pair = s;
+    });
+    if (!pair) return { policy: pc.getConfiguration().iceTransportPolicy, local: null, remote: null };
+    return {
+      policy: pc.getConfiguration().iceTransportPolicy,
+      local: stats.get(pair.localCandidateId)?.candidateType ?? null,
+      remote: stats.get(pair.remoteCandidateId)?.candidateType ?? null,
+    };
+  });
+
+async function call(a, b) {
+  await a.page.evaluate((peer) => window.__ringTest.startCall(peer, 'audio'), b.id);
+  await waitState(b, ['incoming']);
+  await hook(b, () => window.__ringTest.accept());
+  await waitState(a, ['connected']);
+  await waitState(b, ['connected']);
+  // Give ICE a beat to settle on its final pair before reading stats.
+  await new Promise((r) => setTimeout(r, 2000));
+}
+async function hangup(a, b) {
+  await hook(a, () => window.__ringTest.hangup());
+  await waitState(a, ['idle'], 15_000);
+  await waitState(b, ['idle'], 15_000);
+}
+
+const a = await accountWithPcCapture('PathA', 'A');
+const b = await accountWithPcCapture('PathB', 'B');
+await pair(a, b);
+
+// --- default: direct expected (host/prflx on both sides) ---
+await call(a, b);
+const dA = await selectedPair(a);
+const dB = await selectedPair(b);
+console.log(`[default] A policy=${dA.policy} pair=${dA.local}↔${dA.remote}`);
+console.log(`[default] B policy=${dB.policy} pair=${dB.local}↔${dB.remote}`);
+await hangup(a, b);
+const direct = (p) => p.policy === 'all' && ['host', 'prflx'].includes(p.local ?? '');
+if (!direct(dA) || !direct(dB)) throw new Error('expected DIRECT (host/prflx) pair with policy "all" on both sides');
+
+// --- privacy.relayCalls on A: relay expected on A's side ---
+await hook(a, () => window.__ringTest.setSetting('privacy.relayCalls', true));
+await call(a, b);
+const rA = await selectedPair(a);
+const rB = await selectedPair(b);
+console.log(`[relayCalls] A policy=${rA.policy} pair=${rA.local}↔${rA.remote}`);
+console.log(`[relayCalls] B policy=${rB.policy} pair=${rB.local}↔${rB.remote}`);
+await hangup(a, b);
+if (rA.policy !== 'relay' || rA.local !== 'relay') throw new Error('expected A relay-only (policy "relay", local relay candidate)');
+if (rB.remote !== 'relay') throw new Error("expected B's selected remote candidate to be A's relay");
+
+console.log('PROBE PASS: direct by default, relay when privacy.relayCalls is on');
+await sweep([a, b]);
+await done();

--- a/e2e/calls.spec.ts
+++ b/e2e/calls.spec.ts
@@ -2,9 +2,10 @@ import { test, expect } from '@playwright/test';
 import { createAccount, pair, startCall, accept, hangup, waitCallState, remoteTracks } from './helpers';
 
 /**
- * 1:1 call verification against the real, E2EE signalling + DTLS-SRTP path,
- * relayed through the embedded TURN. This both proves 1:1 calling works AND
- * validates the multi-client harness before it's used for group (SFU) calls.
+ * 1:1 call verification against the real, E2EE signalling + DTLS-SRTP path.
+ * Since spec 1043 media goes direct when it can (same-host browsers pick host
+ * candidates) with the embedded TURN as fallback. This both proves 1:1 calling
+ * works AND validates the multi-client harness before the group (mesh) specs.
  */
 test('1:1 audio call connects end-to-end and both sides receive media', async ({ browser }) => {
   const ctxA = await browser.newContext();

--- a/server/cmd/ringd/main.go
+++ b/server/cmd/ringd/main.go
@@ -318,13 +318,14 @@ func run() error {
 	// Embedded TURN/STUN relay for WebRTC calls. Media is relayed opaquely (the
 	// server never sees DTLS keys). In dev it runs plaintext on TurnListen; in
 	// prod it terminates TLS (TURNS) for the SNI host the L4 proxy routes to us.
-	var turnURLs []string
+	var turnURLs, stunURLs []string
 	if cfg.EnableCalls {
 		turnCfg := turnpkg.Config{
 			Realm:        cfg.TurnRealm,
 			RelayIP:      cfg.RelayIP,
 			ListenAddr:   cfg.TurnListen,
 			SharedSecret: secs.TurnSharedSecret,
+			UDPListen:    cfg.TurnUDPListen,
 		}
 		// TURNS over TLS: static cert files win if set; else autocert (the listener
 		// also answers TLS-ALPN-01 challenges); else nil leaves it plaintext (dev).
@@ -361,6 +362,15 @@ func run() error {
 			host := firstNonEmpty(cfg.TurnPublicHost, cfg.TurnHost)
 			port := firstNonEmpty(cfg.TurnPublicPort, "443")
 			turnURLs = []string{fmt.Sprintf("turns:%s:%s?transport=tcp", host, port)}
+			// Operator-opt-in UDP endpoint (spec 1043): advertise STUN for
+			// public-address discovery (direct call paths) and TURN-over-UDP as a
+			// lower-latency relay fallback. Both ride the extra UDP listener; the
+			// STUN entry is credential-less (Binding is unauthenticated).
+			if cfg.TurnUDPListen != "" {
+				turnURLs = append(turnURLs,
+					fmt.Sprintf("turn:%s:%s?transport=udp", cfg.StunPublicHost, cfg.StunPublicPort))
+				stunURLs = []string{fmt.Sprintf("stun:%s:%s", cfg.StunPublicHost, cfg.StunPublicPort)}
+			}
 		} else {
 			host := firstNonEmpty(cfg.TurnPublicHost, cfg.RelayIP, "127.0.0.1")
 			port := firstNonEmpty(cfg.TurnPublicPort, strings.TrimPrefix(cfg.TurnListen, ":"))
@@ -371,9 +381,10 @@ func run() error {
 			}
 		}
 		slog.Info("TURN relay ready", "listen", cfg.TurnListen, "realm", cfg.TurnRealm,
-			"urls", turnURLs, "tls", turnCfg.TLSConfig != nil)
-		// Group calls are peer-to-peer mesh (native DTLS-SRTP per leg) and ride this same
-		// TURN; there is no server-side SFU. See server/docs/CALLING.md.
+			"urls", turnURLs, "stun", stunURLs, "tls", turnCfg.TLSConfig != nil)
+		// Calls are peer-to-peer (1:1 and mesh legs alike, native DTLS-SRTP):
+		// direct when the networks allow it, through this TURN otherwise. There
+		// is no server-side SFU. See server/docs/CALLING.md.
 	}
 
 	handler := api.NewRouter(&api.Handlers{
@@ -383,7 +394,7 @@ func run() error {
 		Version:      version,
 		ReleaseNotes: decodeReleaseNotes(releaseNotesB64),
 		CallsEnabled: cfg.EnableCalls, TurnSharedSecret: secs.TurnSharedSecret,
-		TurnURLs:      turnURLs,
+		TurnURLs: turnURLs, StunURLs: stunURLs,
 		Emoji:     st,
 		StaticDir: cfg.StaticDir,
 		// Dev-only hot-reload proxy: forward the app + HMR socket to the Vite dev

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   db:
     image: postgres:18
+    # Survive Docker-engine/VM restarts (e.g. OrbStack resource changes restart
+    # the whole VM): without this, dev Postgres stays dead until a manual
+    # `make db-up`, silently breaking the dev stack and any running e2e suite.
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ring
       POSTGRES_PASSWORD: ring

--- a/server/docs/CALLING.md
+++ b/server/docs/CALLING.md
@@ -28,15 +28,23 @@ solves this by sending **all** call media over **TURN-over-TLS (TURNS) on 443**:
               (app + /v1 API)          internal :3478
 ```
 
-- **1:1 calls** are peer-to-peer (DTLS-SRTP, natively E2EE); media is relayed
-  through the TURN only when a direct path is blocked.
+- **1:1 calls** are peer-to-peer (DTLS-SRTP, natively E2EE). Media flows
+  **directly between the two devices whenever the networks allow it** — same-LAN
+  peers connect via (mDNS-masked) local candidates with no server involvement,
+  and cross-network peers connect directly when the optional UDP endpoint below
+  is enabled and both NATs cooperate. The TURN relay stays in every candidate
+  set as the automatic fallback, so a blocked direct path never costs a call.
 - **Group calls** are a **full mesh**: each participant holds one direct,
   DTLS-SRTP-encrypted connection to every other participant (N simultaneous 1:1
-  calls), all riding the same TURN. There is no SFU and no server-side media; the
-  server only relays sealed signalling and tracks room membership. Because media is
-  native DTLS-SRTP, group calls work in **every** browser (including Safari/iOS) and
-  the codec is whatever the pair negotiates (e.g. hardware H.264). Mesh uplink grows
-  with participant count, so group calls are capped at **4 (video) / 8 (audio)**.
+  calls); each leg independently goes direct or falls back to the same TURN.
+  There is no SFU and no server-side media; the server only relays sealed
+  signalling and tracks room membership. Because media is native DTLS-SRTP,
+  group calls work in **every** browser (including Safari/iOS) and the codec is
+  whatever the pair negotiates (e.g. hardware H.264). Mesh uplink grows with
+  participant count, so group calls are capped at **4 (video) / 8 (audio)**.
+- Users who don't want call peers to ever see their IP address can switch on
+  **Settings → Privacy → Always relay calls**, which forces their media through
+  the relay (the pre-spec-1043 behavior, per user).
 
 Because TURNS is TLS, it carries an **SNI** the L4 router can switch on. The
 router must do **SNI-based TLS passthrough**: forward `turn.<host>:443` to
@@ -151,6 +159,54 @@ On boot you'll see:
 ```
 INFO TURN relay ready   listen=:3478 ... url="turns:turn.ring-dev.zuptalo.com:443?transport=tcp" tls=true
 ```
+
+---
+
+## 2b. Direct media paths (optional UDP endpoint)
+
+Out of the box, calls already connect **directly on the same network** (mDNS
+host candidates need no server support) and relay everything else through
+TURNS:443. To let calls between *different* networks connect directly too —
+cutting the server's media bandwidth to zero for those calls and shaving the
+double-hop latency — expose one UDP port:
+
+```bash
+TURN_UDP_LISTEN=:3478          # opens a plaintext UDP listener next to the TLS one
+# STUN_PUBLIC_HOST=turn.ring-dev.zuptalo.com   # default: TURN_PUBLIC_HOST/TURN_HOST
+# STUN_PUBLIC_PORT=3478                        # default: TURN_UDP_LISTEN's port
+```
+
+and forward `3478/udp` (or your chosen port) from the public edge to ringd.
+The credentials endpoint then advertises two extra entries:
+
+- `stun:<host>:3478` — credential-less address discovery (STUN Binding), which
+  is what lets clients learn their public address and try direct candidate pairs;
+- `turn:<host>:3478?transport=udp` — the same relay over UDP, a lower-latency
+  fallback than TURNS-over-TCP when UDP is reachable (same ephemeral credentials).
+
+What each exposure level buys:
+
+| Deployment | Same-LAN calls | Cross-network calls |
+|---|---|---|
+| nothing new (default) | direct | relayed via TURNS:443 (as before spec 1043) |
+| `TURN_UDP_LISTEN` + UDP port forwarded | direct | direct when both NATs allow; relayed otherwise |
+
+Notes:
+
+- **Zero-change safety**: without `TURN_UDP_LISTEN`, no listener starts and no
+  port opens; upgrading ringd changes nothing about your network posture.
+- **Forgot the firewall?** Clients simply never find a working direct pair and
+  fall back to the relay — calls keep working, you just don't get the benefit.
+- **Censorship trade-off**: STUN/TURN over UDP is protocol-fingerprintable in a
+  way TURNS-on-443 (indistinguishable from HTTPS) is not. In censored networks
+  the UDP path may be dropped; the client falls back to TURNS:443 automatically,
+  so enabling UDP never makes things worse than today.
+- **`RELAY_IP` (optional tuning)**: with the default loopback `RELAY_IP`, relay
+  allocations are only reachable via the co-located relay itself, so *mixed*
+  pairs (one side direct-capable, the other relay-only) show failed checks in
+  `webrtc-internals` — harmless, relay↔relay still connects. Operators who
+  expose UDP may set `RELAY_IP` to the server's public IP to let one-sided
+  relay pairs connect too.
 
 ---
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -169,11 +169,15 @@ type Handlers struct {
 	// GET /v1/config so clients can pre-validate before encrypting + uploading.
 	MaxBlobBytes int
 	// Calling (WebRTC). CallsEnabled gates GET /v1/turn-credentials; TurnSharedSecret
-	// mints ephemeral TURN credentials; TurnURL is the actual reachable relay URL
-	// advertised to clients (turns:<host>:443 in prod, turn:<ip>:<port> in dev).
+	// mints ephemeral TURN credentials; TurnURLs are the actually-reachable relay
+	// URLs advertised to clients (turns:<host>:443 in prod, turn:<ip>:<port> in
+	// dev). StunURLs, when the operator opted into the UDP endpoint, are the
+	// credential-less stun: entries clients use to discover their public address
+	// for direct call paths (spec 1043).
 	CallsEnabled     bool
 	TurnSharedSecret string
 	TurnURLs         []string
+	StunURLs         []string
 	// Postgres-backed cache for the self-hosted Noto emoji proxy (GET /v1/emoji/...).
 	Emoji EmojiStore
 	// RequireConnection enables the server-enforced connect-request gate: fetching a

--- a/server/internal/api/turn_handlers.go
+++ b/server/internal/api/turn_handlers.go
@@ -19,8 +19,12 @@ const turnCredTTL = time.Hour
 // time-windowed (coturn REST scheme) and minted from the same shared secret the
 // embedded relay validates with, so no per-credential server state is needed.
 //
-// All media rides TURNS on 443 (the only public path), so a single iceServers
-// entry is returned; the client forces iceTransportPolicy:'relay'.
+// Media goes direct when the networks allow it (the client gathers with
+// iceTransportPolicy:'all') and falls back to the relay otherwise. The
+// credentialed entry always carries the TURNS-on-443 relay; when the operator
+// opted into the UDP endpoint it also lists TURN-over-UDP, and a second,
+// credential-less stun: entry is appended for public-address discovery. The
+// response shape is stable — old clients simply ignore the extra entry.
 func (h *Handlers) turnCredentials(w http.ResponseWriter, r *http.Request) {
 	if !h.CallsEnabled {
 		httpx.Error(w, http.StatusServiceUnavailable, "calling is not enabled on this server")
@@ -38,15 +42,21 @@ func (h *Handlers) turnCredentials(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	iceServers := []map[string]any{{
+		// The actual reachable relay URL(s): turns:<host>:443 (TLS, always), plus
+		// turn:<host>:<port>?transport=udp when the UDP endpoint is on; or
+		// plaintext turn:<host>:<port> per advertised transport in dev.
+		"urls":       h.TurnURLs,
+		"username":   username,
+		"credential": password,
+	}}
+	// Credential-less STUN advertisement (STUN Binding is unauthenticated
+	// address discovery); present only when the operator opened the UDP port.
+	if len(h.StunURLs) > 0 {
+		iceServers = append(iceServers, map[string]any{"urls": h.StunURLs})
+	}
 	httpx.JSON(w, http.StatusOK, map[string]any{
-		"iceServers": []map[string]any{{
-			// The actual reachable relay URL(s): turns:<host>:443 (TLS), or
-			// plaintext turn:<host>:<port> with one entry per advertised
-			// transport (UDP preferred, TCP fallback).
-			"urls":       h.TurnURLs,
-			"username":   username,
-			"credential": password,
-		}},
-		"ttl": int(turnCredTTL.Seconds()),
+		"iceServers": iceServers,
+		"ttl":        int(turnCredTTL.Seconds()),
 	})
 }

--- a/server/internal/api/turn_handlers_test.go
+++ b/server/internal/api/turn_handlers_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// newTestServerWithTurn builds a router with calling enabled and the given
+// optional stun advertisement — the two knobs turnCredentials cares about.
+func newTestServerWithTurn(stunURLs []string) http.Handler {
+	as := newFakeStore()
+	return NewRouter(&Handlers{
+		Store:            as,
+		Directory:        as,
+		Contacts:         as,
+		Blocks:           as,
+		Relay:            as,
+		Hub:              nil,
+		Keys:             newFakeKeysStore(),
+		Blobs:            newFakeBlobStore(),
+		Sync:             newFakeSyncStore(),
+		Push:             newFakePushStore(),
+		Invites:          as,
+		PublicURL:        "https://ring.example",
+		CallsEnabled:     true,
+		TurnSharedSecret: "test-shared-secret",
+		TurnURLs:         []string{"turns:ring.example:443?transport=tcp"},
+		StunURLs:         stunURLs,
+	}, []string{"http://localhost:5173"})
+}
+
+// iceServerEntry mirrors one iceServers element loosely so tests can assert
+// which keys are present (the stun entry must carry no credentials at all).
+type iceServerEntry map[string]any
+
+func decodeTurnResponse(t *testing.T, body []byte) (entries []iceServerEntry, ttl int) {
+	t.Helper()
+	var resp struct {
+		IceServers []iceServerEntry `json:"iceServers"`
+		TTL        int              `json:"ttl"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	return resp.IceServers, resp.TTL
+}
+
+func TestTurnCredentialsDisabled(t *testing.T) {
+	srv := newTestServer() // CallsEnabled defaults to false
+	token, _ := registerUser(t, srv)
+	rr := do(t, srv, http.MethodGet, "/v1/turn-credentials", token, "")
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rr.Code)
+	}
+}
+
+func TestTurnCredentialsUnauthenticated(t *testing.T) {
+	srv := newTestServerWithTurn(nil)
+	rr := do(t, srv, http.MethodGet, "/v1/turn-credentials", "", "")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestTurnCredentialsTurnOnly(t *testing.T) {
+	srv := newTestServerWithTurn(nil)
+	token, _ := registerUser(t, srv)
+	rr := do(t, srv, http.MethodGet, "/v1/turn-credentials", token, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	entries, ttl := decodeTurnResponse(t, rr.Body.Bytes())
+	if ttl != 3600 {
+		t.Fatalf("ttl = %d, want 3600", ttl)
+	}
+	// Without a configured stun advertisement the response keeps its historic
+	// shape: exactly one credentialed relay entry (old-client compatibility).
+	if len(entries) != 1 {
+		t.Fatalf("iceServers count = %d, want 1 (%v)", len(entries), entries)
+	}
+	cred := entries[0]
+	if u, _ := cred["username"].(string); u == "" {
+		t.Fatalf("credentialed entry missing username: %v", cred)
+	}
+	if c, _ := cred["credential"].(string); c == "" {
+		t.Fatalf("credentialed entry missing credential: %v", cred)
+	}
+}
+
+func TestTurnCredentialsWithStun(t *testing.T) {
+	srv := newTestServerWithTurn([]string{"stun:ring.example:3478"})
+	token, _ := registerUser(t, srv)
+	rr := do(t, srv, http.MethodGet, "/v1/turn-credentials", token, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	entries, _ := decodeTurnResponse(t, rr.Body.Bytes())
+	if len(entries) != 2 {
+		t.Fatalf("iceServers count = %d, want 2 (%v)", len(entries), entries)
+	}
+	// First entry: the credentialed relay, unchanged.
+	cred := entries[0]
+	if u, _ := cred["username"].(string); u == "" {
+		t.Fatalf("credentialed entry missing username: %v", cred)
+	}
+	// Second entry: the stun advertisement — urls only, NO credentials (STUN
+	// Binding is unauthenticated address discovery).
+	stun := entries[1]
+	urls, ok := stun["urls"].([]any)
+	if !ok || len(urls) != 1 || urls[0] != "stun:ring.example:3478" {
+		t.Fatalf("stun urls = %v, want [stun:ring.example:3478]", stun["urls"])
+	}
+	if _, has := stun["username"]; has {
+		t.Fatalf("stun entry must not carry a username: %v", stun)
+	}
+	if _, has := stun["credential"]; has {
+		t.Fatalf("stun entry must not carry a credential: %v", stun)
+	}
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strconv"
@@ -59,9 +60,11 @@ type Config struct {
 	RequireConnection bool
 
 	// --- Calling (WebRTC) ---
-	// EnableCalls turns on the embedded TURN relay + SFU. Off unless explicitly
-	// enabled in prod (calls need a public relay IP and a TLS cert); on by
-	// default in dev so the signalling/credentials path can be exercised.
+	// EnableCalls turns on the embedded TURN relay. Calls are peer-to-peer
+	// (direct when the networks allow it, relayed otherwise); there is no
+	// server-side media component. Off unless explicitly enabled in prod (calls
+	// need a public relay IP and a TLS cert); on by default in dev so the
+	// signalling/credentials path can be exercised.
 	EnableCalls bool
 	// TurnRealm is the TURN authentication realm (defaults to PublicURL's host).
 	TurnRealm string
@@ -93,6 +96,20 @@ type Config struct {
 	// unless Acme is on (autocert provisions the cert instead).
 	TurnTLSCert string
 	TurnTLSKey  string
+	// TurnUDPListen (TURN_UDP_LISTEN, e.g. ":3478") opens an ADDITIONAL plaintext
+	// UDP listener in TLS mode, serving STUN Binding (public-address discovery
+	// for direct call paths, spec 1043) and TURN-over-UDP with the same ephemeral
+	// credentials. Operator opt-in: empty (the default) opens no listener and no
+	// port, so upgrading changes nothing until the operator asks for it. The
+	// deployment must forward the matching public UDP port. Ignored in plaintext
+	// (dev) mode, which already listens on UDP.
+	TurnUDPListen string
+	// StunPublicHost / StunPublicPort are the publicly reachable host:port
+	// advertised to clients as the stun:/turn-udp endpoint when TurnUDPListen is
+	// set. Host defaults to the advertised TURN host (TurnPublicHost or
+	// TurnHost); port defaults to TurnUDPListen's port.
+	StunPublicHost string
+	StunPublicPort string
 
 	// --- Built-in TLS (ACME / Let's Encrypt) ---
 	// Acme (ACME=true) makes ringd provision + renew its own TLS certs via autocert
@@ -149,6 +166,9 @@ func Load() (Config, error) {
 		TurnPublicTransport: env("TURN_PUBLIC_TRANSPORT", "udp"),
 		TurnTLSCert:         os.Getenv("TURN_TLS_CERT"),
 		TurnTLSKey:          os.Getenv("TURN_TLS_KEY"),
+		TurnUDPListen:       os.Getenv("TURN_UDP_LISTEN"),
+		StunPublicHost:      os.Getenv("STUN_PUBLIC_HOST"),
+		StunPublicPort:      os.Getenv("STUN_PUBLIC_PORT"),
 		Acme:                envBool("ACME", false),
 		AcmeEmail:           os.Getenv("ACME_EMAIL"),
 		AcmeDirectoryURL:    os.Getenv("ACME_DIRECTORY_URL"),
@@ -216,8 +236,36 @@ func Load() (Config, error) {
 				"automatic certs, or ENABLE_CALLS=false")
 	}
 
+	// The optional UDP endpoint (direct call paths, spec 1043) must be a
+	// bindable host:port; derive the advertised port from it when unset. Fail
+	// fast on a malformed value (consistent with the cert check above) rather
+	// than booting with a listener that silently never opened.
+	if c.TurnUDPListen != "" {
+		_, port, err := net.SplitHostPort(c.TurnUDPListen)
+		if err != nil || port == "" {
+			return Config{}, fmt.Errorf(
+				"invalid TURN_UDP_LISTEN %q: want a bind address like \":3478\"", c.TurnUDPListen)
+		}
+		if c.StunPublicPort == "" {
+			c.StunPublicPort = port
+		}
+		if c.StunPublicHost == "" {
+			c.StunPublicHost = firstNonEmptyStr(c.TurnPublicHost, c.TurnHost)
+		}
+	}
+
 	c.VapidSubject = env("VAPID_SUBJECT", defaultVapidSubject(c.PublicURL))
 	return c, nil
+}
+
+// firstNonEmptyStr returns the first non-empty string (config derivation helper).
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // defaultVapidSubject builds a mailto: from PUBLIC_URL's host (Apple Web Push

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -89,3 +89,95 @@ func TestProdCallsWithAcmeOK(t *testing.T) {
 		t.Fatalf("acme config not populated: %+v", c)
 	}
 }
+
+/* ---- optional UDP endpoint for direct call paths (spec 1043) ---- */
+
+func TestTurnUDPListenDerivesStunDefaults(t *testing.T) {
+	t.Setenv("ENV", "dev")
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PUBLIC_URL", "https://ring.example")
+	t.Setenv("TURN_UDP_LISTEN", ":3478")
+	t.Setenv("STUN_PUBLIC_HOST", "")
+	t.Setenv("STUN_PUBLIC_PORT", "")
+	t.Setenv("TURN_PUBLIC_HOST", "")
+	t.Setenv("TURN_HOST", "")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.TurnUDPListen != ":3478" {
+		t.Fatalf("TurnUDPListen = %q", c.TurnUDPListen)
+	}
+	// Port defaults from the listen address; host from the derived TURN host
+	// (turn.<PUBLIC_URL host> when nothing more specific is set).
+	if c.StunPublicPort != "3478" {
+		t.Fatalf("StunPublicPort = %q, want 3478", c.StunPublicPort)
+	}
+	if c.StunPublicHost != "turn.ring.example" {
+		t.Fatalf("StunPublicHost = %q, want turn.ring.example", c.StunPublicHost)
+	}
+}
+
+func TestTurnUDPListenExplicitStunOverrides(t *testing.T) {
+	t.Setenv("ENV", "dev")
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PUBLIC_URL", "https://ring.example")
+	t.Setenv("TURN_UDP_LISTEN", "0.0.0.0:3999")
+	t.Setenv("STUN_PUBLIC_HOST", "media.ring.example")
+	t.Setenv("STUN_PUBLIC_PORT", "443")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.StunPublicHost != "media.ring.example" || c.StunPublicPort != "443" {
+		t.Fatalf("explicit stun advertisement not honored: %+v", c)
+	}
+}
+
+func TestTurnUDPListenPrefersTurnPublicHost(t *testing.T) {
+	t.Setenv("ENV", "dev")
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PUBLIC_URL", "https://ring.example")
+	t.Setenv("TURN_UDP_LISTEN", ":3478")
+	t.Setenv("TURN_PUBLIC_HOST", "edge.ring.example")
+	t.Setenv("STUN_PUBLIC_HOST", "")
+	t.Setenv("STUN_PUBLIC_PORT", "")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.StunPublicHost != "edge.ring.example" {
+		t.Fatalf("StunPublicHost = %q, want edge.ring.example (TURN_PUBLIC_HOST wins)", c.StunPublicHost)
+	}
+}
+
+func TestTurnUDPListenInvalidFailsFast(t *testing.T) {
+	t.Setenv("ENV", "dev")
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PUBLIC_URL", "https://ring.example")
+	t.Setenv("TURN_UDP_LISTEN", "not-a-bind-address")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("an unparseable TURN_UDP_LISTEN must fail fast (a listener that silently never opened)")
+	}
+}
+
+func TestNoTurnUDPListenLeavesStunUnset(t *testing.T) {
+	t.Setenv("ENV", "dev")
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PUBLIC_URL", "https://ring.example")
+	t.Setenv("TURN_UDP_LISTEN", "")
+	t.Setenv("STUN_PUBLIC_HOST", "")
+	t.Setenv("STUN_PUBLIC_PORT", "")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.TurnUDPListen != "" || c.StunPublicHost != "" || c.StunPublicPort != "" {
+		t.Fatalf("zero-config deployment must not grow stun settings: %+v", c)
+	}
+}

--- a/server/internal/turn/server.go
+++ b/server/internal/turn/server.go
@@ -36,6 +36,14 @@ type Config struct {
 	// answers ACME TLS-ALPN-01 challenges). When nil (dev), a plaintext UDP + TCP
 	// relay is started instead so local browsers can reach it.
 	TLSConfig *tls.Config
+	// UDPListen, when non-empty in TLS mode, additionally opens a plaintext UDP
+	// listener (e.g. ":3478"). pion answers STUN Binding on it - the
+	// public-address discovery that lets calls connect directly across networks
+	// (spec 1043) - and serves TURN-over-UDP with the same ephemeral credentials
+	// (a lower-latency relay fallback than TURNS-over-TCP when UDP is reachable).
+	// Operator opt-in: the deployment must forward the matching public UDP port.
+	// Ignored in plaintext mode, which already listens on UDP.
+	UDPListen string
 }
 
 // Server wraps the pion TURN server plus the listeners it owns.
@@ -45,11 +53,7 @@ type Server struct {
 	conns     []net.PacketConn
 }
 
-// Start brings up the relay. Caller must Close it on shutdown. It returns the
-// loopback plaintext UDP address (host:port) the co-located SFU should use to
-// reach this TURN - so the SFU can gather relay candidates at RelayIP that
-// relay-only clients can reach, without the TLS/cert complications of dialing
-// the public TURNS endpoint over loopback.
+// Start brings up the relay. Caller must Close it on shutdown.
 func Start(cfg Config) (srv *Server, err error) {
 	relayIP := cfg.RelayIP
 	if relayIP == "" {
@@ -86,9 +90,26 @@ func Start(cfg Config) (srv *Server, err error) {
 			Listener:              ln,
 			RelayAddressGenerator: relayGen,
 		})
+
+		// Optional plaintext UDP alongside TURNS (spec 1043): STUN Binding for
+		// srflx discovery + TURN-over-UDP relay, both fine to expose publicly -
+		// Binding is unauthenticated by design and relay allocations still
+		// require the ephemeral credentials.
+		if cfg.UDPListen != "" {
+			pc, perr := net.ListenPacket("udp4", cfg.UDPListen)
+			if perr != nil {
+				s.closeListeners()
+				return nil, fmt.Errorf("turn: udp listen %s: %w", cfg.UDPListen, perr)
+			}
+			s.conns = append(s.conns, pc)
+			srvCfg.PacketConnConfigs = append(srvCfg.PacketConnConfigs, turn.PacketConnConfig{
+				PacketConn:            pc,
+				RelayAddressGenerator: relayGen,
+			})
+		}
 	} else {
 		// Dev/local: plaintext UDP + TCP so localhost browsers can relay without
-		// a certificate. Never expose these publicly.
+		// a certificate.
 		pc, perr := net.ListenPacket("udp4", cfg.ListenAddr)
 		if perr != nil {
 			s.closeListeners()

--- a/server/internal/turn/server_test.go
+++ b/server/internal/turn/server_test.go
@@ -2,7 +2,14 @@ package turn
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
+	"math/big"
 	"net"
 	"testing"
 	"time"
@@ -37,6 +44,87 @@ func TestEphemeralCredentialRoundTrip(t *testing.T) {
 	if !bytes.Equal(key, want) {
 		t.Fatalf("auth key mismatch: relay and client-issued password disagree")
 	}
+}
+
+// A TLS-mode relay with UDPListen set must answer STUN Binding requests on the
+// UDP socket (spec 1043: srflx discovery for direct call paths); without
+// UDPListen it must not open a UDP socket at all (zero-deployment-change
+// safety: upgrading never opens a new port unasked).
+func TestTLSModeOptionalUDPListener(t *testing.T) {
+	cert := selfSignedCert(t)
+	base := Config{
+		Realm:        "ring.example",
+		RelayIP:      "127.0.0.1",
+		ListenAddr:   "127.0.0.1:0",
+		SharedSecret: "test-shared-secret-base64urlish",
+		TLSConfig:    &tls.Config{Certificates: []tls.Certificate{cert}},
+	}
+
+	t.Run("without UDPListen no UDP socket opens", func(t *testing.T) {
+		srv, err := Start(base)
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		defer srv.Close()
+		if n := len(srv.conns); n != 0 {
+			t.Fatalf("packet conns = %d, want 0", n)
+		}
+	})
+
+	t.Run("with UDPListen STUN binding gets an answer", func(t *testing.T) {
+		cfg := base
+		cfg.UDPListen = "127.0.0.1:0"
+		srv, err := Start(cfg)
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		defer srv.Close()
+		if n := len(srv.conns); n != 1 {
+			t.Fatalf("packet conns = %d, want 1", n)
+		}
+		addr := srv.conns[0].LocalAddr().String()
+
+		conn, err := net.Dial("udp4", addr)
+		if err != nil {
+			t.Fatalf("dial udp: %v", err)
+		}
+		defer conn.Close()
+		client, err := turn.NewClient(&turn.ClientConfig{
+			STUNServerAddr: addr,
+			Conn:           turn.NewSTUNConn(conn),
+		})
+		if err != nil {
+			t.Fatalf("turn client: %v", err)
+		}
+		defer client.Close()
+		if err := client.Listen(); err != nil {
+			t.Fatalf("client listen: %v", err)
+		}
+		if _, err := client.SendBindingRequest(); err != nil {
+			t.Fatalf("STUN binding request over the UDP listener: %v", err)
+		}
+	})
+}
+
+// selfSignedCert mints a throwaway localhost cert so the TLS listener can start.
+func selfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
 }
 
 func TestExpiredCredentialRejected(t *testing.T) {

--- a/specs/1043-direct-peer-peer/checklists/privacy.md
+++ b/specs/1043-direct-peer-peer/checklists/privacy.md
@@ -1,0 +1,44 @@
+# Zero-Knowledge & Privacy Requirements Checklist: Direct Peer-to-Peer Call Media
+
+**Purpose**: Validate that the requirements fully and unambiguously cover the zero-knowledge boundary, the peer IP-exposure trade-off and its opt-out, relay fallback reliability, and cross-version wire compatibility — before implementation (constitution: checklist REQUIRED for Principle I specs)
+**Created**: 2026-07-12
+**Feature**: [spec.md](../spec.md)
+
+## Zero-Knowledge Boundary
+
+- [x] CHK001 - Does the spec enumerate exactly what crosses the wire on every new path (direct media, relayed media, address discovery, advertised endpoint), and what is encrypted on each? [Completeness, Spec §Zero-Knowledge Impact]
+- [x] CHK002 - Is the "server learns nothing new" claim bounded and verifiable — i.e. does the spec state what the server already sees today (client IPs on HTTP/WS, who-calls-whom) so the delta is objectively checkable? [Measurability, Spec §Zero-Knowledge Impact]
+- [x] CHK003 - Is "no cryptographic change" an explicit, testable requirement rather than an implementation hope? [Clarity, Spec §FR-003, §Zero-Knowledge Impact]
+- [x] CHK004 - Does the spec address the inverse-metadata question — what the server can infer from the *absence* of relay traffic when a leg goes direct? [Coverage, Spec §Zero-Knowledge Impact]
+- [x] CHK005 - Are requirements phrased so that no log line, metric, or error payload could newly expose user content (constitution I) — i.e. does the feature introduce any new server-side data sink at all? [Coverage, Spec §FR-005, data-model.md]
+
+## Peer IP-Exposure Trade-off & Opt-Out
+
+- [x] CHK006 - Is the exposure precisely scoped: which address (public vs local) becomes visible, to whom (accepted call peer only), and under which conditions (direct paths, LAN masking)? [Clarity, Spec §Zero-Knowledge Impact]
+- [x] CHK007 - Does the opt-out requirement avoid overpromising — is it explicit that a relay-forced user still *receives* the peer's candidates and only their *own* address is protected? [Clarity, Spec §Edge Cases, §Zero-Knowledge Impact]
+- [x] CHK008 - Are the opt-out's default value, cross-device sync behavior, and when-it-takes-effect all specified? [Completeness, Spec §FR-007, §FR-008]
+- [x] CHK009 - Is the asymmetric case (one participant forced-relay, the other direct-capable) defined with a required outcome? [Coverage, Spec §FR-009, US3 AS2]
+- [x] CHK010 - Does the opt-out cover group calls (every leg of that user), not just 1:1? [Coverage, Spec §FR-007, US3 AS1]
+- [x] CHK011 - Is the rationale for the default (off) documented against Ring's privacy-first posture so reviewers can evaluate the trade-off rather than infer it? [Traceability, Spec §Assumptions, research.md D4]
+
+## Relay Fallback Reliability
+
+- [x] CHK012 - Is "calls never get less reliable" stated as a measurable acceptance criterion (every scenario that connected before still connects)? [Measurability, Spec §FR-002, §SC-003]
+- [x] CHK013 - Is the allowed call-setup-time regression quantified with a specific budget rather than a vague adjective? [Clarity, Spec §SC-004]
+- [x] CHK014 - Are mid-call path-loss requirements defined (direct path dies → existing reconnection ends on relay)? [Completeness, Spec §FR-010, §Edge Cases]
+- [x] CHK015 - Is the misconfigured-deployment case (UDP endpoint enabled but firewalled) given a required non-hanging outcome? [Edge Case, Spec §Edge Cases]
+- [x] CHK016 - Are credential-expiry and connection-restart behaviors required to match today's on both path types? [Coverage, Spec §Edge Cases]
+- [x] CHK017 - Do the requirements keep the TLS-on-443 relay as the universal baseline (constitution Domain Constraints) with the UDP endpoint strictly additive and opt-in? [Consistency, Spec §FR-005, §Assumptions, plan.md Constitution Check]
+
+## Cross-Version Wire Compatibility
+
+- [x] CHK018 - Are all four client/server version pairings given required outcomes (old↔new in both directions, with and without the new config)? [Coverage, Spec §US2 AS4, contracts/turn-credentials.md compatibility matrix]
+- [x] CHK019 - Is the response-shape stability requirement objectively testable (shape unchanged; additive entry only when configured)? [Measurability, Spec §FR-006, contracts/turn-credentials.md]
+- [x] CHK020 - Is the deployment ordering assumption (server ships before or with client) documented where implementers will see it? [Dependency, Spec §Assumptions, plan.md]
+- [x] CHK021 - Is terminology consistent across spec/plan/contract ("direct" vs "relayed" paths, "relay" for the server component) with no drifting synonyms? [Consistency]
+
+## Notes
+
+- CHK004: initially a [Gap] — the Zero-Knowledge Impact section claimed the server sees *less* but did not state the inference flip-side (absence of relay media reveals that a leg went direct, e.g. same-LAN co-location). Resolved 2026-07-12: sentence added to §Zero-Knowledge Impact.
+- CHK013: initially an [Ambiguity] — SC-004 said "a few hundred milliseconds". Resolved 2026-07-12: SC-004 now pins the budget at 300 ms, matching tasks.md T022.
+- All other items passed on first evaluation against spec.md + plan.md + research.md + contracts/turn-credentials.md.

--- a/specs/1043-direct-peer-peer/checklists/requirements.md
+++ b/specs/1043-direct-peer-peer/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Direct Peer-to-Peer Call Media with Relay Fallback
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The setting key `privacy.relayCalls` and the UDP/STUN endpoint naming appear in Key Entities/FRs as identifiers agreed during planning; they name WHAT is configured, not HOW it is built, and are kept because downstream artifacts (settings sync allowlist, deployment docs) must reference them stably.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/1043-direct-peer-peer/contracts/turn-credentials.md
+++ b/specs/1043-direct-peer-peer/contracts/turn-credentials.md
@@ -1,0 +1,66 @@
+# Contract: GET /v1/turn-credentials (spec 1043)
+
+Bearer-authenticated. Issues ephemeral ICE configuration for calling clients. **Response shape is unchanged by this feature**; the `iceServers` array gains an optional additional element.
+
+## Request
+
+```
+GET /v1/turn-credentials
+Authorization: Bearer <token>
+```
+
+## Response — today (and after upgrade with no new config)
+
+```json
+{
+  "iceServers": [
+    {
+      "urls": ["turns:ring.example.com:443?transport=tcp"],
+      "username": "1752300000:u_abc123",
+      "credential": "<hmac>"
+    }
+  ],
+  "ttl": 3600
+}
+```
+
+## Response — UDP endpoint configured (`TURN_UDP_LISTEN` set)
+
+```json
+{
+  "iceServers": [
+    {
+      "urls": [
+        "turns:ring.example.com:443?transport=tcp",
+        "turn:ring.example.com:3478?transport=udp"
+      ],
+      "username": "1752300000:u_abc123",
+      "credential": "<hmac>"
+    },
+    {
+      "urls": ["stun:ring.example.com:3478"]
+    }
+  ],
+  "ttl": 3600
+}
+```
+
+## Rules
+
+- The credentialed entry always exists and always includes the TURNS-on-443 URL (the universal fallback). The `turn:...?transport=udp` URL joins the same credentialed entry (same REST credentials validate on both listeners).
+- The `stun:` entry, when present, carries **no** `username`/`credential` (STUN Binding is unauthenticated address discovery).
+- `ttl` stays 3600 (1 hour), credentials time-windowed via the coturn REST scheme from `TURN_SHARED_SECRET`.
+- Error cases unchanged: `503` when calling is disabled on the server, `401` when unauthenticated.
+
+## Compatibility matrix
+
+| Client | Server | Result |
+|--------|--------|--------|
+| old (relay-only policy) | new, UDP configured | extra entries unused under `'relay'` policy; calls unchanged |
+| new (`'all'` policy) | old (single turns entry) | no stun entry → LAN-direct (mDNS host) + relay fallback |
+| new | new, UDP not configured | same as above — identical to old-server behavior |
+| new | new, UDP configured | full behavior: host + srflx + relay candidates |
+
+## Client-side consumption
+
+`getTurnConfig()` (`src/services/call/turn.ts`) already passes `data.iceServers` through verbatim to `RTCPeerConnection` — no client parsing change needed for the new entry. The only client change is the ICE policy in `rtcConfig()`/`callRtcConfig()`.

--- a/specs/1043-direct-peer-peer/data-model.md
+++ b/specs/1043-direct-peer-peer/data-model.md
@@ -1,0 +1,36 @@
+# Data Model: Direct Peer-to-Peer Call Media with Relay Fallback (spec 1043)
+
+No database schema changes (client `DB_VERSION` untouched; no server migration). Three small data shapes change or appear.
+
+## 1. Client setting: `privacy.relayCalls`
+
+| Property | Value |
+|----------|-------|
+| Key | `privacy.relayCalls` |
+| Type | boolean |
+| Default | `false` |
+| Storage | existing client settings store (IndexedDB), read via `getSetting<boolean>('privacy.relayCalls', false)` |
+| Sync | added to `SYNCED_PREF_KEYS` (`src/services/ownsync-keys.ts`) — encrypted own-data sync, last-write-wins on `updatedAt` |
+| UI | declarative toggle in the `privacy` node of `src/settings/schema.ts`, title "Always relay calls" |
+| Lifecycle | read at every peer-connection construction (1:1 create, mesh leg build, ICE-restart `setConfiguration`); a change applies from the next call |
+| Constraint | the retired key `privacy.protectIp` stays on the DEAD list and MUST NOT be reused (stale synced snapshots) |
+
+## 2. Server configuration (env)
+
+| Env var | Type / default | Meaning |
+|---------|----------------|---------|
+| `TURN_UDP_LISTEN` | string, default `""` (disabled) | Bind address (e.g. `:3478`) for a plaintext UDP listener that runs **also in TLS mode**. Empty → no listener, no new port (today's behavior). pion serves STUN Binding + TURN-over-UDP on it with the existing REST credentials. |
+| `STUN_PUBLIC_HOST` | string, default: the TURN public host | Hostname/IP advertised to clients for the UDP endpoint. |
+| `STUN_PUBLIC_PORT` | int, default: port of `TURN_UDP_LISTEN` | Port advertised to clients for the UDP endpoint. |
+| `RELAY_IP` | existing, default `127.0.0.1` | Unchanged; docs gain a note that UDP-enabled operators may set it public for one-sided relay. |
+
+Validation: `TURN_UDP_LISTEN` set but unparseable → boot error (same style as existing listen-addr validation). `STUN_PUBLIC_*` without `TURN_UDP_LISTEN` → ignored (nothing to advertise).
+
+## 3. `/v1/turn-credentials` response (contract detail in contracts/turn-credentials.md)
+
+Shape is **unchanged**: `{ "iceServers": [...], "ttl": <seconds> }`. The `iceServers` array gains an optional second element (credential-less STUN/UDP-TURN advertisement) only when the UDP endpoint is configured.
+
+## 4. Derived/computed values (no storage)
+
+- **Effective ICE policy** (client, per connection): `relayOnly = getSetting('privacy.relayCalls', false)` → `iceTransportPolicy: relayOnly ? 'relay' : 'all'`. Computed in one helper (`callRtcConfig()` in `src/services/call/turn.ts`) shared by all call sites.
+- **Advertised URL set** (server, at boot): TLS mode → `turns:<host>:443?transport=tcp` always; plus `stun:` and `turn:...?transport=udp` entries when `TURN_UDP_LISTEN` is set. Dev (no TLS) mode unchanged.

--- a/specs/1043-direct-peer-peer/plan.md
+++ b/specs/1043-direct-peer-peer/plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan: Direct Peer-to-Peer Call Media with Relay Fallback
+
+**Branch**: `feat/1043-direct-peer-peer` | **Date**: 2026-07-12 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1043-direct-peer-peer/spec.md`
+
+## Summary
+
+Today every call leg (1:1 and each group-mesh leg) is forced through the embedded TURN relay: the client builds all peer connections with `iceTransportPolicy: 'relay'` (`src/services/call/turn.ts:63-68`) and `/v1/turn-credentials` advertises a single `turns:` entry (`server/internal/api/turn_handlers.go`). This plan removes the forced relay: the client switches to `iceTransportPolicy: 'all'` so ICE can pick direct paths (same-LAN mDNS host candidates immediately; internet-wide srflx when the operator exposes an optional UDP endpoint), with the relay remaining in the candidate set as automatic fallback. A new synced setting `privacy.relayCalls` (default off) forces relay-only per user. The server gains two opt-in env knobs (`TURN_UDP_LISTEN`, `STUN_PUBLIC_HOST/PORT`); with them unset, no new listener opens and behavior is unchanged. No cryptographic change: media stays native DTLS-SRTP end-to-end on every path; signalling stays sealed over the Double Ratchet.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Vue 3 + Ionic (client), Go 1.26 (server)
+
+**Primary Dependencies**: WebRTC (browser-native `RTCPeerConnection`), `pion/turn/v4` (embedded TURN/STUN relay), libsodium (unchanged, untouched)
+
+**Storage**: Client settings store in IndexedDB via existing `settings` mechanism (no new object store, no `DB_VERSION` bump); server env config only (no migration)
+
+**Testing**: Go handler/relay unit tests against the fake-store pattern (`server/internal/api/*_test.go`, `server/internal/turn/server_test.go`); vitest for `rtcConfig` policy + settings schema + own-sync allowlist; Playwright e2e (`e2e/calls.spec.ts`, unchanged assertions); manual path verification via `drive/` harness + `chrome://webrtc-internals`
+
+**Target Platform**: Installable PWA (evergreen browsers, iOS/Android WebKit/Chromium) + single-container `ringd` deployment
+
+**Project Type**: Web application (client at repo root, Go server in `server/`)
+
+**Performance Goals**: SC-004 — call setup time must not regress by more than a few hundred ms in relay-only network scenarios (ICE gathers a few extra candidates); SC-001/002 — direct legs remove the server round-trip and its media bandwidth entirely
+
+**Constraints**: Relay fallback must never get weaker (SC-003: every call that connected before still connects); zero-deployment-change installs must behave identically except same-LAN direct; response shape of `/v1/turn-credentials` stays `{iceServers, ttl}` for cross-version interop; TURNS-on-443 + SNI-passthrough remains the baseline deployment (constitution Domain Constraints)
+
+**Scale/Scope**: ~6 client files (2 call-path call sites + config helper + settings schema/tests + sync allowlist), ~4 server files (config, turn server, main wiring, handler) + 2 new test files, 3 docs files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Zero-Knowledge Boundary | PASS | Spec carries the required Zero-Knowledge Impact section. No plaintext crosses the wire; server learns nothing it doesn't already see (client IPs on HTTP/WS); direct legs mean the server sees **less** (no media volume/timing). Peer-visible IP exposure is bounded, documented, and opt-out via `privacy.relayCalls`. |
+| II. Spec-Driven Development | PASS | Spec 1043 (ad-hoc band), branch `feat/1043-direct-peer-peer`, full pipeline being followed. |
+| III. Test-Driven Development | PASS | tasks.md will order failing tests first: new `turn_handlers_test.go` + `server_test.go` UDP cases, vitest `rtcConfig` policy cases, schema/own-sync guard updates — all before implementation tasks. |
+| IV. Crypto Discipline | PASS (no-op) | No crypto change. `messaging.ts` and the crypto core are untouched; sealed-signalling path unchanged (only candidate *count* grows, and sealing is already mutex-serialized with mesh-side buffering). `/speckit-checklist` will still run (required: spec touches Principle I territory). |
+| V. Offline-First Data Integrity | PASS | New setting uses the existing settings store; no schema/`DB_VERSION` change. Synced via existing own-sync allowlist (last-write-wins). |
+| VI. Stateless Server & Migrations | PASS | No DB change, no migration, no new state. Two new env knobs; UDP listener is in-process and off by default. |
+| VII. Quality Gates | PASS | Gates enumerated in Verification below; commit subjects drafted as user-facing release-note copy. |
+| VIII. Traceable Delivery | PASS | `taskstoissues` will open one issue per task; PR lists `Closes #N`. ROADMAP regenerated. |
+| IX. Privacy & Data Minimization | PASS | Strictly reduces server-side metadata; peer exposure minimized (mDNS masking) with a synced opt-out. |
+| X. Accessibility & i18n | PASS | One toggle added declaratively to `src/settings/schema.ts`; stock Ionic rendering, no new component. |
+| XI. Ionic-First UI | PASS | No new UI beyond the schema-driven toggle. |
+| Domain: Calls/TLS 443 + SNI passthrough | PASS (additive) | The TURNS-on-443 passthrough path stays the baseline and the universal fallback. The UDP endpoint is an *additional*, operator-opt-in listener; `CALLING.md` is updated to describe both levels and their trade-offs (UDP is more fingerprintable; 443 relay remains the covert path). |
+
+No violations → Complexity Tracking not needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1043-direct-peer-peer/
+├── spec.md              # Feature specification (with Zero-Knowledge Impact)
+├── plan.md              # This file
+├── research.md          # Phase 0: decisions + rationale + alternatives
+├── data-model.md        # Phase 1: entities (setting, config knobs, response shape)
+├── quickstart.md        # Phase 1: how to run + verify each user story
+├── contracts/
+│   └── turn-credentials.md  # /v1/turn-credentials response contract (before/after)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (done)
+└── tasks.md             # Phase 2 (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── services/call/
+│   ├── turn.ts              # rtcConfig() policy change + new callRtcConfig() helper
+│   └── mesh.ts              # buildLeg (:783) + restartLegIce (:377) use callRtcConfig()
+├── composables/
+│   └── useCall.ts           # newPeerConnection (:780) uses callRtcConfig()
+├── settings/
+│   ├── schema.ts            # new privacy.relayCalls toggle (declarative)
+│   └── schema.test.ts       # DEAD-guard comment update + positive assertion
+└── services/
+    ├── ownsync-keys.ts      # add privacy.relayCalls to SYNCED_PREF_KEYS
+    └── ownsync.test.ts      # allowlist coupling test update
+
+server/
+├── cmd/ringd/main.go        # TLS branch: advertise stun:/turn:udp when configured
+├── internal/config/config.go    # TURN_UDP_LISTEN, STUN_PUBLIC_HOST/PORT; fix stale SFU comment
+├── internal/turn/server.go      # optional UDP listener in TLS mode; fix stale comments
+└── internal/api/
+    ├── turn_handlers.go     # StunURLs as extra credential-less iceServers entry
+    └── turn_handlers_test.go  # NEW: handler tests (none exist today)
+
+e2e/calls.spec.ts            # stale header comment fix only (no assertion changes)
+server/docs/CALLING.md       # "Direct media paths (optional UDP)" section; now-true fallback wording
+CLAUDE.md                    # drop phantom "TURN relay + SFU" wording
+```
+
+**Structure Decision**: Existing web-app monorepo layout (client at root, server in `server/`); this feature only edits files in place — no new directories or modules beyond one new server test file.
+
+## Design Decisions (Phase 0 summary — full detail in research.md)
+
+1. **`iceTransportPolicy: 'all'` with the relay always in the candidate set** — ICE natively prefers working direct pairs and falls back to relay; no custom path selection logic.
+2. **Setting read at peer-connection construction** via one shared helper `callRtcConfig()` so all four call sites (1:1 create, mesh `buildLeg`, mesh `restartLegIce` `setConfiguration`, and any future ICE restart) can never diverge in policy.
+3. **New key `privacy.relayCalls`, default `false`** — do NOT resurrect `privacy.protectIp` (stale encrypted own-sync snapshots could silently re-apply it); keep it in the DEAD list.
+4. **No ICE-candidate batching** — sealing is mutex-serialized (`src/services/messaging.ts:62-79`) and the mesh already buffers local ICE until the leg is negotiated (`mesh.ts:822-838`); a new batched signal type would break cross-version calls.
+5. **Server advertises, client decides** — the stun entry rides the existing `{iceServers, ttl}` response as an extra credential-less element; old clients ignore it, new clients against old servers simply get no stun entry (LAN-direct + relay). Ship server first.
+6. **UDP endpoint serves both STUN and TURN-over-UDP** — once the listener exists, advertising `turn:<host>:<port>?transport=udp` too is free and gives UDP-relay quality > TCP-relay when reachable; ICE still prefers direct pairs.
+7. **`RELAY_IP` stays loopback by default** — mixed pairs (one side direct-capable, other relay) still connect because both sides always allocate relay candidates; document that UDP-enabled operators may set `RELAY_IP` public for one-sided relay efficiency. Cosmetic failed-pair checks in diagnostics are expected and documented.
+
+## Reconnection & Quality Interplay (verified against current code)
+
+- 1:1: `disconnected` → grace + wait; `failed` → caller-side `iceRestart: true` offer (`useCall.ts:789-848`). With `'all'`, `failed` still means "every pair including relay failed" — semantics unchanged. Direct-pair blips surface as `disconnected` and recover inside the existing grace window.
+- Mesh: `onLegState` (`mesh.ts:985`) restarts on `failed`; `restartLegIce` (`mesh.ts:377-389`) must receive the same setting-aware config as `buildLeg` (covered by decision 2).
+- Adaptive quality (`src/services/call/quality.ts`) is path-agnostic AIMD per leg, capped at `hd`/4 Mbps — no change; direct paths simply reach higher tiers more often.
+
+## Verification (Definition of Done, Principle VII)
+
+- `npm run build` (vue-tsc typecheck + vite build)
+- `cd server && go build ./... && go vet ./... && go test ./...`
+- `npx vitest run` (coverage floors hold)
+- `npm run test:e2e` (no spec asserts relay; same-host browsers will pick host candidates)
+- Manual: two-browser call on `make start` → selected candidate pair is `host↔host`; toggle `privacy.relayCalls` on one side → pair becomes `relay`; UDP-enabled deployment across networks → `srflx` pair. Compare `markConnect` timings before/after (SC-004).

--- a/specs/1043-direct-peer-peer/quickstart.md
+++ b/specs/1043-direct-peer-peer/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: Direct Peer-to-Peer Call Media with Relay Fallback (spec 1043)
+
+## Run it locally
+
+```sh
+make start          # Postgres + ringd (:8080) + Vite (:5173)
+```
+
+Dev mode already runs the plaintext UDP TURN listener on `:3478`, so both STUN discovery and relay fallback are exercisable locally with no extra config.
+
+## Verify each user story
+
+### US1 — same-LAN direct (two browsers on one machine count as "same network")
+
+1. Open two browser profiles at `http://localhost:5173`, register two accounts (dev invite codes `RINGDEV1`..), pair them, start a 1:1 video call. (Or script it: `node drive/scenarios/...` / the `drive-ui` skill.)
+2. In one browser open `chrome://webrtc-internals` → the call's transport → **selected candidate pair**. Expect `host ↔ host` (mDNS/loopback addresses), not `relay`.
+3. Group: create a group of 3, start a call, confirm each leg's selected pair is direct.
+
+### US2 — internet-wide direct via the UDP endpoint
+
+1. On a TLS deployment set `TURN_UDP_LISTEN=:3478`, forward `3478/udp`, restart. `GET /v1/turn-credentials` (with a bearer token) now shows the extra `stun:` entry and the `turn:...?transport=udp` URL.
+2. Call between two devices on different networks (e.g. phone on LTE vs laptop on home Wi-Fi). Selected pair should be `srflx ↔ srflx` (or `srflx ↔ prflx`) when both NATs allow; `relay` otherwise — the call connects either way.
+
+### US3 — "Always relay calls"
+
+1. Settings → Privacy → switch on **Always relay calls**.
+2. Repeat the US1 same-LAN call from that account: selected pair must now be `relay` on the toggled side, and the peer's inspection shows no direct address for the toggled user.
+3. Sign the same account in on a second device: the toggle arrives on (own-data sync).
+
+### US4 — zero-change safety
+
+1. Deploy the new server with no new env vars: `ss -ulpn | grep 3478` (or equivalent) shows no new UDP listener; credentials response is byte-shape-identical to before.
+2. Cross-network calls still connect (relayed), same as before the upgrade.
+
+## Gates (Definition of Done)
+
+```sh
+npm run build                                   # typecheck + build
+npx vitest run                                  # unit + coverage floors
+cd server && go build ./... && go vet ./... && go test ./...
+npm run test:e2e                                # needs `make db-up`
+```
+
+## Regression watch
+
+- Call setup time: compare the `markConnect` timing (already instrumented in `useCall.ts`, visible in the drive harness console output) before/after on a relay-only scenario — budget: no more than 300 ms added (SC-004).
+- Mid-call fallback (FR-010): during an established direct call on a real device, drop the direct path (toggle Wi-Fi so the device roams to LTE, or briefly disable the interface) — the existing reconnection flow must recover the call, on the relay if that is all that remains.
+- webrtc-internals will show *failed* checks for mixed pairs (srflx ↔ relay-at-127.0.0.1) on default `RELAY_IP` — expected and harmless; see research.md D7.

--- a/specs/1043-direct-peer-peer/research.md
+++ b/specs/1043-direct-peer-peer/research.md
@@ -1,0 +1,59 @@
+# Research: Direct Peer-to-Peer Call Media with Relay Fallback (spec 1043)
+
+All unknowns from Technical Context resolved. Each decision: what / why / what else was considered.
+
+## D1. Path selection mechanism
+
+- **Decision**: Switch every call peer connection from `iceTransportPolicy: 'relay'` to `'all'` and let ICE pick the best working pair; keep the TURN relay in every candidate set.
+- **Rationale**: ICE is the standard, battle-tested mechanism for exactly this problem: it checks all candidate pairs (host, srflx, relay) and selects by priority, preferring direct. No custom logic, no reliability regression — the relay pair that works today is still checked and still wins when nothing else survives.
+- **Alternatives considered**:
+  - *Try direct first, renegotiate to relay on failure*: hand-rolls what ICE already does, adds failure-window complexity, rejected.
+  - *Keep relay-only and add an SFU for groups*: opposite direction — adds a server media component, breaks the "no middle-box" E2EE story (would force per-frame insertable-streams crypto back in), massively more complex. Rejected; this repo deliberately removed its SFU (spec 0004).
+
+## D2. Same-LAN direct without any server change
+
+- **Decision**: Rely on browser mDNS host candidates for same-network direct paths; require no server capability for US1.
+- **Rationale**: All evergreen browsers gather mDNS-obfuscated host candidates by default; two peers on one LAN resolve each other's mDNS names locally and connect directly, while remote peers cannot resolve them (privacy preserved). Works against unmodified deployments.
+- **Alternatives considered**: advertising a STUN entry as mandatory for US1 — unnecessary; srflx is only needed cross-network.
+
+## D3. Internet-wide direct paths (operator opt-in)
+
+- **Decision**: Optional server UDP listener (`TURN_UDP_LISTEN`, default empty = disabled, even in TLS mode) on which the embedded pion server answers STUN Binding (address discovery) and serves TURN-over-UDP with the same time-windowed REST credentials. When configured, advertise `stun:<STUN_PUBLIC_HOST>:<STUN_PUBLIC_PORT>` (credential-less entry) and `turn:<host>:<port>?transport=udp` alongside the existing `turns:` entry.
+- **Rationale**: srflx discovery requires UDP; STUN-over-TCP-443 cannot yield useful UDP srflx. pion/turn already answers STUN on its listeners (the dev branch runs exactly this UDP listener today, `server/internal/turn/server.go:89-113`), so the TLS-mode change is reusing existing code behind a flag. Advertising UDP TURN too is free once the listener exists and upgrades fallback quality (UDP relay beats TCP relay) — ICE still prefers direct pairs, so it never *adds* relay usage.
+- **Alternatives considered**:
+  - *Public third-party STUN (e.g. Google)*: leaks call-timing metadata to a third party; violates the self-hosted, privacy-first posture. Rejected.
+  - *STUN-only on the UDP port (no TURN-over-UDP)*: saves nothing (same listener, pion serves both), forfeits the UDP-relay quality win. Rejected.
+  - *Always-on UDP listener*: surprises operators (new open port on upgrade), breaks "zero-deployment-change installs behave identically". Rejected — opt-in.
+
+## D4. Privacy control
+
+- **Decision**: New synced boolean setting `privacy.relayCalls` ("Always relay calls"), default **off**; when on, that user's peer connections are built with `iceTransportPolicy: 'relay'`. Applied at connection construction (next call), synced via the own-sync allowlist.
+- **Rationale**: Direct connections necessarily reveal a network address to the accepted call peer. Default-off because: calls occur only between mutually accepted parties; browsers mDNS-mask LAN addresses; Signal ships the identical toggle default-off; default-on would nullify the feature for the majority who never open settings. One relay-forced side suffices to keep the pair relayed (their candidate set contains only relay candidates).
+- **Alternatives considered**:
+  - *Resurrect `privacy.protectIp`*: rejected — old encrypted own-sync snapshots may still carry a stale value that would silently re-apply; the key stays on the DEAD list (`src/settings/schema.test.ts:33-37`). New key = clean slate.
+  - *Default on*: rejected per above; also makes SC-001/002 unreachable in practice.
+  - *Per-call choice in the call UI*: more surface, unclear mental model; the synced setting matches the threat model (persistent preference, not per-call whim). Deferred as a possible follow-up.
+
+## D5. ICE candidate volume over sealed signalling
+
+- **Decision**: No batching; candidates continue to be sealed and relayed one at a time as today.
+- **Rationale**: Volume grows from ~1-2 (relay-only) to ~5-15 per side. The seal path is already safe: per-session mutex serializes seals (`src/services/messaging.ts:62-79`), and the mesh buffers local ICE until the leg is negotiated (`mesh.ts:822-838`, flushed :891-901) — the known "never seal during ICE hot path" lesson is about the X3DH preamble race, which the existing buffering already prevents. Each seal is a fast symmetric op.
+- **Alternatives considered**: *batched candidate signal*: a new signal type old clients can't parse → dropped candidates → broken calls across versions. Rejected outright for v1.
+
+## D6. Wire/API compatibility
+
+- **Decision**: `/v1/turn-credentials` keeps its exact response shape `{iceServers: [...], ttl}`; the stun entry is one more array element without `username`/`credential`. Server ships before (or with) the client.
+- **Rationale**: `RTCPeerConnection` accepts credential-less STUN entries natively; old clients pass the extra entry into a `'relay'`-policy connection where it is simply unused. New client + old server → no stun entry → LAN-direct + relay, still correct. No version negotiation needed.
+- **Alternatives considered**: versioned endpoint or capability flag — needless machinery for an additive array element. Rejected.
+
+## D7. `RELAY_IP` and mixed pairs
+
+- **Decision**: Keep `RELAY_IP` defaulting to `127.0.0.1`; document (CALLING.md) that operators enabling UDP may set it to the public IP.
+- **Rationale**: Both sides always allocate relay candidates, and relay↔relay pairs traverse inside the ringd process — that is exactly today's working path, unaffected. With loopback relay addresses, *mixed* pairs (A's srflx ↔ B's relay-at-127.0.0.1) can never succeed — harmless (wasted checks, visible in webrtc-internals) but worth documenting so nobody chases it as a bug. A public `RELAY_IP` enables the one-sided-relay optimization.
+- **Alternatives considered**: auto-detecting the public relay IP — fragile behind NAT/proxies; explicit env knob matches the existing config style. Rejected.
+
+## D8. Setup-latency guardrail (SC-004)
+
+- **Decision**: Accept the small extra gathering/checking cost of `'all'`; verify with the already-instrumented `markConnect` timings (useCall.ts) via the drive harness before/after.
+- **Rationale**: Trickle ICE means candidates flow as discovered; the relay candidate is still gathered immediately and usable as soon as checked. The old header comment's stated reason for `'relay'` ("host/srflx pairs would only add gathering latency") is the trade-off we are consciously reversing — the latency cost is milliseconds against a permanent double-hop for all media.
+- **Alternatives considered**: aggressive ICE timeouts / candidate filtering — premature; measure first.

--- a/specs/1043-direct-peer-peer/spec.md
+++ b/specs/1043-direct-peer-peer/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Direct Peer-to-Peer Call Media with Relay Fallback
+
+**Feature Branch**: `feat/1043-direct-peer-peer`
+
+**Created**: 2026-07-12
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Direct peer-to-peer call media with TURN fallback. Today all call media (1:1 and group mesh) is forced through the server's embedded TURN relay. This costs server bandwidth (O(N·(N-1)) flows per group call) and adds latency even when two devices sit on the same Wi-Fi. Change: allow direct paths when networks permit — same-LAN immediately, internet-wide when the operator opts into exposing a UDP endpoint — with the relay remaining as automatic fallback so calls never get less reliable. Add a synced privacy toggle 'Always relay calls' so a user can force relay and keep their IP hidden from call peers. Zero-deployment-change installs keep working exactly as today except same-LAN calls connect directly."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Same-network calls connect directly (Priority: P1)
+
+Two people on the same Wi-Fi network (a household, an office) place a Ring call. Today their audio and video travel out to the Ring server and back, adding delay and consuming server bandwidth for no benefit. After this change, their call media flows directly between their devices while staying end-to-end encrypted, and the server carries none of it.
+
+**Why this priority**: This is the highest-value, lowest-risk slice. It needs no operator action, no new ports, and no server capability — only the client must stop refusing direct paths. It delivers the latency and server-bandwidth win for the common "family on one Wi-Fi" case immediately.
+
+**Independent Test**: Place a call between two devices (or two browsers) on the same network against an unmodified server deployment; inspect the active connection path and confirm it is device-to-device, not via the relay. Break the direct path (e.g. isolate the clients) and confirm the same call setup still succeeds via the relay.
+
+**Acceptance Scenarios**:
+
+1. **Given** two signed-in users on the same local network, **When** one calls the other (1:1, audio or video), **Then** the call connects and media flows directly between the two devices without transiting the relay.
+2. **Given** a group call whose members are all on the same local network, **When** the call is up, **Then** each mesh leg flows directly between the two devices it connects.
+3. **Given** two users whose networks block any direct path, **When** one calls the other, **Then** the call connects via the relay exactly as today, with no user-visible error.
+4. **Given** an existing deployment with no configuration changes, **When** users call across different networks, **Then** calls behave exactly as today (relayed), with no regression in reliability.
+
+---
+
+### User Story 2 - Internet-wide direct calls when the operator opts in (Priority: P2)
+
+A server operator wants calls between users on different networks to connect directly whenever both sides' networks allow it, so the server stops paying bandwidth for most call media and callers get lower delay and headroom for higher quality. The operator enables one additional public UDP endpoint on the server; from then on, clients discover their public addresses through it and connect directly when possible, falling back to the relay when not.
+
+**Why this priority**: This is the big server-bandwidth and quality win for the general case, but it requires an explicit deployment step (opening a UDP port) and therefore ships as an operator opt-in on top of US1.
+
+**Independent Test**: Against a deployment with the UDP endpoint enabled, place a call between two clients on different networks with ordinary home-router NAT; confirm the selected path is direct. Against the same deployment, place a call from a network that blocks UDP; confirm the call still connects via the relay.
+
+**Acceptance Scenarios**:
+
+1. **Given** a deployment with the direct-path UDP endpoint enabled and two users on different networks whose NATs permit it, **When** they call each other, **Then** media flows directly between their devices and not through the relay.
+2. **Given** the same deployment and a caller on a network that blocks direct traffic, **When** they call, **Then** the call connects through the relay with no user-visible difference except possibly quality.
+3. **Given** a deployment where the operator has NOT enabled the UDP endpoint, **When** users on different networks call each other, **Then** behavior is identical to today (relayed), and nothing warns or errors.
+4. **Given** an older app version talking to an upgraded server (or vice versa), **When** a call is placed, **Then** the call connects; mixed versions never break calling.
+
+---
+
+### User Story 3 - "Always relay calls" privacy choice (Priority: P3)
+
+A privacy-conscious user does not want people they call to learn their network address. They switch on a new setting, "Always relay calls". From then on, every call they place or answer routes their media through the Ring server, so call peers only ever see the server's address. The choice follows them to their other devices like their other synced preferences.
+
+**Why this priority**: Direct connections necessarily reveal a network address to the call peer. Ring is privacy-first, so the escape hatch must ship in the same release as direct paths — but it is a small, self-contained addition on top of US1/US2.
+
+**Independent Test**: Toggle the setting on one device, place a call on that device and confirm the selected path is the relay even on the same LAN; sign in on a second device and confirm the setting arrived there.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with "Always relay calls" switched on, **When** they place or answer any call (1:1 or group), **Then** their media enters and leaves through the relay only, and the call peer never learns a direct address for them.
+2. **Given** a user with the setting on and a peer with it off, **When** they call each other, **Then** the call connects through the relay (one relayed side is enough) and both sides' calls work normally.
+3. **Given** the setting is toggled during an active call, **When** the current call continues, **Then** the change applies from the next call onward.
+4. **Given** the setting is on and the user signs in on another device, **When** the other device syncs, **Then** the setting is on there too.
+
+---
+
+### User Story 4 - Operator clarity and zero-change safety (Priority: P4)
+
+An operator reading the deployment docs can understand exactly what each exposure level buys: doing nothing keeps today's behavior (everything relayed, plus same-LAN direct); opening one UDP port enables internet-wide direct calls. The docs also explain the trade-offs (the UDP endpoint is more fingerprintable than the TLS-on-443 relay path) so operators in restrictive environments can make an informed choice.
+
+**Why this priority**: Documentation and operational safety underpin the other stories but deliver no standalone end-user behavior.
+
+**Independent Test**: Follow the updated deployment docs from scratch on a test host at each exposure level and confirm the documented behavior matches reality.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator who changes nothing, **When** they upgrade the server, **Then** no new ports are opened and no new listeners start.
+2. **Given** an operator following the new docs section, **When** they enable the UDP endpoint and forward the port, **Then** internet-wide direct calls work as described.
+
+---
+
+### Edge Cases
+
+- One participant's network allows direct paths, the other's does not: the call must still connect (via relay) without extra delay beyond normal setup.
+- A direct connection degrades or dies mid-call (e.g. one device roams off Wi-Fi): the existing reconnection behavior must recover the call, falling back to the relay if that is all that remains.
+- Group call where some legs are direct and others relayed: each leg independently picks the best working path; mixed paths within one call are normal.
+- A user with "Always relay calls" on still receives the peer's address candidates during call setup (unavoidable in the signalling); the guarantee is only that *their own* address is never revealed — the spec's privacy wording must not overpromise.
+- Server deployed with the UDP endpoint enabled but the operator forgot the firewall/port-forward: clients simply never find a working direct path across networks and fall back to relay; calls must not hang on the missing path.
+- Credential lifetime expiry mid-call and ICE restarts must behave the same as today on both direct and relayed paths.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Call media (1:1 and every group-mesh leg) MUST be allowed to use a direct device-to-device path when one exists, instead of being unconditionally forced through the server relay.
+- **FR-002**: The server relay MUST remain available as an automatic fallback for every call; a call that would have connected before this change MUST still connect after it.
+- **FR-003**: Call media MUST remain end-to-end encrypted on every path (direct or relayed); no server component may gain access to media plaintext.
+- **FR-004**: On deployments with no configuration changes, calls between devices on the same local network SHOULD connect directly; all other calls MUST behave exactly as today.
+- **FR-005**: The server MUST offer an operator-opt-in public UDP endpoint that lets clients discover their public addresses for direct connections across networks; when it is not configured, no new listener or port is opened.
+- **FR-006**: When the UDP endpoint is configured, the server MUST advertise it to calling clients alongside the existing relay, without changing the shape of the credentials response, so that older clients keep working unmodified.
+- **FR-007**: Users MUST be able to switch on an "Always relay calls" preference that forces all of their call media through the relay so call peers never learn a direct network address for them; it MUST default to off and MUST sync across the user's devices like other synced preferences.
+- **FR-008**: The "Always relay calls" preference MUST take effect from the next call; it is not required to re-route an in-progress call.
+- **FR-009**: A call between one relay-forced participant and one direct-capable participant MUST connect (through the relay) with no user-visible failure.
+- **FR-010**: Mid-call path loss (direct path stops working) MUST be handled by the existing reconnection behavior, ending in a working relayed connection when that is the only remaining path.
+- **FR-011**: Deployment documentation MUST accurately describe media routing at each exposure level (nothing opened; UDP endpoint opened), including the privacy and fingerprintability trade-offs; stale references to a server-side media component that no longer exists MUST be removed.
+- **FR-012**: The settings copy for the new preference MUST follow Ring's plain, user-facing voice and be honest about the trade-off (calls may connect slower or at lower quality when relayed).
+
+### Key Entities
+
+- **Call path**: for each call leg, the route media takes — direct (device to device) or relayed (through the server). Chosen automatically per leg; never user-visible except through quality.
+- **Relay preference** (`privacy.relayCalls`): a per-user, cross-device synced boolean; off by default; when on, the user's legs are always relayed.
+- **Direct-path endpoint**: an optional server-side UDP listener the operator can expose so clients can discover their public addresses; absent by default.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Two devices on the same local network connect calls directly: media round-trip delay between them drops measurably versus today (no server round trip), and the server relays zero media bytes for such calls.
+- **SC-002**: On a deployment with the direct-path endpoint enabled, calls between typical home networks connect directly in the common case, and the server's call-media bandwidth for those calls drops to zero.
+- **SC-003**: Call setup success rate does not regress: every network scenario that could establish a call before this change still establishes one after it.
+- **SC-004**: Call setup time does not regress by more than 300 ms in relay-only network scenarios (measured via the existing call-connect instrumentation, before vs after).
+- **SC-005**: A user who enables "Always relay calls" never exposes a direct network address to call peers, verified by inspecting the connection on their device during calls on the same LAN and across the internet.
+- **SC-006**: An operator can go from the docs to working internet-wide direct calls with a single configuration change plus one firewall rule.
+
+## Zero-Knowledge Impact
+
+*Required by constitution Principle I for any spec that touches the client/server boundary.*
+
+- **What crosses the wire**: unchanged for content — call signalling (SDP offers/answers, connection candidates) stays sealed end-to-end over the existing per-pair Double Ratchet and is relayed by the server as opaque ciphertext; call media stays end-to-end encrypted between devices on every path. New on the wire: the credentials response may carry one additional advertised server address (the direct-path endpoint), which contains no user data; and clients may exchange short address-discovery packets with the server's UDP endpoint, which carry no user content.
+- **What is encrypted**: everything that is encrypted today remains so, under the same schemes. This feature makes **no cryptographic change** — no new keys, no new sealing, no change to `messaging.ts` or the crypto core.
+- **What metadata is unavoidably visible, and to whom**:
+  - *To the server*: nothing new. The server already sees every client's IP on each HTTP/WebSocket connection and already learns who calls whom from signalling relay and room membership. Address discovery reveals the same client IP it already sees. Net effect is **less** data at the server: when a leg goes direct, the server no longer carries (or sees the volume/timing of) that leg's media. The flip side: the server can infer *that* a leg went direct from the absence of relay traffic (e.g. that two participants likely share a network) — strictly less information than it holds today, when it carries every leg and sees full volume/timing anyway.
+  - *To the call peer*: new, bounded exposure — a direct connection necessarily reveals a network address to the accepted call peer (public address across the internet; local addresses stay masked by the browser's built-in obfuscation). This is peer-visible, never server-visible-beyond-today, and is fully suppressible per user via "Always relay calls" (FR-007). A relay-forced user's own address is never revealed; they may still receive the peer's candidates (Edge Cases).
+- **Why this is acceptable**: calls only occur between mutually accepted parties; the exposure matches the long-standing default of comparable private messengers; the opt-out is one synced toggle; and the change strictly reduces the metadata concentration at the server.
+
+## Assumptions
+
+- Calls only ever happen between mutually accepted parties (contacts and joined group rooms), so revealing one's network address to a call peer by default is an acceptable, industry-standard trade-off (the same default as comparable private messengers); the synced preference is the opt-out for stricter threat models.
+- Browsers mask local (LAN) addresses in call setup by default, so same-network direct paths do not expose raw private addresses to remote peers.
+- The existing relay remains reachable on the standard TLS path (port 443) in all deployments; this feature never removes or weakens it, so restrictive-network users lose nothing.
+- The e2e test environment (same-host browsers) will naturally use direct paths after this change; no test asserts that media is relayed.
+- Media encryption is per-leg, end-to-end, independent of path; no cryptographic change is needed or allowed by this feature.
+- The credentials response may gain an additional advertised entry, but its overall shape stays the same, so old clients and new servers (and vice versa) interoperate; the server ships before or with the client.

--- a/specs/1043-direct-peer-peer/spec.md
+++ b/specs/1043-direct-peer-peer/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-12
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1043-direct-peer-peer/spec.md
+++ b/specs/1043-direct-peer-peer/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-12
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1043-direct-peer-peer/tasks.md
+++ b/specs/1043-direct-peer-peer/tasks.md
@@ -33,14 +33,14 @@ No blocking prerequisites shared across stories beyond what US1 itself delivers 
 
 ### Tests for User Story 1 (write first, must fail)
 
-- [ ] T001 [US1] Create vitest unit test `src/services/call/turn.test.ts` for `rtcConfig`: default policy is `'all'`; `{relayOnly: true}` forces `'relay'`; `bundlePolicy` stays `'max-bundle'`; iceServers passed through. Also cover `callRtcConfig()` reading the `privacy.relayCalls` setting (mock `getSetting`, default false). Run `npx vitest run src/services/call/turn.test.ts` and confirm it FAILS against current code (policy is hard-coded `'relay'`, helper doesn't exist).
+- [X] T001 [US1] Create vitest unit test `src/services/call/turn.test.ts` for `rtcConfig`: default policy is `'all'`; `{relayOnly: true}` forces `'relay'`; `bundlePolicy` stays `'max-bundle'`; iceServers passed through. Also cover `callRtcConfig()` reading the `privacy.relayCalls` setting (mock `getSetting`, default false). Run `npx vitest run src/services/call/turn.test.ts` and confirm it FAILS against current code (policy is hard-coded `'relay'`, helper doesn't exist).
 
 ### Implementation for User Story 1
 
-- [ ] T002 [US1] In `src/services/call/turn.ts`: change `rtcConfig(turn)` to `rtcConfig(turn, opts?: {relayOnly?: boolean})` with `iceTransportPolicy: opts?.relayOnly ? 'relay' : 'all'`; add `callRtcConfig(): Promise<RTCConfiguration>` combining `getTurnConfig()` + `getSetting<boolean>('privacy.relayCalls', false)`; rewrite the stale header (lines 1-7) and `rtcConfig` doc comment (lines 58-62) to explain direct-when-possible + relay fallback + the privacy override (keep the repo's explain-the-why comment style). T001 test now passes.
-- [ ] T003 [P] [US1] In `src/composables/useCall.ts` `newPeerConnection()` (~line 780): replace `getTurnConfig()` + `rtcConfig(turn)` with `await callRtcConfig()`.
-- [ ] T004 [P] [US1] In `src/services/call/mesh.ts`: `buildLeg` (~line 783) and `restartLegIce` `setConfiguration` (~line 377) both use `await callRtcConfig()` — the restart path MUST get the same setting-aware config so an ICE restart never flips policy; keep the buildLeg awaits before leg reservation (race re-check at ~784-785 must stay valid); update the file-header claim that media always rides the relay.
-- [ ] T005 [US1] Gates: `npm run build` (typecheck) and `npx vitest run` pass; then manual quickstart.md US1 check via the drive harness or two browser profiles — selected candidate pair is `host ↔ host` on a same-machine call, and the call still connects when only relay pairs survive.
+- [X] T002 [US1] In `src/services/call/turn.ts`: change `rtcConfig(turn)` to `rtcConfig(turn, opts?: {relayOnly?: boolean})` with `iceTransportPolicy: opts?.relayOnly ? 'relay' : 'all'`; add `callRtcConfig(): Promise<RTCConfiguration>` combining `getTurnConfig()` + `getSetting<boolean>('privacy.relayCalls', false)`; rewrite the stale header (lines 1-7) and `rtcConfig` doc comment (lines 58-62) to explain direct-when-possible + relay fallback + the privacy override (keep the repo's explain-the-why comment style). T001 test now passes.
+- [X] T003 [P] [US1] In `src/composables/useCall.ts` `newPeerConnection()` (~line 780): replace `getTurnConfig()` + `rtcConfig(turn)` with `await callRtcConfig()`.
+- [X] T004 [P] [US1] In `src/services/call/mesh.ts`: `buildLeg` (~line 783) and `restartLegIce` `setConfiguration` (~line 377) both use `await callRtcConfig()` — the restart path MUST get the same setting-aware config so an ICE restart never flips policy; keep the buildLeg awaits before leg reservation (race re-check at ~784-785 must stay valid); update the file-header claim that media always rides the relay.
+- [X] T005 [US1] Gates: `npm run build` (typecheck) and `npx vitest run` pass; then manual quickstart.md US1 check via the drive harness or two browser profiles — selected candidate pair is `host ↔ host` on a same-machine call, and the call still connects when only relay pairs survive.
 
 **Checkpoint**: US1 fully functional — direct on LAN, relay fallback intact, no server change needed.
 
@@ -54,16 +54,16 @@ No blocking prerequisites shared across stories beyond what US1 itself delivers 
 
 ### Tests for User Story 2 (write first, must fail)
 
-- [ ] T006 [P] [US2] Create `server/internal/api/turn_handlers_test.go` (none exists) following the sibling handler-test pattern: 503 when `CallsEnabled` is false; 401 unauthenticated; TURN-only config → exactly one credentialed iceServers entry with the configured URLs and `ttl` 3600; with `StunURLs` set → an additional entry carrying only `urls` (no `username`/`credential`) while the credentialed entry is unchanged. Confirm FAIL (the `StunURLs` field doesn't exist yet).
-- [ ] T007 [P] [US2] Extend `server/internal/turn/server_test.go`: TLS-mode `Start` with `UDPListen` set answers a STUN Binding request on the UDP socket (reuse the existing pion round-trip test style); TLS-mode without `UDPListen` opens no UDP socket. Confirm FAIL (Config has no `UDPListen`).
+- [X] T006 [P] [US2] Create `server/internal/api/turn_handlers_test.go` (none exists) following the sibling handler-test pattern: 503 when `CallsEnabled` is false; 401 unauthenticated; TURN-only config → exactly one credentialed iceServers entry with the configured URLs and `ttl` 3600; with `StunURLs` set → an additional entry carrying only `urls` (no `username`/`credential`) while the credentialed entry is unchanged. Confirm FAIL (the `StunURLs` field doesn't exist yet).
+- [X] T007 [P] [US2] Extend `server/internal/turn/server_test.go`: TLS-mode `Start` with `UDPListen` set answers a STUN Binding request on the UDP socket (reuse the existing pion round-trip test style); TLS-mode without `UDPListen` opens no UDP socket. Confirm FAIL (Config has no `UDPListen`).
 
 ### Implementation for User Story 2
 
-- [ ] T008 [P] [US2] In `server/internal/config/config.go`: add `TurnUDPListen` (`TURN_UDP_LISTEN`, default "" = disabled), `StunPublicHost` (`STUN_PUBLIC_HOST`, default: TURN public host) and `StunPublicPort` (`STUN_PUBLIC_PORT`, default: port parsed from `TURN_UDP_LISTEN`); boot error on unparseable `TURN_UDP_LISTEN` (match existing listen-addr validation style); fix the stale "TURN relay + SFU" comment at line ~62.
-- [ ] T009 [US2] In `server/internal/turn/server.go`: add `UDPListen string` to `Config`; when non-empty and `TLSConfig != nil`, additionally open the UDP `PacketConnConfig` the dev branch already uses (lines ~92-101); fix the stale "co-located SFU" (~48-52) and "never expose these publicly" (~90-91) comments. T007 test now passes.
-- [ ] T010 [US2] In `server/cmd/ringd/main.go` TLS branch (~360-372): when the UDP endpoint is configured, advertise `turn:<stunHost>:<stunPort>?transport=udp` in `TurnURLs` and build `StunURLs = ["stun:<stunHost>:<stunPort>"]`; also correct the "no server-side SFU" adjacent stale wording if touched.
-- [ ] T011 [US2] In `server/internal/api/turn_handlers.go`: add `StunURLs []string` to `Handlers`, wire it from main.go, and emit it as a separate credential-less iceServers entry; update the "all media rides TURNS on 443 / client forces relay" comment (lines ~22-23). T006 test now passes.
-- [ ] T012 [US2] Gates: `cd server && go build ./... && go vet ./... && go test ./...` all green; then manual quickstart.md US2 check against a UDP-enabled deployment (or dev stack) — credentials response matches contracts/turn-credentials.md and a cross-network call selects `srflx`.
+- [X] T008 [P] [US2] In `server/internal/config/config.go`: add `TurnUDPListen` (`TURN_UDP_LISTEN`, default "" = disabled), `StunPublicHost` (`STUN_PUBLIC_HOST`, default: TURN public host) and `StunPublicPort` (`STUN_PUBLIC_PORT`, default: port parsed from `TURN_UDP_LISTEN`); boot error on unparseable `TURN_UDP_LISTEN` (match existing listen-addr validation style); fix the stale "TURN relay + SFU" comment at line ~62.
+- [X] T009 [US2] In `server/internal/turn/server.go`: add `UDPListen string` to `Config`; when non-empty and `TLSConfig != nil`, additionally open the UDP `PacketConnConfig` the dev branch already uses (lines ~92-101); fix the stale "co-located SFU" (~48-52) and "never expose these publicly" (~90-91) comments. T007 test now passes.
+- [X] T010 [US2] In `server/cmd/ringd/main.go` TLS branch (~360-372): when the UDP endpoint is configured, advertise `turn:<stunHost>:<stunPort>?transport=udp` in `TurnURLs` and build `StunURLs = ["stun:<stunHost>:<stunPort>"]`; also correct the "no server-side SFU" adjacent stale wording if touched.
+- [X] T011 [US2] In `server/internal/api/turn_handlers.go`: add `StunURLs []string` to `Handlers`, wire it from main.go, and emit it as a separate credential-less iceServers entry; update the "all media rides TURNS on 443 / client forces relay" comment (lines ~22-23). T006 test now passes.
+- [X] T012 [US2] Gates: `cd server && go build ./... && go vet ./... && go test ./...` all green; then manual quickstart.md US2 check against a UDP-enabled deployment (or dev stack) — credentials response matches contracts/turn-credentials.md and a cross-network call selects `srflx`. NOTE: go gates + credentials contract verified; the srflx cross-network check needs a UDP-enabled real deployment - deferred to the PR real-device pass alongside T022.
 
 **Checkpoint**: US1 + US2 both work; zero-config deployments byte-identical (US4 acceptance 1 verified by T007's no-socket case + T006's unchanged-response case).
 
@@ -77,14 +77,14 @@ No blocking prerequisites shared across stories beyond what US1 itself delivers 
 
 ### Tests for User Story 3 (write first, must fail)
 
-- [ ] T013 [P] [US3] In `src/settings/schema.test.ts`: keep `privacy.protectIp` in the DEAD list but rewrite the stale "calls always relay, so protect IP was a no-op" comment (~33-37) to point at the replacement key; add a positive assertion that the schema contains a `privacy.relayCalls` toggle with default `false`. Confirm FAIL (key not in schema yet).
-- [ ] T014 [P] [US3] In `src/services/ownsync.test.ts`: extend the allowlist coupling test to expect `privacy.relayCalls` in `SYNCED_PREF_KEYS`. Confirm FAIL.
+- [X] T013 [P] [US3] In `src/settings/schema.test.ts`: keep `privacy.protectIp` in the DEAD list but rewrite the stale "calls always relay, so protect IP was a no-op" comment (~33-37) to point at the replacement key; add a positive assertion that the schema contains a `privacy.relayCalls` toggle with default `false`. Confirm FAIL (key not in schema yet).
+- [X] T014 [P] [US3] In `src/services/ownsync.test.ts`: extend the allowlist coupling test to expect `privacy.relayCalls` in `SYNCED_PREF_KEYS`. Confirm FAIL.
 
 ### Implementation for User Story 3
 
-- [ ] T015 [P] [US3] In `src/settings/schema.ts` privacy node (~245): add the toggle — title "Always relay calls", key `privacy.relayCalls`, default `false`, footer in Ring copy voice (plain, "you", no em-dashes or semicolons): "Route your calls through the Ring server so people you call never see your IP address. Calls may connect slower and quality may be lower. Applies from your next call." T013 now passes.
-- [ ] T016 [P] [US3] In `src/services/ownsync-keys.ts`: add `'privacy.relayCalls'` to `SYNCED_PREF_KEYS`. T014 now passes.
-- [ ] T017 [US3] Gates: `npm run build` + `npx vitest run` green; manual quickstart.md US3 check — with the toggle ON for exactly one side and OFF for the other (the FR-009 asymmetric pairing), the call connects and the toggled side's selected pair is `relay`; setting arrives on a second signed-in device.
+- [X] T015 [P] [US3] In `src/settings/schema.ts` privacy node (~245): add the toggle — title "Always relay calls", key `privacy.relayCalls`, default `false`, footer in Ring copy voice (plain, "you", no em-dashes or semicolons): "Route your calls through the Ring server so people you call never see your IP address. Calls may connect slower and quality may be lower. Applies from your next call." T013 now passes.
+- [X] T016 [P] [US3] In `src/services/ownsync-keys.ts`: add `'privacy.relayCalls'` to `SYNCED_PREF_KEYS`. T014 now passes.
+- [X] T017 [US3] Gates: `npm run build` + `npx vitest run` green; manual quickstart.md US3 check — with the toggle ON for exactly one side and OFF for the other (the FR-009 asymmetric pairing), the call connects and the toggled side's selected pair is `relay`; setting arrives on a second signed-in device.
 
 **Checkpoint**: All three behavioral stories independently functional (US1 direct, US2 srflx, US3 forced relay).
 
@@ -96,9 +96,9 @@ No blocking prerequisites shared across stories beyond what US1 itself delivers 
 
 ### Implementation for User Story 4 (docs only — no test tasks; behavior covered by T006/T007)
 
-- [ ] T018 [P] [US4] In `server/docs/CALLING.md`: the "relay only when a direct path is blocked" wording (~31-39) is now accurate — keep and sharpen it; add a "Direct media paths (optional UDP)" section covering `TURN_UDP_LISTEN=:3478` + forwarding `3478/udp`, `STUN_PUBLIC_HOST`/`STUN_PUBLIC_PORT`, behavior at each exposure level (nothing open → relay + LAN-direct; UDP open → internet-wide direct), the optional public `RELAY_IP` for one-sided relay, and the censorship note (UDP STUN is fingerprintable; TURNS-on-443 remains the covert path with automatic fallback).
-- [ ] T019 [P] [US4] In `CLAUDE.md`: remove the phantom SFU — "an embedded TURN relay + SFU for calls" (~line 33) and any other SFU mention; describe calls as P2P/mesh, direct when possible, embedded TURN relay as fallback.
-- [ ] T020 [P] [US4] In `e2e/calls.spec.ts` (~line 6): fix the stale "relayed through the embedded TURN" header comment to reflect direct-when-possible (same-host e2e now connects via host candidates).
+- [X] T018 [P] [US4] In `server/docs/CALLING.md`: the "relay only when a direct path is blocked" wording (~31-39) is now accurate — keep and sharpen it; add a "Direct media paths (optional UDP)" section covering `TURN_UDP_LISTEN=:3478` + forwarding `3478/udp`, `STUN_PUBLIC_HOST`/`STUN_PUBLIC_PORT`, behavior at each exposure level (nothing open → relay + LAN-direct; UDP open → internet-wide direct), the optional public `RELAY_IP` for one-sided relay, and the censorship note (UDP STUN is fingerprintable; TURNS-on-443 remains the covert path with automatic fallback).
+- [X] T019 [P] [US4] In `CLAUDE.md`: remove the phantom SFU — "an embedded TURN relay + SFU for calls" (~line 33) and any other SFU mention; describe calls as P2P/mesh, direct when possible, embedded TURN relay as fallback.
+- [X] T020 [P] [US4] In `e2e/calls.spec.ts` (~line 6): fix the stale "relayed through the embedded TURN" header comment to reflect direct-when-possible (same-host e2e now connects via host candidates).
 
 **Checkpoint**: Docs match reality end to end.
 
@@ -106,7 +106,7 @@ No blocking prerequisites shared across stories beyond what US1 itself delivers 
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T021 Run all gates from quickstart.md: `npm run build`, `npx vitest run` (coverage floors hold), `cd server && go build ./... && go vet ./... && go test ./...`, and `npm run test:e2e` (needs `make db-up`) — all green.
+- [X] T021 Run all gates from quickstart.md: `npm run build`, `npx vitest run` (coverage floors hold), `cd server && go build ./... && go vet ./... && go test ./...`, and `npm run test:e2e` (needs `make db-up`) — all green.
 - [ ] T022 Regression watch (SC-004, FR-010): compare `markConnect` call-setup timings (instrumented in `src/composables/useCall.ts`, visible via the drive harness) before/after on a relay-path scenario; budget +300ms per SC-004. Also exercise mid-call direct-path loss once (e.g. drop one side's network interface or toggle Wi-Fi mid-call on a real device) and confirm the existing reconnection recovers the call on the relay. Record the numbers in the PR description.
 - [ ] T023 Bump spec `**Status**:` in `specs/1043-direct-peer-peer/spec.md` (planned → in-progress at implement start, → in-review at PR) and run `make roadmap` so the CI roadmap guard stays green.
 

--- a/specs/1043-direct-peer-peer/tasks.md
+++ b/specs/1043-direct-peer-peer/tasks.md
@@ -108,7 +108,7 @@ No blocking prerequisites shared across stories beyond what US1 itself delivers 
 
 - [X] T021 Run all gates from quickstart.md: `npm run build`, `npx vitest run` (coverage floors hold), `cd server && go build ./... && go vet ./... && go test ./...`, and `npm run test:e2e` (needs `make db-up`) — all green.
 - [ ] T022 Regression watch (SC-004, FR-010): compare `markConnect` call-setup timings (instrumented in `src/composables/useCall.ts`, visible via the drive harness) before/after on a relay-path scenario; budget +300ms per SC-004. Also exercise mid-call direct-path loss once (e.g. drop one side's network interface or toggle Wi-Fi mid-call on a real device) and confirm the existing reconnection recovers the call on the relay. Record the numbers in the PR description.
-- [ ] T023 Bump spec `**Status**:` in `specs/1043-direct-peer-peer/spec.md` (planned → in-progress at implement start, → in-review at PR) and run `make roadmap` so the CI roadmap guard stays green.
+- [X] T023 Bump spec `**Status**:` in `specs/1043-direct-peer-peer/spec.md` (planned → in-progress at implement start, → in-review at PR) and run `make roadmap` so the CI roadmap guard stays green.
 
 ---
 

--- a/specs/1043-direct-peer-peer/tasks.md
+++ b/specs/1043-direct-peer-peer/tasks.md
@@ -1,0 +1,132 @@
+# Tasks: Direct Peer-to-Peer Call Media with Relay Fallback
+
+**Input**: Design documents from `/specs/1043-direct-peer-peer/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/turn-credentials.md, quickstart.md
+
+**Tests**: REQUIRED — constitution Principle III (TDD) mandates failing tests before the implementation that satisfies them. Each story phase orders its tests first.
+
+**Organization**: Tasks are grouped by user story so each story is an independently testable increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+
+## Phase 1: Setup
+
+No setup tasks — the feature edits existing files in an existing monorepo; no new projects, dependencies, stores, or migrations (plan.md Structure Decision).
+
+---
+
+## Phase 2: Foundational
+
+No blocking prerequisites shared across stories beyond what US1 itself delivers (the `callRtcConfig()` helper lands inside US1 and is reused by US3; US2 and US4 touch disjoint files). User stories can begin immediately.
+
+---
+
+## Phase 3: User Story 1 - Same-network calls connect directly (Priority: P1) 🎯 MVP
+
+**Goal**: Stop forcing relay: build every call peer connection (1:1 and each mesh leg) with `iceTransportPolicy: 'all'` via one shared, setting-aware config helper, so same-LAN calls pick direct host pairs and everything else still falls back to the relay.
+
+**Independent Test**: Two browsers on one machine (`make start`), 1:1 video call → `chrome://webrtc-internals` selected candidate pair is `host ↔ host`; block direct (or force relay via the not-yet-existing setting default path) → call still connects via relay. quickstart.md US1.
+
+### Tests for User Story 1 (write first, must fail)
+
+- [ ] T001 [US1] Create vitest unit test `src/services/call/turn.test.ts` for `rtcConfig`: default policy is `'all'`; `{relayOnly: true}` forces `'relay'`; `bundlePolicy` stays `'max-bundle'`; iceServers passed through. Also cover `callRtcConfig()` reading the `privacy.relayCalls` setting (mock `getSetting`, default false). Run `npx vitest run src/services/call/turn.test.ts` and confirm it FAILS against current code (policy is hard-coded `'relay'`, helper doesn't exist).
+
+### Implementation for User Story 1
+
+- [ ] T002 [US1] In `src/services/call/turn.ts`: change `rtcConfig(turn)` to `rtcConfig(turn, opts?: {relayOnly?: boolean})` with `iceTransportPolicy: opts?.relayOnly ? 'relay' : 'all'`; add `callRtcConfig(): Promise<RTCConfiguration>` combining `getTurnConfig()` + `getSetting<boolean>('privacy.relayCalls', false)`; rewrite the stale header (lines 1-7) and `rtcConfig` doc comment (lines 58-62) to explain direct-when-possible + relay fallback + the privacy override (keep the repo's explain-the-why comment style). T001 test now passes.
+- [ ] T003 [P] [US1] In `src/composables/useCall.ts` `newPeerConnection()` (~line 780): replace `getTurnConfig()` + `rtcConfig(turn)` with `await callRtcConfig()`.
+- [ ] T004 [P] [US1] In `src/services/call/mesh.ts`: `buildLeg` (~line 783) and `restartLegIce` `setConfiguration` (~line 377) both use `await callRtcConfig()` — the restart path MUST get the same setting-aware config so an ICE restart never flips policy; keep the buildLeg awaits before leg reservation (race re-check at ~784-785 must stay valid); update the file-header claim that media always rides the relay.
+- [ ] T005 [US1] Gates: `npm run build` (typecheck) and `npx vitest run` pass; then manual quickstart.md US1 check via the drive harness or two browser profiles — selected candidate pair is `host ↔ host` on a same-machine call, and the call still connects when only relay pairs survive.
+
+**Checkpoint**: US1 fully functional — direct on LAN, relay fallback intact, no server change needed.
+
+---
+
+## Phase 4: User Story 2 - Internet-wide direct calls when the operator opts in (Priority: P2)
+
+**Goal**: Optional server UDP endpoint (`TURN_UDP_LISTEN`) that also runs in TLS mode, serving STUN Binding (srflx discovery) and TURN-over-UDP with the existing REST credentials; advertised to clients as an extra credential-less `stun:` iceServers entry plus a `turn:...?transport=udp` URL, per contracts/turn-credentials.md. Unset → no listener, no new port, byte-identical credentials response.
+
+**Independent Test**: With `TURN_UDP_LISTEN` set on a TLS deployment, `GET /v1/turn-credentials` shows the stun entry and a cross-network call selects an `srflx` pair; without it, no UDP socket opens and the response is unchanged. quickstart.md US2/US4.
+
+### Tests for User Story 2 (write first, must fail)
+
+- [ ] T006 [P] [US2] Create `server/internal/api/turn_handlers_test.go` (none exists) following the sibling handler-test pattern: 503 when `CallsEnabled` is false; 401 unauthenticated; TURN-only config → exactly one credentialed iceServers entry with the configured URLs and `ttl` 3600; with `StunURLs` set → an additional entry carrying only `urls` (no `username`/`credential`) while the credentialed entry is unchanged. Confirm FAIL (the `StunURLs` field doesn't exist yet).
+- [ ] T007 [P] [US2] Extend `server/internal/turn/server_test.go`: TLS-mode `Start` with `UDPListen` set answers a STUN Binding request on the UDP socket (reuse the existing pion round-trip test style); TLS-mode without `UDPListen` opens no UDP socket. Confirm FAIL (Config has no `UDPListen`).
+
+### Implementation for User Story 2
+
+- [ ] T008 [P] [US2] In `server/internal/config/config.go`: add `TurnUDPListen` (`TURN_UDP_LISTEN`, default "" = disabled), `StunPublicHost` (`STUN_PUBLIC_HOST`, default: TURN public host) and `StunPublicPort` (`STUN_PUBLIC_PORT`, default: port parsed from `TURN_UDP_LISTEN`); boot error on unparseable `TURN_UDP_LISTEN` (match existing listen-addr validation style); fix the stale "TURN relay + SFU" comment at line ~62.
+- [ ] T009 [US2] In `server/internal/turn/server.go`: add `UDPListen string` to `Config`; when non-empty and `TLSConfig != nil`, additionally open the UDP `PacketConnConfig` the dev branch already uses (lines ~92-101); fix the stale "co-located SFU" (~48-52) and "never expose these publicly" (~90-91) comments. T007 test now passes.
+- [ ] T010 [US2] In `server/cmd/ringd/main.go` TLS branch (~360-372): when the UDP endpoint is configured, advertise `turn:<stunHost>:<stunPort>?transport=udp` in `TurnURLs` and build `StunURLs = ["stun:<stunHost>:<stunPort>"]`; also correct the "no server-side SFU" adjacent stale wording if touched.
+- [ ] T011 [US2] In `server/internal/api/turn_handlers.go`: add `StunURLs []string` to `Handlers`, wire it from main.go, and emit it as a separate credential-less iceServers entry; update the "all media rides TURNS on 443 / client forces relay" comment (lines ~22-23). T006 test now passes.
+- [ ] T012 [US2] Gates: `cd server && go build ./... && go vet ./... && go test ./...` all green; then manual quickstart.md US2 check against a UDP-enabled deployment (or dev stack) — credentials response matches contracts/turn-credentials.md and a cross-network call selects `srflx`.
+
+**Checkpoint**: US1 + US2 both work; zero-config deployments byte-identical (US4 acceptance 1 verified by T007's no-socket case + T006's unchanged-response case).
+
+---
+
+## Phase 5: User Story 3 - "Always relay calls" privacy choice (Priority: P3)
+
+**Goal**: Synced `privacy.relayCalls` toggle (default off) that forces `'relay'` policy for all of the user's calls from the next call onward, so peers never learn a direct address for them.
+
+**Independent Test**: Toggle on → same-LAN call selects a `relay` pair on the toggled side; second device receives the setting via own-sync. quickstart.md US3.
+
+### Tests for User Story 3 (write first, must fail)
+
+- [ ] T013 [P] [US3] In `src/settings/schema.test.ts`: keep `privacy.protectIp` in the DEAD list but rewrite the stale "calls always relay, so protect IP was a no-op" comment (~33-37) to point at the replacement key; add a positive assertion that the schema contains a `privacy.relayCalls` toggle with default `false`. Confirm FAIL (key not in schema yet).
+- [ ] T014 [P] [US3] In `src/services/ownsync.test.ts`: extend the allowlist coupling test to expect `privacy.relayCalls` in `SYNCED_PREF_KEYS`. Confirm FAIL.
+
+### Implementation for User Story 3
+
+- [ ] T015 [P] [US3] In `src/settings/schema.ts` privacy node (~245): add the toggle — title "Always relay calls", key `privacy.relayCalls`, default `false`, footer in Ring copy voice (plain, "you", no em-dashes or semicolons): "Route your calls through the Ring server so people you call never see your IP address. Calls may connect slower and quality may be lower. Applies from your next call." T013 now passes.
+- [ ] T016 [P] [US3] In `src/services/ownsync-keys.ts`: add `'privacy.relayCalls'` to `SYNCED_PREF_KEYS`. T014 now passes.
+- [ ] T017 [US3] Gates: `npm run build` + `npx vitest run` green; manual quickstart.md US3 check — with the toggle ON for exactly one side and OFF for the other (the FR-009 asymmetric pairing), the call connects and the toggled side's selected pair is `relay`; setting arrives on a second signed-in device.
+
+**Checkpoint**: All three behavioral stories independently functional (US1 direct, US2 srflx, US3 forced relay).
+
+---
+
+## Phase 6: User Story 4 - Operator clarity and zero-change safety (Priority: P4)
+
+**Goal**: Docs tell the truth at every exposure level; stale SFU/forced-relay references are gone.
+
+### Implementation for User Story 4 (docs only — no test tasks; behavior covered by T006/T007)
+
+- [ ] T018 [P] [US4] In `server/docs/CALLING.md`: the "relay only when a direct path is blocked" wording (~31-39) is now accurate — keep and sharpen it; add a "Direct media paths (optional UDP)" section covering `TURN_UDP_LISTEN=:3478` + forwarding `3478/udp`, `STUN_PUBLIC_HOST`/`STUN_PUBLIC_PORT`, behavior at each exposure level (nothing open → relay + LAN-direct; UDP open → internet-wide direct), the optional public `RELAY_IP` for one-sided relay, and the censorship note (UDP STUN is fingerprintable; TURNS-on-443 remains the covert path with automatic fallback).
+- [ ] T019 [P] [US4] In `CLAUDE.md`: remove the phantom SFU — "an embedded TURN relay + SFU for calls" (~line 33) and any other SFU mention; describe calls as P2P/mesh, direct when possible, embedded TURN relay as fallback.
+- [ ] T020 [P] [US4] In `e2e/calls.spec.ts` (~line 6): fix the stale "relayed through the embedded TURN" header comment to reflect direct-when-possible (same-host e2e now connects via host candidates).
+
+**Checkpoint**: Docs match reality end to end.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T021 Run all gates from quickstart.md: `npm run build`, `npx vitest run` (coverage floors hold), `cd server && go build ./... && go vet ./... && go test ./...`, and `npm run test:e2e` (needs `make db-up`) — all green.
+- [ ] T022 Regression watch (SC-004, FR-010): compare `markConnect` call-setup timings (instrumented in `src/composables/useCall.ts`, visible via the drive harness) before/after on a relay-path scenario; budget +300ms per SC-004. Also exercise mid-call direct-path loss once (e.g. drop one side's network interface or toggle Wi-Fi mid-call on a real device) and confirm the existing reconnection recovers the call on the relay. Record the numbers in the PR description.
+- [ ] T023 Bump spec `**Status**:` in `specs/1043-direct-peer-peer/spec.md` (planned → in-progress at implement start, → in-review at PR) and run `make roadmap` so the CI roadmap guard stays green.
+
+---
+
+## Dependencies & Execution Order
+
+- **US1 (T001-T005)**: no dependencies — start immediately. MVP.
+- **US2 (T006-T012)**: independent of US1 (server-only files). Can run in parallel with US1.
+- **US3 (T013-T017)**: depends on T002 (`callRtcConfig()` reads the setting) for end-to-end effect; the schema/sync tasks themselves (T013-T016) only need the key name and can run any time.
+- **US4 (T018-T020)**: content depends on US2's final knob names; text-only, run after T008-T011 land.
+- **Polish (T021-T023)**: after all desired stories.
+- Within each story: test tasks strictly before implementation tasks (constitution III).
+
+### Parallel opportunities
+
+- T001 (client test) ∥ T006/T007 (server tests) — different languages, different files.
+- After T002: T003 ∥ T004. After Config lands (T008): T009 → T010 → T011 are sequential (shared wiring), but ∥ any US3 task.
+- T013 ∥ T014; T015 ∥ T016; T018 ∥ T019 ∥ T020.
+
+## Implementation Strategy
+
+MVP = US1 alone (client-only, works against unmodified servers). Ship order for production: US2 (server, additive) can deploy before or with the US1/US3 client per contracts/turn-credentials.md compatibility matrix. Each checkpoint is independently demonstrable via quickstart.md.

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -38,7 +38,7 @@ import { groupAvatar } from '@/db/avatars';
 // the incoming surface must reveal nothing identifying. A neutral name + avatar.
 import { getSelfUserId } from '@/services/auth';
 import { isUnlockedNow, isUnlocked } from '@/services/crypto/identity';
-import { getTurnConfig, warmTurnConfig, rtcConfig } from '@/services/call/turn';
+import { warmTurnConfig, callRtcConfig } from '@/services/call/turn';
 import {
   sendSealedSignal, openSealedSignal, sendControl, meshSessionChatId, sendRecall, sendGroupInviteeCancel,
   sendGroupLeave, sendGroupBusy, sendHoldResume, sendHealth, sendJoinRoom,
@@ -778,8 +778,7 @@ function gumConstraints(kind: CallKind): MediaStreamConstraints {
 }
 
 async function newPeerConnection(): Promise<RTCPeerConnection> {
-  const turn = await getTurnConfig();
-  const conn = new RTCPeerConnection(rtcConfig(turn));
+  const conn = new RTCPeerConnection(await callRtcConfig());
   markConnect('pcCreated');
 
   conn.ontrack = (e) => {

--- a/src/services/call/mesh.ts
+++ b/src/services/call/mesh.ts
@@ -17,7 +17,7 @@
  */
 import { sendLive } from '@/composables/useSync';
 import { getSelfUserId } from '@/services/auth';
-import { getTurnConfig, warmTurnConfig, rtcConfig } from '@/services/call/turn';
+import { getTurnConfig, warmTurnConfig, callRtcConfig } from '@/services/call/turn';
 import { sendSealedSignal, meshSessionChatId, clearCallSession } from '@/services/call/signalling';
 import { pushDiag, setDiagSnapshot } from '@/services/call/diag';
 import {
@@ -373,11 +373,12 @@ export class MeshSession {
 
   /** Restart a leg's ICE with FRESH TURN credentials (spec 0004 FR-034): on a long call the
    *  creds the PC was built with may have expired, so re-fetch (getTurnConfig refreshes) and
-   *  setConfiguration before re-gathering — otherwise the restart re-gathers with dead creds. */
+   *  setConfiguration before re-gathering — otherwise the restart re-gathers with dead creds.
+   *  Uses the same setting-aware callRtcConfig as buildLeg so a restart can never flip the
+   *  transport policy away from what the leg was built with (spec 1043). */
   private async restartLegIce(leg: PeerLeg): Promise<void> {
     try {
-      const turn = await getTurnConfig();
-      leg.pc.setConfiguration(rtcConfig(turn));
+      leg.pc.setConfiguration(await callRtcConfig());
     } catch {
       /* couldn't refresh creds — fall through and restart with what we have */
     }
@@ -773,17 +774,17 @@ export class MeshSession {
   private async buildLeg(peerId: string): Promise<PeerLeg> {
     const existing = this.legs.get(peerId);
     if (existing) return existing;
-    // Fetch fresh TURN credentials for THIS leg (spec 0004 FR-034): getTurnConfig caches and
-    // refreshes ~30s before expiry, so a leg built late in a long call still gets valid,
-    // non-expired relay creds — a once-cached per-session snapshot would go stale and the
-    // late joiner's relay-only ICE would never gather. This await is also the only one before
-    // the leg is reserved below, so two roster updates racing to open the SAME leg could both
-    // get past the check above; re-check and hand back the winner (two PCs to one peer would
-    // glare against itself and wedge the leg).
-    const turn = await getTurnConfig();
+    // Fetch fresh TURN credentials for THIS leg (spec 0004 FR-034): callRtcConfig's
+    // getTurnConfig caches and refreshes ~30s before expiry, so a leg built late in a long
+    // call still gets valid, non-expired relay creds — a once-cached per-session snapshot
+    // would go stale and the late joiner's ICE would never gather relay candidates. This
+    // await is also the only one before the leg is reserved below, so two roster updates
+    // racing to open the SAME leg could both get past the check above; re-check and hand
+    // back the winner (two PCs to one peer would glare against itself and wedge the leg).
+    const cfg = await callRtcConfig();
     const raced = this.legs.get(peerId);
     if (raced) return raced;
-    const pc = new RTCPeerConnection(rtcConfig(turn));
+    const pc = new RTCPeerConnection(cfg);
     const leg: PeerLeg = {
       pc,
       peerId,

--- a/src/services/call/turn.test.ts
+++ b/src/services/call/turn.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { rtcConfig, callRtcConfig, clearTurnConfig, type TurnConfig } from './turn';
+import { getSetting } from '@/db/queries';
+
+// callRtcConfig composes the fetched ICE servers with the user's relay
+// preference; isolate it from the real app by mocking the settings read, the
+// auth token, and the credentials fetch (node env — no real network).
+vi.mock('@/db/queries', () => ({ getSetting: vi.fn() }));
+vi.mock('@/services/auth', () => ({ getToken: () => 'test-token' }));
+vi.mock('@/services/config', () => ({ apiBaseUrl: () => 'http://test.invalid' }));
+
+const ICE_SERVERS: RTCIceServer[] = [
+  { urls: ['turns:ring.test:443?transport=tcp'], username: 'u', credential: 'c' },
+  { urls: ['stun:ring.test:3478'] },
+];
+
+const turn: TurnConfig = { iceServers: ICE_SERVERS, ttl: 3600, fetchedAt: Date.now() };
+
+describe('rtcConfig (spec 1043 — direct when possible, relay on demand)', () => {
+  it('defaults to iceTransportPolicy "all" so direct host/srflx pairs are tried', () => {
+    expect(rtcConfig(turn).iceTransportPolicy).toBe('all');
+  });
+
+  it('forces "relay" when relayOnly is set (Always relay calls)', () => {
+    expect(rtcConfig(turn, { relayOnly: true }).iceTransportPolicy).toBe('relay');
+    expect(rtcConfig(turn, { relayOnly: false }).iceTransportPolicy).toBe('all');
+  });
+
+  it('keeps max-bundle and passes the server-advertised iceServers through untouched', () => {
+    const cfg = rtcConfig(turn);
+    expect(cfg.bundlePolicy).toBe('max-bundle');
+    expect(cfg.iceServers).toEqual(ICE_SERVERS);
+  });
+});
+
+describe('callRtcConfig (setting-aware config shared by every call site)', () => {
+  beforeEach(() => {
+    clearTurnConfig();
+    vi.mocked(getSetting).mockReset();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ iceServers: ICE_SERVERS, ttl: 3600 }),
+      })),
+    );
+  });
+
+  it('reads privacy.relayCalls with a default of false and yields "all"', async () => {
+    vi.mocked(getSetting).mockImplementation(async (_key, fallback) => fallback);
+    const cfg = await callRtcConfig();
+    expect(getSetting).toHaveBeenCalledWith('privacy.relayCalls', false);
+    expect(cfg.iceTransportPolicy).toBe('all');
+    expect(cfg.iceServers).toEqual(ICE_SERVERS);
+  });
+
+  it('yields "relay" when the user switched Always relay calls on', async () => {
+    vi.mocked(getSetting).mockResolvedValue(true);
+    const cfg = await callRtcConfig();
+    expect(cfg.iceTransportPolicy).toBe('relay');
+  });
+});

--- a/src/services/call/turn.ts
+++ b/src/services/call/turn.ts
@@ -1,12 +1,17 @@
 /**
  * Fetches ephemeral ICE/TURN configuration from the server for WebRTC calls.
  *
- * All media rides the self-hosted TURNS relay on 443 (the only public path), so
- * the server returns a single short-lived `turns:` entry. We cache it until just
- * before it expires; callers refresh for long calls and ICE restarts.
+ * Media goes direct when the networks allow it and falls back to the
+ * self-hosted TURN relay when they don't (spec 1043). The server always
+ * advertises the short-lived TURNS-on-443 credential; deployments that opt
+ * into the UDP endpoint additionally advertise a credential-less `stun:`
+ * entry so peers on different networks can discover their public addresses.
+ * We cache the response until just before it expires; callers refresh for
+ * long calls and ICE restarts.
  */
 import { apiBaseUrl } from '@/services/config';
 import { getToken } from '@/services/auth';
+import { getSetting } from '@/db/queries';
 
 export interface TurnConfig {
   iceServers: RTCIceServer[];
@@ -56,14 +61,33 @@ export function warmTurnConfig(): void {
 }
 
 /**
- * Build the RTCConfiguration for a call. We force `iceTransportPolicy: 'relay'`
- * because in the 443-only deployment the only reachable candidate is the TURNS
- * relay; trying host/srflx pairs would only add gathering latency.
+ * Build the RTCConfiguration for a call. Policy is `'all'` so ICE can pick a
+ * direct pair when one works — same-LAN via mDNS host candidates, cross-network
+ * via srflx where the deployment advertises a STUN endpoint — and the TURN
+ * relay stays in the candidate set as the automatic fallback, so no network
+ * that could connect under the old forced-relay behavior gets worse. The
+ * relayOnly override exists for the "Always relay calls" privacy setting:
+ * relay-only gathering never hands the peer a direct address for this user.
  */
-export function rtcConfig(turn: TurnConfig): RTCConfiguration {
+export function rtcConfig(turn: TurnConfig, opts?: { relayOnly?: boolean }): RTCConfiguration {
   return {
     iceServers: turn.iceServers,
-    iceTransportPolicy: 'relay',
+    iceTransportPolicy: opts?.relayOnly ? 'relay' : 'all',
     bundlePolicy: 'max-bundle',
   };
+}
+
+/**
+ * The one place call setup turns user preference into an RTCConfiguration.
+ * Every peer connection — the 1:1 call, each mesh leg, and the mesh's
+ * setConfiguration on ICE restart — must come through here so a restart can
+ * never silently flip the transport policy out from under the privacy setting.
+ * The setting is read per connection, so a toggle applies from the next call.
+ */
+export async function callRtcConfig(): Promise<RTCConfiguration> {
+  const [turn, relayOnly] = await Promise.all([
+    getTurnConfig(),
+    getSetting<boolean>('privacy.relayCalls', false),
+  ]);
+  return rtcConfig(turn, { relayOnly });
 }

--- a/src/services/ownsync-keys.ts
+++ b/src/services/ownsync-keys.ts
@@ -12,6 +12,10 @@ export const SYNCED_PREF_KEYS: string[] = [
   'privacy.lastSeen', 'privacy.online', 'privacy.profilePhoto', 'privacy.about',
   'privacy.groups', 'privacy.messageTimer',
   'privacy.disableLinkPreviews',
+  // "Always relay calls" (spec 1043): a threat-model preference, so it follows
+  // the user to every device. NEVER re-add the retired privacy.protectIp here —
+  // old encrypted snapshots may still carry a stale value for it.
+  'privacy.relayCalls',
   'notifications.message.show', 'notifications.message.reactions', 'notifications.message.sound',
   'notifications.group.show', 'notifications.group.reactions', 'notifications.group.sound',
   'notifications.wall.show', 'notifications.wall.activity', 'notifications.showPreview', 'notifications.badge',

--- a/src/services/ownsync.test.ts
+++ b/src/services/ownsync.test.ts
@@ -10,3 +10,13 @@ describe('own-data sync key allowlist (spec 1026 US2 / FR-010)', () => {
     expect(SYNCED_PREF_KEYS).toContain('privacy.disableLinkPreviews');
   });
 });
+
+describe('own-data sync key allowlist (spec 1043)', () => {
+  it('syncs the "Always relay calls" preference across devices', () => {
+    expect(SYNCED_PREF_KEYS).toContain('privacy.relayCalls');
+  });
+
+  it('never resurrects the retired privacy.protectIp key (stale snapshots)', () => {
+    expect(SYNCED_PREF_KEYS).not.toContain('privacy.protectIp');
+  });
+});

--- a/src/settings/schema.test.ts
+++ b/src/settings/schema.test.ts
@@ -31,8 +31,11 @@ describe('settings schema', () => {
 
   it('carries no dead/removed setting keys', () => {
     // Settings removed in the cleanup: backed nothing (no Status/Stories feature,
-    // camera effects, reminder infra) or were redundant (calls always relay, so
-    // "protect IP" was a no-op). Re-adding any of these should fail this guard.
+    // camera effects, reminder infra) or were redundant at the time. protectIp in
+    // particular must STAY dead even now that calls can go direct (spec 1043):
+    // old encrypted own-sync snapshots may still carry a stale protectIp value
+    // that would silently apply if the key were reused — the replacement is the
+    // new privacy.relayCalls key. Re-adding any of these should fail this guard.
     const DEAD = [
       'privacy.status', 'privacy.statusSharing', 'privacy.protectIp', 'privacy.cameraEffects',
       'notifications.status.show', 'notifications.status.reactions', 'notifications.status.sound',
@@ -50,6 +53,15 @@ describe('settings schema', () => {
     expect(searchSettings('hidden chats').length).toBeGreaterThan(0);
     expect(searchSettings('passkeys')).toHaveLength(0);
     expect(searchSettings('chat backup')).toHaveLength(0);
+  });
+});
+
+describe('settings schema — spec 1043 (direct call media)', () => {
+  it('has the "Always relay calls" toggle on the Privacy page, default off', () => {
+    const items = SETTINGS.privacy.groups.flatMap((g) => g.items);
+    const toggle = items.find((i) => 'key' in i && i.key === 'privacy.relayCalls');
+    expect(toggle?.type).toBe('toggle');
+    expect(toggle && 'default' in toggle && toggle.default).toBe(false);
   });
 });
 

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -285,6 +285,11 @@ export const SETTINGS: Record<string, SettingNode> = {
         footer:
           'When this is on, Ring stops making previews for the links you share, so those sites cannot get a peek at your IP address.',
       },
+      {
+        items: [{ type: 'toggle', title: 'Always relay calls', key: 'privacy.relayCalls', default: false }],
+        footer:
+          'Route your calls through the Ring server so people you call never see your IP address. Calls may connect slower and quality may be lower. Applies from your next call.',
+      },
     ],
   },
   'privacy-hidden-chats': {


### PR DESCRIPTION
**Spec 1043** — deliberately its own PR (per plan) so it stays one-revert-away if direct media misbehaves in real-world use: `git revert` of this squash commit restores today's always-relay behavior with no interaction with the UI/camera batch (#965, already merged in).

## What changes

Today ALL call media (1:1 and every group-mesh leg) is forced through the server's embedded TURN relay (`iceTransportPolicy: 'relay'` + a single advertised `turns:` entry): the server pays for every media byte (O(N·(N-1)) flows per group call) and even two devices on the same Wi-Fi round-trip through it.

- **Client**: every peer connection (1:1, each mesh leg, mesh ICE restarts) now gathers with `iceTransportPolicy: 'all'` via one shared, setting-aware `callRtcConfig()`. Same-LAN calls connect directly (mDNS host candidates, no server change needed); the relay stays in every candidate set as automatic fallback, so no call that connected before can fail now.
- **Server (operator opt-in)**: `TURN_UDP_LISTEN` opens a UDP listener alongside the TLS relay (STUN address discovery + TURN-over-UDP with the same ephemeral credentials); `STUN_PUBLIC_HOST/PORT` control the advertisement. `/v1/turn-credentials` appends a credential-less `stun:` entry only when configured — response shape unchanged, all four old/new client-server pairings interoperate (contract + compat matrix in `specs/1043-direct-peer-peer/contracts/`). No config → no new listener, byte-identical behavior.
- **Privacy**: new synced setting **Always relay calls** (`privacy.relayCalls`, default off) forces relay so call peers never learn your IP. The retired `privacy.protectIp` stays on the DEAD list (stale synced snapshots must not resurrect it).
- **Docs**: CALLING.md gains "Direct media paths (optional UDP)" (exposure levels, `RELAY_IP` note, censorship trade-off — TURNS-on-443 remains the covert path); phantom SFU references removed from CLAUDE.md/comments.
- Zero-knowledge: nothing new crosses the wire; the server sees strictly less (no media volume/timing for direct legs). Spec carries the constitution-required Zero-Knowledge Impact section; `checklists/privacy.md` (21 items) passed.

## Verification

- Red-first tests: `turn.test.ts` (policy + setting), new `turn_handlers_test.go` (503/401/shape/stun-entry), `server_test.go` UDP-in-TLS-mode cases.
- Full gates green on this branch WITH #965 merged in: `npm run build`, 1000 vitest, `go build/vet/test`, full e2e suite earlier (222/223 + the known-flaky thumbnail spec passing isolated), `calls.spec` + `camera-off-avatar` re-run post-merge (9/9).
- Live path proof (`drive/scenarios/probe-call-path.mjs`): default `host↔host` on both sides, policy `all`; with `privacy.relayCalls` on → `relay` policy and the peer receives only the relay candidate.

## Deferred to real-device/deployment pass (tracked in tasks.md T012/T022 notes)

- srflx verification against a UDP-enabled deployment (`TURN_UDP_LISTEN=:3478` + port-forward).
- Mid-call direct-path loss (Wi-Fi→LTE roam) recovering onto the relay.
- SC-004 call-setup timing comparison on relay-only networks (budget +300 ms).

Closes #956
Closes #957
Closes #958
Closes #959
Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7