### PR TITLE
feat(chats): arrange pinned chats your way, and hold a chat to peek at it (spec 1045)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,5 +264,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1043-direct-peer-peer/plan.md`
+`specs/1045-rearrange-pinned-chats/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ Specs are grouped by category band; status moves
 | [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
 | [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | 🟢 shipped |
 | [1044](specs/1044-pinned-chats-show/spec.md) | Pinned Chats Grid (iMessage-style) | 🟢 shipped |
-| [1045](specs/1045-rearrange-pinned-chats/spec.md) | Rearrange pinned chats with drag, stable manual order, and long-press chat preview | 🟡 in-progress |
+| [1045](specs/1045-rearrange-pinned-chats/spec.md) | Rearrange pinned chats with drag, stable manual order, and long-press chat preview | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,6 +70,7 @@ Specs are grouped by category band; status moves
 | [1042](specs/1042-connection-indicator/spec.md) | Show when the app has lost its server connection | 🟢 shipped |
 | [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | 🟢 shipped |
 | [1044](specs/1044-pinned-chats-show/spec.md) | Pinned Chats Grid (iMessage-style) | 🟢 shipped |
+| [1045](specs/1045-rearrange-pinned-chats/spec.md) | Rearrange pinned chats with drag, stable manual order, and long-press chat preview | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/first-pin-dropzone.mjs
+++ b/drive/scenarios/first-pin-dropzone.mjs
@@ -1,0 +1,39 @@
+// Verify (spec 1045 follow-up): with NO pins yet, lifting a row shows the
+// first-pin drop zone, and dropping the row on it creates the first pin.
+import { createAccount, pair, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Me', label: 'A', mobile: true });
+const b = await createAccount({ name: 'Biz', label: 'B' });
+await pair(a, b);
+await say(b, a.id, 'hi'); await waitForMessage(a, b.id, 'hi');
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(500);
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.locator('ion-item-sliding').count(), (n) => n >= 1, { label: 'row' });
+console.log('[state] tiles before (expect 0):', await a.page.locator('.pin-tile').count());
+
+const cdp = await a.page.context().newCDPSession(a.page);
+const row = await a.page.locator('ion-item-sliding').first().boundingBox();
+const from = { x: row.x + row.width / 2, y: row.y + row.height / 2 };
+await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [from] });
+await a.page.waitForTimeout(550); // lift
+await poll(() => a.page.locator('.pin-dropzone').count(), (n) => n === 1, { label: 'drop zone appears' });
+const zone = await a.page.locator('.pin-dropzone').boundingBox();
+const to = { x: zone.x + zone.width / 2, y: zone.y + zone.height / 2 };
+for (let i = 1; i <= 10; i++) {
+  await cdp.send('Input.dispatchTouchEvent', {
+    type: 'touchMove',
+    touchPoints: [{ x: from.x + ((to.x - from.x) * i) / 10, y: from.y + ((to.y - from.y) * i) / 10 }],
+  });
+  await a.page.waitForTimeout(30);
+}
+await a.page.waitForTimeout(250);
+await shot(a, 'firstpin-hover');
+console.log('[state] zone hover class:', await a.page.locator('.pin-dropzone.hover').count());
+await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n === 1, { label: 'first pin created' });
+console.log('[ok] first chat pinned via the drop zone');
+await shot(a, 'firstpin-done');
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/first-pin-mouse.mjs
+++ b/drive/scenarios/first-pin-mouse.mjs
@@ -1,0 +1,35 @@
+// Debug: first-pin drop zone with MOUSE (the e2e path) — zone appears but the
+// drop doesn't pin. Log pointer events + final URL.
+import { createAccount, pair, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Me', label: 'A' });
+const b = await createAccount({ name: 'Biz', label: 'B' });
+await pair(a, b);
+await say(b, a.id, 'hi'); await waitForMessage(a, b.id, 'hi');
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(500);
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.locator('ion-item-sliding').count(), (n) => n >= 1, { label: 'row' });
+await a.page.evaluate(() => {
+  for (const t of ['pointerdown', 'pointermove', 'pointerup', 'pointercancel', 'click']) {
+    document.addEventListener(t, (e) => console.log(`[evt] ${t} ${Math.round(e.clientX)},${Math.round(e.clientY)}`), true);
+  }
+});
+const row = await a.page.locator('ion-item-sliding').first().boundingBox();
+await a.page.mouse.move(row.x + row.width / 2, row.y + row.height / 2);
+await a.page.mouse.down();
+await poll(() => a.page.locator('.drag-proxy').count(), (n) => n === 1, { label: 'proxy' });
+await poll(() => a.page.locator('.pin-dropzone').count(), (n) => n === 1, { label: 'zone' });
+const zone = await a.page.locator('.pin-dropzone').boundingBox();
+console.log('[state] zone box:', JSON.stringify(zone));
+await a.page.mouse.move(row.x + row.width / 2 + 12, row.y + row.height / 2 + 12, { steps: 3 });
+await a.page.mouse.move(zone.x + zone.width / 2, zone.y + zone.height / 2, { steps: 10 });
+await a.page.waitForTimeout(200);
+console.log('[state] hover class mid-drag:', await a.page.locator('.pin-dropzone.hover').count());
+await a.page.mouse.up();
+await a.page.waitForTimeout(800);
+console.log('[state] tiles after drop:', await a.page.locator('.pin-tile').count());
+console.log('[state] url:', a.page.url());
+await shot(a, 'firstpin-mouse');
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/mouse-reorder-debug.mjs
+++ b/drive/scenarios/mouse-reorder-debug.mjs
@@ -1,0 +1,51 @@
+// Debug: e2e mouse drag-reorder became a no-op. Reproduce the exact e2e gesture
+// (mouse, await proxy, nudge, glide, drop) with event logging.
+import { createAccount, pair, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Me', label: 'A' });
+const b = await createAccount({ name: 'Biz', label: 'B' });
+const c = await createAccount({ name: 'Cyr', label: 'C' });
+await pair(a, b);
+await pair(a, c);
+const chatB = await a.page.evaluate((p) => window.__ringTest.chatWith(p), b.id);
+const chatC = await a.page.evaluate((p) => window.__ringTest.chatWith(p), c.id);
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), chatB);
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), chatC);
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(500);
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n >= 2, { label: '2 tiles' });
+
+await a.page.evaluate(() => {
+  for (const t of ['pointerdown', 'pointermove', 'pointerup', 'pointercancel']) {
+    document.addEventListener(
+      t,
+      (e) => console.log(`[evt] ${t} ${Math.round(e.clientX)},${Math.round(e.clientY)} target=${e.target?.className?.toString?.().slice(0, 30) ?? e.target?.tagName}`),
+      true,
+    );
+  }
+});
+
+const gridOrder = () =>
+  a.page.locator('.pin-tile[data-chat-id]').evaluateAll((els) => els.map((e) => e.getAttribute('data-chat-id')));
+console.log("[order] before:", JSON.stringify(await gridOrder()));
+
+const tC = await a.page.locator(`.pin-tile[data-chat-id="${chatC}"]`).boundingBox();
+const tB = await a.page.locator(`.pin-tile[data-chat-id="${chatB}"]`).boundingBox();
+const from = { x: tC.x + tC.width / 2, y: tC.y + tC.height / 2 };
+const to = { x: tB.x + tB.width / 2, y: tB.y + tB.height / 2 };
+await a.page.mouse.move(from.x, from.y);
+await a.page.mouse.down();
+await poll(() => a.page.locator('.drag-proxy').count(), (n) => n === 1, { label: 'proxy up' });
+console.log('[state] proxy visible, nudging');
+await a.page.mouse.move(from.x + 12, from.y + 12, { steps: 3 });
+await a.page.mouse.move(to.x, to.y, { steps: 12 });
+await a.page.waitForTimeout(150);
+console.log('[state] before mouseup, ghost count:', await a.page.locator('.pin-ghost').count());
+await a.page.mouse.up();
+await a.page.waitForTimeout(800);
+console.log("[order] after:", JSON.stringify(await gridOrder()), "(expect C first)");
+await shot(a, 'mousedbg-after');
+
+await sweep([a, b, c]);
+await done();

--- a/drive/scenarios/name-debug-1045.mjs
+++ b/drive/scenarios/name-debug-1045.mjs
@@ -1,0 +1,59 @@
+// Debug (spec 1045 follow-up): after a drag-reorder, the moved tile's NAME stays
+// hidden until the next drag. Reorder by touch, then dump each tile's classes and
+// the computed visibility of its .pin-name.
+import { createAccount, pair, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Me', label: 'A', mobile: true });
+const b = await createAccount({ name: 'Biz', label: 'B' });
+const c = await createAccount({ name: 'Cyr', label: 'C' });
+await pair(a, b);
+await pair(a, c);
+await say(b, a.id, 'hi'); await waitForMessage(a, b.id, 'hi');
+await say(c, a.id, 'yo'); await waitForMessage(a, c.id, 'yo');
+const chatB = await a.page.evaluate((p) => window.__ringTest.chatWith(p), b.id);
+const chatC = await a.page.evaluate((p) => window.__ringTest.chatWith(p), c.id);
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), chatB);
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), chatC);
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(500);
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n >= 2, { label: '2 tiles' });
+
+const cdp = await a.page.context().newCDPSession(a.page);
+async function touchDrag(from, to, steps = 10) {
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [from] });
+  await a.page.waitForTimeout(550);
+  for (let i = 1; i <= steps; i++) {
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x: from.x + ((to.x - from.x) * i) / steps, y: from.y + ((to.y - from.y) * i) / steps }],
+    });
+    await a.page.waitForTimeout(30);
+  }
+  await a.page.waitForTimeout(250);
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+}
+const center = (bx) => ({ x: bx.x + bx.width / 2, y: bx.y + bx.height / 2 });
+
+const dump = () =>
+  a.page.evaluate(() =>
+    [...document.querySelectorAll('.pin-tile')].map((t) => ({
+      id: t.getAttribute('data-chat-id'),
+      cls: t.className,
+      nameVis: getComputedStyle(t.querySelector('.pin-name')).visibility,
+      nameText: t.querySelector('.pin-name')?.textContent?.trim(),
+      avatarVis: getComputedStyle(t.querySelector('.pin-avatar')).visibility,
+      firstChildVis: t.querySelector('.pin-avatar > *') ? getComputedStyle(t.querySelector('.pin-avatar > *')).visibility : 'n/a',
+    })),
+  );
+
+console.log('[before]', JSON.stringify(await dump(), null, 1));
+const tC = await a.page.locator(`.pin-tile[data-chat-id="${chatC}"]`).boundingBox();
+const tB = await a.page.locator(`.pin-tile[data-chat-id="${chatB}"]`).boundingBox();
+await touchDrag(center(tC), center(tB));
+await a.page.waitForTimeout(800);
+console.log('[after-reorder]', JSON.stringify(await dump(), null, 1));
+await shot(a, 'namedbg-after-reorder');
+
+await sweep([a, b, c]);
+await done();

--- a/drive/scenarios/peek-tap-debug.mjs
+++ b/drive/scenarios/peek-tap-debug.mjs
@@ -1,0 +1,86 @@
+// Debug (spec 1045 follow-up): peek menu actions need TWO taps on touch, and
+// Delete's confirm sheet hides behind the still-open peek. Reproduce with real
+// touch events (CDP) on a mobile-emulated client and log what each tap does.
+import { createAccount, pair, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Me', label: 'A', mobile: true });
+const b = await createAccount({ name: 'Biz', label: 'B' });
+await pair(a, b);
+await say(b, a.id, 'hello!');
+await waitForMessage(a, b.id, 'hello!');
+
+// Pin B so we get a tile.
+const chatId = await a.page.evaluate((peer) => window.__ringTest.chatWith(peer), b.id);
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), chatId);
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(600);
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n >= 1, { label: 'tile' });
+
+// Log every pointerdown/click at document capture: target + defaultPrevented.
+await a.page.evaluate(() => {
+  for (const type of ['pointerdown', 'pointerup', 'click']) {
+    document.addEventListener(
+      type,
+      (e) => {
+        const t = e.target;
+        const desc = t?.tagName + (t?.className ? `.${String(t.className).slice(0, 40)}` : '');
+        console.log(`[evt] ${type} on ${desc} defaultPrevented=${e.defaultPrevented}`);
+      },
+      true,
+    );
+  }
+});
+
+const cdp = await a.page.context().newCDPSession(a.page);
+const touch = async (x, y, holdMs) => {
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x, y }] });
+  await a.page.waitForTimeout(holdMs);
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+};
+
+// Long-press the tile with TOUCH → peek.
+const tile = await a.page.locator('.pin-tile').first().boundingBox();
+await touch(tile.x + tile.width / 2, tile.y + tile.height / 2, 1100);
+await poll(() => a.page.locator('.peek-card').count(), (n) => n === 1, { label: 'peek open' });
+await a.page.waitForTimeout(400);
+await shot(a, 'peekdbg-open');
+
+// ONE touch tap on "Unpin" — does it act?
+const unpin = await a.page.locator('.peek-menu ion-item').first().boundingBox();
+console.log('--- tap 1 on Unpin ---');
+await touch(unpin.x + unpin.width / 2, unpin.y + unpin.height / 2, 70);
+await a.page.waitForTimeout(800);
+console.log('[state] peek open after tap1:', await a.page.locator('.peek-card').count());
+console.log('[state] tiles after tap1:', await a.page.locator('.pin-tile').count());
+if (await a.page.locator('.peek-card').count()) {
+  console.log('--- tap 2 on Unpin ---');
+  await touch(unpin.x + unpin.width / 2, unpin.y + unpin.height / 2, 70);
+  await a.page.waitForTimeout(800);
+  console.log('[state] peek open after tap2:', await a.page.locator('.peek-card').count());
+  console.log('[state] tiles after tap2:', await a.page.locator('.pin-tile').count());
+}
+await shot(a, 'peekdbg-after-unpin');
+
+// Re-pin, open peek again with touch, then tap Delete ONCE: where is the sheet?
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), chatId);
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n >= 1, { label: 'tile back' });
+const tile2 = await a.page.locator('.pin-tile').first().boundingBox();
+await touch(tile2.x + tile2.width / 2, tile2.y + tile2.height / 2, 1100);
+await poll(() => a.page.locator('.peek-card').count(), (n) => n === 1, { label: 'peek open 2' });
+await a.page.waitForTimeout(400);
+const del = await a.page.locator('.peek-menu ion-item:has-text("Delete")').boundingBox();
+console.log('--- tap on Delete (twice if needed) ---');
+await touch(del.x + del.width / 2, del.y + del.height / 2, 70);
+await a.page.waitForTimeout(500);
+if ((await a.page.locator('ion-action-sheet').count()) === 0) {
+  await touch(del.x + del.width / 2, del.y + del.height / 2, 70);
+  await a.page.waitForTimeout(500);
+}
+await a.page.waitForTimeout(400);
+console.log('[state] action-sheet count:', await a.page.locator('ion-action-sheet').count());
+console.log('[state] peek open with sheet:', await a.page.locator('.peek-card').count());
+await shot(a, 'peekdbg-delete-sheet');
+
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/pinned-reorder-1045.mjs
+++ b/drive/scenarios/pinned-reorder-1045.mjs
@@ -1,0 +1,131 @@
+// Visual check (spec 1045): user-owned pinned order — drag-reorder a tile, drag a
+// tile out to unpin, drag a row in to pin, and the long-press peek overlay.
+import { createAccount, pair, chatWith, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+async function paintAvatar(p, name, color) {
+  await p.page.evaluate(
+    async ({ nm, col }) => {
+      const c = document.createElement('canvas');
+      c.width = c.height = 128;
+      const g = c.getContext('2d');
+      g.fillStyle = col;
+      g.beginPath();
+      g.arc(64, 64, 64, 0, Math.PI * 2);
+      g.fill();
+      g.fillStyle = '#fff';
+      g.font = 'bold 64px -apple-system, sans-serif';
+      g.textAlign = 'center';
+      g.textBaseline = 'middle';
+      g.fillText(nm[0], 64, 70);
+      await window.__ringTest.setProfile(nm, c.toDataURL('image/png'));
+    },
+    { nm: name, col: color },
+  );
+}
+
+const gridOrder = (p) =>
+  p.page.locator('.pin-tile[data-chat-id]').evaluateAll((els) => els.map((e) => e.getAttribute('data-chat-id')));
+const center = (b) => ({ x: b.x + b.width / 2, y: b.y + b.height / 2 });
+async function drag(p, from, to, { midshot } = {}) {
+  await p.page.mouse.move(from.x, from.y);
+  await p.page.mouse.down();
+  await p.page.waitForTimeout(550); // past the 350ms lift
+  await p.page.mouse.move(from.x + 12, from.y + 12, { steps: 3 });
+  await p.page.mouse.move(to.x, to.y, { steps: 12 });
+  await p.page.waitForTimeout(300);
+  if (midshot) await shot(p, midshot);
+  await p.page.mouse.up();
+}
+
+const COLORS = ['#e74c3c', '#8e44ad', '#2980b9', '#16a085', '#d35400'];
+const a = await createAccount({ name: 'Me', label: 'A' });
+const peers = [];
+for (const [i, name] of ['Biz', 'Feri', 'Rayan', 'Neda'].entries()) {
+  const p = await createAccount({ name, label: name });
+  await paintAvatar(p, name, COLORS[i]);
+  await pair(a, p);
+  peers.push(p);
+}
+for (const p of peers) {
+  await say(p, a.id, `Hi from ${p.label}!`); // 1:1 → pass the PEER id, not a chat id
+  await waitForMessage(a, p.id, `Hi from ${p.label}!`);
+}
+
+// Pin the first three (Biz, Feri, Rayan) — Neda stays a row.
+const chatIds = [];
+for (const p of peers) chatIds.push(await chatWith(a, p.id));
+for (const id of chatIds.slice(0, 3)) {
+  await a.page.evaluate(({ id: c }) => window.__ringTest.pinChat(c, true), { id });
+}
+
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(800);
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n >= 3, { label: '3 tiles' });
+await a.page.waitForTimeout(600);
+console.log('[order] initial:', await gridOrder(a));
+await shot(a, '1045-initial');
+
+// New message must NOT reorder (Biz stays first even though Rayan just wrote).
+await say(peers[2], a.id, 'newest activity!');
+await waitForMessage(a, peers[2].id, 'newest activity!');
+await a.page.waitForTimeout(600);
+console.log('[order] after new message (must be unchanged):', await gridOrder(a));
+await shot(a, '1045-after-message');
+
+// Drag tile 3 (Rayan) onto slot 1 — screenshot mid-drag to show the lift + gap.
+const tile = (id) => a.page.locator(`.pin-tile[data-chat-id="${id}"]`);
+const b3 = await tile(chatIds[2]).boundingBox();
+const b1 = await tile(chatIds[0]).boundingBox();
+await drag(a, center(b3), center(b1), { midshot: '1045-mid-drag' });
+await a.page.waitForTimeout(600);
+console.log('[order] after reorder (Rayan first):', await gridOrder(a));
+await shot(a, '1045-after-reorder');
+
+// Drag first tile out into the list → unpins.
+const bOut = await tile(chatIds[2]).boundingBox();
+const gbox = await a.page.locator('.pin-grid').boundingBox();
+await drag(a, center(bOut), { x: gbox.x + gbox.width / 2, y: gbox.y + gbox.height + 180 });
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n === 2, { label: 'unpinned to 2' });
+await shot(a, '1045-after-unpin');
+
+// Drag the Neda ROW up into the grid at slot 0 → pinned there.
+const rows = a.page.locator('ion-item-sliding');
+const nedaRow = a.page.locator(`ion-item-sliding:has-text("Neda")`).first();
+const rbox = await nedaRow.boundingBox();
+const firstTile = await a.page.locator('.pin-tile[data-chat-id]').first().boundingBox();
+await drag(a, center(rbox), { x: firstTile.x + 8, y: firstTile.y + 8 });
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n === 3, { label: 'row pinned to 3' });
+console.log('[order] after row pinned at slot 0:', await gridOrder(a));
+await shot(a, '1045-after-row-pin');
+
+// Long-press peek on the first tile (hold still ~1s), light + dark.
+const pk = await a.page.locator('.pin-tile[data-chat-id]').first().boundingBox();
+await a.page.mouse.move(center(pk).x, center(pk).y);
+await a.page.mouse.down();
+await a.page.waitForTimeout(1200);
+await a.page.mouse.up();
+await poll(() => a.page.locator('.peek-card').count(), (n) => n === 1, { label: 'peek open' });
+await a.page.waitForTimeout(400);
+await shot(a, '1045-peek-light');
+await a.page.emulateMedia({ colorScheme: 'dark' });
+await a.page.waitForTimeout(400);
+await shot(a, '1045-peek-dark');
+// Tap outside closes.
+await a.page.mouse.click(8, 300);
+await poll(() => a.page.locator('.peek-card').count(), (n) => n === 0, { label: 'peek closed' });
+await a.page.emulateMedia({ colorScheme: 'light' });
+
+// Peek on a list ROW too.
+const rowBox = await rows.first().boundingBox();
+await a.page.mouse.move(center(rowBox).x, center(rowBox).y);
+await a.page.mouse.down();
+await a.page.waitForTimeout(1200);
+await a.page.mouse.up();
+await poll(() => a.page.locator('.peek-card').count(), (n) => n === 1, { label: 'row peek open' });
+await a.page.waitForTimeout(400);
+await shot(a, '1045-row-peek');
+await a.page.mouse.click(8, 300);
+
+await sweep([a, ...peers]);
+await done();

--- a/drive/scenarios/row-slide-glitch.mjs
+++ b/drive/scenarios/row-slide-glitch.mjs
@@ -1,0 +1,55 @@
+// Verify (spec 1045 follow-up): dragging a row up to pin it — with horizontal
+// wobble — must NOT open the row's swipe options underneath (ion-item-sliding
+// stays shut while the row is lifted).
+import { createAccount, pair, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Me', label: 'A', mobile: true });
+const b = await createAccount({ name: 'Biz', label: 'B' });
+const c = await createAccount({ name: 'Cyr', label: 'C' });
+await pair(a, b);
+await pair(a, c);
+await say(b, a.id, 'hi'); await waitForMessage(a, b.id, 'hi');
+await say(c, a.id, 'yo'); await waitForMessage(a, c.id, 'yo');
+const chatB = await a.page.evaluate((p) => window.__ringTest.chatWith(p), b.id);
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), chatB);
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(500);
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n >= 1, { label: 'tile' });
+await poll(() => a.page.locator('ion-item-sliding').count(), (n) => n >= 1, { label: 'row' });
+
+const cdp = await a.page.context().newCDPSession(a.page);
+const row = await a.page.locator('ion-item-sliding').first().boundingBox();
+const tile = await a.page.locator('.pin-tile').first().boundingBox();
+// Press near the RIGHT EDGE of the row (like the user's finger): the travel to
+// the top-left grid slot then has a long horizontal component — the exact case
+// that opened the swipe options.
+const from = { x: row.x + row.width - 30, y: row.y + row.height / 2 };
+const to = { x: tile.x + 10, y: tile.y + 10 };
+
+await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [from] });
+await a.page.waitForTimeout(550);
+// Wobbly path: strong horizontal zigzag while climbing toward the grid.
+for (let i = 1; i <= 12; i++) {
+  // Zigzag hard on the way, but land the final steps ON the target slot.
+  const wobble = i <= 10 ? (i % 2 ? 60 : -60) : 0;
+  const x = from.x + ((to.x - from.x) * i) / 12 + wobble;
+  const y = from.y + ((to.y - from.y) * i) / 12;
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ x, y }] });
+  await a.page.waitForTimeout(35);
+  if (i === 6) {
+    const open = await a.page.evaluate(async () => {
+      const el = document.querySelector('ion-item-sliding');
+      return el?.getOpenAmount ? await el.getOpenAmount() : 'n/a';
+    });
+    console.log('[state] mid-drag slide open amount (must be 0):', open);
+    await shot(a, 'rowslide-mid-drag');
+  }
+}
+await a.page.waitForTimeout(200);
+await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n === 2, { label: 'pinned by drag' });
+console.log('[ok] wobbly row drag pinned the chat without opening the slide');
+
+await sweep([a, b, c]);
+await done();

--- a/drive/scenarios/touch-drag-1045.mjs
+++ b/drive/scenarios/touch-drag-1045.mjs
@@ -1,0 +1,74 @@
+// Verify (spec 1045 follow-up): the pin drags work with REAL TOUCH events (CDP),
+// not just mouse — drag-out-to-unpin died on iOS because (a) the grid unmounted
+// the touch target at lift and (b) Ionic's button touch-action let the browser
+// steal the vertical drag as a scroll. Logs pointercancel so a scroll-hijack is
+// visible in the output.
+import { createAccount, pair, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Me', label: 'A', mobile: true });
+const b = await createAccount({ name: 'Biz', label: 'B' });
+const c = await createAccount({ name: 'Cyr', label: 'C' });
+await pair(a, b);
+await pair(a, c);
+await say(b, a.id, 'hi from b');
+await waitForMessage(a, b.id, 'hi from b');
+await say(c, a.id, 'hi from c');
+await waitForMessage(a, c.id, 'hi from c');
+
+const chatB = await a.page.evaluate((p) => window.__ringTest.chatWith(p), b.id);
+const chatC = await a.page.evaluate((p) => window.__ringTest.chatWith(p), c.id);
+for (const id of [chatB, chatC]) {
+  await a.page.evaluate((cid) => window.__ringTest.pinChat(cid, true), id);
+}
+await a.page.getByText("I'VE SAVED IT").click();
+await a.page.waitForTimeout(600);
+await a.page.goto('/tabs/chats');
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n >= 2, { label: '2 tiles' });
+
+await a.page.evaluate(() => {
+  document.addEventListener('pointercancel', () => console.log('[evt] POINTERCANCEL — browser stole the gesture'), true);
+});
+
+const cdp = await a.page.context().newCDPSession(a.page);
+async function touchDrag(from, to, steps = 10) {
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [from] });
+  await a.page.waitForTimeout(550); // past the 350ms lift, before the peek
+  for (let i = 1; i <= steps; i++) {
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x: from.x + ((to.x - from.x) * i) / steps, y: from.y + ((to.y - from.y) * i) / steps }],
+    });
+    await a.page.waitForTimeout(30);
+  }
+  await a.page.waitForTimeout(250);
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+}
+const center = (b2) => ({ x: b2.x + b2.width / 2, y: b2.y + b2.height / 2 });
+const gridOrder = () =>
+  a.page.locator('.pin-tile[data-chat-id]').evaluateAll((els) => els.map((e) => e.getAttribute('data-chat-id')));
+
+// 1) TOUCH drag tile C down into the list → unpins.
+const tC = await a.page.locator(`.pin-tile[data-chat-id="${chatC}"]`).boundingBox();
+const grid = await a.page.locator('.pin-grid').boundingBox();
+await touchDrag(center(tC), { x: grid.x + grid.width / 2, y: grid.y + grid.height + 200 });
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n === 1, { label: 'touch unpin → 1 tile' });
+console.log('[ok] touch drag-out unpinned');
+await shot(a, 'touchdrag-after-unpin');
+
+// 2) TOUCH drag the C row back into the grid at slot 0 → pinned first.
+const row = await a.page.locator('ion-item-sliding').first().boundingBox();
+const tB = await a.page.locator(`.pin-tile[data-chat-id="${chatB}"]`).boundingBox();
+await touchDrag(center(row), { x: tB.x + 8, y: tB.y + 8 });
+await poll(() => a.page.locator('.pin-tile').count(), (n) => n === 2, { label: 'touch pin → 2 tiles' });
+console.log('[order] after row pinned at 0:', await gridOrder(), '(expect C first)');
+
+// 3) TOUCH drag reorder: C onto B's slot → order flips back.
+const tC2 = await a.page.locator(`.pin-tile[data-chat-id="${chatC}"]`).boundingBox();
+const tB2 = await a.page.locator(`.pin-tile[data-chat-id="${chatB}"]`).boundingBox();
+await touchDrag(center(tC2), center(tB2));
+await a.page.waitForTimeout(600);
+console.log('[order] after reorder:', await gridOrder(), '(expect B first)');
+await shot(a, 'touchdrag-final');
+
+await sweep([a, b, c]);
+await done();

--- a/e2e/pinned-grid.spec.ts
+++ b/e2e/pinned-grid.spec.ts
@@ -12,11 +12,11 @@ const pinChat = (p: any, chatId: string, pinned = true) =>
   );
 
 /**
- * Spec 1044: pinned chats render as an iMessage-style avatar grid above the chat
- * list (up to 9); while gridded they leave the list rows; tapping a tile opens the
- * chat; long-press opens the actions sheet whose new Unpin returns them to the
- * list; search shows pinned chats as plain rows again. Chat rows are
- * ion-item-sliding (the swipeable ChatListItem root); tiles carry data-chat-id.
+ * Spec 1044 (+1045): pinned chats render as an iMessage-style avatar grid above the
+ * chat list (up to 9); while gridded they leave the list rows; tapping a tile opens
+ * the chat; a STILL long-press (~1s, spec 1045) opens the peek overlay whose Unpin
+ * returns them to the list; search shows pinned chats as plain rows again. Chat rows
+ * are ion-item-sliding (the swipeable ChatListItem root); tiles carry data-chat-id.
  */
 test('pinned chats form the avatar grid, leave the list, and manage via long-press', async ({
   browser,
@@ -63,15 +63,17 @@ test('pinned chats form the avatar grid, leave the list, and manage via long-pre
   await a.page.locator('ion-searchbar input').fill('');
   await expect(tiles()).toHaveCount(2, { timeout: 10_000 });
 
-  // Long-press a tile → actions sheet → Unpin returns the chat to the list.
+  // STILL long-press a tile (spec 1045: lift at ~350ms, peek at ~900ms with no
+  // movement) → the peek overlay → its Unpin returns the chat to the list.
   // hover() auto-waits for the tile to be stable/visible so the press can't land
   // on empty space while the grid reflows after the search clear.
   const tileC = a.page.locator(`.pin-tile[data-chat-id="${chatC}"]`);
   await tileC.hover();
   await a.page.mouse.down();
-  await a.page.waitForTimeout(700);
+  await a.page.waitForTimeout(1200);
   await a.page.mouse.up();
-  const unpin = a.page.locator('ion-item', { hasText: 'Unpin' });
+  await expect(a.page.locator('.peek-card')).toBeVisible({ timeout: 10_000 });
+  const unpin = a.page.locator('.peek-menu ion-item', { hasText: 'Unpin' });
   await expect(unpin).toBeVisible({ timeout: 10_000 });
   await unpin.click();
   await expect(tiles()).toHaveCount(1, { timeout: 10_000 });

--- a/e2e/pinned-reorder.spec.ts
+++ b/e2e/pinned-reorder.spec.ts
@@ -62,6 +62,28 @@ test('pinned order is user-owned: drag to rearrange, drag in/out to pin/unpin, h
   await a.page.goto('/tabs/chats');
   await expect(a.page.locator('ion-item-sliding')).toHaveCount(2, { timeout: 15_000 });
 
+  // First-pin drop zone: with NO pins, lifting a row summons a drop target where
+  // the grid will be; dropping there creates the first pin.
+  const row0 = await a.page.locator('ion-item-sliding').first().boundingBox();
+  if (!row0) throw new Error('row not laid out');
+  await a.page.mouse.move(row0.x + row0.width / 2, row0.y + row0.height / 2);
+  await a.page.mouse.down();
+  await expect(a.page.locator('.drag-proxy')).toBeVisible({ timeout: 5_000 });
+  // Nudge IMMEDIATELY: it kills the peek timer. Only then take the slow steps
+  // (zone lookup + boundingBox) — under CI load those can exceed the peek window.
+  await a.page.mouse.move(row0.x + row0.width / 2 + 12, row0.y + row0.height / 2 + 12, { steps: 3 });
+  await expect(a.page.locator('.pin-dropzone')).toBeVisible({ timeout: 5_000 });
+  const zone = await a.page.locator('.pin-dropzone').boundingBox();
+  if (!zone) throw new Error('drop zone not laid out');
+  await a.page.mouse.move(zone.x + zone.width / 2, zone.y + zone.height / 2, { steps: 10 });
+  await a.page.waitForTimeout(150);
+  await a.page.mouse.up();
+  await expect(a.page.locator('.pin-tile')).toHaveCount(1, { timeout: 10_000 });
+  // Reset to the no-pins baseline for the arranged-order flow below.
+  const firstPinned = await a.page.locator('.pin-tile[data-chat-id]').getAttribute('data-chat-id');
+  await a.page.evaluate((id: string) => (window as any).__ringTest.pinChat(id, false), firstPinned!);
+  await expect(a.page.locator('.pin-tile')).toHaveCount(0, { timeout: 10_000 });
+
   // Pin both; pin order (not recency) is the arrangement: B then C.
   await pinChat(a, chatB);
   await pinChat(a, chatC);

--- a/e2e/pinned-reorder.spec.ts
+++ b/e2e/pinned-reorder.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type Page } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const chatWith = (p: any, peerId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.chatWith(id), peerId);
+const pinChat = (p: any, chatId: string) =>
+  p.page.evaluate((id: string) => (window as any).__ringTest.pinChat(id, true), chatId);
+const sendIn = (p: any, chatId: string, body: string) =>
+  p.page.evaluate(
+    ({ id, b }: { id: string; b: string }) => (window as any).__ringTest.sendChatMessage(id, b),
+    { id: chatId, b: body },
+  );
+
+const gridOrder = (page: Page) =>
+  page.locator('.pin-tile[data-chat-id]').evaluateAll((els) => els.map((e) => e.getAttribute('data-chat-id')));
+
+/** Press-and-hold until the lift (spec 1045: 350ms), drag to (x,y), release. */
+async function dragTile(page: Page, from: { x: number; y: number }, to: { x: number; y: number }): Promise<void> {
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  await page.waitForTimeout(550); // past the lift, before the peek
+  // First a small nudge to commit to dragging (kills the peek timer), then glide.
+  await page.mouse.move(from.x + 12, from.y + 12, { steps: 3 });
+  await page.mouse.move(to.x, to.y, { steps: 12 });
+  await page.waitForTimeout(150); // let hover/FLIP settle
+  await page.mouse.up();
+}
+
+const center = (box: { x: number; y: number; width: number; height: number }) => ({
+  x: box.x + box.width / 2,
+  y: box.y + box.height / 2,
+});
+
+/**
+ * Spec 1045: the pinned grid keeps the USER'S order — activity never moves a tile;
+ * drag rearranges (and persists across a reload); dragging a tile out unpins it;
+ * dragging a row in pins it at the drop slot; a still long-press opens the peek
+ * (tap outside closes it, its menu acts on the chat).
+ */
+test('pinned order is user-owned: drag to rearrange, drag in/out to pin/unpin, hold to peek', async ({
+  browser,
+}) => {
+  test.setTimeout(180_000);
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'PINRRDA1');
+  const b = await createAccount(ctxB, 'PINRRDB1');
+  const c = await createAccount(ctxC, 'PINRRDC1');
+  await pair(a, b);
+  await pair(a, c);
+
+  const chatB = (await chatWith(a, b.id)) as string;
+  const chatC = (await chatWith(a, c.id)) as string;
+  const tile = (id: string) => a.page.locator(`.pin-tile[data-chat-id="${id}"]`);
+
+  await a.page.goto('/tabs/chats');
+  await expect(a.page.locator('ion-item-sliding')).toHaveCount(2, { timeout: 15_000 });
+
+  // Pin both; pin order (not recency) is the arrangement: B then C.
+  await pinChat(a, chatB);
+  await pinChat(a, chatC);
+  await expect(a.page.locator('.pin-tile')).toHaveCount(2, { timeout: 10_000 });
+  expect(await gridOrder(a.page)).toEqual([chatB, chatC]);
+
+  // US1: a new message in C lights its badge but does NOT move it forward. (B stays
+  // read — the later peek asserts its "Mark as Unread" label.)
+  await sendIn(c, (await chatWith(c, a.id)) as string, 'hello from c');
+  await expect(tile(chatC).locator('ion-badge')).toBeVisible({ timeout: 15_000 });
+  expect(await gridOrder(a.page)).toEqual([chatB, chatC]);
+
+  // US2: drag C onto B's slot → order flips and persists across a reload.
+  const boxB = await tile(chatB).boundingBox();
+  const boxC = await tile(chatC).boundingBox();
+  if (!boxB || !boxC) throw new Error('tiles not laid out');
+  await dragTile(a.page, center(boxC), center(boxB));
+  await expect
+    .poll(() => gridOrder(a.page), { timeout: 10_000 })
+    .toEqual([chatC, chatB]);
+  await a.page.reload();
+  await a.page.waitForFunction(() => !!(window as any).__ringTest, null, { timeout: 30_000 });
+  await expect(a.page.locator('.pin-tile')).toHaveCount(2, { timeout: 15_000 });
+  expect(await gridOrder(a.page)).toEqual([chatC, chatB]);
+
+  // US3a: drag B DOWN into the list area → it unpins and returns as a row.
+  const boxB2 = await tile(chatB).boundingBox();
+  const gridBox = await a.page.locator('.pin-grid').boundingBox();
+  if (!boxB2 || !gridBox) throw new Error('grid not laid out');
+  await dragTile(a.page, center(boxB2), {
+    x: gridBox.x + gridBox.width / 2,
+    y: gridBox.y + gridBox.height + 160,
+  });
+  await expect(a.page.locator('.pin-tile')).toHaveCount(1, { timeout: 10_000 });
+  await expect(a.page.locator('ion-item-sliding')).toHaveCount(1, { timeout: 10_000 });
+
+  // US3b: drag the row back UP into the grid, dropping on the FIRST slot → pinned
+  // there (before C).
+  const rowB = a.page.locator('ion-item-sliding').first();
+  const rowBox = await rowB.boundingBox();
+  const tileCBox = await tile(chatC).boundingBox();
+  if (!rowBox || !tileCBox) throw new Error('row/tile not laid out');
+  await dragTile(a.page, center(rowBox), { x: tileCBox.x + 10, y: tileCBox.y + 10 });
+  await expect(a.page.locator('.pin-tile')).toHaveCount(2, { timeout: 10_000 });
+  await expect.poll(() => gridOrder(a.page), { timeout: 10_000 }).toEqual([chatB, chatC]);
+
+  // US4: a STILL hold opens the peek; tapping outside closes it without opening
+  // the chat; Mark as Unread from the menu shows the manual-unread dot.
+  const tileB = tile(chatB);
+  await tileB.hover();
+  await a.page.mouse.down();
+  await a.page.waitForTimeout(1200);
+  await a.page.mouse.up();
+  await expect(a.page.locator('.peek-card')).toBeVisible({ timeout: 10_000 });
+  await a.page.mouse.click(8, 300); // backdrop, outside card + menu
+  await expect(a.page.locator('.peek-card')).toHaveCount(0, { timeout: 10_000 });
+  await expect(a.page).toHaveURL(/tabs\/chats/);
+
+  await tileB.hover();
+  await a.page.mouse.down();
+  await a.page.waitForTimeout(1200);
+  await a.page.mouse.up();
+  const markUnread = a.page.locator('.peek-menu ion-item', { hasText: 'Mark as Unread' });
+  await expect(markUnread).toBeVisible({ timeout: 10_000 });
+  await markUnread.click();
+  await expect(tileB.locator('.pin-dot')).toBeVisible({ timeout: 10_000 });
+
+  // Tapping INSIDE the peek opens the chat.
+  await tileB.hover();
+  await a.page.mouse.down();
+  await a.page.waitForTimeout(1200);
+  await a.page.mouse.up();
+  await expect(a.page.locator('.peek-card')).toBeVisible({ timeout: 10_000 });
+  await a.page.locator('.peek-card').click();
+  await expect(a.page).toHaveURL(new RegExp(`/chat/${chatB}`), { timeout: 10_000 });
+
+  await ctxA.close();
+  await ctxB.close();
+  await ctxC.close();
+});

--- a/e2e/pinned-reorder.spec.ts
+++ b/e2e/pinned-reorder.spec.ts
@@ -16,12 +16,15 @@ const sendIn = (p: any, chatId: string, body: string) =>
 const gridOrder = (page: Page) =>
   page.locator('.pin-tile[data-chat-id]').evaluateAll((els) => els.map((e) => e.getAttribute('data-chat-id')));
 
-/** Press-and-hold until the lift (spec 1045: 350ms), drag to (x,y), release. */
+/** Press-and-hold until the lift (spec 1045: 350ms), drag to (x,y), release.
+ *  The lift is awaited via its OBSERVABLE signal — the floating proxy appearing —
+ *  not a fixed sleep: under parallel-test CPU load the page's lift timer can lag,
+ *  and moving before it fires legitimately cancels the hold (scroll wins). */
 async function dragTile(page: Page, from: { x: number; y: number }, to: { x: number; y: number }): Promise<void> {
   await page.mouse.move(from.x, from.y);
   await page.mouse.down();
-  await page.waitForTimeout(550); // past the lift, before the peek
-  // First a small nudge to commit to dragging (kills the peek timer), then glide.
+  await expect(page.locator('.drag-proxy')).toBeVisible({ timeout: 5_000 });
+  // A small nudge to commit to dragging (kills the peek timer), then glide.
   await page.mouse.move(from.x + 12, from.y + 12, { steps: 3 });
   await page.mouse.move(to.x, to.y, { steps: 12 });
   await page.waitForTimeout(150); // let hover/FLIP settle

--- a/specs/1045-rearrange-pinned-chats/checklists/requirements.md
+++ b/specs/1045-rearrange-pinned-chats/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Rearrange pinned chats with drag, stable manual order, and long-press chat preview
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The user's description was unusually detailed (explicit iMessage parity,
+  timings, cap behaviour, preview actions), so no critical ambiguities
+  remained; defaults chosen are recorded in the spec's Assumptions section.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/1045-rearrange-pinned-chats/data-model.md
+++ b/specs/1045-rearrange-pinned-chats/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: spec 1045
+
+## Chat (existing store `chats` — field-level extension, no DB_VERSION bump)
+
+```ts
+export interface Chat {
+  // ... existing fields ...
+  pinned?: boolean;      // existing (spec 1044): member of the pinned grid
+  pinnedRank?: number;   // NEW: 0-based position in the user's arrangement.
+                         // Present only while pinned; deleted on unpin/archive.
+}
+```
+
+### Semantics
+
+| Operation | Effect on `pinnedRank` |
+|---|---|
+| Pin via swipe / sheet / peek menu | `max(existing ranks) + 1` (append at end) — FR-002 |
+| Pin via drag-into-grid at slot *i* | rank *i*; ranks of the pinned set renumbered 0..n-1 |
+| Drag-reorder to slot *i* | pinned set renumbered 0..n-1 with the moved chat at *i* |
+| Unpin (any surface, incl. drag-out) | field deleted, together with `pinned` |
+| Archive | field deleted (archives already drop `pinned`) |
+| New message / read / mute / any non-arrange interaction | **unchanged** — FR-001 |
+
+### Ordering (client sort, `chatOrder` in queries.ts)
+
+1. Pinned before unpinned (unchanged).
+2. Among pinned: `pinnedRank ?? Infinity` ascending; ties (sync merges, legacy
+   pins) fall back to `lastMessageTime` desc, then `id` — total and stable.
+3. Among unpinned: `lastMessageTime` desc (unchanged).
+
+### Migration / legacy
+
+`ensurePinRanks()` (queries.ts): if any non-archived pinned chat lacks a rank,
+stamp the entire pinned set 0..n-1 in current visual order. Runs once per
+device (idempotent afterwards), invoked from the Chats tab mount and before
+any rank write.
+
+### Sync
+
+Chat records already ride encrypted own-data sync (`SYNCED` stores in
+`ownsync.ts`), sealed client-side, LWW per record on `updatedAt`. `pinnedRank`
+adds no wire format, no server column, no new metadata — the server continues
+to see one opaque blob.
+
+## Transient (not persisted)
+
+- **Drag state** (`useChatDrag`): `{ phase: idle|held|lifted|dragging,
+  chatId, origin: grid|list, pointer x/y, hoverIndex | null, blocked }` —
+  in-memory only.
+- **Peek state**: `{ chat, messages: Message[] (≤15, read-only) }` — queried on
+  open, discarded on dismiss; never writes.

--- a/specs/1045-rearrange-pinned-chats/plan.md
+++ b/specs/1045-rearrange-pinned-chats/plan.md
@@ -1,0 +1,171 @@
+# Implementation Plan: Rearrange pinned chats with drag, stable manual order, and long-press chat preview
+
+**Branch**: `feat/1045-rearrange-pinned-chats` | **Date**: 2026-07-13 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/1045-rearrange-pinned-chats/spec.md`
+
+## Summary
+
+Give the pinned-chat grid (spec 1044) a user-owned order: a `pinnedRank` field on
+the Chat record (synced like `pinned` via encrypted own-data sync) replaces
+recency as the grid's sort key, so message activity never moves a pin. A
+pointer-event drag controller on the Chats tab implements iMessage-style
+rearrange (lift → drag → drop), drag-out-to-unpin, and drag-row-in-to-pin (with
+a forbidden badge at the 9-pin cap). A longer press opens a read-only "peek"
+overlay of the chat's latest messages with Pin/Unpin, Mark as Unread/Read, and
+Delete beneath it. Client-only; the server is untouched.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Vue 3 `<script setup>` + Ionic 8 (client only)
+
+**Primary Dependencies**: Existing app stack — Ionic components, `useLiveQuery`,
+`idb.ts` wrapper, `queries.ts` data layer, `message-preview.ts` helpers. No new
+dependencies (drag is hand-rolled on pointer events; no drag library).
+
+**Storage**: IndexedDB `chats` store gains an optional `pinnedRank?: number`
+field on existing records — no new object store, **no DB_VERSION bump needed**
+(field-level addition; absent = legacy pin). Rides the existing encrypted
+own-data sync (whole chat records, LWW on `updatedAt`).
+
+**Testing**: vitest unit tests for the pure pin-order/drag-math helpers
+(`src/utils/chat-pins.ts` + new `src/utils/drag-math.ts`); Playwright e2e for
+reorder-persists + peek behaviours; `npm run build` typecheck gate.
+
+**Target Platform**: Installable PWA — touch (iOS/Android) and desktop
+(mouse) drive the same pointer-event gestures.
+
+**Project Type**: Web app (client half of the monorepo; zero server changes).
+
+**Performance Goals**: Drag tracking at 60 fps (transform-only updates on the
+floating element; grid gap animations via CSS transitions; no re-sort or DB I/O
+until drop).
+
+**Constraints**: Zero-knowledge boundary untouched (no new wire data —
+`pinnedRank` is inside the already-sealed own-data snapshot). The peek overlay
+must not mark the chat read. Long-press must not fight scrolling, Ionic swipe
+gestures, or the existing tap/contextmenu handlers.
+
+**Scale/Scope**: ≤ 9 pinned chats; peek renders ~15 most-recent messages from
+local IndexedDB. Three components touched, one new component, one new
+composable, two new pure-helper modules.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary** — PASS. No new server surface. `pinnedRank`
+  lives inside chat records that already sync as sealed ciphertext. The peek
+  overlay renders local data only. (Zero-Knowledge Impact section added to the
+  spec.)
+- **II. Spec-Driven Development** — PASS. Spec 1045 (ad-hoc band), this plan,
+  tasks to follow; branch `feat/1045-rearrange-pinned-chats`.
+- **III. Test-Driven Development** — PASS. Pure helpers get failing-first
+  vitest coverage (order comparator, reorder/insert math, hit-testing); e2e
+  extends the chats suite for reorder persistence + peek. Tasks order tests
+  before implementation.
+- **IV. Crypto Discipline** — N/A (no crypto changes; nothing new touches
+  `messaging.ts`).
+- **V. Offline-First Data Integrity** — PASS. Field-level addition to the
+  `chats` store via the `idb` wrapper; no store added → no `DB_VERSION` bump.
+  Legacy pins (no rank) keep working; ranks are stamped by a one-time
+  normalizer. LWW on `updatedAt` unchanged.
+- **VI. Stateless Server** — N/A (server untouched).
+- **VII. Quality Gates** — PASS. `npm run build`, vitest, e2e planned; commit
+  subjects will be release-note copy.
+- **VIII. Traceable Delivery** — `taskstoissues` deferred until after the
+  user's local test round (explicit user instruction: nothing leaves the
+  machine yet); issues will be created before the PR.
+- **X. Accessibility & i18n** — PASS. Tiles/rows keep aria labels; the peek
+  gets `role="dialog"` + labelled actions; drag is an enhancement — every
+  outcome (reorder aside, which is new) remains reachable via existing
+  swipe/sheet surfaces; RTL-safe (logical positions, `dir="auto"` preserved).
+- **XI. Ionic-First UI** — PASS with one justified custom piece. The peek
+  overlay composes `ion-backdrop`, `ion-list`/`ion-item` (menu), existing
+  `UserAvatar`/`EmojiText`; the floating drag avatar and message-bubble
+  mini-list are custom because no Ionic primitive provides a drag proxy or an
+  iMessage peek card (`ion-reorder-group` only reorders vertical lists, not a
+  3-column grid, and cannot cross grid↔list surfaces). Both reuse existing
+  theme tokens.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1045-rearrange-pinned-chats/
+├── spec.md              # Feature specification (done)
+├── plan.md              # This file
+├── research.md          # Phase 0: decisions & alternatives
+├── data-model.md        # Phase 1: Chat.pinnedRank semantics
+├── quickstart.md        # Phase 1: how to run/verify locally
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (done)
+└── tasks.md             # Phase 2 (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── utils/
+│   ├── chat-pins.ts             # EXTEND: rank comparator, insert/renumber helpers
+│   ├── chat-pins.test.ts        # EXTEND: rank ordering + reorder math tests
+│   ├── drag-math.ts             # NEW: pure hit-testing/slot math for the drag
+│   └── drag-math.test.ts        # NEW: unit tests
+├── db/
+│   ├── types.ts                 # EXTEND: Chat.pinnedRank?: number
+│   └── queries.ts               # EXTEND: rank-aware chatOrder, setChatPinned(atRank),
+│                                #         setPinnedOrder(), ensurePinRanks()
+├── composables/
+│   └── useChatDrag.ts           # NEW: lift/drag/drop + peek-timer state machine
+├── components/
+│   ├── PinnedChatsGrid.vue      # EXTEND: drag source/target, gap preview, lift visuals
+│   ├── ChatListItem.vue         # EXTEND: long-press lift (avatar proxy) + peek trigger
+│   └── ChatPeekOverlay.vue      # NEW: message peek + Pin/Unpin, Unread/Read, Delete menu
+└── views/tabs/
+    └── ChatsPage.vue            # EXTEND: hosts drag controller + peek overlay
+
+e2e/
+└── pinned-reorder.spec.ts       # NEW: reorder persists; peek open/act/dismiss
+```
+
+**Structure Decision**: All work is in the existing client tree; the drag state
+machine lives in a composable owned by `ChatsPage.vue` because the gesture
+crosses two components (grid tiles and list rows) and must coordinate a single
+floating proxy, one active gesture, and page-level auto-scroll.
+
+## Design Decisions (Phase 0 summary — full trail in research.md)
+
+1. **Order storage: `pinnedRank?: number` per chat** (not an ordered-ids array
+   in settings). It inherits the pin's own sync/LWW/tombstone story, can't
+   drift from `pinned` membership, and partitions cleanly. Ties/gaps are
+   tolerated: sort key is `(pinnedRank ?? ∞, then recency)`; every local
+   rearrange renumbers 0..n-1.
+2. **Legacy pins**: `ensurePinRanks()` stamps missing ranks once (in current
+   visual order) when the Chats tab mounts, making order stable from the first
+   run of this build.
+3. **Hand-rolled pointer-event drag** (no library, no HTML5 DnD — poor touch
+   support; no `ion-reorder-group` — vertical lists only). One controller:
+   pointerdown starts a 350 ms lift timer; >8 px movement before lift cancels
+   (scroll/swipe win); after lift, a floating avatar proxy follows the pointer
+   (transform only), grid slot from `elementsFromPoint`-free rect math,
+   placeholder gap animates via CSS. Holding ~550 ms past the lift with no
+   drag opens the peek instead.
+4. **Peek overlay**: fixed overlay + `ion-backdrop`; card shows the last ~15
+   messages via `listMessagesOlder(chatId, null, 15)` rendered as minimal
+   bubbles (text via `EmojiText`, media/other kinds as icon + label via
+   `mediaPreview`, deleted/expired placeholders); menu is an inset `ion-list`
+   with Pin/Unpin, Mark as Unread/Read, Delete (+ **More…** opening the
+   existing ChatActionsSheet so pinned chats keep Mute/Hide/Lock etc. on touch,
+   where this gesture replaces the old long-press-for-sheet).
+5. **Scroll discipline**: while lifted, a non-passive `touchmove` preventDefault
+   plus pointer capture stops page scroll; near-edge auto-scroll of the
+   `ion-content` scroll element keeps far-down rows pinnable.
+6. **Cap behaviour**: dragging a row over the grid with 9 pins shows a
+   `ban`-icon badge on the proxy's top right; drop is a no-op (FR-007).
+
+## Complexity Tracking
+
+No constitution violations. The only bespoke UI (floating drag proxy, peek
+card) is justified under Principle XI in the Constitution Check above.

--- a/specs/1045-rearrange-pinned-chats/quickstart.md
+++ b/specs/1045-rearrange-pinned-chats/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: spec 1045 — rearrange pinned chats + peek
+
+## Run it
+
+```sh
+make start          # dev stack: Vite :5173 → ringd :8080
+```
+
+Open http://localhost:5173, register/log in (dev invite codes `RINGDEV1`..`9`),
+have a few chats, pin 2–4 of them (swipe right → Pin, or row long-hold → peek →
+Pin).
+
+## Try the gestures (Chats tab, "All" chip)
+
+- **Rearrange**: press a pinned avatar ~½ s until it lifts, drag to another
+  slot, release. Order sticks — send yourself messages in another pin and watch
+  it *not* move.
+- **Unpin by drag**: lift a pinned avatar, drag it down over the list, release.
+- **Pin by drag**: press a list row ~½ s — it shrinks into a round avatar —
+  drag it into the grid, drop at any slot. With 9 pins already, a ⊘ badge
+  appears on the floating avatar and dropping does nothing.
+- **Peek**: press and HOLD (~1 s, don't move): a preview of the latest
+  messages opens. Tap the card → opens the chat; tap outside → closes; menu
+  below: Pin/Unpin, Mark as Unread/Read, Delete, More….
+
+## Verify
+
+```sh
+npm run build                    # vue-tsc typecheck + vite build
+npx vitest run src/utils/chat-pins.test.ts src/utils/drag-math.test.ts
+npm run test:e2e -- pinned-reorder   # needs `make db-up`
+```
+
+Multi-user reproduction with screenshots: `node drive/scenarios/…` (see
+`drive/README.md`).

--- a/specs/1045-rearrange-pinned-chats/research.md
+++ b/specs/1045-rearrange-pinned-chats/research.md
@@ -1,0 +1,118 @@
+# Research: Rearrange pinned chats + long-press peek (spec 1045)
+
+## D1 — Where does the manual order live?
+
+- **Decision**: An optional `pinnedRank?: number` field on the `Chat` record,
+  set only while pinned, deleted on unpin. Sort key for pinned chats becomes
+  `(pinnedRank ?? Infinity, lastMessageTime desc, id)`; every local rearrange
+  renumbers the full pinned set 0..n-1.
+- **Rationale**: The rank inherits everything the `pinned` flag already has —
+  encrypted own-data sync of whole chat records, LWW on `updatedAt`, delete
+  tombstones — with zero new sync machinery. Membership (`pinned`) and order
+  (`pinnedRank`) can't drift apart because they live on the same record and
+  are written together. ≤ 9 records renumbered per rearrange is trivial I/O.
+- **Alternatives considered**:
+  - *Ordered id array in a synced setting* (like `chats.tabFilters`): a second
+    source of truth that must be reconciled against pin membership on every
+    read (deleted chats, pins from other devices mid-sync); whole-array LWW
+    means one device's reorder silently drops another device's concurrent new
+    pin. Rejected.
+  - *Fractional ranks (no renumber)*: avoids rewriting siblings but accumulates
+    float dust and still needs a normalizer; renumbering 9 records is cheaper
+    than the edge cases. Rejected.
+
+## D2 — Legacy pins (records that predate the rank)
+
+- **Decision**: `ensurePinRanks()` in `queries.ts`: if any non-archived pinned
+  chat lacks `pinnedRank`, stamp the whole pinned set with ranks matching the
+  current visual order (rank-first, then recency). Called once from the Chats
+  tab on mount (fire-and-forget) and defensively from the reorder writers.
+- **Rationale**: Matches the spec assumption "existing pins keep their current
+  relative order until first rearranged" and avoids a DB_VERSION bump — the
+  `chats` store's shape is unchanged (optional field), and Principle V only
+  demands a bump for store-level changes.
+- **Alternatives**: an `onupgradeneeded` migration — requires a DB_VERSION bump
+  for a field default, heavier than needed and can't see the "current visual
+  order" anyway (sorting logic lives above the DB layer). Rejected.
+
+## D3 — Sync conflicts on order
+
+- **Decision**: Accept per-chat LWW as the merge. Ties or gaps in ranks after a
+  merge are tolerated by the comparator (stable fallback to recency then id);
+  the next local rearrange renumbers cleanly.
+- **Rationale**: Concurrent cross-device rearranges are rare and low-stakes;
+  the grid never crashes or duplicates (comparator is total). This mirrors how
+  `pinned` itself merges today.
+
+## D4 — Drag implementation
+
+- **Decision**: Hand-rolled pointer-events state machine in a composable
+  (`useChatDrag.ts`), owned by `ChatsPage.vue`; grid tiles and list rows are
+  registered as drag sources. Floating proxy = one absolutely-positioned
+  element updated with `transform: translate3d` only. Grid targeting = rect
+  math over the grid element (cheap: ≤ 9 tiles), not DOM elementFromPoint.
+  Placeholder gap rendered by the grid from `{dragId, hoverIndex}` props with
+  CSS transitions.
+- **Rationale**:
+  - HTML5 drag-and-drop: no touch support on iOS Safari, ugly ghost images,
+    can't style the proxy. Rejected.
+  - `ion-reorder-group`: vertical single-list reorder only; cannot host a
+    3-column grid nor a cross-surface (list ↔ grid) drag. Rejected (noted in
+    the Principle XI justification).
+  - A drag library (SortableJS, vue-draggable): new dependency for one screen,
+    still can't do the row→grid morph + forbidden badge without fighting the
+    library. Rejected; the repo prefers stdlib-first equivalents.
+- **Timings** (from the user's iMessage description): press 350 ms → lift
+  (scale + shadow + light haptic if available); movement > 8 px before lift
+  cancels the hold; after lift, movement > 6 px enters drag; holding a further
+  550 ms (≈ 900 ms total) with no drag opens the peek. A completed lift
+  swallows the trailing click (same trick the grid already uses).
+- **Scroll discipline**: while lifted/dragging, a non-passive `touchmove`
+  listener calls `preventDefault()` (registered at lift time — safe because
+  scroll hasn't started, the finger has been still for 350 ms) and the pointer
+  is captured. Near-edge auto-scroll (top/bottom 15% of the content viewport)
+  scrolls the `ion-content` scroll element so far-down rows can reach the grid.
+
+## D5 — Peek overlay
+
+- **Decision**: New `ChatPeekOverlay.vue`: `ion-backdrop` + a fixed, centered
+  column (blurred backdrop like the games overlay pattern): a rounded card
+  listing the newest ~15 messages (from `listMessagesOlder(chatId, null, 15)`,
+  read-only), then an inset `ion-list` menu. Menu items: Pin/Unpin (existing
+  `setChatPinned` + cap toast), Mark as Unread / Mark as Read (existing
+  `markChatUnread`/`markChatRead`), Delete / Exit group (existing confirm
+  action sheet), plus **More…** → the existing ChatActionsSheet.
+- **Message rendering**: minimal bubbles — outgoing right-aligned with the
+  primary tint, incoming left; group messages show sender names; text bodies
+  through `EmojiText`; non-text kinds render icon + `mediaPreview()` label
+  (image/video get their `posterData`/thumb when already local); `deleted` →
+  the standard "deleted" placeholder. No players, no read receipts sent, no
+  `markChatRead`.
+- **Why "More…"**: on touch, this gesture REPLACES the tile's old
+  long-press-→-actions-sheet, which was the pinned chat's only management
+  surface (spec 1044). Without a bridge, Mute/Hide/Lock/Favorites would become
+  unreachable for pinned chats on phones — an FR-013 violation. One extra row
+  keeps every existing capability reachable.
+- **Alternatives**: `ion-modal` with breakpoints — brings sheet semantics
+  (drag-to-dismiss, focus trapping tuned for sheets) that fight the
+  tap-outside-to-dismiss + anchored-card look; `ion-popover` — anchors to the
+  pressed element and clips the message list on small screens. Rejected.
+
+## D6 — What the peek must NOT do
+
+- No `markChatRead`, no seen receipts (`seenReportedAt` writes stay in the
+  chat view), no media downloads triggered (pending media renders as its
+  label/poster only), and hidden-chat rules hold for free: the overlay is only
+  reachable from rows/tiles already visible in the list, and it renders only
+  local plaintext the list is already allowed to show.
+
+## D7 — e2e approach
+
+- **Decision**: One new Playwright spec: seed two accounts + a few chats via
+  the existing `__ringTest` helpers; pin three; assert (a) a new inbound
+  message does not reorder the grid, (b) mouse-drag reorder persists across
+  reload, (c) long-hold opens the peek, tap-outside closes, tap-inside
+  navigates, (d) Mark-as-Unread from the peek shows the badge dot.
+  Mouse-only drag (Playwright `mouse.down/move/up`) — the pointer-event
+  machine is input-agnostic, and headless touch synthesis is flaky (memory:
+  e2e-ci-webrtc-flakiness).

--- a/specs/1045-rearrange-pinned-chats/spec.md
+++ b/specs/1045-rearrange-pinned-chats/spec.md
@@ -1,0 +1,254 @@
+# Feature Specification: Rearrange pinned chats with drag, stable manual order, and long-press chat preview
+
+**Feature Branch**: `feat/1045-rearrange-pinned-chats`
+
+**Created**: 2026-07-13
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "iMessage-style manual arrangement of pinned chats plus a long-press chat preview: drag a lifted pinned avatar to any grid position and it stays there; new messages never move a pin; drag a pin down into the list to unpin; drag a list row up into the grid to pin it at a chosen spot (forbidden badge when the 9-pin cap is reached); a longer hold opens a preview of the chat's latest messages with Pin/Unpin, Mark as Unread/Read, and Delete actions beneath it."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pinned chats keep the order I gave them (Priority: P1)
+
+I pin the people who matter most and arrange them the way I think of them —
+family in the first row, work below. Once arranged, that layout is mine: a new
+message in any pinned chat lights up its badge but never moves the avatar.
+
+**Why this priority**: This is the core promise of pinning. Today the grid
+reorders itself by latest activity, so the muscle memory of "mom is top-left"
+breaks every time someone writes. Every other story builds on a stable order.
+
+**Independent Test**: Pin three chats, receive a message in the last one, and
+confirm the grid order is unchanged (only the unread badge updates).
+
+**Acceptance Scenarios**:
+
+1. **Given** three pinned chats A, B, C in that order, **When** a new message
+   arrives in C, **Then** the grid still shows A, B, C and C shows its unread badge.
+2. **Given** a pinned chat, **When** I open it, send messages, mute it, or mark
+   it unread, **Then** its position in the grid does not change.
+3. **Given** pinned chats arranged on this device, **When** the same account
+   syncs to another device, **Then** the arrangement arrives there too.
+
+---
+
+### User Story 2 - Drag a pinned avatar to rearrange (Priority: P1)
+
+A short press-and-hold on a pinned avatar lifts it slightly (it grows and
+floats above the grid). I can then drag it anywhere in the grid; the other
+avatars part to make room, and when I let go it settles where I dropped it and
+stays there.
+
+**Why this priority**: Manual arrangement is the feature the user asked for by
+name; a stable order (US1) without a way to set it is only half the job.
+
+**Independent Test**: With 4+ pins, long-press the last avatar, drag it to the
+first slot, release, and confirm the new order persists across app restarts.
+
+**Acceptance Scenarios**:
+
+1. **Given** pinned chats A, B, C, **When** I short-long-press C and drag it
+   before A, **Then** the grid shows C, A, B and keeps that order afterwards.
+2. **Given** a lifted avatar mid-drag, **When** I hover it between two others,
+   **Then** the others visibly make room so I can see where it will land.
+3. **Given** a lifted avatar, **When** I release it without moving it, **Then**
+   nothing changes and no chat opens.
+4. **Given** a short tap (no hold) on a pinned avatar, **Then** the chat opens
+   as before.
+
+---
+
+### User Story 3 - Drag between the grid and the list to pin/unpin (Priority: P2)
+
+Dragging a pinned avatar down into the regular chat list unpins it — it slides
+back into the list where its recent activity puts it. Dragging a regular chat
+row up into the grid pins it at the exact spot I drop it: while lifted, the row
+shrinks into a round avatar so it reads as "becoming a pin". If nine chats are
+already pinned, the hovering avatar shows a forbidden badge at its top right,
+and dropping it does nothing.
+
+**Why this priority**: Completes the drag language so pin membership and pin
+order are one gesture, but pinning/unpinning is already possible via swipe and
+the actions sheet, so it's not the MVP.
+
+**Independent Test**: Drag a pin into the list and confirm it unpins; drag a
+row into the grid and confirm it pins at the drop position; fill nine pins and
+confirm the forbidden badge appears and the drop is rejected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pinned chat, **When** I drag its avatar below the grid into the
+   list area and release, **Then** it is unpinned and appears in the list at
+   its normal recency position.
+2. **Given** fewer than nine pins, **When** I short-long-press a list row, drag
+   it into the grid between two avatars and release, **Then** it is pinned at
+   that position.
+3. **Given** nine pinned chats, **When** I lift a list row and hover it over
+   the grid, **Then** a forbidden badge shows at the top right of the floating
+   avatar and releasing it changes nothing.
+4. **Given** a lifted list row dropped back where it came from (outside the
+   grid), **Then** nothing changes.
+
+---
+
+### User Story 4 - Hold longer for a peek at the chat (Priority: P2)
+
+If I keep holding (without dragging), the app opens a preview card of that
+chat's latest messages — enough to read the recent back-and-forth without
+opening the chat and marking it read. Tapping the preview opens the chat.
+Tapping outside dismisses it. Under the preview sits a small menu: Pin or
+Unpin, Mark as Unread or Mark as Read, and Delete.
+
+**Why this priority**: A peek is a big quality-of-life win and iMessage parity,
+but it doesn't gate the ordering work.
+
+**Independent Test**: Long-hold a chat (tile or row), read the preview, tap
+outside to dismiss; long-hold again and tap the preview to enter the chat;
+use each menu action.
+
+**Acceptance Scenarios**:
+
+1. **Given** any chat (pinned tile or list row), **When** I press and hold
+   without moving past the lift, **Then** a preview of the latest messages
+   appears with the action menu beneath it.
+2. **Given** an open preview, **When** I tap inside the preview, **Then** the
+   chat opens; **When** I tap outside, **Then** the preview closes and nothing
+   else happens.
+3. **Given** an open preview of an unread chat, **Then** viewing the preview
+   does not mark the chat read.
+4. **Given** the action menu, **Then** it shows "Unpin" for a pinned chat /
+   "Pin" for an unpinned one, "Mark as Unread" for a read chat / "Mark as
+   Read" for an unread one, and "Delete" (or "Exit group" for a group), with
+   Delete asking for confirmation first.
+5. **Given** nine existing pins and the preview of an unpinned chat, **When** I
+   tap "Pin", **Then** I see the existing "You can only pin 9 chats" notice.
+
+---
+
+### Edge Cases
+
+- A drag that starts scrolling: movement before the lift completes cancels the
+  hold and the page scrolls normally; after the lift, the page must not scroll
+  while dragging.
+- Release exactly on the grid/list boundary: the drop counts as "in the grid"
+  only while hovering over the grid area; anywhere else behaves as a cancel
+  (for a row) or an unpin (for a pin dragged out).
+- Arrangements from another device (sync) may briefly disagree with local
+  order; the most recent change wins, and duplicate/missing order values must
+  not crash the grid — ties fall back to recency.
+- Pins that predate this feature have no saved position: they keep their
+  current relative order (recency at upgrade time) until first rearranged.
+- The preview must respect existing content protections: previews of the
+  latest messages render the same redacted forms used by the chat list (e.g.
+  "Photo", deleted-message placeholder), then real bubbles for text.
+- During an active search or a non-"All" filter chip there is no grid; rows
+  behave as today (no drag; the long-hold preview still works).
+- Deleting a pinned chat from the preview removes it from the grid.
+- The unread badge, mention badge, and manual-unread dot keep rendering on a
+  tile mid-drag (they move with it).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Pinned chats MUST display in a user-defined order that is
+  unaffected by message activity, opening, muting, read/unread changes, or any
+  interaction other than an explicit rearrangement.
+- **FR-002**: A newly pinned chat (via swipe, actions sheet, or preview menu)
+  MUST join the grid at the END of the current arrangement; a chat pinned by
+  drag-into-grid MUST join at the drop position.
+- **FR-003**: A short press-and-hold (~0.4 s) on a pinned avatar MUST lift it
+  (visible elevation) and enter drag mode; dragging MUST live-preview the
+  landing slot by moving the other avatars aside; releasing MUST commit the
+  new order immediately and persist it.
+- **FR-004**: The committed arrangement MUST survive app restarts and MUST
+  sync to the user's other devices with last-write-wins semantics, without any
+  plaintext leaving the device (order data rides the existing encrypted
+  own-data sync).
+- **FR-005**: Dragging a pinned avatar out of the grid (over the list area)
+  and releasing MUST unpin it; the chat then sorts by recency in the list.
+- **FR-006**: A short press-and-hold on a regular list row MUST lift it as a
+  round avatar (pin-shaped); dropping it over the grid MUST pin it at the
+  hovered position when fewer than nine chats are pinned.
+- **FR-007**: When nine chats are already pinned, a lifted list row MUST show
+  a forbidden badge at the top right of the floating avatar while over the
+  grid, and releasing MUST NOT pin it.
+- **FR-008**: Movement beyond a small threshold before the lift completes MUST
+  cancel the hold (normal scrolling/swiping wins); after the lift, drag
+  movement MUST NOT scroll the page.
+- **FR-009**: Continuing to hold (~0.9 s total) without dragging MUST open a
+  preview overlay of the chat's latest messages, on both pinned tiles and
+  list rows.
+- **FR-010**: The preview MUST be read-only and MUST NOT mark the chat read
+  or alter unread counts.
+- **FR-011**: Tapping the preview MUST open the chat; tapping outside MUST
+  dismiss the overlay with no side effects.
+- **FR-012**: Beneath the preview a menu MUST offer: Pin/Unpin (label matches
+  current state, honouring the nine-pin cap with the existing notice),
+  Mark as Unread/Mark as Read (label matches current state), and Delete
+  (Exit group for groups) with the existing confirmation.
+- **FR-013**: All existing entry points (tap to open, swipe actions, the
+  actions sheet, contextmenu on tiles) MUST keep working unchanged.
+- **FR-014**: Hidden-chat protections MUST hold: the preview and drag surfaces
+  only ever operate on chats already visible in the list, and the preview
+  renders the same content the chat is allowed to show in its list row.
+
+### Key Entities
+
+- **Chat pin position**: for each pinned chat, its place in the user's
+  arrangement (first, second, …). Stored with the chat's other organisation
+  flags, synced encrypted like them, absent for unpinned chats.
+- **Chat preview**: a transient, read-only view of the most recent messages of
+  one chat; never persisted, never affects message/read state.
+
+## Zero-Knowledge Impact *(constitution I)*
+
+- **What crosses the wire**: nothing new. The pin arrangement is stored on the
+  chat record, which already travels inside the encrypted own-data sync blob;
+  the server keeps seeing one opaque ciphertext snapshot per account.
+- **What is encrypted**: the arrangement (like the pinned flag itself) is
+  sealed client-side under the user's keys before sync.
+- **Unavoidably visible metadata**: unchanged — only blob size/timing of the
+  existing own-data sync, which this feature does not alter in any observable
+  way (one small numeric field on up to nine records).
+- **Preview**: rendered entirely from local device data; opening it sends
+  nothing (no read receipts, no media downloads it wouldn't already have).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A pinned chat's grid position never changes across 100% of
+  message receipts/sends — only explicit user rearrangement moves it.
+- **SC-002**: Users can move a pin from any slot to any other slot in a single
+  gesture of under 3 seconds, and the result is visible immediately.
+- **SC-003**: Rearrangements persist across a full app restart and appear on a
+  second signed-in device after its next sync.
+- **SC-004**: Pinning by drag is impossible past nine pins, and users get the
+  forbidden-badge cue 100% of the time they try.
+- **SC-005**: Opening the preview never marks a chat read and never triggers
+  navigation unless the user taps inside the preview.
+
+## Assumptions
+
+- The nine-pin cap and its "You can only pin 9 chats." notice stay as they are
+  (spec 1044); this feature adds order, not capacity.
+- Pinned arrangement is per-account (synced), like the pinned flag itself —
+  not per-device.
+- The preview shows the latest messages (about the last screenful, most recent
+  at the bottom) rendered from local data only; media shows as its existing
+  list-preview label/thumbnail, not full players.
+- Drag interactions target the main Chats tab in "All" view where the grid
+  lives; search results and filter chips keep plain rows (today's behaviour),
+  though the long-hold preview works everywhere rows exist.
+- Mouse and touch both drive the same gestures (press-and-hold applies to
+  both; desktop users may also keep using contextmenu/swipe surfaces).
+- Existing pins at upgrade keep their current visual order until the user
+  first rearranges them.

--- a/specs/1045-rearrange-pinned-chats/spec.md
+++ b/specs/1045-rearrange-pinned-chats/spec.md
@@ -176,7 +176,9 @@ use each menu action.
   and releasing MUST unpin it; the chat then sorts by recency in the list.
 - **FR-006**: A short press-and-hold on a regular list row MUST lift it as a
   round avatar (pin-shaped); dropping it over the grid MUST pin it at the
-  hovered position when fewer than nine chats are pinned.
+  hovered position when fewer than nine chats are pinned. When NO chats are
+  pinned yet (no grid exists), lifting a row MUST reveal a drop target where
+  the grid will appear, so the first pin can also be created by drag.
 - **FR-007**: When nine chats are already pinned, a lifted list row MUST show
   a forbidden badge at the top right of the floating avatar while over the
   grid, and releasing MUST NOT pin it.

--- a/specs/1045-rearrange-pinned-chats/spec.md
+++ b/specs/1045-rearrange-pinned-chats/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1045-rearrange-pinned-chats/tasks.md
+++ b/specs/1045-rearrange-pinned-chats/tasks.md
@@ -1,0 +1,155 @@
+# Tasks: Rearrange pinned chats with drag, stable manual order, and long-press chat preview
+
+**Input**: Design documents from `specs/1045-rearrange-pinned-chats/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Included — the constitution mandates TDD (Principle III): failing
+unit tests land before the logic they gate; e2e covers the changed user-facing
+behavior.
+
+**Organization**: Grouped by user story; US1 (stable order) is the MVP and the
+foundation the drag stories write through.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+*(No project setup needed — existing app, no new dependencies.)*
+
+- [ ] T001 Confirm branch `feat/1045-rearrange-pinned-chats` is current and
+      `npm run build` is green before changes (baseline).
+
+## Phase 2: Foundational (blocking all stories)
+
+- [ ] T002 [P] Extend `src/db/types.ts`: add `pinnedRank?: number` to `Chat`
+      with a why-comment (position in the user's arrangement; present only
+      while pinned; synced like `pinned`).
+
+## Phase 3: US1 — Pinned chats keep the order I gave them (P1) 🎯 MVP
+
+**Goal**: Grid order = user's arrangement; message activity never moves a pin.
+
+**Independent test**: Pin three chats, message the last one, order unchanged;
+order survives restart and syncs.
+
+- [ ] T003 [US1] RED: extend `src/utils/chat-pins.test.ts` with failing tests:
+      rank-aware pinned comparator (rank asc, missing rank → after ranked +
+      recency fallback, total/stable on ties), `nextPinRank`, and
+      `partitionPinned` returning the grid rank-sorted.
+- [ ] T004 [US1] GREEN: implement in `src/utils/chat-pins.ts`: `pinnedOrder`
+      comparator + `nextPinRank(chats)` helper; keep the module pure and
+      dependency-free.
+- [ ] T005 [US1] Wire `src/db/queries.ts`: `chatOrder` uses `pinnedOrder`
+      among pinned chats; `setChatPinned` stamps `pinnedRank = nextPinRank(...)`
+      on pin and deletes it on unpin; `setChatArchived`/`archiveAllChats`
+      delete it alongside `pinned`.
+- [ ] T006 [US1] Add `ensurePinRanks()` to `src/db/queries.ts` (stamp missing
+      ranks in current visual order, idempotent) and call it (fire-and-forget)
+      from `src/views/tabs/ChatsPage.vue` on mount.
+- [ ] T007 [US1] Verify: `npx vitest run src/utils/chat-pins.test.ts` green;
+      `npm run build` green.
+
+## Phase 4: US2 — Drag a pinned avatar to rearrange (P1)
+
+**Goal**: Short-hold lifts a tile; drag shows a live gap; drop commits and
+persists the new order.
+
+- [ ] T008 [US2] RED: create `src/utils/drag-math.test.ts` with failing tests
+      for `src/utils/drag-math.ts`: slot index from pointer position + grid
+      rect (3 columns, row math, clamping), `moveItem(list, from, to)`
+      reorder, hover-gap layout mapping (which tile shifts where), and
+      "outside grid" detection.
+- [ ] T009 [US2] GREEN: implement `src/utils/drag-math.ts` as pure functions.
+- [ ] T010 [US2] Add `setPinnedOrder(orderedIds: string[])` to
+      `src/db/queries.ts`: renumber ranks 0..n-1 (only write records whose
+      rank changed), bumping `updatedAt` for sync.
+- [ ] T011 [US2] Create `src/composables/useChatDrag.ts`: pointer-event state
+      machine (idle → held → lifted → dragging), 350 ms lift timer, 8 px
+      pre-lift cancel threshold, pointer capture + non-passive `touchmove`
+      preventDefault while lifted, floating-proxy position (translate3d),
+      peek timer hook (fires `peek` at ~900 ms total if never dragged),
+      drop/cancel resolution, and near-edge auto-scroll of the ion-content
+      scroll element.
+- [ ] T012 [US2] Rework `src/components/PinnedChatsGrid.vue`: register tiles
+      as drag sources (replacing the old 500 ms sheet timer), render the
+      lifted tile's slot as a gap + shift siblings from `{dragId, hoverIndex}`
+      props (CSS transitions), keep tap-to-open + contextmenu-to-sheet, keep
+      badges/dot on the proxy source data.
+- [ ] T013 [US2] Host in `src/views/tabs/ChatsPage.vue`: instantiate
+      `useChatDrag`, render the floating avatar proxy (teleport to page,
+      UserAvatar + badges, lifted styling: scale/shadow), commit grid drops
+      via `setPinnedOrder`.
+- [ ] T014 [US2] Verify: unit suites green; `npm run build` green; manual
+      drive check that a reorder sticks after reload.
+
+## Phase 5: US3 — Drag between the grid and the list to pin/unpin (P2)
+
+**Goal**: Pin ⇄ list membership by drag, with the ⊘ badge at the 9-pin cap.
+
+- [ ] T015 [US3] Extend `src/db/queries.ts` `setChatPinned` with an optional
+      `atRank` (insert position → renumber via the US2 helper); cap check
+      unchanged (returns false at 9).
+- [ ] T016 [US3] Extend `src/components/ChatListItem.vue`: register the row as
+      a drag source through the same controller (long-press lifts a round
+      avatar proxy; pre-lift horizontal movement cancels so ion-item-sliding
+      swipes still win; tap/click unchanged).
+- [ ] T017 [US3] Drop semantics in `useChatDrag` + `ChatsPage.vue`: pinned
+      tile released outside the grid → unpin (toast-free, it just slides into
+      the list); list row released over the grid with < 9 pins → pin at the
+      hovered slot; with 9 pins → show `ban` icon badge at the proxy's top
+      right while over the grid and make the drop a no-op.
+- [ ] T018 [US3] Verify: unit + build green; drive-harness screenshot of the
+      ⊘ badge with 9 pins.
+
+## Phase 6: US4 — Hold longer for a peek at the chat (P2)
+
+**Goal**: ~1 s still hold opens a read-only preview + Pin/Unpin, Mark as
+Unread/Read, Delete (+ More…) menu.
+
+- [ ] T019 [US4] Create `src/components/ChatPeekOverlay.vue`: ion-backdrop +
+      centered card; newest ~15 messages via `listMessagesOlder(chatId, null,
+      15)` rendered as minimal bubbles (outgoing/incoming alignment, group
+      sender names, `EmojiText` bodies, icon + `mediaPreview()` label for
+      non-text kinds, poster thumb when local, deleted placeholder); menu:
+      Pin/Unpin (cap toast), Mark as Unread/Read, Delete/Exit group (existing
+      confirm sheets), More… (opens ChatActionsHost sheet); tap card → emit
+      `open`, tap backdrop → emit `dismiss`; `role="dialog"`, labels, and NO
+      `markChatRead`/receipt writes.
+- [ ] T020 [US4] Wire the peek: `useChatDrag`'s `peek` event (tiles AND rows,
+      including on chips/search views where rows don't drag) opens the overlay
+      from `src/views/tabs/ChatsPage.vue`; navigation on `open`.
+- [ ] T021 [US4] Update `e2e/pinned-grid.spec.ts`: the tile hold now opens the
+      PEEK (not the actions sheet) — hold ~1.2 s, assert the peek, use its
+      Unpin; keep the rest of the 1044 assertions intact.
+- [ ] T022 [US4] Verify: `npm run build` green; drive-harness screenshots of
+      the peek (light + dark).
+
+## Phase 7: Polish & cross-cutting
+
+- [ ] T023 [P] New e2e `e2e/pinned-reorder.spec.ts`: (a) inbound message does
+      not reorder the grid; (b) mouse-drag reorder persists across reload;
+      (c) drag a row into the grid pins it at the slot; (d) long-hold peek:
+      tap-outside closes, tap-inside opens the chat, Mark as Unread shows the
+      dot. Reuse `e2e/helpers` account/pair utilities.
+- [ ] T024 Run the full gates: `npm run test:unit`, `npm run build`,
+      `npm run test:e2e -- pinned` (grid + reorder specs), fix fallout.
+- [ ] T025 Update `specs/1045-rearrange-pinned-chats/spec.md` Status →
+      in-review when the user validates locally; run `make roadmap` and commit
+      the regenerated `ROADMAP.md`.
+- [ ] T026 (deferred, needs user go-ahead) `/speckit-taskstoissues` + PR with
+      `Closes #N` lines — nothing is pushed until the user has tested locally.
+
+## Dependencies
+
+- T002 → everything.
+- US1 (T003–T007) → US2 (ranks must exist before reorder writes).
+- US2's controller + math (T008–T013) → US3 (T015–T018) and the peek trigger
+  (T020). T019 is parallel to US2/US3 (component in isolation).
+- e2e polish (T023) after US2–US4.
+
+## Implementation strategy
+
+US1 alone is a shippable MVP (stable order, no visual change beyond stability).
+US2 delivers the headline gesture; US3 and US4 complete iMessage parity. Tests
+red-first within each story; `npm run build` after every story.

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -2,7 +2,10 @@
   <!-- One chat row + its swipe actions. Reused by the Chats tab, the Archived view,
        and the filtered lists. Quick actions live on the swipe; the full set is in the
        per-chat "More" sheet (opened via the `more` emit). -->
-  <ion-item-sliding ref="sliding">
+  <!-- Swiping is disabled while this row rides the drag proxy (spec 1045): the
+       sliding gesture stays armed during a lift, and the drag's horizontal
+       wobble was opening the swipe options under the ghost row. -->
+  <ion-item-sliding ref="sliding" :disabled="lifted">
     <!-- Start side (swipe right): Mark Unread/Read + Pin/Unpin. Icon-over-label like
          WhatsApp. The label names the action: "Read" when it'll clear unread, else
          "Unread"; "Unpin" when pinned, else "Pin". -->
@@ -90,7 +93,7 @@
 
 <script setup lang="ts">
 import UserAvatar from '@/components/UserAvatar.vue';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import {
   IonItemSliding, IonItem, IonItemOptions, IonItemOption, IonAvatar, IonLabel, IonNote,
   IonBadge, IonIcon,
@@ -124,6 +127,15 @@ const sliding = ref<{ $el: HTMLIonItemSlidingElement } | null>(null);
 function closeSwipe(): void {
   void (sliding.value?.$el as HTMLIonItemSlidingElement | undefined)?.close?.();
 }
+// A slide can already be a few pixels open by the time the lift lands (the
+// :disabled bind stops NEW gesture input but doesn't reset an in-flight one) —
+// snap it shut so the ghost row sits flush while it's being dragged.
+watch(
+  () => props.lifted,
+  (v) => {
+    if (v) closeSwipe();
+  },
+);
 
 const PREVIEW_ICONS: Record<NonNullable<Chat['lastKind']>, string | null> = {
   image: cameraOutline, video: videocamOutline, videonote: videocamOutline, voice: micOutline,

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -17,7 +17,16 @@
       </ion-item-option>
     </ion-item-options>
 
-    <ion-item button :detail="false" :class="{ 'hidden-row': isHidden }" @click="$emit('open', chat.id)">
+    <!-- pointerdown feeds the page's drag/peek controller (spec 1045): a short hold
+         lifts the row as a pin-shaped avatar, a still hold opens the peek. Movement
+         before the lift cancels the hold, so the sliding swipes and scrolling win. -->
+    <ion-item
+      button
+      :detail="false"
+      :class="{ 'hidden-row': isHidden, 'lifted-row': lifted }"
+      @click="$emit('open', chat.id)"
+      @pointerdown="$emit('press', chat, $event)"
+    >
       <div class="avatar-wrap" slot="start">
         <ion-avatar>
           <!-- Unread demands attention: the emoji picture keeps moving until read (FR-028). -->
@@ -104,8 +113,12 @@ import { activityFor, activityKindLabel } from '@/composables/useTyping';
 import { formatTime } from '@/utils/time';
 import type { Chat } from '@/db/types';
 
-const props = defineProps<{ chat: Chat; draft?: string }>();
-const emit = defineEmits<{ (e: 'open', id: string): void; (e: 'more', chat: Chat): void }>();
+const props = defineProps<{ chat: Chat; draft?: string; lifted?: boolean }>();
+const emit = defineEmits<{
+  (e: 'open', id: string): void;
+  (e: 'more', chat: Chat): void;
+  (e: 'press', chat: Chat, ev: PointerEvent): void;
+}>();
 
 const sliding = ref<{ $el: HTMLIonItemSlidingElement } | null>(null);
 function closeSwipe(): void {
@@ -212,6 +225,11 @@ function more(): void {
 }
 .hidden-ico {
   color: var(--ion-color-medium);
+}
+/* The row whose avatar is riding the drag proxy (spec 1045): stays in place but
+   clearly "picked up" — it either returns (cancel) or leaves for the grid (pin). */
+.lifted-row {
+  opacity: 0.35;
 }
 .unread-dot {
   width: 11px;

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -231,6 +231,15 @@ function more(): void {
 .lifted-row {
   opacity: 0.35;
 }
+/* The press-and-hold gesture owns the long press (spec 1045). Without this, iOS
+   starts a TEXT SELECTION on the row's name/preview during the hold, and an
+   active selection then eats the first tap on whatever opens (the peek's menu
+   needed two taps). Matches the pinned tiles. */
+ion-item {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+}
 .unread-dot {
   width: 11px;
   height: 11px;

--- a/src/components/ChatPeekOverlay.vue
+++ b/src/components/ChatPeekOverlay.vue
@@ -142,20 +142,26 @@ function kindLabel(m: Message): string {
   }
 }
 
+// Every action dismisses the peek FIRST. The overlay teleports to <body> above
+// ion-app, so anything Ionic presents (action sheets, toasts) while it's still
+// open renders BEHIND it — Delete's confirmation was invisible until the user
+// closed the peek by hand.
 async function togglePin(): Promise<void> {
-  if (!props.chat) return;
-  const ok = await setChatPinned(props.chat.id, !props.chat.pinned);
+  const c = props.chat;
+  if (!c) return;
+  emit('dismiss');
+  const ok = await setChatPinned(c.id, !c.pinned);
   if (!ok) {
     await appToast({ message: `You can only pin ${MAX_PINNED_CHATS} chats.`, duration: 2200 });
   }
-  emit('dismiss');
 }
 
 async function toggleUnread(): Promise<void> {
-  if (!props.chat) return;
-  if (unread.value) await markChatRead(props.chat.id);
-  else await markChatUnread(props.chat.id);
+  const c = props.chat;
+  if (!c) return;
   emit('dismiss');
+  if (unread.value) await markChatRead(c.id);
+  else await markChatUnread(c.id);
 }
 
 function openMore(): void {
@@ -165,6 +171,9 @@ function openMore(): void {
 async function confirmRemove(): Promise<void> {
   const c = props.chat;
   if (!c) return;
+  emit('dismiss');
+  // Let the peek's leave transition finish so the sheet's enter isn't swallowed.
+  await new Promise((r) => setTimeout(r, 220));
   const sheet = await actionSheetController.create({
     header: c.isGroup ? `Leave "${c.name}"?` : 'Delete this chat?',
     buttons: [
@@ -177,8 +186,6 @@ async function confirmRemove(): Promise<void> {
     ],
   });
   await sheet.present();
-  await sheet.onDidDismiss();
-  emit('dismiss');
 }
 </script>
 

--- a/src/components/ChatPeekOverlay.vue
+++ b/src/components/ChatPeekOverlay.vue
@@ -1,0 +1,314 @@
+<template>
+  <!-- Long-press chat peek (spec 1045): a read-only card of the latest messages with
+       a small action menu beneath, iMessage-style. Strictly a LOCAL view — opening it
+       never marks the chat read, sends no receipts, and triggers no downloads
+       (pending media renders as its label/poster only). Tap the card to really open
+       the chat; tap anywhere else to dismiss. -->
+  <Teleport to="body">
+    <Transition name="peek">
+      <div v-if="isOpen && chat" class="peek-root">
+        <div class="peek-backdrop" @click="$emit('dismiss')" />
+        <div class="peek-stack" role="dialog" :aria-label="`Preview of ${chat.name}`">
+          <div
+            class="peek-card"
+            role="button"
+            :aria-label="`Open ${chat.name}`"
+            tabindex="0"
+            @click="$emit('open', chat.id)"
+            @keydown.enter="$emit('open', chat.id)"
+          >
+            <div class="peek-head">
+              <ion-avatar class="peek-av"><user-avatar :src="chat.avatar" :alt="chat.name" /></ion-avatar>
+              <span class="peek-title" dir="auto">{{ chat.name }}</span>
+            </div>
+            <div class="peek-msgs">
+              <p v-if="loaded && msgs.length === 0" class="peek-empty">No messages yet</p>
+              <div
+                v-for="m in msgs"
+                :key="m.id"
+                class="peek-row"
+                :class="{ out: m.outgoing }"
+              >
+                <div class="peek-bubble" :class="{ out: m.outgoing }">
+                  <span v-if="chat.isGroup && !m.outgoing" class="peek-sender" dir="auto">{{ m.senderName }}</span>
+                  <img
+                    v-if="!m.deleted && m.posterData"
+                    class="peek-thumb"
+                    :src="m.posterData"
+                    :alt="m.kind"
+                  />
+                  <span v-if="m.deleted" class="peek-label">Message deleted</span>
+                  <template v-else>
+                    <span v-if="kindLabel(m)" class="peek-label">{{ kindLabel(m) }}</span>
+                    <span v-if="m.kind === 'text' || m.body" class="peek-body" dir="auto">
+                      <emoji-text :text="m.body" />
+                    </span>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- The action menu. Pin/Unpin honours the 9-pin cap with the existing
+               toast; Delete confirms like the actions sheet; More… bridges to the
+               full sheet so pinned chats keep Mute/Hide/Lock on touch (this gesture
+               replaced their old long-press-for-sheet). -->
+          <ion-list :inset="true" class="peek-menu" @click.stop>
+            <ion-item button :detail="false" @click="togglePin">
+              <ion-icon slot="start" :icon="pinOutline" />
+              <ion-label>{{ chat.pinned ? 'Unpin' : 'Pin' }}</ion-label>
+            </ion-item>
+            <ion-item button :detail="false" @click="toggleUnread">
+              <ion-icon slot="start" :icon="unread ? mailOpenOutline : mailUnreadOutline" />
+              <ion-label>{{ unread ? 'Mark as Read' : 'Mark as Unread' }}</ion-label>
+            </ion-item>
+            <ion-item button :detail="false" @click="openMore">
+              <ion-icon slot="start" :icon="ellipsisHorizontal" />
+              <ion-label>More…</ion-label>
+            </ion-item>
+            <ion-item button :detail="false" @click="confirmRemove">
+              <ion-icon slot="start" color="danger" :icon="chat.isGroup ? exitOutline : trashOutline" />
+              <ion-label color="danger">{{ chat.isGroup ? 'Exit group' : 'Delete' }}</ion-label>
+            </ion-item>
+          </ion-list>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import {
+  IonList, IonItem, IonLabel, IonIcon, IonAvatar, actionSheetController,
+} from '@ionic/vue';
+import {
+  pinOutline, mailOpenOutline, mailUnreadOutline, trashOutline, exitOutline,
+  ellipsisHorizontal,
+} from 'ionicons/icons';
+import UserAvatar from '@/components/UserAvatar.vue';
+import EmojiText from '@/components/EmojiText.vue';
+import {
+  listMessagesOlder, setChatPinned, markChatRead, markChatUnread, deleteChat, leaveGroup,
+  MAX_PINNED_CHATS,
+} from '@/db/queries';
+import { mediaPreview } from '@/services/message-preview';
+import { appToast } from '@/services/toast';
+import { GAMES } from '@/games/registry';
+import type { Chat, Message } from '@/db/types';
+
+const PEEK_MESSAGES = 15; // about a screenful; the card scrolls if tall
+
+const props = defineProps<{ chat: Chat | null; isOpen: boolean }>();
+const emit = defineEmits<{
+  (e: 'dismiss'): void;
+  (e: 'open', id: string): void;
+  (e: 'more', chat: Chat): void;
+}>();
+
+const msgs = ref<Message[]>([]);
+const loaded = ref(false);
+watch(
+  () => [props.isOpen, props.chat?.id] as const,
+  async ([open, id]) => {
+    if (!open || !id) return;
+    loaded.value = false;
+    msgs.value = await listMessagesOlder(id, null, PEEK_MESSAGES); // oldest→newest
+    loaded.value = true;
+  },
+);
+
+const unread = computed(() => !!props.chat && (props.chat.unread > 0 || !!props.chat.manualUnread));
+
+/** The muted label line for non-text kinds ("" for plain text bubbles). */
+function kindLabel(m: Message): string {
+  switch (m.kind) {
+    case 'text':
+      return '';
+    case 'location':
+      return m.location?.label || 'Location';
+    case 'poll':
+      return m.poll?.question || 'Poll';
+    case 'contact':
+      return m.contact?.name || 'Contact';
+    case 'game':
+    case 'gamechallenge':
+      return m.game ? GAMES[m.game.gameType]?.displayName ?? 'Game' : 'Game';
+    case 'call':
+      return 'Call';
+    default:
+      // Media kinds: label + duration; the body (caption) renders separately below.
+      return mediaPreview(m.kind, m.durationSec, m.body || undefined, m.videoNote);
+  }
+}
+
+async function togglePin(): Promise<void> {
+  if (!props.chat) return;
+  const ok = await setChatPinned(props.chat.id, !props.chat.pinned);
+  if (!ok) {
+    await appToast({ message: `You can only pin ${MAX_PINNED_CHATS} chats.`, duration: 2200 });
+  }
+  emit('dismiss');
+}
+
+async function toggleUnread(): Promise<void> {
+  if (!props.chat) return;
+  if (unread.value) await markChatRead(props.chat.id);
+  else await markChatUnread(props.chat.id);
+  emit('dismiss');
+}
+
+function openMore(): void {
+  if (props.chat) emit('more', props.chat);
+}
+
+async function confirmRemove(): Promise<void> {
+  const c = props.chat;
+  if (!c) return;
+  const sheet = await actionSheetController.create({
+    header: c.isGroup ? `Leave "${c.name}"?` : 'Delete this chat?',
+    buttons: [
+      {
+        text: c.isGroup ? 'Exit group' : 'Delete chat',
+        role: 'destructive',
+        handler: () => void (c.isGroup ? leaveGroup(c.id) : deleteChat(c.id)),
+      },
+      { text: 'Cancel', role: 'cancel' as const },
+    ],
+  });
+  await sheet.present();
+  await sheet.onDidDismiss();
+  emit('dismiss');
+}
+</script>
+
+<style scoped>
+.peek-root {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.peek-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+}
+.peek-stack {
+  position: relative;
+  width: min(92vw, 440px);
+  max-height: calc(100% - 48px);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.peek-card {
+  background: var(--ion-background-color, #fff);
+  border-radius: 18px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 140px;
+  max-height: 55vh;
+  cursor: pointer;
+  box-shadow: 0 24px 60px -18px rgba(0, 0, 0, 0.55);
+}
+.peek-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px 8px;
+}
+.peek-av {
+  width: 30px;
+  height: 30px;
+}
+.peek-title {
+  font-weight: 700;
+  font-size: 15px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.peek-msgs {
+  flex: 1;
+  overflow: hidden; /* read-only peek: the newest messages fill from the bottom */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 4px 12px 14px;
+}
+.peek-empty {
+  text-align: center;
+  color: var(--ion-color-medium);
+  margin: 24px 0;
+}
+.peek-row {
+  display: flex;
+  justify-content: flex-start;
+}
+.peek-row.out {
+  justify-content: flex-end;
+}
+.peek-bubble {
+  max-width: 78%;
+  padding: 7px 11px;
+  border-radius: 15px;
+  background: var(--app-bubble-in);
+  border: 1px solid color-mix(in srgb, var(--app-text, #000) 14%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 14.5px;
+  line-height: 1.3;
+}
+.peek-bubble.out {
+  background: var(--app-bubble-out);
+}
+.peek-sender {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ion-color-primary);
+}
+.peek-thumb {
+  max-width: 180px;
+  max-height: 130px;
+  border-radius: 10px;
+  object-fit: cover;
+}
+.peek-label {
+  color: var(--app-text-muted, var(--ion-color-medium));
+  font-style: italic;
+}
+.peek-body {
+  unicode-bidi: plaintext;
+  text-align: start;
+  overflow-wrap: anywhere;
+}
+.peek-menu {
+  margin: 0;
+  border-radius: 14px;
+}
+/* Enter/leave: quick iMessage-style pop. */
+.peek-enter-active,
+.peek-leave-active {
+  transition: opacity 0.16s ease;
+}
+.peek-enter-active .peek-stack,
+.peek-leave-active .peek-stack {
+  transition: transform 0.16s ease;
+}
+.peek-enter-from,
+.peek-leave-to {
+  opacity: 0;
+}
+.peek-enter-from .peek-stack,
+.peek-leave-to .peek-stack {
+  transform: scale(0.92);
+}
+</style>

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -1,65 +1,77 @@
 <template>
-  <!-- iMessage-style pinned chats (spec 1044): large circular avatars in a 3-column
-       grid above the list. Tap opens the chat; LONG-PRESS opens the actions sheet —
-       pinned chats leave the list rows, so the row's swipe gestures can't reach
-       them and the sheet (with its Pin/Unpin action) is their management surface. -->
-  <div class="pin-grid" role="list" aria-label="Pinned chats">
-    <button
-      v-for="chat in chats"
-      :key="chat.id"
-      type="button"
-      class="pin-tile"
-      role="listitem"
-      :aria-label="chat.name"
-      :data-chat-id="chat.id"
-      @click="onTap(chat)"
-      @pointerdown="pressStart(chat)"
-      @pointerup="pressEnd"
-      @pointercancel="pressEnd"
-      @contextmenu.prevent="$emit('more', chat)"
-    >
-      <div class="pin-avatar">
-        <user-avatar :src="chat.avatar" :alt="chat.name" :attention="chat.unread > 0" />
-        <ion-badge v-if="chat.unread" color="primary" class="pin-badge">{{ chat.unread }}</ion-badge>
-        <span v-else-if="chat.manualUnread" class="pin-dot" aria-hidden="true" />
+  <!-- iMessage-style pinned chats (specs 1044 + 1045): large circular avatars in a
+       3-column grid above the list, in the USER'S order. Tap opens the chat. A short
+       press-and-hold lifts a tile into the page's drag controller (rearrange /
+       drag-out-to-unpin); holding still opens the peek. Right-click (desktop) keeps
+       the full actions sheet — on touch the peek's menu (incl. More…) replaced it.
+       The TransitionGroup FLIP-animates tiles as the drag's preview gap moves. -->
+  <TransitionGroup ref="root" tag="div" name="pin" class="pin-grid" role="list" aria-label="Pinned chats">
+    <template v-for="id in displayIds" :key="id">
+      <!-- The dragged chat's slot: an empty well under the floating proxy. Keyed as
+           the chat so the gap itself is what FLIP moves around the grid. -->
+      <div v-if="id === dragId" class="pin-tile pin-ghost" role="listitem" aria-hidden="true">
+        <div class="pin-avatar pin-well" />
       </div>
-      <span class="pin-name" dir="auto">{{ chat.name }}</span>
-    </button>
-  </div>
+      <button
+        v-else-if="byId[id]"
+        type="button"
+        class="pin-tile"
+        role="listitem"
+        :aria-label="byId[id].name"
+        :data-chat-id="id"
+        @click="$emit('open', id)"
+        @pointerdown="$emit('press', byId[id], $event)"
+        @contextmenu.prevent="$emit('more', byId[id])"
+      >
+        <div class="pin-avatar">
+          <user-avatar :src="byId[id].avatar" :alt="byId[id].name" :attention="byId[id].unread > 0" />
+          <ion-badge v-if="byId[id].unread" color="primary" class="pin-badge">{{ byId[id].unread }}</ion-badge>
+          <span v-else-if="byId[id].manualUnread" class="pin-dot" aria-hidden="true" />
+        </div>
+        <span class="pin-name" dir="auto">{{ byId[id].name }}</span>
+      </button>
+    </template>
+  </TransitionGroup>
 </template>
 
 <script setup lang="ts">
+import { computed, ref } from 'vue';
 import { IonBadge } from '@ionic/vue';
 import UserAvatar from '@/components/UserAvatar.vue';
 import type { Chat } from '@/db/types';
 
-defineProps<{ chats: Chat[] }>();
-const emit = defineEmits<{ (e: 'open', id: string): void; (e: 'more', chat: Chat): void }>();
+const props = defineProps<{
+  /** Pinned chats in the user's (rank) order. */
+  chats: Chat[];
+  /** Render order mid-drag (the live gap); falls back to `chats`' order. */
+  displayOrder?: string[];
+  /** The chat currently riding the floating proxy (its slot renders as a well). */
+  dragId?: string | null;
+}>();
+defineEmits<{
+  (e: 'open', id: string): void;
+  (e: 'more', chat: Chat): void;
+  (e: 'press', chat: Chat, ev: PointerEvent): void;
+}>();
 
-// Long-press → the actions sheet; a completed long-press swallows the click that
-// follows on pointerup so the chat doesn't ALSO open underneath the sheet.
-const LONG_PRESS_MS = 500;
-let pressTimer: ReturnType<typeof setTimeout> | null = null;
-let longPressed = false;
+const byId = computed(() => {
+  const m: Record<string, Chat> = {};
+  for (const c of props.chats) m[c.id] = c;
+  return m;
+});
+// Ids to render: the drag preview order when given, else the true order. Foreign
+// ids (a list row hovering in) have no chat here — they render as the ghost well.
+const displayIds = computed(() => {
+  const order = props.displayOrder ?? props.chats.map((c) => c.id);
+  return order.filter((id) => byId.value[id] || id === props.dragId);
+});
 
-function pressStart(chat: Chat): void {
-  longPressed = false;
-  pressTimer = setTimeout(() => {
-    longPressed = true;
-    emit('more', chat);
-  }, LONG_PRESS_MS);
-}
-function pressEnd(): void {
-  if (pressTimer) clearTimeout(pressTimer);
-  pressTimer = null;
-}
-function onTap(chat: Chat): void {
-  if (longPressed) {
-    longPressed = false;
-    return;
-  }
-  emit('open', chat.id);
-}
+// The grid's root element, for the page's drag controller hit-testing. The ref
+// lands on the TransitionGroup component; its $el is the rendered .pin-grid div.
+const root = ref<{ $el: HTMLElement } | null>(null);
+defineExpose({
+  el: (): HTMLElement | null => root.value?.$el ?? null,
+});
 </script>
 
 <style scoped>
@@ -79,11 +91,28 @@ function onTap(chat: Chat): void {
   padding: 0;
   cursor: pointer;
   min-width: 0; /* let the name ellipsize instead of widening the column */
+  /* A press-and-hold must lift the tile, never select its label or pop the iOS
+     callout — the gesture owns the long press now. */
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+}
+/* FLIP: tiles glide to their new slot as the drag gap moves. */
+.pin-move {
+  transition: transform 0.2s ease;
 }
 .pin-avatar {
   position: relative;
   width: 88px;
   height: 88px;
+}
+/* The empty well left behind by (or opening up for) the floating avatar. */
+.pin-well {
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--app-text, #000) 8%, transparent);
+}
+.pin-ghost .pin-name {
+  visibility: hidden;
 }
 .pin-badge {
   position: absolute;

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -121,16 +121,23 @@ defineExpose({
 }
 /* The empty well left behind by (or opening up for) the floating avatar. Applied
    to the SAME tile element (CSS only — see the template note about iOS): its
-   content hides, the avatar box becomes the well. */
+   content hides, the avatar box becomes the well. Hidden via OPACITY, not
+   visibility: flipping visibility back while the tile's FLIP transform settles
+   hit a WebKit stale-paint bug — the dropped tile's NAME stayed invisible until
+   the next grid invalidation (i.e. the next drag). Opacity changes always go
+   through the compositor, and the transition forces the repaint. */
 .pin-ghost .pin-avatar {
   border-radius: 50%;
   background: color-mix(in srgb, var(--app-text, #000) 8%, transparent);
 }
-.pin-ghost .pin-avatar > * {
-  visibility: hidden;
+.pin-avatar > *,
+.pin-name {
+  opacity: 1;
+  transition: opacity 0.12s ease;
 }
+.pin-ghost .pin-avatar > *,
 .pin-ghost .pin-name {
-  visibility: hidden;
+  opacity: 0;
 }
 .pin-badge {
   position: absolute;

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -110,6 +110,12 @@ defineExpose({
      touches on a tile belong to the drag; scrolls still start anywhere else. */
   touch-action: none;
 }
+/* The avatar <img> must never start a NATIVE image drag under the mouse — the
+   browser pointercancels our gesture when it does (belt to the dragstart block
+   in useChatDrag). */
+.pin-tile img {
+  -webkit-user-drag: none;
+}
 /* FLIP: tiles glide to their new slot as the drag gap moves. */
 .pin-move {
   transition: transform 0.2s ease;

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -7,17 +7,19 @@
        The TransitionGroup FLIP-animates tiles as the drag's preview gap moves. -->
   <TransitionGroup ref="root" tag="div" name="pin" class="pin-grid" role="list" aria-label="Pinned chats">
     <template v-for="id in displayIds" :key="id">
-      <!-- The dragged chat's slot: an empty well under the floating proxy. Keyed as
-           the chat so the gap itself is what FLIP moves around the grid. -->
-      <div v-if="id === dragId" class="pin-tile pin-ghost" role="listitem" aria-hidden="true">
-        <div class="pin-avatar pin-well" />
-      </div>
+      <!-- A member tile. While it's the one riding the drag proxy it renders as the
+           ghost well via CSS ONLY — the BUTTON MUST STAY MOUNTED: iOS stops
+           delivering the gesture's touch/pointer events the moment their original
+           target leaves the DOM, which froze the drag (and let the peek timer fire
+           mid-drag). Keyed as the chat so FLIP moves the gap around the grid. -->
       <button
-        v-else-if="byId[id]"
+        v-if="byId[id]"
         type="button"
         class="pin-tile"
+        :class="{ 'pin-ghost': id === dragId }"
         role="listitem"
         :aria-label="byId[id].name"
+        :aria-hidden="id === dragId ? 'true' : undefined"
         :data-chat-id="id"
         @click="$emit('open', id)"
         @pointerdown="$emit('press', byId[id], $event)"
@@ -30,6 +32,12 @@
         </div>
         <span class="pin-name" dir="auto">{{ byId[id].name }}</span>
       </button>
+      <!-- A FOREIGN drag (a list row hovering in): no chat data here, so the well is
+           its own element. It's never the gesture's touch target, so (un)mounting
+           it mid-drag is safe. -->
+      <div v-else-if="id === dragId" class="pin-tile pin-ghost" role="listitem" aria-hidden="true">
+        <div class="pin-avatar" />
+      </div>
     </template>
   </TransitionGroup>
 </template>
@@ -96,6 +104,11 @@ defineExpose({
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
+  /* Ionic's global css puts touch-action: manipulation on every <button>, which
+     lets the browser claim a vertical touch drag as a page scroll and KILL the
+     gesture with pointercancel — drag-a-tile-out-to-unpin died on iOS. none =
+     touches on a tile belong to the drag; scrolls still start anywhere else. */
+  touch-action: none;
 }
 /* FLIP: tiles glide to their new slot as the drag gap moves. */
 .pin-move {
@@ -106,10 +119,15 @@ defineExpose({
   width: 88px;
   height: 88px;
 }
-/* The empty well left behind by (or opening up for) the floating avatar. */
-.pin-well {
+/* The empty well left behind by (or opening up for) the floating avatar. Applied
+   to the SAME tile element (CSS only — see the template note about iOS): its
+   content hides, the avatar box becomes the well. */
+.pin-ghost .pin-avatar {
   border-radius: 50%;
   background: color-mix(in srgb, var(--app-text, #000) 8%, transparent);
+}
+.pin-ghost .pin-avatar > * {
+  visibility: hidden;
 }
 .pin-ghost .pin-name {
   visibility: hidden;

--- a/src/composables/useChatDrag.ts
+++ b/src/composables/useChatDrag.ts
@@ -1,0 +1,323 @@
+/**
+ * Pointer-event state machine for the pinned-grid drag + long-press peek
+ * (spec 1045). One controller per Chats page: the gesture crosses two components
+ * (grid tiles and list rows) and must coordinate a single floating proxy, one
+ * active gesture, page auto-scroll, and click swallowing — so it lives here, not
+ * in either component.
+ *
+ * Gesture timeline (iMessage parity):
+ *   press ──350ms──► LIFT (proxy floats, scroll locked)
+ *     · >8px movement BEFORE the lift cancels the hold — scroll/swipe win.
+ *     · after the lift, >6px movement enters DRAG (grid gap follows the pointer).
+ *     · still holding ~550ms past the lift with no drag → PEEK (read-only
+ *       preview overlay; the gesture ends there).
+ *   release while dragging → drop: reorder / pin-at-slot / unpin / cancel.
+ *
+ * All geometry/list math is pure (src/utils/drag-math.ts) and unit-tested; this
+ * file owns only timers, listeners, and reactive state.
+ */
+import { reactive, computed } from 'vue';
+import { gridSlotAt, previewOrder, edgeScrollVelocity } from '@/utils/drag-math';
+import type { Chat } from '@/db/types';
+
+const LIFT_MS = 350; // press-and-hold until the avatar lifts
+const PEEK_MS = 550; // further still-hold until the peek opens (≈900ms total)
+const PRE_LIFT_CANCEL_PX = 8; // movement before the lift = the user is scrolling/swiping
+const DRAG_START_PX = 6; // movement after the lift that commits to dragging
+const GRID_SLACK_PX = 24; // forgiveness around the grid rect while targeting
+
+export type DragPhase = 'idle' | 'held' | 'lifted' | 'dragging';
+export type DragOrigin = 'grid' | 'list';
+
+export interface DragState {
+  phase: DragPhase;
+  origin: DragOrigin;
+  chat: Chat | null;
+  /** Pointer position (viewport coords). */
+  x: number;
+  y: number;
+  /** Where the pressed element was at lift time (proxy start box). */
+  startRect: { left: number; top: number; width: number; height: number };
+  startX: number;
+  startY: number;
+  /** Grid slot the drag currently targets (null = not over the grid). */
+  hoverIndex: number | null;
+  /** Over the grid but the 9-pin cap blocks pinning (list-origin only) → ⊘ badge. */
+  blocked: boolean;
+}
+
+export interface ChatDragOptions {
+  /** The .pin-grid element (null when no pins / other filter). */
+  gridEl: () => HTMLElement | null;
+  /** The ion-content scroll element, for near-edge auto-scroll. */
+  scrollEl: () => HTMLElement | null;
+  /** Rank-ordered pinned chat ids (the grid's true order). */
+  pinnedIds: () => string[];
+  /** The pin cap (MAX_PINNED_CHATS), injected to keep this module UI-only. */
+  maxPins: number;
+  /** Grid-origin drop inside the grid: the full new arrangement. */
+  onReorder: (orderedIds: string[]) => void;
+  /** Grid-origin drop outside the grid: unpin. */
+  onUnpin: (chatId: string) => void;
+  /** List-origin drop over the grid below the cap: pin at that slot. */
+  onPin: (chatId: string, atIndex: number) => void;
+  /** Still-hold past the lift: open the peek overlay. */
+  onPeek: (chat: Chat) => void;
+}
+
+export function useChatDrag(opts: ChatDragOptions) {
+  const state = reactive<DragState>({
+    phase: 'idle',
+    origin: 'grid',
+    chat: null,
+    x: 0,
+    y: 0,
+    startRect: { left: 0, top: 0, width: 0, height: 0 },
+    startX: 0,
+    startY: 0,
+    hoverIndex: null,
+    blocked: false,
+  });
+
+  let liftTimer: ReturnType<typeof setTimeout> | null = null;
+  let peekTimer: ReturnType<typeof setTimeout> | null = null;
+  let pointerId = -1;
+  let captureEl: HTMLElement | null = null;
+  let scrollRaf = 0;
+  // A completed lift/peek/drag must NOT let the trailing click open the chat
+  // underneath; consumed by the page's open() handler.
+  let swallowNextClick = false;
+  // Belt and braces for the same problem: the release-click's TARGET is
+  // unpredictable (pointer capture may retarget it to the pressed tile; a peek
+  // means it lands on the just-opened overlay — which must not instantly
+  // dismiss). A one-shot document-capture listener eats it wherever it lands.
+  // The browser doesn't always FIRE that release-click (down/up targets may
+  // diverge), so the trap also disarms on the next pointerDOWN — a new press
+  // means the release-click came and went (or never will), and the new tap's
+  // own click must pass.
+  const clickTrap = (e: MouseEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();
+    disarmClickTrap();
+  };
+  const trapDisarmOnDown = (): void => disarmClickTrap();
+  function armClickTrap(): void {
+    document.addEventListener('click', clickTrap, true);
+    document.addEventListener('pointerdown', trapDisarmOnDown, true);
+  }
+  function disarmClickTrap(): void {
+    document.removeEventListener('click', clickTrap, true);
+    document.removeEventListener('pointerdown', trapDisarmOnDown, true);
+  }
+
+  /** The grid's display order mid-drag (drives the live gap). */
+  const displayIds = computed(() => {
+    if ((state.phase !== 'dragging' && state.phase !== 'lifted') || !state.chat) {
+      return opts.pinnedIds();
+    }
+    return previewOrder(opts.pinnedIds(), state.chat.id, state.hoverIndex);
+  });
+
+  function clearTimers(): void {
+    if (liftTimer) clearTimeout(liftTimer);
+    if (peekTimer) clearTimeout(peekTimer);
+    liftTimer = peekTimer = null;
+  }
+
+  // While lifted/dragging the page must not scroll under the finger. The
+  // listener is registered AT LIFT TIME — safe, because the finger has been
+  // still for LIFT_MS, so no scroll gesture is in flight to conflict with.
+  const blockTouchMove = (e: TouchEvent): void => e.preventDefault();
+  // Android synthesizes a contextmenu on long-press; while a gesture is live it
+  // must not pop the actions sheet (or the OS menu) over the lift/peek.
+  const blockContextMenu = (e: Event): void => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  function lockPage(): void {
+    document.addEventListener('touchmove', blockTouchMove, { passive: false });
+    document.addEventListener('contextmenu', blockContextMenu, true);
+  }
+  function unlockPage(): void {
+    document.removeEventListener('touchmove', blockTouchMove);
+    document.removeEventListener('contextmenu', blockContextMenu, true);
+  }
+
+  function cleanup(): void {
+    clearTimers();
+    stopAutoScroll();
+    unlockPage();
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('pointercancel', onPointerCancel);
+    if (captureEl && pointerId !== -1) {
+      try {
+        captureEl.releasePointerCapture(pointerId);
+      } catch {
+        /* already released */
+      }
+    }
+    captureEl = null;
+    pointerId = -1;
+    state.phase = 'idle';
+    state.chat = null;
+    state.hoverIndex = null;
+    state.blocked = false;
+  }
+
+  /** Entry point: components call this from a tile's/row's pointerdown. */
+  function pressStart(e: PointerEvent, chat: Chat, origin: DragOrigin): void {
+    // Primary button/touch only; a second finger while a gesture is live is noise.
+    if (state.phase !== 'idle' || (e.pointerType === 'mouse' && e.button !== 0)) return;
+    const el = e.currentTarget as HTMLElement;
+    state.phase = 'held';
+    state.origin = origin;
+    state.chat = chat;
+    state.x = state.startX = e.clientX;
+    state.y = state.startY = e.clientY;
+    const r = el.getBoundingClientRect();
+    state.startRect = { left: r.left, top: r.top, width: r.width, height: r.height };
+    pointerId = e.pointerId;
+    captureEl = el;
+    swallowNextClick = false;
+    disarmClickTrap(); // a stale trap from an interrupted gesture must not eat this tap
+
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerCancel);
+
+    liftTimer = setTimeout(lift, LIFT_MS);
+  }
+
+  function lift(): void {
+    if (state.phase !== 'held') return;
+    state.phase = 'lifted';
+    swallowNextClick = true;
+    armClickTrap();
+    try {
+      captureEl?.setPointerCapture(pointerId);
+    } catch {
+      /* pointer already gone (e.g. torn-down node) — the up/cancel handlers cope */
+    }
+    lockPage();
+    try {
+      navigator.vibrate?.(10);
+    } catch {
+      /* haptics are best-effort */
+    }
+    peekTimer = setTimeout(() => {
+      // Still holding, never dragged → the peek. The gesture ends here; the
+      // armed trap eats the release-click (if the browser fires one) so it
+      // can't instantly dismiss the fresh overlay.
+      const chat = state.chat;
+      cleanup();
+      if (chat) opts.onPeek(chat);
+    }, PEEK_MS);
+  }
+
+  function onPointerMove(e: PointerEvent): void {
+    if (e.pointerId !== pointerId) return;
+    state.x = e.clientX;
+    state.y = e.clientY;
+    const dist = Math.hypot(e.clientX - state.startX, e.clientY - state.startY);
+
+    if (state.phase === 'held') {
+      // Movement before the lift = a scroll or a row swipe; get out of the way.
+      if (dist > PRE_LIFT_CANCEL_PX) cleanup();
+      return;
+    }
+    if (state.phase === 'lifted' && dist > DRAG_START_PX) {
+      state.phase = 'dragging';
+      if (peekTimer) clearTimeout(peekTimer);
+      peekTimer = null;
+      startAutoScroll();
+    }
+    if (state.phase === 'dragging') updateHover();
+  }
+
+  function updateHover(): void {
+    const grid = opts.gridEl();
+    if (!grid || !state.chat) {
+      state.hoverIndex = null;
+      state.blocked = false;
+      return;
+    }
+    const rect = grid.getBoundingClientRect();
+    const pins = opts.pinnedIds().length;
+    // A member drag rearranges `pins` slots; a foreign (list) drag previews an
+    // insertion, so the trailing slot is a target too.
+    const count = state.origin === 'grid' ? pins : pins + 1;
+    const slot = gridSlotAt(state.x, state.y, rect, count, 3, GRID_SLACK_PX);
+    if (state.origin === 'list' && slot != null && pins >= opts.maxPins) {
+      // Over the grid but full: show the ⊘ badge, keep the gap closed.
+      state.blocked = true;
+      state.hoverIndex = null;
+      return;
+    }
+    state.blocked = false;
+    state.hoverIndex = slot;
+  }
+
+  // Near-edge auto-scroll: dragging a far-down row toward the grid needs the page
+  // to follow. Runs on rAF while dragging; hover is re-derived after each nudge
+  // because scrolling moves the grid under the (stationary) pointer.
+  function startAutoScroll(): void {
+    if (scrollRaf) return;
+    const step = (): void => {
+      scrollRaf = 0;
+      if (state.phase !== 'dragging') return;
+      const el = opts.scrollEl();
+      if (el) {
+        const r = el.getBoundingClientRect();
+        const v = edgeScrollVelocity(state.y, r.top, r.height);
+        if (v !== 0) {
+          el.scrollTop += v;
+          updateHover();
+        }
+      }
+      scrollRaf = requestAnimationFrame(step);
+    };
+    scrollRaf = requestAnimationFrame(step);
+  }
+  function stopAutoScroll(): void {
+    if (scrollRaf) cancelAnimationFrame(scrollRaf);
+    scrollRaf = 0;
+  }
+
+  function onPointerUp(e: PointerEvent): void {
+    if (e.pointerId !== pointerId) return;
+    const { phase, origin, chat, hoverIndex, blocked } = state;
+    if (phase === 'dragging' && chat) {
+      if (origin === 'grid') {
+        if (hoverIndex == null) {
+          opts.onUnpin(chat.id); // dropped over the list (or anywhere off-grid)
+        } else {
+          const next = previewOrder(opts.pinnedIds(), chat.id, hoverIndex);
+          const prev = opts.pinnedIds();
+          if (next.some((id, i) => id !== prev[i])) opts.onReorder(next);
+        }
+      } else if (hoverIndex != null && !blocked) {
+        opts.onPin(chat.id, hoverIndex);
+      }
+      // else: list-origin drop off-grid (or blocked) → nothing, it floats home.
+    }
+    // 'held' = a plain tap: cleanup without swallowing, the click opens the chat.
+    cleanup();
+  }
+
+  function onPointerCancel(e: PointerEvent): void {
+    if (e.pointerId !== pointerId) return;
+    cleanup();
+  }
+
+  /** True once after a lift/drag/peek — the page's open() consults this so the
+   *  trailing click can't ALSO open the chat under the gesture. */
+  function consumeClickSwallow(): boolean {
+    const s = swallowNextClick;
+    swallowNextClick = false;
+    return s;
+  }
+
+  return { state, displayIds, pressStart, consumeClickSwallow };
+}

--- a/src/composables/useChatDrag.ts
+++ b/src/composables/useChatDrag.ts
@@ -134,10 +134,15 @@ export function useChatDrag(opts: ChatDragOptions) {
     e.preventDefault();
     e.stopPropagation();
   };
+  // Avatars are <img>s: a mouse drag over one starts a NATIVE HTML5 image drag,
+  // and the browser kills our pointer stream with pointercancel the moment it
+  // does. Block dragstart for the duration of the gesture.
+  const blockDragStart = (e: Event): void => e.preventDefault();
 
   function lockPage(): void {
     document.addEventListener('touchmove', blockTouchMove, { passive: false });
     document.addEventListener('contextmenu', blockContextMenu, true);
+    document.addEventListener('dragstart', blockDragStart, true);
     // iOS can have started a text selection during the hold (rows are full of
     // text); an active selection eats the next tap, so kill it and keep
     // selection off for the rest of the gesture.
@@ -152,6 +157,7 @@ export function useChatDrag(opts: ChatDragOptions) {
   function unlockPage(): void {
     document.removeEventListener('touchmove', blockTouchMove);
     document.removeEventListener('contextmenu', blockContextMenu, true);
+    document.removeEventListener('dragstart', blockDragStart, true);
     document.documentElement.style.removeProperty('-webkit-user-select');
     document.documentElement.style.removeProperty('user-select');
     try {

--- a/src/composables/useChatDrag.ts
+++ b/src/composables/useChatDrag.ts
@@ -138,10 +138,27 @@ export function useChatDrag(opts: ChatDragOptions) {
   function lockPage(): void {
     document.addEventListener('touchmove', blockTouchMove, { passive: false });
     document.addEventListener('contextmenu', blockContextMenu, true);
+    // iOS can have started a text selection during the hold (rows are full of
+    // text); an active selection eats the next tap, so kill it and keep
+    // selection off for the rest of the gesture.
+    try {
+      window.getSelection()?.removeAllRanges();
+    } catch {
+      /* selection API quirks are non-fatal */
+    }
+    document.documentElement.style.setProperty('-webkit-user-select', 'none');
+    document.documentElement.style.setProperty('user-select', 'none');
   }
   function unlockPage(): void {
     document.removeEventListener('touchmove', blockTouchMove);
     document.removeEventListener('contextmenu', blockContextMenu, true);
+    document.documentElement.style.removeProperty('-webkit-user-select');
+    document.documentElement.style.removeProperty('user-select');
+    try {
+      window.getSelection()?.removeAllRanges();
+    } catch {
+      /* ditto */
+    }
   }
 
   function cleanup(): void {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -73,7 +73,7 @@ import type {
 // Lives in the dependency-free chat-pins module so unit tests reach it without
 // pulling in this whole data layer; re-exported here for the existing importers.
 export { MAX_PINNED_CHATS } from '@/utils/chat-pins';
-import { MAX_PINNED_CHATS } from '@/utils/chat-pins';
+import { MAX_PINNED_CHATS, pinnedOrder, nextPinRank } from '@/utils/chat-pins';
 
 const now = () => Date.now();
 const matches = (haystack: string, q: string) =>
@@ -81,10 +81,13 @@ const matches = (haystack: string, q: string) =>
 
 /* ---- chats ---- */
 
-// Pinned chats sort above the rest; within each group, newest activity first. Used
-// by both the main list and any filtered view so pins stay on top everywhere.
+// Pinned chats sort above the rest. Among pinned chats the USER'S arrangement wins
+// (spec 1045: `pinnedRank`, recency only as the legacy/tie fallback); among the rest,
+// newest activity first. Used by both the main list and any filtered view so pins
+// stay on top everywhere.
 function chatOrder(a: Chat, b: Chat): number {
   if (!!a.pinned !== !!b.pinned) return a.pinned ? -1 : 1;
+  if (a.pinned && b.pinned) return pinnedOrder(a, b);
   return b.lastMessageTime - a.lastMessageTime;
 }
 
@@ -181,19 +184,72 @@ export async function toggleChatFavorite(chatId: string): Promise<boolean> {
 }
 
 /** Pin/unpin a chat. Returns false (and makes no change) if pinning would exceed
- *  MAX_PINNED_CHATS, so the caller can surface a toast. */
-export async function setChatPinned(chatId: string, pinned: boolean): Promise<boolean> {
+ *  MAX_PINNED_CHATS, so the caller can surface a toast. A new pin appends at the
+ *  END of the user's arrangement (spec 1045 FR-002) unless `atRank` places it
+ *  (drag-into-grid); unpinning drops its rank with it. */
+export async function setChatPinned(chatId: string, pinned: boolean, atRank?: number): Promise<boolean> {
   const chat = await getChat(chatId);
   if (!chat) return false;
   if (pinned && !chat.pinned) {
-    const count = (await getAll<Chat>('chats')).filter((c) => c.pinned && !c.archived).length;
+    const all = await getAll<Chat>('chats');
+    const count = all.filter((c) => c.pinned && !c.archived).length;
     if (count >= MAX_PINNED_CHATS) return false;
+    chat.pinned = true;
+    if (atRank == null) {
+      chat.pinnedRank = nextPinRank(all.filter((c) => !c.archived));
+      chat.updatedAt = now();
+      await put('chats', chat);
+    } else {
+      // Insert at the dropped slot: splice into the current arrangement and
+      // renumber the whole (≤9) set so ranks stay dense.
+      chat.updatedAt = now();
+      await put('chats', chat);
+      const orderedIds = all
+        .filter((c) => c.pinned && !c.archived && c.id !== chatId)
+        .sort(pinnedOrder)
+        .map((c) => c.id);
+      orderedIds.splice(Math.max(0, Math.min(atRank, orderedIds.length)), 0, chatId);
+      await setPinnedOrder(orderedIds);
+    }
+    return true;
   }
   if (pinned) chat.pinned = true;
-  else delete chat.pinned;
+  else {
+    delete chat.pinned;
+    delete chat.pinnedRank;
+  }
   chat.updatedAt = now();
   await put('chats', chat);
   return true;
+}
+
+/** Commit a full pinned arrangement (spec 1045): `orderedIds` is the pinned set in
+ *  the user's order; ranks are renumbered 0..n-1. Only records whose rank actually
+ *  changes are written (each write bumps updatedAt → rides own-data sync). */
+export async function setPinnedOrder(orderedIds: string[]): Promise<void> {
+  for (let i = 0; i < orderedIds.length; i++) {
+    const chat = await getChat(orderedIds[i]);
+    if (!chat || !chat.pinned || chat.pinnedRank === i) continue;
+    chat.pinnedRank = i;
+    chat.updatedAt = now();
+    await put('chats', chat);
+  }
+}
+
+/** One-time normalisation for pins that predate spec 1045: if any visible pinned
+ *  chat lacks a rank, stamp the WHOLE pinned set in its current visual order
+ *  (rank-first, then recency — pinnedOrder), so the grid's order is stable from
+ *  the first run of this build. Idempotent; cheap when nothing is missing. */
+export async function ensurePinRanks(): Promise<void> {
+  const pinned = (await getAll<Chat>('chats')).filter((c) => c.pinned && !c.archived);
+  if (!pinned.some((c) => c.pinnedRank == null)) return;
+  pinned.sort(pinnedOrder);
+  for (let i = 0; i < pinned.length; i++) {
+    if (pinned[i].pinnedRank === i) continue;
+    pinned[i].pinnedRank = i;
+    pinned[i].updatedAt = now();
+    await put('chats', pinned[i]);
+  }
 }
 
 /** Archive/unarchive a chat (moves it in/out of the Archived view). Unarchiving on a
@@ -204,6 +260,7 @@ export async function setChatArchived(chatId: string, archived: boolean): Promis
   if (archived) {
     chat.archived = true;
     delete chat.pinned; // archived chats aren't pinned in the main list
+    delete chat.pinnedRank;
   } else delete chat.archived;
   chat.updatedAt = now();
   await put('chats', chat);
@@ -220,6 +277,7 @@ export async function archiveAllChats(): Promise<number> {
     if (chat.pending || chat.archived || chat.locked || hidden.has(chat.id)) continue;
     chat.archived = true;
     delete chat.pinned;
+    delete chat.pinnedRank;
     chat.updatedAt = now();
     await put('chats', chat);
     n += 1;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -126,6 +126,12 @@ export interface Chat {
   favorite?: boolean;
   // Pinned to the top of the chat list (sorted before unpinned, capped per device).
   pinned?: boolean;
+  // 0-based position in the user's pinned-grid arrangement (spec 1045). Present only
+  // while pinned; deleted on unpin/archive. Message activity NEVER touches it — only
+  // an explicit rearrange/pin does — so the grid keeps the order the user gave it.
+  // Synced like `pinned` (whole-record encrypted own-data sync, LWW on updatedAt);
+  // absent on pins that predate the feature until ensurePinRanks() stamps them.
+  pinnedRank?: number;
   // Archived: hidden from the main list into the Archived view.
   archived?: boolean;
   // Locked: hidden from the main list behind the app's auth gate (Locked chats).

--- a/src/utils/chat-pins.test.ts
+++ b/src/utils/chat-pins.test.ts
@@ -1,7 +1,7 @@
 // MAX_PINNED_CHATS lives here (dependency-free, like ownsync-keys) so this test
 // never has to import the full IDB data layer; queries.ts re-imports it.
 import { describe, it, expect } from 'vitest';
-import { partitionPinned, PINNED_GRID_MAX, MAX_PINNED_CHATS } from './chat-pins';
+import { partitionPinned, pinnedOrder, nextPinRank, PINNED_GRID_MAX, MAX_PINNED_CHATS } from './chat-pins';
 
 type C = { id: string; pinned?: boolean };
 const chats: C[] = [
@@ -47,5 +47,89 @@ describe('pin cap (spec 1044)', () => {
   it('raises MAX_PINNED_CHATS to 9', () => {
     expect(MAX_PINNED_CHATS).toBe(9);
     expect(PINNED_GRID_MAX).toBe(9);
+  });
+});
+
+/* ---- spec 1045: user-defined pinned order ---- */
+
+type R = { id: string; pinnedRank?: number; lastMessageTime: number };
+const byOrder = (list: R[]) => [...list].sort(pinnedOrder).map((c) => c.id);
+
+describe('pinnedOrder (spec 1045 — manual arrangement)', () => {
+  it('sorts by rank ascending, ignoring recency', () => {
+    const pins: R[] = [
+      { id: 'b', pinnedRank: 1, lastMessageTime: 900 },
+      { id: 'c', pinnedRank: 2, lastMessageTime: 500 },
+      { id: 'a', pinnedRank: 0, lastMessageTime: 100 },
+    ];
+    expect(byOrder(pins)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('is unaffected by new activity (the rank is the only mover)', () => {
+    const pins: R[] = [
+      { id: 'a', pinnedRank: 0, lastMessageTime: 100 },
+      { id: 'b', pinnedRank: 1, lastMessageTime: 200 },
+    ];
+    pins[1].lastMessageTime = 99_999; // "new message arrives in b"
+    expect(byOrder(pins)).toEqual(['a', 'b']);
+  });
+
+  it('sorts legacy pins (no rank) after ranked ones, newest first', () => {
+    const pins: R[] = [
+      { id: 'legacyOld', lastMessageTime: 100 },
+      { id: 'ranked', pinnedRank: 3, lastMessageTime: 1 },
+      { id: 'legacyNew', lastMessageTime: 900 },
+    ];
+    expect(byOrder(pins)).toEqual(['ranked', 'legacyNew', 'legacyOld']);
+  });
+
+  it('breaks rank ties (post-sync merges) by recency, then keeps stable input order', () => {
+    const pins: R[] = [
+      { id: 'y', pinnedRank: 1, lastMessageTime: 100 },
+      { id: 'x', pinnedRank: 1, lastMessageTime: 100 },
+      { id: 'w', pinnedRank: 1, lastMessageTime: 500 },
+    ];
+    // w wins on recency; the x/y tie falls through to the (stable) input order.
+    expect(byOrder(pins)).toEqual(['w', 'y', 'x']);
+  });
+});
+
+describe('nextPinRank (spec 1045 — new pins append at the end)', () => {
+  it('is 0 for the first pin', () => {
+    expect(nextPinRank([])).toBe(0);
+    expect(nextPinRank([{ id: 'a', lastMessageTime: 1 }])).toBe(0); // unpinned ignored
+  });
+
+  it('appends after the highest existing rank', () => {
+    const chats = [
+      { id: 'a', pinned: true, pinnedRank: 0, lastMessageTime: 1 },
+      { id: 'b', pinned: true, pinnedRank: 4, lastMessageTime: 1 }, // gaps tolerated
+      { id: 'c', lastMessageTime: 1 },
+    ];
+    expect(nextPinRank(chats)).toBe(5);
+  });
+
+  it('counts legacy ranked-less pins so an append never collides below them', () => {
+    const chats = [
+      { id: 'a', pinned: true, lastMessageTime: 1 }, // legacy, no rank
+      { id: 'b', pinned: true, pinnedRank: 1, lastMessageTime: 1 },
+    ];
+    // Two pins exist: the next rank must be >= the pinned count so a later
+    // ensurePinRanks() normalisation can't shuffle the appended pin backwards.
+    expect(nextPinRank(chats)).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('partitionPinned returns the grid in rank order (spec 1045)', () => {
+  it('grid is rank-sorted even when the incoming array is recency-ordered', () => {
+    const mixed = [
+      { id: 'p2', pinned: true, pinnedRank: 2, lastMessageTime: 900 },
+      { id: 'p0', pinned: true, pinnedRank: 0, lastMessageTime: 500 },
+      { id: 'row', lastMessageTime: 400 },
+      { id: 'p1', pinned: true, pinnedRank: 1, lastMessageTime: 100 },
+    ];
+    const { grid, list } = partitionPinned(mixed, { filterAll: true, searching: false });
+    expect(grid.map((c) => c.id)).toEqual(['p0', 'p1', 'p2']);
+    expect(list.map((c) => c.id)).toEqual(['row']);
   });
 });

--- a/src/utils/chat-pins.ts
+++ b/src/utils/chat-pins.ts
@@ -1,8 +1,10 @@
 /**
- * Pinned-chats grid logic (spec 1044). Pure and dependency-free (imported by both
- * the data layer and unit tests, like ownsync-keys) — the Chats tab renders pinned
- * chats as an iMessage-style avatar grid ABOVE the list, and the pinned rows leave
- * the list while the grid shows them.
+ * Pinned-chats grid logic (specs 1044 + 1045). Pure and dependency-free (imported by
+ * both the data layer and unit tests, like ownsync-keys) — the Chats tab renders
+ * pinned chats as an iMessage-style avatar grid ABOVE the list, and the pinned rows
+ * leave the list while the grid shows them. Since spec 1045 the grid's order is the
+ * USER'S arrangement (`pinnedRank`), not recency — a new message lights the badge
+ * but never moves the tile.
  */
 
 // iMessage parity: at most 9 pinned chats (3 rows of 3). Enforced at pin time by
@@ -10,6 +12,44 @@
 // from another device is applied as-is (the cap gates new pins, not existing data).
 export const MAX_PINNED_CHATS = 9;
 export const PINNED_GRID_MAX = MAX_PINNED_CHATS;
+
+/** The slice of Chat these helpers need (kept structural so tests stay tiny). */
+export interface PinOrderable {
+  id: string;
+  pinned?: boolean;
+  pinnedRank?: number;
+  lastMessageTime?: number;
+}
+
+/**
+ * Order among PINNED chats (spec 1045): the user's arrangement first (`pinnedRank`
+ * ascending), with legacy/unranked pins after the ranked ones. Ties — rank gaps and
+ * duplicates happen after a cross-device sync merge, ranks are absent on pins that
+ * predate the feature — fall back to recency and then to the (stable) input order,
+ * so the grid is always deterministic and never crashes on odd data. Local writes
+ * renumber 0..n-1, so ties heal on the next rearrange.
+ */
+export function pinnedOrder(a: PinOrderable, b: PinOrderable): number {
+  const ra = a.pinnedRank ?? Infinity;
+  const rb = b.pinnedRank ?? Infinity;
+  if (ra !== rb) return ra - rb;
+  return (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0);
+}
+
+/**
+ * Rank for a chat being pinned via a non-drag surface (swipe / sheet / peek menu):
+ * append at the END of the arrangement (FR-002). `max(rank) + 1` normally; the
+ * pinned COUNT is the floor so that legacy unranked pins (which a later
+ * ensurePinRanks() will stamp into the low ranks) can never end up after it.
+ */
+export function nextPinRank(chats: PinOrderable[]): number {
+  const pinned = chats.filter((c) => c.pinned);
+  let maxRank = -1;
+  for (const c of pinned) {
+    if (typeof c.pinnedRank === 'number' && c.pinnedRank > maxRank) maxRank = c.pinnedRank;
+  }
+  return Math.max(maxRank + 1, pinned.length);
+}
 
 export interface PartitionOpts {
   /** The "All" chip is active (the grid only shows there). */
@@ -19,17 +59,19 @@ export interface PartitionOpts {
 }
 
 /**
- * Split a (already filter-applied, pinned-first-ordered) chat array into the grid
- * and the remaining list rows. Outside the All-chip/empty-search context the grid
- * is empty and every chat stays a row — search results and filter chips treat
- * pinned chats like any other chat.
+ * Split a (already filter-applied) chat array into the grid and the remaining list
+ * rows. The grid is re-sorted by the user's arrangement here (defence in depth —
+ * chatOrder upstream already sorts pinned chats the same way, but search results
+ * and other callers aren't guaranteed to). Outside the All-chip/empty-search
+ * context the grid is empty and every chat stays a row — search results and filter
+ * chips treat pinned chats like any other chat.
  */
-export function partitionPinned<T extends { pinned?: boolean }>(
+export function partitionPinned<T extends PinOrderable>(
   chats: T[],
   opts: PartitionOpts,
 ): { grid: T[]; list: T[] } {
   if (!opts.filterAll || opts.searching) return { grid: [], list: chats };
-  const pinned = chats.filter((c) => c.pinned);
+  const pinned = chats.filter((c) => c.pinned).sort(pinnedOrder);
   const grid = pinned.slice(0, PINNED_GRID_MAX);
   const overflow = new Set(pinned.slice(PINNED_GRID_MAX));
   const list = chats.filter((c) => !c.pinned || overflow.has(c));

--- a/src/utils/drag-math.test.ts
+++ b/src/utils/drag-math.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { gridSlotAt, moveItem, previewOrder, isInside, edgeScrollVelocity } from './drag-math';
+
+// A 3-column grid: 300 wide, tiles ~100 each; two rows of height 120.
+const grid = { left: 0, top: 100, width: 300, height: 240 };
+
+describe('gridSlotAt (spec 1045 — which slot is the pointer over?)', () => {
+  it('maps a point to its column/row cell', () => {
+    expect(gridSlotAt(50, 160, grid, 6)).toBe(0);
+    expect(gridSlotAt(150, 160, grid, 6)).toBe(1);
+    expect(gridSlotAt(250, 160, grid, 6)).toBe(2);
+    expect(gridSlotAt(50, 280, grid, 6)).toBe(3);
+    expect(gridSlotAt(250, 280, grid, 6)).toBe(5);
+  });
+
+  it('clamps a cell beyond the last slot to the last slot (ragged final row)', () => {
+    // 4 tiles → row 2 has one tile; pointing at row 2, col 3 must clamp to slot 3.
+    expect(gridSlotAt(250, 280, grid, 4)).toBe(3);
+  });
+
+  it('returns null outside the grid rect', () => {
+    expect(gridSlotAt(150, 50, grid, 6)).toBeNull(); // above
+    expect(gridSlotAt(150, 500, grid, 6)).toBeNull(); // below (the list area)
+    expect(gridSlotAt(-10, 160, grid, 6)).toBeNull(); // left
+  });
+
+  it('honours the slack margin so the gesture is forgiving at the edges', () => {
+    expect(gridSlotAt(150, 90, grid, 6, 3, 16)).toBe(1); // 10px above, within slack
+    expect(gridSlotAt(150, 50, grid, 6, 3, 16)).toBeNull(); // beyond slack
+  });
+});
+
+describe('moveItem', () => {
+  it('moves forward and backward without mutating the input', () => {
+    const src = ['a', 'b', 'c', 'd'];
+    expect(moveItem(src, 0, 2)).toEqual(['b', 'c', 'a', 'd']);
+    expect(moveItem(src, 3, 0)).toEqual(['d', 'a', 'b', 'c']);
+    expect(src).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('is a no-op for equal or out-of-range indices', () => {
+    expect(moveItem(['a', 'b'], 1, 1)).toEqual(['a', 'b']);
+    expect(moveItem(['a', 'b'], 5, 0)).toEqual(['a', 'b']);
+  });
+});
+
+describe('previewOrder (live gap while dragging)', () => {
+  const ids = ['a', 'b', 'c'];
+
+  it('moves a member id to the hovered slot (grid-origin drag)', () => {
+    expect(previewOrder(ids, 'c', 0)).toEqual(['c', 'a', 'b']);
+    expect(previewOrder(ids, 'a', 2)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('inserts a foreign id at the hovered slot (list-origin drag)', () => {
+    expect(previewOrder(ids, 'x', 1)).toEqual(['a', 'x', 'b', 'c']);
+    expect(previewOrder(ids, 'x', 3)).toEqual(['a', 'b', 'c', 'x']);
+  });
+
+  it('clamps the hover slot and restores order when the pointer leaves (null)', () => {
+    expect(previewOrder(ids, 'x', 99)).toEqual(['a', 'b', 'c', 'x']);
+    expect(previewOrder(ids, 'c', null)).toEqual(['a', 'b', 'c']);
+    expect(previewOrder(ids, 'x', null)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('isInside', () => {
+  it('detects containment with optional slack', () => {
+    expect(isInside(10, 110, grid)).toBe(true);
+    expect(isInside(10, 90, grid)).toBe(false);
+    expect(isInside(10, 90, grid, 16)).toBe(true);
+  });
+});
+
+describe('edgeScrollVelocity (auto-scroll while dragging near the edges)', () => {
+  it('is zero in the middle of the viewport', () => {
+    expect(edgeScrollVelocity(400, 0, 800)).toBe(0);
+  });
+
+  it('scrolls up near the top and down near the bottom, faster at the very edge', () => {
+    const nearTop = edgeScrollVelocity(40, 0, 800);
+    const atTop = edgeScrollVelocity(0, 0, 800);
+    expect(nearTop).toBeLessThan(0);
+    expect(atTop).toBeLessThan(nearTop);
+    const nearBottom = edgeScrollVelocity(760, 0, 800);
+    const atBottom = edgeScrollVelocity(800, 0, 800);
+    expect(nearBottom).toBeGreaterThan(0);
+    expect(atBottom).toBeGreaterThan(nearBottom);
+  });
+});

--- a/src/utils/drag-math.ts
+++ b/src/utils/drag-math.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure geometry/list math for the pinned-grid drag (spec 1045). Dependency-free on
+ * purpose (like chat-pins): the pointer-event state machine in useChatDrag feeds
+ * DOM rects in and gets slot indices / preview orders out, so all the fiddly
+ * clamping logic is unit-testable without a DOM.
+ */
+
+export interface RectLike {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Which grid slot (0-based, row-major) is the pointer over? `count` is the number
+ * of REAL slots the caller is considering (pass pins+1 when previewing an
+ * insertion so the trailing gap is reachable); a cell past the last slot (ragged
+ * final row) clamps to the last slot. `slack` grows the rect on every side so the
+ * gesture is forgiving right at the edge. Returns null outside the (slackened)
+ * rect — the caller treats that as "not over the grid".
+ */
+export function gridSlotAt(
+  x: number,
+  y: number,
+  rect: RectLike,
+  count: number,
+  cols = 3,
+  slack = 0,
+): number | null {
+  if (count <= 0 || !isInside(x, y, rect, slack)) return null;
+  const col = Math.min(cols - 1, Math.max(0, Math.floor(((x - rect.left) / rect.width) * cols)));
+  const rows = Math.ceil(count / cols);
+  const row = Math.min(rows - 1, Math.max(0, Math.floor(((y - rect.top) / rect.height) * rows)));
+  return Math.min(count - 1, row * cols + col);
+}
+
+/** Containment test with optional slack margin. */
+export function isInside(x: number, y: number, rect: RectLike, slack = 0): boolean {
+  return (
+    x >= rect.left - slack &&
+    x <= rect.left + rect.width + slack &&
+    y >= rect.top - slack &&
+    y <= rect.top + rect.height + slack
+  );
+}
+
+/** Move list[from] to index `to` (immutably). Out-of-range or equal → unchanged. */
+export function moveItem<T>(list: T[], from: number, to: number): T[] {
+  if (from === to || from < 0 || from >= list.length || to < 0 || to > list.length) {
+    return [...list];
+  }
+  const next = [...list];
+  const [item] = next.splice(from, 1);
+  next.splice(Math.min(to, next.length), 0, item);
+  return next;
+}
+
+/**
+ * The order the grid should DISPLAY mid-drag: `dragId` moved (member) or inserted
+ * (foreign, i.e. a list row being pinned) at `hoverIndex`. A null hover restores
+ * the true order — the pointer has left the grid, so the gap closes.
+ */
+export function previewOrder(ids: string[], dragId: string, hoverIndex: number | null): string[] {
+  if (hoverIndex == null) return [...ids]; // pointer left the grid → true order, gap closed
+  const without = ids.filter((id) => id !== dragId);
+  const at = Math.max(0, Math.min(hoverIndex, without.length));
+  without.splice(at, 0, dragId);
+  return without;
+}
+
+// Auto-scroll tuning: the outer 15% of the viewport is "hot"; speed ramps
+// linearly from 0 at the inner edge to MAX at the physical edge.
+const EDGE_FRACTION = 0.15;
+const MAX_EDGE_SPEED = 14; // px per frame — brisk but trackable
+
+/**
+ * Signed auto-scroll velocity (px/frame) for a drag at viewport-y `y`: negative
+ * near the top (scroll up), positive near the bottom, 0 in the calm middle.
+ */
+export function edgeScrollVelocity(
+  y: number,
+  viewportTop: number,
+  viewportHeight: number,
+): number {
+  const edge = viewportHeight * EDGE_FRACTION;
+  const fromTop = y - viewportTop;
+  const fromBottom = viewportTop + viewportHeight - y;
+  if (fromTop < edge) {
+    const t = Math.max(0, Math.min(1, 1 - fromTop / edge));
+    return -t * MAX_EDGE_SPEED;
+  }
+  if (fromBottom < edge) {
+    const t = Math.max(0, Math.min(1, 1 - fromBottom / edge));
+    return t * MAX_EDGE_SPEED;
+  }
+  return 0;
+}

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -21,7 +21,7 @@
       </ion-toolbar>
     </ion-header>
 
-    <ion-content :fullscreen="true">
+    <ion-content ref="contentRef" :fullscreen="true">
       <!-- Pull down to recover: force a fresh reconnect so the server re-runs its on-connect
            queue flush and we pull anything missed while the socket was dropped. -->
       <ion-refresher slot="fixed" @ion-refresh="onPullRefresh">
@@ -30,7 +30,7 @@
       <!-- The iOS large title yields its space to the pinned grid when pins exist
            (spec 1044): the grid already anchors the page visually, and stacking
            both pushed the first rows below the fold. -->
-      <ion-header v-if="!(ready && pinParts.grid.length)" collapse="condense">
+      <ion-header v-if="!(ready && gridChats.length)" collapse="condense">
         <ion-toolbar>
           <ion-title size="large">Chats</ion-title>
         </ion-toolbar>
@@ -55,22 +55,29 @@
           <ion-label>Hide hidden chats</ion-label>
         </ion-item>
 
-        <!-- Pinned chats: the iMessage-style avatar grid (spec 1044). Gated on
-             `ready` so the fail-closed hidden state can't flash tiles at cold open. -->
+        <!-- Pinned chats: the iMessage-style avatar grid (spec 1044), in the user's
+             own order with drag-to-rearrange (spec 1045). Gated on `ready` so the
+             fail-closed hidden state can't flash tiles at cold open. -->
         <PinnedChatsGrid
-          v-if="ready && pinParts.grid.length"
-          :chats="pinParts.grid"
+          v-if="ready && gridChats.length"
+          ref="gridComp"
+          :chats="gridChats"
+          :display-order="gridOrder"
+          :drag-id="dragActive ? dragState.chat?.id ?? null : null"
           @open="open"
           @more="(c) => actions?.openMore(c)"
+          @press="(c, e) => pressStart(e, c, 'grid')"
         />
 
         <ChatListItem
-          v-for="chat in pinParts.list"
+          v-for="chat in listChats"
           :key="chat.id"
           :chat="chat"
           :draft="draftFor(chat.id)"
+          :lifted="dragActive && dragState.origin === 'list' && dragState.chat?.id === chat.id"
           @open="open"
           @more="(c) => actions?.openMore(c)"
+          @press="(c, e) => pressStart(e, c, 'list')"
         />
       </ion-list>
 
@@ -93,6 +100,39 @@
       </div>
 
       <ChatActionsHost ref="actions" />
+
+      <!-- Long-press peek (spec 1045): read-only preview + quick actions. -->
+      <ChatPeekOverlay
+        :chat="peekChat"
+        :is-open="peekOpen"
+        @dismiss="peekOpen = false"
+        @open="(id) => { peekOpen = false; router.push(`/chat/${id}`); }"
+        @more="onPeekMore"
+      />
+
+      <!-- The floating drag proxy (spec 1045): the lifted chat's avatar riding the
+           pointer. Pin-shaped for BOTH origins (a lifted row "becomes a pin"); shows
+           the ⊘ badge when the grid is full and this row can't land there. -->
+      <Teleport to="body">
+        <div
+          v-if="dragActive && dragState.chat"
+          class="drag-proxy"
+          :class="{ dragging: dragState.phase === 'dragging' }"
+          :style="proxyStyle"
+          aria-hidden="true"
+        >
+          <div class="proxy-avatar">
+            <user-avatar :src="dragState.chat.avatar" :alt="dragState.chat.name" />
+            <span v-if="dragState.blocked" class="proxy-ban">
+              <ion-icon :icon="banOutline" />
+            </span>
+            <ion-badge v-else-if="dragState.chat.unread" color="primary" class="proxy-badge">
+              {{ dragState.chat.unread }}
+            </ion-badge>
+          </div>
+          <span class="proxy-name" dir="auto">{{ dragState.chat.name }}</span>
+        </div>
+      </Teleport>
 
       <!-- Lists "More" sheet + Edit Chats tab editor + New/Edit list (chip-row flows). -->
       <ChatListsSheet
@@ -182,22 +222,28 @@ import { useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton,
   IonIcon, IonSearchbar, IonContent, IonList, IonListHeader, IonItem, IonAvatar,
-  IonLabel, IonNote, IonModal, IonRefresher, IonRefresherContent,
+  IonLabel, IonNote, IonModal, IonRefresher, IonRefresherContent, IonBadge,
   type RefresherCustomEvent,
 } from '@ionic/vue';
 import {
   createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline,
-  eyeOffOutline,
+  eyeOffOutline, banOutline,
 } from 'ionicons/icons';
 import ChatListItem from '@/components/ChatListItem.vue';
 import PinnedChatsGrid from '@/components/PinnedChatsGrid.vue';
-import { partitionPinned } from '@/utils/chat-pins';
+import ChatPeekOverlay from '@/components/ChatPeekOverlay.vue';
+import { partitionPinned, MAX_PINNED_CHATS } from '@/utils/chat-pins';
+import { useChatDrag } from '@/composables/useChatDrag';
 import ChatActionsHost from '@/components/ChatActionsHost.vue';
 import ChatFilterBar from '@/components/ChatFilterBar.vue';
 import ChatListsSheet from '@/components/ChatListsSheet.vue';
 import EditChatTabsModal from '@/components/EditChatTabsModal.vue';
 import NewListModal from '@/components/NewListModal.vue';
-import { listArchivedChats, listLockedChats, listContacts, startDirectChat, getSetting, listDrafts } from '@/db/queries';
+import {
+  listArchivedChats, listLockedChats, listContacts, startDirectChat, getSetting, listDrafts,
+  ensurePinRanks, setPinnedOrder, setChatPinned,
+} from '@/db/queries';
+import { appToast } from '@/services/toast';
 import { useChatFilters } from '@/services/chat-filters';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useConnect } from '@/composables/useConnect';
@@ -230,6 +276,9 @@ const { revealed, reveal, relock } = useHiddenChats();
 const pinLen = ref<number | null>(null);
 const hiddenEnabled = ref(false);
 onMounted(async () => {
+  // Stamp arrangement ranks onto pins that predate spec 1045 (one-time, idempotent)
+  // so the grid's order is stable from this build's first run.
+  void ensurePinRanks();
   pinLen.value = await hiddenPinLength();
   hiddenEnabled.value = await getSetting<boolean>('privacy.hiddenChatsEnabled', false);
 });
@@ -266,6 +315,99 @@ watch(allChats, () => { if (isUnlocked.value) ready.value = true; }, { immediate
 const pinParts = computed(() =>
   partitionPinned(chats.value, { filterAll: activeFilter.value === 'all', searching: !!search.value.trim() }),
 );
+
+/* ---- Pinned-grid drag + long-press peek (spec 1045) ---- */
+
+// Optimistic grid order: set at drop time so the grid doesn't flash back to the
+// pre-drop order in the beat between the gesture ending and the IndexedDB write
+// landing in the live query. Cleared when the query catches up (watch below) or
+// by the safety timeout (a failed write must not wedge the UI).
+const optimisticGrid = ref<string[] | null>(null);
+let optimisticClear: ReturnType<typeof setTimeout> | null = null;
+function setOptimistic(ids: string[]): void {
+  optimisticGrid.value = ids;
+  if (optimisticClear) clearTimeout(optimisticClear);
+  optimisticClear = setTimeout(() => (optimisticGrid.value = null), 1500);
+}
+watch(pinParts, (p) => {
+  const o = optimisticGrid.value;
+  if (!o) return;
+  const ids = p.grid.map((c) => c.id);
+  if (ids.length === o.length && ids.every((id, i) => id === o[i])) optimisticGrid.value = null;
+});
+
+// What the grid/list actually render: the optimistic projection when one is
+// pending, else the query's partition. A just-pinned row leaves the list at
+// once; a just-unpinned tile re-enters it when the write lands (recency decides
+// its slot, so there's nothing sensible to project meanwhile).
+const chatById = computed(() => {
+  const m = new Map<string, Chat>();
+  for (const c of chats.value) m.set(c.id, c);
+  return m;
+});
+const gridChats = computed<Chat[]>(() => {
+  const o = optimisticGrid.value;
+  if (!o) return pinParts.value.grid;
+  return o.map((id) => chatById.value.get(id)).filter((c): c is Chat => !!c);
+});
+const listChats = computed<Chat[]>(() => {
+  const o = optimisticGrid.value;
+  if (!o) return pinParts.value.list;
+  const inGrid = new Set(o);
+  return pinParts.value.list.filter((c) => !inGrid.has(c.id));
+});
+
+const gridComp = ref<{ el: () => HTMLElement | null } | null>(null);
+const contentRef = ref<{ $el: HTMLIonContentElement } | null>(null);
+const scrollEl = ref<HTMLElement | null>(null);
+onMounted(async () => {
+  scrollEl.value = (await contentRef.value?.$el.getScrollElement()) ?? null;
+});
+
+const peekChat = ref<Chat | null>(null);
+const peekOpen = ref(false);
+// The peek's More… bridges to the full actions sheet; give the overlay's leave
+// transition a beat so the sheet's own enter animation isn't swallowed.
+function onPeekMore(chat: Chat): void {
+  peekOpen.value = false;
+  setTimeout(() => actions.value?.openMore(chat), 220);
+}
+
+const { state: dragState, displayIds: gridOrder, pressStart, consumeClickSwallow } = useChatDrag({
+  gridEl: () => gridComp.value?.el() ?? null,
+  scrollEl: () => scrollEl.value,
+  pinnedIds: () => optimisticGrid.value ?? pinParts.value.grid.map((c) => c.id),
+  maxPins: MAX_PINNED_CHATS,
+  onReorder: (ids) => {
+    setOptimistic(ids);
+    void setPinnedOrder(ids);
+  },
+  onUnpin: (id) => {
+    setOptimistic((optimisticGrid.value ?? pinParts.value.grid.map((c) => c.id)).filter((x) => x !== id));
+    void setChatPinned(id, false);
+  },
+  onPin: (id, at) => {
+    const base = optimisticGrid.value ?? pinParts.value.grid.map((c) => c.id);
+    const next = [...base];
+    next.splice(Math.min(at, next.length), 0, id);
+    setOptimistic(next);
+    void setChatPinned(id, true, at).then((ok) => {
+      if (ok) return;
+      optimisticGrid.value = null; // raced past the cap (e.g. another device pinned)
+      void appToast({ message: `You can only pin ${MAX_PINNED_CHATS} chats.`, duration: 2200 });
+    });
+  },
+  onPeek: (chat) => {
+    peekChat.value = chat;
+    peekOpen.value = true;
+  },
+});
+const dragActive = computed(() => dragState.phase === 'lifted' || dragState.phase === 'dragging');
+// The proxy follows the pointer, hovering just above the finger. transform-only
+// updates so tracking stays cheap at 60fps.
+const proxyStyle = computed(() => ({
+  transform: `translate3d(${dragState.x - 44}px, ${dragState.y - 100}px, 0)`,
+}));
 const listsSheetOpen = ref(false);
 const editTabsOpen = ref(false);
 const newListOpen = ref(false);
@@ -330,6 +472,8 @@ const draftMap = computed(() => {
 const draftFor = (id: string): string | undefined => draftMap.value.get(id);
 
 function open(id: string) {
+  // A completed lift/drag/peek must not ALSO open the chat via the trailing click.
+  if (consumeClickSwallow()) return;
   router.push(`/chat/${id}`);
 }
 
@@ -377,5 +521,63 @@ async function newGroup() {
 }
 .hint-list ion-icon {
   font-size: 24px;
+}
+</style>
+
+<style>
+/* The drag proxy teleports to <body>, so its styles must be unscoped. */
+.drag-proxy {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 10001;
+  width: 88px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  pointer-events: none; /* the pointer stays on the page underneath */
+  filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.35));
+  transition: scale 0.15s ease;
+  scale: 1.06;
+}
+.drag-proxy.dragging {
+  scale: 1.12;
+}
+.drag-proxy .proxy-avatar {
+  position: relative;
+  width: 88px;
+  height: 88px;
+}
+.drag-proxy .proxy-name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--ion-text-color);
+}
+.drag-proxy .proxy-badge {
+  position: absolute;
+  top: -2px;
+  inset-inline-end: -6px;
+  border-radius: 10px;
+}
+/* No room in the grid (9 pins): the forbidden badge at the proxy's top right. */
+.drag-proxy .proxy-ban {
+  position: absolute;
+  top: -4px;
+  inset-inline-end: -8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--ion-color-danger, #eb445a);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.drag-proxy .proxy-ban ion-icon {
+  font-size: 18px;
 }
 </style>

--- a/src/views/tabs/ChatsPage.vue
+++ b/src/views/tabs/ChatsPage.vue
@@ -55,6 +55,20 @@
           <ion-label>Hide hidden chats</ion-label>
         </ion-item>
 
+        <!-- First-pin drop zone (spec 1045): with NO pins there is no grid to drop
+             on, so while a row is lifted this stands in where the grid would be.
+             Its element doubles as the drag controller's grid target. -->
+        <div
+          v-if="showFirstPinZone"
+          ref="dropZone"
+          class="pin-dropzone"
+          :class="{ hover: dragState.hoverIndex != null }"
+          aria-hidden="true"
+        >
+          <div class="dz-well"><ion-icon :icon="pinOutline" /></div>
+          <span class="dz-label">Drag here to pin</span>
+        </div>
+
         <!-- Pinned chats: the iMessage-style avatar grid (spec 1044), in the user's
              own order with drag-to-rearrange (spec 1045). Gated on `ready` so the
              fail-closed hidden state can't flash tiles at cold open. -->
@@ -227,7 +241,7 @@ import {
 } from '@ionic/vue';
 import {
   createOutline, personAddOutline, peopleOutline, archiveOutline, lockClosedOutline,
-  eyeOffOutline, banOutline,
+  eyeOffOutline, banOutline, pinOutline,
 } from 'ionicons/icons';
 import ChatListItem from '@/components/ChatListItem.vue';
 import PinnedChatsGrid from '@/components/PinnedChatsGrid.vue';
@@ -358,6 +372,17 @@ const listChats = computed<Chat[]>(() => {
 });
 
 const gridComp = ref<{ el: () => HTMLElement | null } | null>(null);
+// The first-pin drop zone (no pins yet): shown only while a ROW is lifted on the
+// All view — the only context where the grid (and so drag-pinning) exists.
+const dropZone = ref<HTMLElement | null>(null);
+const showFirstPinZone = computed(
+  () =>
+    dragActive.value &&
+    dragState.origin === 'list' &&
+    gridChats.value.length === 0 &&
+    activeFilter.value === 'all' &&
+    !search.value.trim(),
+);
 const contentRef = ref<{ $el: HTMLIonContentElement } | null>(null);
 const scrollEl = ref<HTMLElement | null>(null);
 onMounted(async () => {
@@ -374,7 +399,7 @@ function onPeekMore(chat: Chat): void {
 }
 
 const { state: dragState, displayIds: gridOrder, pressStart, consumeClickSwallow } = useChatDrag({
-  gridEl: () => gridComp.value?.el() ?? null,
+  gridEl: () => gridComp.value?.el() ?? dropZone.value,
   scrollEl: () => scrollEl.value,
   pinnedIds: () => optimisticGrid.value ?? pinParts.value.grid.map((c) => c.id),
   maxPins: MAX_PINNED_CHATS,
@@ -515,6 +540,39 @@ async function newGroup() {
   text-align: center;
   margin-top: 40px;
 }
+/* First-pin drop zone (spec 1045): a dashed well where the pinned grid will be,
+   shown only mid-drag when there are no pins yet. */
+.pin-dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 8px 10px;
+}
+.dz-well {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  border: 2px dashed color-mix(in srgb, var(--app-text, #000) 25%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--app-text-muted, var(--ion-color-medium));
+  font-size: 30px;
+  transition: border-color 0.15s ease, background-color 0.15s ease, transform 0.15s ease;
+}
+.dz-label {
+  font-size: 13px;
+  color: var(--app-text-muted, var(--ion-color-medium));
+}
+/* The lifted avatar is over the zone: light up so the drop reads as accepted. */
+.pin-dropzone.hover .dz-well {
+  border-color: var(--ion-color-primary, #10b981);
+  background: color-mix(in srgb, var(--ion-color-primary, #10b981) 12%, transparent);
+  color: var(--ion-color-primary, #10b981);
+  transform: scale(1.06);
+}
+
 /* "Start a conversation" hint row, flush at the top like the Contacts browse row. */
 .hint-list {
   padding-top: 0;


### PR DESCRIPTION
## Spec 1045 — Rearrange pinned chats with drag, stable manual order, and long-press chat preview

iMessage-parity interactions for the pinned-chat grid (spec 1044):

- **Your order is law**: `Chat.pinnedRank` replaces recency as the grid's sort key. New messages light the badge but never move a tile; the arrangement rides the existing encrypted own-data sync (whole chat records, LWW) — zero new wire data, zero server changes. Legacy pins get ranks stamped once at Chats-tab mount.
- **Drag to rearrange**: ~350 ms hold lifts a tile onto a floating proxy; other tiles part to preview the slot (FLIP); release renumbers ranks 0..n-1. Movement before the lift cancels (scroll/swipe win); after it, the page can't scroll and near-edge auto-scroll keeps far rows reachable.
- **Drag across the boundary**: pull a tile into the list to unpin; lift a row (it becomes a pin-shaped avatar) and drop it on any grid slot to pin right there. At nine pins a ⊘ badge shows on the proxy and the drop is a no-op. With no pins yet, a "Drag here to pin" target appears so the first pin works by drag too.
- **Long-press peek** (~0.9 s still hold, tiles and rows): read-only preview of the latest messages — never marks read, no receipts, no downloads. Tap inside opens the chat, outside dismisses; menu: Pin/Unpin, Mark as Unread/Read, More… (bridges to the full actions sheet so pinned chats keep Mute/Hide/Lock on touch), Delete/Exit group with confirmation.

Hardened through four rounds of real-device testing: single-tap peek actions (iOS text-selection lock), keep-the-touch-target-mounted ghost (iOS kills a gesture's events when its target unmounts), `touch-action`/native-image-drag blocks, WebKit stale-paint workaround (opacity ghost), and swipe-options disabled while a row is lifted.

**Verification**: 25 new unit tests (rank ordering + drag math, red-first), new `e2e/pinned-reorder.spec.ts` (stable order, reorder persistence across reload, first-pin drop zone, pin/unpin by drag, peek flows), `e2e/pinned-grid.spec.ts` updated to the new hold gesture, touch-event verification scenarios under `drive/scenarios/`. `npm run build`, vitest, and the pinned e2e suites are green.

Closes #969
Closes #970
Closes #971
Closes #972
Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7