### PR TITLE
docs(spec): specs 1043, 2028, 2029, 1044 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,8 +68,8 @@ Specs are grouped by category band; status moves
 | [1040](specs/1040-incoming-call-notifications/spec.md) | Incoming Call & Friend-Request Notifications — Identity, Badge, and Missed-Call Trace | 🟢 shipped |
 | [1041](specs/1041-merge-waiting-caller/spec.md) | Merge a Waiting Caller into the Ongoing Call | 🟢 shipped |
 | [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
-| [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | 🔵 in-review |
-| [1044](specs/1044-pinned-chats-show/spec.md) | Pinned Chats Grid (iMessage-style) | 🔵 in-review |
+| [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | 🟢 shipped |
+| [1044](specs/1044-pinned-chats-show/spec.md) | Pinned Chats Grid (iMessage-style) | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -102,5 +102,5 @@ Specs are grouped by category band; status moves
 | [2025](specs/2025-video-calls-look/spec.md) | Video calls look sharp again and recover from quality dips | 🟢 shipped |
 | [2026](specs/2026-call-markers-stored/spec.md) | Call markers must never surface as messages | 🟢 shipped |
 | [2027](specs/2027-long-media-captions/spec.md) | Media captions wrap at the photo's edge | 🟢 shipped |
-| [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🔵 in-review |
-| [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🔵 in-review |
+| [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
+| [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |

--- a/specs/1043-direct-peer-peer/spec.md
+++ b/specs/1043-direct-peer-peer/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-12
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1044-pinned-chats-show/spec.md
+++ b/specs/1044-pinned-chats-show/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-review
+**Status**: shipped
 
 **Input**: User description: "Make pinned chats look like iMessage: large circular avatars in a grid at the top of the Chats tab, up to 9 pins." (with reference screenshot of iMessage's pinned grid)
 

--- a/specs/2028-quick-forward-button/spec.md
+++ b/specs/2028-quick-forward-button/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-review
+**Status**: shipped
 
 **Input**: User bug report with screenshots: "The forward icon is in wrong position!" — on a tall portrait photo message, the floating quick-forward button hovers vertically centered beside the image, far from the caption/footer where the eye expects it. (A second screenshot caught the swipe-to-delete affordance mid-swipe at the same height, compounding the misplaced look.)
 

--- a/specs/2029-camera-off-shows/spec.md
+++ b/specs/2029-camera-off-shows/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-review
+**Status**: shipped
 
 **Input**: User bug report: "when I stop my camera feed, my profile avatar is only visible to myself and not others, they see a black screen only."
 


### PR DESCRIPTION
Status bumps to shipped + regenerated ROADMAP for the four specs merged in #965 and #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7