### PR TITLE
fix(wall): a failing post stops auto-retrying and offers Retry, instead of crash-looping the app (spec 2037)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,3 +120,4 @@ Specs are grouped by category band; status moves
 | [2034](specs/2034-wall-video-posts/spec.md) | Wall Video Posts — Honest Progress, Real Avatar, Media That Fits | 🔵 in-review |
 | [2035](specs/2035-link-previews-look/spec.md) | Link Previews Look Sharp | 🟡 in-progress |
 | [2036](specs/2036-video-posts-finish/spec.md) | Video Posts Finish Cleanly | 🟡 in-progress |
+| [2037](specs/2037-pending-post-auto/spec.md) | Pending-Post Auto-Retry Gets an Attempt Budget | 🟡 in-progress |

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -119,14 +119,16 @@ test('unknown paths redirect into the app; back at a tab root stays in-app', asy
   await a.page.waitForURL('**/tabs/chats');
   expect(await a.page.evaluate(() => history.length)).toBeGreaterThanOrEqual(2);
   await a.page.goBack();
-  expect(a.page.url()).not.toContain('about:blank');
-  expect(await a.page.evaluate(() => location.pathname)).not.toBe('');
   // Landing on the catch-all entry remounts the app via a FULL document load —
-  // poll for the mount instead of a fixed beat (a loaded CI runner loses a
-  // 300ms race; the guarantee is "stays in-app", not "remounts instantly").
+  // let the navigation settle before touching the page (an evaluate fired
+  // mid-navigation dies with "execution context was destroyed"), then poll for
+  // the mount (the guarantee is "stays in-app", not "remounts instantly").
+  await a.page.waitForLoadState('domcontentloaded').catch(() => {});
+  expect(a.page.url()).not.toContain('about:blank');
   await a.page.waitForFunction(() => !!document.querySelector('ion-app, ion-router-outlet'), undefined, {
     timeout: 15_000,
   });
+  expect(await a.page.evaluate(() => location.pathname)).not.toBe('');
 
   await ctx.close();
 });

--- a/specs/2037-pending-post-auto/spec.md
+++ b/specs/2037-pending-post-auto/spec.md
@@ -1,0 +1,42 @@
+# Feature Specification: Pending-Post Auto-Retry Gets an Attempt Budget
+
+**Feature Branch**: `fix/2037-pending-post-auto`
+
+**Created**: 2026-07-15
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User bug report (2026-07-15, iPhone screenshots): after spec 2036, a
+failing video post puts the installed app into a never-ending crash loop on the
+Wall tab — iOS shows "A problem repeatedly occurred on …/tabs/wall", the pending
+card no longer offers Cancel/Finish, and it auto-retries forever.
+
+## Diagnosis
+
+Spec 2036 made startup recovery leave byte-backed 'uploading' records for the
+drain to resume — correct for the zombie-draft bug, but it removed the only
+brake the old behavior accidentally provided (draft-ifying on every launch).
+`uploadOne` increments `attempts` and NOTHING ever consults it: on a device
+where the resumed transcode of a large video exhausts the web view's memory,
+WebKit kills the page, the reload auto-resumes the same record, and the loop
+never converges — while the record stays 'uploading', so the user never gets
+the failed/interrupted affordances to break out themselves.
+
+## Requirements
+
+- **FR-001**: Automatic drains MUST honor a per-record attempt budget: once
+  `attempts` reaches the cap (3), the record flips to 'failed' with a clear
+  reason BEFORE any heavy work runs — a crash-looping device breaks the loop on
+  the first launch past the budget, with Retry/Cancel visible again.
+- **FR-002**: A manual Retry keeps resetting the budget (existing behavior),
+  so the user can always try again deliberately.
+- **FR-003**: The budget check MUST precede the transcode/upload (the loop must
+  break even when the heavy work itself is what crashes the app).
+
+## Success Criteria
+
+- **SC-001**: Unit tests pin: a record at the cap is marked failed without
+  createPost running; below the cap it uploads; manual retry resets and runs.
+- **SC-002**: The reporter's device recovers: after updating, the Wall loads,
+  the stuck post shows a failed card with Retry/Cancel, and the app stays up.

--- a/src/services/pending-posts.test.ts
+++ b/src/services/pending-posts.test.ts
@@ -54,15 +54,19 @@ vi.mock('@/db/queries', () => ({
   },
 }));
 
-import { recoverInterruptedPosts, __resetRecoveryForTest } from './pending-posts';
+import { recoverInterruptedPosts, drainPendingPosts, retryPendingPost, __resetRecoveryForTest } from './pending-posts';
 
 const bytes = () => new Uint8Array([1, 2, 3]);
 
-beforeEach(() => {
+beforeEach(async () => {
   H.outbox.clear();
   H.posts.clear();
   H.deleteOnNextGet.clear();
   __resetRecoveryForTest();
+  // Recovery kicks a DETACHED drain; flush any straggler from the previous test
+  // against the now-empty outbox, then reset call counts.
+  await drainPendingPosts();
+  vi.mocked((await import('@/db/queries')).createPost).mockClear();
 });
 
 describe('recoverInterruptedPosts (spec 2036)', () => {
@@ -117,5 +121,34 @@ describe('recoverInterruptedPosts (spec 2036)', () => {
     H.deleteOnNextGet.add('a'); // the upload completes right at the re-read
     await recoverInterruptedPosts();
     expect(H.outbox.has('a')).toBe(false); // stayed deleted — no zombie draft
+  });
+});
+
+describe('auto-retry attempt budget (spec 2037)', () => {
+  it('a record at the cap flips to failed WITHOUT running createPost (the crash-loop breaker)', async () => {
+    const q = await import('@/db/queries');
+    H.outbox.set('a', { id: 'a', status: 'uploading', body: 'x', attempts: 3, items: [{ kind: 'video', bytes: bytes() }] });
+    await drainPendingPosts();
+    expect(H.outbox.get('a')?.status).toBe('failed');
+    expect(vi.mocked(q.createPost)).not.toHaveBeenCalled();
+  });
+
+  it('below the cap the upload runs and the record drains', async () => {
+    const q = await import('@/db/queries');
+    H.outbox.set('a', { id: 'a', status: 'uploading', body: 'x', attempts: 2, items: [{ kind: 'video', bytes: bytes() }] });
+    await drainPendingPosts();
+    expect(vi.mocked(q.createPost)).toHaveBeenCalledTimes(1);
+    expect(H.outbox.has('a')).toBe(false); // drained on success
+  });
+
+  it('manual Retry resets the budget and the upload runs again', async () => {
+    const q = await import('@/db/queries');
+    H.outbox.set('a', { id: 'a', status: 'failed', body: 'x', attempts: 3, items: [{ kind: 'video', bytes: bytes() }] });
+    await retryPendingPost('a');
+    // retry kicks the drain DETACHED (drainPendingPosts self-guards re-entry);
+    // wait for that kick to empty the outbox instead of racing it.
+    for (let i = 0; i < 100 && H.outbox.size > 0; i++) await new Promise((r) => setTimeout(r, 5));
+    expect(vi.mocked(q.createPost)).toHaveBeenCalled();
+    expect(H.outbox.has('a')).toBe(false);
   });
 });

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -70,9 +70,26 @@ async function dropPendingPost(id: string): Promise<void> {
 // only a genuine hang — e.g. reading an unreadable cached blob — goes silent this long.
 const UPLOAD_STALL_MS = 45_000;
 
+// (spec 2037) Automatic attempts per record before the drain STOPS and surfaces a
+// failed card (Retry/Cancel) instead. `attempts` is persisted BEFORE the heavy
+// work starts, so even a resume whose transcode crashes the whole web view (the
+// reported iOS crash loop: OOM → WebKit kill → reload → auto-resume → …) breaks
+// the loop on the first launch past the budget. Manual Retry resets the budget.
+const MAX_AUTO_ATTEMPTS = 3;
+
 async function uploadOne(id: string): Promise<void> {
   const rec = await getPendingPost(id);
   if (!rec || rec.status !== 'uploading') return; // canceled / interrupted / already gone
+  // (spec 2037) Budget check FIRST — before the transcode/upload that may itself
+  // be what kills the app. Reaching here at the cap means the previous attempts
+  // never finished (crash, kill, stall): stop auto-retrying and hand control
+  // back to the user as a failed card.
+  if (rec.attempts >= MAX_AUTO_ATTEMPTS) {
+    rec.status = 'failed';
+    rec.error = "Couldn't finish this post after several tries. Tap Retry to try again.";
+    await updatePendingPost(rec);
+    return;
+  }
   rec.attempts += 1;
   await updatePendingPost(rec);
   let lastTick = Date.now();


### PR DESCRIPTION
## Summary

Emergency follow-up to #1002, from the field (iPhone crash loop on /tabs/wall, "A problem repeatedly occurred"): the 2036 auto-resume removed the accidental brake the old draft-ify recovery provided. `attempts` was counted but never consulted, so a resume whose transcode OOMs the web view crash-looped forever with no Cancel/Finish affordance.

- Automatic drains now honor a **3-attempt budget**, checked **before** any heavy work (attempts persist before the transcode, so crashed attempts still burn budget) → the first launch past the budget flips the record to a failed card with Retry/Cancel and the app loads normally.
- Manual Retry keeps resetting the budget.
- Unit-pinned: at-cap → failed without createPost; below-cap → uploads; retry → resets and runs (8/8 with the 2036 suite).

Merging immediately per the standing merge directive — this unblocks the reporter's device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7