### PR TITLE
fix(wall): honest video-post progress, real avatar on the pending card, all media aspect ratios fit the feed (spec 2034)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,4 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
-| [2034](specs/2034-wall-video-posts/spec.md) | Wall Video Posts — Honest Progress, Real Avatar, Media That Fits | 🟡 in-progress |
+| [2034](specs/2034-wall-video-posts/spec.md) | Wall Video Posts — Honest Progress, Real Avatar, Media That Fits | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,3 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
+| [2034](specs/2034-wall-video-posts/spec.md) | Wall Video Posts — Honest Progress, Real Avatar, Media That Fits | 🟡 in-progress |

--- a/drive/scenarios/wall-media-fit.mjs
+++ b/drive/scenarios/wall-media-fit.mjs
@@ -1,0 +1,31 @@
+/**
+ * Spec 2034 visual check: tall (9:16-ish) single media on the Wall — image AND
+ * video — must letterbox WHOLE inside a 4:5 capped box (blurred fill, controls
+ * visible), while landscape media keeps its true ratio. Mobile viewport.
+ *
+ *   node drive/scenarios/wall-media-fit.mjs
+ */
+import { createAccount, pair, shot, sweep, done } from '../driver.mjs';
+
+const kim = await createAccount({ name: 'Kim', mobile: true });
+const pal = await createAccount({ name: 'Pal' });
+await pair(kim, pal); // a post needs an audience
+
+// Tall image + tall video + a landscape video, through the REAL createPost path.
+await kim.page.evaluate(() => window.__ringTest.postTallMedia('image'));
+await kim.page.evaluate(() => window.__ringTest.postTallMedia('video'));
+await kim.page.evaluate(() => window.__ringTest.postVideo());
+
+// Let posters/blobs settle, then inspect the feed (newest first: landscape video,
+// tall video, tall image — scroll for the last).
+await kim.page.waitForTimeout(2500);
+await shot(kim, 'wall-top', { route: '/tabs/wall' });
+await kim.page.evaluate(() => {
+  const sc = document.querySelector('ion-content');
+  sc?.scrollToBottom?.(0);
+});
+await kim.page.waitForTimeout(800);
+await shot(kim, 'wall-bottom');
+
+await sweep([kim, pal]);
+await done();

--- a/drive/scenarios/wall-tall-video.mjs
+++ b/drive/scenarios/wall-tall-video.mjs
@@ -1,0 +1,14 @@
+/** Spec 2034: a tall 9:16 VIDEO post alone — the capped 4:5 box must show the whole
+ *  clip pillarboxed with the player's bottom control bar visible. */
+import { createAccount, pair, shot, sweep, done } from '../driver.mjs';
+
+const kim = await createAccount({ name: 'Kim', mobile: true });
+const pal = await createAccount({ name: 'Pal' });
+await pair(kim, pal);
+
+await kim.page.evaluate(() => window.__ringTest.postTallMedia('video'));
+await kim.page.waitForTimeout(2500);
+await shot(kim, 'wall-tall-video', { route: '/tabs/wall' });
+
+await sweep([kim, pal]);
+await done();

--- a/specs/2034-wall-video-posts/spec.md
+++ b/specs/2034-wall-video-posts/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Wall Video Posts — Honest Progress, Real Avatar, Media That Fits
+
+**Feature Branch**: `fix/2034-wall-video-posts`
+
+**Created**: 2026-07-14
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User bug report (2026-07-14, with iPhone screenshots): "uploading videos as post on the wall stay on 2% for most of the duration, then jumps to 63% and immediately after that finishes, the avatar while posting shows Y instead of my avatar! Also on my iphone the video is not shown fully so I don't see the controllers but looks fine on the desktop!" Followed up mid-fix with: "we should cover all aspect ratios for media on the wall, they should all fit in as best as they can regardless if they are images or videos."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Posting a video shows honest, forward-moving progress (Priority: P1)
+
+Kamran shares a video to his Wall. The pending card's progress bar should move steadily through the work actually happening (compressing, then uploading) and never sit frozen near 0% for most of a minute before leaping to the end.
+
+**Why this priority**: A stuck-at-2% bar reads as a hung upload; users may kill the app or retry, duplicating work. Root cause: when the fast hardware transcode (WebCodecs) completed but couldn't shrink an already-efficient clip, the pipeline silently fell into the ffmpeg.wasm leg — a ~30 MB engine download with no progress events plus a slow single-threaded second transcode that almost never shrinks such a clip either, while the bar sat at the bottom of the same 0–50% encode band.
+
+**Independent Test**: Post an already-well-compressed H.264 clip (a downloaded meme video). The post completes without the multi-ten-second frozen-bar phase, and the bar never moves backwards.
+
+**Acceptance Scenarios**:
+
+1. **Given** a video whose hardware re-encode completes but is not smaller than the source, **When** it is posted, **Then** the original is uploaded directly (labeled honestly per spec 2007) with no second transcode attempt.
+2. **Given** any engine fallback or phase transition during a post, **Then** the visible progress value never decreases.
+
+---
+
+### User Story 2 - The pending card is unmistakably mine (Priority: P2)
+
+While a post uploads, the pending "Posting…" card shows the user's real profile picture — the same avatar the published post will show — not a generic "Y" initial disc.
+
+**Acceptance Scenarios**:
+
+1. **Given** a profile with an avatar set, **When** a post is uploading, **Then** the pending card shows that avatar; the "Y" initials disc appears only when no avatar exists.
+
+---
+
+### User Story 3 - Every aspect ratio fits the feed, images and videos alike (Priority: P1)
+
+Wall media of ANY aspect ratio shows WHOLE in the feed. Tall (portrait) photos and videos are letterboxed into a bounded frame — like the album slides already are — instead of growing a box taller than the phone's viewport. For videos this guarantees the inline player's control bar is always visible; on the reporter's iPhone a 9:16 video overflowed its clamped box and the controls were unreachable (desktop, with more viewport height, never hit the clamp).
+
+**Independent Test**: Post a 9:16 portrait video, a 9:16 portrait photo, a square photo, and a wide landscape photo. Each shows fully in the feed on a phone-sized viewport; the video's play/scrub/fullscreen bar is visible without scrolling tricks.
+
+**Acceptance Scenarios**:
+
+1. **Given** a portrait video taller than 5:4, **When** it renders in the feed, **Then** its box is capped at 4:5, the clip letterboxes whole inside it over a blurred fill (album-slide style), and the player controls are fully visible.
+2. **Given** a portrait photo taller than 5:4, **Then** the same capped, letterboxed-whole presentation applies.
+3. **Given** square or landscape media, **Then** it keeps its true aspect ratio (it already fits at any width) — no regression.
+4. **Given** an album post, **Then** nothing changes (albums already use the 4:5 contained frame).
+
+---
+
+### Edge Cases
+
+- Media records without stored dimensions keep today's 4:3 fallback box.
+- A video with no poster yet still renders (no blurred fill, black background).
+- The progress high-water mark applies per item, so multi-item posts still advance item-by-item.
+- The WebCodecs → ffmpeg fallback is preserved for genuine WebCodecs FAILURES (unsupported codec, decode error) — only the completed-but-not-smaller outcome short-circuits to the original.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A completed hardware (WebCodecs) transcode whose output is not smaller than the source MUST result in the original being uploaded, with no ffmpeg attempt; ffmpeg remains the fallback for WebCodecs failures only.
+- **FR-002**: Pending-post progress MUST be monotonic per item (never displayed decreasing).
+- **FR-003**: The pending "Posting…" card MUST show the user's profile avatar when one exists, with initials only as the no-avatar fallback.
+- **FR-004**: Single-media feed boxes MUST be capped at a 4:5 aspect ratio for taller media; capped media MUST render whole (contain) over a blurred self-fill, matching the album-slide presentation; square/landscape media keep their true ratio.
+- **FR-005**: The inline video player's control bar MUST be fully visible within the feed box for every aspect ratio on phone-sized viewports.
+
+## Zero-Knowledge Impact
+
+- **What crosses the wire**: unchanged — same encrypted media upload; skipping a local transcode changes only WHICH locally-produced bytes are encrypted and uploaded (the original instead of a failed-to-shrink re-encode), a path that already existed.
+- **Visible metadata**: unchanged.
+- **Why**: pure client pipeline/UI change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Posting an already-compressed clip shows no frozen-progress phase longer than a few seconds (the reporter's repro: ~1 minute at 2%).
+- **SC-002**: The reporter confirms on-device: real avatar on the pending card, video controls visible on a 9:16 post, portrait photos shown whole.
+- **SC-003**: Client typecheck and the existing wall e2e suites stay green.
+
+## Assumptions
+
+- 4:5 (the existing album frame ratio) is the right portrait cap for single media — it matches the already-shipped album behavior and mainstream feed conventions.
+- The "2% stall" diagnosis (ffmpeg leg after a completed-but-not-smaller WebCodecs pass) is from code-path analysis of the reported symptoms (2% ≈ restart of the encode band; 63% ≈ first upload progress event after the 50% band boundary); the reporter's on-device pass is the final confirmation (SC-002).

--- a/specs/2034-wall-video-posts/spec.md
+++ b/specs/2034-wall-video-posts/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-14
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/services/media-video.test.ts
+++ b/src/services/media-video.test.ts
@@ -38,13 +38,15 @@ describe('compressVideoAdaptive fallback ladder', () => {
     expect(out).toBe(small);
   });
 
-  it('falls through to ffmpeg when WebCodecs output is not smaller', async () => {
+  it('sends the ORIGINAL (no ffmpeg detour) when a completed WebCodecs pass is not smaller (spec 2034 FR-001)', async () => {
+    // A hardware re-encode that can't shrink the clip means the source is already
+    // efficient for the preset. The old ffmpeg fallback here cost a silent ~30 MB
+    // wasm download + a slow second transcode while the posting bar sat near 0%.
     const src = mp4(1000);
-    const small = mp4(450);
     vi.mocked(webcodecsTranscode).mockResolvedValue(mp4(1000)); // not smaller
-    vi.mocked(ffmpegTranscode).mockResolvedValue(small);
     const out = await compressVideoAdaptive(src, 'sd');
-    expect(out).toBe(small);
+    expect(out).toBe(src);
+    expect(ffmpegTranscode).not.toHaveBeenCalled();
   });
 
   it('never blocks the send: returns the ORIGINAL blob when both engines fail (FR-006)', async () => {

--- a/src/services/media-video.ts
+++ b/src/services/media-video.ts
@@ -48,7 +48,15 @@ export async function compressVideoAdaptive(
         const out = await webcodecsTranscode(blob, preset, onProgress);
         console.info('[video] webcodecs output', { bytes: out.size, vs: blob.size });
         if (out.size > 0 && out.size < blob.size) return out;
-        console.warn('[video] webcodecs output not smaller; trying ffmpeg');
+        // A COMPLETED hardware re-encode that isn't smaller means the source is
+        // already efficiently compressed for this preset — the honest result is
+        // the original (achievedQuality labels it so). Falling into ffmpeg here
+        // cost a silent ~30 MB wasm download plus a slow single-threaded second
+        // transcode that almost never shrinks such a clip either, and the
+        // posting progress bar sat near 0% for the whole detour. ffmpeg remains
+        // the fallback for webcodecs FAILURES only.
+        console.info('[video] webcodecs output not smaller — source already efficient, sending original');
+        return blob;
       }
     } catch (e) {
       console.warn('[video] WebCodecs transcode FAILED; trying ffmpeg', e);

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -213,7 +213,10 @@ async function writeProgress(
   lastProgressWrite.set(id, t);
   const rec = await getPendingPost(id);
   if (!rec || rec.status !== 'uploading' || !rec.items[p.index]) return;
-  // encode is the first half of an item, upload the second half.
-  rec.items[p.index].progress = p.phase === 'encoding' ? p.value * 0.5 : 0.5 + p.value * 0.5;
+  // encode is the first half of an item, upload the second half. High-water mark:
+  // an engine fallback (WebCodecs → ffmpeg) restarts the encode band from 0, and
+  // a bar that winds BACKWARDS reads as a broken upload — never regress it.
+  const next = p.phase === 'encoding' ? p.value * 0.5 : 0.5 + p.value * 0.5;
+  rec.items[p.index].progress = Math.max(rec.items[p.index].progress ?? 0, next);
   await updatePendingPost(rec);
 }

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -1448,6 +1448,33 @@ export function installTestHook(): void {
       });
       return p.id;
     },
+    /** (spec 2034) A TALL (9:16-ish) single-media post — image or real video — so the
+     *  feed's capped 4:5 letterbox presentation can be checked visually/e2e. The image
+     *  carries a full-edge white border: fully visible ⇔ shown whole (contain). */
+    postTallMedia: async (kind: 'image' | 'video'): Promise<string> => {
+      if (kind === 'video') {
+        const blob = await makeTestVideo(360, 640, 2);
+        const p = await dbCreatePost({ audience: 'friends', lifetime: '24h', media: { blob, kind: 'video', name: 'tall.mp4' } });
+        return p.id;
+      }
+      const c = document.createElement('canvas');
+      c.width = 600;
+      c.height = 1200;
+      const ctx = c.getContext('2d')!;
+      ctx.fillStyle = '#8b5cf6';
+      ctx.fillRect(0, 0, 600, 1200);
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineWidth = 50;
+      ctx.strokeRect(25, 25, 550, 1150);
+      ctx.fillStyle = 'rgba(255,255,255,0.95)';
+      ctx.font = '80px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('TALL', 300, 600);
+      const blob = await new Promise<Blob>((res) => c.toBlob((b) => res(b!), 'image/png'));
+      const p = await dbCreatePost({ audience: 'friends', lifetime: '24h', media: { blob, kind: 'image', name: 'tall.png' } });
+      return p.id;
+    },
     /** Post an album of 2 real videos + 2 images through createPost, timing each progress
      *  phase, to reproduce the "stuck while processing" report. Returns elapsed ms + last
      *  progress seen (so a hang shows up as a never-resolving promise / frozen last phase). */

--- a/src/views/tabs/WallPage.vue
+++ b/src/views/tabs/WallPage.vue
@@ -59,7 +59,13 @@
       <ion-item v-for="pp in pending" :key="pp.id" lines="none" class="postitem">
         <div class="post pending-post">
           <div class="phead">
-            <ion-avatar class="avatar"><div class="ph">{{ initial('You') }}</div></ion-avatar>
+            <!-- Same avatar resolution as a posted card: the real profile picture,
+                 initials only as the no-avatar fallback (a pending card that showed
+                 "Y" next to your own face rows read as someone else posting). -->
+            <ion-avatar class="avatar">
+              <user-avatar v-if="selfAvatar" :src="selfAvatar" alt="You" />
+              <div v-else class="ph">{{ initial('You') }}</div>
+            </ion-avatar>
             <div class="who">
               <div class="name">You</div>
               <div class="sub">
@@ -178,9 +184,19 @@
             <div
               v-else-if="p.kind === 'image' || p.kind === 'video'"
               class="thumb"
-              :class="{ loading: p.kind === 'image' && !mediaLoaded[p.id] }"
+              :class="{ loading: p.kind === 'image' && !mediaLoaded[p.id], 'thumb-video': p.kind === 'video', 'fit-contain': mediaCapped(p) }"
               :style="mediaStyle(p)"
             >
+              <!-- Capped (tall) media letterboxes over its own blurred copy — the album
+                   slides' fill trick, so single posts and albums read the same. Always an
+                   image (a video's poster), never a second <video>. -->
+              <img
+                v-if="mediaCapped(p) && (p.kind === 'video' ? p.posterUrl : p.posterUrl || p.mediaUrl)"
+                class="thumb-fill"
+                :src="p.kind === 'video' ? p.posterUrl : p.posterUrl || p.mediaUrl"
+                alt=""
+                aria-hidden="true"
+              />
               <!-- Image: poster shows instantly; tap or ⤢ opens the minimal full-screen image. -->
               <template v-if="p.kind === 'image' && (p.posterUrl || p.mediaUrl)">
                 <img
@@ -329,6 +345,7 @@ import WallVideo from '@/components/WallVideo.vue';
 import VoicePlayer from '@/components/VoicePlayer.vue';
 import WallGameCard from '@/components/WallGameCard.vue';
 import { useWall, type WallPost } from '@/composables/useWall';
+import { useSelfProfile } from '@/composables/useSelfProfile';
 import { usePendingPosts } from '@/composables/usePendingPosts';
 import { retryPendingPost, cancelPendingPost } from '@/services/pending-posts';
 import { useReactionPicker } from '@/composables/useReactionPicker';
@@ -344,6 +361,9 @@ import { timeLeft, ago } from '@/utils/post-time';
 const router = useRouter();
 const { wall, now, loaded, synced } = useWall();
 const { pending } = usePendingPosts();
+// Own profile picture for the pending "Posting…" card (same source useWall
+// resolves for our published posts).
+const { avatar: selfAvatar } = useSelfProfile();
 
 // Pull-to-refresh: re-pull the feed (new posts stream in via the live query) and release the
 // control when the sync settles.
@@ -405,8 +425,20 @@ const mediaLoaded = reactive<Record<string, boolean>>({});
 function onMediaLoad(id: string): void {
   mediaLoaded[id] = true;
 }
+// Tall media (image OR video) gets its feed box capped at 4:5 — the album frame's
+// ratio — and is letterboxed WHOLE inside it (contain + a blurred fill, exactly like
+// album slides). A full-height 9:16 box at phone width is taller than the viewport
+// allows, and the .thumb max-height clamp + overflow:hidden then swallowed the bottom
+// of the media — including the video player's control bar — on iPhones (desktop never
+// hits the clamp, which is why it only reproduced on the phone). Landscape/square
+// media keeps its true ratio: it already fits at any width.
+function mediaCapped(p: WallPost): boolean {
+  return !!p.mediaW && !!p.mediaH && p.mediaH > p.mediaW * 1.25;
+}
 function mediaStyle(p: WallPost): Record<string, string> {
-  return { aspectRatio: p.mediaW && p.mediaH ? `${p.mediaW} / ${p.mediaH}` : '4 / 3' };
+  if (!p.mediaW || !p.mediaH) return { aspectRatio: '4 / 3' };
+  if (mediaCapped(p)) return { aspectRatio: '4 / 5' };
+  return { aspectRatio: `${p.mediaW} / ${p.mediaH}` };
 }
 // One stable, slightly-vertical 4:5 frame for a whole mixed-aspect album (Instagram-style):
 // portraits — the common case — nearly fill it, while squares/landscapes sit contained with
@@ -792,6 +824,29 @@ ion-item-sliding ion-item-option {
   max-height: 60vh;
   overflow: hidden;
   background: var(--ion-color-step-100, rgba(120, 120, 128, 0.12));
+}
+/* Video boxes sit on black (their pillarbox/letterbox bands), not the gray skeleton tint. */
+.thumb-video {
+  background: #000;
+}
+/* Capped tall media (see mediaCapped): the main image switches cover → contain so the
+   WHOLE picture shows inside the 4:5 frame, over its blurred fill. The fill mirrors
+   .aslide-fill so single posts and album slides read identically. */
+.thumb.fit-contain {
+  background: #000;
+}
+.thumb.fit-contain > img:not(.thumb-fill) {
+  position: relative;
+  object-fit: contain;
+}
+.thumb > img.thumb-fill {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.15); /* hide the blur's soft edge */
+  filter: blur(22px) brightness(0.85) saturate(1.1);
 }
 /* Inline album gallery: a horizontal scroll-snap row inside the aspect-ratio box, so you
    can swipe every photo/video right in the feed. */


### PR DESCRIPTION
## Summary

Field report (iPhone screenshots, 2026-07-14): video posts sat at 2% for most of a minute then jumped to 63% and finished; the pending "Posting…" card showed a "Y" initial instead of the profile avatar; a 9:16 video overflowed the feed box so the player controls were cut off (fine on desktop). Follow-up request: ALL aspect ratios — images and videos — should fit the feed whole.

### Changes
- **Progress (US1):** a completed WebCodecs re-encode that isn't smaller now uploads the original directly (honest 'original' label per spec 2007) instead of silently detouring through the ffmpeg.wasm leg (~30 MB engine download with no progress events + a slow single-thread second transcode — the frozen-at-2% phase). ffmpeg stays as the fallback for genuine WebCodecs failures. Pending progress is a per-item high-water mark, so no phase transition ever winds the bar backwards.
- **Avatar (US2):** the pending card resolves the same profile avatar a published post shows; initials only when no avatar exists.
- **Media fit (US3):** tall media — image or video — letterboxes whole in a 4:5 frame over a blurred self-fill (the album-slide presentation); square/landscape keep their true ratio. This keeps the inline player's control bar visible on phone viewports where the old aspect-ratio box + max-height clamp cut it off.

### Verification
- `media-video.test.ts` updated red-first for the no-ffmpeg-detour rule (4/4 green).
- New drive scenarios `wall-media-fit.mjs` / `wall-tall-video.mjs` (dev-only `postTallMedia` hook): screenshots confirm tall image shown whole (full border visible), tall video pillarboxed with controls visible, landscape unchanged.
- Wall/album e2e regression (wall, wall-thumbnails, wall-autoplay, album-posts, album-ui): 12/12 green. Client typecheck green.

**⚠️ Hold for real-device verification before merging** (same device pass as PRs #992–#997). On-device checklist: post a downloaded/compressed video (progress should move honestly, no long 2% stall), confirm your avatar on the pending card, confirm a 9:16 video's controls are visible on iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7