### PR TITLE
fix(contacts): your friends and close-friends list now survive reinstalling and recovering your account

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,3 +121,4 @@ Specs are grouped by category band; status moves
 | [2035](specs/2035-link-previews-look/spec.md) | Link Previews Look Sharp | 🟡 in-progress |
 | [2036](specs/2036-video-posts-finish/spec.md) | Video Posts Finish Cleanly | 🟡 in-progress |
 | [2037](specs/2037-pending-post-auto/spec.md) | Pending-Post Auto-Retry Gets an Attempt Budget | 🟡 in-progress |
+| [2040](specs/2040-recovered-devices-rebuild/spec.md) | Recovered Devices Rebuild Their Friends Ledger | 🟡 in-progress |

--- a/drive/scenarios/friends-ledger-heal.mjs
+++ b/drive/scenarios/friends-ledger-heal.mjs
@@ -1,0 +1,53 @@
+// Spec 2040 end-to-end: a device whose connected-peers ledger is wiped (the
+// recovery/reinstall state — contacts present, ledger empty) heals it from the
+// server on the next connect, restoring listFriends()/close-friends.
+import { createAccount, pair, poll, sweep, done } from '../driver.mjs';
+
+const ledger = (page) =>
+  page.evaluate(
+    () =>
+      new Promise((resolve, reject) => {
+        const req = indexedDB.open('ring');
+        req.onerror = () => reject(req.error);
+        req.onsuccess = () => {
+          const db = req.result;
+          const get = db.transaction('settings').objectStore('settings').get('connectedPeers');
+          get.onsuccess = () => { db.close(); resolve(get.result?.value ?? {}); };
+          get.onerror = () => { db.close(); reject(get.error); };
+        };
+      }),
+  );
+
+const a = await createAccount('Heala');
+const b = await createAccount('Healb');
+await pair(a, b);
+
+// Sanity: the live accept populated the ledger.
+await poll(() => ledger(a.page), (v) => v[b.id] === true, { label: 'ledger has b after pair' });
+console.log('[heal] ledger populated by live accept');
+
+// Simulate recovery: wipe the ledger row (contacts stay), then reload.
+await a.page.evaluate(
+  () =>
+    new Promise((resolve, reject) => {
+      const req = indexedDB.open('ring');
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => {
+        const db = req.result;
+        const tx = db.transaction('settings', 'readwrite');
+        tx.objectStore('settings').delete('connectedPeers');
+        tx.oncomplete = () => { db.close(); resolve(); };
+        tx.onerror = () => { db.close(); reject(tx.error); };
+      };
+    }),
+);
+console.log('[heal] ledger wiped, reloading (simulated recovered install)');
+await a.page.reload();
+await a.page.waitForSelector('ion-tab-bar', { timeout: 30_000 });
+
+// The boot refreshConnections() must rebuild it from ?include=friends.
+await poll(() => ledger(a.page), (v) => v[b.id] === true, { label: 'ledger healed after reload' });
+console.log('[heal] PASS — ledger rebuilt from the server after wipe+reload');
+
+await sweep([a, b]);
+await done();

--- a/server/internal/api/connections_handlers.go
+++ b/server/internal/api/connections_handlers.go
@@ -217,10 +217,25 @@ func (h *Handlers) listConnections(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusInternalServerError, "could not list connections")
 		return
 	}
-	httpx.JSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"incoming": connDTOs(incoming),
 		"outgoing": connDTOs(outgoing),
-	})
+	}
+	// `?include=friends` (spec 2040) adds the full accepted-peer list so a
+	// recovered device can rebuild its local friends ledger. Always an array
+	// (never null) so clients can distinguish "no friends" from "old server".
+	if r.URL.Query().Get("include") == "friends" {
+		friends, err := h.Connections.AcceptedPeers(r.Context(), uid)
+		if err != nil {
+			httpx.Error(w, http.StatusInternalServerError, "could not list connections")
+			return
+		}
+		if friends == nil {
+			friends = []string{}
+		}
+		resp["friends"] = friends
+	}
+	httpx.JSON(w, http.StatusOK, resp)
 }
 
 func connDTOs(rs []store.ConnectionReq) []connDTO {

--- a/server/internal/api/connections_handlers_test.go
+++ b/server/internal/api/connections_handlers_test.go
@@ -50,6 +50,7 @@ type fakeConn struct {
 	withdrawn map[[2]string]bool // (requester,target) -> true
 	rejected  map[[2]string]bool // (requester,target) declined → suppressed (FR-007)
 	outgoing  []store.ConnectionReq // what OutgoingRequests returns (spec 1040)
+	friends []string // spec 2040: AcceptedPeers result
 }
 
 func newFakeConn() *fakeConn {
@@ -97,6 +98,10 @@ func (c *fakeConn) OutgoingWithRecentAccepts(_ context.Context, _ string) ([]sto
 	// rejected + accepted-within-24h (the window is SQL-side; the fake returns
 	// everything injected via `outgoing`).
 	return c.outgoing, nil
+}
+
+func (c *fakeConn) AcceptedPeers(_ context.Context, _ string) ([]string, error) {
+	return c.friends, nil
 }
 
 // newConnTestServer builds the router with a real fake store (for register/auth)
@@ -327,5 +332,52 @@ func TestListConnectionsAcceptedRowsAreOptIn(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "friend-1") {
 		t.Errorf("accepted row missing from include=accepted response")
+	}
+}
+
+// Spec 2040: `?include=friends` returns the full accepted-peer list so a
+// recovered device can rebuild its local friends ledger. The field is opt-in
+// (absent by default) and always an array, even when the user has no friends —
+// clients use its presence to tell "no friends" apart from an old server.
+func TestListConnectionsFriendsAreOptIn(t *testing.T) {
+	conn := newFakeConn()
+	srv, _ := newConnTestServer(conn)
+	tok, _, _ := registerNamed(t, srv, "alice")
+
+	conn.friends = []string{"friend-1", "friend-2"}
+
+	// Default: no friends field.
+	rr := do(t, srv, http.MethodGet, "/v1/connections", tok, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var def map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &def); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, present := def["friends"]; present {
+		t.Errorf("default response must NOT carry friends, got %s", rr.Body.String())
+	}
+
+	// Opt-in: the accepted peers come back verbatim.
+	rr = do(t, srv, http.MethodGet, "/v1/connections?include=friends", tok, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list(include=friends) status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Friends []string `json:"friends"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Friends) != 2 || resp.Friends[0] != "friend-1" || resp.Friends[1] != "friend-2" {
+		t.Errorf("friends = %v, want [friend-1 friend-2]", resp.Friends)
+	}
+
+	// Empty ledger still serializes as [], never null.
+	conn.friends = nil
+	rr = do(t, srv, http.MethodGet, "/v1/connections?include=friends", tok, "")
+	if !strings.Contains(rr.Body.String(), `"friends":[]`) {
+		t.Errorf("empty friends must serialize as [], body=%s", rr.Body.String())
 	}
 }

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -101,6 +101,9 @@ func (c *fakePostConn) IncomingRequests(context.Context, string) ([]store.Connec
 func (c *fakePostConn) OutgoingRequests(context.Context, string) ([]store.ConnectionReq, error) {
 	return nil, nil
 }
+func (c *fakePostConn) AcceptedPeers(context.Context, string) ([]string, error) {
+	return nil, nil
+}
 func (c *fakePostConn) OutgoingWithRecentAccepts(context.Context, string) ([]store.ConnectionReq, error) {
 	return nil, nil
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -54,6 +54,10 @@ type ConnectionStore interface {
 	// Spec 1040: OutgoingRequests + accepted rows updated within 24h, served only
 	// for GET /v1/connections?include=accepted (the SW's accepted-note reconcile).
 	OutgoingWithRecentAccepts(ctx context.Context, user string) ([]store.ConnectionReq, error)
+	// Spec 2040: every accepted peer (either direction), served for
+	// GET /v1/connections?include=friends — the ledger a recovered device
+	// rebuilds its local friends list from.
+	AcceptedPeers(ctx context.Context, user string) ([]string, error)
 }
 
 // BlockStore is the per-user block-list persistence. *store.Store satisfies it.

--- a/server/internal/store/connections.go
+++ b/server/internal/store/connections.go
@@ -156,6 +156,35 @@ func (s *Store) OutgoingRequests(ctx context.Context, user string) ([]Connection
 		   ORDER BY updated_at DESC`, user)
 }
 
+// AcceptedPeers returns every peer this user has an accepted connection with,
+// in either direction (spec 2040): the authoritative friend list a recovered
+// device rebuilds its local ledger from. Blocked pairs are excluded the same
+// way Connected() excludes them.
+func (s *Store) AcceptedPeers(ctx context.Context, user string) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT DISTINCT CASE WHEN c.requester = $1 THEN c.target ELSE c.requester END
+		   FROM connections c
+		  WHERE c.state = 'accepted'
+		    AND (c.requester = $1 OR c.target = $1)
+		    AND NOT EXISTS (
+		      SELECT 1 FROM blocks b
+		       WHERE (b.blocker = c.requester AND b.blocked = c.target)
+		          OR (b.blocker = c.target AND b.blocked = c.requester))`, user)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
 // OutgoingWithRecentAccepts is OutgoingRequests plus RECENTLY accepted rows
 // (spec 1040), served only when a client explicitly asks
 // (GET /v1/connections?include=accepted): the service worker's closed-app

--- a/specs/2040-recovered-devices-rebuild/spec.md
+++ b/specs/2040-recovered-devices-rebuild/spec.md
@@ -1,0 +1,47 @@
+# Feature Specification: Recovered Devices Rebuild Their Friends Ledger
+
+**Feature Branch**: `fix/2040-recovered-devices-rebuild`
+
+**Created**: 2026-07-15
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User bug report (2026-07-15): after removing the app and logging back
+in with the recovery key, contacts and chat placeholders restore — but the
+Close Friends screen is empty and offers no contacts to pick.
+
+## Diagnosis
+
+`listFriends()` (the source for Close Friends AND every Wall-post audience)
+filters contacts through the local `connectedPeers` settings ledger, which is
+written ONLY by live accept/connect events and is neither own-synced nor
+rehydrated. A recovered install therefore has restored contacts but an empty
+friends ledger: the Close Friends picker is blank, and — silently worse —
+Wall posts from that device fan out to an EMPTY audience. The server has the
+authoritative accepted-connection graph but exposes no way to list it.
+
+## Requirements
+
+- **FR-001**: The connections API MUST let a client list its ACCEPTED peer ids
+  (`GET /v1/connections?include=friends` adds a `friends: [userId]` field —
+  metadata the server already owns; no new knowledge).
+- **FR-002**: The client MUST reconcile the local ledger from that list inside
+  the existing `refreshConnections()` flow (boot + reconnect + connect events):
+  additive marking of every accepted peer — idempotent, heals EVERY previously
+  recovered install, not just fresh recoveries.
+- **FR-003**: Restored contact rows keep their `closeFriend` flags (already the
+  case via own-sync) so the close list reappears once the ledger heals.
+
+## Zero-Knowledge Impact
+
+None — the accepted-connection graph is metadata the server already stores and
+enforces (post audience checks); returning it to its own account adds nothing.
+
+## Success Criteria
+
+- **SC-001**: Go handler/store tests pin `include=friends` returning accepted
+  peers (both directions) and nothing else.
+- **SC-002**: Client unit test: reconcile marks all listed peers connected.
+- **SC-003**: The reporter's recovered phone shows friends + close friends
+  after one app start on the fixed build.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -577,11 +577,17 @@ export async function connectLink(target: string): Promise<void> {
   if (!res.ok) throw new Error(`connect link failed: ${res.status}`);
 }
 
-/** The caller's incoming (awaiting accept) + outgoing (pending/rejected) requests. */
-export async function listConnections(): Promise<{ incoming: ConnReq[]; outgoing: ConnReq[] }> {
-  const res = await fetch(`${apiBaseUrl()}/v1/connections`, { headers: authHeaders() });
+/** The caller's incoming (awaiting accept) + outgoing (pending/rejected) requests.
+ *  With `includeFriends` the server also returns the full accepted-peer id list
+ *  (spec 2040) — the authoritative friend graph a recovered device rebuilds its
+ *  local connected-peers ledger from. `friends` is undefined on older servers. */
+export async function listConnections(
+  includeFriends = false,
+): Promise<{ incoming: ConnReq[]; outgoing: ConnReq[]; friends?: string[] }> {
+  const url = `${apiBaseUrl()}/v1/connections${includeFriends ? '?include=friends' : ''}`;
+  const res = await fetch(url, { headers: authHeaders() });
   if (!res.ok) throw new Error(`list connections failed: ${res.status}`);
-  return (await res.json()) as { incoming: ConnReq[]; outgoing: ConnReq[] };
+  return (await res.json()) as { incoming: ConnReq[]; outgoing: ConnReq[]; friends?: string[] };
 }
 
 /** Register a browser push subscription with the backend. */

--- a/src/services/connections.test.ts
+++ b/src/services/connections.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Spec 2040: refreshConnections rebuilds the device-local connected-peers
+ * ledger from the server's accepted-friends list, so a recovered install
+ * (contacts restored via own-sync, ledger empty) heals on first connect
+ * instead of showing an empty close-friends picker and posting to nobody.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const marked: string[] = [];
+let friendsFromServer: string[] | undefined;
+
+vi.mock('@/services/api', () => ({
+  listConnections: vi.fn(async (includeFriends?: boolean) => ({
+    incoming: [],
+    outgoing: [],
+    ...(includeFriends && friendsFromServer ? { friends: friendsFromServer } : {}),
+  })),
+  connectRequest: vi.fn(),
+  connectAccept: vi.fn(),
+  connectReject: vi.fn(),
+  connectWithdraw: vi.fn(),
+  connectLink: vi.fn(),
+  fetchDirectoryUser: vi.fn(async () => null),
+}));
+vi.mock('@/services/directory', () => ({ importDirectoryUser: vi.fn() }));
+vi.mock('@/db/queries', () => ({
+  getContact: vi.fn(async () => undefined),
+  markContactConnected: vi.fn(async (id: string) => {
+    if (id === 'boom') throw new Error('bad row');
+    marked.push(id);
+  }),
+}));
+
+import { refreshConnections } from './connections';
+import { listConnections } from '@/services/api';
+
+describe('refreshConnections friends-ledger reconcile (spec 2040)', () => {
+  beforeEach(() => {
+    marked.length = 0;
+    friendsFromServer = undefined;
+    vi.mocked(listConnections).mockClear();
+  });
+
+  it('asks the server for the accepted-friends list and marks every peer connected', async () => {
+    friendsFromServer = ['friend-a', 'friend-b', 'friend-c'];
+    await refreshConnections();
+    expect(listConnections).toHaveBeenCalledWith(true);
+    expect(marked).toEqual(['friend-a', 'friend-b', 'friend-c']);
+  });
+
+  it('tolerates old servers that omit the friends field', async () => {
+    friendsFromServer = undefined;
+    await expect(refreshConnections()).resolves.toBeUndefined();
+    expect(marked).toEqual([]);
+  });
+
+  it('a failing row does not stop the rest of the ledger from healing', async () => {
+    friendsFromServer = ['friend-a', 'boom', 'friend-b'];
+    await refreshConnections();
+    expect(marked).toEqual(['friend-a', 'friend-b']);
+  });
+});

--- a/src/services/connections.ts
+++ b/src/services/connections.ts
@@ -46,9 +46,26 @@ async function hydrate(userId: string): Promise<{ name: string; avatar: string }
 export async function refreshConnections(): Promise<void> {
   let data: Awaited<ReturnType<typeof listConnections>>;
   try {
-    data = await listConnections();
+    data = await listConnections(true);
   } catch {
     return;
+  }
+  // Spec 2040: the connected-peers ledger is device-local and written only by
+  // live accept events, so a recovered install restores contacts but an EMPTY
+  // friends list (blank close-friends picker, wall posts with no audience).
+  // The server owns the accepted graph — additively re-mark every accepted
+  // peer here so the ledger self-heals on every boot/reconnect. Additive only:
+  // marking is idempotent, and ids without a contact row are harmless (the
+  // ledger is intersected with contacts at read time, and the contact may
+  // simply not have own-synced down yet).
+  if (Array.isArray(data.friends)) {
+    for (const id of data.friends) {
+      try {
+        await markContactConnected(id);
+      } catch {
+        /* one bad row must not break request-list refresh */
+      }
+    }
   }
   incomingRequests.value = await Promise.all(
     data.incoming.map(async (r) => ({


### PR DESCRIPTION
## Spec 2040 — recovered devices rebuild their friends ledger

**The bug (user report):** after reinstalling and logging in with the recovery key, contacts and chats restore but the close-friends screen is empty and posting to "All friends" says *add friends first*.

**Root cause:** the device-local `connectedPeers` ledger gates `listFriends()` (close-friends picker AND every wall-post audience), but it's written only by live accept events — never synced, never rehydrated. A recovered install therefore silently posts to an empty audience.

**Fix:**
- Server: `GET /v1/connections?include=friends` returns the caller's accepted peer ids (both directions, blocked pairs excluded, always `[]` never null) — metadata the server already owns and enforces, nothing new crosses the zero-knowledge boundary.
- Client: `refreshConnections()` requests it and additively re-marks every accepted peer on each connect — heals every previously recovered install automatically. Close-friend flags themselves already restore via own-sync.

**Tests:** Go handler tests (opt-in field, verbatim list, empty-array contract), client vitest (marks all peers, old-server tolerant, bad row doesn't stop the loop), and a drive scenario that wipes the ledger in a live browser and watches it heal on reload.

**Verified on the reporter's device** (recovered install shows friends + close friends again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7