### PR TITLE
fix(app): stale installs self-heal and iPad taps work — dead-button double bug (spec 2032)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,3 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
+| [2032](specs/2032-ipad-taps-dead/spec.md) | iPad Taps Dead on Send & Quick-React | ⚪ planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,4 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
-| [2032](specs/2032-ipad-taps-dead/spec.md) | iPad Taps Dead on Send & Quick-React | ⚪ planned |
+| [2032](specs/2032-ipad-taps-dead/spec.md) | iPad Taps Dead on Send & Quick-React | 🟡 in-progress |

--- a/drive/scenarios/ipad-send-repro-2032.mjs
+++ b/drive/scenarios/ipad-send-repro-2032.mjs
@@ -1,0 +1,47 @@
+/**
+ * Spec 2032 repro: does a TOUCH tap on the composer Send button work?
+ * Hypothesis: @pointerdown.prevent suppresses the compatibility `click` for
+ * touch pointers per the Pointer Events spec — iPhone Safari synthesizes the
+ * click anyway (legacy path), iPadOS desktop-mode and Chromium do not.
+ */
+import { createAccount, pair, chatWith, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Pad', mobile: true }); // touch-enabled profile
+const b = await createAccount({ name: 'Phone' });
+await pair(a, b);
+const chat = await chatWith(a, b.id);
+
+// Clear the onboarding gate (blocks navigation until acknowledged), then open the chat.
+const saved = a.page.getByText("I'VE SAVED IT");
+if (await saved.count()) await saved.click();
+await a.page.waitForTimeout(600);
+await a.page.evaluate((id) => window.__ringTest.navigate(`/chat/${id}`), chat);
+await a.page.waitForTimeout(1500);
+
+// Type a draft so the Send button renders.
+const input = a.page.locator('ion-textarea textarea').first();
+await input.click();
+await input.fill('touch tap test');
+await a.page.waitForTimeout(400);
+await shot(a, 'ipad-send-repro-composer');
+
+const send = a.page.locator('[aria-label="Send"]').first(); // pierces shadow DOM
+const count = () => a.page.evaluate((id) => window.__ringTest.messages(id).then((m) => m.length), chat);
+const before = await count();
+
+// 1) A real TOUCH tap (what a finger does).
+const box = await send.boundingBox();
+await a.page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2);
+await a.page.waitForTimeout(1500);
+const afterTouch = await count();
+
+// 2) A mouse-style click (what desktop pointers do).
+await send.click().catch(() => {});
+await a.page.waitForTimeout(1500);
+const afterClick = await count();
+
+console.log(JSON.stringify({ before, afterTouch, afterClick, touchWorked: afterTouch > before, clickWorked: afterClick > afterTouch }));
+await shot(a, 'ipad-send-repro');
+
+await sweep([a, b]);
+await done();

--- a/server/internal/api/static.go
+++ b/server/internal/api/static.go
@@ -61,6 +61,19 @@ func spaHandler(dir string) http.Handler {
 			return
 		}
 
+		// A missing fingerprinted asset is NEVER a client-side route — it's a chunk
+		// from a superseded deploy that this dist no longer carries. Falling back to
+		// index.html here (the pre-spec-2032 behavior) served HTML as JavaScript with
+		// a 200: a stale installed PWA (old shell served cache-first by its SW, its
+		// precache partially evicted by the OS, dist since rebuilt) would import an
+		// old-hash chunk, receive the app shell instead, and every feature in that
+		// chunk died silently — dead buttons, no error, no update prompt. A 404 makes
+		// the failure honest so the client's chunk-error handling can recover.
+		if strings.HasPrefix(clean, "/assets/") {
+			http.NotFound(w, r)
+			return
+		}
+
 		// SPA fallback: hand the route to index.html. It must always revalidate so
 		// a fresh deploy (new asset hashes) is picked up on the next load.
 		w.Header().Set("Cache-Control", "no-cache")

--- a/server/internal/api/static_test.go
+++ b/server/internal/api/static_test.go
@@ -54,6 +54,13 @@ func TestSPAHandler(t *testing.T) {
 		// (400), never escaping the tree. In production the stdlib mux also cleans
 		// the path before the handler runs, so a real traversal can't leak a file.
 		{name: "traversal rejected", path: "/assets/../../../etc/passwd", wantCode: 400},
+		// Spec 2032: a MISSING fingerprinted asset is a dead chunk from a superseded
+		// deploy, never a client-side route — it must 404, not fall back to the app
+		// shell. Serving index.html as JavaScript is how a stale installed PWA (old
+		// shell cache-first, precache partially evicted, dist since rebuilt) ends up
+		// with silently dead features: the module loader receives HTML and the whole
+		// chunk's handlers never wire up.
+		{name: "missing hashed asset 404s", path: "/assets/gone.def456.js", wantCode: 404},
 	}
 
 	for _, tc := range cases {

--- a/specs/2032-ipad-taps-dead/checklists/requirements.md
+++ b/specs/2032-ipad-taps-dead/checklists/requirements.md
@@ -1,0 +1,3 @@
+# Specification Quality Checklist: iPad Taps Dead
+
+All content/completeness items pass 2026-07-13 with one deliberate open: the H1/H2 discriminator requires the reporter's device (recorded under Assumptions; clarify = that single question).

--- a/specs/2032-ipad-taps-dead/spec.md
+++ b/specs/2032-ipad-taps-dead/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category
@@ -27,14 +27,23 @@ On an iPad, tapping Send delivers the typed message and tapping the react afford
 2. **Given** a received message on iPad, **When** the react affordance is tapped, **Then** the quick-react bar opens and picking an emoji applies it.
 3. **Given** the fix, **Then** iPhone and desktop behavior is unchanged (including the keyboard staying open while reacting, which is what the current pointerdown-prevent idiom protects).
 
-## Diagnosis state (from the initial investigation, 2026-07-13)
+## Root cause (CONFIRMED 2026-07-14, server logs + live probe)
 
-Two live hypotheses; the discriminating test needs the physical iPad:
+**H1 was right, and it is a real server bug, not just a stale cache.** The chain:
 
-- **H1 — stale installed-PWA shell (most likely given context)**: the iPad points at the dev deployment whose `dist/` was rebuilt many times that evening; an installed app that never accepted the update prompt can hold a precached shell referencing renamed hashed chunks. Symptom signature matches: the controls whose code-split chunk fails to load go dead while the rest of the app works, and the freshly-updated iPhone is fine. **Discriminator**: compare Settings → About version on iPad vs iPhone; accept any pending update / close-and-reopen; if versions match and taps still fail → H2. A remote-inspector console (Safari on a Mac) showing failed chunk loads confirms H1 outright.
-- **H2 — iPadOS input-pipeline difference**: both dead controls (composer Send, bubble react button) carry `@pointerdown.prevent` (the spec-1045 keyboard/selection-protection idiom) + `@click`. Canceling `pointerdown` for a touch pointer suppresses compatibility mouse events per the Pointer Events spec; iPhone Safari's legacy touch→click synthesis still delivers the click, and Chromium+touch demonstrably works (drive/scenarios/ipad-send-repro-2032.mjs → touch tap sends). iPadOS desktop-mode Safari may follow the stricter path. **Not reproducible headless here** (Playwright WebKit unsupported on this macOS); needs the device or a newer Mac.
+1. An installed PWA's service worker serves the app shell cache-first (deliberate — iOS cold-start), so a long-lived install keeps running its old shell until an update is *applied*.
+2. iPadOS evicted part of the old shell's precache (routine storage pressure), so lazily-loaded chunks went to the network with their OLD fingerprinted names.
+3. The dev server's `dist/` had been rebuilt several times since — those names no longer exist.
+4. `spaHandler`'s SPA fallback answered the missing `/assets/*.js` with **`index.html`, HTTP 200** (proven by live probe: `status=200 type=text/html` for a nonexistent chunk). The module loader received HTML as JavaScript, the chunk's features never wired up: dead Send, dead react button, no visible error.
+5. No update prompt appeared because every new-worker install attempted DURING the rebuild storm hit a half-written `dist/` (precache fetch fails → the whole SW install aborts → no waiting worker → nothing to prompt about).
 
-If H2: the candidate fix is replacing `@pointerdown.prevent` with `@mousedown.prevent` on the affected controls (protects focus/selection on all pointer types without ever being able to cancel a touch click), verified on iPad + iPhone + desktop. If H1: no code change — but consider whether the install-gate auto-update behavior should extend to installed-PWA dev channels.
+The iPhone escaped only because its precache was intact. H2 (pointerdown/click pipeline) is **withdrawn**: Chromium+touch reproduces nothing (harness kept on the branch), and the confirmed mechanism explains every observation including the missing prompt.
+
+## Fix (this branch)
+
+- **Server**: a missing `/assets/*` path now returns an honest **404** instead of the app shell — a dead fingerprinted chunk is never a client-side route. Regression test first (`static_test.go`: "missing hashed asset 404s", red → green).
+- **Client self-heal**: `useAppUpdate` now listens for Vite's `vite:preloadError` (a lazy chunk failed to load) and pulls the waiting update / reloads through the existing `applyUpdate` machinery — one attempt per tab, never mid-call. A future stale device un-strands itself instead of sitting with dead buttons.
+- **Stranded-device remedy (no code)**: with `dist/` stable again, one full close-and-reopen lets the new worker install cleanly and the normal prompt appears; failing that, reinstalling the PWA is the hard reset.
 
 ## Requirements *(mandatory)*
 

--- a/specs/2032-ipad-taps-dead/spec.md
+++ b/specs/2032-ipad-taps-dead/spec.md
@@ -37,13 +37,14 @@ On an iPad, tapping Send delivers the typed message and tapping the react afford
 4. `spaHandler`'s SPA fallback answered the missing `/assets/*.js` with **`index.html`, HTTP 200** (proven by live probe: `status=200 type=text/html` for a nonexistent chunk). The module loader received HTML as JavaScript, the chunk's features never wired up: dead Send, dead react button, no visible error.
 5. No update prompt appeared because every new-worker install attempted DURING the rebuild storm hit a half-written `dist/` (precache fetch fails → the whole SW install aborts → no waiting worker → nothing to prompt about).
 
-The iPhone escaped only because its precache was intact. H2 (pointerdown/click pipeline) is **withdrawn**: Chromium+touch reproduces nothing (harness kept on the branch), and the confirmed mechanism explains every observation including the missing prompt.
+The iPhone escaped only because its precache was intact. H2 (pointerdown/click pipeline) was briefly withdrawn — then **reinstated and confirmed as a second, independent bug** by the post-heal field report: with a fresh shell, everything gesture-driven works on the iPad (hold-to-record audio, video notes, calls, long-press action menu — all pointer/gesture handlers) while exactly the click-actions behind a bare `@pointerdown.prevent` stay dead (composer Send, both react buttons, and by inspection the @mention picker rows and the banner quick-reply send). iPadOS's desktop-class pipeline honors the spec: canceling `pointerdown` for a touch pointer suppresses the synthesized `click`; iPhone Safari's legacy touch path forgives it, and so does Chromium (which is why the touch repro passed).
 
 ## Fix (this branch)
 
 - **Server**: a missing `/assets/*` path now returns an honest **404** instead of the app shell — a dead fingerprinted chunk is never a client-side route. Regression test first (`static_test.go`: "missing hashed asset 404s", red → green).
 - **Client self-heal**: `useAppUpdate` now listens for Vite's `vite:preloadError` (a lazy chunk failed to load) and pulls the waiting update / reloads through the existing `applyUpdate` machinery — one attempt per tab, never mid-call. A future stale device un-strands itself instead of sitting with dead buttons.
 - **Stranded-device remedy (no code)**: with `dist/` stable again, one full close-and-reopen lets the new worker install cleanly and the normal prompt appears; failing that, reinstalling the PWA is the hard reset.
+- **Input fix (bug #2)**: every BARE `@pointerdown.prevent` focus-guard paired with a `@click` action is now `@mousedown.prevent` (five sites: Send, 2× react, mention picker, banner quick-reply) — synthetic mouse events fire after the touch sequence, so the focus shift is still blocked on every platform and the click can never be cancelled. Regression pinned by a source-level guard test (`src/components/pointer-tap-guard.test.ts`, red with the five offenders → green), since the failing engine (iPadOS WebKit) cannot run in CI. `@pointerdown.prevent="handler"` (acting ON the down, e.g. PinPad) remains legal.
 
 ## Requirements *(mandatory)*
 

--- a/specs/2032-ipad-taps-dead/spec.md
+++ b/specs/2032-ipad-taps-dead/spec.md
@@ -1,0 +1,58 @@
+# Feature Specification: iPad Taps Dead on Send & Quick-React
+
+**Feature Branch**: `fix/2032-ipad-taps-dead`
+
+**Created**: 2026-07-13
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User bug report (2026-07-13): "On iPad, send button doesn't work and tapping the emoji button to react on a message also doesn't open anything! But they work fine on my iPhone!"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Every tap works on iPad (Priority: P1)
+
+On an iPad, tapping Send delivers the typed message and tapping the react affordance opens the quick-react bar, exactly as on iPhone. No control in the chat screen may be dead on any supported device class.
+
+**Independent Test**: On the reporter's iPad: type a message, tap Send → it sends; tap the react button on a bubble → the emoji bar opens. Regression fence: same actions still work on iPhone and desktop.
+
+**Acceptance Scenarios**:
+
+1. **Given** a chat with a typed draft on iPad, **When** Send is tapped by finger, **Then** the message sends.
+2. **Given** a received message on iPad, **When** the react affordance is tapped, **Then** the quick-react bar opens and picking an emoji applies it.
+3. **Given** the fix, **Then** iPhone and desktop behavior is unchanged (including the keyboard staying open while reacting, which is what the current pointerdown-prevent idiom protects).
+
+## Diagnosis state (from the initial investigation, 2026-07-13)
+
+Two live hypotheses; the discriminating test needs the physical iPad:
+
+- **H1 — stale installed-PWA shell (most likely given context)**: the iPad points at the dev deployment whose `dist/` was rebuilt many times that evening; an installed app that never accepted the update prompt can hold a precached shell referencing renamed hashed chunks. Symptom signature matches: the controls whose code-split chunk fails to load go dead while the rest of the app works, and the freshly-updated iPhone is fine. **Discriminator**: compare Settings → About version on iPad vs iPhone; accept any pending update / close-and-reopen; if versions match and taps still fail → H2. A remote-inspector console (Safari on a Mac) showing failed chunk loads confirms H1 outright.
+- **H2 — iPadOS input-pipeline difference**: both dead controls (composer Send, bubble react button) carry `@pointerdown.prevent` (the spec-1045 keyboard/selection-protection idiom) + `@click`. Canceling `pointerdown` for a touch pointer suppresses compatibility mouse events per the Pointer Events spec; iPhone Safari's legacy touch→click synthesis still delivers the click, and Chromium+touch demonstrably works (drive/scenarios/ipad-send-repro-2032.mjs → touch tap sends). iPadOS desktop-mode Safari may follow the stricter path. **Not reproducible headless here** (Playwright WebKit unsupported on this macOS); needs the device or a newer Mac.
+
+If H2: the candidate fix is replacing `@pointerdown.prevent` with `@mousedown.prevent` on the affected controls (protects focus/selection on all pointer types without ever being able to cancel a touch click), verified on iPad + iPhone + desktop. If H1: no code change — but consider whether the install-gate auto-update behavior should extend to installed-PWA dev channels.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Send and quick-react MUST respond to touch taps on iPadOS (Safari and installed PWA), with iPhone/desktop behavior unchanged.
+- **FR-002**: Per the hotfix rule (constitution III), the fix MUST start from a failing regression test where the cause is automatable; if the cause proves environmental (H1), the spec documents the root cause and any preventive follow-up instead.
+- **FR-003**: The keyboard-preservation behavior the current idiom protects (reacting without dismissing the composer keyboard) MUST survive the fix.
+
+## Zero-Knowledge Impact
+
+None — device-local input handling / caching; nothing touches the wire.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Reporter confirms both actions work on the iPad (the only conclusive gate — the failing configuration cannot be emulated on the dev machine).
+- **SC-002**: Existing chat e2e (send, quick-react, reply, mentions) stays green; the chromium-touch drive repro keeps passing.
+
+## Assumptions
+
+- Awaiting the H1/H2 discriminator from the reporter before the pipeline continues (clarify is effectively this one question).

--- a/src/components/NotificationBanners.vue
+++ b/src/components/NotificationBanners.vue
@@ -69,7 +69,7 @@
             :class="{ ready: draft.trim() }"
             :disabled="!draft.trim()"
             aria-label="Send"
-            @pointerdown.prevent
+            @mousedown.prevent
             @click="sendReply(b)"
           >
             <ion-icon :icon="sendOutline" />

--- a/src/components/pointer-tap-guard.test.ts
+++ b/src/components/pointer-tap-guard.test.ts
@@ -1,0 +1,48 @@
+// Spec 2032: BARE `@pointerdown.prevent` (no handler — used purely as a
+// focus/selection guard next to a `@click` action) is banned app-wide.
+//
+// Why: per the Pointer Events spec, canceling `pointerdown` for a touch pointer
+// suppresses the compatibility mouse events. iPhone Safari synthesizes the click
+// anyway (legacy touch path) and Chromium tolerates it too — but iPadOS Safari's
+// desktop-class pipeline honors the suppression, so every control built this way
+// is a DEAD BUTTON on iPad (field report: composer Send, the react buttons, the
+// mention picker, the banner quick-reply). The iPad engine cannot run in CI
+// (Playwright WebKit is unavailable on this host), so this source-level guard is
+// the regression test: it pins the *class* of bug on the only surface we can.
+//
+// The correct idiom for "act on click but don't steal focus / dismiss the
+// keyboard" is `@mousedown.prevent`: synthetic mouse events fire AFTER the touch
+// sequence, so preventing mousedown blocks the focus shift on every platform and
+// can never cancel the click. `@pointerdown.prevent="handler"` (acting ON the
+// down, like PinPad) stays legal — there is no click to lose.
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function vueFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...vueFiles(p));
+    else if (e.name.endsWith('.vue')) out.push(p);
+  }
+  return out;
+}
+
+describe('spec 2032 — no bare @pointerdown.prevent (kills taps on iPadOS)', () => {
+  it('every focus-guard uses @mousedown.prevent instead', () => {
+    const root = join(__dirname, '..');
+    const offenders: string[] = [];
+    for (const f of vueFiles(root)) {
+      const src = readFileSync(f, 'utf8');
+      // Bare modifier only: `@pointerdown.prevent` NOT followed by `="handler"`.
+      const re = /@pointerdown\.prevent(?!\s*=)/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src))) {
+        const line = src.slice(0, m.index).split('\n').length;
+        offenders.push(`${f.replace(root, 'src')}:${line}`);
+      }
+    }
+    expect(offenders, `bare @pointerdown.prevent found (dead buttons on iPad):\n${offenders.join('\n')}`).toEqual([]);
+  });
+});

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -58,6 +58,9 @@ let lastCheck = 0;
 const CHECK_THROTTLE_MS = 10_000;
 // One silent install-gate auto-update per tab session (loop guard — see maybePrompt).
 const GATE_UPDATED_KEY = 'ring.installGateAutoUpdated';
+// Spec 2032: one chunk-failure self-heal per tab, so a heal that doesn't take
+// (e.g. the server is mid-deploy) can't reload-loop.
+const CHUNK_HEAL_KEY = 'ring.chunkHealApplied';
 
 /**
  * Ask the service worker to check for a newer deployed build. Safe to call on app
@@ -159,6 +162,25 @@ export function useAppUpdate(): void {
       }
     },
   });
+
+  // Spec 2032: a lazily-loaded chunk that fails to arrive means THIS shell is
+  // stale — its fingerprinted assets no longer exist on the server (which now
+  // answers them with an honest 404 instead of index.html). Left alone, that is
+  // the "some buttons just do nothing" failure: the feature whose chunk died
+  // never wires up and no error surfaces. Vite emits vite:preloadError exactly
+  // for this, so pull the waiting update (or force the check + reload) instead
+  // of letting the user sit in a half-dead app. One attempt per tab; never
+  // mid-call (the next failure after the call re-triggers, guard permitting).
+  if (typeof window !== 'undefined') {
+    window.addEventListener('vite:preloadError', (e) => {
+      let already = false;
+      try { already = sessionStorage.getItem(CHUNK_HEAL_KEY) === '1'; } catch { /* ignore */ }
+      if (already || isInCall()) return;
+      try { sessionStorage.setItem(CHUNK_HEAL_KEY, '1'); } catch { /* ignore */ }
+      e.preventDefault(); // recovery is ours; don't also throw the raw import error
+      void applyUpdate(updateServiceWorker);
+    });
+  }
 
   let prompting = false;
 

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -501,7 +501,7 @@
                   class="react-btn"
                   aria-label="React"
                   @click.stop="openQuickReact(m, $event)"
-                  @pointerdown.prevent
+                  @mousedown.prevent
                 >
                   <ion-icon :icon="happyOutline" />
                 </button>
@@ -652,7 +652,7 @@
                   class="react-btn"
                   aria-label="React"
                   @click.stop="openQuickReact(item.messages[0], $event)"
-                  @pointerdown.prevent
+                  @mousedown.prevent
                 >
                   <ion-icon :icon="happyOutline" />
                 </button>
@@ -759,7 +759,7 @@
           :key="c.everyone ? '@everyone' : c.id"
           type="button"
           class="mention-row"
-          @pointerdown.prevent
+          @mousedown.prevent
           @click="pickMention(c)"
         >
           <ion-icon v-if="c.everyone" :icon="megaphoneOutline" class="mention-row-ico" />
@@ -977,12 +977,15 @@
                 <span v-if="effectiveTtlMs" class="ttl-badge">{{ msgTtlShort }}</span>
               </span>
             </ion-button>
+            <!-- @mousedown.prevent (NOT pointerdown): keeps the tap from stealing focus
+                 (keyboard stays open) without cancelling the click. Cancelling pointerdown
+                 suppresses the synthesized click entirely on iPadOS — dead button (spec 2032). -->
             <ion-button
               v-if="draft.trim() || pendingMedia.length"
               color="primary"
               aria-label="Send"
               @click="send"
-              @pointerdown.prevent
+              @mousedown.prevent
             >
               <ion-icon slot="icon-only" :icon="sendOutline" />
             </ion-button>


### PR DESCRIPTION
Two independent bugs behind one field report ("send and react do nothing on iPad, fine on iPhone"), both fixed test-first — full story in specs/2032-ipad-taps-dead/spec.md.

1. **HTML served as JavaScript**: a missing fingerprinted `/assets/*` chunk fell through the SPA fallback to `index.html` with a 200, so a stale installed PWA (old shell cache-first, precache partly evicted, dist since redeployed) imported HTML and its features died silently — also why no update prompt ever appeared (SW installs kept failing against half-written deploys). Now: honest 404 (red-first regression in `static_test.go`) + a `vite:preloadError` self-heal that pulls the waiting update via the existing applyUpdate flow (once per tab, never mid-call).
2. **Prevented pointerdown kills clicks on iPadOS**: five controls guarded focus with bare `@pointerdown.prevent` next to `@click`; iPadOS's desktop-class pipeline suppresses the synthesized click (iPhone's legacy path and Chromium both forgive it — no CI engine reproduces). Swapped to `@mousedown.prevent`; a source-level guard test bans the bare idiom app-wide.

**Verified**: reporter confirmed send/react/quick-reply working on the physical iPad. ⚠️ Do not merge until the reporter's morning device pass on the full stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7