### PR TITLE
fix(chats): shared links show sharp, full-quality preview thumbnails (spec 2035)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,3 +114,4 @@ Specs are grouped by category band; status moves
 | [2029](specs/2029-camera-off-shows/spec.md) | Camera Off Shows Your Picture to the Call, Not a Black Screen | 🟢 shipped |
 | [2030](specs/2030-rtl-names-truncate/spec.md) | RTL Names Truncate at the Correct End | 🔵 in-review |
 | [2032](specs/2032-ipad-taps-dead/spec.md) | iPad Taps Dead on Send & Quick-React | 🟡 in-progress |
+| [2035](specs/2035-link-previews-look/spec.md) | Link Previews Look Sharp | 🟡 in-progress |

--- a/drive/scenarios/link-preview-2035.mjs
+++ b/drive/scenarios/link-preview-2035.mjs
@@ -1,0 +1,31 @@
+/** Spec 2035: a youtu.be link must produce a SHARP video-thumbnail hero
+ *  (og:image sits past the old 512 KiB unfurl cap — SC-001, live relay). */
+import { createAccount, pair, chatWith, say, waitForMessage, shot, poll, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Ava' });
+const b = await createAccount({ name: 'Ben', mobile: true });
+await pair(a, b);
+
+const URL = 'https://youtu.be/S0sjxWJXPog';
+await say(a, b.id, `check this out ${URL}`);
+await waitForMessage(b, a.id, 'check this out');
+
+// The preview is built sender-side and attaches deferred — wait until B's copy
+// carries an IMAGE (not just the meta), then check its recorded natural width.
+const bChat = await chatWith(b, a.id);
+const width = await poll(
+  async () => {
+    const ms = await b.page.evaluate((id) => window.__ringTest.messages(id), bChat);
+    const m = ms.find((x) => x.body.includes('youtu.be'));
+    return m?.linkPreview?.hasImage ? (m.linkPreview.imageWidth ?? -1) : null;
+  },
+  (v) => v !== null,
+  { timeout: 30_000, label: 'link preview image attached' },
+);
+console.log(`[2035] preview image width: ${width}px (hero needs >= 200)`);
+if (width >= 200) console.log('[2035] PASS — real og:image thumbnail, hero-sized');
+else console.log('[2035] FAIL — favicon-class image, would render iconic');
+
+await shot(b, 'link-preview-2035', { route: `/chat/${bChat}` });
+await sweep([a, b]);
+await done();

--- a/server/internal/api/unfurl_handler.go
+++ b/server/internal/api/unfurl_handler.go
@@ -32,10 +32,15 @@ import (
 // blocked at dial time.
 
 const (
-	unfurlTimeout   = 10 * time.Second
-	unfurlMaxHTML   = 512 << 10 // 512 KiB - og tags live in <head>, so truncation is safe
-	unfurlMaxImage  = 2 << 20   // 2 MiB cap on a preview image
-	unfurlMaxHops   = 5         // redirect cap
+	unfurlTimeout = 10 * time.Second
+	// HTML cap (spec 2035): og tags nominally live in <head>, but heavyweight pages
+	// push them deep — YouTube's watch pages carry og:image around byte ~641K, so the
+	// old 512 KiB cap silently starved the client of the real thumbnail and it fell
+	// back to a favicon (rendered as a blurry stretched hero). 1.5 MiB covers the
+	// major offenders with headroom while staying firmly bounded.
+	unfurlMaxHTML   = 1536 << 10 // 1.5 MiB
+	unfurlMaxImage  = 2 << 20    // 2 MiB cap on a preview image
+	unfurlMaxHops   = 5          // redirect cap
 	unfurlUserAgent = "RingLinkPreview/1.0 (+https://github.com/zuptalo/ring)"
 )
 

--- a/server/internal/api/unfurl_handler_test.go
+++ b/server/internal/api/unfurl_handler_test.go
@@ -139,6 +139,29 @@ func TestUnfurlTruncatesLargeHTML(t *testing.T) {
 	}
 }
 
+// (spec 2035) og tags buried DEEP in a heavyweight page still reach the client:
+// YouTube's watch pages carry og:image around byte ~641K, past the old 512 KiB
+// cap — the client then fell back to the favicon and rendered a blurry hero.
+func TestUnfurlDeepOgTagsSurviveTheCap(t *testing.T) {
+	allowLoopback(t)
+	const ogOffset = 700 << 10 // beyond the old 512 KiB cap, inside the new one
+	page := strings.Repeat("x", ogOffset) +
+		`<meta property="og:image" content="https://example.com/thumb.jpg">`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	rec := doUnfurl(t, srv.URL, false)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "og:image") {
+		t.Errorf("og tag at %d bytes was truncated away (cap %d)", ogOffset, unfurlMaxHTML)
+	}
+}
+
 // Upstream 404 → 404; any other non-200 → 502.
 func TestUnfurlUpstreamStatus(t *testing.T) {
 	allowLoopback(t)

--- a/specs/2035-link-previews-look/spec.md
+++ b/specs/2035-link-previews-look/spec.md
@@ -1,0 +1,47 @@
+# Feature Specification: Link Previews Look Sharp
+
+**Feature Branch**: `fix/2035-link-previews-look`
+
+**Created**: 2026-07-14
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User bug report (2026-07-14, iPhone screenshot): a shared YouTube link's preview shows a massively blurry, stretched red play-button image instead of the video's thumbnail.
+
+## Diagnosis (from the field repro)
+
+YouTube DOES serve a full-quality `og:image` (maxresdefault.jpg) to Ring's unfurl
+agent — but on the reported page it sits at byte offset ~641 KB, past the unfurl
+relay's 512 KiB HTML cap. The sender's client never sees the tag, falls back to
+the page favicon/apple-touch-icon (≤192 px), and the bubble's link card renders
+ANY image `width:100%; object-fit:cover` — upscaling the icon ~6× into the blurry
+hero the user saw. Two independent defects: the cap silently starves big pages of
+their og tags, and the renderer has no floor below which an image is treated as
+an icon rather than a hero.
+
+## Requirements
+
+- **FR-001**: The unfurl relay's HTML cap MUST cover real-world og-tag offsets on
+  major pages (YouTube ≈ 641 KB today): raise to 1.5 MiB, still bounded. A
+  regression test pins that a page with og tags past 512 KiB unfurls fully.
+- **FR-002**: The link card MUST never upscale a preview image into the hero
+  slot: images whose natural width is below a hero threshold (200 px) render as
+  a small fixed-size icon beside the title/description instead. Previews
+  without a recorded width keep today's hero presentation.
+- **FR-003**: No wire or crypto change — `LinkPreview.imageWidth` already rides
+  sealed in the payload; only the relay cap (server) and the card CSS/markup
+  (client) change.
+
+## Zero-Knowledge Impact
+
+None — the relay still streams unparsed bytes and stores nothing; the preview is
+still built and sealed on the sender's device.
+
+## Success Criteria
+
+- **SC-001**: A youtu.be link produces a sharp video-thumbnail hero (verified
+  against the live site through the relay).
+- **SC-002**: A page with only a favicon renders a compact icon card, never a
+  stretched blurry hero (unit-verifiable via the width gate; visual via drive).
+- **SC-003**: Existing unfurl SSRF guards and limits tests stay green.

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -551,6 +551,10 @@ export function installTestHook(): void {
         contact: m.contact ?? null,
         audio: m.audio ?? null,
         callLog: m.callLog ?? null, // spec 1040: missed-trace assertions
+        // spec 2035: link-preview quality assertions (image presence + natural width).
+        linkPreview: m.linkPreview
+          ? { hasImage: !!m.linkPreview.image, imageWidth: m.linkPreview.imageWidth ?? null, domain: m.linkPreview.domain }
+          : null,
       })),
     /* ---- media blob lifecycle (server cleanup tests) ---- */
     /** A message's media state: whether the bytes are on-device (mediaId), still pending,

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -420,11 +420,15 @@
               <a
                 v-if="m.kind === 'text' && m.linkPreview"
                 class="link-card rich"
+                :class="{ 'lp-iconic': isIconPreview(m.linkPreview) }"
                 :href="m.linkPreview.url"
                 target="_blank"
                 rel="noopener noreferrer"
                 @click.stop.prevent="openExternal(m.linkPreview.url)"
               >
+                <!-- (spec 2035) A tiny source image (favicon-class, no real og:image)
+                     renders as a fixed-size icon beside the text — a hero slot would
+                     upscale it into a blurry smear (the reported YouTube card). -->
                 <img v-if="m.linkPreview.image" class="lp-thumb" :src="m.linkPreview.image" alt="" />
                 <span class="lp-meta">
                   <span v-if="m.linkPreview.title" class="lp-title">{{ m.linkPreview.title }}</span>
@@ -1736,6 +1740,11 @@ function onBubbleTap(m: Message, ev: Event): void {
 const LINK_RE = /\bhttps?:\/\/[^\s]+/i;
 const hasLink = (s: string) => LINK_RE.test(s);
 const linkOf = (s: string) => s.match(LINK_RE)?.[0] ?? '';
+// (spec 2035) A preview whose image is favicon-class (tiny natural width) renders
+// as a compact icon card — the hero slot would upscale it into a blurry smear.
+// Previews without a recorded width (older senders) keep the hero presentation.
+const isIconPreview = (lp: { image?: string; imageWidth?: number }): boolean =>
+  !!lp.image && lp.imageWidth !== undefined && lp.imageWidth < 200;
 const linkDomain = (s: string) => {
   try {
     return new URL(linkOf(s)).hostname.replace(/^www\./, '');
@@ -5406,6 +5415,20 @@ function cancelRecording() {
   max-height: 160px;
   object-fit: cover;
   display: block;
+}
+/* (spec 2035) Favicon-class preview image: a compact icon row instead of a hero —
+   the image sits at a fixed small size beside the meta, never upscaled. */
+.link-card.lp-iconic {
+  display: flex;
+  align-items: center;
+}
+.link-card.lp-iconic .lp-thumb {
+  width: 48px;
+  height: 48px;
+  flex: 0 0 auto;
+  margin-left: 10px;
+  border-radius: 8px;
+  object-fit: contain;
 }
 .lp-meta {
   min-width: 0;


### PR DESCRIPTION
## Summary

Field report (iPhone screenshot): a YouTube link's preview rendered as a massively blurry, stretched play-button.

### Root cause (verified against the live site)
1. The unfurl relay capped HTML at **512 KiB**, but YouTube's `og:image` tag sits near byte **641K** — the client never saw the real thumbnail and fell back to the page favicon.
2. The link card rendered **any** image `width:100%; object-fit:cover`, upscaling that ≤192px icon ~6× into the blurry hero.

### Changes
- Relay HTML cap → **1.5 MiB** (still bounded; SSRF guards untouched). Go regression test pins og tags past 512 KiB surviving the relay.
- Favicon-class preview images (natural width < 200px, using the sealed `imageWidth` already on the wire) render as a compact 48px icon beside the title/description — never a hero. Previews without a recorded width keep today's presentation.
- Dev-only: `messages()` testhook exposes link-preview presence/width; drive scenario `link-preview-2035.mjs` verifies the live youtu.be flow (now: sharp 640px `maxresdefault` thumbnail, screenshot in session).

No wire or crypto change; ZK posture unchanged (relay still streams unparsed bytes, preview still built and sealed sender-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7