### PR TITLE
fix(wall): posting a big video no longer crashes the app on iPhone

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,3 +120,4 @@ Specs are grouped by category band; status moves
 | [2034](specs/2034-wall-video-posts/spec.md) | Wall Video Posts — Honest Progress, Real Avatar, Media That Fits | 🔵 in-review |
 | [2035](specs/2035-link-previews-look/spec.md) | Link Previews Look Sharp | 🟡 in-progress |
 | [2036](specs/2036-video-posts-finish/spec.md) | Video Posts Finish Cleanly | 🟡 in-progress |
+| [2038](specs/2038-videos-reasonable-size/spec.md) | Reasonable Videos Upload As-Is | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -122,3 +122,4 @@ Specs are grouped by category band; status moves
 | [2036](specs/2036-video-posts-finish/spec.md) | Video Posts Finish Cleanly | 🟡 in-progress |
 | [2037](specs/2037-pending-post-auto/spec.md) | Pending-Post Auto-Retry Gets an Attempt Budget | 🟡 in-progress |
 | [2038](specs/2038-videos-reasonable-size/spec.md) | Reasonable Videos Upload As-Is | 🟡 in-progress |
+| [2041](specs/2041-video-post-memory/spec.md) | Video Posts Must Not Exhaust iPhone Memory | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,6 +121,6 @@ Specs are grouped by category band; status moves
 | [2035](specs/2035-link-previews-look/spec.md) | Link Previews Look Sharp | 🟡 in-progress |
 | [2036](specs/2036-video-posts-finish/spec.md) | Video Posts Finish Cleanly | 🟡 in-progress |
 | [2037](specs/2037-pending-post-auto/spec.md) | Pending-Post Auto-Retry Gets an Attempt Budget | 🟡 in-progress |
-| [2038](specs/2038-videos-reasonable-size/spec.md) | Reasonable Videos Upload As-Is | 🟡 in-progress |
-| [2039](specs/2039-boot-loop-safe/spec.md) | Boot-Loop Safe Mode | 🟡 in-progress |
+| [2038](specs/2038-videos-reasonable-size/spec.md) | Reasonable Videos Upload As-Is | 🟢 shipped |
+| [2039](specs/2039-boot-loop-safe/spec.md) | Boot-Loop Safe Mode | 🟢 shipped |
 | [2041](specs/2041-video-post-memory/spec.md) | Video Posts Must Not Exhaust iPhone Memory | 🔵 in-review |

--- a/drive/scenarios/wall-real-video-post.mjs
+++ b/drive/scenarios/wall-real-video-post.mjs
@@ -69,6 +69,16 @@ console.log('[realpost] DOM:', JSON.stringify(domState));
 console.log(domState.pendingCards === 0 && domState.videos >= 1 ? '[realpost] PASS — clean finish, video posted' : '[realpost] FAIL — leftover card or missing video');
 await shot(kim, 'real-post-wall-after');
 
+// TEMP probe: the posted video must be playable with a real duration.
+const dur = await kim.page.evaluate(async () => {
+  const v = document.querySelector('.post video');
+  if (!v) return 'no-video-el';
+  for (let i = 0; i < 40 && !(v.duration > 0); i++) await new Promise((r) => setTimeout(r, 250));
+  return { duration: v.duration, w: v.videoWidth, h: v.videoHeight };
+});
+console.log('[realpost] playback probe:', JSON.stringify(dur));
+
+
 // Recipient sanity: Pal sees the post arrive too.
 await pal.page.goto('/tabs/wall');
 await poll(

--- a/drive/scenarios/wall-video-memory.mjs
+++ b/drive/scenarios/wall-video-memory.mjs
@@ -1,0 +1,138 @@
+/**
+ * Spec 2041: the video-post pipeline must keep peak JS-heap growth bounded by
+ * the demux WINDOW, not the FILE. Two probes through the real UI:
+ *   1. the reporter's real 16 MB portrait clip (1080×1920 → transcodes at 'hd'),
+ *   2. a synthesized BIG 4K H.264 clip recorded in-page (MediaRecorder), large
+ *      enough that the old whole-file demux would hold several file-copies.
+ * Both must finish cleanly (no leftover card, playable post) while the sampled
+ * heap delta stays far below the old pipeline's multiples of file size.
+ *
+ *   node drive/scenarios/wall-video-memory.mjs
+ */
+import { createAccount, pair, poll, sweep, done } from '../driver.mjs';
+
+const REAL_FILE = process.argv[2] ?? '/Users/kamran/Desktop/When You Think You Can Handle It.mp4';
+
+const kim = await createAccount({ name: 'Kim' });
+const pal = await createAccount({ name: 'Pal' });
+await pair(kim, pal);
+
+/** Sample usedJSHeapSize continuously in-page; returns peak-minus-baseline MB.
+ *  CAVEAT: without --enable-precise-memory-info chromium quantizes and
+ *  rate-limits this value (often reading +0), so the cap is a tripwire for
+ *  gross regressions only — the structural demux tests and the on-device pass
+ *  are the real memory evidence. */
+const startHeapWatch = (page) =>
+  page.evaluate(() => {
+    const m = performance.memory;
+    if (!m) return false;
+    window.__heapWatch = { base: m.usedJSHeapSize, peak: m.usedJSHeapSize };
+    window.__heapTimer = setInterval(() => {
+      const u = performance.memory.usedJSHeapSize;
+      if (u > window.__heapWatch.peak) window.__heapWatch.peak = u;
+    }, 100);
+    return true;
+  });
+const stopHeapWatch = (page) =>
+  page.evaluate(() => {
+    clearInterval(window.__heapTimer);
+    const w = window.__heapWatch;
+    return w ? Math.round((w.peak - w.base) / 1048576) : -1;
+  });
+
+/** Open the composer, let `setFiles` attach media, Share, and measure. */
+async function postAndMeasure(label, setFiles, { maxDeltaMb, minVideos }) {
+  await kim.page.goto('/tabs/wall');
+  await kim.page.getByRole('button', { name: 'New post' }).first().click();
+  await kim.page.waitForURL('**/wall/compose', { timeout: 15_000 });
+  await kim.page.waitForSelector('input[type="file"]', { state: 'attached', timeout: 15_000 });
+  const skip = (await setFiles()) === 'skip';
+  if (skip) {
+    console.log(`[mem] ${label}: SKIPPED`);
+    await kim.page.goto('/tabs/wall');
+    return;
+  }
+  await kim.page.waitForTimeout(1500);
+  const watching = await startHeapWatch(kim.page);
+  await kim.page.getByText('Share', { exact: true }).click();
+  await kim.page.waitForURL('**/tabs/wall', { timeout: 15_000 });
+  const t0 = Date.now();
+  await poll(
+    () => kim.page.evaluate(() => window.__ringTest.pendingPostCount()),
+    (n) => n === 0,
+    { timeout: 600_000, every: 1000, label: `${label} drains` },
+  );
+  const deltaMb = watching ? await stopHeapWatch(kim.page) : -1;
+  const domState = await kim.page.evaluate(() => ({
+    pendingCards: document.querySelectorAll('.pending-post').length,
+    videos: document.querySelectorAll('.post .wv-video, .post video').length,
+  }));
+  const dur = await kim.page.evaluate(async () => {
+    const v = document.querySelector('.post video');
+    if (!v) return null;
+    for (let i = 0; i < 40 && !(v.duration > 0); i++) await new Promise((r) => setTimeout(r, 250));
+    return { duration: v.duration, w: v.videoWidth, h: v.videoHeight };
+  });
+  const clean = domState.pendingCards === 0 && domState.videos >= minVideos && dur && dur.duration > 0;
+  const memOk = deltaMb < 0 || deltaMb <= maxDeltaMb;
+  console.log(
+    `[mem] ${label}: ${((Date.now() - t0) / 1000).toFixed(1)}s, heap +${deltaMb} MB (cap ${maxDeltaMb}), ` +
+      `playback ${JSON.stringify(dur)} → ${clean && memOk ? 'PASS' : 'FAIL'}`,
+  );
+  if (!clean || !memOk) throw new Error(`${label} failed (clean=${clean} memOk=${memOk} dom=${JSON.stringify(domState)})`);
+}
+
+// Probe 1: the reporter's real portrait clip (1920-edge → real transcode at 'hd').
+await postAndMeasure('real-16MB', () => kim.page.setInputFiles('input[type="file"]', REAL_FILE), {
+  maxDeltaMb: 400,
+  minVideos: 1,
+});
+
+// Probe 2: synthesize a big 4K H.264 mp4 IN the composer page (animated noise
+// defeats compression → high bitrate), attach it without leaving the page.
+let bigSizeMb = 0;
+await postAndMeasure(
+  'big-4K',
+  async () => {
+    const size = await kim.page.evaluate(async () => {
+      const mime = 'video/mp4;codecs=avc1';
+      if (typeof MediaRecorder === 'undefined' || !MediaRecorder.isTypeSupported(mime)) return -1;
+      const c = document.createElement('canvas');
+      c.width = 3840;
+      c.height = 2160;
+      const ctx = c.getContext('2d');
+      const rec = new MediaRecorder(c.captureStream(30), { mimeType: mime, videoBitsPerSecond: 45_000_000 });
+      const parts = [];
+      rec.ondataavailable = (e) => parts.push(e.data);
+      const stopped = new Promise((r) => (rec.onstop = r));
+      rec.start(1000);
+      const t0 = performance.now();
+      while (performance.now() - t0 < 20_000) {
+        for (let i = 0; i < 250; i++) {
+          ctx.fillStyle = `hsl(${Math.random() * 360},80%,${30 + Math.random() * 40}%)`;
+          ctx.fillRect(Math.random() * 3840, Math.random() * 2160, 120, 120);
+        }
+        await new Promise((r) => requestAnimationFrame(r));
+      }
+      rec.stop();
+      await stopped;
+      const file = new File(parts, 'big-4k.mp4', { type: 'video/mp4' });
+      const input = document.querySelector('input[type="file"]');
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      input.files = dt.files;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      return file.size;
+    });
+    if (size < 0) return 'skip';
+    bigSizeMb = Math.round(size / 1048576);
+    console.log(`[mem] synthesized 4K clip: ${bigSizeMb} MB`);
+  },
+  // Old pipeline held ≥3 file-copies (outbox bytes + demux buffer + chunk
+  // copies) before frames even queued; streaming must stay well under ONE
+  // file-size over baseline plus queues/muxer. Cap resolved after synthesis.
+  { get maxDeltaMb() { return bigSizeMb + 150; }, minVideos: 2 },
+);
+
+await sweep([kim, pal]);
+await done();

--- a/specs/2038-videos-reasonable-size/spec.md
+++ b/specs/2038-videos-reasonable-size/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-15
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User direction (2026-07-15): "If a video file size to length ratio is

--- a/specs/2038-videos-reasonable-size/spec.md
+++ b/specs/2038-videos-reasonable-size/spec.md
@@ -1,0 +1,43 @@
+# Feature Specification: Reasonable Videos Upload As-Is
+
+**Feature Branch**: `fix/2038-videos-reasonable-size`
+
+**Created**: 2026-07-15
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User direction (2026-07-15): "If a video file size to length ratio is
+reasonable and doesn't really need conversion we should just simply upload it as
+is; only videos captured on the phone itself in 4k quality are large enough to
+require conversion to smaller and more compatible global format to make it work
+across apple android and desktop."
+
+## Requirements
+
+- **FR-001**: Before any transcode engine loads, a video whose bitrate
+  (size ÷ duration) is within 1.5× the target preset's bitrate AND whose
+  resolution fits the preset MUST upload as-is — no re-encode, instant
+  progression to the upload phase.
+- **FR-002**: The as-is path MUST be limited to universally playable content:
+  MP4/QuickTime containers carrying H.264 video. HEVC/AV1/VP9 (typical modern
+  phone captures) and non-MP4 containers keep today's transcode-to-H.264 path —
+  that is exactly the cross-platform conversion the user wants preserved.
+- **FR-003**: 4K-class or preset-exceeding resolutions always transcode
+  (downscale), whatever their bitrate.
+- **FR-004**: Any probe/sniff failure falls back to today's behavior — the
+  check can only ever SKIP work, never block a send.
+
+## Why this also matters for stability
+
+The transcode is the memory-heavy step behind the spec-2037 crash loop; not
+running it at all for already-efficient clips removes the risk for the most
+common share (downloaded/already-compressed videos).
+
+## Success Criteria
+
+- **SC-001**: Pure-rule unit tests: bitrate/resolution gate + codec sniff
+  (H.264 accepts; HEVC/AV1/VP9 markers reject).
+- **SC-002**: The reporter's real 17 MB clip posts with NO encode phase (drive
+  validation: progress starts in the upload band immediately) when its codec is
+  H.264; a synthetic HEVC-marked buffer still routes to the transcode.

--- a/specs/2039-boot-loop-safe/spec.md
+++ b/specs/2039-boot-loop-safe/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-15
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: Field incident (2026-07-15): an iPhone stuck on an old build crash-

--- a/specs/2041-video-post-memory/spec.md
+++ b/specs/2041-video-post-memory/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-15
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
 
 **Input**: User report (2026-07-15, after specs 2036–2039 shipped to the dev

--- a/specs/2041-video-post-memory/spec.md
+++ b/specs/2041-video-post-memory/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Video Posts Must Not Exhaust iPhone Memory
+
+**Feature Branch**: `fix/2041-video-post-memory`
+
+**Created**: 2026-07-15
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped. -->
+
+**Input**: User report (2026-07-15, after specs 2036–2039 shipped to the dev
+stack): "the app still crashes when posting a video on the wall on my iphone."
+The 2037/2039 guards now stop the *loop* (3 attempts → failed card, safe mode),
+but the crash itself remains: iOS kills the page on memory pressure (jetsam)
+during the video pipeline.
+
+## Diagnosis — where the memory goes
+
+For one N-byte video post today, the JS heap simultaneously holds up to:
+
+1. `enqueuePendingPost` inlines the whole file as an ArrayBuffer (N) plus the
+   IDB structured-clone copy in flight (transiently ~2N at Share).
+2. Every drain reads the record back (N) and rebuilds an in-memory Blob; the
+   record (and its bytes) stays referenced for the entire createPost await.
+3. `webcodecsTranscode` reads the blob into ONE whole-file ArrayBuffer for
+   mp4box (N) and then copies EVERY compressed sample into
+   `EncodedVideoChunk`s before decoding starts (≈N again).
+4. Decoded 4K frame queues (bounded at 8 since spec 2038, ~100–200 MB) plus
+   the in-memory muxer output.
+
+A 1-minute iPhone 4K clip (~400 MB) peaks well past 1 GB — beyond what iOS
+grants a standalone PWA. The ffmpeg.wasm fallback is worse (whole file into
+the wasm heap plus a 30 MB runtime).
+
+## Requirements
+
+- **FR-001**: Outbox items above a size threshold MUST be stored as Blobs
+  (disk-backed by the browser) instead of inline ArrayBuffers. Small items
+  keep the proven inline-bytes path (spec 1024's iOS restart lesson).
+- **FR-002**: Recovery MUST probe Blob-backed items for readability after a
+  restart; unreadable ones fall back to the existing draft-ify path instead of
+  wedging or crashing the drain.
+- **FR-003**: The drain MUST NOT retain the outbox record's bytes across the
+  createPost await (release before the heavy pipeline runs).
+- **FR-004**: The WebCodecs transcode MUST demux incrementally: feed mp4box a
+  bounded window of the source at a time, decode with the existing
+  backpressure as samples arrive, and release consumed samples/buffers, so
+  peak input-side memory is O(window + queues), not O(file).
+- **FR-005**: Container layouts with trailing metadata (iPhone camera files:
+  `mdat` before `moov`) MUST be handled without buffering the media data —
+  follow mp4box's next-parse-position steering to locate `moov` first.
+- **FR-006**: The ffmpeg.wasm leg MUST refuse inputs above a size bound with a
+  clean error (degrading to the existing original/failed-card paths) instead
+  of attempting a transcode that exhausts memory.
+- **FR-007**: Pipeline behavior is otherwise unchanged: same presets, same
+  as-is gate (spec 2038), same rotation baking, same output-playability gate,
+  same progress reporting and attempt budget.
+
+## Zero-Knowledge Impact
+
+None — all changes are client-side memory management; the wire format and
+server remain untouched.
+
+## Success Criteria
+
+- **SC-001**: Unit tests pin the outbox threshold rules (large → Blob-backed,
+  small → inline bytes) and the recovery readability probe.
+- **SC-002**: Unit tests exercise the streaming demuxer against a real mp4
+  fixture (both moov-first and moov-last layouts) and assert sample counts,
+  order, and that consumed buffers are released.
+- **SC-003**: A drive scenario posts a real video and asserts the page's peak
+  JS heap growth during the post stays far below the whole-file multiples of
+  the old pipeline.
+- **SC-004**: The reporter's iPhone posts a camera video without the app
+  being killed.

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3106,12 +3106,18 @@ export async function createPost(opts: {
     let h: number | undefined;
     if (m.kind === 'image') ({ width: w, height: h } = await readImageMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
     else if (m.kind === 'video') ({ width: w, height: h } = await readVideoMeta(toUpload).catch(() => ({ width: undefined, height: undefined })));
+    // (spec 2041 rider) The byte upload owns only 50→90% of the item's bar
+    // (value ≤ 0.8 in the uploading band). A converted clip is small (~5 MB for
+    // 16 s at 'hd'), so its upload can finish in a blink — mapping it straight
+    // to 100% left the card sitting on "100%" for the ~10 s of real work that
+    // FOLLOWS (poster + tiers + sealing + registering + per-friend envelopes).
+    // The tail values below keep the bar moving through that finishing stretch.
     const ref = await prepareOutgoingMedia(
       toUpload,
       m.name,
       m.durationSec,
       { width: w, height: h, quality: achieved },
-      (value) => opts.onProgress?.({ phase: 'uploading', index, total, value }),
+      (value) => opts.onProgress?.({ phase: 'uploading', index, total, value: value * 0.8 }),
     );
     refs.push(ref);
     const id = uid();
@@ -3132,7 +3138,9 @@ export async function createPost(opts: {
       // while with no upload traffic — heartbeat the outbox stall-watchdog so it
       // only ever fires on a GENUINE hang (an abandoned attempt races a detached,
       // non-cancellable createPost into server-side duplicate churn).
-      opts.onProgress?.({ phase: 'uploading', index, total, value: 1 });
+      // (spec 2041 rider) …at 0.84, not 1: the bar shows ~92% while the poster
+      // work runs instead of a premature "100%".
+      opts.onProgress?.({ phase: 'uploading', index, total, value: 0.84 });
       const dataUrl = await generateVideoPoster(toUpload).catch(() => undefined);
       // Embed the poster (a small JPEG data URL, ≤~40KB) in the sealed MediaRef so a RECIPIENT
       // shows the thumbnail without downloading/decoding the clip — exactly how chat video
@@ -3166,8 +3174,10 @@ export async function createPost(opts: {
   else if (refs.length > 1) payload.album = refs;
 
   const built = buildPost(payload, audience);
-  // (spec 2036) Same heartbeat before the post-blob seal/upload/register leg.
-  if (mediaList.length) opts.onProgress?.({ phase: 'uploading', index: mediaList.length - 1, total, value: 1 });
+  // (spec 2036) Same heartbeat before the post-blob seal/upload/register leg —
+  // (spec 2041 rider) at 0.9 (~95% shown), so the register/envelope stretch is
+  // visible movement instead of a stall on a premature 100%.
+  if (mediaList.length) opts.onProgress?.({ phase: 'uploading', index: mediaList.length - 1, total, value: 0.9 });
   const blobId = await uploadBlob(new Blob([built.blob as BlobPart]));
   const id = opts.id ?? uid();
   const createdAt = now();
@@ -3196,6 +3206,10 @@ export async function createPost(opts: {
     updatedAt: createdAt,
   };
   await put<Post>('posts', post);
+  // (spec 2041 rider) 100% only when the post really EXISTS (registered +
+  // stored) — the card hits full and disappears together instead of idling
+  // on a premature 100% through the finishing work.
+  if (mediaList.length) opts.onProgress?.({ phase: 'uploading', index: mediaList.length - 1, total, value: 1 });
   return post;
 }
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -3201,6 +3201,11 @@ export async function createPost(opts: {
 
 // ---- spec 1024: resilient-posting outbox (`pendingPosts` store) ----
 
+/** (spec 2041) Items at or below this ride the outbox as inline bytes (bulletproof across an iOS
+ *  restart); larger ones are stored as disk-backed Blobs so a phone video never sits in the JS
+ *  heap. 24 MB keeps every image/voice note and short clip on the proven inline path. */
+export const OUTBOX_INLINE_MAX_BYTES = 24 << 20;
+
 /** Cache the staged media + metadata as a pending post and return its id. The composer dismisses
  *  the moment this resolves; the upload worker (services/pending-posts) drains it in the
  *  background. The blobs are the app's OWN cached copies, so removing the source can't break it. */
@@ -3222,16 +3227,25 @@ export async function enqueuePendingPost(input: {
   }[];
 }): Promise<string> {
   const id = uid();
-  // Read every item's bytes and store them INLINE (as an ArrayBuffer, not a Blob). This is what lets
-  // a post survive a full app close: a Blob read back from IDB after a restart can be unreadable on
-  // iOS, an ArrayBuffer always reads back. So an interrupted post keeps its photos/videos/voice and
-  // can be finished from the recovered draft. The read happens once here, at Share (in-session, while
-  // the picked files are still readable).
+  // Read every SMALL item's bytes and store them INLINE (as an ArrayBuffer, not a Blob). This is
+  // what lets a post survive a full app close: a Blob read back from IDB after a restart can be
+  // unreadable on iOS, an ArrayBuffer always reads back. So an interrupted post keeps its
+  // photos/videos/voice and can be finished from the recovered draft. The read happens once here,
+  // at Share (in-session, while the picked files are still readable).
+  //
+  // (spec 2041) LARGE items are stored as the Blob itself instead: inlining a phone video means the
+  // whole file in the JS heap plus a structured-clone copy at put() — at Share time, and again on
+  // every drain read — which was a big slice of the out-of-memory kill behind "posting a video
+  // crashes the app" on iPhone. A stored Blob is disk-backed by the browser (put() clones it by
+  // reference), costing ~zero heap on both sides. The iOS unreadable-Blob risk this trades back in
+  // is handled at recovery: recoverInterruptedPosts PROBES blob-backed items and draft-ifies the
+  // post if one doesn't read (the pre-1024 fallback), instead of wedging the drain.
   const items: OutboxItem[] = [];
   for (const it of input.items) {
+    const inline = it.blob.size <= OUTBOX_INLINE_MAX_BYTES;
     items.push({
       localId: uid(),
-      bytes: await it.blob.arrayBuffer(),
+      ...(inline ? { bytes: await it.blob.arrayBuffer() } : { blob: it.blob }),
       kind: it.kind,
       name: it.name,
       mime: it.mime,

--- a/src/services/media-video-ffmpeg.ts
+++ b/src/services/media-video-ffmpeg.ts
@@ -70,7 +70,7 @@ export async function ffmpegTranscode(
   if (onProgress) ff.on('progress', onProg);
   await ff.writeFile(input, await fetchFile(blob));
   try {
-    await ff.exec([
+    const rc = await ff.exec([
       '-i', input,
       // spec 1018 US1: do NOT pass -noautorotate. ffmpeg auto-applies the source display matrix,
       // baking the upright orientation into the pixels (and clearing the matrix), so the recipient
@@ -86,6 +86,14 @@ export async function ffmpegTranscode(
       '-movflags', '+faststart',
       output,
     ], FFMPEG_TIMEOUT_MS);
+    // (spec 2038) ffmpeg.wasm's exec RESOLVES with an exit code — it never
+    // rejects on a conversion failure. Reading the output regardless shipped a
+    // PARTIAL file that passed the smaller-than-source guard and posted as an
+    // unplayable 0-duration video (the reported desktop breakage). Non-zero rc
+    // → throw, so the orchestrator falls back to the original.
+    if (rc !== 0) {
+      throw new Error(`ffmpeg conversion failed (exit ${rc})`);
+    }
     const data = (await ff.readFile(output)) as Uint8Array;
     const out = new Blob([data.buffer as ArrayBuffer], { type: 'video/mp4' });
     // Keep whichever is smaller (re-encoding a small clip can grow it).

--- a/src/services/media-video-webcodecs.ts
+++ b/src/services/media-video-webcodecs.ts
@@ -349,7 +349,32 @@ export async function webcodecsTranscode(
     checkDone();
   });
 
-  for (const chunk of videoChunks) decoder.decode(chunk);
+  // (spec 2038) BACKPRESSURE: flooding the decoder with every chunk at once let
+  // decoded frames pile up faster than the canvas→encoder leg drained them — on
+  // phones that raw-frame pileup was the out-of-memory kill behind the crash
+  // loop (a single 4K frame is ~33 MB; a long clip queued hundreds). Feed the
+  // pipeline in bounded steps instead: wait until both queues drain below the
+  // cap before decoding the next chunk. The 'dequeue' event wakes us where
+  // supported; the timer is the safety net.
+  const MAX_QUEUE = 8;
+  const queuesDrained = () => decoder.decodeQueueSize < MAX_QUEUE && encoder.encodeQueueSize < MAX_QUEUE;
+  for (const chunk of videoChunks) {
+    while (!queuesDrained()) {
+      if (fatalError) throw fatalError;
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(done, 20);
+        function done(): void {
+          clearTimeout(t);
+          decoder.removeEventListener?.('dequeue', done);
+          encoder.removeEventListener?.('dequeue', done);
+          resolve();
+        }
+        decoder.addEventListener?.('dequeue', done);
+        encoder.addEventListener?.('dequeue', done);
+      });
+    }
+    decoder.decode(chunk);
+  }
   await decoder.flush();
   await encoder.flush();
   // A decode/encode error reported asynchronously (captured by `fail`) becomes a

--- a/src/services/media-video-webcodecs.ts
+++ b/src/services/media-video-webcodecs.ts
@@ -106,6 +106,62 @@ export function synthAacAsc(sampleRate?: number, channels?: number): Uint8Array 
   return new Uint8Array([(objectType << 3) | (fi >> 1), ((fi & 1) << 7) | (ch << 3)]);
 }
 
+/* ---- streaming demux (spec 2041) ----
+ * The old demux read the WHOLE source into one ArrayBuffer for mp4box and then
+ * copied every compressed sample into EncodedVideoChunks before decoding — on a
+ * phone that's 2× the file in the JS heap before a single frame decodes, and it
+ * was the out-of-memory kill (iOS jetsam) behind the "app crashes while posting
+ * a video" report. The streaming demux keeps input-side memory O(window):
+ *  1. scan the top-level box layout with tiny header reads (no media data),
+ *  2. feed mp4box only the metadata boxes plus each mdat's bare HEADER — mp4box
+ *     skips a header-only mdat (processIncompleteMdat seeks to its end), so a
+ *     trailing moov (every iPhone camera file) parses without buffering mdat,
+ *  3. pump the mdat bodies through in bounded windows, decoding as samples
+ *     surface and releasing consumed sample data (appendBuffer drops fully-used
+ *     buffers via cleanBuffers on every call).
+ */
+
+/** One top-level box in an mp4 container. */
+export interface Mp4BoxRange {
+  type: string;
+  start: number;
+  size: number;
+  headerLen: number;
+}
+
+/** Index the top-level boxes of an mp4 by reading only their headers (8–16 bytes
+ *  each) — a handful of tiny slice reads, never the media data. Throws on
+ *  anything that doesn't look like an ISO-BMFF layout, which sends the caller
+ *  down the ffmpeg/original fallback exactly like the old parse timeout did. */
+export async function scanTopLevelBoxes(blob: Blob): Promise<Mp4BoxRange[]> {
+  const out: Mp4BoxRange[] = [];
+  let off = 0;
+  while (off + 8 <= blob.size) {
+    const head = new DataView(await blob.slice(off, Math.min(off + 16, blob.size)).arrayBuffer());
+    let size: number = head.getUint32(0);
+    const type = String.fromCharCode(head.getUint8(4), head.getUint8(5), head.getUint8(6), head.getUint8(7));
+    if (!/^[\x20-\x7e]{4}$/.test(type)) throw new Error(`not an mp4: bad box type at ${off}`);
+    let headerLen = 8;
+    if (size === 1) {
+      // 64-bit largesize (large mdat)
+      if (head.byteLength < 16) throw new Error('not an mp4: truncated largesize box');
+      size = head.getUint32(8) * 2 ** 32 + head.getUint32(12);
+      headerLen = 16;
+    } else if (size === 0) {
+      size = blob.size - off; // box extends to EOF
+    }
+    if (size < headerLen || off + size > blob.size) throw new Error(`not an mp4: bad box size at ${off}`);
+    out.push({ type, start: off, size, headerLen });
+    off += size;
+  }
+  if (off !== blob.size) throw new Error('not an mp4: trailing garbage');
+  return out;
+}
+
+// Bytes of mdat pumped through mp4box per step. Big enough that a 400 MB clip is
+// a few dozen appends, small enough that input-side heap stays trivial.
+const DEMUX_WINDOW_BYTES = 16 << 20;
+
 export async function webcodecsTranscode(
   blob: Blob,
   preset: VideoPreset,
@@ -113,29 +169,35 @@ export async function webcodecsTranscode(
 ): Promise<Blob> {
   if (!webCodecsSupported()) throw new Error('WebCodecs unavailable');
 
+  const boxes = await scanTopLevelBoxes(blob);
+  if (!boxes.some((b) => b.type === 'moov')) throw new Error('not an mp4: no moov box');
+
   const file = MP4Box.createFile();
-  // mp4box fires NEITHER onReady nor onError for an input it can't parse (a corrupt or
-  // non-mp4 container, or too-few bytes), which would hang the whole send forever in
-  // 'compressing'. A timeout turns that into a clean rejection so the orchestrator falls
-  // through to ffmpeg/original and the send is never blocked (spec 2007 FR-006).
-  const READY_TIMEOUT_MS = 15_000;
-  const info = await new Promise<any>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error('mp4box: parse timed out (unsupported container?)')), READY_TIMEOUT_MS);
-    file.onReady = (i: any) => {
-      clearTimeout(timer);
-      resolve(i);
-    };
-    file.onError = (e: string) => {
-      clearTimeout(timer);
-      reject(new Error(`mp4box: ${e}`));
-    };
-    const ab = blob.arrayBuffer() as Promise<ArrayBuffer & { fileStart?: number }>;
-    void ab.then((buf) => {
-      (buf as any).fileStart = 0;
-      file.appendBuffer(buf as any);
-      file.flush();
-    });
-  });
+  // Parse errors surface via onError DURING appendBuffer; capture and rethrow
+  // between appends so a corrupt container is a clean rejection (spec 2007
+  // FR-006) — the orchestrator falls through to ffmpeg/original.
+  let parseError: Error | null = null;
+  file.onError = (e: string) => {
+    parseError ??= new Error(`mp4box: ${e}`);
+  };
+  let readyInfo: any = null;
+  file.onReady = (i: any) => {
+    readyInfo = i;
+  };
+  const appendRange = async (start: number, end: number) => {
+    const buf = (await blob.slice(start, end).arrayBuffer()) as ArrayBuffer & { fileStart: number };
+    buf.fileStart = start;
+    file.appendBuffer(buf);
+    if (parseError) throw parseError;
+  };
+  // Metadata boxes in full; mdat as bare header (mp4box skips over a header-only
+  // mdat to keep parsing the boxes that follow it — the trailing-moov layout).
+  for (const b of boxes) {
+    if (b.type === 'mdat') await appendRange(b.start, b.start + b.headerLen);
+    else await appendRange(b.start, b.start + b.size);
+  }
+  if (!readyInfo) throw new Error('mp4box: moov did not parse (unsupported container?)');
+  const info = readyInfo;
 
   const vTrack = info.videoTracks?.[0];
   if (!vTrack) throw new Error('no video track');
@@ -275,90 +337,15 @@ export async function webcodecsTranscode(
     synthesized: !!aTrack && !audioSpecificConfig(file, aTrack.id) && !!asc,
   });
   if (aTrack && !asc) throw new Error('cannot read audio config'); // avoid a silent result
-  const videoChunks: EncodedVideoChunk[] = [];
-  let audioCount = 0;
 
-  // Collect ALL samples before decoding. mp4box delivers samples across one or more
-  // onSamples callbacks; we must wait for genuine completion (every track's full
-  // nb_samples received), counting cumulatively rather than guessing from the last
-  // batch's sample number. The previous `setTimeout(resolve, 0)` "safety" could
-  // resolve BEFORE the batches arrived, yielding truncated/empty output that then
-  // tripped the "not smaller"/"audio dropped" guards and fell into the OOM-prone
-  // ffmpeg leg — the silent degrade-to-original on large iPhone 4K clips (spec 2007).
-  // A real wall-clock timeout now REJECTS (a clean failure → fallback), never resolves
-  // a partial result as success.
-  const EXTRACT_TIMEOUT_MS = 60_000;
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error('mp4box sample extraction timed out')),
-      EXTRACT_TIMEOUT_MS,
-    );
-    const finish = (err?: Error) => {
-      clearTimeout(timer);
-      if (err) reject(err);
-      else resolve();
-    };
-    const checkDone = () => {
-      const vDone = videoChunks.length >= vTrack.nb_samples;
-      const aDone = !aTrack || audioCount >= aTrack.nb_samples;
-      if (vDone && aDone) finish();
-    };
-    file.onSamples = (id: number, _u: any, samples: any[]) => {
-      try {
-        if (id === vTrack.id) {
-          for (const s of samples) {
-            videoChunks.push(
-              new EncodedVideoChunk({
-                type: s.is_sync ? 'key' : 'delta',
-                timestamp: (s.cts / s.timescale) * 1e6,
-                duration: (s.duration / s.timescale) * 1e6,
-                data: s.data,
-              }),
-            );
-          }
-        } else if (aTrack && id === aTrack.id) {
-          for (const s of samples) {
-            const chunk = new EncodedAudioChunk({
-              type: 'key',
-              timestamp: (s.cts / s.timescale) * 1e6,
-              duration: (s.duration / s.timescale) * 1e6,
-              data: s.data,
-            });
-            muxer.addAudioChunk(chunk, {
-              decoderConfig: {
-                codec: 'mp4a.40.2',
-                sampleRate: aTrack.audio.sample_rate,
-                numberOfChannels: aTrack.audio.channel_count,
-                description: asc,
-              },
-            } as any);
-            audioCount++;
-          }
-        }
-        checkDone();
-      } catch (e) {
-        finish(e as Error);
-      }
-    };
-    file.setExtractionOptions(vTrack.id, null, { nbSamples: Number.POSITIVE_INFINITY });
-    if (aTrack) file.setExtractionOptions(aTrack.id, null, { nbSamples: Number.POSITIVE_INFINITY });
-    file.start();
-    file.flush();
-    // mp4box delivers everything it can synchronously during start()/flush(); if the
-    // counts already satisfy completion, resolve now. Otherwise the timeout guards it.
-    checkDone();
-  });
-
-  // (spec 2038) BACKPRESSURE: flooding the decoder with every chunk at once let
-  // decoded frames pile up faster than the canvas→encoder leg drained them — on
-  // phones that raw-frame pileup was the out-of-memory kill behind the crash
-  // loop (a single 4K frame is ~33 MB; a long clip queued hundreds). Feed the
-  // pipeline in bounded steps instead: wait until both queues drain below the
+  // (spec 2038) BACKPRESSURE: flooding the decoder let decoded frames pile up
+  // faster than the canvas→encoder leg drained them — a single 4K frame is
+  // ~33 MB; a long clip queued hundreds. Wait until both queues drain below the
   // cap before decoding the next chunk. The 'dequeue' event wakes us where
   // supported; the timer is the safety net.
   const MAX_QUEUE = 8;
   const queuesDrained = () => decoder.decodeQueueSize < MAX_QUEUE && encoder.encodeQueueSize < MAX_QUEUE;
-  for (const chunk of videoChunks) {
+  const awaitQueues = async () => {
     while (!queuesDrained()) {
       if (fatalError) throw fatalError;
       await new Promise<void>((resolve) => {
@@ -373,8 +360,97 @@ export async function webcodecsTranscode(
         encoder.addEventListener?.('dequeue', done);
       });
     }
-    decoder.decode(chunk);
+  };
+
+  // (spec 2041) Samples are converted the moment mp4box surfaces them (both
+  // chunk constructors and the muxer COPY the bytes, so the mp4box-side sample
+  // data is released immediately after each batch), video chunks are decoded
+  // with backpressure between windows, and the per-batch release plus
+  // appendBuffer's cleanBuffers keep the demux-side heap bounded by the window
+  // size instead of the file size.
+  let pendingVideo: EncodedVideoChunk[] = [];
+  let videoCount = 0;
+  let audioCount = 0;
+  file.onSamples = (id: number, _u: any, samples: any[]) => {
+    if (!samples.length) return;
+    if (id === vTrack.id) {
+      for (const s of samples) {
+        pendingVideo.push(
+          new EncodedVideoChunk({
+            type: s.is_sync ? 'key' : 'delta',
+            timestamp: (s.cts / s.timescale) * 1e6,
+            duration: (s.duration / s.timescale) * 1e6,
+            data: s.data,
+          }),
+        );
+      }
+      videoCount += samples.length;
+    } else if (aTrack && id === aTrack.id) {
+      for (const s of samples) {
+        const chunk = new EncodedAudioChunk({
+          type: 'key',
+          timestamp: (s.cts / s.timescale) * 1e6,
+          duration: (s.duration / s.timescale) * 1e6,
+          data: s.data,
+        });
+        muxer.addAudioChunk(chunk, {
+          decoderConfig: {
+            codec: 'mp4a.40.2',
+            sampleRate: aTrack.audio.sample_rate,
+            numberOfChannels: aTrack.audio.channel_count,
+            description: asc,
+          },
+        } as any);
+        audioCount++;
+      }
+    } else {
+      return;
+    }
+    file.releaseUsedSamples(id, samples[samples.length - 1].number + 1);
+  };
+  const drainPendingVideo = async () => {
+    if (!pendingVideo.length) return;
+    const batch = pendingVideo;
+    pendingVideo = [];
+    for (const chunk of batch) {
+      await awaitQueues();
+      decoder.decode(chunk);
+    }
+  };
+
+  file.setExtractionOptions(vTrack.id, null, { nbSamples: 200 });
+  if (aTrack) file.setExtractionOptions(aTrack.id, null, { nbSamples: 200 });
+  file.start();
+
+  // Pump each mdat's BODY through in bounded windows (the headers went in during
+  // the open phase). Windows are appended in file order; mp4box surfaces samples
+  // as their bytes become contiguous, onSamples converts them, and we decode
+  // between appends so the frame queues never outrun the encoder.
+  for (const b of boxes) {
+    if (b.type !== 'mdat') continue;
+    let off = b.start + b.headerLen;
+    const end = b.start + b.size;
+    while (off < end) {
+      const next = Math.min(end, off + DEMUX_WINDOW_BYTES);
+      await appendRange(off, next);
+      off = next;
+      await drainPendingVideo();
+      if (fatalError) throw fatalError;
+    }
   }
+  file.flush();
+  if (parseError) throw parseError;
+  await drainPendingVideo();
+
+  // Completeness guard (spec 2007 lesson, kept from the collect-first design):
+  // a truncated extraction must be a clean REJECTION, never silently muxed as a
+  // shorter clip — the orchestrator falls through to ffmpeg/original instead.
+  if (videoCount < vTrack.nb_samples || (aTrack && audioCount < aTrack.nb_samples)) {
+    throw new Error(
+      `mp4box sample extraction incomplete (video ${videoCount}/${vTrack.nb_samples}, audio ${audioCount}/${aTrack?.nb_samples ?? 0})`,
+    );
+  }
+
   await decoder.flush();
   await encoder.flush();
   // A decode/encode error reported asynchronously (captured by `fail`) becomes a

--- a/src/services/media-video.test.ts
+++ b/src/services/media-video.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // The WebCodecs + ffmpeg engines are browser-only; here we mock them and assert the
 // ORCHESTRATION decisions of compressVideoAdaptive (spec 2007). A real transcode is
 // exercised by the e2e suite + on-device verification, not vitest.
-vi.mock('./media-video-webcodecs', () => ({
+vi.mock('./media-video-webcodecs', async (importOriginal) => ({
+  // Keep the real pure helpers (the spec 2041 box scanner is unit-tested here);
+  // only the engine entry points are mocked.
+  ...(await importOriginal<object>()),
   webCodecsSupported: vi.fn(() => true),
   webcodecsTranscode: vi.fn(),
 }));
@@ -87,5 +90,67 @@ describe('upload-as-is gate (spec 2038)', () => {
     expect(sniffMp4CodecIsPlainH264(buf('av01'))).toBe(false);
     expect(sniffMp4CodecIsPlainH264(buf('vp09'))).toBe(false);
     expect(sniffMp4CodecIsPlainH264(new TextEncoder().encode('..no codec here..'))).toBe(false);
+  });
+});
+
+/* ---- spec 2041: header-only codec sniff + box scanner ---- */
+
+/** Build a synthetic top-level box: 4-byte size, 4-byte type, payload. */
+function box(type: string, payload: Uint8Array): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(8 + payload.length);
+  new DataView(out.buffer).setUint32(0, out.length);
+  for (let i = 0; i < 4; i++) out[4 + i] = type.charCodeAt(i);
+  out.set(payload, 8);
+  return out;
+}
+const fourcc = (s: string): Uint8Array<ArrayBuffer> => new Uint8Array([...s].map((c) => c.charCodeAt(0)));
+
+describe('scanTopLevelBoxes (spec 2041)', () => {
+  it('indexes a moov-last (iPhone camera) layout without touching media data', async () => {
+    const { scanTopLevelBoxes } = await import('./media-video-webcodecs');
+    const blob = new Blob([box('ftyp', fourcc('isom')), box('mdat', new Uint8Array(1000)), box('moov', fourcc('avc1'))]);
+    const boxes = await scanTopLevelBoxes(blob);
+    expect(boxes.map((b) => b.type)).toEqual(['ftyp', 'mdat', 'moov']);
+    expect(boxes[1].size).toBe(1008);
+    expect(boxes[2].start).toBe(12 + 1008);
+  });
+
+  it('handles a 64-bit largesize mdat', async () => {
+    const { scanTopLevelBoxes } = await import('./media-video-webcodecs');
+    const payload = new Uint8Array(100);
+    const big = new Uint8Array(16 + payload.length) as Uint8Array<ArrayBuffer>;
+    const dv = new DataView(big.buffer);
+    dv.setUint32(0, 1); // size==1 → largesize follows
+    for (let i = 0; i < 4; i++) big[4 + i] = 'mdat'.charCodeAt(i);
+    dv.setUint32(8, 0);
+    dv.setUint32(12, big.length);
+    const blob = new Blob([box('ftyp', fourcc('isom')), big, box('moov', fourcc('avc1'))]);
+    const boxes = await scanTopLevelBoxes(blob);
+    expect(boxes[1]).toMatchObject({ type: 'mdat', size: big.length, headerLen: 16 });
+  });
+
+  it('rejects a non-mp4 byte stream', async () => {
+    const { scanTopLevelBoxes } = await import('./media-video-webcodecs');
+    await expect(scanTopLevelBoxes(new Blob([new Uint8Array(64).fill(0xab)]))).rejects.toThrow(/not an mp4/);
+  });
+});
+
+describe('sniffBlobCodecIsPlainH264 (spec 2041)', () => {
+  it('finds avc1 in the moov without reading mdat', async () => {
+    const { sniffBlobCodecIsPlainH264 } = await import('./media-video');
+    // mdat contains an hvc1 marker to prove it is NOT scanned (only moov is).
+    const blob = new Blob([box('ftyp', fourcc('isom')), box('mdat', fourcc('hvc1')), box('moov', fourcc('avc1'))]);
+    expect(await sniffBlobCodecIsPlainH264(blob)).toBe(true);
+  });
+
+  it('rejects an HEVC moov', async () => {
+    const { sniffBlobCodecIsPlainH264 } = await import('./media-video');
+    const blob = new Blob([box('ftyp', fourcc('isom')), box('moov', fourcc('hvc1'))]);
+    expect(await sniffBlobCodecIsPlainH264(blob)).toBe(false);
+  });
+
+  it('an unscannable container is simply not-compatible (transcode as before)', async () => {
+    const { sniffBlobCodecIsPlainH264 } = await import('./media-video');
+    expect(await sniffBlobCodecIsPlainH264(new Blob([new Uint8Array(32).fill(1)]))).toBe(false);
   });
 });

--- a/src/services/media-video.test.ts
+++ b/src/services/media-video.test.ts
@@ -11,7 +11,7 @@ vi.mock('./media-video-ffmpeg', () => ({
   ffmpegTranscode: vi.fn(),
 }));
 
-import { compressVideoAdaptive } from './media-video';
+import { compressVideoAdaptive, shouldUploadAsIs, sniffMp4CodecIsPlainH264, VIDEO_PRESETS } from './media-video';
 import { webcodecsTranscode } from './media-video-webcodecs';
 import { ffmpegTranscode } from './media-video-ffmpeg';
 
@@ -55,5 +55,37 @@ describe('compressVideoAdaptive fallback ladder', () => {
     vi.mocked(ffmpegTranscode).mockRejectedValue(new Error('oom / too large'));
     const out = await compressVideoAdaptive(src, 'hd');
     expect(out).toBe(src);
+  });
+});
+
+describe('upload-as-is gate (spec 2038)', () => {
+  const hd = VIDEO_PRESETS.hd;
+  const base = { sizeBytes: 15_000_000, durationSec: 40, width: 1280, height: 720, h264Compatible: true };
+
+  it('an efficient, preset-fitting H.264 clip skips the transcode', () => {
+    // 15MB / 40s = 3.0 Mbps ≤ 1.5 × 2.5 Mbps
+    expect(shouldUploadAsIs(base, hd)).toBe(true);
+  });
+  it('a fat bitrate transcodes', () => {
+    expect(shouldUploadAsIs({ ...base, sizeBytes: 60_000_000 }, hd)).toBe(false); // 12 Mbps
+  });
+  it('4K-class resolution always transcodes, whatever the bitrate', () => {
+    expect(shouldUploadAsIs({ ...base, width: 3840, height: 2160 }, hd)).toBe(false);
+  });
+  it('incompatible codecs always transcode', () => {
+    expect(shouldUploadAsIs({ ...base, h264Compatible: false }, hd)).toBe(false);
+  });
+  it('zero/unknown duration never skips', () => {
+    expect(shouldUploadAsIs({ ...base, durationSec: 0 }, hd)).toBe(false);
+  });
+
+  const buf = (s: string) => new TextEncoder().encode(`....${s}....avc1....`);
+  it('codec sniff accepts plain H.264 and rejects modern-codec markers', () => {
+    expect(sniffMp4CodecIsPlainH264(new TextEncoder().encode('..moov..avc1..'))).toBe(true);
+    expect(sniffMp4CodecIsPlainH264(buf('hvc1'))).toBe(false);
+    expect(sniffMp4CodecIsPlainH264(buf('hev1'))).toBe(false);
+    expect(sniffMp4CodecIsPlainH264(buf('av01'))).toBe(false);
+    expect(sniffMp4CodecIsPlainH264(buf('vp09'))).toBe(false);
+    expect(sniffMp4CodecIsPlainH264(new TextEncoder().encode('..no codec here..'))).toBe(false);
   });
 });

--- a/src/services/media-video.ts
+++ b/src/services/media-video.ts
@@ -26,6 +26,71 @@ export const VIDEO_PRESETS: Record<'sd' | 'hd' | 'fhd', VideoPreset> = {
   fhd: { maxEdge: 1920, bitrate: 5_000_000 },
 };
 
+
+/* ---- spec 2038: upload-as-is gate ---- */
+
+// A clip already within 1.5× of the preset's target bitrate gains little from a
+// re-encode; re-encoding it anyway costs time, battery, quality — and on weak
+// devices the transcode is the memory-heavy step behind the spec-2037 loop.
+const AS_IS_BITRATE_FACTOR = 1.5;
+
+/** Pure rule: may this clip skip the transcode entirely? Codec compatibility is
+ *  the caller's input (see sniffMp4Codecs) — this only judges the numbers. */
+export function shouldUploadAsIs(
+  info: { sizeBytes: number; durationSec: number; width: number; height: number; h264Compatible: boolean },
+  preset: VideoPreset,
+): boolean {
+  if (!info.h264Compatible) return false;
+  if (!(info.durationSec > 0)) return false;
+  if (Math.max(info.width, info.height) > preset.maxEdge) return false; // 4K-class → downscale
+  const bps = (info.sizeBytes * 8) / info.durationSec;
+  return bps <= preset.bitrate * AS_IS_BITRATE_FACTOR;
+}
+
+/** Scan an MP4/QuickTime file's bytes for codec FourCCs. Returns whether the clip
+ *  is plain H.264 (universally playable on Apple/Android/desktop) with no
+ *  modern-codec track (HEVC/AV1/VP9 — typical recent phone captures) that would
+ *  need the compatibility transcode. A dumb byte scan is deliberate: it needs no
+ *  demuxer, handles moov-at-end files, and a false negative only means we
+ *  transcode like before. */
+export function sniffMp4CodecIsPlainH264(bytes: Uint8Array): boolean {
+  const has = (fourcc: string): boolean => {
+    const a = fourcc.charCodeAt(0), b = fourcc.charCodeAt(1), c = fourcc.charCodeAt(2), d = fourcc.charCodeAt(3);
+    for (let i = 0; i + 3 < bytes.length; i++) {
+      if (bytes[i] === a && bytes[i + 1] === b && bytes[i + 2] === c && bytes[i + 3] === d) return true;
+    }
+    return false;
+  };
+  if (has('hvc1') || has('hev1') || has('av01') || has('vp09') || has('vp08')) return false;
+  return has('avc1') || has('avc3');
+}
+
+/** Cheap metadata probe (duration + dimensions) via a detached <video> element —
+ *  loads headers only, decodes no frames. Null on any failure/timeout. */
+function probeVideoMeta(blob: Blob): Promise<{ durationSec: number; width: number; height: number } | null> {
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(blob);
+    const v = document.createElement('video');
+    v.preload = 'metadata';
+    const finish = (out: { durationSec: number; width: number; height: number } | null) => {
+      URL.revokeObjectURL(url);
+      v.removeAttribute('src');
+      resolve(out);
+    };
+    const timer = setTimeout(() => finish(null), 5000);
+    v.onloadedmetadata = () => {
+      clearTimeout(timer);
+      const d = v.duration;
+      finish(Number.isFinite(d) && d > 0 ? { durationSec: d, width: v.videoWidth, height: v.videoHeight } : null);
+    };
+    v.onerror = () => {
+      clearTimeout(timer);
+      finish(null);
+    };
+    v.src = url;
+  });
+}
+
 // WebCodecs is the fast path; flip to false to force the ffmpeg path everywhere
 // (e.g. if a device produces bad WebCodecs output).
 const WEBCODECS_ENABLED = true;
@@ -37,6 +102,24 @@ export async function compressVideoAdaptive(
 ): Promise<Blob> {
   const preset = VIDEO_PRESETS[quality];
   console.info('[video] compress start', { quality, type: blob.type, bytes: blob.size, preset });
+
+  // (spec 2038) A clip that is already efficient AND universally playable ships
+  // as-is: no engine load, no re-encode, straight to upload. Any probe failure
+  // just falls through to the normal ladder.
+  if (typeof document !== 'undefined' && /(mp4|quicktime|m4v)/i.test(blob.type)) {
+    try {
+      const meta = await probeVideoMeta(blob);
+      if (meta) {
+        const h264Compatible = sniffMp4CodecIsPlainH264(new Uint8Array(await blob.arrayBuffer()));
+        if (shouldUploadAsIs({ sizeBytes: blob.size, durationSec: meta.durationSec, width: meta.width, height: meta.height, h264Compatible }, preset)) {
+          console.info('[video] uploading as-is (spec 2038)', { bps: Math.round((blob.size * 8) / meta.durationSec), ...meta });
+          return blob;
+        }
+      }
+    } catch (e) {
+      console.info('[video] as-is probe failed; transcoding as usual', e);
+    }
+  }
 
   // 1. WebCodecs fast path, mp4/mov containers only (mp4box demux).
   if (WEBCODECS_ENABLED && /(mp4|quicktime|m4v)/i.test(blob.type)) {

--- a/src/services/media-video.ts
+++ b/src/services/media-video.ts
@@ -95,6 +95,17 @@ function probeVideoMeta(blob: Blob): Promise<{ durationSec: number; width: numbe
 // (e.g. if a device produces bad WebCodecs output).
 const WEBCODECS_ENABLED = true;
 
+
+/** (spec 2038) Final sanity gate on ANY transcode output: if the browser cannot
+ *  even read its metadata, the file is broken — never upload it (a corrupt
+ *  partial output once shipped as an unplayable 0-duration post). Outside a DOM
+ *  (unit tests) this trusts the engine result. */
+async function transcodeOutputPlayable(out: Blob): Promise<boolean> {
+  if (typeof document === 'undefined') return true;
+  const meta = await probeVideoMeta(out);
+  return meta !== null && meta.durationSec > 0;
+}
+
 export async function compressVideoAdaptive(
   blob: Blob,
   quality: 'sd' | 'hd' | 'fhd',
@@ -130,7 +141,7 @@ export async function compressVideoAdaptive(
       if (supported) {
         const out = await webcodecsTranscode(blob, preset, onProgress);
         console.info('[video] webcodecs output', { bytes: out.size, vs: blob.size });
-        if (out.size > 0 && out.size < blob.size) return out;
+        if (out.size > 0 && out.size < blob.size && (await transcodeOutputPlayable(out))) return out;
         // A COMPLETED hardware re-encode that isn't smaller means the source is
         // already efficiently compressed for this preset — the honest result is
         // the original (achievedQuality labels it so). Falling into ffmpeg here
@@ -153,6 +164,10 @@ export async function compressVideoAdaptive(
     const { ffmpegTranscode } = await import('./media-video-ffmpeg');
     const out = await ffmpegTranscode(blob, preset, onProgress);
     console.info('[video] ffmpeg output', { bytes: out.size, vs: blob.size });
+    if (out !== blob && !(await transcodeOutputPlayable(out))) {
+      console.warn('[video] ffmpeg output unreadable; sending original');
+      return blob;
+    }
     return out;
   } catch (e) {
     console.warn('[video] ffmpeg transcode FAILED; sending original', e);

--- a/src/services/media-video.ts
+++ b/src/services/media-video.ts
@@ -36,12 +36,22 @@ const AS_IS_BITRATE_FACTOR = 1.5;
 
 /** Pure rule: may this clip skip the transcode entirely? Codec compatibility is
  *  the caller's input (see sniffMp4Codecs) — this only judges the numbers. */
+// (spec 2041) The largest video we ever hand to the seal+upload path unconverted.
+// Encryption holds plaintext AND ciphertext in the heap at once, so shipping an
+// arbitrarily large original is the same out-of-memory kill the transcode fix
+// removed — and the server caps a blob at 256 MiB anyway. Anything above this
+// must convert or fail honestly (never crash the app trying).
+export const ORIGINAL_MAX_BYTES = 128 << 20;
+
+/** Pure rule: may this clip skip the transcode entirely? Codec compatibility is
+ *  the caller's input (see sniffMp4Codecs) — this only judges the numbers. */
 export function shouldUploadAsIs(
   info: { sizeBytes: number; durationSec: number; width: number; height: number; h264Compatible: boolean },
   preset: VideoPreset,
 ): boolean {
   if (!info.h264Compatible) return false;
   if (!(info.durationSec > 0)) return false;
+  if (info.sizeBytes > ORIGINAL_MAX_BYTES) return false; // must shrink first (spec 2041)
   if (Math.max(info.width, info.height) > preset.maxEdge) return false; // 4K-class → downscale
   const bps = (info.sizeBytes * 8) / info.durationSec;
   return bps <= preset.bitrate * AS_IS_BITRATE_FACTOR;
@@ -53,6 +63,32 @@ export function shouldUploadAsIs(
  *  need the compatibility transcode. A dumb byte scan is deliberate: it needs no
  *  demuxer, handles moov-at-end files, and a false negative only means we
  *  transcode like before. */
+/** (spec 2041) sniffMp4CodecIsPlainH264 over a Blob without loading the media
+ *  data: reads only the non-mdat top-level boxes (ftyp/moov/…, where the sample
+ *  descriptions live). Any scan failure or an implausibly large header region
+ *  returns false — "not known-compatible", so the caller transcodes as before. */
+export async function sniffBlobCodecIsPlainH264(blob: Blob): Promise<boolean> {
+  const HEADER_SNIFF_MAX_BYTES = 16 << 20;
+  try {
+    const { scanTopLevelBoxes } = await import('./media-video-webcodecs');
+    const boxes = (await scanTopLevelBoxes(blob)).filter((b) => b.type !== 'mdat');
+    const total = boxes.reduce((n, b) => n + b.size, 0);
+    if (total === 0 || total > HEADER_SNIFF_MAX_BYTES) return false;
+    const parts = await Promise.all(
+      boxes.map(async (b) => new Uint8Array(await blob.slice(b.start, b.start + b.size).arrayBuffer())),
+    );
+    const bytes = new Uint8Array(total);
+    let off = 0;
+    for (const p of parts) {
+      bytes.set(p, off);
+      off += p.length;
+    }
+    return sniffMp4CodecIsPlainH264(bytes);
+  } catch {
+    return false;
+  }
+}
+
 export function sniffMp4CodecIsPlainH264(bytes: Uint8Array): boolean {
   const has = (fourcc: string): boolean => {
     const a = fourcc.charCodeAt(0), b = fourcc.charCodeAt(1), c = fourcc.charCodeAt(2), d = fourcc.charCodeAt(3);
@@ -121,7 +157,13 @@ export async function compressVideoAdaptive(
     try {
       const meta = await probeVideoMeta(blob);
       if (meta) {
-        const h264Compatible = sniffMp4CodecIsPlainH264(new Uint8Array(await blob.arrayBuffer()));
+        // (spec 2041) Sniff the codec from the METADATA boxes only. The codec
+        // FourCCs live in the moov sample descriptions, so reading the non-mdat
+        // boxes (a few MB even for a long clip) replaces the old whole-file
+        // arrayBuffer() read — which put the entire video in the heap just to
+        // answer a yes/no question. An oversized or unscannable header simply
+        // means "not known-compatible" → the normal transcode ladder.
+        const h264Compatible = await sniffBlobCodecIsPlainH264(blob);
         if (shouldUploadAsIs({ sizeBytes: blob.size, durationSec: meta.durationSec, width: meta.width, height: meta.height, h264Compatible }, preset)) {
           console.info('[video] uploading as-is (spec 2038)', { bps: Math.round((blob.size * 8) / meta.durationSec), ...meta });
           return blob;
@@ -150,7 +192,7 @@ export async function compressVideoAdaptive(
         // posting progress bar sat near 0% for the whole detour. ffmpeg remains
         // the fallback for webcodecs FAILURES only.
         console.info('[video] webcodecs output not smaller — source already efficient, sending original');
-        return blob;
+        return originalOrThrow(blob);
       }
     } catch (e) {
       console.warn('[video] WebCodecs transcode FAILED; trying ffmpeg', e);
@@ -166,14 +208,27 @@ export async function compressVideoAdaptive(
     console.info('[video] ffmpeg output', { bytes: out.size, vs: blob.size });
     if (out !== blob && !(await transcodeOutputPlayable(out))) {
       console.warn('[video] ffmpeg output unreadable; sending original');
-      return blob;
+      return originalOrThrow(blob);
     }
-    return out;
+    return out === blob ? originalOrThrow(blob) : out;
   } catch (e) {
+    if ((e as Error)?.message?.includes('too big to send')) throw e;
     console.warn('[video] ffmpeg transcode FAILED; sending original', e);
   }
 
-  // 3. Give up → original (never block the send).
+  // 3. Give up → original (never block the send — unless shipping it would
+  // crash the app; see originalOrThrow).
   console.warn('[video] no engine succeeded, sending original', { bytes: blob.size });
+  return originalOrThrow(blob);
+}
+
+/** (spec 2041) The "ship the original" escape hatch, bounded. Sealing holds
+ *  plaintext + ciphertext in the heap together, so an oversized original is the
+ *  same jetsam kill the streaming transcode removed. A clean, explained failure
+ *  card beats a crashed app. */
+function originalOrThrow(blob: Blob): Blob {
+  if (blob.size > ORIGINAL_MAX_BYTES) {
+    throw new Error('This video is too big to send without converting and converting failed on this device. Try a shorter or smaller clip.');
+  }
   return blob;
 }

--- a/src/services/pending-posts.test.ts
+++ b/src/services/pending-posts.test.ts
@@ -152,3 +152,35 @@ describe('auto-retry attempt budget (spec 2037)', () => {
     expect(H.outbox.has('a')).toBe(false);
   });
 });
+
+describe('blob-backed outbox items (spec 2041)', () => {
+  const readableBlob = { slice: () => ({ arrayBuffer: async () => new ArrayBuffer(1) }) };
+  const hangingBlob = { slice: () => ({ arrayBuffer: () => new Promise(() => {}) }) };
+
+  it('a record whose stored Blob still reads is left alone for the drain to resume', async () => {
+    H.outbox.set('v', { id: 'v', status: 'uploading', body: 'clip', attempts: 0, items: [{ kind: 'video', blob: readableBlob }] });
+    const res = await recoverInterruptedPosts();
+    expect(res).toEqual({ recovered: 0, discarded: 0 });
+    expect(H.outbox.get('v')?.status).toBe('uploading'); // untouched — resumable
+  });
+
+  it('a hanging Blob read (the iOS failure mode) drafts the post instead of wedging recovery', async () => {
+    vi.useFakeTimers();
+    try {
+      H.outbox.set('v', {
+        id: 'v', status: 'uploading', body: 'clip', attempts: 2,
+        items: [{ kind: 'video', blob: hangingBlob }, { kind: 'image', bytes: bytes() }],
+      });
+      const run = recoverInterruptedPosts();
+      await vi.advanceTimersByTimeAsync(3_500); // past the probe timeout
+      const res = await run;
+      expect(res).toEqual({ recovered: 1, discarded: 0 });
+      const rec = H.outbox.get('v');
+      expect(rec?.status).toBe('interrupted'); // drafted for the user
+      expect(rec?.items.length).toBe(1); // unreadable video dropped, image kept
+      expect(rec?.items[0].kind).toBe('image');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -78,7 +78,7 @@ const UPLOAD_STALL_MS = 45_000;
 const MAX_AUTO_ATTEMPTS = 3;
 
 async function uploadOne(id: string): Promise<void> {
-  const rec = await getPendingPost(id);
+  let rec = await getPendingPost(id);
   if (!rec || rec.status !== 'uploading') return; // canceled / interrupted / already gone
   // (spec 2037) Budget check FIRST — before the transcode/upload that may itself
   // be what kills the app. Reaching here at the cap means the previous attempts
@@ -92,6 +92,27 @@ async function uploadOne(id: string): Promise<void> {
   }
   rec.attempts += 1;
   await updatePendingPost(rec);
+  // (spec 2041) Everything createPost needs is copied OUT of the record here, and the record
+  // reference is dropped before the heavy pipeline runs. Holding `rec` across the createPost await
+  // kept every inline-bytes ArrayBuffer alive for the entire transcode+upload — for a video post
+  // that was a whole extra file-copy pinned in the heap exactly when memory pressure peaks on a
+  // phone. (new Blob([bytes]) copies into browser blob storage, so the inline bytes are collectable
+  // the moment `rec` is released; large items are Blob-backed and pass straight through.)
+  const body = rec.body || undefined;
+  const audience = rec.audience ?? 'friends';
+  const lifetime = rec.lifetime ?? '72h';
+  const media = rec.items.length
+    ? rec.items.map((it) => ({
+        // Rebuild a fresh in-memory Blob from the inline bytes (always readable, unlike a Blob
+        // read back from IDB after a restart). Large/legacy items carry a stored Blob instead.
+        blob: it.bytes ? new Blob([it.bytes], { type: it.mime }) : (it.blob as Blob),
+        kind: it.kind,
+        name: it.name,
+        durationSec: it.durationSec,
+        quality: 'hd' as const,
+      }))
+    : undefined;
+  rec = undefined;
   let lastTick = Date.now();
   let watchdog: ReturnType<typeof setInterval> | undefined;
   let attempt: Promise<unknown> | undefined;
@@ -106,20 +127,10 @@ async function uploadOne(id: string): Promise<void> {
         // the same local Post instead of minting a second one. (See the "already made" guard below for
         // the kill-after-send window the stable id alone can't cover.)
         id,
-        body: rec.body || undefined,
-        audience: rec.audience ?? 'friends',
-        lifetime: rec.lifetime ?? '72h',
-        media: rec.items.length
-          ? rec.items.map((it) => ({
-              // Rebuild a fresh in-memory Blob from the inline bytes (always readable, unlike a Blob
-              // read back from IDB after a restart). Fall back to a legacy stored Blob if present.
-              blob: it.bytes ? new Blob([it.bytes], { type: it.mime }) : (it.blob as Blob),
-              kind: it.kind,
-              name: it.name,
-              durationSec: it.durationSec,
-              quality: 'hd' as const,
-            }))
-          : undefined,
+        body,
+        audience,
+        lifetime,
+        media,
         onProgress: (p) => {
           lastTick = Date.now(); // each progress event keeps the watchdog from firing
           void writeProgress(id, p);
@@ -208,6 +219,22 @@ export function __resetRecoveryForTest(): void {
   recovered = false;
 }
 
+/** (spec 2041) Does a stored Blob still read after a restart? Probes a 1 KB slice
+ *  under a timeout: the iOS failure mode for an IDB Blob is a read that HANGS,
+ *  so a bare await would wedge recovery. A timed-out read is 'unreadable'. */
+const BLOB_PROBE_TIMEOUT_MS = 3_000;
+async function blobReads(b: Blob): Promise<boolean> {
+  try {
+    await Promise.race([
+      b.slice(0, 1024).arrayBuffer(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('probe timed out')), BLOB_PROBE_TIMEOUT_MS)),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Run ONCE at app start (after unlock). A pending post still around is left over
  * from a previous session. Since spec 1024 every item's bytes ride INLINE in the
@@ -239,16 +266,24 @@ export async function recoverInterruptedPosts(): Promise<{ recovered: number; di
       await deletePendingPost(rec.id);
       continue;
     }
-    if (rec.items.every((it) => !!it.bytes)) {
-      // Fully byte-backed (every post the current composer creates): the drain
+    // (spec 2041) An item is resumable if it carries inline bytes OR a stored Blob
+    // that still READS. Blob-backed items (large videos) trade the iOS
+    // unreadable-Blob risk back in for bounded memory, so each one is probed here
+    // — with a timeout, because the iOS failure mode is a HANG (arrayBuffer()
+    // never settles), and an un-raced probe would wedge recovery itself.
+    const itemOk = await Promise.all(
+      rec.items.map(async (it) => !!it.bytes || (!!it.blob && (await blobReads(it.blob)))),
+    );
+    if (itemOk.every(Boolean)) {
+      // Fully readable (every post the current composer creates): the drain
       // resumes it as-is. Don't touch the record — two writers on one row was
       // exactly the reported zombie-draft bug.
       resumable += 1;
       continue;
     }
-    // Legacy items without inline bytes can't be re-read after a restart: draft
-    // what survives (caption + byte-backed items) for the user to finish.
-    const usable = rec.items.filter((it) => !!it.bytes);
+    // Items that can't be re-read after a restart: draft what survives
+    // (caption + readable items) for the user to finish.
+    const usable = rec.items.filter((_, i) => itemOk[i]);
     // FR-002: re-read before writing — the record may have completed (and been
     // deleted) or changed since the list snapshot; never write over that.
     const fresh = await getPendingPost(rec.id);

--- a/src/services/pending-posts.ts
+++ b/src/services/pending-posts.ts
@@ -133,7 +133,10 @@ async function uploadOne(id: string): Promise<void> {
         media,
         onProgress: (p) => {
           lastTick = Date.now(); // each progress event keeps the watchdog from firing
-          void writeProgress(id, p);
+          // Detached + best-effort: a progress write that loses an IDB race (or
+          // times out under load) must not surface as an unhandled rejection —
+          // the next event repaints the bar anyway.
+          void writeProgress(id, p).catch(() => {});
         },
       });
     await Promise.race([attempt, stalled]);


### PR DESCRIPTION
## Spec 2041 — video posts must not exhaust iPhone memory

**The bug (user report, after 2036–2039):** posting a camera video still crashed the app on iPhone. The earlier fixes made the failure *recoverable* (attempt budget, safe mode) but the crash itself was iOS killing the page on memory pressure (jetsam) — invisible to JS, so no guard could catch it.

**Root cause:** one video post held ~4 whole-file copies in the JS heap at once: the outbox's inline ArrayBuffer (pinned across the entire upload), the demuxer's whole-file read, a full compressed-sample copy before any frame decoded, plus 4K frame queues. A 1-minute 4K clip peaked well past 1 GB.

**Fix (four legs):**
- **Blob-backed outbox:** items over 24 MB ride IndexedDB as disk-backed Blobs instead of inline bytes; recovery probes each stored Blob under a timeout (the iOS failure mode is a hanging read) and drafts the post if unreadable. The drain releases the record's bytes before the heavy pipeline runs.
- **Streaming demux:** the WebCodecs path now indexes the container from box headers only, parses `moov` without touching media data (mp4box skips a header-only `mdat`, so iPhone trailing-moov files work), then pumps `mdat` in 16 MB windows — converting and releasing samples as they surface under the existing backpressure. Peak input memory is O(window), not O(file). Fragmented mp4 (MediaRecorder) works too.
- **Header-only codec sniff:** the as-is gate no longer reads the whole file to check the codec.
- **Bounded originals:** every ship-the-original fallback goes through a 128 MB ceiling (sealing holds plaintext + ciphertext together; the server caps blobs at 256 MiB) — an unconvertible oversized video now fails with a clear message instead of crashing.

**Riders:** honest progress tail (upload owns 50→90%, poster/registration visible to 100%, no more 10 s sit at "100%"), and progress writes are best-effort (no unhandled rejection under IDB load).

**Tests:** box scanner + blob sniff + recovery probe unit suites (1,151 total green), plus a drive scenario posting the reporter's real clip and a synthesized 4K fragmented clip through the streaming path.

**Verified on the reporter's iPhone** (camera clip posts cleanly; progress bar honest end to end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7