### PR TITLE
feat(chats): reaction notifications and replies that reach you through muted groups (spec 1048)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,5 +264,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1046-quick-call-tiles/plan.md`
+`specs/1048-notify-reactions-messages/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,6 +73,7 @@ Specs are grouped by category band; status moves
 | [1045](specs/1045-rearrange-pinned-chats/spec.md) | Rearrange pinned chats with drag, stable manual order, and long-press chat preview | 🟢 shipped |
 | [1046](specs/1046-quick-call-tiles/spec.md) | Quick Call tiles on the Calls tab, usage totals move to Network usage | 🔵 in-review |
 | [1047](specs/1047-chat-background-contrast/spec.md) | Chat background pattern reads clearly in both themes | 🔵 in-review |
+| [1048](specs/1048-notify-reactions-messages/spec.md) | Reaction Notifications & Group Reply Escalation | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,8 +71,8 @@ Specs are grouped by category band; status moves
 | [1043](specs/1043-direct-peer-peer/spec.md) | Direct Peer-to-Peer Call Media with Relay Fallback | 🟢 shipped |
 | [1044](specs/1044-pinned-chats-show/spec.md) | Pinned Chats Grid (iMessage-style) | 🟢 shipped |
 | [1045](specs/1045-rearrange-pinned-chats/spec.md) | Rearrange pinned chats with drag, stable manual order, and long-press chat preview | 🟢 shipped |
-| [1046](specs/1046-quick-call-tiles/spec.md) | Quick Call tiles on the Calls tab, usage totals move to Network usage | 🔵 in-review |
-| [1047](specs/1047-chat-background-contrast/spec.md) | Chat background pattern reads clearly in both themes | 🔵 in-review |
+| [1046](specs/1046-quick-call-tiles/spec.md) | Quick Call tiles on the Calls tab, usage totals move to Network usage | 🟢 shipped |
+| [1047](specs/1047-chat-background-contrast/spec.md) | Chat background pattern reads clearly in both themes | 🟢 shipped |
 | [1048](specs/1048-notify-reactions-messages/spec.md) | Reaction Notifications & Group Reply Escalation | ⚪ planned |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,7 +73,7 @@ Specs are grouped by category band; status moves
 | [1045](specs/1045-rearrange-pinned-chats/spec.md) | Rearrange pinned chats with drag, stable manual order, and long-press chat preview | 🟢 shipped |
 | [1046](specs/1046-quick-call-tiles/spec.md) | Quick Call tiles on the Calls tab, usage totals move to Network usage | 🟢 shipped |
 | [1047](specs/1047-chat-background-contrast/spec.md) | Chat background pattern reads clearly in both themes | 🟢 shipped |
-| [1048](specs/1048-notify-reactions-messages/spec.md) | Reaction Notifications & Group Reply Escalation | ⚪ planned |
+| [1048](specs/1048-notify-reactions-messages/spec.md) | Reaction Notifications & Group Reply Escalation | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/reaction-notify-1048.mjs
+++ b/drive/scenarios/reaction-notify-1048.mjs
@@ -1,0 +1,59 @@
+/**
+ * Spec 1048 verification: reaction notifications + reply escalation, live.
+ *
+ *   node drive/scenarios/reaction-notify-1048.mjs
+ *
+ * Bob reacts to Alice's message → Alice (on the Chats tab) should show the
+ * in-app banner "Reacted ❤️ to: …". Then in a muted group, Bob replies to
+ * Alice's message → the banner pierces the mute. Screenshots in .tmp/drive/.
+ */
+import {
+  createAccount, pair, group, chatWith, say, waitForMessage, messageId, react, shot, sweep, done,
+} from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+const cara = await createAccount({ name: 'Cara' });
+await pair(alice, bob);
+await pair(alice, cara);
+
+// --- US1: reaction to Alice's 1:1 message banners on Alice's device ---
+await say(alice, bob.id, 'my painting is done');
+await waitForMessage(bob, alice.id, 'my painting is done');
+const bobChat = await chatWith(bob, alice.id);
+const mid = await messageId(bob, bobChat, 'my painting is done');
+
+// Park Alice on the Chats tab so the banner (not the open chat) shows the reaction.
+await alice.page.evaluate(() => window.__ringTest.navigate('/tabs/chats'));
+await react(bob, mid, '❤️');
+await alice.page.waitForFunction(
+  () => window.__ringTest.notices().some((n) => String(n.body).includes('Reacted ❤️')),
+  undefined,
+  { timeout: 30_000 },
+);
+await shot(alice, 'alice-reaction-banner');
+
+// --- US2: a reply to Alice pierces her muted group ---
+const gid = await group(alice, 'Mural crew', [bob, cara]);
+await say(alice, gid, 'sketch is ready', { isGroup: true });
+await waitForMessage(bob, gid, 'sketch is ready', { isGroup: true });
+await alice.page.evaluate((id) => window.__ringTest.muteChat(id, Date.now() + 3_600_000), gid);
+const gm = await messageId(bob, gid, 'sketch is ready');
+await bob.page.evaluate(
+  ([id, q]) => window.__ringTest.sendReply(id, 'love it, adding clouds', q),
+  [gid, gm],
+);
+await alice.page.waitForFunction(
+  () => window.__ringTest.notices().some((n) => String(n.body).includes('love it, adding clouds')),
+  undefined,
+  { timeout: 30_000 },
+);
+await shot(alice, 'alice-muted-group-reply-banner');
+console.log('unreadMentions:', await alice.page.evaluate((id) => window.__ringTest.unreadMentions(id), gid));
+
+// --- Settings: the new Reactions sound page renders ---
+await shot(alice, 'alice-notifications-settings', { route: '/settings/notifications' });
+await shot(alice, 'alice-reaction-sound-page', { route: '/settings/notifications-reactions-sound' });
+
+await sweep([alice, bob, cara]);
+await done();

--- a/e2e/mentions.spec.ts
+++ b/e2e/mentions.spec.ts
@@ -76,3 +76,98 @@ test('mentions: individual + owner-only @everyone, counted and validated on rece
   await ctxB.close();
   await ctxC.close();
 });
+
+/**
+ * Replies-to-you escalate like mentions (spec 1048, US2): a direct reply to a
+ * message YOU authored pierces a muted group and lights the unread-mentions
+ * indicator; a reply to someone else's message stays muted noise; and the same
+ * per-chat "mentions" pref that gates mention escalation gates replies too.
+ */
+test('replies to your message escalate a muted group like a mention', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'RREPLY1');
+  const b = await createAccount(ctxB, 'RREPLY2');
+  const c = await createAccount(ctxC, 'RREPLY3');
+  await setProfile(a, 'Alice');
+  await setProfile(b, 'Bob');
+  await setProfile(c, 'Carol');
+  await pair(a, b);
+  await pair(a, c);
+
+  const gid = await a.page.evaluate((ids) => (window as any).__ringTest.createGroup('Dinner', ids), [b.id, c.id]);
+  for (const p of [b, c]) {
+    await p.page.waitForFunction(
+      (g) => (window as any).__ringTest.groupChats().then((gs: any[]) => gs.some((x) => x.id === g)),
+      gid,
+      { timeout: 30_000 },
+    );
+  }
+
+  // A posts, C posts, everyone receives both; then A mutes the group.
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'planning dinner'), gid);
+  await c.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'count me in'), gid);
+  const msgIdOf = async (body: string): Promise<string> => {
+    let found: string | null = null;
+    await expect
+      .poll(
+        async () => {
+          found = await b.page.evaluate(
+            ([g, want]: [string, string]) =>
+              (window as any).__ringTest
+                .messages(g)
+                .then((ms: any[]) => (ms.find((m) => m.body === want)?.id as string | undefined) ?? null),
+            [gid, body] as [string, string],
+          );
+          return typeof found === 'string' ? found : null;
+        },
+        { timeout: 30_000 },
+      )
+      .not.toBeNull();
+    return found as unknown as string;
+  };
+  const ids = { mine: await msgIdOf('planning dinner'), other: await msgIdOf('count me in') };
+  await a.page.evaluate((id) => (window as any).__ringTest.muteChat(id, Date.now() + 3_600_000), gid);
+
+  // 1) B replies to A's message → the reply pierces A's mute (banner) and counts.
+  await b.page.evaluate(
+    ([id, q]: [string, string]) => (window as any).__ringTest.sendReply(id, 'on my way to you', q),
+    [gid, ids.mine] as [string, string],
+  );
+  await a.page.waitForFunction(
+    () => (window as any).__ringTest.notices().some((n: { body: string }) => String(n.body).includes('on my way to you')),
+    undefined,
+    { timeout: 30_000 },
+  );
+  await waitMentions(a, gid, 1);
+
+  // 2) B replies to CAROL's message → muted noise for A: no new count, no banner.
+  await b.page.evaluate(
+    ([id, q]: [string, string]) => (window as any).__ringTest.sendReply(id, 'nice carol', q),
+    [gid, ids.other] as [string, string],
+  );
+  await a.page.waitForTimeout(2500);
+  expect(await unreadMentions(a, gid)).toBe(1);
+
+  // Reading clears the indicator, as with mentions.
+  await a.page.evaluate((id) => (window as any).__ringTest.markChatRead(id), gid);
+  await waitMentions(a, gid, 0);
+
+  // 3) The chat's mentions pref off → a reply-to-you no longer escalates (still
+  //    counted on the indicator, but no banner pierces the mute).
+  await a.page.evaluate((id) => (window as any).__ringTest.setChatNotify(id, { mentions: false }), gid);
+  await a.page.waitForFunction(() => (window as any).__ringTest.notices().length === 0, undefined, { timeout: 30_000 });
+  await b.page.evaluate(
+    ([id, q]: [string, string]) => (window as any).__ringTest.sendReply(id, 'still coming?', q),
+    [gid, ids.mine] as [string, string],
+  );
+  await waitMentions(a, gid, 1);
+  expect(
+    await a.page.evaluate(() => (window as any).__ringTest.notices().map((n: { body: string }) => n.body)),
+  ).toEqual([]);
+
+  await ctxA.close();
+  await ctxB.close();
+  await ctxC.close();
+});

--- a/e2e/mentions.spec.ts
+++ b/e2e/mentions.spec.ts
@@ -105,7 +105,16 @@ test('replies to your message escalate a muted group like a mention', async ({ b
     );
   }
 
-  // A posts, C posts, everyone receives both; then A mutes the group.
+  // A posts, C posts, everyone receives both; then A mutes the group. B also says
+  // one thing FIRST and A receives it — B's replies below must be immediately
+  // decryptable by A, which needs B's sender key to have landed (a first-ever group
+  // frame can race the key distribution in a seconds-old group).
+  await b.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'bob is here'), gid);
+  await a.page.waitForFunction(
+    (id) => (window as any).__ringTest.messages(id).then((ms: any[]) => ms.some((m: any) => m.body === 'bob is here')),
+    gid,
+    { timeout: 30_000 },
+  );
   await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'planning dinner'), gid);
   await c.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'count me in'), gid);
   const msgIdOf = async (body: string): Promise<string> => {
@@ -131,15 +140,18 @@ test('replies to your message escalate a muted group like a mention', async ({ b
   await a.page.evaluate((id) => (window as any).__ringTest.muteChat(id, Date.now() + 3_600_000), gid);
 
   // 1) B replies to A's message → the reply pierces A's mute (banner) and counts.
-  await b.page.evaluate(
-    ([id, q]: [string, string]) => (window as any).__ringTest.sendReply(id, 'on my way to you', q),
-    [gid, ids.mine] as [string, string],
-  );
-  await a.page.waitForFunction(
+  // Arm the banner wait BEFORE sending: banners auto-dismiss after ~4.5s, so a wait
+  // started after the trigger can miss one under a loaded runner.
+  const replySeen = a.page.waitForFunction(
     () => (window as any).__ringTest.notices().some((n: { body: string }) => String(n.body).includes('on my way to you')),
     undefined,
     { timeout: 30_000 },
   );
+  await b.page.evaluate(
+    ([id, q]: [string, string]) => (window as any).__ringTest.sendReply(id, 'on my way to you', q),
+    [gid, ids.mine] as [string, string],
+  );
+  await replySeen;
   await waitMentions(a, gid, 1);
 
   // 2) B replies to CAROL's message → muted noise for A: no new count, no banner.

--- a/e2e/reaction-notify.spec.ts
+++ b/e2e/reaction-notify.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const AVATAR = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>';
+
+const setProfile = (p: any, name: string) =>
+  p.page.evaluate(([n, av]: [string, string]) => (window as any).__ringTest.setProfile(n, av), [name, AVATAR]);
+
+const react = (p: any, messageId: string, emoji: string) =>
+  p.page.evaluate((args: [string, string]) => (window as any).__ringTest.reactToMessage(args[0], args[1]), [messageId, emoji]);
+
+/** Current in-app banner bodies. */
+const banners = (p: any): Promise<string[]> =>
+  p.page.evaluate(() => (window as any).__ringTest.notices().map((n: any) => n.body));
+
+/** Wait until a banner whose body contains `text` is showing. */
+const waitBanner = (p: any, text: string) =>
+  p.page.waitForFunction(
+    (t: string) => (window as any).__ringTest.notices().some((n: any) => String(n.body).includes(t)),
+    text,
+    { timeout: 30_000 },
+  );
+
+/** Wait until no banner is showing (they auto-dismiss after ~4.5s). */
+const waitQuiet = (p: any) =>
+  p.page.waitForFunction(() => (window as any).__ringTest.notices().length === 0, undefined, { timeout: 30_000 });
+
+/**
+ * Spec 1048 (US1/US3): a reaction to YOUR message notifies you — and only you —
+ * through the in-app banner path; removals stay silent; viewing the chat suppresses
+ * the banner; and the settings toggle really gates it (no more dead control).
+ */
+test('reaction notifications: author-only, viewing suppresses, toggle gates', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'RNOTIF1');
+  const b = await createAccount(ctxB, 'RNOTIF2');
+  await setProfile(a, 'Alice');
+  await setProfile(b, 'Bob');
+  await pair(a, b);
+
+  // A sends a message; the id is shared by both sides of the chat.
+  const aChat = await a.page.evaluate((id) => (window as any).__ringTest.chatWith(id), b.id);
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'my painting is done'), aChat);
+  const msgId = (await a.page
+    .waitForFunction(
+      (id) => (window as any).__ringTest.messages(id).then((ms: any[]) => ms.find((m) => m.body === 'my painting is done')?.id),
+      aChat,
+      { timeout: 30_000 },
+    )
+    .then((h) => h.jsonValue())) as string;
+  await b.page.waitForFunction(
+    async (aid) => {
+      const id = await (window as any).__ringTest.chatWith(aid);
+      if (!id) return false;
+      const ms = await (window as any).__ringTest.messages(id);
+      return ms.some((m: any) => m.body === 'my painting is done');
+    },
+    a.id,
+    { timeout: 30_000 },
+  );
+
+  // 1) B reacts ❤️ → A (on the Chats tab, not in the chat) gets the reaction banner.
+  await react(b, msgId, '❤️');
+  await waitBanner(a, 'Reacted ❤️ to: my painting is done');
+
+  // 2) Removal is silent: B toggles the same emoji off → no new banner appears.
+  await waitQuiet(a);
+  await react(b, msgId, '❤️'); // second tap = remove
+  await a.page.waitForTimeout(2500);
+  expect(await banners(a)).toEqual([]);
+
+  // 3) Viewing the chat suppresses the banner (the reaction is visible inline).
+  //    Wait until the chat page has actually registered itself as active — the
+  //    route push and the page's onMounted are async.
+  await a.page.evaluate((id) => (window as any).__ringTest.navigate(`/chat/${id}`), aChat);
+  await a.page.waitForFunction((id: string) => (window as any).__ringTest.isChatActive(id), aChat, { timeout: 30_000 });
+  await react(b, msgId, '👍');
+  await a.page.waitForTimeout(2500);
+  expect(await banners(a)).toEqual([]);
+  await a.page.evaluate(() => (window as any).__ringTest.navigate('/tabs/chats'));
+  await a.page.waitForFunction((id: string) => !(window as any).__ringTest.isChatActive(id), aChat, { timeout: 30_000 });
+
+  // 4) Toggle OFF (SC-005 — the control must really gate): no banner, but the
+  //    reaction still syncs and the chat list still shows the "reacted" preview.
+  await a.page.evaluate(() => (window as any).__ringTest.setGlobalSetting('notifications.message.reactions', false));
+  await react(b, msgId, '😂');
+  await expect
+    .poll(
+      () => a.page.evaluate((id: string) => (window as any).__ringTest.getReactions(id).then((rs: any[]) => rs.map((r: any) => r.emoji)), msgId),
+      { timeout: 30_000 },
+    )
+    .toContain('😂');
+  expect(await banners(a)).toEqual([]);
+  const preview = await a.page.evaluate((id) => (window as any).__ringTest.chatPreview(id), aChat);
+  expect(preview?.lastMessage ?? '').toContain('reacted');
+  expect(preview?.lastKind).toBe('reaction');
+
+  // 5) Toggle back ON → notifications resume.
+  await a.page.evaluate(() => (window as any).__ringTest.setGlobalSetting('notifications.message.reactions', true));
+  await react(b, msgId, '🎉');
+  await waitBanner(a, 'Reacted 🎉 to: my painting is done');
+
+  await ctxA.close();
+  await ctxB.close();
+});
+
+/**
+ * Spec 1048 (US1 AC3): in a group, only the AUTHOR of the reacted-to message is
+ * notified — other members see nothing for someone else's reaction.
+ */
+test('group reactions notify only the message author', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const ctxC = await browser.newContext();
+  const a = await createAccount(ctxA, 'RNOTIF3');
+  const b = await createAccount(ctxB, 'RNOTIF4');
+  const c = await createAccount(ctxC, 'RNOTIF5');
+  await setProfile(a, 'Alice');
+  await setProfile(b, 'Bob');
+  await setProfile(c, 'Carol');
+  await pair(a, b);
+  await pair(a, c);
+
+  const gid = await a.page.evaluate((ids) => (window as any).__ringTest.createGroup('Studio', ids), [b.id, c.id]);
+  for (const p of [b, c]) {
+    await p.page.waitForFunction(
+      (g) => (window as any).__ringTest.groupChats().then((gs: any[]) => gs.some((x: any) => x.id === g)),
+      gid,
+      { timeout: 30_000 },
+    );
+  }
+
+  await a.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'sketch for the mural'), gid);
+  const msgId = (await a.page
+    .waitForFunction(
+      (id) => (window as any).__ringTest.messages(id).then((ms: any[]) => ms.find((m) => m.body === 'sketch for the mural')?.id),
+      gid,
+      { timeout: 30_000 },
+    )
+    .then((h) => h.jsonValue())) as string;
+  await c.page.waitForFunction(
+    (id) => (window as any).__ringTest.messages(id).then((ms: any[]) => ms.some((m: any) => m.body === 'sketch for the mural')),
+    gid,
+    { timeout: 30_000 },
+  );
+
+  // Let Bob's ordinary "new message" banner for Alice's post dismiss first, so the
+  // assertion below isolates the REACTION's effect.
+  await waitQuiet(b);
+
+  // Carol reacts to ALICE's message → Alice gets the banner naming Carol…
+  await react(c, msgId, '🔥');
+  await waitBanner(a, 'Carol reacted 🔥 to: sketch for the mural');
+
+  // …and Bob (a member, but not the author) sees nothing for it.
+  await b.page.waitForTimeout(1500);
+  expect(await banners(b)).toEqual([]);
+
+  await ctxA.close();
+  await ctxB.close();
+  await ctxC.close();
+});

--- a/e2e/reaction-notify.spec.ts
+++ b/e2e/reaction-notify.spec.ts
@@ -15,8 +15,10 @@ const react = (p: any, messageId: string, emoji: string) =>
 const banners = (p: any): Promise<string[]> =>
   p.page.evaluate(() => (window as any).__ringTest.notices().map((n: any) => n.body));
 
-/** Wait until a banner whose body contains `text` is showing. */
-const waitBanner = (p: any, text: string) =>
+/** Arm a wait for a banner whose body contains `text`. ARM BEFORE triggering the
+ *  event: banners auto-dismiss after ~4.5s, so a wait started after the trigger can
+ *  miss a banner that came and went while the (loaded) runner was elsewhere. */
+const bannerSeen = (p: any, text: string) =>
   p.page.waitForFunction(
     (t: string) => (window as any).__ringTest.notices().some((n: any) => String(n.body).includes(t)),
     text,
@@ -26,6 +28,32 @@ const waitBanner = (p: any, text: string) =>
 /** Wait until no banner is showing (they auto-dismiss after ~4.5s). */
 const waitQuiet = (p: any) =>
   p.page.waitForFunction(() => (window as any).__ringTest.notices().length === 0, undefined, { timeout: 30_000 });
+
+/** Wait until `predicate` holds over the target message's reaction emojis on `who`'s
+ *  device. The e2e relay occasionally leaves a half-open socket that stalls delivery
+ *  for tens of seconds (the app's own keepalive recovers it eventually); after ~12s
+ *  of nothing we compress that recovery by force-reconnecting both sides, exactly the
+ *  lever the app itself pulls. 60s hard budget. */
+async function reactionState(who: any, other: any, messageId: string, predicate: (emojis: string[]) => boolean): Promise<void> {
+  const read = (): Promise<string[]> =>
+    who.page.evaluate(
+      (id: string) => (window as any).__ringTest.getReactions(id).then((rs: any[]) => rs.map((r: any) => r.emoji)),
+      messageId,
+    );
+  const t0 = Date.now();
+  let kicked = false;
+  for (;;) {
+    const emojis = await read();
+    if (predicate(emojis)) return;
+    if (Date.now() - t0 > 60_000) throw new Error(`reaction state not reached in 60s (have: ${emojis.join(' ') || 'none'})`);
+    if (!kicked && Date.now() - t0 > 12_000) {
+      kicked = true;
+      await who.page.evaluate(() => (window as any).__ringTest.forceReconnect());
+      await other.page.evaluate(() => (window as any).__ringTest.forceReconnect());
+    }
+    await who.page.waitForTimeout(400);
+  }
+}
 
 /**
  * Spec 1048 (US1/US3): a reaction to YOUR message notifies you — and only you —
@@ -62,15 +90,24 @@ test('reaction notifications: author-only, viewing suppresses, toggle gates', as
     { timeout: 30_000 },
   );
 
+  // A's post-unlock settle window (2.5s after registration) damps non-escalated
+  // banners BY DESIGN — and reactions never escalate. On a warm runner the whole
+  // setup can finish inside it, so wait it out before asserting banners.
+  await a.page.waitForFunction(() => (window as any).__ringTest.settleMsLeft() === 0, undefined, { timeout: 30_000 });
+
   // 1) B reacts ❤️ → A (on the Chats tab, not in the chat) gets the reaction banner.
+  const first = bannerSeen(a, 'Reacted ❤️ to: my painting is done');
   await react(b, msgId, '❤️');
-  await waitBanner(a, 'Reacted ❤️ to: my painting is done');
+  // Split diagnosis: the reaction must LAND on A (delivery, reconnect-hardened)…
+  await reactionState(a, b, msgId, (e) => e.includes('❤️'));
+  // …and the armed wait must have caught the banner (alerting).
+  await first;
 
   // 2) Removal is silent: B toggles the same emoji off → no new banner appears.
   await waitQuiet(a);
   await react(b, msgId, '❤️'); // second tap = remove
-  await a.page.waitForTimeout(2500);
-  expect(await banners(a)).toEqual([]);
+  await reactionState(a, b, msgId, (e) => !e.includes('❤️')); // the removal has landed…
+  expect(await banners(a)).toEqual([]); // …and produced no banner
 
   // 3) Viewing the chat suppresses the banner (the reaction is visible inline).
   //    Wait until the chat page has actually registered itself as active — the
@@ -78,8 +115,8 @@ test('reaction notifications: author-only, viewing suppresses, toggle gates', as
   await a.page.evaluate((id) => (window as any).__ringTest.navigate(`/chat/${id}`), aChat);
   await a.page.waitForFunction((id: string) => (window as any).__ringTest.isChatActive(id), aChat, { timeout: 30_000 });
   await react(b, msgId, '👍');
-  await a.page.waitForTimeout(2500);
-  expect(await banners(a)).toEqual([]);
+  await reactionState(a, b, msgId, (e) => e.includes('👍')); // landed while viewing…
+  expect(await banners(a)).toEqual([]); // …with no banner (active-chat suppress)
   await a.page.evaluate(() => (window as any).__ringTest.navigate('/tabs/chats'));
   await a.page.waitForFunction((id: string) => !(window as any).__ringTest.isChatActive(id), aChat, { timeout: 30_000 });
 
@@ -87,12 +124,7 @@ test('reaction notifications: author-only, viewing suppresses, toggle gates', as
   //    reaction still syncs and the chat list still shows the "reacted" preview.
   await a.page.evaluate(() => (window as any).__ringTest.setGlobalSetting('notifications.message.reactions', false));
   await react(b, msgId, '😂');
-  await expect
-    .poll(
-      () => a.page.evaluate((id: string) => (window as any).__ringTest.getReactions(id).then((rs: any[]) => rs.map((r: any) => r.emoji)), msgId),
-      { timeout: 30_000 },
-    )
-    .toContain('😂');
+  await reactionState(a, b, msgId, (e) => e.includes('😂'));
   expect(await banners(a)).toEqual([]);
   const preview = await a.page.evaluate((id) => (window as any).__ringTest.chatPreview(id), aChat);
   expect(preview?.lastMessage ?? '').toContain('reacted');
@@ -100,8 +132,10 @@ test('reaction notifications: author-only, viewing suppresses, toggle gates', as
 
   // 5) Toggle back ON → notifications resume.
   await a.page.evaluate(() => (window as any).__ringTest.setGlobalSetting('notifications.message.reactions', true));
+  const resumed = bannerSeen(a, 'Reacted 🎉 to: my painting is done');
   await react(b, msgId, '🎉');
-  await waitBanner(a, 'Reacted 🎉 to: my painting is done');
+  await reactionState(a, b, msgId, (e) => e.includes('🎉'));
+  await resumed;
 
   await ctxA.close();
   await ctxB.close();
@@ -147,13 +181,32 @@ test('group reactions notify only the message author', async ({ browser }) => {
     { timeout: 30_000 },
   );
 
-  // Let Bob's ordinary "new message" banner for Alice's post dismiss first, so the
-  // assertion below isolates the REACTION's effect.
+  // Carol's first group SEND is about to happen. Make it a plain message first and
+  // wait for Alice to receive it: that proves Carol's sender key reached Alice, so
+  // the reaction that follows is decryptable immediately (otherwise the reaction —
+  // Carol's first-ever frame in a seconds-old group — can race the key distribution
+  // and arrive undecryptable, flaking the banner wait).
+  await c.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'carol is here'), gid);
+  await a.page.waitForFunction(
+    (id) => (window as any).__ringTest.messages(id).then((ms: any[]) => ms.some((m: any) => m.body === 'carol is here')),
+    gid,
+    { timeout: 30_000 },
+  );
+
+  // Let the ordinary "new message" banners dismiss first, so the assertions below
+  // isolate the REACTION's effect.
   await waitQuiet(b);
+  await waitQuiet(a);
+
+  // Alice's settle window must have lapsed before a banner can be asserted
+  // (reactions never pierce it — by design).
+  await a.page.waitForFunction(() => (window as any).__ringTest.settleMsLeft() === 0, undefined, { timeout: 30_000 });
 
   // Carol reacts to ALICE's message → Alice gets the banner naming Carol…
+  const carolSeen = bannerSeen(a, 'Carol reacted 🔥 to: sketch for the mural');
   await react(c, msgId, '🔥');
-  await waitBanner(a, 'Carol reacted 🔥 to: sketch for the mural');
+  await reactionState(a, c, msgId, (e) => e.includes('🔥'));
+  await carolSeen;
 
   // …and Bob (a member, but not the author) sees nothing for it.
   await b.page.waitForTimeout(1500);

--- a/specs/1046-quick-call-tiles/spec.md
+++ b/specs/1046-quick-call-tiles/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1047-chat-background-contrast/spec.md
+++ b/specs/1047-chat-background-contrast/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-review
+**Status**: shipped
 
 **Input**: User description: "Make the chat background lines a bit brighter on the dark theme and darker on the bright theme." (An earlier richer-wallpaper direction was explored and reverted by request — the original artwork stays; only its per-theme contrast changes.)
 

--- a/specs/1048-notify-reactions-messages/checklists/requirements.md
+++ b/specs/1048-notify-reactions-messages/checklists/requirements.md
@@ -35,5 +35,8 @@
   precedents, not implementation prescriptions; the push-health invariant (FR-013) and zero-knowledge
   constraint (FR-014) are product/platform constraints, so naming them here is intentional.
 - No [NEEDS CLARIFICATION] markers: reasonable market-standard defaults were chosen and recorded in
-  Assumptions (reaction-change notifies, removals never, no new settings, unread counts unchanged).
-- Items all pass as of 2026-07-13; ready for `/speckit-clarify` (or directly `/speckit-plan`).
+  Assumptions (reaction-change notifies, removals never, unread state unchanged).
+- Clarify session 2026-07-13 (4 questions) confirmed the swap/unread/catch-up defaults and CHANGED
+  one decision: reactions get a dedicated sound preference with a silent option (FR-004a) instead of
+  reusing the message tone — the sole new setting this feature introduces.
+- Items all pass as of 2026-07-13; clarified and ready for `/speckit-plan`.

--- a/specs/1048-notify-reactions-messages/checklists/requirements.md
+++ b/specs/1048-notify-reactions-messages/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Reaction Notifications & Group Reply Escalation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec references prior specs (1020 mentions, 2010 one-owner, 2022/1034 push health) as behavioral
+  precedents, not implementation prescriptions; the push-health invariant (FR-013) and zero-knowledge
+  constraint (FR-014) are product/platform constraints, so naming them here is intentional.
+- No [NEEDS CLARIFICATION] markers: reasonable market-standard defaults were chosen and recorded in
+  Assumptions (reaction-change notifies, removals never, no new settings, unread counts unchanged).
+- Items all pass as of 2026-07-13; ready for `/speckit-clarify` (or directly `/speckit-plan`).

--- a/specs/1048-notify-reactions-messages/contracts/notification-decisions.md
+++ b/specs/1048-notify-reactions-messages/contracts/notification-decisions.md
@@ -1,0 +1,55 @@
+# Contract: Notification decisions for reactions & replies (spec 1048)
+
+This is the behavioral contract BOTH delivery paths (live page `notify.ts` + service worker
+`sw-inbox.ts`) must satisfy identically, extending the spec-2010 one-owner model. Unit tests
+on each side assert these tables; drift between the sides is a defect.
+
+Inputs: `T` = surface toggle (`message.reactions` / `group.reactions`), `M` = chat muted,
+`H` = hidden (locked), `C` = per-chat content (`full`/`generic`/`none`), `P` = global
+showPreview, `W` = per-chat webPush, `A` = viewing this chat foregrounded,
+`NM` = chat `notifyMentions` pref, `S` = post-unlock settle window active (not push-woken).
+
+## Table 1 — Inbound reaction (add) to MY message, reactor ≠ self
+
+| Condition | Outcome (app open) | Outcome (app closed / SW) |
+|---|---|---|
+| `T` off | nothing (silent side-effect, as today) | `{note:null, wasMessage:false}` → existing visible-wake fallback |
+| `H` | traceless per hidden rules (no reaction surface at all) | today's hidden handling, nothing reaction-specific |
+| `M` (never escalates) | suppress | `silenced` badge-only shape → existing fallback |
+| `A` (viewing the chat) | suppress + reaction tone only | n/a (app open) |
+| `S` | suppress (damped with the burst) | n/a (settle is a page concept) |
+| `C='none'` or `W` off (closed) | suppress / badge-only | `silenced` |
+| `C='full'` ∧ `P` | banner: title sender/group, body `«Alice reacted ❤️ to: <preview>»`, reaction tone | note: same text, tag `ring:<chatId>`, `silent` iff tone `none` |
+| `C='generic'` or `!P` | fully generic (existing "Ring / New message" shape — reactor NOT named) | same |
+| target message missing / `remove:true` / not my message / reactor = self | nothing, all paths | `{note:null, wasMessage:false}` |
+
+Invariants: never escalates; never changes `chat.unread`/`unreadMentions`/badge; coalesces
+under the chat's existing tag (burst of N ⇒ one updating notification, cumulative count).
+
+## Table 2 — Group message whose `reply.senderId` = me
+
+| Condition | Outcome |
+|---|---|
+| `NM` off | ordinary group message (Table “plain message” rules, no escalation) |
+| `H` | hidden rules win — no escalation, traceless |
+| `M` ∧ `NM` on | **escalates** — notification shows despite mute (both paths) |
+| `C='none'`/`W` off/in-app off/`S`, ∧ `NM` on | **escalates** past each (mention parity, exactly) |
+| masked content (`C≠'full'` or `!P`) | body `«Alice replied to you»` (names replier, no message text) |
+| full content | normal message body; SW may use `«Alice replied to you: <preview>»` wording |
+| also mentions me | ONE notification, mention wording wins |
+| 1:1 chat, or reply to someone else's message, or my own reply | no escalation — ordinary message |
+| unread | `chat.unreadMentions` +1 when not viewing (cleared on read), same as mentions |
+
+## Table 3 — Push-health (FR-013, all cases above)
+
+Every SW wake outcome maps to an established shape: a shown note, `silenced`, or
+`{note:null}` — each of which already ends visibly via spec-2016/2017/2023 (summary
+re-assert / quiet generic / licensed Chromium skip). **No new outcome shapes may be
+introduced.** The server is never consulted (FR-014).
+
+## Settings contract
+
+- `notifications.message.reactions` / `notifications.group.reactions`: independent gates
+  (SC-005: each observably changes behavior from the settings screen).
+- `notifications.reactions.sound`: page = in-app tone via `playTone` (`none` ⇒ silent banner);
+  SW = `silent:true` iff `none`. Synced via `SYNCED_PREF_KEYS`.

--- a/specs/1048-notify-reactions-messages/data-model.md
+++ b/specs/1048-notify-reactions-messages/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Reaction Notifications & Group Reply Escalation (spec 1048)
+
+No new object stores, no `DB_VERSION` bump, no wire-format change. This feature reads
+existing sealed payload fields and adds one settings row plus small extensions to two
+in-memory interfaces.
+
+## Wire / sealed payload (UNCHANGED — read-only consumers added)
+
+| Field | Where | Used by 1048 as |
+|---|---|---|
+| `payload.reaction: ReactionSignal` `{messageId, emoji, remove, at}` | sealed `MessagePayload`, kind `'reaction'` | trigger for the reaction notification decision (add only; `remove` stays silent) |
+| `payload.reply: ReplyRef` `{id, senderId, preview, …}` | sealed `MessagePayload` on ordinary messages | `reply.senderId === selfId` ⇒ reply-to-me escalation (groups only) |
+| `payload.mentions` / `mentionsEveryone` | sealed | unchanged; mention wording wins when combined with a reply |
+
+## Settings (existing `settings` store, existing sync mechanism)
+
+| Key | Type | Default | Status |
+|---|---|---|---|
+| `notifications.message.reactions` | boolean | `true` | EXISTS (dead) → becomes the 1:1 reaction gate |
+| `notifications.group.reactions` | boolean | `true` | EXISTS (dead) → becomes the group reaction gate |
+| `notifications.reactions.sound` | choice over `TONES` (incl. `none`) | `'pop'` | **NEW** — reaction alert tone; add to `SYNCED_PREF_KEYS` and the `notify.ts` prefs cache |
+
+Per-chat inputs (unchanged, already persisted on `Chat`): `mutedUntil`, `notifyWebPush`,
+`notifyInApp`, `notifyContent`, `notifyMentions` (now also gates reply escalation),
+`unreadMentions` (now also incremented by replies-to-you; cleared on read as today).
+
+## In-memory interface extensions (not persisted)
+
+### `IncomingNotice` (`src/services/notify.ts:86`)
+
+```ts
+// NEW optional fields:
+reaction?: boolean;   // this notice is a reaction alert → use the reaction tone,
+                      // never escalate, mask to fully-generic under restricted content
+replied?: boolean;    // this message directly replies to one of my messages →
+                      // feeds the mention-escalation path with "replied to you" wording
+```
+
+`mention`/`mentionName` keep their exact meaning; when `replied` is set the caller reuses
+`mentionName` for the replier's display name (one naming field, two wordings).
+
+### `SwNote` (`src/services/sw-inbox.ts`)
+
+```ts
+// NEW optional field:
+silent?: boolean;     // reaction notes when notifications.reactions.sound === 'none'
+                      // → threaded to showNotification({ silent: true }) in sw.ts
+```
+
+`aggregate` and the spec-2017 `ShownSummary` treat reaction/reply notes identically to
+message notes (same `ring:<chatId>` tag) — no shape change there.
+
+## Validation rules (enforced in code, unit-tested)
+
+1. Reaction notifies only when ALL hold: `!signal.remove` ∧ target message resolves ∧
+   target is own-authored (`m.outgoing || m.senderId === 'me'`) ∧ reactor ≠ self ∧
+   surface toggle on (`isGroup ? group.reactions : message.reactions`) ∧ owner-policy
+   result is not `suppress` (mute/hidden/content/settle all suppress; never escalates).
+2. Reply escalates only when ALL hold: group chat ∧ `payload.reply?.senderId === selfId` ∧
+   `chat.notifyMentions !== false`. Escalation semantics = mention semantics exactly
+   (`isMention` input of `notificationOwner`; predicate unchanged).
+3. Unread invariants: reactions never touch `chat.unread`, `chat.unreadMentions`, or the
+   app badge (`wasMessage: false` on the SW side). Replies-to-you increment
+   `chat.unreadMentions` (not `unread` beyond the normal message increment).
+4. Suppressed SW outcomes reuse today's shapes — `{note:null, wasMessage:false}` or
+   `silenced: true` — so the spec-2016/2017/2023 visible-wake fallback applies unchanged.
+
+## State transitions
+
+None. No entity changes state; the feature is a pure notification-decision layer.

--- a/specs/1048-notify-reactions-messages/plan.md
+++ b/specs/1048-notify-reactions-messages/plan.md
@@ -1,0 +1,160 @@
+# Implementation Plan: Reaction Notifications & Group Reply Escalation
+
+**Branch**: `feat/1048-notify-reactions-messages` | **Date**: 2026-07-13 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/1048-notify-reactions-messages/spec.md`
+
+## Summary
+
+Make the two existing-but-dead reaction toggles real (notify a message's author when
+someone reacts, in 1:1 and groups) and escalate direct replies-to-you in groups past
+mute exactly like @mentions (spec 1020). Client-only: reactions and reply references
+already travel in sealed payloads, so **nothing new crosses the wire** — both features
+are receiving-device notification decisions layered onto the existing two-path
+notification architecture (live page `queries.ts → notify.ts` with the spec-2010
+one-owner policy in `notify-policy.ts`, and the closed-app SW path `sw-inbox.ts
+buildNote`). Suppressed deliveries inherit the established spec-2016/2017/2023
+visible-outcome machinery unchanged, so no new class of silent wakes is possible.
+One new setting (per clarification): a dedicated reaction alert tone with a silent
+option, `notifications.reactions.sound`.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Vue 3 `<script setup>` + Ionic 8 (client only — no Go/server change)
+
+**Primary Dependencies**: existing notification stack — `src/services/notify.ts` (in-app banners),
+`src/services/notify-policy.ts` (pure one-owner predicate, spec 2010), `src/services/sw-inbox.ts`
+(SW note building), `src/sw.ts` (push wake + quiet-generic fallback, specs 1034/2016/2017/2023),
+`src/services/sound.ts` (synthesized tones), `src/settings/schema.ts` (declarative settings),
+`src/services/ownsync-keys.ts` (synced-prefs allowlist)
+
+**Storage**: IndexedDB via `src/db/idb.ts` (no new object stores; no `DB_VERSION` bump — one new
+row in the existing `settings` store)
+
+**Testing**: vitest unit tests colocated (`*.test.ts`, coverage floors are a ratchet);
+Playwright e2e under `e2e/` (extend `e2e/mentions.spec.ts`, new reaction-notification spec)
+
+**Target Platform**: installable PWA (iOS WebKit is the binding constraint: webpushd's
+cumulative 3-strike silent-push counter, spec 2022/1034)
+
+**Project Type**: web app (client half of the Ring monorepo)
+
+**Performance Goals**: notification decision adds ≤1 IndexedDB `get` per inbound reaction
+(the target-message lookup `handleReaction` already performs); no measurable latency change
+on the receive path (SC-001: visible within 5 s of delivery)
+
+**Constraints**: zero-knowledge (server cannot filter reaction pushes — FR-014); every push
+wake must end visibly (FR-013); `messaging.ts` stays crypto-only (all changes live in
+`queries.ts`/services, dependency direction preserved); no unread-count changes (clarified)
+
+**Scale/Scope**: ~6 source files touched, ~4 unit-test files, 2 e2e specs; no server, no
+migrations, no new components (settings UI is a data edit per Principle X/XI)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Verdict | Notes |
+|---|---|---|
+| I. Zero-Knowledge Boundary | ✅ PASS | No wire change at all. Reactions (`payload.reaction`) and reply refs (`payload.reply`) are already inside sealed envelopes; all new decisions run on the receiving device. Spec carries a Zero-Knowledge Impact section (FR-014). |
+| II. Spec-Driven Development | ✅ PASS | Spec 1048, clarified 2026-07-13; this plan; tasks/analyze/taskstoissues to follow in order. |
+| III. Test-Driven Development | ✅ PASS (plan) | tasks.md must order failing unit tests (notify.ts dispatch, sw-inbox buildNote, queries escalation) and e2e before implementation. No crypto/auth/store/HTTP-handler change; user-facing behavior ⇒ e2e required. |
+| IV. Crypto Discipline | ✅ N/A | No crypto change. `messaging.ts` untouched; `previewPacket` (SW read-only decrypt) reused as-is. |
+| V. Offline-First Data Integrity | ✅ PASS | No store/schema change; one new `settings` row through the existing `idb` wrapper + change bus. |
+| VI. Stateless Server | ✅ N/A | Server untouched. |
+| VII. Quality Gates | ✅ PASS (plan) | `npm run build`, vitest + floors, e2e where behavior changed. Release-note subject: plain-language (e.g. "feat(chats): get notified when someone reacts to your message"). |
+| VIII. Traceable Delivery | ✅ PASS | taskstoissues + `Closes #N` on the PR. |
+| IX. Privacy & Data Minimization | ✅ PASS | Content-masking parity: reaction/reply notifications reveal no more than message notifications at the same preference level (SC-006). |
+| X/XI. A11y & Ionic-First | ✅ PASS | New setting is a data edit to `src/settings/schema.ts` (choice page identical to the existing message/group tone pages); no new components. |
+
+`/speckit-checklist` is **not required**: no Principle I or IV surface is touched (nothing
+new crosses the wire, no crypto change). The ZK Impact statement lives in the spec regardless.
+
+**Post-design re-check (after Phase 1)**: still clean — the design introduced no new moving
+parts beyond the one settings key; Complexity Tracking stays empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1048-notify-reactions-messages/
+├── spec.md              # Feature spec (clarified 2026-07-13)
+├── plan.md              # This file
+├── research.md          # Phase 0: decisions + codebase findings
+├── data-model.md        # Phase 1: touched types/keys (no new stores)
+├── quickstart.md        # Phase 1: how to run/verify this feature in dev
+├── contracts/
+│   └── notification-decisions.md  # Phase 1: decision tables both paths must satisfy
+├── checklists/requirements.md     # From /speckit-specify
+└── tasks.md             # Phase 2 (/speckit-tasks — NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── settings/schema.ts            # + 'Reaction sound' link page (choice, TONES, default 'pop')
+├── services/
+│   ├── ownsync-keys.ts           # + 'notifications.reactions.sound' in SYNCED_PREF_KEYS
+│   ├── notify.ts                 # IncomingNotice: reaction/reply variants; reaction tone; masked bodies
+│   ├── notify-policy.ts          # UNCHANGED (isMention flag already models "escalates"; replies reuse it)
+│   ├── sw-inbox.ts               # reaction branch builds a note; reply joins the mention escalation
+│   └── sw-drain.ts               # inherits via shared buildNote (drain already defers reaction frames)
+├── sw.ts                         # thread SwNote.silent → showNotification options (reaction tone 'none')
+└── db/queries.ts                 # handleReaction → notify dispatch; selfReplied escalation + unreadMentions
+
+e2e/
+├── mentions.spec.ts              # extend: reply-to-you escalates a muted group; notifyMentions=off downgrade
+└── reaction-notify.spec.ts       # new: reaction notifies author only; toggles; coalescing; removal silent
+
+src/services/*.test.ts            # notify.reactions.test.ts, sw-inbox.reactions.test.ts,
+                                  # sw-inbox reply cases, queries-side escalation unit coverage
+```
+
+**Structure Decision**: single-project client change inside the existing monorepo layout;
+no server directory involvement.
+
+## Architecture decisions (what implementation must follow)
+
+Full rationale in [research.md](./research.md); the binding decisions:
+
+1. **Reply-to-you detection is lookup-free**: `payload.reply?.senderId === selfId`
+   (`ReplyRef.senderId` is the quoted message's author, `src/db/types.ts:268`). Works
+   identically on the page (`queries.ts:6012` area) and in the SW (`sw-inbox.ts:426` area),
+   even when the quoted message no longer exists locally. Self-replies are excluded because
+   inbound frames are never from self (and outgoing skips the path entirely).
+2. **Reaction "is mine" detection reuses the existing lookup**: `handleReaction`
+   (`queries.ts:705`) already `getMessage(signal.messageId)`; mine ⇔ `m.outgoing || m.senderId === 'me'`
+   (the codebase's own-message idiom, `queries.ts:1661`). The SW does the same read-only
+   `get<Message>('messages', id)` — it already reads chats/settings stores. Unresolvable
+   target (deleted / not-yet-arrived) ⇒ stays today's silent side-effect (edge case per spec).
+3. **Escalation reuses `isMention` wholesale**: `notificationOwner` (`notify-policy.ts`)
+   is NOT modified. Callers compute `isMention = selfMentioned || selfRepliedTo`, both gated
+   by the chat's existing `notifyMentions` pref. Only the display strings differ
+   ("mentioned you" vs "replied to you"); a message that is both mentions-and-reply renders
+   the mention wording (one notification, FR-012).
+4. **Reactions never escalate**: the reaction dispatch always passes `isMention: false`
+   and flows through `notificationOwner` like a plain message, so mute / in-app-off /
+   content-none / settle-window / hidden all suppress it (FR-005). `wasMessage` stays
+   `false` on the SW side and unread counts are untouched (clarified: notification only).
+5. **Push health needs NO new machinery**: today a reaction-only wake already ends via the
+   spec-2016/2017/2023 pattern (re-assert coalesced summary silently, else quiet generic via
+   `showQuietUnlessVisible`/`guardedPush`, `sw.ts:304-374`). Suppressed reaction/reply notes
+   return the same shapes buildNote returns today (`{note:null, wasMessage:false}` or
+   `silenced`), inheriting that guarantee (FR-013). The feature only ADDS visible notes.
+6. **One new setting**: `notifications.reactions.sound` (choice over the existing `TONES`
+   list which already includes `none`; default **`pop`** — subtle, distinct from the message
+   default `note`, satisfying the clarification). Rendered as a link page identical to
+   `notifications-message-sound` (`schema.ts:566`), added to `SYNCED_PREF_KEYS`. On the SW
+   path (no Web Audio), tone `none` maps to `silent: true` on `showNotification`; any other
+   tone keeps the OS default sound — the closest the platform allows.
+7. **Coalescing is free**: reaction/reply notes use the chat's existing `ring:<chatId>` tag,
+   so `aggregate` + the spec-2017 cumulative summary collapse bursts into the one updating
+   per-chat notification (FR-003, SC-004).
+8. **Chat-list surfacing already exists** (`lastKind: 'reaction'`, `handleReaction`) and is
+   not changed; this feature adds only the alerting layer.
+
+## Complexity Tracking
+
+> No constitution violations — table intentionally empty.

--- a/specs/1048-notify-reactions-messages/quickstart.md
+++ b/specs/1048-notify-reactions-messages/quickstart.md
@@ -1,0 +1,49 @@
+# Quickstart: verifying reaction notifications & reply escalation (spec 1048)
+
+## Unit tests (fast loop)
+
+```sh
+npx vitest run src/services/sw-inbox.reactions.test.ts src/services/notify.reactions.test.ts
+npx vitest run src/services/sw-inbox.test.ts src/services/notify-policy.test.ts   # no regressions
+npm run build                                                                     # typecheck gate
+```
+
+## Live-app verification (drive/ harness against `make start`)
+
+```sh
+make start           # dev stack (other terminal)
+HEADED=1 node drive/scenarios/dm-and-react.mjs   # existing reaction scenario as a base
+```
+
+Scenario shape for this feature (see `drive/README.md`; ~15 lines):
+1. `createAccount` A + B, `pair(a, b)`; A sends B a message.
+2. B reacts ❤️ → **A** (on `/tabs/chats`, chat NOT open) sees an in-app banner
+   "B reacted ❤️ to: …" — `shot()` it; assert via the banner DOM (`.notify-banner`, the
+   shared overlay — appToast/banners are NOT ion-toast).
+3. A opens the chat, B reacts again → no banner (active-chat suppress), tone only.
+4. Toggle `notifications.message.reactions` off via `__ringTest`/settings → react again →
+   nothing appears; chat list still updates its "reacted" preview line.
+5. Group with A+B+C, A muted the group: C replies to A's message (reply affordance, not a
+   bare message) → banner despite mute, wording "replied to you" under generic content.
+   B (not the replied-to author) gets nothing while muted.
+
+Gotchas (from prior specs): onboarding gate blocks nav until "I'VE SAVED IT"; use the
+driver's `waitForMessage`/`poll`; 1:1 chat ids differ per device (`chatWith` each side).
+
+## e2e (hermetic)
+
+```sh
+npm run test:e2e -- e2e/reaction-notify.spec.ts e2e/mentions.spec.ts
+```
+
+Needs `make db-up`. The SW-closed path is asserted at the unit level (buildNote contract
+tables) — e2e covers the live-page path like `mentions.spec.ts` does for spec 1020.
+
+## Closed-app / real-push spot check (manual, iOS PWA)
+
+1. Install the PWA (dev deployment: client changes need `npm run build` to show —
+   HMR only reaches `:5173`).
+2. Close the app on device A; react from device B → device A shows the OS notification,
+   coalesced under the chat; tap lands in the chat.
+3. Toggle reactions off on A, react 3+ times from B, then send a plain message —
+   the message still arrives as a push notification (subscription not revoked = FR-013/SC-003).

--- a/specs/1048-notify-reactions-messages/research.md
+++ b/specs/1048-notify-reactions-messages/research.md
@@ -1,0 +1,150 @@
+# Research: Reaction Notifications & Group Reply Escalation (spec 1048)
+
+**Date**: 2026-07-13 · All Technical Context unknowns resolved; no NEEDS CLARIFICATION remain.
+
+## R1. Where inbound reactions flow today, and why the toggles are dead
+
+**Finding**: `receiveIncoming` short-circuits reaction frames at `src/db/queries.ts:5814`
+(`if (payload.reaction) await handleReaction(...)`), and `handleReaction` (`queries.ts:705`)
+applies the reaction + updates the chat-list preview (`lastKind: 'reaction'`) but never calls
+`notifyIncoming`. On the SW side, `buildNote` lumps reactions with poll votes / edits / erases
+as "silent side effects" (`src/services/sw-inbox.ts:390-395`). The schema toggles
+`notifications.message.reactions` / `notifications.group.reactions` (`schema.ts:517/525`,
+default `true`, already in `SYNCED_PREF_KEYS` at `ownsync-keys.ts:19-20`) have zero consumers.
+
+**Decision**: hook the notification dispatch into `handleReaction` (page path) and into the
+reaction branch of `buildNote` (SW path); gate by `chat.isGroup ? group.reactions : message.reactions`.
+
+**Alternatives considered**: dispatch at the `queries.ts:5814` call site instead — rejected;
+`handleReaction` already holds the resolved message + chat, so the hook is one lookup cheaper
+and keeps the reaction logic in one function.
+
+## R2. Detecting "reaction to MY message" (both paths)
+
+**Finding**: `ReactionSignal` carries only `{messageId, emoji, remove, at}`. But
+`handleReaction` already does `getMessage(signal.messageId)`; own messages are identified as
+`m.outgoing || m.senderId === 'me'` (idiom at `queries.ts:1661`; `newOutgoing` writes
+`senderId: 'me'`). The SW can perform the same read-only `get<Message>('messages', id)` — it
+already reads the `chats` and `settings` stores via `@/db/idb`.
+
+**Decision**: page and SW both resolve the target message and require it to be own-authored;
+an unresolvable target (deleted, or reaction raced ahead of the message) stays a silent
+side-effect exactly as today (spec edge case: "no orphan notification, never a crash").
+
+**Alternatives considered**: adding an `authorId` field to `ReactionSignal` — rejected: wire
+format change for information the receiver already has locally, and old senders wouldn't send it.
+
+## R3. Detecting "reply to MY message" without a lookup
+
+**Finding**: `ReplyRef` (`src/db/types.ts:268`) carries `senderId` — "the quoted message's
+author's Ring user id" — snapshotted by the sender so quotes render even if the original is
+gone. So reply-to-me ⇔ `payload.reply?.senderId === selfId`, computable in both paths with no
+message lookup, and robust to the quoted message being deleted locally.
+
+**Decision**: use `payload.reply.senderId === selfId` (page: next to `selfMentioned` at
+`queries.ts:6012`; SW: next to the mention check at `sw-inbox.ts:426`). "Directly replied-to
+author only" (spec edge case) falls out naturally — a reply chain quotes exactly one message.
+Self-replies never escalate: inbound frames are never from self, and outgoing messages skip
+`receiveIncoming` entirely.
+
+**Alternatives considered**: resolving `reply.id` against the messages store — rejected: extra
+read, and breaks when the quoted message was deleted (the snapshot exists precisely for that).
+
+## R4. Escalation machinery: reuse `isMention`, don't extend the policy
+
+**Finding**: `notificationOwner` (`src/services/notify-policy.ts`) is the deliberately pure,
+shared spec-2010 predicate; `pref.isMention` already means "escalates past the per-chat
+silencers — mute, in-app-off, content=none, web-push-off, settle window — but not the
+structural gates". That is *exactly* the semantics spec 1048 FR-008 assigns to replies-to-you
+("no more, no less"), and it is already gated by the chat's `notifyMentions` pref at both call
+sites (FR-009).
+
+**Decision**: `notify-policy.ts` stays byte-identical. Callers widen what feeds the flag:
+`escalate = selfMentioned || selfRepliedTo`. Display strings differentiate ("Alice replied to
+you" vs "Alice mentioned you"); when a message both replies-to and mentions the user, mention
+wording wins and exactly one notification shows (FR-012 — trivially true since it is one
+message → one note). `chat.unreadMentions` increments for either trigger (FR-011); the field
+name stays (it is a UI counter, not a wire format).
+
+**Alternatives considered**: a separate `isReply` input on `NotifyInput` with its own branch
+logic — rejected: it would duplicate every silencer exception and reintroduce the two-sides-
+drift problem notify-policy exists to kill.
+
+## R5. Push-health invariant (FR-013) — existing machinery suffices
+
+**Finding**: reaction frames ALREADY wake the SW today and end silently at the buildNote level,
+yet the app is 3-strikes-safe because the wake pipeline (specs 1034/2016/2017/2023) guarantees a
+visible ending independent of note content: re-assert the freshest coalesced per-chat summary
+silently (`renotify:false`+`silent`), else the quiet generic via `showQuietUnlessVisible`
+(`sw.ts:304-374`), with silence licensed only on Chromium with a focused visible window
+(`mayEndWakeSilently`). The `silenced` (badge-only) and `{note:null}` outcomes are established,
+iOS-tolerated shapes.
+
+**Decision**: suppressed reaction/reply outcomes return the same shapes buildNote returns today;
+no new fallback code. The feature strictly *increases* the share of wakes that end with rich
+visible content. Tests assert the suppressed-path return shapes so a refactor can't silently
+create a new outcome class.
+
+**Alternatives considered**: none viable — server-side filtering is impossible (zero-knowledge,
+FR-014), and any client-side "swallow" would be exactly the silent wake FR-013 forbids.
+
+## R6. The dedicated reaction sound (clarification #2)
+
+**Finding**: tones are synthesized on-device (`src/services/sound.ts`, `playTone`); the
+settings pattern is a link page with one choice over `TONES` (`schema.ts:146` — already
+includes `{value:'none'}`), cf. `notifications-message-sound` (`schema.ts:566`). In-app sound
+plays via `inAppSound()` (`notify.ts:353`) using the cached `messageSound`. SW `showNotification`
+cannot play custom tones; it only has the binary `silent` option.
+
+**Decision**: one global key `notifications.reactions.sound`, choice over `TONES`, default
+**`pop`** (subtle + distinct from the message default `note`, per the spec assumption "quiet/
+subtle, distinct from the message tone"). Page path: reaction dispatch plays this tone instead
+of `messageSound` (a `none` value ⇒ no tone; banner still shows). SW path: `none` ⇒
+`silent: true` on the note; any tone ⇒ platform default sound. Add the key to
+`SYNCED_PREF_KEYS` (its siblings are all synced) and to the notify.ts prefs cache
+(`NotifyPrefs` + `loadPrefs`).
+
+**Alternatives considered**: per-surface keys (1:1 vs group reaction sound) — rejected: the
+clarification asked for one dedicated preference; the gating toggles are already per-surface.
+Reusing `notifications.message.sound` — rejected by clarification.
+
+## R7. Notification content, masking, and coalescing
+
+**Finding**: masking is centralized: page `notify.ts:445-479` (content/showPreview →
+generic body "New message", generic title "Ring"; mentions keep naming the mentioner), SW
+`sw-inbox.ts:430-467` (same rules; group bodies prefix the sender; tag `ring:<chatId>` drives
+`aggregate` + the spec-2017 cumulative summary). `notifyPreview` + `previewText`
+(`queries.ts:2096`) provide short message snapshots (previewText is already used for reaction
+chat-list lines).
+
+**Decision**:
+- Full content: title = sender (1:1) / group name (group); body = `Alice reacted ❤️ to: <previewText(target)>`
+  (SW group bodies keep the existing group title convention; the reactor is named in the body).
+- `content='generic'` or global preview off: fully generic (reaction notes do NOT name the
+  reactor — they never escalate, FR-002/edge case), falling into the existing
+  "Ring / New message" shape.
+- Escalated reply under masked content: `Alice replied to you` (mention parity, FR-010).
+- Tag stays `ring:<chatId>` so reactions/replies coalesce into the chat's one updating
+  notification (FR-003); no new tag namespace.
+
+**Alternatives considered**: a distinct `ring:reaction:<chatId>` tag for a separate stack —
+rejected by spec (FR-003: never a separate per-reaction stack).
+
+## R8. Test surface
+
+**Finding**: rich existing suites to extend: `notify-policy.test.ts` (pure predicate),
+`sw-inbox.test.ts` + focused siblings (`sw-inbox.badge/hidden/preview/reassert.test.ts`),
+`notify.hidden.test.ts` pattern for page-path tests, `e2e/mentions.spec.ts` (spec 1020
+escalation flows, drives via `window.__ringTest`). Vitest coverage floors are a ratchet
+(Principle III).
+
+**Decision** (test-first ordering for tasks.md):
+- Unit (red first): sw-inbox reaction-note cases (mine/not-mine/remove/toggle-off/muted ⇒
+  `silenced` shape/hidden/generic-content), sw-inbox reply-escalation cases, notify.ts
+  reaction dispatch (tone choice, active-chat suppress, no unread change), queries-side
+  `selfRepliedTo` + `unreadMentions` increment.
+- e2e: extend `mentions.spec.ts` (reply in muted group notifies; `notifyMentions` off ⇒
+  ordinary), new `reaction-notify.spec.ts` (author-only, toggle off ⇒ nothing, removal
+  silent, burst coalesces — assert via the existing notification-capture helpers).
+- notify-policy.test.ts needs no new cases (predicate unchanged) but gets a comment-level
+  note that replies feed `isMention`.

--- a/specs/1048-notify-reactions-messages/spec.md
+++ b/specs/1048-notify-reactions-messages/spec.md
@@ -13,6 +13,15 @@
 
 **Input**: User description: "Notify users when someone reacts to their message (the existing reaction-notification toggles are dead controls today), and escalate direct replies to you in groups past mute the same way @mentions escalate. Hard constraint: every push delivered to a device must end in a visible outcome — after 3 hidden notifications the platform revokes the push subscription — so suppressed reaction pushes must follow the established visible-outcome pattern rather than being silently swallowed."
 
+## Clarifications
+
+### Session 2026-07-13
+
+- Q: When someone changes their reaction (👍 → ❤️), notify again? → A: Yes — a swap counts as a new reaction add; per-chat coalescing bounds the noise.
+- Q: Should reaction notifications play the normal message sound or be quiet? → A: Neither fixed choice — add a dedicated reaction-sound preference (with a silent option), separate from the message tone.
+- Q: Should reactions affect unread state (chat unread count / app badge)? → A: No — notification only; reactions are not messages and never change unread counts or increment the badge.
+- Q: How should an offline catch-up backlog of reactions/replies behave? → A: Existing settle-window rules — reactions follow the same catch-up quieting as ordinary messages; replies follow mention parity exactly (they punch through only what mentions punch through today).
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Know when someone reacts to your message (Priority: P1)
@@ -80,6 +89,7 @@ Maya finds reaction notifications noisy and switches the existing "Reactions" to
 - **Reply chain**: Alex replies to Maya's reply, which quoted Sara — only the author of the *directly replied-to* message (Maya) gets escalation; Sara does not.
 - **Reply-to-you while the target chat is open on screen**: follows today's rule for messages (no notification for the chat you're actively viewing).
 - **Global "show notifications" off**: reactions and replies respect the master message-notification switch exactly as ordinary messages do; escalation for replies punches through the same suppressions mentions punch through today, and no more.
+- **Offline catch-up backlog**: when a device reconnects and syncs a backlog of reactions and replies, the existing settle-window catch-up quieting applies — reactions are quieted like ordinary backlog messages; replies-to-you behave exactly as backlog mentions do today. No new catch-up threshold is introduced.
 - **Preview privacy**: with the global "show preview" off or a per-chat generic-content preference, reaction and reply notifications must not leak message text; replies may still name the replier (mention-parity), reactions fall back to fully generic text.
 - **Older senders / mixed versions**: messages from clients that predate this feature carry no new information; devices must handle their reactions/replies with the same rules (a reaction is a reaction regardless of sender version).
 
@@ -92,8 +102,9 @@ Maya finds reaction notifications noisy and switches the existing "Reactions" to
 - **FR-001**: The system MUST notify a user when another participant adds a reaction to a message that user authored, in both 1:1 and group chats.
 - **FR-002**: The reaction notification MUST identify the reactor and the emoji and include a short preview of the reacted-to message, subject to the user's content-privacy settings: with previews disabled globally or the chat set to generic content, no message text or reactor identity leaks beyond what suppressed message notifications reveal today.
 - **FR-003**: Reaction notifications MUST coalesce with the chat's existing notification (one updating entry per chat), never a separate per-reaction stack.
-- **FR-004**: The two existing settings toggles for reactions (one for direct messages, one for groups, both defaulting to on) MUST gate this behavior and MUST be independently effective. No new settings are introduced.
-- **FR-005**: Reaction notifications MUST respect every existing suppression layer — per-chat mute, per-chat notification preferences (delivery channels and content level), hidden-chat rules, and the global message-notification switch — and MUST NOT escalate past any of them.
+- **FR-004**: The two existing settings toggles for reactions (one for direct messages, one for groups, both defaulting to on) MUST gate this behavior and MUST be independently effective.
+- **FR-004a**: Reaction notifications MUST use a dedicated, user-selectable reaction sound preference — separate from the message tone and including a silent option — added alongside the existing notification sound settings. A silent choice affects only the tone; the notification itself still shows.
+- **FR-005**: Reaction notifications MUST respect every existing suppression layer — per-chat mute, per-chat notification preferences (delivery channels and content level), hidden-chat rules, the global message-notification switch, and the existing sync catch-up quieting (settle window) — and MUST NOT escalate past any of them.
 - **FR-006**: The system MUST NOT notify for: reaction removals, reactions to messages the user did not author, the user's own reactions (including echoes from their other devices), or reactions in hidden chats beyond the existing traceless pattern.
 - **FR-007**: Reaction notifications MUST work both while the app is open (in-app banner path) and while it is closed (system notification path), with exactly one surface notifying per event, consistent with the existing one-owner notification policy.
 
@@ -128,9 +139,9 @@ Maya finds reaction notifications noisy and switches the existing "Reactions" to
 
 ## Assumptions
 
-- **Changing a reaction** (swapping one emoji for another) counts as a new reaction add and may notify again; coalescing bounds the noise. Removals never notify.
-- **Unread counts are unchanged**: reactions are not messages and do not increment the chat's unread message count; only the notification (and existing badge rules) surface them. Replies-to-you additionally light the unread-mentions indicator, as mentions do today.
-- **No new sounds or settings**: reaction notifications reuse the chat's existing sound/preference machinery; the only user-facing controls are the two existing (currently dead) toggles and the existing per-chat preferences.
+- **Changing a reaction** (swapping one emoji for another) counts as a new reaction add and may notify again; coalescing bounds the noise. Removals never notify. *(Confirmed in clarification.)*
+- **Unread state is unchanged**: reactions are not messages — they never change a chat's unread count or increment the app icon badge; the notification is the only surface. Replies-to-you additionally light the unread-mentions indicator, as mentions do today. *(Confirmed in clarification.)*
+- **One new setting only**: a dedicated reaction sound preference (with a silent option) is the single new user-facing control (per clarification); everything else reuses the two existing (currently dead) toggles and the existing per-chat preferences. The reaction sound's default is a quiet/subtle choice, distinct from the message tone, finalized at planning.
 - **"Reply" means an explicit reply reference** to a specific message; quoting or thematically responding without the reply affordance does not escalate.
 - **Escalation parity is intentional**: replies punch through exactly the suppressions mentions punch through today (per spec 1020), including the hidden-chat exception — hidden chats never escalate anything.
 - **Existing wire formats suffice**: reactions and reply references already travel in sealed payloads today; this feature changes only receiving-device behavior, so no compatibility window or server change is expected.

--- a/specs/1048-notify-reactions-messages/spec.md
+++ b/specs/1048-notify-reactions-messages/spec.md
@@ -132,7 +132,7 @@ Maya finds reaction notifications noisy and switches the existing "Reactions" to
 
 - **SC-001**: When someone reacts to a user's message, the author sees a notification within 5 seconds of delivery while online, in both open-app and closed-app states.
 - **SC-002**: A direct reply to the user's message in a muted group produces a notification in 100% of attempts (mentions preference on); a reply to someone else's message in the same muted group produces none.
-- **SC-003**: With a reactions toggle off, zero reaction notifications are shown across at least 10 consecutive suppressed reaction deliveries to a closed app, and the device's push subscription remains active afterwards (no platform revocation).
+- **SC-003**: With a reactions toggle off, zero reaction notifications are shown across at least 10 consecutive suppressed reaction deliveries to a closed app, and the device's push subscription remains active afterwards (no platform revocation). *Verification is split: automated tests prove every suppressed delivery produces one of the pre-existing, platform-tolerated outcome shapes; the subscription-survival half is confirmed manually on a real device (see quickstart).*
 - **SC-004**: A burst of 5+ reactions to the same chat results in at most one visible notification entry for that chat.
 - **SC-005**: Both reaction toggles observably change behavior from the settings screen — the app no longer ships dead controls (verified by toggling each and confirming the corresponding behavior change).
 - **SC-006**: No content leak: with previews off or generic content set, reaction and reply notifications reveal no message text in any tested scenario.

--- a/specs/1048-notify-reactions-messages/spec.md
+++ b/specs/1048-notify-reactions-messages/spec.md
@@ -137,6 +137,22 @@ Maya finds reaction notifications noisy and switches the existing "Reactions" to
 - **SC-005**: Both reaction toggles observably change behavior from the settings screen — the app no longer ships dead controls (verified by toggling each and confirming the corresponding behavior change).
 - **SC-006**: No content leak: with previews off or generic content set, reaction and reply notifications reveal no message text in any tested scenario.
 
+## Zero-Knowledge Impact
+
+- **What crosses the wire**: nothing new. Reactions and reply references already travel
+  inside sealed envelopes today; this feature adds no payload field, no message type, and
+  no server endpoint or behavior change.
+- **What is encrypted**: everything relevant already is — the reaction (emoji, target
+  message id, add/remove) and the reply reference (quoted id, author, preview snapshot)
+  are E2EE payload content the server never sees.
+- **Unavoidably visible metadata**: unchanged — the server continues to see only that a
+  sealed frame was relayed to a recipient and the content-free push tickle it already
+  sends. It cannot distinguish a reaction from a message, which is precisely why all
+  notification decisions (including suppression) are made on the receiving device (FR-014)
+  and why suppressed deliveries must still end visibly on the device (FR-013).
+- **Why**: notifying about reactions/replies requires reading their plaintext, which only
+  the recipient's device can do. No server-side assistance is possible or introduced.
+
 ## Assumptions
 
 - **Changing a reaction** (swapping one emoji for another) counts as a new reaction add and may notify again; coalescing bounds the noise. Removals never notify. *(Confirmed in clarification.)*

--- a/specs/1048-notify-reactions-messages/spec.md
+++ b/specs/1048-notify-reactions-messages/spec.md
@@ -1,0 +1,137 @@
+# Feature Specification: Reaction Notifications & Group Reply Escalation
+
+**Feature Branch**: `feat/1048-notify-reactions-messages`
+
+**Created**: 2026-07-13
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Notify users when someone reacts to their message (the existing reaction-notification toggles are dead controls today), and escalate direct replies to you in groups past mute the same way @mentions escalate. Hard constraint: every push delivered to a device must end in a visible outcome — after 3 hidden notifications the platform revokes the push subscription — so suppressed reaction pushes must follow the established visible-outcome pattern rather than being silently swallowed."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Know when someone reacts to your message (Priority: P1)
+
+Sara sends Alex a photo of her finished painting. Alex reacts with ❤️. Today Sara learns this only if she happens to reopen the chat. With this feature, Sara gets a gentle notification — "Alex reacted ❤️ to: my painting is done!" — the same way she would in WhatsApp, Telegram, or Messenger. The same works in groups: when a group member reacts to Sara's message, Sara (and only Sara) hears about it.
+
+**Why this priority**: This is the core gap. It is market-standard behavior in every major messenger, and Ring's settings screen already shows "reaction" toggles that currently do nothing — the app is promising a behavior it doesn't deliver. Reactions are also the lightest form of connection between people; losing them silently makes the app feel less alive.
+
+**Independent Test**: With two accounts in a 1:1 chat, account B reacts to a message account A sent. Account A receives a visible notification naming B and the emoji, both while the app is open (in-app banner) and while it is closed (system notification). Repeat in a group with a third member reacting to A's message: only A is notified.
+
+**Acceptance Scenarios**:
+
+1. **Given** Alex and Sara have a 1:1 chat and Sara's app is closed, **When** Alex reacts 👍 to a message Sara sent, **Then** Sara's device shows a notification identifying Alex, the emoji, and a preview of the reacted-to message, and tapping it opens that chat.
+2. **Given** Sara's app is open on the Chats tab, **When** Alex reacts to her message, **Then** Sara sees an in-app banner (not a duplicate system notification), consistent with how message notifications behave today.
+3. **Given** a group where Sara, Alex, and Maya are members and Alex reacts to Sara's message, **When** the reaction is delivered, **Then** Sara is notified and Maya is not.
+4. **Given** Alex removes his reaction, or reacts to a message Maya (not Sara) sent, **When** the event is delivered to Sara's device, **Then** Sara sees no reaction notification.
+5. **Given** several people react to Sara's message in quick succession, **When** the reactions arrive, **Then** they collapse into the chat's single updating notification rather than stacking one notification per reaction.
+6. **Given** Sara reacts to her own message, or her reaction echoes back from her second device, **Then** no notification is shown.
+
+---
+
+### User Story 2 - A reply to you cuts through a muted group (Priority: P2)
+
+Sara muted the busy "Family" group. Alex replies directly to a message Sara wrote there, asking her a question. Today that reply is suppressed with the rest of the group noise and Sara never sees it. With this feature, a direct reply to one of Sara's own messages is treated as personally directed — like an @mention — and reaches her even though the group is muted.
+
+**Why this priority**: Mentions already escalate past mute (spec 1020); replies-to-you are the same "this is addressed to you" signal and the market treats them identically (Telegram notifies for replies in muted groups by default). Without this, muting a group means missing direct questions. Priority below P1 because the mention machinery already gives users a partial workaround (the replier can @mention).
+
+**Independent Test**: Account A mutes a group, account B replies directly to a message A authored. A receives a notification despite the mute; the group's unread-mentions indicator lights up. A reply to a message authored by someone else stays suppressed.
+
+**Acceptance Scenarios**:
+
+1. **Given** Sara has muted a group, **When** Alex sends a message that directly replies to a message Sara authored, **Then** Sara receives a notification as if she had been @mentioned.
+2. **Given** Sara has muted a group and set its content preference to hide message contents, **When** Alex replies to her message, **Then** the notification still names the replier in a content-safe way (e.g., "Alex replied to you") without revealing the message body.
+3. **Given** Sara turned off the group's per-chat "notify on mentions" preference, **When** Alex replies to her message, **Then** the reply is treated like any ordinary group message (no escalation).
+4. **Given** Alex replies to Sara's message in an *unmuted* group, **Then** Sara gets one normal notification (no double-notify, no changed behavior beyond the mention-style indicator).
+5. **Given** Alex's reply to Sara's message *also* @mentions Sara, **Then** Sara receives exactly one notification.
+6. **Given** a 1:1 chat, **When** Alex replies to Sara's message, **Then** behavior is unchanged from today (1:1 messages already notify; no escalation concept applies).
+7. **Given** Sara replies to her own message in a group, **Then** no escalation occurs.
+8. **Given** Alex replied to Sara's message in a muted group, **When** Sara looks at her chat list, **Then** the group shows the unread-mentions indicator, and it clears when she reads the chat.
+
+---
+
+### User Story 3 - Turning it off really turns it off, without breaking push (Priority: P3)
+
+Maya finds reaction notifications noisy and switches the existing "Reactions" toggles off (separately for direct messages and groups). She stops seeing reaction notifications entirely — but her device keeps receiving the underlying deliveries, and her push registration must stay healthy: the platform revokes push after repeated deliveries that produce nothing visible.
+
+**Why this priority**: Controls that silently break push are worse than no controls. This story exists to make the suppression path an explicit, testable requirement rather than an afterthought — it protects the P1 feature from becoming a reliability regression.
+
+**Independent Test**: With reaction notifications toggled off, deliver a series of reactions to a closed app. No reaction notification appears, yet every delivery ends in the same visible-outcome pattern used today for muted/suppressed messages, and the push subscription remains active afterward.
+
+**Acceptance Scenarios**:
+
+1. **Given** Maya turned the 1:1 reactions toggle off, **When** someone reacts to her message in a 1:1 chat, **Then** no reaction notification or banner appears, while group reactions still notify (and vice versa — the two toggles are independent).
+2. **Given** Maya muted a chat, **When** someone reacts to her message there, **Then** no reaction notification appears (reactions never escalate past mute, unlike mentions).
+3. **Given** Maya's app is closed and a reaction delivery is suppressed by a toggle, mute, or hidden-chat rules, **When** the delivery wakes the device, **Then** the wake ends in the same user-visible outcome the app already uses for suppressed message deliveries — never an invisible no-op.
+4. **Given** a chat is hidden and locked, **When** a reaction or reply-to-you arrives in it, **Then** the existing traceless hidden-chat behavior applies unchanged (no content, no escalation, no trace).
+
+---
+
+### Edge Cases
+
+- **Reaction changed (👍 → ❤️)**: treated as a new reaction; may notify again, but coalescing under the chat's single notification keeps this from stacking.
+- **Reaction to a message that was deleted locally, or arriving before the original message** (out-of-order delivery): no notification if the reacted-to message can't be resolved as one of the user's own; never a crash or an orphan notification.
+- **Burst of reactions** (e.g., 10 members react to one message): must collapse into the chat's one updating notification with a sensible summary, not 10 entries.
+- **Reply chain**: Alex replies to Maya's reply, which quoted Sara — only the author of the *directly replied-to* message (Maya) gets escalation; Sara does not.
+- **Reply-to-you while the target chat is open on screen**: follows today's rule for messages (no notification for the chat you're actively viewing).
+- **Global "show notifications" off**: reactions and replies respect the master message-notification switch exactly as ordinary messages do; escalation for replies punches through the same suppressions mentions punch through today, and no more.
+- **Preview privacy**: with the global "show preview" off or a per-chat generic-content preference, reaction and reply notifications must not leak message text; replies may still name the replier (mention-parity), reactions fall back to fully generic text.
+- **Older senders / mixed versions**: messages from clients that predate this feature carry no new information; devices must handle their reactions/replies with the same rules (a reaction is a reaction regardless of sender version).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Reaction notifications**
+
+- **FR-001**: The system MUST notify a user when another participant adds a reaction to a message that user authored, in both 1:1 and group chats.
+- **FR-002**: The reaction notification MUST identify the reactor and the emoji and include a short preview of the reacted-to message, subject to the user's content-privacy settings: with previews disabled globally or the chat set to generic content, no message text or reactor identity leaks beyond what suppressed message notifications reveal today.
+- **FR-003**: Reaction notifications MUST coalesce with the chat's existing notification (one updating entry per chat), never a separate per-reaction stack.
+- **FR-004**: The two existing settings toggles for reactions (one for direct messages, one for groups, both defaulting to on) MUST gate this behavior and MUST be independently effective. No new settings are introduced.
+- **FR-005**: Reaction notifications MUST respect every existing suppression layer — per-chat mute, per-chat notification preferences (delivery channels and content level), hidden-chat rules, and the global message-notification switch — and MUST NOT escalate past any of them.
+- **FR-006**: The system MUST NOT notify for: reaction removals, reactions to messages the user did not author, the user's own reactions (including echoes from their other devices), or reactions in hidden chats beyond the existing traceless pattern.
+- **FR-007**: Reaction notifications MUST work both while the app is open (in-app banner path) and while it is closed (system notification path), with exactly one surface notifying per event, consistent with the existing one-owner notification policy.
+
+**Reply escalation in groups**
+
+- **FR-008**: A group message that directly replies to a message the user authored MUST be treated as personally directed: it escalates past mute and the other suppression layers exactly as an @mention does today — no more, no less.
+- **FR-009**: Reply escalation MUST be gated by the same per-chat "notify on mentions" preference that governs mention escalation; with it off, a reply-to-you notifies as an ordinary group message.
+- **FR-010**: Under masked/generic content, an escalated reply MUST still name the replier in a content-safe form (parity with how escalated mentions name the mentioner) without revealing the message body.
+- **FR-011**: Replies-to-you MUST count toward the chat's unread-mentions indicator and clear when the chat is read.
+- **FR-012**: Reply escalation applies only in groups, only when the replied-to message was authored by the recipient, and never for self-replies. A message that both replies to the user and @mentions them MUST produce exactly one notification. 1:1 reply behavior is unchanged.
+
+**Push-health invariant (applies to all of the above)**
+
+- **FR-013**: Every push delivery that reaches a device MUST end in a user-visible outcome, even when the reaction or reply notification itself is suppressed by settings, mute, or hidden-chat rules. Suppressed deliveries MUST follow the same established visible-outcome pattern the app already uses for suppressed message deliveries (specs 2022/1034), because the platform revokes the push subscription after repeated deliveries that produce nothing visible. This feature MUST NOT introduce any new class of silent wakes.
+- **FR-014**: Because the server cannot inspect sealed payloads (zero-knowledge boundary), all reaction/reply notification decisions MUST be made on the receiving device; no server-side filtering of these events may be introduced.
+
+### Key Entities
+
+- **Reaction event**: an existing sealed payload conveying reactor, emoji, target message, and add/remove; gains a notification decision on the receiving device but no new wire format.
+- **Reply-to-you**: an existing group message whose reply reference targets a message authored by the recipient; classified on-device as an implicit mention for notification and unread-indicator purposes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When someone reacts to a user's message, the author sees a notification within 5 seconds of delivery while online, in both open-app and closed-app states.
+- **SC-002**: A direct reply to the user's message in a muted group produces a notification in 100% of attempts (mentions preference on); a reply to someone else's message in the same muted group produces none.
+- **SC-003**: With a reactions toggle off, zero reaction notifications are shown across at least 10 consecutive suppressed reaction deliveries to a closed app, and the device's push subscription remains active afterwards (no platform revocation).
+- **SC-004**: A burst of 5+ reactions to the same chat results in at most one visible notification entry for that chat.
+- **SC-005**: Both reaction toggles observably change behavior from the settings screen — the app no longer ships dead controls (verified by toggling each and confirming the corresponding behavior change).
+- **SC-006**: No content leak: with previews off or generic content set, reaction and reply notifications reveal no message text in any tested scenario.
+
+## Assumptions
+
+- **Changing a reaction** (swapping one emoji for another) counts as a new reaction add and may notify again; coalescing bounds the noise. Removals never notify.
+- **Unread counts are unchanged**: reactions are not messages and do not increment the chat's unread message count; only the notification (and existing badge rules) surface them. Replies-to-you additionally light the unread-mentions indicator, as mentions do today.
+- **No new sounds or settings**: reaction notifications reuse the chat's existing sound/preference machinery; the only user-facing controls are the two existing (currently dead) toggles and the existing per-chat preferences.
+- **"Reply" means an explicit reply reference** to a specific message; quoting or thematically responding without the reply affordance does not escalate.
+- **Escalation parity is intentional**: replies punch through exactly the suppressions mentions punch through today (per spec 1020), including the hidden-chat exception — hidden chats never escalate anything.
+- **Existing wire formats suffice**: reactions and reply references already travel in sealed payloads today; this feature changes only receiving-device behavior, so no compatibility window or server change is expected.
+- **Both delivery paths are in scope**: open-app (in-app banner) and closed-app (system notification) must behave consistently under the one-owner policy (spec 2010).

--- a/specs/1048-notify-reactions-messages/spec.md
+++ b/specs/1048-notify-reactions-messages/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1048-notify-reactions-messages/tasks.md
+++ b/specs/1048-notify-reactions-messages/tasks.md
@@ -14,8 +14,8 @@
 
 **Purpose**: the one new user-facing control, so every later task can read it
 
-- [ ] T001 Add the `notifications.reactions.sound` choice (options `TONES`, default `'pop'`) as a new link page + entry beside the existing message/group Sound links in src/settings/schema.ts, and extend src/settings/schema.test.ts to cover the key and default
-- [ ] T002 Add `'notifications.reactions.sound'` to `SYNCED_PREF_KEYS` in src/services/ownsync-keys.ts (siblings `notifications.message.reactions` / `notifications.group.reactions` are already listed)
+- [x] T001 Add the `notifications.reactions.sound` choice (options `TONES`, default `'pop'`) as a new link page + entry beside the existing message/group Sound links in src/settings/schema.ts, and extend src/settings/schema.test.ts to cover the key and default
+- [x] T002 Add `'notifications.reactions.sound'` to `SYNCED_PREF_KEYS` in src/services/ownsync-keys.ts (siblings `notifications.message.reactions` / `notifications.group.reactions` are already listed)
 
 ---
 
@@ -23,8 +23,8 @@
 
 **Purpose**: interface changes both stories build on; typecheck-only, no behavior yet
 
-- [ ] T003 Extend `IncomingNotice` with optional `reaction?: boolean` and `replied?: boolean` fields (documented per data-model.md) in src/services/notify.ts, and add `reactionSound` to the `NotifyPrefs` cache + `loadPrefs`
-- [ ] T004 [P] Extend `SwNote` with optional `silent?: boolean` in src/services/sw-inbox.ts and thread it into the `showNotification` options at the note-show call sites in src/sw.ts (default unchanged when absent)
+- [x] T003 Extend `IncomingNotice` with optional `reaction?: boolean` and `replied?: boolean` fields (documented per data-model.md) in src/services/notify.ts, and add `reactionSound` to the `NotifyPrefs` cache + `loadPrefs`
+- [x] T004 [P] Extend `SwNote` with optional `silent?: boolean` in src/services/sw-inbox.ts and thread it into the `showNotification` options at the note-show call sites in src/sw.ts (default unchanged when absent)
 
 **Checkpoint**: `npm run build` passes; zero behavior change
 
@@ -38,15 +38,15 @@
 
 ### Tests for User Story 1 (write first, MUST fail) ⚠️
 
-- [ ] T005 [P] [US1] New unit suite src/services/sw-inbox.reactions.test.ts asserting contract Table 1 (specs/1048-notify-reactions-messages/contracts/notification-decisions.md): note built only for own-authored target + toggle on; correct title/body/tag `ring:<chatId>`; `silent` iff tone `'none'`; suppressed rows return today's exact shapes (`{note:null, wasMessage:false}` / `silenced`); remove/not-mine/self/missing-target silent; group vs 1:1 gated by the right toggle; generic content / preview-off fully generic; hidden chat unchanged
-- [ ] T006 [P] [US1] New unit suite src/services/notify.reactions.test.ts for the page path: reaction notice plays `notifications.reactions.sound` (not `messageSound`), `'none'` tone ⇒ banner without tone, active-chat ⇒ suppress + tone only, muted/settle ⇒ suppress (no escalation), masked content ⇒ generic body, and `chat.unread`/`unreadMentions` untouched
-- [ ] T007 [P] [US1] New e2e spec e2e/reaction-notify.spec.ts (live-page path, per quickstart.md): B reacts to A's message ⇒ A's banner shows "reacted ❤️"; A viewing the chat ⇒ no banner; reaction to C's message ⇒ nothing for A; reaction removal ⇒ nothing; burst of reactions ⇒ single coalesced banner (dedup by target)
+- [x] T005 [P] [US1] New unit suite src/services/sw-inbox.reactions.test.ts asserting contract Table 1 (specs/1048-notify-reactions-messages/contracts/notification-decisions.md): note built only for own-authored target + toggle on; correct title/body/tag `ring:<chatId>`; `silent` iff tone `'none'`; suppressed rows return today's exact shapes (`{note:null, wasMessage:false}` / `silenced`); remove/not-mine/self/missing-target silent; group vs 1:1 gated by the right toggle; generic content / preview-off fully generic; hidden chat unchanged
+- [x] T006 [P] [US1] New unit suite src/services/notify.reactions.test.ts for the page path: reaction notice plays `notifications.reactions.sound` (not `messageSound`), `'none'` tone ⇒ banner without tone, active-chat ⇒ suppress + tone only, muted/settle ⇒ suppress (no escalation), masked content ⇒ generic body, and `chat.unread`/`unreadMentions` untouched
+- [x] T007 [P] [US1] New e2e spec e2e/reaction-notify.spec.ts (live-page path, per quickstart.md): B reacts to A's message ⇒ A's banner shows "reacted ❤️"; A viewing the chat ⇒ no banner; reaction to C's message ⇒ nothing for A; reaction removal ⇒ nothing; burst of reactions ⇒ single coalesced banner (dedup by target)
 
 ### Implementation for User Story 1
 
-- [ ] T008 [US1] Dispatch the reaction notification from `handleReaction` in src/db/queries.ts: on add (not remove), target own-authored (`m.outgoing || m.senderId === 'me'`), reactor ≠ self, gated by `chat.isGroup ? 'notifications.group.reactions' : 'notifications.message.reactions'` → `notifyIncoming({kind:'message', reaction:true, chatId, msgId, name, body: "<first-name> reacted <emoji> to: <previewText(m)>", pushWoken})`; never touch unread counters
-- [ ] T009 [US1] Handle `reaction: true` notices in `notifyIncoming` in src/services/notify.ts: always `isMention:false`, reaction tone via `inAppSound` variant, masked content ⇒ fully generic body (reactor not named), otherwise existing banner flow (coalescing by target URL already applies)
-- [ ] T010 [US1] Build reaction notes in `buildNote` in src/services/sw-inbox.ts: replace the silent lump for `payload.reaction` with the Table 1 decision (read-only `get<Message>('messages', id)`, self id via existing session helper, toggles + per-chat prefs + hidden + mute exactly as the contract table; suppressed rows return today's shapes; tag `ring:<chatId>`; `silent` from the tone setting); poll votes/edits/erase/rekey/ttl stay silent side effects
+- [x] T008 [US1] Dispatch the reaction notification from `handleReaction` in src/db/queries.ts: on add (not remove), target own-authored (`m.outgoing || m.senderId === 'me'`), reactor ≠ self, gated by `chat.isGroup ? 'notifications.group.reactions' : 'notifications.message.reactions'` → `notifyIncoming({kind:'message', reaction:true, chatId, msgId, name, body: "<first-name> reacted <emoji> to: <previewText(m)>", pushWoken})`; never touch unread counters
+- [x] T009 [US1] Handle `reaction: true` notices in `notifyIncoming` in src/services/notify.ts: always `isMention:false`, reaction tone via `inAppSound` variant, masked content ⇒ fully generic body (reactor not named), otherwise existing banner flow (coalescing by target URL already applies)
+- [x] T010 [US1] Build reaction notes in `buildNote` in src/services/sw-inbox.ts: replace the silent lump for `payload.reaction` with the Table 1 decision (read-only `get<Message>('messages', id)`, self id via existing session helper, toggles + per-chat prefs + hidden + mute exactly as the contract table; suppressed rows return today's shapes; tag `ring:<chatId>`; `silent` from the tone setting); poll votes/edits/erase/rekey/ttl stay silent side effects
 
 **Checkpoint**: T005–T007 green; `npm run build` + full `npx vitest run` green — MVP demoable via quickstart drive scenario
 
@@ -60,15 +60,15 @@
 
 ### Tests for User Story 2 (write first, MUST fail) ⚠️
 
-- [ ] T011 [P] [US2] Extend src/services/sw-inbox.test.ts (mention/escalation block) with contract Table 2 cases: `payload.reply.senderId === selfId` in a muted group ⇒ note despite mute with "replied to you" wording under masked content; `notifyMentions` off ⇒ ordinary handling; reply to someone else / 1:1 reply ⇒ no escalation; reply that also mentions me ⇒ ONE note with mention wording
-- [ ] T012 [P] [US2] New unit coverage for the page path (extend src/services/notify.reactions.test.ts or a sibling notify.replies.test.ts in src/services/): `replied: true` notice escalates past mute/in-app-off/content-none/settle exactly like `mention: true`, body "«name» replied to you" when masked, and both flags together render mention wording once
-- [ ] T013 [P] [US2] Extend e2e/mentions.spec.ts: reply-to-A's-message in a muted group surfaces A's banner and bumps the chat's unread-mentions indicator, cleared on read; with the chat's mentions pref off the reply is suppressed like any muted message
+- [x] T011 [P] [US2] *(landed as the new src/services/sw-inbox.replies.test.ts — sw-inbox.test.ts holds only the 2016/2017 pure helpers, so escalation cases got their own focused suite)* Contract Table 2 cases: `payload.reply.senderId === selfId` in a muted group ⇒ note despite mute with "replied to you" wording under masked content; `notifyMentions` off ⇒ ordinary handling; reply to someone else / 1:1 reply ⇒ no escalation; reply that also mentions me ⇒ ONE note with mention wording
+- [x] T012 [P] [US2] New unit coverage for the page path (extend src/services/notify.reactions.test.ts or a sibling notify.replies.test.ts in src/services/): `replied: true` notice escalates past mute/in-app-off/content-none/settle exactly like `mention: true`, body "«name» replied to you" when masked, and both flags together render mention wording once
+- [x] T013 [P] [US2] Extend e2e/mentions.spec.ts: reply-to-A's-message in a muted group surfaces A's banner and bumps the chat's unread-mentions indicator, cleared on read; with the chat's mentions pref off the reply is suppressed like any muted message
 
 ### Implementation for User Story 2
 
-- [ ] T014 [US2] Compute `selfRepliedTo` (`isGroupMsg && payload.reply?.senderId === selfId`) beside `selfMentioned` in the receive path of src/db/queries.ts; feed `unreadMentions` increment and pass `replied: selfRepliedTo` + existing `mention`/`mentionName` through `notifyIncoming`
-- [ ] T015 [US2] Escalate `replied` notices in src/services/notify.ts: fold into the existing `isMention` computation (gated by `chatPrefs.mentions`), wording "«mentionName» replied to you" when masked with mention wording taking precedence when both flags set
-- [ ] T016 [US2] Escalate replies in `buildNote` in src/services/sw-inbox.ts: widen the `selfMentioned` check with `payload.reply?.senderId === selfId` (same `chat?.notifyMentions !== false` gate, hidden still wins), body "«sender» replied to you[: preview]" with mention wording when both apply
+- [x] T014 [US2] Compute `selfRepliedTo` (`isGroupMsg && payload.reply?.senderId === selfId`) beside `selfMentioned` in the receive path of src/db/queries.ts; feed `unreadMentions` increment and pass `replied: selfRepliedTo` + existing `mention`/`mentionName` through `notifyIncoming`
+- [x] T015 [US2] Escalate `replied` notices in src/services/notify.ts: fold into the existing `isMention` computation (gated by `chatPrefs.mentions`), wording "«mentionName» replied to you" when masked with mention wording taking precedence when both flags set
+- [x] T016 [US2] Escalate replies in `buildNote` in src/services/sw-inbox.ts: widen the `selfMentioned` check with `payload.reply?.senderId === selfId` (same `chat?.notifyMentions !== false` gate, hidden still wins), body "«sender» replied to you[: preview]" with mention wording when both apply
 
 **Checkpoint**: T011–T013 green; US1 suites still green
 
@@ -82,13 +82,13 @@
 
 ### Tests for User Story 3 (write first where not already red) ⚠️
 
-- [ ] T017 [P] [US3] Extend src/services/sw-inbox.reactions.test.ts with toggle-independence cases (1:1 off + group on, and inverse) and an explicit shape-equality assertion that every suppressed reaction outcome deep-equals the pre-1048 outcomes for the same frames (guards FR-013: no new outcome class for sw.ts's visible-wake fallback)
-- [ ] T018 [P] [US3] Extend src/services/sw-inbox.badge.test.ts asserting reaction frames keep `wasMessage: false` in every branch (shown, suppressed, silenced) so badge counting is unchanged
-- [ ] T019 [US3] Extend e2e/reaction-notify.spec.ts: toggle `notifications.message.reactions` off via settings ⇒ subsequent reactions show nothing while the chat-list "reacted" preview still updates; toggle back on ⇒ notifications resume (SC-005 dead-controls check)
+- [x] T017 [P] [US3] Extend src/services/sw-inbox.reactions.test.ts with toggle-independence cases (1:1 off + group on, and inverse) and an explicit shape-equality assertion that every suppressed reaction outcome deep-equals the pre-1048 outcomes for the same frames (guards FR-013: no new outcome class for sw.ts's visible-wake fallback)
+- [x] T018 [P] [US3] *(covered in src/services/sw-inbox.reactions.test.ts instead — every branch there asserts `wasMessage: false`, incl. the shown path; sw-inbox.badge.test.ts tests `unreadCount`, which reactions never feed since they don't touch `chat.unread`)* Reaction frames keep `wasMessage: false` in every branch (shown, suppressed, silenced) so badge counting is unchanged
+- [x] T019 [US3] Extend e2e/reaction-notify.spec.ts: toggle `notifications.message.reactions` off via settings ⇒ subsequent reactions show nothing while the chat-list "reacted" preview still updates; toggle back on ⇒ notifications resume (SC-005 dead-controls check)
 
 ### Implementation for User Story 3
 
-- [ ] T020 [US3] Fix any gaps T017–T019 expose in src/services/sw-inbox.ts / src/services/notify.ts / src/db/queries.ts (expected: none — the US1 implementation must already satisfy the contract; this task exists to make red→green explicit if it isn't)
+- [x] T020 [US3] Fix any gaps T017–T019 expose in src/services/sw-inbox.ts / src/services/notify.ts / src/db/queries.ts (expected: none — the US1 implementation must already satisfy the contract; this task exists to make red→green explicit if it isn't)
 
 **Checkpoint**: all three stories green and independently demonstrable
 
@@ -96,8 +96,8 @@
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T021 [P] Note in src/services/notify-policy.ts's `isMention` doc comment that replies-to-you (spec 1048) feed the same flag — no logic change (predicate stays byte-identical; its test file untouched)
-- [ ] T022 [P] Run the quickstart.md drive scenario against `make start` (new throwaway scenario under drive/scenarios/, screenshots to .tmp/drive/) and fix anything it exposes
+- [x] T021 [P] Note in src/services/notify-policy.ts's `isMention` doc comment that replies-to-you (spec 1048) feed the same flag — no logic change (predicate stays byte-identical; its test file untouched)
+- [x] T022 [P] Run the quickstart.md drive scenario against `make start` (new throwaway scenario under drive/scenarios/, screenshots to .tmp/drive/) and fix anything it exposes
 - [ ] T023 Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e` (needs `make db-up`), and `cd server && go build ./... && go vet ./... && go test ./...` (expected no-op — proves no server surface was touched)
 - [ ] T024 Flip spec Status to `in-progress`→`in-review` as work proceeds and run `make roadmap` (CI staleness guard)
 

--- a/specs/1048-notify-reactions-messages/tasks.md
+++ b/specs/1048-notify-reactions-messages/tasks.md
@@ -1,0 +1,128 @@
+# Tasks: Reaction Notifications & Group Reply Escalation
+
+**Input**: Design documents from `/specs/1048-notify-reactions-messages/`
+
+**Prerequisites**: plan.md, spec.md (clarified), research.md, data-model.md, contracts/notification-decisions.md, quickstart.md
+
+**Tests**: INCLUDED and ordered first — TDD is constitutionally mandated (Principle III): failing tests land before the implementation that satisfies them. New user-facing behavior ⇒ e2e coverage required.
+
+**Organization**: grouped by user story; US1 (reactions) is the MVP slice, US2 (reply escalation) is fully independent of US1, US3 (suppression + push health) hardens US1's off-switches.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup (settings surface)
+
+**Purpose**: the one new user-facing control, so every later task can read it
+
+- [ ] T001 Add the `notifications.reactions.sound` choice (options `TONES`, default `'pop'`) as a new link page + entry beside the existing message/group Sound links in src/settings/schema.ts, and extend src/settings/schema.test.ts to cover the key and default
+- [ ] T002 Add `'notifications.reactions.sound'` to `SYNCED_PREF_KEYS` in src/services/ownsync-keys.ts (siblings `notifications.message.reactions` / `notifications.group.reactions` are already listed)
+
+---
+
+## Phase 2: Foundational (shared type extensions)
+
+**Purpose**: interface changes both stories build on; typecheck-only, no behavior yet
+
+- [ ] T003 Extend `IncomingNotice` with optional `reaction?: boolean` and `replied?: boolean` fields (documented per data-model.md) in src/services/notify.ts, and add `reactionSound` to the `NotifyPrefs` cache + `loadPrefs`
+- [ ] T004 [P] Extend `SwNote` with optional `silent?: boolean` in src/services/sw-inbox.ts and thread it into the `showNotification` options at the note-show call sites in src/sw.ts (default unchanged when absent)
+
+**Checkpoint**: `npm run build` passes; zero behavior change
+
+---
+
+## Phase 3: User Story 1 - Know when someone reacts to your message (Priority: P1) 🎯 MVP
+
+**Goal**: an author gets a coalesced, masking-aware, never-escalating notification when someone reacts to their message, in 1:1 and groups, on both delivery paths
+
+**Independent Test**: two accounts; B reacts to A's message → A sees banner (app open) / OS note (app closed) naming B + emoji; a third member's reaction to someone else's message shows nothing
+
+### Tests for User Story 1 (write first, MUST fail) ⚠️
+
+- [ ] T005 [P] [US1] New unit suite src/services/sw-inbox.reactions.test.ts asserting contract Table 1 (specs/1048-notify-reactions-messages/contracts/notification-decisions.md): note built only for own-authored target + toggle on; correct title/body/tag `ring:<chatId>`; `silent` iff tone `'none'`; suppressed rows return today's exact shapes (`{note:null, wasMessage:false}` / `silenced`); remove/not-mine/self/missing-target silent; group vs 1:1 gated by the right toggle; generic content / preview-off fully generic; hidden chat unchanged
+- [ ] T006 [P] [US1] New unit suite src/services/notify.reactions.test.ts for the page path: reaction notice plays `notifications.reactions.sound` (not `messageSound`), `'none'` tone ⇒ banner without tone, active-chat ⇒ suppress + tone only, muted/settle ⇒ suppress (no escalation), masked content ⇒ generic body, and `chat.unread`/`unreadMentions` untouched
+- [ ] T007 [P] [US1] New e2e spec e2e/reaction-notify.spec.ts (live-page path, per quickstart.md): B reacts to A's message ⇒ A's banner shows "reacted ❤️"; A viewing the chat ⇒ no banner; reaction to C's message ⇒ nothing for A; reaction removal ⇒ nothing; burst of reactions ⇒ single coalesced banner (dedup by target)
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] Dispatch the reaction notification from `handleReaction` in src/db/queries.ts: on add (not remove), target own-authored (`m.outgoing || m.senderId === 'me'`), reactor ≠ self, gated by `chat.isGroup ? 'notifications.group.reactions' : 'notifications.message.reactions'` → `notifyIncoming({kind:'message', reaction:true, chatId, msgId, name, body: "<first-name> reacted <emoji> to: <previewText(m)>", pushWoken})`; never touch unread counters
+- [ ] T009 [US1] Handle `reaction: true` notices in `notifyIncoming` in src/services/notify.ts: always `isMention:false`, reaction tone via `inAppSound` variant, masked content ⇒ fully generic body (reactor not named), otherwise existing banner flow (coalescing by target URL already applies)
+- [ ] T010 [US1] Build reaction notes in `buildNote` in src/services/sw-inbox.ts: replace the silent lump for `payload.reaction` with the Table 1 decision (read-only `get<Message>('messages', id)`, self id via existing session helper, toggles + per-chat prefs + hidden + mute exactly as the contract table; suppressed rows return today's shapes; tag `ring:<chatId>`; `silent` from the tone setting); poll votes/edits/erase/rekey/ttl stay silent side effects
+
+**Checkpoint**: T005–T007 green; `npm run build` + full `npx vitest run` green — MVP demoable via quickstart drive scenario
+
+---
+
+## Phase 4: User Story 2 - A reply to you cuts through a muted group (Priority: P2)
+
+**Goal**: a direct reply to one of YOUR messages in a group escalates exactly like an @mention (same pref, same silencer set), names the replier under masked content, and counts in the unread-mentions indicator
+
+**Independent Test**: A mutes a group; B replies to A's message ⇒ A is notified + `@` indicator; B replies to C's message ⇒ A stays silent; `notifyMentions` off ⇒ ordinary message
+
+### Tests for User Story 2 (write first, MUST fail) ⚠️
+
+- [ ] T011 [P] [US2] Extend src/services/sw-inbox.test.ts (mention/escalation block) with contract Table 2 cases: `payload.reply.senderId === selfId` in a muted group ⇒ note despite mute with "replied to you" wording under masked content; `notifyMentions` off ⇒ ordinary handling; reply to someone else / 1:1 reply ⇒ no escalation; reply that also mentions me ⇒ ONE note with mention wording
+- [ ] T012 [P] [US2] New unit coverage for the page path (extend src/services/notify.reactions.test.ts or a sibling notify.replies.test.ts in src/services/): `replied: true` notice escalates past mute/in-app-off/content-none/settle exactly like `mention: true`, body "«name» replied to you" when masked, and both flags together render mention wording once
+- [ ] T013 [P] [US2] Extend e2e/mentions.spec.ts: reply-to-A's-message in a muted group surfaces A's banner and bumps the chat's unread-mentions indicator, cleared on read; with the chat's mentions pref off the reply is suppressed like any muted message
+
+### Implementation for User Story 2
+
+- [ ] T014 [US2] Compute `selfRepliedTo` (`isGroupMsg && payload.reply?.senderId === selfId`) beside `selfMentioned` in the receive path of src/db/queries.ts; feed `unreadMentions` increment and pass `replied: selfRepliedTo` + existing `mention`/`mentionName` through `notifyIncoming`
+- [ ] T015 [US2] Escalate `replied` notices in src/services/notify.ts: fold into the existing `isMention` computation (gated by `chatPrefs.mentions`), wording "«mentionName» replied to you" when masked with mention wording taking precedence when both flags set
+- [ ] T016 [US2] Escalate replies in `buildNote` in src/services/sw-inbox.ts: widen the `selfMentioned` check with `payload.reply?.senderId === selfId` (same `chat?.notifyMentions !== false` gate, hidden still wins), body "«sender» replied to you[: preview]" with mention wording when both apply
+
+**Checkpoint**: T011–T013 green; US1 suites still green
+
+---
+
+## Phase 5: User Story 3 - Turning it off really turns it off, without breaking push (Priority: P3)
+
+**Goal**: the two reaction toggles are independently effective, every suppressed delivery still ends the wake visibly (FR-013), and no unread/badge state changes leak in
+
+**Independent Test**: toggles off ⇒ zero reaction notifications while deliveries continue; suppressed outcomes are byte-identical to today's shapes so the spec-2016/2017/2023 fallback applies
+
+### Tests for User Story 3 (write first where not already red) ⚠️
+
+- [ ] T017 [P] [US3] Extend src/services/sw-inbox.reactions.test.ts with toggle-independence cases (1:1 off + group on, and inverse) and an explicit shape-equality assertion that every suppressed reaction outcome deep-equals the pre-1048 outcomes for the same frames (guards FR-013: no new outcome class for sw.ts's visible-wake fallback)
+- [ ] T018 [P] [US3] Extend src/services/sw-inbox.badge.test.ts asserting reaction frames keep `wasMessage: false` in every branch (shown, suppressed, silenced) so badge counting is unchanged
+- [ ] T019 [US3] Extend e2e/reaction-notify.spec.ts: toggle `notifications.message.reactions` off via settings ⇒ subsequent reactions show nothing while the chat-list "reacted" preview still updates; toggle back on ⇒ notifications resume (SC-005 dead-controls check)
+
+### Implementation for User Story 3
+
+- [ ] T020 [US3] Fix any gaps T017–T019 expose in src/services/sw-inbox.ts / src/services/notify.ts / src/db/queries.ts (expected: none — the US1 implementation must already satisfy the contract; this task exists to make red→green explicit if it isn't)
+
+**Checkpoint**: all three stories green and independently demonstrable
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T021 [P] Note in src/services/notify-policy.ts's `isMention` doc comment that replies-to-you (spec 1048) feed the same flag — no logic change (predicate stays byte-identical; its test file untouched)
+- [ ] T022 [P] Run the quickstart.md drive scenario against `make start` (new throwaway scenario under drive/scenarios/, screenshots to .tmp/drive/) and fix anything it exposes
+- [ ] T023 Full gates: `npm run build`, `npx vitest run` (coverage floors), `npm run test:e2e` (needs `make db-up`), and `cd server && go build ./... && go vet ./... && go test ./...` (expected no-op — proves no server surface was touched)
+- [ ] T024 Flip spec Status to `in-progress`→`in-review` as work proceeds and run `make roadmap` (CI staleness guard)
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (P1)**: T001–T002 first (T001 → T002 touch different files, may run [P] in practice)
+- **Foundational (P2)**: T003–T004 after setup; **blocks all stories** (types must exist for tests to compile)
+- **US1 (P3)**: T005–T007 (parallel, different files) → T008–T010 (T009 and T010 parallel after T008's notice shape exists)
+- **US2 (P4)**: independent of US1 code-wise but shares files — run after US1 to avoid same-file conflicts; T011–T013 (parallel) → T014 → T015–T016 (parallel)
+- **US3 (P5)**: after US1 (it hardens US1 behavior); T017–T019 (parallel) → T020
+- **Polish (P6)**: T021–T022 parallel; T023 after everything; T024 bookkeeping
+
+### Parallel opportunities
+
+- All test-first tasks within a story ([P] marked) — different files
+- T009 ‖ T010 (page vs SW), T015 ‖ T016 (same split)
+- T021 ‖ T022 in polish
+
+---
+
+## Implementation Strategy
+
+MVP = Phases 1–3 (US1): reaction notifications shipped-quality behind the existing toggles.
+Then US2 (independent feature), then US3 (hardening, mostly test-enforced). Stop at any
+checkpoint to validate; each story is demoable through the quickstart drive scenario.
+Commit after each task or logical group (`test(notify): …` red commits are fine).

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -701,7 +701,11 @@ export async function reactToMessage(
 }
 
 /** Apply an inbound reaction from `from` to the target message (side effect,
- *  never a stored message). */
+ *  never a stored message). A reaction ADD to one of MY OWN messages also alerts
+ *  me (spec 1048) — gated by the per-surface toggles, dispatched through
+ *  notifyIncoming so mute / per-chat prefs / hidden / settle all apply and the
+ *  alert can NEVER escalate (a reaction is not a mention). Deliberately no unread
+ *  or badge change: a reaction is not a message (spec 1048 clarification). */
 async function handleReaction(from: string, signal: ReactionSignal): Promise<void> {
   const message = await getMessage(signal.messageId);
   if (!message) return; // we don't have that message (yet), drop it
@@ -717,6 +721,35 @@ async function handleReaction(from: string, signal: ReactionSignal): Promise<voi
       chat.lastMessageTime = signal.at;
       chat.updatedAt = signal.at;
       await put('chats', chat);
+
+      const selfId = getSelfUserId() ?? '';
+      const mine = message.outgoing || message.senderId === 'me';
+      if (mine && from !== selfId) {
+        const enabled = await getSetting<boolean>(
+          chat.isGroup ? 'notifications.group.reactions' : 'notifications.message.reactions',
+          true,
+        );
+        if (enabled) {
+          const first = name.split(' ')[0];
+          const quote = previewText(message);
+          // 1:1: the title already names the reactor, so the body starts at the verb;
+          // groups: the title is the group, so the body names who reacted.
+          const line = chat.isGroup
+            ? quote ? `${first} reacted ${signal.emoji} to: ${quote}` : `${first} reacted ${signal.emoji} to your message`
+            : quote ? `Reacted ${signal.emoji} to: ${quote}` : `Reacted ${signal.emoji} to your message`;
+          // Same awaited-but-swallowed contract as the message dispatch (spec 1015):
+          // a notify error must never block the ack/dedup that follow.
+          await notifyIncoming({
+            kind: 'message',
+            reaction: true,
+            chatId: chat.id,
+            msgId: message.id,
+            name: chat.isGroup ? chat.name : name,
+            body: line,
+            pushWoken: pushWakeActive(),
+          }).catch(() => {});
+        }
+      }
     }
   }
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -6046,6 +6046,12 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     isGroupMsg &&
     (!!payload.mentions?.includes(selfId) ||
       (!!payload.mentionsEveryone && !!chat?.createdBy && from === chat.createdBy));
+  // Replies-to-me (spec 1048): a group message that directly replies to a message I
+  // authored is an implicit mention — the sender snapshots the quoted author into
+  // reply.senderId (types.ts ReplyRef), so this is a plain comparison, robust even
+  // when the quoted message was deleted locally. Escalates + counts exactly like a
+  // mention, gated by the same per-chat notifyMentions pref downstream.
+  const selfRepliedTo = isGroupMsg && !!selfId && payload.reply?.senderId === selfId;
   if (chat) {
     // Group previews show the sender's first name (WhatsApp-style).
     chat.lastMessage = isGroupMsg ? `${contact.name.split(' ')[0]}: ${preview}` : preview;
@@ -6056,7 +6062,8 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     // (the open chat sends the read receipt), so don't grow the unread badge.
     const active = isChatActive(targetChatId);
     chat.unread = active ? 0 : (chat.unread ?? 0) + 1;
-    if (selfMentioned && !active) chat.unreadMentions = (chat.unreadMentions ?? 0) + 1;
+    // A mention OR a reply-to-me lights the unread-mentions indicator (spec 1048).
+    if ((selfMentioned || selfRepliedTo) && !active) chat.unreadMentions = (chat.unreadMentions ?? 0) + 1;
     // A new message pulls an archived chat back to the main list, UNLESS the user has
     // "Keep chats archived" on (chats.keepArchived). Locked chats stay put regardless.
     if (chat.archived && !chat.locked && !(await getSetting<boolean>('chats.keepArchived', false))) {
@@ -6084,7 +6091,9 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     // on), unlike the terser `preview` used for the chats list above.
     body: isGroupMsg ? `${contact.name}: ${notifyPreview(payload)}` : notifyPreview(payload) || 'New message',
     // @mentions (spec 1020): a mention escalates past mute/quiet and names the mentioner.
+    // A direct reply to my message (spec 1048) escalates identically, with its own wording.
     mention: selfMentioned,
+    replied: selfRepliedTo,
     mentionName: contact.name,
     // A ring:drain push woke us to fetch this → bypass the post-unlock settle window
     // and let the SW (which already fired for that push) own the OS notification, so

--- a/src/services/notify-policy.ts
+++ b/src/services/notify-policy.ts
@@ -54,7 +54,10 @@ export interface NotifyInput {
      *  alert escalates past the per-chat silencers — mute, in-app-off, content=none,
      *  web-push-off, and the settle window — while the structural gates (locked,
      *  active-chat) and the GLOBAL "Show notifications" master + OS DND (enforced by
-     *  the caller before this runs) still hold. Computed by each caller (page + SW). */
+     *  the caller before this runs) still hold. Computed by each caller (page + SW).
+     *  Spec 1048 widened what FEEDS this flag: a direct reply to a message the user
+     *  authored is an implicit mention (same pref, same silencer set) — the callers
+     *  pass mention-or-replied here, so this predicate stays byte-identical. */
     isMention?: boolean;
   };
 }

--- a/src/services/notify.reactions.test.ts
+++ b/src/services/notify.reactions.test.ts
@@ -1,0 +1,202 @@
+// Spec 1048 (US1/US2) — the PAGE-side dispatch for reaction alerts and reply-to-you
+// escalation. Reactions use their own tone and never escalate; replies escalate
+// exactly like mentions (same pref, same silencer set) with "replied to you" wording.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  notifyLocal: vi.fn(),
+  tones: vi.fn(),
+  settings: new Map<string, unknown>(),
+  muted: new Set<string>(),
+  chatPrefs: null as null | { webPush: boolean; inApp: boolean; content: string; mentions: boolean },
+  // notify.ts hydrates its prefs cache once and refreshes on the settings change
+  // bus; capture that subscription so tests can drive the refresh after mutating
+  // h.settings (otherwise a tone set in one test leaks into the next).
+  onSettings: undefined as undefined | (() => void),
+}));
+
+vi.mock('@ionic/vue', () => ({ alertController: { create: vi.fn() } }));
+vi.mock('@/router', () => ({ default: { push: vi.fn(), currentRoute: { value: { path: '/' } } } }));
+vi.mock('@/db/queries', () => ({
+  getSetting: async (key: string, fallback: unknown) => h.settings.get(key) ?? fallback,
+  isChatMuted: async (id: string) => h.muted.has(id),
+  getChat: async () => undefined,
+}));
+vi.mock('@/db/idb', () => ({
+  subscribe: (_stores: unknown, cb: () => void) => {
+    h.onSettings = cb;
+    return () => {};
+  },
+  touch: () => {},
+}));
+vi.mock('@/services/push', () => ({ notifyLocal: h.notifyLocal, pushSubscriptionActive: async () => false }));
+vi.mock('@/services/sw-inbox', () => ({ recordPageShown: vi.fn() }));
+vi.mock('@/services/notify-prefs', () => ({
+  inAppGloballyEnabled: async () => true,
+  getChatNotifyPrefs: async () => h.chatPrefs,
+}));
+vi.mock('@/services/crypto/identity', () => ({
+  isUnlockedNow: () => true,
+  isUnlocked: { value: true },
+}));
+vi.mock('@/services/sound', () => ({ playTone: h.tones }));
+
+import { notifyIncoming, notifyBanners, setActiveChat, deferNotificationsFor } from './notify';
+import { registerHiddenLoader, clearHiddenState } from './hidden-state';
+
+const g = globalThis as { document?: { visibilityState: string } };
+
+/** Flush the current h.settings into notify.ts's hydrated prefs cache. */
+async function refreshPrefs(): Promise<void> {
+  h.onSettings?.();
+  await new Promise((r) => setTimeout(r));
+}
+
+beforeEach(async () => {
+  h.notifyLocal.mockClear();
+  h.tones.mockClear();
+  h.settings.clear();
+  h.muted.clear();
+  h.chatPrefs = null;
+  notifyBanners.value = [];
+  setActiveChat(null);
+  deferNotificationsFor(0);
+  clearHiddenState();
+  registerHiddenLoader(async () => new Set<string>());
+  g.document = { visibilityState: 'visible' }; // foregrounded by default
+  h.settings.set('notifications.inapp.sounds', true); // make tones observable
+  await refreshPrefs();
+});
+
+afterEach(() => {
+  delete g.document;
+});
+
+const reactionNotice = (over: Record<string, unknown> = {}) =>
+  ({
+    kind: 'message',
+    reaction: true,
+    chatId: 'c1',
+    msgId: 'm1',
+    name: 'Alice Smith',
+    body: 'Reacted ❤️ to: hi there',
+    ...over,
+  }) as never;
+
+const replyNotice = (over: Record<string, unknown> = {}) =>
+  ({
+    kind: 'message',
+    replied: true,
+    mentionName: 'Alice Smith',
+    chatId: 'g1',
+    msgId: 'm2',
+    name: 'Team',
+    body: 'Alice Smith: sure, tomorrow works',
+    ...over,
+  }) as never;
+
+describe('spec 1048 US1 — reaction alerts on the page path', () => {
+  it('foregrounded on another screen: banner with the reaction body + the REACTION tone', async () => {
+    h.settings.set('notifications.message.sound', 'note');
+    h.settings.set('notifications.reactions.sound', 'chime');
+    await refreshPrefs();
+    const presented = await notifyIncoming(reactionNotice());
+    expect(presented).toBe(true);
+    expect(notifyBanners.value).toHaveLength(1);
+    expect(notifyBanners.value[0].body).toBe('Reacted ❤️ to: hi there');
+    expect(h.tones).toHaveBeenCalledWith('chime');
+    expect(h.tones).not.toHaveBeenCalledWith('note');
+  });
+
+  it('defaults to the subtle pop tone (not the message tone)', async () => {
+    await notifyIncoming(reactionNotice());
+    expect(h.tones).toHaveBeenCalledWith('pop');
+  });
+
+  it("reaction tone 'none': the banner still shows, silently", async () => {
+    h.settings.set('notifications.reactions.sound', 'none');
+    await refreshPrefs();
+    const presented = await notifyIncoming(reactionNotice());
+    expect(presented).toBe(true);
+    expect(notifyBanners.value).toHaveLength(1);
+    // playTone('none') is a no-op by contract; nothing else may fire either.
+    for (const call of h.tones.mock.calls) expect(call[0]).toBe('none');
+  });
+
+  it('viewing the reacted chat: no banner, just the subtle reaction tone', async () => {
+    setActiveChat('c1');
+    const presented = await notifyIncoming(reactionNotice());
+    expect(presented).toBe(false);
+    expect(notifyBanners.value).toHaveLength(0);
+    expect(h.tones).toHaveBeenCalledWith('pop');
+  });
+
+  it('muted chat: fully silent — a reaction never escalates past mute', async () => {
+    h.muted.add('c1');
+    const presented = await notifyIncoming(reactionNotice());
+    expect(presented).toBe(false);
+    expect(notifyBanners.value).toHaveLength(0);
+    expect(h.tones).not.toHaveBeenCalled();
+  });
+
+  it('settle window damps a non-woken reaction like any backlog item', async () => {
+    deferNotificationsFor(60_000);
+    const presented = await notifyIncoming(reactionNotice({ pushWoken: false }));
+    expect(presented).toBe(false);
+    expect(notifyBanners.value).toHaveLength(0);
+  });
+
+  it("per-chat content 'generic': the banner masks the reaction text", async () => {
+    h.chatPrefs = { webPush: true, inApp: true, content: 'generic', mentions: true };
+    await notifyIncoming(reactionNotice());
+    expect(notifyBanners.value[0]?.body).toBe('New message');
+  });
+
+  it('backgrounded (no push subscription): bridges the local notification like a message', async () => {
+    g.document = { visibilityState: 'hidden' };
+    const presented = await notifyIncoming(reactionNotice({ msgId: undefined }));
+    expect(presented).toBe(false);
+    expect(h.notifyLocal).toHaveBeenCalled();
+    expect(h.notifyLocal.mock.calls[0][1]).toContain('Reacted ❤️');
+  });
+});
+
+describe('spec 1048 US2 — reply-to-you escalation on the page path', () => {
+  it('escalates past mute exactly like a mention', async () => {
+    h.muted.add('g1');
+    const presented = await notifyIncoming(replyNotice());
+    expect(presented).toBe(true);
+    expect(notifyBanners.value).toHaveLength(1);
+  });
+
+  it('masked content names the replier: "… replied to you"', async () => {
+    h.muted.add('g1');
+    h.chatPrefs = { webPush: true, inApp: true, content: 'none', mentions: true };
+    await notifyIncoming(replyNotice());
+    expect(notifyBanners.value[0]?.body).toBe('Alice Smith replied to you');
+  });
+
+  it('the per-chat mentions pref gates it: off → the reply is an ordinary muted message', async () => {
+    h.muted.add('g1');
+    h.chatPrefs = { webPush: true, inApp: true, content: 'full', mentions: false };
+    const presented = await notifyIncoming(replyNotice());
+    expect(presented).toBe(false);
+    expect(notifyBanners.value).toHaveLength(0);
+  });
+
+  it('reply + mention together render the mention wording once', async () => {
+    h.muted.add('g1');
+    h.chatPrefs = { webPush: true, inApp: true, content: 'none', mentions: true };
+    await notifyIncoming(replyNotice({ mention: true }));
+    expect(notifyBanners.value).toHaveLength(1);
+    expect(notifyBanners.value[0]?.body).toBe('Alice Smith mentioned you');
+  });
+
+  it('a reply uses the MESSAGE tone (it is a message, not a reaction)', async () => {
+    h.settings.set('notifications.message.sound', 'note');
+    h.settings.set('notifications.reactions.sound', 'chime');
+    await refreshPrefs();
+    await notifyIncoming(replyNotice());
+    expect(h.tones).toHaveBeenCalledWith('note');
+  });
+});

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -40,6 +40,7 @@ interface NotifyPrefs {
   showPreview: boolean;
   inappSounds: boolean;
   messageSound: string;
+  reactionSound: string; // dedicated reaction tone (spec 1048); 'none' = visible but silent
   inappStyle: string;
 }
 const PREF_DEFAULTS: NotifyPrefs = {
@@ -47,20 +48,22 @@ const PREF_DEFAULTS: NotifyPrefs = {
   showPreview: true,
   inappSounds: false,
   messageSound: 'note',
+  reactionSound: 'pop',
   inappStyle: 'banners',
 };
 let prefs: NotifyPrefs = { ...PREF_DEFAULTS };
 let prefsHydrated = false;
 
 async function loadPrefs(): Promise<void> {
-  const [showMessages, showPreview, inappSounds, messageSound, inappStyle] = await Promise.all([
+  const [showMessages, showPreview, inappSounds, messageSound, reactionSound, inappStyle] = await Promise.all([
     getSetting<boolean>('notifications.message.show', PREF_DEFAULTS.showMessages),
     getSetting<boolean>('notifications.showPreview', PREF_DEFAULTS.showPreview),
     getSetting<boolean>('notifications.inapp.sounds', PREF_DEFAULTS.inappSounds),
     getSetting<string>('notifications.message.sound', PREF_DEFAULTS.messageSound),
+    getSetting<string>('notifications.reactions.sound', PREF_DEFAULTS.reactionSound),
     getSetting<string>('notifications.inapp.style', PREF_DEFAULTS.inappStyle),
   ]);
-  prefs = { showMessages, showPreview, inappSounds, messageSound, inappStyle };
+  prefs = { showMessages, showPreview, inappSounds, messageSound, reactionSound, inappStyle };
 }
 
 async function ensurePrefs(): Promise<NotifyPrefs> {
@@ -104,6 +107,16 @@ export interface IncomingNotice {
   // mute/quiet, and the banner names the mentioner even under a masked content level.
   mention?: boolean;
   mentionName?: string; // who mentioned me (the sender's display name)
+  // Reaction alert (spec 1048): someone reacted to MY message. Plays the dedicated
+  // reaction tone instead of the message tone, NEVER escalates (unlike a mention),
+  // and masks to a fully generic body under restricted content (the reactor is not
+  // named — reactions carry no opt-in escalation the way mentions do).
+  reaction?: boolean;
+  // Reply-to-me (spec 1048): a group message that directly replies to one of MY
+  // messages. Escalates exactly like a mention (same per-chat pref, same silencer
+  // set) with "replied to you" wording; `mentionName` names the replier. When a
+  // message both mentions AND replies, mention wording wins (one notification).
+  replied?: boolean;
 }
 
 /* ---- in-app notification banners (custom green overlay; see NotificationBanners.vue) ---- */

--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -363,10 +363,13 @@ function targetUrl(n: IncomingNotice): string {
   return '/tabs/contacts'; // request
 }
 
-async function inAppSound(): Promise<void> {
+/** Play the in-app tone for a notice. Reactions carry their own dedicated tone
+ *  (spec 1048) so a burst of hearts never sounds like a burst of messages;
+ *  everything else uses the message tone. playTone no-ops on 'none'. */
+async function inAppSound(tone?: string): Promise<void> {
   const p = await ensurePrefs();
   if (p.inappSounds) {
-    playTone(p.messageSound);
+    playTone(tone ?? p.messageSound);
   }
 }
 
@@ -415,11 +418,20 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
       inAppGloballyEnabled(),
     ]);
     const content = chatPrefs?.content ?? 'full';
-    // @mentions (spec 1020): escalate only when this message mentions me AND the chat's
-    // "mentions even when muted" pref is on. The global master (p.showMessages, checked
-    // above) + OS DND still gate everything.
-    const isMention = !!n.mention && (chatPrefs?.mentions ?? true);
-    const mentionBody = `${n.mentionName ?? 'Someone'} mentioned you`;
+    // @mentions (spec 1020) + replies-to-you (spec 1048): escalate only when this
+    // message is personally directed at me AND the chat's "mentions even when muted"
+    // pref is on — a direct reply to my message is an implicit mention, gated by the
+    // SAME pref so there is one dial for "personally-directed pierces mute". The
+    // global master (p.showMessages, checked above) + OS DND still gate everything.
+    // A reaction notice never sets mention/replied, so it can never escalate.
+    const isMention = !!(n.mention || n.replied) && (chatPrefs?.mentions ?? true);
+    // Wording: an explicit @mention wins over the implicit reply variant when a
+    // message is both (one notification either way — it's one message).
+    const mentionBody = n.mention
+      ? `${n.mentionName ?? 'Someone'} mentioned you`
+      : `${n.mentionName ?? 'Someone'} replied to you`;
+    // The reaction tone (spec 1048): dedicated + subtle; undefined = message tone.
+    const noticeTone = n.reaction ? p.reactionSound : undefined;
     const owner = notificationOwner({
       appVisible: appVisible(),
       unlocked: true, // isUnlockedNow() was checked above
@@ -440,7 +452,7 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
       // Viewing this chat while visible → still give a subtle sound (the user sees
       // the message inline). Every other suppress reason (muted / content=none /
       // in-app off / settle-swallowed) is fully silent.
-      if (n.chatId && n.chatId === activeChatId && appVisible()) await inAppSound();
+      if (n.chatId && n.chatId === activeChatId && appVisible()) await inAppSound(noticeTone);
       return false;
     }
     if (owner === 'sw-notification') {
@@ -484,7 +496,7 @@ export async function notifyIncoming(n: IncomingNotice): Promise<boolean> {
 
     // owner === 'page-banner': show the in-app banner/alert.
     const showFull = content === 'full' && p.showPreview;
-    await inAppSound();
+    await inAppSound(noticeTone);
     if (p.inappStyle === 'none') return false; // sound only; no visible surface
     const url = targetUrl(n);
     const bodyText = showFull ? n.body : isMention ? mentionBody : 'New message';

--- a/src/services/ownsync-keys.ts
+++ b/src/services/ownsync-keys.ts
@@ -18,6 +18,8 @@ export const SYNCED_PREF_KEYS: string[] = [
   'privacy.relayCalls',
   'notifications.message.show', 'notifications.message.reactions', 'notifications.message.sound',
   'notifications.group.show', 'notifications.group.reactions', 'notifications.group.sound',
+  // Reaction alert tone (spec 1048): a preference like its siblings, follows the user.
+  'notifications.reactions.sound',
   'notifications.wall.show', 'notifications.wall.activity', 'notifications.showPreview', 'notifications.badge',
   // Game notifications (spec 0009). Deliberately NOT games.follows — the follow
   // set is device-local and private by spec FR-006.

--- a/src/services/sw-inbox.reactions.test.ts
+++ b/src/services/sw-inbox.reactions.test.ts
@@ -1,0 +1,195 @@
+// Spec 1048 (US1/US3): the SW builds a notification for a reaction to MY message —
+// and ONLY then. These tests pin contract Table 1
+// (specs/1048-notify-reactions-messages/contracts/notification-decisions.md): who
+// gets a note, how it masks, and — critically for push health (FR-013) — that every
+// suppressed outcome keeps the exact pre-1048 shape `{note:null, wasMessage:false}`,
+// so the established visible-wake fallback (specs 2016/2017/2023) applies unchanged.
+import { describe, it, expect } from 'vitest';
+import { noteForPayload } from './sw-inbox';
+import type { Chat, Contact, Message } from '@/db/types';
+import type { MessagePayload } from './crypto/message';
+
+const SELF = 'self-1';
+const PEER = 'peer-1';
+
+const contacts = [{ id: PEER, name: 'Alice Smith' }] as unknown as Contact[];
+
+const dmChat = { id: 'c1', isGroup: false, participantIds: [PEER], name: 'Alice Smith' } as unknown as Chat;
+const groupChat = { id: 'g1', isGroup: true, participantIds: [PEER, 'peer-2'], name: 'Team' } as unknown as Chat;
+
+/** My own stored message (the reaction target). */
+const myMsg = (over: Partial<Message> = {}): Message =>
+  ({ id: 'm1', chatId: 'c1', senderId: 'me', outgoing: true, body: 'hi there', timestamp: 1, updatedAt: 1, ...over }) as Message;
+
+const frame = { t: 'msg', id: 'f1', from: PEER };
+
+const reaction = (over: Record<string, unknown> = {}): MessagePayload =>
+  ({ body: '', kind: 'reaction', timestamp: 2, reaction: { messageId: 'm1', emoji: '❤️', remove: false, at: 2 }, ...over }) as MessagePayload;
+
+type Ctx = { row?: Message; prefs?: { dm: boolean; group: boolean; tone: string } };
+const ctx = (over: Partial<Ctx> = {}): Ctx => ({ row: myMsg(), prefs: { dm: true, group: true, tone: 'pop' }, ...over });
+
+/** The pre-1048 outcome for every reaction frame — suppressed cases must keep it EXACTLY. */
+const SILENT_SIDE_EFFECT = { note: null, wasMessage: false };
+
+function run(
+  payload: MessagePayload,
+  chats: Chat[],
+  rc: Ctx | undefined,
+  opts: { showMessages?: boolean; showPreview?: boolean; hidden?: Set<string>; selfId?: string } = {},
+) {
+  return noteForPayload(
+    frame,
+    payload,
+    chats,
+    contacts,
+    opts.showMessages ?? true,
+    opts.showPreview ?? true,
+    opts.hidden ?? new Set(),
+    opts.selfId ?? SELF,
+    undefined,
+    rc,
+  );
+}
+
+describe('spec 1048 US1 — reaction notes (SW path, contract Table 1)', () => {
+  it('1:1 reaction to my message → note under the chat tag, reactor tone not silent', () => {
+    const r = run(reaction(), [dmChat], ctx());
+    expect(r.wasMessage).toBe(false);
+    expect(r.note).toMatchObject({
+      title: 'Alice Smith',
+      body: 'Reacted ❤️ to: hi there',
+      url: '/chat/c1',
+      tag: 'ring:c1',
+    });
+    expect(r.note?.silent).toBeFalsy();
+  });
+
+  it('group reaction names the reactor in the body, group name in the title', () => {
+    const r = run(reaction({ groupId: 'g1' }), [groupChat], ctx({ row: myMsg({ chatId: 'g1' }) }));
+    expect(r.note).toMatchObject({
+      title: 'Team',
+      body: 'Alice reacted ❤️ to: hi there',
+      tag: 'ring:g1',
+      url: '/chat/g1',
+    });
+  });
+
+  it("tone 'none' → the note shows but is silent (visible wake, no sound)", () => {
+    const r = run(reaction(), [dmChat], ctx({ prefs: { dm: true, group: true, tone: 'none' } }));
+    expect(r.note).not.toBeNull();
+    expect(r.note?.silent).toBe(true);
+  });
+
+  it('a media target (no body text) still reads naturally', () => {
+    const r = run(reaction(), [dmChat], ctx({ row: myMsg({ body: '' }) }));
+    expect(r.note?.body).toBe('Reacted ❤️ to your message');
+  });
+
+  it('long target text is truncated to a short snippet', () => {
+    const long = 'x'.repeat(200);
+    const r = run(reaction(), [dmChat], ctx({ row: myMsg({ body: long }) }));
+    expect((r.note?.body ?? '').length).toBeLessThan(120);
+  });
+});
+
+describe('spec 1048 US1 — never-notify set (FR-006): silent side effects keep the pre-1048 shape', () => {
+  it('reaction REMOVAL stays silent', () => {
+    const p = reaction();
+    (p.reaction as { remove?: boolean }).remove = true;
+    expect(run(p, [dmChat], ctx())).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it("a reaction to someone ELSE's message stays silent", () => {
+    expect(run(reaction(), [dmChat], ctx({ row: myMsg({ senderId: PEER, outgoing: false }) }))).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it('my own reaction echoed from my other device stays silent', () => {
+    const r = noteForPayload(
+      { ...frame, from: SELF },
+      reaction(),
+      [dmChat],
+      contacts,
+      true,
+      true,
+      new Set(),
+      SELF,
+      undefined,
+      ctx(),
+    );
+    expect(r).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it('an unresolvable target (deleted / not yet arrived) stays silent — no orphan note', () => {
+    expect(run(reaction(), [dmChat], ctx({ row: undefined }))).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it('no prefetched context at all (e.g. a deferring drain path) stays silent', () => {
+    expect(run(reaction(), [dmChat], undefined)).toEqual(SILENT_SIDE_EFFECT);
+  });
+});
+
+describe('spec 1048 US1/US3 — suppression layers (FR-005): reactions NEVER escalate', () => {
+  it('1:1 toggle off → silent, exact pre-1048 shape', () => {
+    expect(run(reaction(), [dmChat], ctx({ prefs: { dm: false, group: true, tone: 'pop' } }))).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it('group toggle off → silent for the group reaction', () => {
+    const r = run(reaction({ groupId: 'g1' }), [groupChat], ctx({ row: myMsg({ chatId: 'g1' }), prefs: { dm: true, group: false, tone: 'pop' } }));
+    expect(r).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it('the toggles are independent: 1:1 off leaves group reactions alerting (and vice versa)', () => {
+    const dmOff = { dm: false, group: true, tone: 'pop' };
+    expect(run(reaction({ groupId: 'g1' }), [groupChat], ctx({ row: myMsg({ chatId: 'g1' }), prefs: dmOff })).note).not.toBeNull();
+    const groupOff = { dm: true, group: false, tone: 'pop' };
+    expect(run(reaction(), [dmChat], ctx({ prefs: groupOff })).note).not.toBeNull();
+  });
+
+  it('muted chat → silent (a reaction never pierces mute, unlike a mention)', () => {
+    const muted = { ...dmChat, mutedUntil: Date.now() + 60_000 } as Chat;
+    expect(run(reaction(), [muted], ctx())).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it('per-chat web push off → silent', () => {
+    const off = { ...dmChat, notifyWebPush: false } as Chat;
+    expect(run(reaction(), [off], ctx())).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it("content 'none' (badge-only chat) → silent", () => {
+    const none = { ...dmChat, notifyContent: 'none' } as Chat;
+    expect(run(reaction(), [none], ctx())).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it('hidden chat → traceless, exactly as today', () => {
+    expect(run(reaction(), [dmChat], ctx(), { hidden: new Set(['c1']) })).toEqual(SILENT_SIDE_EFFECT);
+  });
+
+  it('global "Show notifications" off → silent', () => {
+    expect(run(reaction(), [dmChat], ctx(), { showMessages: false })).toEqual(SILENT_SIDE_EFFECT);
+  });
+});
+
+describe('spec 1048 US1 — content masking (FR-002/SC-006)', () => {
+  it("per-chat content 'generic' → generic body, chat still named", () => {
+    const generic = { ...dmChat, notifyContent: 'generic' } as Chat;
+    const r = run(reaction(), [generic], ctx());
+    expect(r.note?.body).toBe('New message');
+    expect(r.note?.title).toBe('Alice Smith');
+  });
+
+  it('global preview off → fully generic (no reactor, no text)', () => {
+    const r = run(reaction(), [dmChat], ctx(), { showPreview: false });
+    expect(r.note?.title).toBe('Ring');
+    expect(r.note?.body).toBe('New message');
+  });
+});
+
+describe('spec 1048 — the OTHER side-effect signals stay silent (regression guard)', () => {
+  it('poll votes / edits / erases are untouched by the reaction branch', () => {
+    for (const extra of [{ pollVote: { messageId: 'm1', option: 0 } }, { edit: { messageId: 'm1', body: 'x' } }, { erase: { messageId: 'm1' } }]) {
+      const p = { body: '', kind: 'text', timestamp: 2, ...extra } as unknown as MessagePayload;
+      expect(run(p, [dmChat], ctx())).toEqual(SILENT_SIDE_EFFECT);
+    }
+  });
+});

--- a/src/services/sw-inbox.replies.test.ts
+++ b/src/services/sw-inbox.replies.test.ts
@@ -1,0 +1,96 @@
+// Spec 1048 (US2): a group message that directly REPLIES to one of my messages is
+// personally directed — the SW escalates it exactly like an @mention (spec 1020):
+// same notifyMentions gate, same silencer set, "replied to you" wording. These pin
+// contract Table 2 (specs/1048-notify-reactions-messages/contracts/).
+import { describe, it, expect } from 'vitest';
+import { noteForPayload } from './sw-inbox';
+import type { Chat, Contact } from '@/db/types';
+import type { MessagePayload } from './crypto/message';
+
+const SELF = 'self-1';
+const PEER = 'peer-1';
+
+const contacts = [{ id: PEER, name: 'Alice Smith' }] as unknown as Contact[];
+const frame = { t: 'msg', id: 'f1', from: PEER };
+
+const mutedGroup = (over: Partial<Chat> = {}): Chat =>
+  ({
+    id: 'g1',
+    isGroup: true,
+    participantIds: [PEER, 'peer-2'],
+    name: 'Team',
+    mutedUntil: Date.now() + 60_000,
+    ...over,
+  }) as unknown as Chat;
+
+/** A plain group text that replies to the quoted message's author `senderId`. */
+const replyMsg = (senderId: string, over: Record<string, unknown> = {}): MessagePayload =>
+  ({
+    body: 'sure, tomorrow works',
+    kind: 'text',
+    timestamp: 2,
+    groupId: 'g1',
+    reply: { id: 'm1', senderId, preview: 'hi there' },
+    ...over,
+  }) as unknown as MessagePayload;
+
+function run(payload: MessagePayload, chat: Chat, opts: { showPreview?: boolean } = {}) {
+  return noteForPayload(frame, payload, [chat], contacts, true, opts.showPreview ?? true, new Set(), SELF);
+}
+
+describe('spec 1048 US2 — replies-to-me escalate in the SW like mentions', () => {
+  it('a reply to MY message pierces a muted group, naming the replier', () => {
+    const r = run(replyMsg(SELF), mutedGroup());
+    expect(r.note).toMatchObject({
+      title: 'Team',
+      body: 'Alice Smith replied to you: sure, tomorrow works',
+      url: '/chat/g1',
+      tag: 'ring:g1',
+    });
+    expect(r.wasMessage).toBe(true);
+  });
+
+  it('masked content still names the replier without the text', () => {
+    const chat = mutedGroup({ notifyContent: 'generic' } as Partial<Chat>);
+    const r = run(replyMsg(SELF), chat);
+    expect(r.note?.body).toBe('Alice Smith replied to you');
+  });
+
+  it('the notifyMentions pref gates it: off → ordinary muted handling (silenced)', () => {
+    const chat = mutedGroup({ notifyMentions: false } as Partial<Chat>);
+    const r = run(replyMsg(SELF), chat);
+    expect(r.note).toBeNull();
+    expect(r.silenced).toBe(true);
+  });
+
+  it("a reply to someone ELSE's message stays an ordinary muted message", () => {
+    const r = run(replyMsg('peer-2'), mutedGroup());
+    expect(r.note).toBeNull();
+    expect(r.silenced).toBe(true);
+  });
+
+  it('1:1 replies never escalate (no groupId → ordinary handling)', () => {
+    const dm = { id: 'c1', isGroup: false, participantIds: [PEER], name: 'Alice Smith', mutedUntil: Date.now() + 60_000 } as unknown as Chat;
+    const p = replyMsg(SELF, { groupId: undefined });
+    const r = noteForPayload(frame, p, [dm], contacts, true, true, new Set(), SELF);
+    expect(r.note).toBeNull();
+    expect(r.silenced).toBe(true);
+  });
+
+  it('a reply that ALSO mentions me renders the mention wording, once', () => {
+    const r = run(replyMsg(SELF, { mentions: [SELF] }), mutedGroup());
+    expect(r.note?.body).toBe('Alice Smith mentioned you: sure, tomorrow works');
+  });
+
+  it('hidden still wins: a hidden muted group reply shows only the traceless generic', () => {
+    const r = noteForPayload(frame, replyMsg(SELF), [mutedGroup()], contacts, true, true, new Set(['g1']), SELF);
+    expect(r.note).toMatchObject({ title: 'Ring', body: 'New message', url: '/tabs/chats' });
+  });
+
+  it('an unmuted group reply produces ONE note (the escalation wording, never a duplicate)', () => {
+    const chat = mutedGroup({ mutedUntil: undefined } as Partial<Chat>);
+    const r = run(replyMsg(SELF), chat);
+    expect(r.note?.body).toBe('Alice Smith replied to you: sure, tomorrow works');
+    expect(r.wasMessage).toBe(true);
+  });
+});

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -484,22 +484,29 @@ export function noteForPayload(
       wasMessage: true,
     };
   }
-  // @mentions (spec 1020): a message that @mentions me (individually, or an @everyone
-  // from the actual group OWNER) escalates past the per-chat silencers below (mute,
-  // web-push-off, content=none), and names the mentioner — UNLESS the chat turned the
-  // "mentions even when muted" pref off. (Hidden chats above still win — a hidden chat
-  // never escalates.) The global "Show notifications" master is honored above.
+  // @mentions (spec 1020) + replies-to-me (spec 1048): a message that @mentions me
+  // (individually, or an @everyone from the actual group OWNER) OR directly replies
+  // to a message I authored (the sender snapshots the quoted author into
+  // reply.senderId, so this needs no store lookup) escalates past the per-chat
+  // silencers below (mute, web-push-off, content=none), and names the sender —
+  // UNLESS the chat turned the "mentions even when muted" pref off (ONE dial for
+  // "personally-directed pierces mute"). (Hidden chats above still win — a hidden
+  // chat never escalates.) The global "Show notifications" master is honored above.
   const selfMentioned =
     isGroup &&
     (!!payload.mentions?.includes(selfId) ||
       (!!payload.mentionsEveryone && !!chat?.createdBy && from === chat.createdBy));
-  if (selfMentioned && chat?.notifyMentions !== false) {
+  const selfReplied = isGroup && !!selfId && payload.reply?.senderId === selfId;
+  if ((selfMentioned || selfReplied) && chat?.notifyMentions !== false) {
     const showText = (chat?.notifyContent ?? 'full') === 'full' && showPreview;
+    // An explicit @mention outranks the implicit reply variant when both apply —
+    // one message, one note, the stronger wording.
+    const verb = selfMentioned ? 'mentioned you' : 'replied to you';
     return {
       note: {
         ids: [f.id as string],
         title: groupChat?.name || 'Group',
-        body: showText ? `${senderName} mentioned you: ${notifyPreview(payload)}` : `${senderName} mentioned you`,
+        body: showText ? `${senderName} ${verb}: ${notifyPreview(payload)}` : `${senderName} ${verb}`,
         url: chat?.id ? `/chat/${chat.id}` : '/tabs/chats',
         tag: chat?.id ? `ring:${chat.id}` : `ring:from:${from}`,
       },

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -72,6 +72,10 @@ export interface SwNote {
   // so the show path can make it CUMULATIVE across overlapping burst wakes (via the persisted
   // per-chat summary) instead of a per-pass slice. Defaults to ids.length when unset.
   count?: number;
+  // (spec 1048) Show without the platform alert sound. A SW can't play the app's
+  // synthesized tones, so the reaction tone 'none' maps to this — the note is still
+  // VISIBLE (the wake ends visibly either way); only the sound is dropped.
+  silent?: boolean;
 }
 
 /** Background-preview result. `notes` are the displayable notifications, `pending`

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -209,6 +209,15 @@ export function noteForPayload(
     prefs?: { turn: boolean; challenges: boolean; followMoves: boolean; followResults: boolean };
     follows?: Record<string, number>;
   },
+  // Reaction context (spec 1048), prefetched by previewPending: the reacted-to
+  // message's stored row (to tell "reaction to MY message" and quote it) plus the
+  // gating toggles and the dedicated reaction tone. Absent (e.g. a caller that
+  // defers reactions, like the authoritative drain) → the reaction stays the
+  // silent side effect it was before spec 1048.
+  reactionCtx?: {
+    row?: Message;
+    prefs?: { dm: boolean; group: boolean; tone: string };
+  },
 ): { note: SwNote | null; wasMessage: boolean; silenced?: boolean } {
   const from = f.from as string;
   const known = contacts.find((c) => c.id === from)?.name;
@@ -388,11 +397,64 @@ export function noteForPayload(
     };
   }
 
-  // Reactions / poll votes / edits / delete-for-everyone / link-preview attach, and
-  // the session re-key + disappearing-message TTL controls, are silent side effects
-  // with nothing to show.
+  // Reactions (spec 1048): a reaction ADD to one of MY OWN messages notifies the
+  // author (the two settings toggles gate it per surface) — everything else about a
+  // reaction stays the silent side effect it always was. Critically for push health
+  // (FR-013): every suppressed case below returns the EXACT pre-1048 shape
+  // `{note:null, wasMessage:false}`, so sw.ts's established visible-wake fallback
+  // (specs 2016/2017/2023) applies unchanged — no new class of silent wake exists.
+  // Reactions NEVER escalate (unlike mentions): mute, web-push-off, content='none',
+  // hidden, and the global master all silence them. wasMessage stays false — a
+  // reaction is not a message and must not badge or count unread (spec 1048
+  // clarification).
+  if (payload.reaction) {
+    const sig = payload.reaction;
+    const row = reactionCtx?.row;
+    const rChat = payload.groupId
+      ? chats.find((c) => c.id === payload.groupId && c.isGroup)
+      : chats.find((c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === from);
+    const mine = !!row && (row.outgoing || row.senderId === 'me');
+    const enabled = rChat?.isGroup ? reactionCtx?.prefs?.group === true : reactionCtx?.prefs?.dm === true;
+    const suppressedByChat =
+      !rChat ||
+      hidden.has(rChat.id) ||
+      (rChat.mutedUntil !== undefined && rChat.mutedUntil > Date.now()) ||
+      rChat.notifyWebPush === false ||
+      (rChat.notifyContent ?? 'full') === 'none';
+    if (sig.remove || !mine || from === selfId || !enabled || !showMessages || suppressedByChat) {
+      return { note: null, wasMessage: false };
+    }
+    const showText = (rChat.notifyContent ?? 'full') === 'full' && showPreview;
+    const name = known || 'Someone';
+    const first = name.split(' ')[0];
+    // A short quote of the reacted-to message; media/empty bodies read naturally.
+    const raw = (row.body || '').replace(/\s+/g, ' ').trim();
+    const quote = raw.length > 80 ? `${raw.slice(0, 79)}…` : raw;
+    const line = rChat.isGroup
+      ? quote ? `${first} reacted ${sig.emoji} to: ${quote}` : `${first} reacted ${sig.emoji} to your message`
+      : quote ? `Reacted ${sig.emoji} to: ${quote}` : `Reacted ${sig.emoji} to your message`;
+    return {
+      note: {
+        ids: [f.id as string],
+        // Same masking rules as a plain message: preview off hides WHO as well.
+        title: showPreview ? (rChat.isGroup ? rChat.name || 'Group' : name) : 'Ring',
+        body: showText ? line : 'New message',
+        url: `/chat/${rChat.id}`,
+        // The chat's own tag: reactions coalesce into the ONE per-chat notification
+        // (spec 2017 summary machinery included) instead of stacking (FR-003).
+        tag: `ring:${rChat.id}`,
+        // Tone 'none' = visible but quiet; a SW can't play the app's synthesized tones.
+        silent: reactionCtx?.prefs?.tone === 'none',
+      },
+      wasMessage: false,
+    };
+  }
+
+  // Poll votes / edits / delete-for-everyone / link-preview attach, and the session
+  // re-key + disappearing-message TTL controls, are silent side effects with
+  // nothing to show.
   if (
-    payload.reaction || payload.pollVote || payload.edit || payload.erase ||
+    payload.pollVote || payload.edit || payload.erase ||
     payload.linkPreviewSig || payload.rekey || payload.ttl !== undefined
   ) {
     return { note: null, wasMessage: false };
@@ -891,7 +953,21 @@ export async function previewPending(): Promise<PreviewResult> {
           follows: await setting<Record<string, number>>('games.follows', {}),
         }
       : undefined;
-    const { note, wasMessage, silenced } = noteForPayload(f, payload, chats, contacts, showMessages, showPreview, hidden, selfId ?? '', gameCtx);
+    // Reaction context (spec 1048): the reacted-to message's stored row (tells
+    // "is it MINE?" + provides the quote) and the gates/tone. The row read is the
+    // same read-only pattern as the game context above; an unresolvable target
+    // (deleted, or the reaction outran its message) keeps the reaction silent.
+    const reactionCtx = payload.reaction
+      ? {
+          row: await get<Message>('messages', payload.reaction.messageId),
+          prefs: {
+            dm: await setting<boolean>('notifications.message.reactions', true),
+            group: await setting<boolean>('notifications.group.reactions', true),
+            tone: await setting<string>('notifications.reactions.sound', 'pop'),
+          },
+        }
+      : undefined;
+    const { note, wasMessage, silenced } = noteForPayload(f, payload, chats, contacts, showMessages, showPreview, hidden, selfId ?? '', gameCtx, reactionCtx);
     if (note) raw.push(note);
     else if (silenced) silencedMessage = true;
     else if (wasMessage && !showMessages) withheldMessage = true;

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -72,6 +72,7 @@ import {
   sendMediaMessage as dbSendMediaMessage,
   setChatTtl as dbSetChatTtl,
   setChatNotifyPrefs as dbSetChatNotifyPrefs,
+  setChatMute as dbSetChatMute,
   type ChatNotifyPrefs,
   sweepExpiredMessages as dbSweepExpired,
   getChat as dbGetChat,
@@ -437,6 +438,8 @@ export function installTestHook(): void {
     setChatTtl: (chatId: string, ms: number | null) => dbSetChatTtl(chatId, ms),
     /** Set per-chat notification controls (spec 1015): { webPush?, inApp?, content? }. */
     setChatNotify: (chatId: string, patch: Partial<ChatNotifyPrefs>) => dbSetChatNotifyPrefs(chatId, patch),
+    /** Mute a chat's alerting until `until` epoch-ms (null = unmute) — spec 1048 e2e. */
+    muteChat: (chatId: string, until: number | null) => dbSetChatMute(chatId, until),
     /** Write a global setting (e.g. notifications.inapp.enabled) for assertions. */
     setGlobalSetting: (key: string, value: unknown) => dbSetSetting(key, value),
     sweepExpired: () => dbSweepExpired(),

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -352,6 +352,9 @@ export function installTestHook(): void {
     /** Reconnect the WebSocket (drains the queue for real). */
     reconnect: () => nudgeReconnect(),
     forceReconnect: () => forceReconnect(),
+    /** Remaining post-unlock settle suppression in ms (spec 1048 e2e: banner
+     *  assertions must wait this out — non-escalated alerts are damped inside it). */
+    settleMsLeft: () => settleMsLeft(),
     /** Lock memory (to test re-unlock on reload). */
     lockNow: () => lockIdentity(),
     /** Whether this device auto-unlocks (no passcode lock). */

--- a/src/settings/schema.test.ts
+++ b/src/settings/schema.test.ts
@@ -82,6 +82,26 @@ describe('settings schema — spec 1025 cleanup', () => {
 
 });
 
+describe('settings schema — spec 1048 (reaction notifications)', () => {
+  it('has a dedicated reaction tone with a silent option, default pop', () => {
+    const node = settingNode('notifications-reactions-sound');
+    expect(node).toBeDefined();
+    const choice = node!.groups.flatMap((g) => g.items).find((i) => 'key' in i && i.key === 'notifications.reactions.sound');
+    expect(choice?.type).toBe('choice');
+    expect(choice && 'default' in choice && choice.default).toBe('pop');
+    expect(choice && 'options' in choice && choice.options.some((o) => o.value === 'none')).toBe(true);
+  });
+
+  it('the Notifications page links to the reaction tone beside the per-surface gates', () => {
+    const items = SETTINGS.notifications.groups.flatMap((g) => g.items);
+    expect(items.some((i) => i.type === 'link' && i.id === 'notifications-reactions-sound')).toBe(true);
+    // The existing gates this spec wires up must stay present (they become live controls).
+    const keys = new Set(items.filter((i): i is Extract<SettingItem, { key: string }> => 'key' in i).map((i) => i.key));
+    expect(keys.has('notifications.message.reactions')).toBe(true);
+    expect(keys.has('notifications.group.reactions')).toBe(true);
+  });
+});
+
 describe('settings schema — spec 1026 (friends-only & refinements)', () => {
   it('US2: no "Advanced" sub-page and nothing links to it (FR-006)', () => {
     expect(settingNode('privacy-advanced')).toBeUndefined();

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -526,6 +526,15 @@ export const SETTINGS: Record<string, SettingNode> = {
         ],
       },
       {
+        // Reactions get their OWN tone (spec 1048): the on/off gates live per surface
+        // above (message/group "Reaction notifications"), but the sound is one shared,
+        // deliberately subtler choice so a burst of hearts never sounds like a burst
+        // of messages. "None" keeps reaction alerts visible but silent.
+        header: 'Reactions',
+        items: [{ type: 'link', id: 'notifications-reactions-sound', title: 'Sound', icon: 'music' }],
+        footer: 'Reactions to your messages play their own tone. Pick None to keep them quiet.',
+      },
+      {
         header: 'Wall notifications',
         items: [
           { type: 'toggle', title: 'Show notifications', key: 'notifications.wall.show', default: true },
@@ -572,6 +581,13 @@ export const SETTINGS: Record<string, SettingNode> = {
     id: 'notifications-group-sound',
     title: 'Sound',
     groups: [{ header: 'Alert tones', items: [{ type: 'choice', key: 'notifications.group.sound', default: 'note', options: TONES }] }],
+  },
+  // Reaction alert tone (spec 1048). Default 'pop' — subtle and distinct from the
+  // message default 'note', so a reaction never masquerades as a new message.
+  'notifications-reactions-sound': {
+    id: 'notifications-reactions-sound',
+    title: 'Sound',
+    groups: [{ header: 'Alert tones', items: [{ type: 'choice', key: 'notifications.reactions.sound', default: 'pop', options: TONES }] }],
   },
   'notifications-badge': {
     id: 'notifications-badge',

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -283,6 +283,9 @@ async function showNotes(notes: SwNote[]): Promise<number> {
         tag: n.tag,
         renotify: true, // a genuinely-new message on this tag should re-alert (a silent re-assert
         // for "nothing new" uses reassertFromSummary below, which sets renotify:false)
+        // (spec 1048) A reaction note with the tone set to None shows without the
+        // platform sound — visible (the wake still ends visibly), just quiet.
+        silent: n.silent === true,
         data: { url: n.url },
       });
     } catch (e) {


### PR DESCRIPTION
Makes the two existing-but-dead reaction toggles real and treats a direct reply to your message as an implicit @mention — full design in specs/1048-notify-reactions-messages/.

- The author of a message is notified when someone reacts (1:1 + groups, live page + closed-app SW path), coalesced under the chat's single notification, masked by the same content rules as messages, never escalating past mute. Reactions carry their own alert tone (new `notifications.reactions.sound`, default Pop, None = visible-but-silent).
- A direct reply to YOUR message in a group pierces mute exactly like an @mention (same per-chat pref, `notify-policy.ts` byte-identical — `ReplyRef.senderId` makes detection lookup-free), names the replier under masked content, and counts in the unread-mentions indicator.
- Push-health invariant (FR-013): every suppressed delivery keeps its exact pre-1048 outcome shape, so the spec-2016/2017/2023 visible-wake machinery applies unchanged — no new class of silent wakes.
- e2e hardened against three real harness races (armed banner waits, sender-key warm-up, settle-window wait): 6 consecutive mixed runs green, retries off.

Closes #981
Closes #982
Closes #983
Closes #984
Closes #985

⚠️ Merge order: this first, then #1049/#1050 stack. Hold all merges for the reporter's morning real-device pass (reaction push checks are on the manual matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7