### PR TITLE
fix(chats): long Persian and Arabic names keep their beginning when shortened

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,3 +104,4 @@ Specs are grouped by category band; status moves
 | [2027](specs/2027-long-media-captions/spec.md) | Media captions wrap at the photo's edge | 🟢 shipped |
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
+| [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |

--- a/e2e/rtl-name-truncation.spec.ts
+++ b/e2e/rtl-name-truncation.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const chatWith = (p: any, peerId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
+
+// Long enough to truncate everywhere; starts with a strong RTL character.
+const RTL_NAME = 'خانواده پفک نمکی و تاجی و همه فامیل های دور و نزدیک';
+
+/**
+ * Spec 2030: single-line name surfaces must derive their DIRECTION from the
+ * name's content (dir="auto"), because text-overflow places the ellipsis by the
+ * element's computed direction — with the app-shell ltr, a long Persian name
+ * clipped its BEGINNING (the user-reported bug). :dir(rtl) resolving is the
+ * machine-checkable proxy for "ellipsis on the correct side".
+ */
+test('RTL names resolve RTL directionality in the header and pinned tiles', async ({
+  browser,
+}) => {
+  test.setTimeout(90_000);
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'RTLNAMA1');
+  const b = await createAccount(ctxB, 'RTLNAMB1');
+  await pair(a, b);
+
+  // A group carries the RTL name (group names are user-chosen free text).
+  const groupId = await a.page.evaluate(
+    ({ name, members }: { name: string; members: string[] }) =>
+      (window as any).__ringTest.createGroup(name, members),
+    { name: RTL_NAME, members: [b.id] },
+  );
+  expect(groupId).toBeTruthy();
+
+  // Chat header: the name element must resolve RTL for RTL content.
+  await a.page.goto(`/chat/${groupId}`);
+  const header = a.page.locator('.chat-header-name');
+  await expect(header).toBeVisible({ timeout: 15_000 });
+  await expect(a.page.locator('.chat-header-name:dir(rtl)')).toHaveCount(1);
+
+  // Pinned tile: same rule in the grid.
+  await a.page.evaluate((id: string) => (window as any).__ringTest.pinChat(id, true), groupId);
+  await a.page.goto('/tabs/chats');
+  await expect(a.page.locator('.pin-tile')).toHaveCount(1, { timeout: 15_000 });
+  await expect(a.page.locator('.pin-name:dir(rtl)')).toHaveCount(1);
+
+  // And a Latin name keeps LTR (no behavior change for existing users).
+  const dm = (await chatWith(a, b.id)) as string;
+  await a.page.goto(`/chat/${dm}`);
+  await expect(a.page.locator('.chat-header-name')).toBeVisible({ timeout: 15_000 });
+  await expect(a.page.locator('.chat-header-name:dir(ltr)')).toHaveCount(1);
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/specs/2030-rtl-names-truncate/plan.md
+++ b/specs/2030-rtl-names-truncate/plan.md
@@ -1,0 +1,23 @@
+# Implementation Plan: RTL Name Truncation (spec 2030)
+
+**Branch**: `fix/2030-rtl-names-truncate` | **Date**: 2026-07-13 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Browsers place `text-overflow: ellipsis` by the element's computed `direction`; `unicode-bidi: plaintext` (already present on some name elements) reorders glyphs but leaves `direction: ltr`, so RTL names clip at their beginning. Fix: `dir="auto"` on each single-line name element — the attribute sets computed directionality from content (first strong character), which moves both render order AND the ellipsis to the correct side, per engine spec. Keep each element's existing `text-align` so nothing shifts; drop now-redundant `unicode-bidi: plaintext` only where the attribute supersedes it on the same element.
+
+## Surfaces (from audit)
+
+`ChatDetailPage.vue:46` `.chat-header-name` · `ChatListItem.vue:29` name `<h2>` · `PinnedChatsGrid.vue:26` `.pin-name` · `CallActivePage.vue:11` `.incoming-name`, `:72/:127` `.cw-text strong`, `:175` `.tile-label`, `:323` `.name` · `IncomingCallOverlay.vue:11` `.ring-name` · `MinimizedCall.vue:22` `.mini-name`.
+
+## Constitution Check
+
+I: no wire impact — PASS. II: spec 2030 hotfix band — PASS. III: red-first e2e (`:dir(rtl)` resolution + header/tile coverage) — PASS. X: this IS the bidi mandate — PASS. XI: attribute on existing elements — PASS.
+
+## Regression test (red first)
+
+`e2e/rtl-name-truncation.spec.ts`: create a group named with a long Persian string, open the chat → assert `.chat-header-name:dir(rtl)` matches (and a Latin-named chat's header matches `:dir(ltr)`); pin the group → assert `.pin-name:dir(rtl)` on its tile. Fails today (no `dir` attribute → everything `:dir(ltr)`).
+
+## Verification
+
+`npm run build`, `npx vitest run`, new e2e red→green + `pinned-grid` suite; drive screenshot with the reporter's exact group name for the PR.

--- a/specs/2030-rtl-names-truncate/spec.md
+++ b/specs/2030-rtl-names-truncate/spec.md
@@ -1,0 +1,55 @@
+# Feature Specification: RTL Names Truncate at the Correct End
+
+**Feature Branch**: `fix/2030-rtl-names-truncate`
+
+**Created**: 2026-07-13
+
+**Status**: in-review
+
+**Input**: User bug report with screenshots: a long Persian group name ("خانواده پفک نمکی و تاجی") truncates by clipping the BEGINNING of the name (the visually rightmost part an RTL reader starts from), in the chat header and the new pinned-chats grid tiles.
+
+## Bug
+
+Single-line name surfaces use `text-overflow: ellipsis`, and browsers place the ellipsis at the line's end edge as determined by the element's computed `direction` — which is `ltr` everywhere in the app shell. For RTL names this clips the name's start and puts the … where the name begins, not where it continues. The existing `unicode-bidi: plaintext` on some of these elements fixes rendering order but demonstrably does NOT move the ellipsis (the report's screenshots show surfaces that already have it).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - RTL names truncate from their reading end (Priority: P1)
+
+A user with Persian/Arabic contact and group names sees long names keep their beginning (the part that identifies them) with the ellipsis at the continuation side — in the chat header, chat rows, pinned-grid tiles, and call surfaces — while Latin names keep today's behavior exactly.
+
+**Independent Test**: Give a group an overlong Persian name; the chat header and its pinned tile keep the name's first words visible with … at the visual left. A long Latin name still ellipsizes at the right.
+
+**Acceptance Scenarios**:
+
+1. **Given** a group with a long RTL name, **When** it renders in the chat header, a chat row, or a pinned tile, **Then** the name's beginning is visible and the ellipsis sits at the visual left.
+2. **Given** a long LTR name, **Then** truncation is unchanged (… at the visual right).
+3. **Given** RTL names on call surfaces (incoming overlay, active-call header, tile labels, call-waiting banner, minimized pill), **Then** the same rule holds.
+4. **Given** a mixed-direction name, **Then** the first strong character decides the direction (platform `dir="auto"` semantics).
+
+### Edge Cases
+
+- Names starting with emoji/neutral characters: `dir="auto"` skips neutrals and uses the first strong character.
+- Layout alignment must not shift: elements keep their current text-align (rows stay start-aligned, headers/tiles centered) — only the ellipsis side and render order follow the name's direction.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every single-line, ellipsis-truncated name surface MUST derive its direction from the name's content so truncation preserves the name's beginning: chat header, chat list rows, pinned-grid tiles, incoming-call overlay, active-call header and tile labels, call-waiting banner, minimized-call pill.
+- **FR-002**: LTR names and surrounding layout alignment MUST be unaffected.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The name elements resolve to RTL directionality for RTL content (machine-checkable via `:dir(rtl)`), and to LTR for Latin content — covered by an automated test that fails on today's code.
+- **SC-002**: Visual confirmation on the reported surfaces (header + pinned tile) with the reporter's group name.
+
+## Zero-Knowledge Impact
+
+None. Pure client rendering; nothing crosses the wire.
+
+## Assumptions
+
+- `dir="auto"` (first-strong heuristic) is the intended behavior for mixed-direction names, matching platform conventions; constitution X's bidi mandate applies.

--- a/specs/2030-rtl-names-truncate/tasks.md
+++ b/specs/2030-rtl-names-truncate/tasks.md
@@ -1,0 +1,5 @@
+# Tasks: RTL Name Truncation (spec 2030)
+
+- [X] T001 [US1] Failing e2e first: `e2e/rtl-name-truncation.spec.ts` — RTL-named group's `.chat-header-name` and pinned `.pin-name` match `:dir(rtl)`; a Latin-named chat matches `:dir(ltr)`. Confirm FAIL.
+- [X] T002 [US1] Add `dir="auto"` to every audited name element (plan §Surfaces); keep text-align; remove same-element redundant `unicode-bidi: plaintext`. T001 green.
+- [X] T003 Gates: build + vitest + new e2e + `pinned-grid`; drive screenshot with the reported Persian name (header + tile) for the PR.

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -26,7 +26,7 @@
         <span v-if="isOnline" class="presence-dot" aria-hidden="true" />
       </div>
       <ion-label>
-        <h2>{{ chat.name }}</h2>
+        <h2 dir="auto">{{ chat.name }}</h2>
         <p class="preview-row">
           <template v-if="activityLabel">
             <span class="preview activity">{{ activityLabel }}</span>

--- a/src/components/IncomingCallOverlay.vue
+++ b/src/components/IncomingCallOverlay.vue
@@ -8,7 +8,7 @@
       <user-avatar :src="callMeta.avatar" :alt="callMeta.name" />
     </ion-avatar>
     <div class="ring-text">
-      <div class="ring-name">{{ callMeta.name }}</div>
+      <div class="ring-name" dir="auto">{{ callMeta.name }}</div>
       <div class="ring-kind">
         {{ callMeta.isGroup ? 'Group · ' : '' }}Incoming {{ callMeta.kind === 'video' ? 'video' : 'voice' }} call…
       </div>

--- a/src/components/MinimizedCall.vue
+++ b/src/components/MinimizedCall.vue
@@ -19,7 +19,7 @@
         <user-avatar v-if="callMeta" :src="callMeta.avatar" :alt="callMeta.name" />
       </ion-avatar>
       <div class="mini-info">
-        <div class="mini-name">{{ callMeta?.name }}</div>
+        <div class="mini-name" dir="auto">{{ callMeta?.name }}</div>
         <div class="mini-status">{{ statusText }}</div>
       </div>
     </template>

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -23,7 +23,7 @@
         <ion-badge v-if="chat.unread" color="primary" class="pin-badge">{{ chat.unread }}</ion-badge>
         <span v-else-if="chat.manualUnread" class="pin-dot" aria-hidden="true" />
       </div>
-      <span class="pin-name">{{ chat.name }}</span>
+      <span class="pin-name" dir="auto">{{ chat.name }}</span>
     </button>
   </div>
 </template>

--- a/src/views/detail/CallActivePage.vue
+++ b/src/views/detail/CallActivePage.vue
@@ -8,7 +8,7 @@
       <div v-if="callState === 'incoming' && callMeta" class="incoming-fs">
         <div class="incoming-info">
           <ion-avatar class="incoming-avatar"><user-avatar :src="callMeta.avatar" :alt="callMeta.name" /></ion-avatar>
-          <h2 class="incoming-name">{{ callMeta.name }}</h2>
+          <h2 class="incoming-name" dir="auto">{{ callMeta.name }}</h2>
           <p class="incoming-kind">
             {{ callMeta.isGroup ? 'Group · ' : '' }}Incoming {{ callMeta.kind === 'video' ? 'video' : 'voice' }} call…
           </p>
@@ -69,7 +69,7 @@
               <ion-icon v-else :icon="personOutline" />
             </ion-avatar>
             <div class="cw-text">
-              <strong>{{ incomingSecond.name }}</strong>
+              <strong dir="auto">{{ incomingSecond.name }}</strong>
               <span>Incoming {{ incomingSecond.callKind === 'video' ? 'video ' : '' }}call</span>
             </div>
           </div>
@@ -124,7 +124,7 @@
           >
             <ion-icon :icon="swapHorizontalOutline" aria-hidden="true" />
             <span class="cw-swap-text">
-              <strong>Switch to {{ heldCall.name }}</strong>
+              <strong dir="auto">Switch to {{ heldCall.name }}</strong>
               <small>On hold · tap to swap calls</small>
             </span>
           </button>
@@ -172,7 +172,7 @@
                   <ion-icon v-else :icon="personOutline" />
                 </div>
                 <span class="leave-wave"><emoji emoji="👋" /></span>
-                <span v-if="t.name" class="tile-label">{{ t.name }}</span>
+                <span v-if="t.name" class="tile-label" dir="auto">{{ t.name }}</span>
               </template>
               <template v-else>
                 <!-- All tiles are MUTED here: remote audio plays through the persistent
@@ -320,7 +320,7 @@
           <button class="minimize-btn" aria-label="Minimize call" @click.stop="minimizeCall">
             <ion-icon :icon="chevronDownOutline" />
           </button>
-          <h2 class="name">{{ callMeta?.name }}</h2>
+          <h2 class="name" dir="auto">{{ callMeta?.name }}</h2>
           <p class="status">{{ statusText }}</p>
           <!-- Calling someone already in a call who can take a second one: reassure the caller
                they're queued, not ignored (spec 0005). -->

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -43,7 +43,7 @@
             <user-avatar :src="chat.avatar" :alt="chat.name" />
           </ion-avatar>
           <span class="chat-header-text">
-            <span class="chat-header-name">{{ chat.name }}</span>
+            <span class="chat-header-name" dir="auto">{{ chat.name }}</span>
             <span v-if="statusLine" class="chat-header-status">{{ statusLine }}</span>
           </span>
         </button>


### PR DESCRIPTION
**Spec 2030** (hotfix). User report with screenshots: a long RTL group name truncated by clipping its BEGINNING (the part an RTL reader identifies it by), in the chat header and pinned tiles.

Root cause: `text-overflow: ellipsis` is placed at the line edge chosen by the element's computed `direction` — `ltr` app-wide. The existing `unicode-bidi: plaintext` reorders glyphs but does not move the ellipsis (the reported surfaces already had it — screenshots prove it insufficient).

Fix: `dir="auto"` on every single-line name element, which sets computed directionality from the name's first strong character — correct render order AND correct ellipsis side, Latin names unchanged. Surfaces: chat header, chat rows, pinned-grid tiles, incoming-call overlay, active-call header + tile labels + call-waiting banner, minimized-call pill.

Red-first e2e (`rtl-name-truncation.spec.ts`) asserts `:dir(rtl)`/`:dir(ltr)` resolution on header + pinned tile; gates green (build, 1000 vitest, rtl + pinned-grid e2e); verified visually with the reporter's exact group name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7