### PR TITLE
fix(call): join-call invite reads as a button + the redundant held 1:1 retires on join (spec 2031)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,4 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
-| [2031](specs/2031-join-call-invite/spec.md) | Join-Call Invite Affordance & Redundant Held Call | ⚪ planned |
+| [2031](specs/2031-join-call-invite/spec.md) | Join-Call Invite Affordance & Redundant Held Call | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,4 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
-| [2031](specs/2031-join-call-invite/spec.md) | Join-Call Invite Affordance & Redundant Held Call | 🟡 in-progress |
+| [2031](specs/2031-join-call-invite/spec.md) | Join-Call Invite Affordance & Redundant Held Call | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,3 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
+| [2031](specs/2031-join-call-invite/spec.md) | Join-Call Invite Affordance & Redundant Held Call | ⚪ planned |

--- a/e2e/call-invite-retire.spec.ts
+++ b/e2e/call-invite-retire.spec.ts
@@ -37,7 +37,7 @@ const awaitRoster = (c: RingClient, ids: string[]): Promise<unknown> =>
       return want.every((id) => r.includes(id));
     },
     ids,
-    { timeout: 15_000 },
+    { timeout: 30_000 },
   );
 
 /** A and B connected 1:1 (the call that will be parked); C calls A and A

--- a/e2e/call-invite-retire.spec.ts
+++ b/e2e/call-invite-retire.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import {
-  createAccount, pair, startCall, accept, hangup, waitCallState, waitRemotes, roster,
+  createAccount, pair, startCall, accept, hangup, waitCallState, waitRemotes,
   acceptAndHold, heldCallId, type RingClient,
 } from './helpers';
 
@@ -28,6 +28,17 @@ const awaitJoinPrompt = (c: RingClient): Promise<unknown> =>
   c.page.waitForFunction(() => !!(window as any).__ringTest.joinRequest(), null, { timeout: 20_000 });
 const awaitHeldGone = (c: RingClient): Promise<unknown> =>
   c.page.waitForFunction(() => (window as any).__ringTest.heldCallId() === null, null, { timeout: 15_000 });
+// Mesh streams can land a beat BEFORE the server's roster broadcast updates the
+// local roster array — poll for membership instead of asserting a snapshot.
+const awaitRoster = (c: RingClient, ids: string[]): Promise<unknown> =>
+  c.page.waitForFunction(
+    (want: string[]) => {
+      const r = (window as any).__ringTest.callRoster() as string[];
+      return want.every((id) => r.includes(id));
+    },
+    ids,
+    { timeout: 15_000 },
+  );
 
 /** A and B connected 1:1 (the call that will be parked); C calls A and A
  *  accepts-and-holds → active A↔C, held A↔B (B sees "on hold"). */
@@ -60,10 +71,7 @@ test('held party accepting the invite retires the redundant 1:1 on both sides (U
 
   // Everyone lands in one merged 3-way call…
   for (const p of [a, b, c]) await waitRemotes(p, 2);
-  for (const p of [a, b, c]) {
-    const r = await roster(p);
-    for (const id of [a.id, b.id, c.id]) expect(r).toContain(id);
-  }
+  for (const p of [a, b, c]) await awaitRoster(p, [a.id, b.id, c.id]);
 
   // …and the redundant held 1:1 is gone from A (no swap pill), while B has only
   // the merged call (his old 1:1 dissolved into it on accept).

--- a/e2e/call-invite-retire.spec.ts
+++ b/e2e/call-invite-retire.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccount, pair, startCall, accept, hangup, waitCallState, waitRemotes, roster,
+  acceptAndHold, heldCallId, type RingClient,
+} from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 2031 — inviting the HELD party into the active call and having them accept
+// makes the old 1:1 between the same two people redundant: it must retire by
+// itself on both sides the moment the invitee actually lands in the merged call
+// (FR-001), and it logs as a normally-ended call, not missed (FR-003). The
+// waiting-caller variant of the merge is covered by call-merge-consent.spec.ts;
+// this file covers the HELD variant the field report came from. AUDIO only
+// (headless CI constraint).
+
+const mergeHeld = (c: RingClient): Promise<void> =>
+  c.page.evaluate(() => (window as any).__ringTest.mergeHeld());
+const acceptJoin = (c: RingClient): Promise<void> =>
+  c.page.evaluate(() => (window as any).__ringTest.acceptJoinRequest());
+const addPeople = (c: RingClient, ids: string[]): Promise<void> =>
+  c.page.evaluate((x: string[]) => (window as any).__ringTest.addPeople(x), ids);
+const isGroup = (c: RingClient): Promise<boolean> =>
+  c.page.evaluate(() => !!(window as any).__ringTest.callMeta()?.isGroup);
+const callRows = (c: RingClient): Promise<Array<{ contactId: string; missed: boolean }>> =>
+  c.page.evaluate(() => (window as any).__ringTest.callRows());
+
+const awaitJoinPrompt = (c: RingClient): Promise<unknown> =>
+  c.page.waitForFunction(() => !!(window as any).__ringTest.joinRequest(), null, { timeout: 20_000 });
+const awaitHeldGone = (c: RingClient): Promise<unknown> =>
+  c.page.waitForFunction(() => (window as any).__ringTest.heldCallId() === null, null, { timeout: 15_000 });
+
+/** A and B connected 1:1 (the call that will be parked); C calls A and A
+ *  accepts-and-holds → active A↔C, held A↔B (B sees "on hold"). */
+async function heldTrio(browser: any, codes: [string, string, string]) {
+  const ctx = await Promise.all([0, 1, 2].map(() => browser.newContext()));
+  const [a, b, c] = await Promise.all(codes.map((code, i) => createAccount(ctx[i], code)));
+  await pair(a, b); await pair(a, c); await pair(b, c);
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+  await waitCallState(b, ['connected']);
+  await startCall(c, a.id, 'audio');
+  await a.page.waitForFunction(() => !!(window as any).__ringTest.hasSecondIncoming(), null, { timeout: 30_000 });
+  await acceptAndHold(a);
+  await waitCallState(c, ['connected']);
+  await b.page.waitForFunction(() => (window as any).__ringTest.isRemoteHeld() === true, null, { timeout: 15_000 });
+  return { ctx, a, b, c };
+}
+
+test('held party accepting the invite retires the redundant 1:1 on both sides (US1)', async ({ browser }) => {
+  test.setTimeout(150_000);
+  const { ctx, a, b, c } = await heldTrio(browser, ['RET1A', 'RET1B', 'RET1C']);
+  expect(await heldCallId(a)).not.toBeNull();
+
+  // A invites the held B into the active A↔C call; B consents.
+  await mergeHeld(a);
+  await awaitJoinPrompt(b);
+  await acceptJoin(b);
+
+  // Everyone lands in one merged 3-way call…
+  for (const p of [a, b, c]) await waitRemotes(p, 2);
+  for (const p of [a, b, c]) {
+    const r = await roster(p);
+    for (const id of [a.id, b.id, c.id]) expect(r).toContain(id);
+  }
+
+  // …and the redundant held 1:1 is gone from A (no swap pill), while B has only
+  // the merged call (his old 1:1 dissolved into it on accept).
+  await awaitHeldGone(a);
+  expect(await heldCallId(b)).toBeNull();
+
+  // FR-003: the retired 1:1 logged as a normal completed call on both sides.
+  await a.page.waitForTimeout(3500); // let the deferred spec-1040 markers settle
+  const aRows = (await callRows(a)).filter((r) => r.contactId === b.id);
+  expect(aRows.length).toBeGreaterThan(0);
+  expect(aRows.filter((r) => r.missed)).toEqual([]);
+  expect((await callRows(b)).filter((r) => r.contactId === a.id && r.missed)).toEqual([]);
+
+  for (const p of [a, b, c]) await hangup(p);
+  await Promise.all(ctx.map((x) => x.close()));
+});
+
+test('the retire also fires when the active call is already a group (the family-call shape)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const ctx4 = await Promise.all([0, 1, 2, 3].map(() => browser.newContext()));
+  const [a, b, c, d] = await Promise.all(
+    ['RET2A', 'RET2B', 'RET2C', 'RET2D'].map((code, i) => createAccount(ctx4[i], code)),
+  );
+  await pair(a, b); await pair(a, c); await pair(a, d); await pair(c, d);
+
+  // A↔B 1:1 (the call that gets parked), then C calls A → A accepts & holds.
+  await startCall(a, b.id, 'audio');
+  await waitCallState(b, ['incoming']);
+  await accept(b);
+  await waitCallState(a, ['connected']);
+  await startCall(c, a.id, 'audio');
+  await a.page.waitForFunction(() => !!(window as any).__ringTest.hasSecondIncoming(), null, { timeout: 30_000 });
+  await acceptAndHold(a);
+  await waitCallState(c, ['connected']);
+  await b.page.waitForFunction(() => (window as any).__ringTest.isRemoteHeld() === true, null, { timeout: 15_000 });
+
+  // Grow the ACTIVE call into a room (A, C, D) — the held 1:1 with B stays parked.
+  await addPeople(a, [d.id]);
+  await waitCallState(d, ['incoming']);
+  await accept(d);
+  for (const p of [a, c, d]) await waitRemotes(p, 2);
+  expect(await isGroup(a)).toBe(true);
+  expect(await heldCallId(a)).not.toBeNull();
+
+  // Invite held B into the group; B accepts → 4-way, held 1:1 retires.
+  await mergeHeld(a);
+  await awaitJoinPrompt(b);
+  await acceptJoin(b);
+  for (const p of [a, b, c, d]) await waitRemotes(p, 3);
+  await awaitHeldGone(a);
+  expect(await heldCallId(b)).toBeNull();
+
+  for (const p of [a, b, c, d]) await hangup(p);
+  await Promise.all(ctx4.map((x) => x.close()));
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -119,10 +119,14 @@ test('unknown paths redirect into the app; back at a tab root stays in-app', asy
   await a.page.waitForURL('**/tabs/chats');
   expect(await a.page.evaluate(() => history.length)).toBeGreaterThanOrEqual(2);
   await a.page.goBack();
-  await a.page.waitForTimeout(300);
   expect(a.page.url()).not.toContain('about:blank');
   expect(await a.page.evaluate(() => location.pathname)).not.toBe('');
-  expect(await a.page.evaluate(() => !!document.querySelector('ion-app, ion-router-outlet'))).toBe(true);
+  // Landing on the catch-all entry remounts the app via a FULL document load —
+  // poll for the mount instead of a fixed beat (a loaded CI runner loses a
+  // 300ms race; the guarantee is "stays in-app", not "remounts instantly").
+  await a.page.waitForFunction(() => !!document.querySelector('ion-app, ion-router-outlet'), undefined, {
+    timeout: 15_000,
+  });
 
   await ctx.close();
 });

--- a/specs/2031-join-call-invite/checklists/requirements.md
+++ b/specs/2031-join-call-invite/checklists/requirements.md
@@ -1,0 +1,20 @@
+# Specification Quality Checklist: Join-Call Invite Affordance & Redundant Held Call
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details / focused on user value / non-technical / mandatory sections complete
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers (the reporter's requirement statement IS the P1 behavior)
+- [x] Testable, measurable, bounded; edge cases (races, group case, failed join) identified
+
+## Feature Readiness
+- [x] FRs map to acceptance scenarios; SC-003 is an explicit reporter sign-off; SC-004 pins the regression fence
+
+## Notes
+- Hotfix band (2031): behavior defect (redundant held call) + discoverability defect (invite affordance),
+  reported together from one real session — kept as one spec because they live in the same flow/screen.
+- Pipeline from clarify/plan onward NOT yet run — queued behind specs 1048/1049 (in flight on their branches).

--- a/specs/2031-join-call-invite/spec.md
+++ b/specs/2031-join-call-invite/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category
@@ -85,5 +85,6 @@ The "Ask Kambiz to join this call" control currently renders as a plain dark tex
 ## Assumptions
 
 - The stated behavior ("their existing call should terminate automatically") is the requirement — no clarification needed on the P1 outcome; the retire fires on JOIN (media established), not on mere accept, to satisfy the stranding edge case.
+- Root cause found during implementation (2026-07-14): the pre-2031 retire ran only on receipt of the sealed `joinreq-accept` reply — a single lossable frame (see spec 2033); when it was lost while the active call was already a group, the invitee still meshed into the room via the room signaling and the held 1:1 survived, exactly as reported. The retire is therefore keyed on the server's roster broadcast (the authoritative join signal), which also satisfies the join-not-accept requirement. A second latent defect fell out of the red test: any CONNECTED 1:1 dissolving into a room (merge-accept or ordinary promotion) never closed its Calls-tab record, leaving the callee's provisional "missed" row permanently — a phantom missed call from someone they actually talked to (FR-003 now covers it).
 - Real-device verification is required for the final sign-off (the reporter's two-phone setup), since the join flow involves real WebRTC renegotiation; e2e covers the state machine per the established call-suite patterns.
 - Scope excludes any redesign of the broader add-people/merge flows beyond the two reported items.

--- a/specs/2031-join-call-invite/spec.md
+++ b/specs/2031-join-call-invite/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Join-Call Invite Affordance & Redundant Held Call
+
+**Feature Branch**: `fix/2031-join-call-invite`
+
+**Created**: 2026-07-13
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User bug report (2026-07-13, with screenshots from a real two-call session on iPhone): "Ask Kambiz to join the call doesn't look like a button at all and I accidentally discovered it. Also when the one you have invited to join the call accepts the invite, their existing call should terminate automatically — right now it keeps the 1:1 call alive and even gives you an option to switch between them!"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Accepting a join invite retires the now-redundant call (Priority: P1)
+
+Kamran is on a video call. His other call with Kambiz is on hold. He asks Kambiz to join the current call, and Kambiz accepts. From that moment Kamran and Kambiz are together in one call — the old held 1:1 between the same two people serves no purpose. It should end by itself on both sides. Today it stays alive: Kamran keeps a "Switch to Kambiz · On hold · tap to swap calls" control, and tapping it would put him in a phantom second call with someone he is already talking to.
+
+**Why this priority**: Functional defect with real confusion potential — swapping into the stale call splits the two people across two calls again, and the held call keeps consuming a call slot. The reporter hit this in an actual family call.
+
+**Independent Test**: Two devices in a 1:1 call; caller starts or answers a second call (first goes on hold), invites the held party into the active call, and the held party accepts. The moment the invitee joins, the old 1:1 disappears from both devices — no swap pill, no held-call entry, no lingering call screen — and the merged call carries on.
+
+**Acceptance Scenarios**:
+
+1. **Given** Kamran is in call B with a held 1:1 call A to Kambiz, **When** Kambiz accepts the invite and joins call B, **Then** call A ends automatically on BOTH sides, the "Switch to Kambiz" pill disappears from Kamran's screen, and no missed/dropped-call artifact is logged for call A beyond a normal ended call.
+2. **Given** the same setup, **When** Kambiz joins, **Then** Kambiz's device shows only the merged call — his old 1:1 with Kamran does not remain as a held call on his side either.
+3. **Given** Kambiz DECLINES the invite (or lets it lapse), **Then** nothing changes: the held 1:1 stays exactly as today, swappable.
+4. **Given** the invitee accepts but fails to actually connect to the merged call (network death mid-join), **Then** the held 1:1 is not torn down until the invitee's media is established in the new call — never strand both parties with no call at all.
+5. **Given** the held call is with a DIFFERENT person than the accepted invitee, **Then** it is untouched (only the redundant same-person call retires).
+
+---
+
+### User Story 2 - The join invite reads as a button (Priority: P2)
+
+The "Ask Kambiz to join this call" control currently renders as a plain dark text pill — visually identical to the passive "Invited" status chip it turns into after tapping. The reporter discovered it was tappable by accident. It must look like an action: styled like the app's other in-call action affordances (e.g. the green swap pill right below it), with a pressed state, and clearly distinct from the non-interactive "Invited" status it becomes.
+
+**Why this priority**: Discoverability defect on a useful feature; cosmetic-plus. Below US1 because nothing breaks — it's just invisible.
+
+**Independent Test**: In the two-call state, the invite control is visually identifiable as a button (color/shape/icon parity with sibling actions), and after tapping, the resulting "Invited" state is visually passive (chip/label) so the two states cannot be confused.
+
+**Acceptance Scenarios**:
+
+1. **Given** a held 1:1 while in another call, **When** the call screen shows the join-invite control, **Then** it looks like a tappable action (button styling consistent with the swap pill: fill/tint, icon, pressed feedback), not a text label.
+2. **Given** the invite has been sent, **Then** the control transitions to a clearly passive "Invited" status presentation, and repeated taps do nothing (no duplicate invites).
+
+---
+
+### Edge Cases
+
+- Invitee accepts at the exact moment the inviter manually ends the held call — teardown must be idempotent (no error, no double-ended artifacts).
+- Invitee accepts while the inviter's active call is itself ending — the invite resolves against a dying call; the held 1:1 must NOT be torn down in that case.
+- Group case: the held "call" with the invitee is a group call containing others — it must NOT auto-end (only a redundant 1:1 with exactly the invitee retires).
+- Call history: the retired 1:1 logs as a normal completed call with its real duration, not as missed/cancelled.
+- Both sides' UI updates promptly even if the retire signal races the join media (states may arrive in either order).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When an invited party accepts a join-call invite and successfully connects to the inviter's active call, the now-redundant held 1:1 call between the same two parties MUST end automatically on both devices, without user action.
+- **FR-002**: The automatic retire MUST NOT fire on decline, lapse, or failed join (invitee never establishes media in the new call), and MUST only ever target a held 1:1 whose sole peer is the accepted invitee.
+- **FR-003**: The retired call MUST be recorded as a normally-ended call (correct duration, not missed/cancelled) and MUST free its call slot immediately.
+- **FR-004**: The join-invite control MUST be visually recognizable as a tappable action, consistent with the in-call action styling (the swap pill family), including a pressed state — composed from stock Ionic primitives per the Ionic-first principle.
+- **FR-005**: After sending, the control MUST present as a passive "Invited" status clearly distinct from the actionable state, and further taps MUST NOT send duplicate invites.
+- **FR-006**: All teardown/ordering paths MUST be race-safe (accept vs manual hangup, accept vs active-call end) — no state where both calls are gone or both alive with the same peer.
+
+## Zero-Knowledge Impact
+
+- **What crosses the wire**: no new payloads expected — the join/accept signals already exist (sealed call signaling); the retire is a device-local decision on an existing state transition, possibly reusing the existing sealed call-end signal for the old call.
+- **Visible metadata**: unchanged; the server continues to relay opaque call signaling.
+- **Why**: pure client call-state-machine + UI change. (To be re-verified at plan time; any new signal must ride the existing sealed channel.)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In the accept-and-join flow, the redundant held 1:1 is gone from both devices within 3 seconds of the invitee's media connecting, in 100% of e2e runs.
+- **SC-002**: Decline/lapse/failed-join leave the held call intact in 100% of e2e runs.
+- **SC-003**: A usability check (the reporter) confirms the invite control reads as a button at a glance and the Invited state as a status.
+- **SC-004**: No regression across the existing call-waiting/merge e2e suites (hold, swap, merge-consent, add-cap and friends stay green).
+
+## Assumptions
+
+- The stated behavior ("their existing call should terminate automatically") is the requirement — no clarification needed on the P1 outcome; the retire fires on JOIN (media established), not on mere accept, to satisfy the stranding edge case.
+- Real-device verification is required for the final sign-off (the reporter's two-phone setup), since the join flow involves real WebRTC renegotiation; e2e covers the state machine per the established call-suite patterns.
+- Scope excludes any redesign of the broader add-people/merge flows beyond the two reported items.

--- a/specs/2031-join-call-invite/spec.md
+++ b/specs/2031-join-call-invite/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-13
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -1016,10 +1016,14 @@ export function canRequestJoin(partyId: string): boolean {
   return s ? jrCanRequest(s, partyId, capacityOk) : capacityOk;
 }
 
-/** Is a request to `partyId` outstanding? (Drives the "Invited" button state.) */
+/** Is a request to `partyId` outstanding or accepted-and-joining? (Drives the
+ *  "Invited" button state — it stays passive from the tap until they either
+ *  land in the room, which retires the held call and the whole affordance, or
+ *  the call ends. Spec 2031 FR-005: never re-askable mid-flight.) */
 export function joinRequestPendingFor(partyId: string): boolean {
   void joinRequestVersion.value;
-  return joinRequests?.pending.has(partyId) ?? false;
+  const s = joinRequests;
+  return s ? s.pending.has(partyId) || s.accepted.has(partyId) : false;
 }
 
 /** The waiting/held party answered our request. */
@@ -1046,13 +1050,49 @@ async function handleJoinReply(partyId: string, verdict: 'joinreq-accept' | 'joi
     markNotJoining(partyId, false);
     armMemberRingTimer(partyId);
   });
-  // Their old 1:1 leg to us dissolves as they convert: clear whichever slot
-  // held them (the waiting prompt, or the held call).
+  // Their old 1:1 leg to us dissolves as they convert: clear a waiting prompt
+  // for them. A HELD 1:1 with them is NOT retired here (spec 2031 FR-001): the
+  // accept is only a promise to join — tearing the parked call down before
+  // their media lands would strand both parties if the join dies mid-flight.
+  // The retire happens in the roster handler the moment they actually arrive
+  // (retireRedundantHeld), which also survives a lost accept reply.
   if (incomingSecond.value?.from === partyId) {
     incomingSecond.value = null;
     secondIce = [];
   }
-  if (heldSlot && heldSlot.meta.peerUserId === partyId) freeHeldSlot();
+}
+
+/** (spec 2031 FR-001) A party WE invited out of a parked call actually LANDED
+ *  in the room (the server's roster broadcast — authoritative, unlike the
+ *  sealed accept reply, which is one lossable frame): the old held 1:1 with
+ *  them is now redundant. End it locally as a normally-completed call
+ *  (FR-003: real duration, never "missed") and free the slot. No signal is
+ *  sent — their side already dissolved its leg into the room when it accepted
+ *  — and a held call with anyone we did NOT invite is never touched (FR-002):
+ *  a deliberately parked 1:1 with someone who happens to be in the group
+ *  stays swappable. */
+async function retireRedundantHeld(joinerId: string): Promise<void> {
+  const slot = heldSlot;
+  const s = joinRequests;
+  if (!slot || slot.meta.isGroup || slot.meta.peerUserId !== joinerId) return;
+  if (!s || !(s.pending.has(joinerId) || s.accepted.has(joinerId))) return;
+  if (s.pending.has(joinerId)) {
+    // The accept reply never made it, but they're in the room — their join IS
+    // the acceptance. Settle the ledger so the "Invited" chip resolves.
+    jrAccept(s, joinerId);
+    touchJoinRequests();
+  }
+  const durationSec = callDurationSec(slot.meta);
+  freeHeldSlot();
+  await finishCall(slot.meta.callId, durationSec);
+  if (slot.meta.chatId) {
+    await logCallToChat(slot.meta.chatId, {
+      direction: slot.meta.direction,
+      video: slot.meta.kind === 'video',
+      missed: false,
+      durationSec,
+    });
+  }
 }
 
 /** The waiting attempt died (their cancel/end, or our decline): forget any
@@ -2103,6 +2143,17 @@ async function convertActiveToRoom(
   remoteVideoMuted.value = true; // next call starts avatar-until-first-frame (spec 2029)
   remoteHeld.value = false;
   reprimeBytes = true; // re-baseline byte counters against the new mesh session
+  // (spec 2031 FR-003) A CONNECTED 1:1 dissolving into the room was a real,
+  // answered call — close out its Calls-tab record here, because no teardown
+  // will ever run for it. Without this, an incoming call's provisional
+  // "missed" row (createCall) stayed missed forever: a phantom missed call
+  // from someone you actually talked to, left behind by every promotion and
+  // merge-accept. A still-ringing attempt converting (the waiting-caller
+  // accept) keeps today's behavior — it never connected, and its record
+  // settles through the answered-elsewhere cancel machinery.
+  if (callMeta.value && !callMeta.value.isGroup && callState.value === 'connected') {
+    await finishCall(callMeta.value.callId, callDurationSec(callMeta.value), lastBytes.up + lastBytes.down);
+  }
   if (callMeta.value) callMeta.value.tornDown = true; // the old 1:1 meta is retired
   await enterGroupCall(roomId, kind, name, avatar, direction, [], stream);
   // (spec 1030 US2) The 1:1 peer following us into the promoted room isn't a new
@@ -4088,6 +4139,9 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
         // (spec 1040) They joined → settle their marker so no closed device of
         // theirs logs a false missed call (and its stale ring retires).
         settleGroupCallEvent(frame.roomId, id, 'answered');
+        // (spec 2031) An invited held party landing in the room retires the
+        // now-redundant parked 1:1 with them, on the JOIN (not the accept).
+        await retireRedundantHeld(id);
       }
       // (spec 1030 US2) "{name} joined the call": the first roster of a call seeds
       // silently (whoever is already in the room was here before us, or is us);

--- a/src/composables/useCall.ts
+++ b/src/composables/useCall.ts
@@ -4141,7 +4141,11 @@ export async function handleCallFrame(frame: CallFrame): Promise<void> {
         settleGroupCallEvent(frame.roomId, id, 'answered');
         // (spec 2031) An invited held party landing in the room retires the
         // now-redundant parked 1:1 with them, on the JOIN (not the accept).
-        await retireRedundantHeld(id);
+        // DETACHED and non-fatal: the retire does IndexedDB writes, and roster
+        // processing (the state assignments below) must never wait on it or die
+        // with it — a stalled retire once left the roster stale for good,
+        // because a roster frame is never redelivered.
+        void retireRedundantHeld(id).catch((e) => console.warn('[call] held-call retire failed', e));
       }
       // (spec 1030 US2) "{name} joined the call": the first roster of a call seeds
       // silently (whoever is already in the room was here before us, or is us);

--- a/src/services/call/join-request.test.ts
+++ b/src/services/call/join-request.test.ts
@@ -42,13 +42,27 @@ describe('join-request state (spec 1041)', () => {
     expect(canRequest(s, 'kamran', true)).toBe(true);
   });
 
-  it('accept clears the pending entry and returns the attempt callId', () => {
+  it('accept moves the party pending → accepted and returns the attempt callId', () => {
     const s = fresh();
     request(s, 'sara', 'call-1');
     expect(accept(s, 'sara')).toBe('call-1');
     expect(accept(s, 'sara')).toBeUndefined(); // idempotent
-    // an accepted party could in principle be requested again (they left the call later)
-    expect(canRequest(s, 'sara', true)).toBe(true);
+    expect(s.accepted.has('sara')).toBe(true);
+    // (spec 2031 FR-005) An accepted party is on their way into the room: no
+    // re-request while they join — the affordance stays "Invited" until their
+    // roster arrival retires it (or the call ends).
+    expect(canRequest(s, 'sara', true)).toBe(false);
+    expect(request(s, 'sara', 'call-2')).toBe(false);
+  });
+
+  it('a lost accept reply still resolves through accept() at roster time (spec 2031)', () => {
+    const s = fresh();
+    request(s, 'sara', 'call-1');
+    // No reply ever arrives; their roster join calls accept() late.
+    expect(s.pending.has('sara')).toBe(true);
+    accept(s, 'sara');
+    expect(s.pending.has('sara')).toBe(false);
+    expect(s.accepted.has('sara')).toBe(true);
   });
 
   it('a waiting attempt dying clears its pending entry silently (FR-013)', () => {

--- a/src/services/call/join-request.ts
+++ b/src/services/call/join-request.ts
@@ -20,20 +20,26 @@ export interface JoinRequestState {
   roomId: string; // pre-minted for a 1:1 ongoing call; the real roomId for a group
   pending: Map<string, string>; // partyId → their waiting attempt's callId
   rejected: Set<string>; // rejection-final for THIS call
+  // (spec 2031) Parties who ACCEPTED and are on their way into the room. Kept so
+  // (a) the invite affordance stays "Invited" (not re-askable) while they join,
+  // and (b) the roster-join retire of a redundant held 1:1 can prove the join
+  // came from OUR invite — even when the sealed accept reply itself was lost
+  // (the roster broadcast is the authoritative join signal).
+  accepted: Set<string>;
 }
 
 export function createJoinRequests(roomId: string): JoinRequestState {
-  return { roomId, pending: new Map(), rejected: new Set() };
+  return { roomId, pending: new Map(), rejected: new Set(), accepted: new Set() };
 }
 
 /** May the callee send this party a join request right now? */
 export function canRequest(s: JoinRequestState, partyId: string, capacityOk: boolean): boolean {
-  return capacityOk && !s.rejected.has(partyId) && !s.pending.has(partyId);
+  return capacityOk && !s.rejected.has(partyId) && !s.pending.has(partyId) && !s.accepted.has(partyId);
 }
 
 /** Register an outgoing request. Returns false when the state forbids it. */
 export function request(s: JoinRequestState, partyId: string, callId: string): boolean {
-  if (s.rejected.has(partyId) || s.pending.has(partyId)) return false;
+  if (s.rejected.has(partyId) || s.pending.has(partyId) || s.accepted.has(partyId)) return false;
   s.pending.set(partyId, callId);
   return true;
 }
@@ -44,10 +50,11 @@ export function reject(s: JoinRequestState, partyId: string): void {
   s.rejected.add(partyId);
 }
 
-/** The party accepted: clear pending, hand back their attempt's callId. */
+/** The party accepted: pending → accepted, hand back their attempt's callId. */
 export function accept(s: JoinRequestState, partyId: string): string | undefined {
   const callId = s.pending.get(partyId);
   s.pending.delete(partyId);
+  s.accepted.add(partyId);
   return callId;
 }
 

--- a/src/views/detail/CallActivePage.vue
+++ b/src/views/detail/CallActivePage.vue
@@ -130,15 +130,20 @@
           </button>
           <!-- (spec 1041 FR-002) Invite the held party into the active call — the same
                consent-gated join request the second-incoming prompt sends. Gone once they
-               said no (rejection is final for this call); "Invited" while they decide. -->
+               said no (rejection is final for this call); "Invited" while they decide.
+               (spec 2031 US2) Styled as a REAL action in the swap pill's family — the plain
+               dark pill it used to be was indistinguishable from its passive "Invited"
+               state and users found it tappable only by accident. -->
           <button
             v-if="heldPeerId && heldInviteState !== 'blocked'"
             class="cw-held cw-invite"
+            :class="{ sent: heldInviteState === 'invited' }"
             :disabled="heldInviteState === 'invited'"
             :aria-label="`Invite ${heldCall.name} to join this call`"
             @click.stop="() => void mergeHeld()"
           >
-            {{ heldInviteState === 'invited' ? 'Invited' : `Ask ${heldCall.name} to join this call` }}
+            <ion-icon :icon="heldInviteState === 'invited' ? checkmarkCircleOutline : personAddOutline" aria-hidden="true" />
+            {{ heldInviteState === 'invited' ? 'Invited · waiting for them to join' : `Ask ${heldCall.name} to join this call` }}
           </button>
         </template>
         <!-- (spec 2011) The small active-call "On hold" pill used to live here; it's redundant with
@@ -475,7 +480,7 @@ import {
   volumeHighOutline, bluetoothOutline, warningOutline,
   phonePortraitOutline, cameraReverseOutline, desktopOutline, chevronDownOutline,
   cellularOutline, informationCircleOutline, personOutline, personAddOutline, refreshOutline,
-  chatbubbleEllipsesOutline, pauseOutline, swapHorizontalOutline,
+  chatbubbleEllipsesOutline, pauseOutline, swapHorizontalOutline, checkmarkCircleOutline,
 } from 'ionicons/icons';
 import router from '@/router';
 import { getSelfUserId } from '@/services/auth';
@@ -1423,17 +1428,29 @@ const diag = computed(() => {
   color: #fff;
   box-shadow: 0 6px 22px rgba(0, 0, 0, 0.4);
 }
-/* (spec 1041) The held-party invite sits just above the swap bar: same pill,
-   its own row, disabled while their answer is pending. */
+/* (spec 1041) The held-party invite sits just above the swap bar, its own row.
+   (spec 2031 US2) It reads as an ACTION in the swap pill's family — green-tinted
+   fill + person-add icon + press feedback — clearly distinct from the passive
+   "Invited" status chip it turns into after the tap (.sent). */
 .cw-invite {
   bottom: calc(env(safe-area-inset-bottom, 0px) + 158px);
   padding: 10px 16px;
   font-size: 13px;
   font-weight: 600;
-  border: none;
+  gap: 8px;
+  border: 1.5px solid rgba(16, 185, 129, 0.85);
+  background: rgba(16, 185, 129, 0.3);
 }
-.cw-invite:disabled {
-  opacity: 0.55;
+.cw-invite ion-icon {
+  font-size: 18px;
+  flex: 0 0 auto;
+}
+/* Sent → a quiet status chip: no action tint, no border, no press affordance. */
+.cw-invite.sent {
+  border-color: transparent;
+  background: rgba(28, 28, 30, 0.92);
+  opacity: 0.8;
+  cursor: default;
 }
 /* Column layout so the name/subtitle row and the action buttons each stay on one line
    (the old single-row layout wrapped the text on narrow phones). */


### PR DESCRIPTION
## Summary

Field report (real two-phone family call): the "Ask X to join this call" control didn't look tappable, and after the invited held party accepted and joined, the old 1:1 stayed alive with a live "Switch to X" pill.

### Root cause
The pre-2031 retire ran only on receipt of the sealed `joinreq-accept` reply — a single lossable frame (see spec 2033). When it was lost while the active call was already a group, the invitee still meshed into the room via the room signaling, so the user saw them in the call **and** the stale held 1:1.

### Changes
- **Retire on JOIN, not accept (FR-001/FR-002):** the held 1:1 retires when the invitee lands in the server's roster broadcast (authoritative), gated on the join-request ledger so a deliberately parked 1:1 with someone already in the group is never touched. Accept alone no longer tears the held call down — an invitee who never lands leaves the held call intact (the stranding edge).
- **Ledger:** `accepted` set in join-request state — no re-request mid-join, "Invited" chip persists until the join lands, and a lost reply resolves through the roster arrival.
- **Phantom missed calls (FR-003):** any CONNECTED 1:1 dissolving into a room (merge accept or ordinary promotion) now closes out its Calls-tab record. Previously the callee's provisional "missed" row was never finished — a permanent phantom missed call from someone they actually talked to. The retired held call also logs as a normally-ended call with its real talk time.
- **US2:** the invite is a real action button (green-tinted, person-add icon, swap-pill family) with a clearly passive "Invited · waiting for them to join" state.

### Tests
- `e2e/call-invite-retire.spec.ts` (new, red-first): held-merge retire for both a 1:1-promoted and an already-group active call + history assertions. Stable 6/6 locally once free of CPU contention.
- `join-request.test.ts`: accepted-set semantics incl. the lost-reply path.
- `call-merge-consent` + `call-merge-held` suites green; client typecheck green.

**⚠️ Hold for real-device verification before merging** (same-device pass as the other open PRs #992–#996).

Closes nothing (hotfix spec 2031, no issues filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7