### PR TITLE
feat(app): the app rescues itself from repeated startup crashes (spec 2039)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,3 +121,4 @@ Specs are grouped by category band; status moves
 | [2035](specs/2035-link-previews-look/spec.md) | Link Previews Look Sharp | 🟡 in-progress |
 | [2036](specs/2036-video-posts-finish/spec.md) | Video Posts Finish Cleanly | 🟡 in-progress |
 | [2037](specs/2037-pending-post-auto/spec.md) | Pending-Post Auto-Retry Gets an Attempt Budget | 🟡 in-progress |
+| [2039](specs/2039-boot-loop-safe/spec.md) | Boot-Loop Safe Mode | 🟡 in-progress |

--- a/specs/2039-boot-loop-safe/spec.md
+++ b/specs/2039-boot-loop-safe/spec.md
@@ -1,0 +1,35 @@
+# Feature Specification: Boot-Loop Safe Mode
+
+**Feature Branch**: `fix/2039-boot-loop-safe`
+
+**Created**: 2026-07-15
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: Field incident (2026-07-15): an iPhone stuck on an old build crash-
+looped at boot (background upload OOM), and BECAUSE the crash came so early the
+update toast never survived long enough to be tapped — the device could not
+even receive the build containing the fix. The app needs a self-rescue path
+that requires nothing from the crashed feature itself.
+
+## Requirements
+
+- **FR-001**: The app MUST detect a boot crash-loop generically: a persisted
+  boot counter increments at startup and resets only after a healthy-uptime
+  window (20s); reaching 3 without a healthy boot enters SAFE MODE for the next
+  launch.
+- **FR-002**: Safe mode MUST pause deferrable background work for that boot —
+  the pending-post drain and pending media resumes — and tell the user plainly
+  ("Background work is paused after repeated restarts").
+- **FR-003**: Safe mode MUST auto-apply a WAITING app update immediately (no
+  toast interaction), since escaping a broken build is exactly what the mode is
+  for; the installed registerType:'prompt' behavior stays for healthy boots.
+- **FR-004**: A healthy safe-mode boot (20s uptime) clears the counter; the
+  next boot is normal — safe mode is one boot's shield, not a latch.
+
+## Success Criteria
+
+- **SC-001**: Unit tests pin the counter/threshold/reset logic (pure module).
+- **SC-002**: With the drain gated off in safe mode, a seeded heavy outbox
+  record does not start uploading on a safe-mode boot (unit-level gate check).

--- a/src/composables/useAppUpdate.ts
+++ b/src/composables/useAppUpdate.ts
@@ -22,6 +22,7 @@ import { useRegisterSW } from 'virtual:pwa-register/vue';
 import { modalController } from '@ionic/vue';
 import { sparklesOutline } from 'ionicons/icons';
 import { fetchServerConfig } from '@/services/api';
+import { inSafeMode } from '@/services/boot-guard';
 import { showActionBanner, type NotifyAction } from '@/services/notify';
 import { computeDelta, userFacing, displayVersion, type ReleaseNote } from '@/services/release-notes';
 import WhatsNewSheet from '@/components/WhatsNewSheet.vue';
@@ -193,6 +194,20 @@ export function useAppUpdate(): void {
   // for someone who never fully closes the app — it comes back next time they reopen it.
   async function maybePrompt(): Promise<void> {
     if (!needRefresh.value || prompting) return;
+    // (spec 2039) Safe-mode boot: apply the waiting update SILENTLY — a device
+    // crash-looping on a broken build cannot keep a toast alive long enough to
+    // tap it, and escaping that build is exactly what safe mode is for. Same
+    // one-per-tab cap as the install-gate auto-pull below.
+    if (inSafeMode()) {
+      let alreadySafe = false;
+      try { alreadySafe = sessionStorage.getItem(GATE_UPDATED_KEY) === '1'; } catch { /* ignore */ }
+      if (!alreadySafe) {
+        try { sessionStorage.setItem(GATE_UPDATED_KEY, '1'); } catch { /* ignore */ }
+        prompting = true;
+        await applyUpdate(updateServiceWorker);
+        return;
+      }
+    }
     // Install-gate visitor: don't offer a card they'd have to tap — a browser-gated
     // visitor must never install a stale cached build. Silently pull the waiting update
     // (skipWaiting + reload) so the guide they read and the shell they install are the

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -39,6 +39,7 @@ import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deri
 import { THUMB_TIERS } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview, shouldBuildLinkPreview } from '@/services/link-preview';
+import { inSafeMode } from '@/services/boot-guard';
 import { ensureHiddenLoaded, isRevealed, isHiddenKnown } from '@/services/hidden-state';
 import { hiddenCallKeys } from '@/db/hidden-calls';
 import { routeInboundFrom } from '@/db/inbound-route';
@@ -2728,6 +2729,8 @@ export async function downloadMessageMedia(
 
 /** Resume any interrupted compressions (called on app start + when reconnecting). */
 export async function resumePendingMediaJobs(): Promise<void> {
+  // (spec 2039) Safe-mode boot: heavy media resumes wait for a healthy boot.
+  if (inSafeMode()) return;
   const msgs = await getAll<Message>('messages');
   for (const m of msgs) {
     if (m.status === 'compressing') void processMediaJob(m.id);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,11 @@
 import { createApp } from 'vue';
+import { initBootGuard } from '@/services/boot-guard';
+
+// Spec 2039: arm the boot-loop guard BEFORE anything heavy can run — a device
+// crash-looping at startup gets one safe boot (background work paused, waiting
+// update auto-applied) instead of being trapped on a broken build forever.
+const bootSafeMode = initBootGuard();
+if (bootSafeMode) console.warn('[boot] safe mode: repeated early crashes detected — background work paused this boot');
 import { IonicVue } from '@ionic/vue';
 import { iosTransitionAnimation, createAnimation } from '@ionic/core';
 import type { TransitionOptions } from '@ionic/core';

--- a/src/services/boot-guard.test.ts
+++ b/src/services/boot-guard.test.ts
@@ -1,0 +1,46 @@
+/** Spec 2039 — the boot-loop guard's pure rules + the safe-mode drain gate. */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { isCrashLoop, MAX_CRASHY_BOOTS, inSafeMode, __setSafeModeForTest } from './boot-guard';
+
+const H = vi.hoisted(() => ({ outbox: new Map<string, { id: string; status: string; attempts: number; items: unknown[] }>() }));
+
+vi.mock('@/db/idb', () => ({ get: async () => undefined, put: async () => undefined, remove: async () => undefined }));
+vi.mock('@/db/queries', () => ({
+  createPost: vi.fn(async () => ({ id: 'p' })),
+  listPendingPosts: async () => [...H.outbox.values()],
+  getPendingPost: async (id: string) => H.outbox.get(id),
+  getPost: async () => undefined,
+  updatePendingPost: async (r: never) => {
+    H.outbox.set((r as { id: string }).id, r);
+  },
+  deletePendingPost: async (id: string) => {
+    H.outbox.delete(id);
+  },
+}));
+
+import { kickPendingPosts } from './pending-posts';
+
+beforeEach(() => {
+  H.outbox.clear();
+  __setSafeModeForTest(false);
+});
+
+describe('boot-loop guard (spec 2039)', () => {
+  it('trips at the crashy-boot threshold, not before', () => {
+    expect(isCrashLoop(0)).toBe(false);
+    expect(isCrashLoop(MAX_CRASHY_BOOTS - 1)).toBe(false);
+    expect(isCrashLoop(MAX_CRASHY_BOOTS)).toBe(true);
+    expect(isCrashLoop(MAX_CRASHY_BOOTS + 5)).toBe(true);
+  });
+
+  it('safe mode gates the automatic drain (no upload starts on a safe boot)', async () => {
+    const q = await import('@/db/queries');
+    H.outbox.set('a', { id: 'a', status: 'uploading', attempts: 0, items: [] });
+    __setSafeModeForTest(true);
+    expect(inSafeMode()).toBe(true);
+    kickPendingPosts();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(vi.mocked(q.createPost)).not.toHaveBeenCalled();
+    expect(H.outbox.get('a')?.status).toBe('uploading'); // untouched, waits for a healthy boot
+  });
+});

--- a/src/services/boot-guard.ts
+++ b/src/services/boot-guard.ts
@@ -1,0 +1,70 @@
+/**
+ * Boot-loop safe mode (spec 2039).
+ *
+ * If the app crashes repeatedly right after launch (an OOM in background work,
+ * a broken cached build, …), the device can end up unable to even RECEIVE the
+ * fixed build: the update toast dies with every crash. This guard is the
+ * self-rescue path, deliberately independent of whatever feature is crashing:
+ *
+ *   - every boot increments a persisted counter (localStorage: it survives the
+ *     full app relaunches a crash loop produces, unlike sessionStorage);
+ *   - a boot that stays alive HEALTHY_UPTIME_MS clears the counter;
+ *   - reaching MAX_CRASHY_BOOTS without a healthy boot puts the NEXT boot into
+ *     safe mode: deferrable background work (pending-post drain, media resume)
+ *     is paused for that boot, and a WAITING app update is applied immediately
+ *     without asking — escaping a broken build is exactly what the mode is for.
+ *
+ * Safe mode is one boot's shield, not a latch: surviving the healthy-uptime
+ * window clears the counter and the next boot is normal.
+ */
+
+const KEY = 'ring.bootAttempts';
+const HEALTHY_UPTIME_MS = 20_000;
+export const MAX_CRASHY_BOOTS = 3;
+
+let safeMode = false;
+
+/** Pure rule, unit-tested: does this boot enter safe mode? */
+export function isCrashLoop(attempts: number): boolean {
+  return attempts >= MAX_CRASHY_BOOTS;
+}
+
+function readAttempts(): number {
+  try {
+    const n = Number(localStorage.getItem(KEY) ?? '0');
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  } catch {
+    return 0; // storage unavailable → never trip the guard
+  }
+}
+
+/** Call ONCE, as early in boot as possible. Returns whether this boot runs in
+ *  safe mode. Arms the healthy-uptime timer that clears the counter. */
+export function initBootGuard(): boolean {
+  const attempts = readAttempts();
+  safeMode = isCrashLoop(attempts);
+  try {
+    localStorage.setItem(KEY, String(attempts + 1));
+  } catch {
+    /* storage unavailable — guard stays inert */
+  }
+  setTimeout(() => {
+    try {
+      localStorage.setItem(KEY, '0');
+    } catch {
+      /* ignore */
+    }
+  }, HEALTHY_UPTIME_MS);
+  return safeMode;
+}
+
+/** Is the CURRENT boot in safe mode? Deferrable background starters consult
+ *  this (pending-post drain, media resumes) and skip for the boot. */
+export function inSafeMode(): boolean {
+  return safeMode;
+}
+
+/** Test-only. */
+export function __setSafeModeForTest(v: boolean): void {
+  safeMode = v;
+}

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -25,8 +25,14 @@ import {
 
 let draining = false;
 
-/** Fire-and-forget kick — safe to call repeatedly (enqueue, in-session Retry). */
+import { inSafeMode } from './boot-guard';
+
+/** Fire-and-forget kick — safe to call repeatedly (enqueue, in-session Retry).
+ *  (spec 2039) A safe-mode boot skips automatic drains entirely — the drain's
+ *  heavy work (a resumed transcode) is a prime crash-loop suspect. A manual
+ *  Retry still runs (deliberate user action drains directly). */
 export function kickPendingPosts(): void {
+  if (inSafeMode()) return;
   void drainPendingPosts();
 }
 
@@ -193,7 +199,7 @@ export async function retryPendingPost(id: string): Promise<void> {
   rec.error = undefined;
   rec.attempts = 0;
   await updatePendingPost(rec);
-  kickPendingPosts();
+  void drainPendingPosts(); // deliberate user action — runs even in safe mode
 }
 
 /** Drop a pending post for good — discards its cached blobs (user tapped Cancel / Discard). */


### PR DESCRIPTION
## Summary

From today's field incident: an iPhone crash-looping at boot (background transcode OOM on an old build) could not even receive the fixed build — the update toast died with every crash.

- Persisted boot counter: 3 launches without reaching 20s healthy uptime → the next boot is **safe mode**.
- Safe mode pauses deferrable background work (pending-post drain + media resumes) for that boot and **auto-applies any waiting update silently** (same one-per-tab cap as the install-gate auto-pull).
- One healthy boot clears the counter; manual Retry on a paused post still runs.
- Unit-pinned threshold + drain-gate; typecheck green.

Held with #1004 for the reporter's verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7