### PR TITLE
fix(chats): quick back-to-back messages between new group members no longer go missing (spec 2033)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,4 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
-| [2033](specs/2033-second-consecutive-frame/spec.md) | Second Consecutive Frame on a Fresh Carrier Session Is Lost | ⚪ planned |
+| [2033](specs/2033-second-consecutive-frame/spec.md) | Second Consecutive Frame on a Fresh Carrier Session Is Lost | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,3 +108,4 @@ Specs are grouped by category band; status moves
 | [2028](specs/2028-quick-forward-button/spec.md) | Quick-Forward Button Sits at the Bottom Edge of Tall Media Messages | 🟢 shipped |
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
+| [2033](specs/2033-second-consecutive-frame/spec.md) | Second Consecutive Frame on a Fresh Carrier Session Is Lost | ⚪ planned |

--- a/drive/scenarios/ratchet-2033.mjs
+++ b/drive/scenarios/ratchet-2033.mjs
@@ -1,0 +1,61 @@
+/**
+ * Spec 2033 live repro: in a group where B and C are NOT paired, C's second
+ * consecutive frame to B (a reaction after "carol here") historically failed
+ * to decrypt on B. Runs against the live dev stack so messaging.ts console
+ * instrumentation streams straight to stdout.
+ *
+ *   node drive/scenarios/ratchet-2033.mjs
+ */
+import { createAccount, pair, group, say, waitForMessage, messageId, react, poll, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Alice' });
+const b = await createAccount({ name: 'Bob' });
+const c = await createAccount({ name: 'Carol' });
+await pair(a, b);
+await pair(a, c);
+
+const gid = await group(a, 'Ratchet crew', [b, c]);
+
+await say(a, gid, 'hello crew', { isGroup: true });
+await waitForMessage(b, gid, 'hello crew', { isGroup: true });
+await waitForMessage(c, gid, 'hello crew', { isGroup: true });
+
+// B speaks first: B initiates X3DH B→C (serialized, no both-initiate fork).
+await say(b, gid, 'bob here', { isGroup: true });
+await waitForMessage(a, gid, 'bob here', { isGroup: true });
+await waitForMessage(c, gid, 'bob here', { isGroup: true });
+
+// C's responder-side first send — historically fine everywhere.
+await say(c, gid, 'carol here', { isGroup: true });
+await waitForMessage(a, gid, 'carol here', { isGroup: true });
+await waitForMessage(b, gid, 'carol here', { isGroup: true });
+
+// C's SECOND consecutive frame: react to Alice's message. The bug: B never
+// converges (decrypt failure logged on B's console).
+const mid = await messageId(c, gid, 'hello crew');
+await react(c, mid, '🔥');
+
+const bSees = async () => {
+  const bMid = await messageId(b, gid, 'hello crew');
+  const ms = await b.page.evaluate((id) => window.__ringTest.messages(id), gid);
+  const m = ms.find((x) => x.id === bMid);
+  return (m?.reactions ?? []).some((r) => r.emoji === '🔥');
+};
+try {
+  await poll(bSees, (v) => v === true, { timeout: 25_000, label: 'B sees the 🔥 reaction' });
+  console.log('[2033] PASS — B converged; bug did not reproduce');
+} catch {
+  console.log('[2033] REPRODUCED — B never saw the reaction');
+}
+
+// A must have converged either way (control).
+const aSees = async () => {
+  const aMid = await messageId(a, gid, 'hello crew');
+  const ms = await a.page.evaluate((id) => window.__ringTest.messages(id), gid);
+  return (ms.find((x) => x.id === aMid)?.reactions ?? []).some((r) => r.emoji === '🔥');
+};
+await poll(aSees, (v) => v === true, { timeout: 25_000, label: 'A sees the 🔥 reaction' });
+console.log('[2033] control: A converged');
+
+await sweep([a, b, c]);
+await done();

--- a/e2e/push-routing.spec.ts
+++ b/e2e/push-routing.spec.ts
@@ -88,20 +88,6 @@ test('group fan-out: author + co-reactors loud, bystanders silent; creation is q
       { timeout: 30_000 },
     );
   }
-  // KNOWN BUG DODGE (filed as spec 2033): on a fresh carrier session, a SECOND
-  // consecutive frame to a member who never wrote back is undecryptable (the
-  // pre-1050 client fails identically — see the spec's repro notes). Bob
-  // interjecting resets every sender's chain so the reactions below ride the
-  // proven send-after-receive path. Remove once 2033 lands.
-  await b.page.evaluate((id) => (window as any).__ringTest.sendChatMessage(id, 'ok'), gid);
-  for (const p of [a, c]) {
-    await p.page.waitForFunction(
-      (id) => (window as any).__ringTest.messages(id).then((ms: any[]) => ms.some((m: any) => m.body === 'ok')),
-      gid,
-      { timeout: 30_000 },
-    );
-  }
-
   // Let the message banners clear so the reaction assertions start clean.
   for (const p of [a, b, c]) {
     await p.page.waitForFunction(() => (window as any).__ringTest.notices().length === 0, undefined, { timeout: 30_000 });

--- a/e2e/ratchet-consecutive.spec.ts
+++ b/e2e/ratchet-consecutive.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair, type RingClient } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Spec 2033 — consecutive sealed frames on a fresh carrier session.
+//
+// In a group whose members aren't all mutually paired, a co-member pair's
+// Double-Ratchet session is the group's hidden 1:1 carrier, bootstrapped on
+// demand. The field bug (found by spec 1050's fan-out e2e): the RESPONDER
+// side's SECOND consecutive frame — sent with no frame received in between —
+// failed to decrypt on the initiator ("ciphertext cannot be decrypted") and,
+// since the relay had already dropped it, was lost forever. FR-001: a member
+// must be able to send arbitrarily many consecutive frames.
+
+const sendMsg = (c: RingClient, chatId: string, body: string): Promise<void> =>
+  c.page.evaluate(({ id, b }) => (window as any).__ringTest.sendChatMessage(id, b), { id: chatId, b: body });
+const awaitBody = (c: RingClient, chatId: string, body: string): Promise<unknown> =>
+  c.page.waitForFunction(
+    ({ id, b }) => (window as any).__ringTest.messages(id).then((ms: any[]) => ms.some((m: any) => m.body === b)),
+    { id: chatId, b: body },
+    { timeout: 30_000 },
+  );
+const setProfile = (c: RingClient, name: string): Promise<void> =>
+  c.page.evaluate((n) => (window as any).__ringTest.setProfile(n, ''), name);
+// Poll via evaluate (NOT waitForFunction + jsonValue, which returns undefined
+// for ids often enough to flake — e2e lesson from spec 1048).
+const msgIdOf = async (c: RingClient, chatId: string, body: string): Promise<string> => {
+  for (let i = 0; i < 60; i++) {
+    const id = (await c.page.evaluate(
+      ({ cid, b }) => (window as any).__ringTest.messages(cid).then((ms: any[]) => ms.find((m: any) => m.body === b)?.id ?? null),
+      { cid: chatId, b: body },
+    )) as string | null;
+    if (id) return id;
+    await c.page.waitForTimeout(500);
+  }
+  throw new Error(`message "${body}" never appeared in ${chatId}`);
+};
+const react = (c: RingClient, messageId: string, emoji: string): Promise<void> =>
+  c.page.evaluate(({ id, e }) => (window as any).__ringTest.reactToMessage(id, e), { id: messageId, e: emoji });
+const emojisOn = (c: RingClient, chatId: string, messageId: string): Promise<string[]> =>
+  c.page.evaluate(
+    ({ cid, mid }) =>
+      (window as any).__ringTest
+        .messages(cid)
+        .then((ms: any[]) => (ms.find((m: any) => m.id === mid)?.reactions ?? []).map((r: any) => r.emoji)),
+    { cid: chatId, mid: messageId },
+  );
+
+test('a responder can send many consecutive frames over a fresh carrier session (FR-001)', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const ctx = await Promise.all([0, 1, 2].map(() => browser.newContext()));
+  const [a, b, c] = await Promise.all(
+    ['RAT1A', 'RAT1B', 'RAT1C'].map((code, i) => createAccount(ctx[i], code)),
+  );
+  // Profiles first (the 1050 repro had them): contact/profile cards ride the
+  // same pairwise sessions as messages, so they're part of the field traffic.
+  await setProfile(a, 'Alice');
+  await setProfile(b, 'Bob');
+  await setProfile(c, 'Carol');
+  // B and C are deliberately NOT paired: their pairwise session is the group's
+  // hidden carrier, bootstrapped when B first fans out to C.
+  await pair(a, b);
+  await pair(a, c);
+
+  const gid = (await a.page.evaluate(
+    (ids) => (window as any).__ringTest.createGroup('Ratchet crew', ids),
+    [b.id, c.id],
+  )) as string;
+  for (const p of [b, c]) {
+    await p.page.waitForFunction(
+      (g) => (window as any).__ringTest.groupChats().then((gs: any[]) => gs.some((x: any) => x.id === g)),
+      gid,
+      { timeout: 30_000 },
+    );
+  }
+
+  // A speaks; then B speaks FIRST (B initiates X3DH B→C), serialized so B and C
+  // can't both initiate the pair session (that fork is a separate known issue).
+  await sendMsg(a, gid, 'hello crew');
+  for (const p of [b, c]) await awaitBody(p, gid, 'hello crew');
+  await sendMsg(b, gid, 'bob here');
+  for (const p of [a, c]) await awaitBody(p, gid, 'bob here');
+
+  // C's first frame rides the freshly-established responder side — this works.
+  await sendMsg(c, gid, 'carol 1');
+  for (const p of [a, b]) await awaitBody(p, gid, 'carol 1');
+
+  // The bug: with B staying silent, C's SECOND consecutive frame was lost on B.
+  // The field repro's second frame was a REACTION (to Alice's message) — use
+  // exactly that, then more plain messages to pin the whole chain.
+  const helloId = await msgIdOf(c, gid, 'hello crew');
+  await react(c, helloId, '🔥');
+  for (const p of [a, b]) {
+    await expect
+      .poll(async () => emojisOn(p, gid, await msgIdOf(p, gid, 'hello crew')), { timeout: 30_000 })
+      .toContain('🔥');
+  }
+  await sendMsg(c, gid, 'carol 2');
+  await sendMsg(c, gid, 'carol 3');
+  for (const p of [a, b]) {
+    await awaitBody(p, gid, 'carol 2');
+    await awaitBody(p, gid, 'carol 3');
+  }
+
+  await Promise.all(ctx.map((x) => x.close()));
+});

--- a/specs/2033-second-consecutive-frame/checklists/requirements.md
+++ b/specs/2033-second-consecutive-frame/checklists/requirements.md
@@ -1,0 +1,1 @@
+# Checklist: pending clarify/plan (crypto spec — /speckit-checklist REQUIRED at plan time; Principle IV)

--- a/specs/2033-second-consecutive-frame/spec.md
+++ b/specs/2033-second-consecutive-frame/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-14
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: Found while building spec 1050's fan-out e2e (2026-07-14): in a fresh 3-member group, a member's SECOND consecutive sealed frame to a co-member who has not written back since fails to decrypt ("ciphertext cannot be decrypted using that key", ratchetDecrypt normal packet) and — because the relay already dropped the sender's outbox copy — is permanently lost for that recipient. Reproduced identically on the pre-1050 client (bisect via `git stash push src/`), so this is a live bug in the shipped ratchet/session layer, not a 1050 regression.

--- a/specs/2033-second-consecutive-frame/spec.md
+++ b/specs/2033-second-consecutive-frame/spec.md
@@ -1,0 +1,59 @@
+# Feature Specification: Second Consecutive Frame on a Fresh Carrier Session Is Lost
+
+**Feature Branch**: `fix/2033-second-consecutive-frame`
+
+**Created**: 2026-07-14
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: Found while building spec 1050's fan-out e2e (2026-07-14): in a fresh 3-member group, a member's SECOND consecutive sealed frame to a co-member who has not written back since fails to decrypt ("ciphertext cannot be decrypted using that key", ratchetDecrypt normal packet) and — because the relay already dropped the sender's outbox copy — is permanently lost for that recipient. Reproduced identically on the pre-1050 client (bisect via `git stash push src/`), so this is a live bug in the shipped ratchet/session layer, not a 1050 regression.
+
+## Reproduction (deterministic, from the 1050 work)
+
+Accounts A,B,C; pair(A,B), pair(A,C) — B and C are NOT paired (their session is the
+group's hidden 1:1 carrier). A creates a group {A,B,C}; A: "hello crew"; B: "bob here"
+(B initiates X3DH B→C); wait until everyone has it; C: "carol here" (C's responder-side
+first send — decrypts fine everywhere); then, with B staying silent, C sends ANY second
+frame (the repro used a reaction signal): B logs
+`failed to open incoming message {from: C, packet: normal}` and C's frame never applies
+on B. Interjecting any B→group frame between C's two sends avoids it (send-after-receive
+resets the chain), which is the temporary dodge marked in e2e/push-routing.spec.ts.
+The full-suite flake in games-group.spec.ts (challenge→accept→observers) has the same
+shape and is plausibly this bug.
+
+## User impact
+
+In groups containing not-mutually-paired members, back-to-back frames from one member
+(two quick messages, a message + reaction, game move bursts) silently vanish for
+co-members who haven't spoken since — no error, no retry, permanent divergence.
+
+## Requirements
+
+- **FR-001**: A member MUST be able to send arbitrarily many consecutive sealed frames
+  over a fresh carrier session without any recipient losing one (Double Ratchet
+  consecutive-send on the responder-established side).
+- **FR-002**: Per the constitution (III, hotfix rule; IV crypto discipline), the fix
+  MUST start from a failing regression test — unit-level in the crypto core (pure
+  ratchet: initiator/responder, consecutive sends, out-of-order, skipped keys) plus
+  the e2e choreography above un-dodged — and MUST get a security review.
+- **FR-003**: Recovery for already-diverged sessions rides the existing re-key path;
+  the fix must not invalidate healthy sessions.
+
+## Zero-Knowledge Impact
+
+None — on-device crypto correctness; nothing about the wire or server changes.
+
+## Success Criteria
+
+- **SC-001**: The un-dodged 1050 choreography passes 10/10 locally; the dodge comment
+  in e2e/push-routing.spec.ts is removed by this spec's PR.
+- **SC-002**: New pure-ratchet consecutive-send tests cover both establishment sides.
+- **SC-003**: games-group.spec.ts stops flaking in full-suite runs (tracked across CI).
+
+## Assumptions
+
+- Suspected locus: session persistence/advance around responder-established carriers
+  (`messaging.ts` open/seal + ratchet state save ordering) — to be confirmed by the
+  failing unit tests before any fix (no diagnosis is trusted until a pure test
+  reproduces it).

--- a/specs/2033-second-consecutive-frame/spec.md
+++ b/specs/2033-second-consecutive-frame/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-14
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: Found while building spec 1050's fan-out e2e (2026-07-14): in a fresh 3-member group, a member's SECOND consecutive sealed frame to a co-member who has not written back since fails to decrypt ("ciphertext cannot be decrypted using that key", ratchetDecrypt normal packet) and — because the relay already dropped the sender's outbox copy — is permanently lost for that recipient. Reproduced identically on the pre-1050 client (bisect via `git stash push src/`), so this is a live bug in the shipped ratchet/session layer, not a 1050 regression.

--- a/src/services/crypto/ratchet.test.ts
+++ b/src/services/crypto/ratchet.test.ts
@@ -10,6 +10,8 @@ import {
   ratchetInitAlice,
   ratchetInitBob,
   ratchetDecryptPreview,
+  sessionRecord,
+  sessionFromRecord,
   type RatchetState,
 } from './ratchet';
 import { sealMessage, openMessage } from './message';
@@ -86,6 +88,53 @@ describe('Double Ratchet', () => {
     const r1 = ratchetDecryptPreview(bob, dhStep.header, dhStep.env, ad);
     expect(JSON.parse(new TextDecoder().decode(r1.plaintext)).body).toBe('m2 new chain');
     expect(r1.advancedDh).toBe(true);
+  });
+
+  it('responder sends many consecutive frames on a fresh session (spec 2033 FR-001, pure level)', () => {
+    // The exact field shape: initiator speaks once, then the RESPONDER sends
+    // back-to-back frames with nothing received in between. The pure ratchet
+    // must derive every key; the field loss lived in the layer above.
+    const { alice, bob, ad } = setupPair();
+    expect(openMessage(bob, sealMessage(alice, msg('bob here'), ad), ad).body).toBe('bob here');
+    const s1 = sealMessage(bob, msg('carol 1'), ad);
+    const s2 = sealMessage(bob, msg('carol 2'), ad);
+    const s3 = sealMessage(bob, msg('carol 3'), ad);
+    const s4 = sealMessage(bob, msg('carol 4'), ad);
+    expect(openMessage(alice, s1, ad).body).toBe('carol 1');
+    expect(openMessage(alice, s2, ad).body).toBe('carol 2');
+    expect(openMessage(alice, s3, ad).body).toBe('carol 3');
+    expect(openMessage(alice, s4, ad).body).toBe('carol 4');
+  });
+
+  it('consecutive sends survive a serialize/deserialize round-trip between every step (spec 2033)', () => {
+    // Mirror the persistence layer: every seal/open is a load→advance→save, so
+    // the state crosses SerializedSession (and IndexedDB's structured clone,
+    // approximated by JSON) between each frame on BOTH sides.
+    const roundTrip = (s: RatchetState): RatchetState =>
+      sessionFromRecord(JSON.parse(JSON.stringify(sessionRecord('t', s))));
+    const { alice, bob, ad } = setupPair();
+    let A = alice;
+    let B = bob;
+    const send = (from: 'A' | 'B', body: string) => {
+      const st = from === 'A' ? A : B;
+      const wire = sealMessage(st, msg(body), ad);
+      if (from === 'A') A = roundTrip(A);
+      else B = roundTrip(B);
+      return wire;
+    };
+    const recv = (at: 'A' | 'B', wire: ReturnType<typeof sealMessage>, body: string) => {
+      const st = at === 'A' ? A : B;
+      expect(openMessage(st, wire, ad).body).toBe(body);
+      if (at === 'A') A = roundTrip(A);
+      else B = roundTrip(B);
+    };
+    recv('B', send('A', 'bob here'), 'bob here');
+    const w1 = send('B', 'carol 1');
+    const w2 = send('B', 'carol 2');
+    recv('A', w1, 'carol 1');
+    const w3 = send('B', 'carol 3');
+    recv('A', w2, 'carol 2');
+    recv('A', w3, 'carol 3');
   });
 
   it('handles out-of-order delivery (skipped message keys)', () => {

--- a/src/services/crypto/ratchet.ts
+++ b/src/services/crypto/ratchet.ts
@@ -327,6 +327,13 @@ export function sessionRecord(chatId: string, state: RatchetState): SerializedSe
   return serialize(chatId, state);
 }
 
+/** Rehydrate a state from a sessions-store row (the inverse of sessionRecord).
+ *  Exercised directly by the spec-2033 persistence-round-trip regression tests;
+ *  production reads go through loadSession. */
+export function sessionFromRecord(rec: SerializedSession): RatchetState {
+  return deserialize(rec);
+}
+
 export async function loadSession(chatId: string): Promise<RatchetState | null> {
   const rec = await get<SerializedSession>('sessions', chatId);
   return rec ? deserialize(rec) : null;

--- a/src/services/messaging.test.ts
+++ b/src/services/messaging.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Spec 2033 — the X3DH both-initiate collision at the MESSAGING layer.
+ *
+ * The pure Double Ratchet is fine (ratchet.test.ts); the field loss lived here:
+ * when two peers who have never spoken both initiate X3DH to each other at
+ * nearly the same time (a group fan-out makes this routine), each side's
+ * "peer re-initiated" fallback REPLACED its own session with a responder of
+ * the other's — a criss-cross where B sends on C's session lineage and C on
+ * B's. Every later normal packet was undecryptable, and the crossing rekeys
+ * re-raced the same collision instead of converging (the "second consecutive
+ * frame lost" field signature).
+ *
+ * These tests simulate BOTH parties through the real sealForChat/openPacket
+ * against a mocked IndexedDB + keystore (sessions are keyed by chatId, so the
+ * two parties coexist in one store under their own carrier chat ids). The
+ * invariant under test: after a simultaneous-initiation collision, BOTH
+ * directions converge and keep working, in EVERY tie-break order — which is
+ * why each scenario runs several rounds with fresh random identities.
+ */
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+interface Party {
+  bundle: import('./crypto/identity').SecretBundle;
+  userId: string;
+  chatId: string; // this party's local carrier chat for the OTHER party
+}
+
+const H = vi.hoisted(() => ({
+  actor: 'B' as 'B' | 'C',
+  parties: {} as Record<'B' | 'C', Party>,
+  store: new Map<string, unknown>(),
+}));
+
+vi.mock('@/db/idb', () => ({
+  // Rows are keyed like the real stores: sessions by `id`, settings by `key`.
+  get: async (store: string, id: string) => H.store.get(`${store}:${id}`) ?? undefined,
+  put: async (store: string, rec: { id?: string; key?: string }) => {
+    H.store.set(`${store}:${rec.id ?? rec.key}`, rec);
+  },
+  remove: async (store: string, id: string) => {
+    H.store.delete(`${store}:${id}`);
+  },
+}));
+
+vi.mock('./cross-lock', () => ({
+  withSessionLock: async (_id: string, fn: () => unknown) => fn(),
+  LockTimeoutError: class LockTimeoutError extends Error {},
+}));
+
+vi.mock('./crypto/identity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./crypto/identity')>();
+  return {
+    ...actual,
+    getIdentityKeys: () => ({ ed: H.parties[H.actor].bundle.ed, x: H.parties[H.actor].bundle.x }),
+    getSignedPreKey: () => ({
+      id: H.parties[H.actor].bundle.signedPreKey.id,
+      keypair: H.parties[H.actor].bundle.signedPreKey.keypair,
+    }),
+    getOneTimePreKeyById: (id: string) =>
+      H.parties[H.actor].bundle.oneTimePreKeys.find((p) => p.id === id)?.keypair ?? null,
+    isUnlockedNow: () => true,
+  };
+});
+
+vi.mock('./api', () => ({
+  fetchPeerBundle: async (userId: string) => {
+    const who: 'B' | 'C' = userId === H.parties.B.userId ? 'B' : 'C';
+    const { publicBundleOf } = await import('./crypto/identity');
+    const pub = publicBundleOf(H.parties[who].bundle);
+    return {
+      edPub: pub.edPub,
+      xPub: pub.xPub,
+      signedPreKey: pub.signedPreKey,
+      // A stable one-time prekey (not popped): the keystore lookup must find it.
+      oneTimePreKey: pub.oneTimePreKeys[0],
+    };
+  },
+  publishPreKeys: async () => undefined,
+  preKeyCount: async () => 99,
+  addOneTimeKeys: async () => undefined,
+}));
+
+import { ready } from './crypto/primitives';
+import { generateIdentityMaterial } from './crypto/identity';
+import { sealForChat, openPacket, type WirePacket } from './messaging';
+import type { MessagePayload } from './crypto/message';
+
+const msg = (body: string): MessagePayload => ({ body, kind: 'text', timestamp: 1 });
+const peerOf = (a: 'B' | 'C'): 'B' | 'C' => (a === 'B' ? 'C' : 'B');
+
+async function seal(actor: 'B' | 'C', body: string): Promise<WirePacket> {
+  H.actor = actor;
+  const me = H.parties[actor];
+  const sealed = await sealForChat(me.chatId, H.parties[peerOf(actor)].userId, false, msg(body));
+  if (!sealed) throw new Error('seal returned null');
+  return sealed.packet;
+}
+
+async function open(actor: 'B' | 'C', packet: WirePacket): Promise<MessagePayload> {
+  H.actor = actor;
+  return openPacket(H.parties[actor].chatId, packet);
+}
+
+function freshParties(): void {
+  H.store.clear();
+  H.parties = {
+    B: { bundle: generateIdentityMaterial(2), userId: 'user-b', chatId: 'carrier-on-b' },
+    C: { bundle: generateIdentityMaterial(2), userId: 'user-c', chatId: 'carrier-on-c' },
+  };
+}
+
+beforeAll(async () => {
+  await ready();
+});
+
+beforeEach(freshParties);
+
+// The tie-break winner depends on random X3DH ephemerals, so every scenario
+// runs several rounds with fresh identities — the invariant must hold in BOTH
+// orders (and a failure message says which round broke).
+const ROUNDS = 6;
+
+describe('X3DH both-initiate collision (spec 2033)', () => {
+  it('simultaneous initiations converge: consecutive frames flow BOTH ways afterwards (FR-001)', async () => {
+    for (let round = 0; round < ROUNDS; round++) {
+      freshParties();
+      // Both sides initiate before seeing anything from the other (the group
+      // fan-out shape).
+      const pB1 = await seal('B', 'bob here');
+      const pC1 = await seal('C', 'carol here');
+      // Each opens the other's colliding initiation — content must arrive.
+      expect((await open('B', pC1)).body, `round ${round}`).toBe('carol here');
+      expect((await open('C', pB1)).body, `round ${round}`).toBe('bob here');
+      // The field bug: the next consecutive frames were permanently lost.
+      const pC2 = await seal('C', 'carol 2');
+      expect((await open('B', pC2)).body, `round ${round}`).toBe('carol 2');
+      const pB2 = await seal('B', 'bob 2');
+      expect((await open('C', pB2)).body, `round ${round}`).toBe('bob 2');
+      // And the chains keep working (arbitrarily many consecutive frames).
+      const pC3 = await seal('C', 'carol 3');
+      const pC4 = await seal('C', 'carol 4');
+      expect((await open('B', pC3)).body, `round ${round}`).toBe('carol 3');
+      expect((await open('B', pC4)).body, `round ${round}`).toBe('carol 4');
+    }
+  });
+
+  it('straggler frames sent before the collision resolves are all readable', async () => {
+    for (let round = 0; round < ROUNDS; round++) {
+      freshParties();
+      const pB1 = await seal('B', 'b1');
+      // C sends SEVERAL frames on its doomed initiation before ever hearing B.
+      const pC1 = await seal('C', 'c1');
+      const pC2 = await seal('C', 'c2');
+      const pC3 = await seal('C', 'c3');
+      expect((await open('B', pC1)).body, `round ${round}`).toBe('c1');
+      expect((await open('B', pC2)).body, `round ${round}`).toBe('c2');
+      expect((await open('C', pB1)).body, `round ${round}`).toBe('b1');
+      expect((await open('B', pC3)).body, `round ${round}`).toBe('c3');
+      // Post-collision traffic converges both ways.
+      const pC4 = await seal('C', 'c4');
+      expect((await open('B', pC4)).body, `round ${round}`).toBe('c4');
+      const pB2 = await seal('B', 'b2');
+      expect((await open('C', pB2)).body, `round ${round}`).toBe('b2');
+    }
+  });
+
+  it('the plain initiator→responder flow is untouched (no collision)', async () => {
+    const pB1 = await seal('B', 'hi');
+    expect((await open('C', pB1)).body).toBe('hi');
+    const pC1 = await seal('C', 'hey');
+    expect((await open('B', pC1)).body).toBe('hey');
+    const pC2 = await seal('C', 'hey again'); // responder's consecutive send
+    expect((await open('B', pC2)).body).toBe('hey again');
+    const pB2 = await seal('B', 'more');
+    expect((await open('C', pB2)).body).toBe('more');
+  });
+
+  it("a peer's genuine re-initiation (deleted chat) still replaces the session", async () => {
+    // Establish + confirm a healthy session both ways.
+    const pB1 = await seal('B', 'hi');
+    expect((await open('C', pB1)).body).toBe('hi');
+    const pC1 = await seal('C', 'hey');
+    expect((await open('B', pC1)).body).toBe('hey');
+    // C loses its session (deleted the chat) and re-initiates from scratch.
+    const { clearSession } = await import('./messaging');
+    H.actor = 'C';
+    await clearSession(H.parties.C.chatId);
+    const pC2 = await seal('C', 'fresh start');
+    expect((await open('B', pC2)).body).toBe('fresh start');
+    // The replaced session carries traffic both ways.
+    const pB2 = await seal('B', 'welcome back');
+    expect((await open('C', pB2)).body).toBe('welcome back');
+    const pC3 = await seal('C', 'thanks');
+    expect((await open('B', pC3)).body).toBe('thanks');
+  });
+});

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -101,6 +101,7 @@ async function setSessionMeta(chatId: string, meta: SessionMeta): Promise<void> 
  *  the call ends (a later call simply re-runs X3DH). A no-op if nothing is stored. */
 export async function clearSession(chatId: string): Promise<void> {
   await remove('sessions', chatId);
+  await remove('sessions', `${chatId}#x3dh-collision`); // spec 2033 side session, if any
   await remove('settings', `smeta:${chatId}`);
 }
 
@@ -190,6 +191,14 @@ function establishResponderSession(p: PreKeyPreamble): RatchetState {
   return ratchetInitBob(sk, spk.keypair);
 }
 
+/** The sessions-store row holding the COLLISION side session (spec 2033): when a
+ *  simultaneous-initiation tie-break declares OUR X3DH the winner, the loser's
+ *  in-flight frames (sealed on their doomed initiation) are decrypted with a
+ *  responder session persisted under this id. It is receive-only — the send path
+ *  never touches it — and is dropped the moment the peer proves convergence by
+ *  sending on OUR session. */
+const collisionSessionId = (chatId: string) => `${chatId}#x3dh-collision`;
+
 /**
  * Decrypt an incoming wire packet for a (local) chat, advancing/establishing
  * the session. Returns the plaintext payload. The caller (db/queries) persists
@@ -202,6 +211,7 @@ export async function openPacket(chatId: string, raw: unknown): Promise<MessageP
   }
   // Serialize per chat with the matching seals — see withSessionLock.
   return withSessionLock(chatId, async () => {
+  const sideId = collisionSessionId(chatId);
   let session = await loadSession(chatId);
   const hadExistingSession = !!session;
   if (!session) {
@@ -211,33 +221,101 @@ export async function openPacket(chatId: string, raw: unknown): Promise<MessageP
     session = establishResponderSession(packet);
   }
 
+  // Which state actually opened the packet decides ALL the bookkeeping below:
+  //   main    — our existing/fresh-first-contact session worked.
+  //   adopted — the peer's initiation replaced ours (re-init, or we lost the tie-break).
+  //   side    — WE won a simultaneous-initiation tie-break; their frame was read
+  //             with the receive-only collision session and our own initiation stands.
+  let openedWith: 'main' | 'adopted' | 'side' = 'main';
   let payload: MessagePayload;
   try {
     payload = openMessage(session, packet.msg);
   } catch (e) {
-    // The existing session couldn't open this. If it's a prekey packet, the peer
-    // RE-INITIATED a fresh session, most commonly because they deleted the chat
-    // (which tears down their ratchet) and started a new one, so the new chat
-    // re-runs X3DH. Establish a new responder session from this preamble and
-    // decrypt with it, replacing the stale ratchet. (A replayed old prekey could
-    // also land here; it can only reset our state, never decrypt our traffic.)
-    if (hadExistingSession && packet.type === 'prekey') {
+    const meta0 = await getSessionMeta(chatId);
+    // (spec 2033) SIMULTANEOUS INITIATION: the failing packet is a DIFFERENT
+    // X3DH initiation while our own initiation is still unconfirmed (we hold a
+    // live preamble). Pre-2033 both sides ADOPTED the other's session here — a
+    // criss-cross (each sending on the session the other just abandoned) whose
+    // every later normal frame was undecryptable, and whose rekey recoveries
+    // re-raced the same collision. The fix is a deterministic tie-break BOTH
+    // sides compute identically from values both possess (each side sees its
+    // own preamble and the peer's): compare the two X3DH ephemeral keys; the
+    // larger b64url string wins. The loser adopts the winner's session; the
+    // winner keeps its initiation and reads the loser's in-flight frames via
+    // the persisted receive-only side session.
+    const collision =
+      hadExistingSession && packet.type === 'prekey' && !!meta0?.sendPreamble && !!meta0.preamble;
+    if (collision && (meta0.preamble as PreKeyPreamble).eph > (packet as PreKeyPreamble & { type: 'prekey' }).eph) {
+      // WE WIN: our session + preamble stay untouched. Their colliding frames
+      // (all prekey-wrapped — the loser keeps its preamble until it hears back,
+      // and by then it has adopted OURS) decrypt with the side session.
+      let side = await loadSession(sideId);
+      if (side) {
+        try {
+          payload = openMessage(side, packet.msg);
+        } catch {
+          // A DIFFERENT initiation than the side session's (e.g. the peer rekeyed
+          // mid-collision): re-establish from THIS preamble. Throws if bad.
+          side = establishResponderSession(packet);
+          payload = openMessage(side, packet.msg);
+        }
+      } else {
+        side = establishResponderSession(packet);
+        payload = openMessage(side, packet.msg); // throws if this also fails
+      }
+      await saveSession(sideId, side);
+      openedWith = 'side';
+    } else if (hadExistingSession && packet.type === 'prekey') {
+      // The peer RE-INITIATED (they deleted the chat and re-ran X3DH), or this
+      // is a collision WE LOSE: establish a responder session from the preamble
+      // and decrypt with it, replacing our ratchet. (A replayed old prekey could
+      // also land here; it can only reset our state, never decrypt our traffic —
+      // and with the tie-break an unconfirmed initiator is no longer resettable
+      // by a losing replay at all.)
       const fresh = establishResponderSession(packet);
       payload = openMessage(fresh, packet.msg); // throws if this also fails
       session = fresh;
+      openedWith = 'adopted';
+    } else if (packet.type === 'normal') {
+      // Belt-and-braces: a loser's straggler that arrives as a NORMAL packet
+      // (possible if their preamble cleared early) still opens on the side
+      // session when a collision is pending.
+      const side = await loadSession(sideId);
+      if (!side) throw e;
+      try {
+        payload = openMessage(side, packet.msg);
+      } catch {
+        throw e; // surface the MAIN session's failure, not the side probe's
+      }
+      await saveSession(sideId, side);
+      openedWith = 'side';
     } else {
       throw e;
     }
   }
-  await saveSession(chatId, session);
+  if (openedWith !== 'side') await saveSession(chatId, session);
 
-  // If we were the initiator awaiting the peer, the session is now confirmed,
-  // so stop prepending the prekey preamble to our outgoing messages.
   const meta = await getSessionMeta(chatId);
-  if (meta?.sendPreamble) {
-    meta.sendPreamble = false;
-    await setSessionMeta(chatId, meta);
+  if (openedWith === 'main') {
+    // The peer sent on OUR session — it is confirmed. Stop prepending the
+    // preamble, and drop any collision side state: the loser has converged.
+    if (meta?.sendPreamble) {
+      meta.sendPreamble = false;
+      await setSessionMeta(chatId, meta);
+    }
+    await remove('sessions', sideId);
+  } else if (openedWith === 'adopted') {
+    // We are the responder of THEIR session now; our own initiation (if any)
+    // is dead — never advertise its preamble again. Any side state belonged
+    // to an abandoned collision.
+    if (meta?.sendPreamble) {
+      await setSessionMeta(chatId, { ...meta, sendPreamble: false, preamble: undefined });
+    }
+    await remove('sessions', sideId);
   }
+  // openedWith === 'side': deliberately NOTHING else — our initiation stands,
+  // the preamble keeps riding our outgoing frames (the loser needs it to adopt),
+  // and the side session waits for more stragglers.
 
   return payload;
   });


### PR DESCRIPTION
## Summary

Fixes the pre-existing ratchet-layer bug found while building spec 1050's fan-out e2e: in groups whose members aren't all mutually paired, back-to-back frames from one member (two quick messages, a message + reaction, game-move bursts) silently vanished for co-members who hadn't written back — no error surfaced, permanent divergence.

### Root cause (from a full frame-by-frame trace of the deterministic repro)
A classic **X3DH both-initiate collision**. When two members who have never spoken message each other nearly simultaneously (exactly what a group fan-out produces), both sides initiate X3DH. Each side's "peer re-initiated" fallback then **replaced its own session with a responder of the other's** — a criss-cross where B sends on C's session lineage and C on B's. Every later normal packet was undecryptable, and the crossing rekey recoveries re-raced the same collision instead of converging. "Second consecutive frame lost" was the field signature: the first *normal* (non-preamble, hence non-recoverable) packet.

### Fix (messaging.ts only; wire format unchanged)
- **Deterministic tie-break** both sides compute identically from values both possess (each sees its own preamble and the peer's): the larger X3DH ephemeral key wins.
- The **loser adopts** the winner's session and retires its preamble.
- The **winner keeps its initiation** and reads the loser's in-flight frames via a persisted, **receive-only collision side session** (`<chatId>#x3dh-collision`), dropped the moment the peer proves convergence by sending on the winner's session. The send path never touches it.
- `sendPreamble` now clears **only when a frame opens on our own session** (proof the peer holds it) — previously any successful open cleared it, including adopts.

### Security review notes (FR-002)
- The tie-break is a total order over values already public in the packet preamble; no negotiation, no downgrade path, no new wire surface (ZK impact: none).
- Replay: a **losing** replayed preamble can no longer reset an unconfirmed initiator's session at all (it lands on the receive-only side path and only re-delivers an already-authenticated old message, deduped upstream). The confirmed-session re-init adopt keeps today's documented exposure (a replay can reset state, never decrypt traffic) — unchanged.
- The side session never seals, is bounded (one per chat), is dropped on convergence, and is cleared by `clearSession`.
- Failed decrypts still never persist a mutated session (openPacket's save is success-path only).
- Old-client interop: fixed↔unfixed converges after at most one rekey round instead of oscillating; fixed↔fixed converges immediately.

### Verification
- **Red-first unit** (`messaging.test.ts`): both parties simulated through the real `sealForChat`/`openPacket`; reproduced the exact field failure; collision + straggler scenarios green across randomized tie-break orders; plain initiator/responder and genuine re-initiation flows pinned unchanged. New pure-ratchet tests pin responder consecutive sends + persistence round-trips (foundation was already correct).
- **SC-001**: the previously-dodged spec-1050 fan-out choreography passes **10/10** (was deterministically red; runs also dropped from ~44s to ~14s — the rekey storms are gone).
- **Regression sweep**: push-routing, ratchet-consecutive, games-group (the long-suspected same-bug flake), groups, reactions, mentions, reaction-notify — 14/14, zero decrypt failures. Full unit suite 597/597; typecheck green.

### Follow-up
The dodge comment + Bob-interject in `e2e/push-routing.spec.ts` lives on the spec-1050 branch (PR #994); removing it requires this fix on develop first, so the un-dodge lands as a rider after #994 and this PR both merge (verified un-dodged on the merged dev-stack already).

**⚠️ Hold for the real-device pass with the other open PRs (#992–#998).** Crypto-layer change — please give the security-review notes above an explicit look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7