### PR TITLE
feat(wall): efficient videos upload as-is; conversions get memory backpressure (spec 2038)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,3 +120,4 @@ Specs are grouped by category band; status moves
 | [2034](specs/2034-wall-video-posts/spec.md) | Wall Video Posts — Honest Progress, Real Avatar, Media That Fits | 🔵 in-review |
 | [2035](specs/2035-link-previews-look/spec.md) | Link Previews Look Sharp | 🟡 in-progress |
 | [2036](specs/2036-video-posts-finish/spec.md) | Video Posts Finish Cleanly | 🟡 in-progress |
+| [2038](specs/2038-videos-reasonable-size/spec.md) | Reasonable Videos Upload As-Is | 🟡 in-progress |

--- a/drive/scenarios/wall-real-video-post.mjs
+++ b/drive/scenarios/wall-real-video-post.mjs
@@ -69,6 +69,16 @@ console.log('[realpost] DOM:', JSON.stringify(domState));
 console.log(domState.pendingCards === 0 && domState.videos >= 1 ? '[realpost] PASS — clean finish, video posted' : '[realpost] FAIL — leftover card or missing video');
 await shot(kim, 'real-post-wall-after');
 
+// TEMP probe: the posted video must be playable with a real duration.
+const dur = await kim.page.evaluate(async () => {
+  const v = document.querySelector('.post video');
+  if (!v) return 'no-video-el';
+  for (let i = 0; i < 40 && !(v.duration > 0); i++) await new Promise((r) => setTimeout(r, 250));
+  return { duration: v.duration, w: v.videoWidth, h: v.videoHeight };
+});
+console.log('[realpost] playback probe:', JSON.stringify(dur));
+
+
 // Recipient sanity: Pal sees the post arrive too.
 await pal.page.goto('/tabs/wall');
 await poll(

--- a/specs/2038-videos-reasonable-size/spec.md
+++ b/specs/2038-videos-reasonable-size/spec.md
@@ -1,0 +1,43 @@
+# Feature Specification: Reasonable Videos Upload As-Is
+
+**Feature Branch**: `fix/2038-videos-reasonable-size`
+
+**Created**: 2026-07-15
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User direction (2026-07-15): "If a video file size to length ratio is
+reasonable and doesn't really need conversion we should just simply upload it as
+is; only videos captured on the phone itself in 4k quality are large enough to
+require conversion to smaller and more compatible global format to make it work
+across apple android and desktop."
+
+## Requirements
+
+- **FR-001**: Before any transcode engine loads, a video whose bitrate
+  (size ÷ duration) is within 1.5× the target preset's bitrate AND whose
+  resolution fits the preset MUST upload as-is — no re-encode, instant
+  progression to the upload phase.
+- **FR-002**: The as-is path MUST be limited to universally playable content:
+  MP4/QuickTime containers carrying H.264 video. HEVC/AV1/VP9 (typical modern
+  phone captures) and non-MP4 containers keep today's transcode-to-H.264 path —
+  that is exactly the cross-platform conversion the user wants preserved.
+- **FR-003**: 4K-class or preset-exceeding resolutions always transcode
+  (downscale), whatever their bitrate.
+- **FR-004**: Any probe/sniff failure falls back to today's behavior — the
+  check can only ever SKIP work, never block a send.
+
+## Why this also matters for stability
+
+The transcode is the memory-heavy step behind the spec-2037 crash loop; not
+running it at all for already-efficient clips removes the risk for the most
+common share (downloaded/already-compressed videos).
+
+## Success Criteria
+
+- **SC-001**: Pure-rule unit tests: bitrate/resolution gate + codec sniff
+  (H.264 accepts; HEVC/AV1/VP9 markers reject).
+- **SC-002**: The reporter's real 17 MB clip posts with NO encode phase (drive
+  validation: progress starts in the upload band immediately) when its codec is
+  H.264; a synthetic HEVC-marked buffer still routes to the transcode.

--- a/src/services/media-video-ffmpeg.ts
+++ b/src/services/media-video-ffmpeg.ts
@@ -70,7 +70,7 @@ export async function ffmpegTranscode(
   if (onProgress) ff.on('progress', onProg);
   await ff.writeFile(input, await fetchFile(blob));
   try {
-    await ff.exec([
+    const rc = await ff.exec([
       '-i', input,
       // spec 1018 US1: do NOT pass -noautorotate. ffmpeg auto-applies the source display matrix,
       // baking the upright orientation into the pixels (and clearing the matrix), so the recipient
@@ -86,6 +86,14 @@ export async function ffmpegTranscode(
       '-movflags', '+faststart',
       output,
     ], FFMPEG_TIMEOUT_MS);
+    // (spec 2038) ffmpeg.wasm's exec RESOLVES with an exit code — it never
+    // rejects on a conversion failure. Reading the output regardless shipped a
+    // PARTIAL file that passed the smaller-than-source guard and posted as an
+    // unplayable 0-duration video (the reported desktop breakage). Non-zero rc
+    // → throw, so the orchestrator falls back to the original.
+    if (rc !== 0) {
+      throw new Error(`ffmpeg conversion failed (exit ${rc})`);
+    }
     const data = (await ff.readFile(output)) as Uint8Array;
     const out = new Blob([data.buffer as ArrayBuffer], { type: 'video/mp4' });
     // Keep whichever is smaller (re-encoding a small clip can grow it).

--- a/src/services/media-video-webcodecs.ts
+++ b/src/services/media-video-webcodecs.ts
@@ -349,7 +349,32 @@ export async function webcodecsTranscode(
     checkDone();
   });
 
-  for (const chunk of videoChunks) decoder.decode(chunk);
+  // (spec 2038) BACKPRESSURE: flooding the decoder with every chunk at once let
+  // decoded frames pile up faster than the canvas→encoder leg drained them — on
+  // phones that raw-frame pileup was the out-of-memory kill behind the crash
+  // loop (a single 4K frame is ~33 MB; a long clip queued hundreds). Feed the
+  // pipeline in bounded steps instead: wait until both queues drain below the
+  // cap before decoding the next chunk. The 'dequeue' event wakes us where
+  // supported; the timer is the safety net.
+  const MAX_QUEUE = 8;
+  const queuesDrained = () => decoder.decodeQueueSize < MAX_QUEUE && encoder.encodeQueueSize < MAX_QUEUE;
+  for (const chunk of videoChunks) {
+    while (!queuesDrained()) {
+      if (fatalError) throw fatalError;
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(done, 20);
+        function done(): void {
+          clearTimeout(t);
+          decoder.removeEventListener?.('dequeue', done);
+          encoder.removeEventListener?.('dequeue', done);
+          resolve();
+        }
+        decoder.addEventListener?.('dequeue', done);
+        encoder.addEventListener?.('dequeue', done);
+      });
+    }
+    decoder.decode(chunk);
+  }
   await decoder.flush();
   await encoder.flush();
   // A decode/encode error reported asynchronously (captured by `fail`) becomes a

--- a/src/services/media-video.test.ts
+++ b/src/services/media-video.test.ts
@@ -11,7 +11,7 @@ vi.mock('./media-video-ffmpeg', () => ({
   ffmpegTranscode: vi.fn(),
 }));
 
-import { compressVideoAdaptive } from './media-video';
+import { compressVideoAdaptive, shouldUploadAsIs, sniffMp4CodecIsPlainH264, VIDEO_PRESETS } from './media-video';
 import { webcodecsTranscode } from './media-video-webcodecs';
 import { ffmpegTranscode } from './media-video-ffmpeg';
 
@@ -55,5 +55,37 @@ describe('compressVideoAdaptive fallback ladder', () => {
     vi.mocked(ffmpegTranscode).mockRejectedValue(new Error('oom / too large'));
     const out = await compressVideoAdaptive(src, 'hd');
     expect(out).toBe(src);
+  });
+});
+
+describe('upload-as-is gate (spec 2038)', () => {
+  const hd = VIDEO_PRESETS.hd;
+  const base = { sizeBytes: 15_000_000, durationSec: 40, width: 1280, height: 720, h264Compatible: true };
+
+  it('an efficient, preset-fitting H.264 clip skips the transcode', () => {
+    // 15MB / 40s = 3.0 Mbps ≤ 1.5 × 2.5 Mbps
+    expect(shouldUploadAsIs(base, hd)).toBe(true);
+  });
+  it('a fat bitrate transcodes', () => {
+    expect(shouldUploadAsIs({ ...base, sizeBytes: 60_000_000 }, hd)).toBe(false); // 12 Mbps
+  });
+  it('4K-class resolution always transcodes, whatever the bitrate', () => {
+    expect(shouldUploadAsIs({ ...base, width: 3840, height: 2160 }, hd)).toBe(false);
+  });
+  it('incompatible codecs always transcode', () => {
+    expect(shouldUploadAsIs({ ...base, h264Compatible: false }, hd)).toBe(false);
+  });
+  it('zero/unknown duration never skips', () => {
+    expect(shouldUploadAsIs({ ...base, durationSec: 0 }, hd)).toBe(false);
+  });
+
+  const buf = (s: string) => new TextEncoder().encode(`....${s}....avc1....`);
+  it('codec sniff accepts plain H.264 and rejects modern-codec markers', () => {
+    expect(sniffMp4CodecIsPlainH264(new TextEncoder().encode('..moov..avc1..'))).toBe(true);
+    expect(sniffMp4CodecIsPlainH264(buf('hvc1'))).toBe(false);
+    expect(sniffMp4CodecIsPlainH264(buf('hev1'))).toBe(false);
+    expect(sniffMp4CodecIsPlainH264(buf('av01'))).toBe(false);
+    expect(sniffMp4CodecIsPlainH264(buf('vp09'))).toBe(false);
+    expect(sniffMp4CodecIsPlainH264(new TextEncoder().encode('..no codec here..'))).toBe(false);
   });
 });

--- a/src/services/media-video.ts
+++ b/src/services/media-video.ts
@@ -26,6 +26,71 @@ export const VIDEO_PRESETS: Record<'sd' | 'hd' | 'fhd', VideoPreset> = {
   fhd: { maxEdge: 1920, bitrate: 5_000_000 },
 };
 
+
+/* ---- spec 2038: upload-as-is gate ---- */
+
+// A clip already within 1.5× of the preset's target bitrate gains little from a
+// re-encode; re-encoding it anyway costs time, battery, quality — and on weak
+// devices the transcode is the memory-heavy step behind the spec-2037 loop.
+const AS_IS_BITRATE_FACTOR = 1.5;
+
+/** Pure rule: may this clip skip the transcode entirely? Codec compatibility is
+ *  the caller's input (see sniffMp4Codecs) — this only judges the numbers. */
+export function shouldUploadAsIs(
+  info: { sizeBytes: number; durationSec: number; width: number; height: number; h264Compatible: boolean },
+  preset: VideoPreset,
+): boolean {
+  if (!info.h264Compatible) return false;
+  if (!(info.durationSec > 0)) return false;
+  if (Math.max(info.width, info.height) > preset.maxEdge) return false; // 4K-class → downscale
+  const bps = (info.sizeBytes * 8) / info.durationSec;
+  return bps <= preset.bitrate * AS_IS_BITRATE_FACTOR;
+}
+
+/** Scan an MP4/QuickTime file's bytes for codec FourCCs. Returns whether the clip
+ *  is plain H.264 (universally playable on Apple/Android/desktop) with no
+ *  modern-codec track (HEVC/AV1/VP9 — typical recent phone captures) that would
+ *  need the compatibility transcode. A dumb byte scan is deliberate: it needs no
+ *  demuxer, handles moov-at-end files, and a false negative only means we
+ *  transcode like before. */
+export function sniffMp4CodecIsPlainH264(bytes: Uint8Array): boolean {
+  const has = (fourcc: string): boolean => {
+    const a = fourcc.charCodeAt(0), b = fourcc.charCodeAt(1), c = fourcc.charCodeAt(2), d = fourcc.charCodeAt(3);
+    for (let i = 0; i + 3 < bytes.length; i++) {
+      if (bytes[i] === a && bytes[i + 1] === b && bytes[i + 2] === c && bytes[i + 3] === d) return true;
+    }
+    return false;
+  };
+  if (has('hvc1') || has('hev1') || has('av01') || has('vp09') || has('vp08')) return false;
+  return has('avc1') || has('avc3');
+}
+
+/** Cheap metadata probe (duration + dimensions) via a detached <video> element —
+ *  loads headers only, decodes no frames. Null on any failure/timeout. */
+function probeVideoMeta(blob: Blob): Promise<{ durationSec: number; width: number; height: number } | null> {
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(blob);
+    const v = document.createElement('video');
+    v.preload = 'metadata';
+    const finish = (out: { durationSec: number; width: number; height: number } | null) => {
+      URL.revokeObjectURL(url);
+      v.removeAttribute('src');
+      resolve(out);
+    };
+    const timer = setTimeout(() => finish(null), 5000);
+    v.onloadedmetadata = () => {
+      clearTimeout(timer);
+      const d = v.duration;
+      finish(Number.isFinite(d) && d > 0 ? { durationSec: d, width: v.videoWidth, height: v.videoHeight } : null);
+    };
+    v.onerror = () => {
+      clearTimeout(timer);
+      finish(null);
+    };
+    v.src = url;
+  });
+}
+
 // WebCodecs is the fast path; flip to false to force the ffmpeg path everywhere
 // (e.g. if a device produces bad WebCodecs output).
 const WEBCODECS_ENABLED = true;
@@ -37,6 +102,24 @@ export async function compressVideoAdaptive(
 ): Promise<Blob> {
   const preset = VIDEO_PRESETS[quality];
   console.info('[video] compress start', { quality, type: blob.type, bytes: blob.size, preset });
+
+  // (spec 2038) A clip that is already efficient AND universally playable ships
+  // as-is: no engine load, no re-encode, straight to upload. Any probe failure
+  // just falls through to the normal ladder.
+  if (typeof document !== 'undefined' && /(mp4|quicktime|m4v)/i.test(blob.type)) {
+    try {
+      const meta = await probeVideoMeta(blob);
+      if (meta) {
+        const h264Compatible = sniffMp4CodecIsPlainH264(new Uint8Array(await blob.arrayBuffer()));
+        if (shouldUploadAsIs({ sizeBytes: blob.size, durationSec: meta.durationSec, width: meta.width, height: meta.height, h264Compatible }, preset)) {
+          console.info('[video] uploading as-is (spec 2038)', { bps: Math.round((blob.size * 8) / meta.durationSec), ...meta });
+          return blob;
+        }
+      }
+    } catch (e) {
+      console.info('[video] as-is probe failed; transcoding as usual', e);
+    }
+  }
 
   // 1. WebCodecs fast path, mp4/mov containers only (mp4box demux).
   if (WEBCODECS_ENABLED && /(mp4|quicktime|m4v)/i.test(blob.type)) {

--- a/src/services/media-video.ts
+++ b/src/services/media-video.ts
@@ -95,6 +95,17 @@ function probeVideoMeta(blob: Blob): Promise<{ durationSec: number; width: numbe
 // (e.g. if a device produces bad WebCodecs output).
 const WEBCODECS_ENABLED = true;
 
+
+/** (spec 2038) Final sanity gate on ANY transcode output: if the browser cannot
+ *  even read its metadata, the file is broken — never upload it (a corrupt
+ *  partial output once shipped as an unplayable 0-duration post). Outside a DOM
+ *  (unit tests) this trusts the engine result. */
+async function transcodeOutputPlayable(out: Blob): Promise<boolean> {
+  if (typeof document === 'undefined') return true;
+  const meta = await probeVideoMeta(out);
+  return meta !== null && meta.durationSec > 0;
+}
+
 export async function compressVideoAdaptive(
   blob: Blob,
   quality: 'sd' | 'hd' | 'fhd',
@@ -130,7 +141,7 @@ export async function compressVideoAdaptive(
       if (supported) {
         const out = await webcodecsTranscode(blob, preset, onProgress);
         console.info('[video] webcodecs output', { bytes: out.size, vs: blob.size });
-        if (out.size > 0 && out.size < blob.size) return out;
+        if (out.size > 0 && out.size < blob.size && (await transcodeOutputPlayable(out))) return out;
         // A COMPLETED hardware re-encode that isn't smaller means the source is
         // already efficiently compressed for this preset — the honest result is
         // the original (achievedQuality labels it so). Falling into ffmpeg here
@@ -153,6 +164,10 @@ export async function compressVideoAdaptive(
     const { ffmpegTranscode } = await import('./media-video-ffmpeg');
     const out = await ffmpegTranscode(blob, preset, onProgress);
     console.info('[video] ffmpeg output', { bytes: out.size, vs: blob.size });
+    if (out !== blob && !(await transcodeOutputPlayable(out))) {
+      console.warn('[video] ffmpeg output unreadable; sending original');
+      return blob;
+    }
     return out;
   } catch (e) {
     console.warn('[video] ffmpeg transcode FAILED; sending original', e);


### PR DESCRIPTION
## Summary

Per the reporter's direction: a video whose size-to-length ratio is reasonable shouldn't be converted at all — only oversized/4K/modern-codec captures need the compatibility transcode.

- **Upload-as-is gate** (before any engine loads): MP4/QuickTime + plain **H.264** + resolution within the preset + bitrate ≤ 1.5× the preset target → ships untouched, straight to upload. HEVC/AV1/VP9 (typical recent phone captures) and 4K-class clips keep the transcode-to-H.264 path — that's exactly the cross-platform conversion worth keeping. Probe/sniff failures fall back to today's ladder (the gate can only skip work, never block a send).
- **WebCodecs backpressure**: the transcode flooded the decoder with every chunk up front, letting raw decoded frames pile up unboundedly — the OOM behind the iOS crash loop (spec 2037's budget breaks the loop; this removes the bomb). Decode/encode queue depths are now capped, dequeue-event driven.

Validated with the reporter's real 17 MB H.264 clip (drive scenario, as-is path, clean finish). Unit: pure gate rules + codec sniff, 17/17 across the media-video suites.

Merge after #1003 (the crash-loop breaker, auto-merge armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7