### PR TITLE
feat(contacts): set an emoji as a contact's photo, and reset a changed photo back to theirs (spec 1054)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,5 +264,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1050-quiet-housekeeping-frames/plan.md`
+`specs/1054-pick-emoji-contact/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,7 @@ Specs are grouped by category band; status moves
 | [1051](specs/1051-message-bubble-grows/spec.md) | Message Bubble Grows to Hold Its Reactions | 🟡 in-progress |
 | [1052](specs/1052-group-adds-you/spec.md) | Group Adds You Can Trust | 🟡 in-progress |
 | [1053](specs/1053-composer-buttons-transition/spec.md) | Composer Buttons Transition Like WhatsApp | 🟡 in-progress |
-| [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🟡 in-progress |
+| [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,6 +79,7 @@ Specs are grouped by category band; status moves
 | [1051](specs/1051-message-bubble-grows/spec.md) | Message Bubble Grows to Hold Its Reactions | 🟡 in-progress |
 | [1052](specs/1052-group-adds-you/spec.md) | Group Adds You Can Trust | 🟡 in-progress |
 | [1053](specs/1053-composer-buttons-transition/spec.md) | Composer Buttons Transition Like WhatsApp | 🟡 in-progress |
+| [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/contact-emoji-1054.mjs
+++ b/drive/scenarios/contact-emoji-1054.mjs
@@ -1,0 +1,83 @@
+/**
+ * Spec 1054: the contact "Change photo" action sheet — Take photo / Choose
+ * photo / Pick an emoji / Reset to their photo. Verifies the real file-chooser
+ * path (a real PNG through pickImageFile → downscale), the emoji override, and
+ * the photo-only reset, with screenshots of the sheet and resulting avatars.
+ *
+ *   node drive/scenarios/contact-emoji-1054.mjs
+ */
+import { createAccount, pair, poll, shot, sweep, done } from '../driver.mjs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const PNG = path.join(ROOT, 'public', 'apple-touch-icon.png');
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob', mobile: true });
+
+// Alice picks an emoji profile picture BEFORE pairing so Bob's first-learned
+// profile applies directly (avatar = remoteAvatar = the 😎 disc).
+await alice.page.evaluate(() => window.__ringTest.setEmojiAvatar('😎'));
+await pair(bob, alice);
+await poll(
+  () => bob.page.evaluate((id) => window.__ringTest.contactAvatarEmoji(id), alice.id),
+  (v) => v === '😎',
+  { label: "Alice's 😎 landed as Bob's contact avatar" },
+);
+
+const openSheet = async () => {
+  await bob.page.locator('ion-action-sheet').waitFor({ state: 'detached', timeout: 8000 }).catch(() => {});
+  await bob.page.getByText('Change photo').click();
+  await bob.page.locator('ion-action-sheet button', { hasText: 'Take photo' }).waitFor({ timeout: 8000 });
+};
+
+await bob.page.goto(`/contact/${alice.id}`);
+await bob.page.getByText('Change photo').waitFor({ timeout: 15000 });
+await shot(bob, '1054-1-contact-baseline');
+
+// The sheet: three sources, no reset entry yet (nothing overridden).
+await openSheet();
+await shot(bob, '1054-2-sheet-no-reset');
+
+// Real photo path: "Choose photo" → OS file chooser → a real PNG.
+const chooser = bob.page.waitForEvent('filechooser');
+await bob.page.locator('ion-action-sheet button', { hasText: 'Choose photo' }).click();
+await (await chooser).setFiles(PNG);
+await poll(
+  () => bob.page.evaluate((id) => window.__ringTest.contactName(id).then(() => window.__ringTest.contactAvatarEmoji(id)), alice.id),
+  (v) => v === null, // a JPEG photo decodes to no emoji → the photo landed
+  { label: 'chosen photo applied as the contact avatar' },
+);
+await shot(bob, '1054-3-photo-override');
+
+// Now overridden → the sheet gains "Reset to their photo".
+await openSheet();
+await shot(bob, '1054-4-sheet-with-reset');
+
+// Pick an emoji instead.
+await bob.page.locator('ion-action-sheet button', { hasText: 'Pick an emoji' }).click();
+await bob.page.locator('emoji-picker').waitFor({ timeout: 15000 });
+await bob.page.evaluate(() => {
+  document.querySelector('emoji-picker').dispatchEvent(new CustomEvent('emoji-click', { detail: { unicode: '🐙' } }));
+});
+await poll(
+  () => bob.page.evaluate((id) => window.__ringTest.contactAvatarEmoji(id), alice.id),
+  (v) => v === '🐙',
+  { label: '🐙 override applied' },
+);
+await shot(bob, '1054-5-emoji-override');
+
+// Reset → back to Alice's own 😎.
+await openSheet();
+await bob.page.locator('ion-action-sheet button', { hasText: 'Reset to their photo' }).click();
+await poll(
+  () => bob.page.evaluate((id) => window.__ringTest.contactAvatarEmoji(id), alice.id),
+  (v) => v === '😎',
+  { label: 'reset restored Alice’s own 😎' },
+);
+await shot(bob, '1054-6-after-reset');
+
+console.log('[PASS] photo via file chooser, emoji override, and photo-only reset all behaved');
+await sweep([bob, alice]);
+await done();

--- a/e2e/contact-emoji-avatar.spec.ts
+++ b/e2e/contact-emoji-avatar.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, type Page } from '@playwright/test';
+import { createAccount, pair } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 1054: the contact photo menu mirrors the profile-picture sheet —
+ * Take photo / Choose photo / Pick an emoji — and, once the photo is locally
+ * overridden, gains "Reset to their photo", which reverts ONLY the photo back
+ * to what the contact published while a custom name survives.
+ *
+ * The emoji pick inside the shadow-DOM `emoji-picker` web component is driven
+ * by dispatching its public `emoji-click` event (exactly what EmojiPickerModal
+ * listens for) — clicking a specific glyph in the virtualised grid is flaky.
+ */
+
+async function openPhotoSheet(page: Page): Promise<void> {
+  // A just-dismissed sheet lingers in the DOM during its leave animation; wait
+  // it out so the click can't land on its backdrop and the locators can't
+  // match the stale overlay.
+  await page
+    .locator('ion-action-sheet')
+    .waitFor({ state: 'detached', timeout: 10_000 })
+    .catch(() => {});
+  await page.getByText('Change photo').click();
+  await page.locator('ion-action-sheet button', { hasText: 'Take photo' }).waitFor({ timeout: 10_000 });
+}
+
+async function dismissSheet(page: Page): Promise<void> {
+  await page.locator('ion-action-sheet button', { hasText: 'Cancel' }).click();
+  await page.locator('ion-action-sheet').waitFor({ state: 'detached', timeout: 10_000 });
+}
+
+test('emoji contact photo via the sheet; reset returns their photo and keeps a custom name', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'RINGTST4');
+  const b = await createAccount(ctxB, 'RINGTST9');
+
+  // B picks an emoji profile picture BEFORE pairing, so A's FIRST-learned
+  // profile applies directly (avatar = remoteAvatar = the 😎 disc). A post-pair
+  // change would arrive STAGED behind the adopt prompt instead.
+  await b.page.evaluate(() => (window as any).__ringTest.setEmojiAvatar('😎'));
+  await pair(a, b);
+  await expect
+    .poll(() => a.page.evaluate((id: string) => (window as any).__ringTest.contactAvatarEmoji(id), b.id), {
+      timeout: 30_000,
+    })
+    .toBe('😎');
+
+  // A opens B's contact page. The photo sheet offers the profile-picture
+  // options — but no reset entry: nothing is overridden yet (FR-004).
+  await a.page.goto(`/contact/${b.id}`);
+  await openPhotoSheet(a.page);
+  const sheet = a.page.locator('ion-action-sheet');
+  await expect(sheet.locator('button', { hasText: 'Take photo' })).toBeVisible();
+  await expect(sheet.locator('button', { hasText: 'Choose photo' })).toBeVisible();
+  await expect(sheet.locator('button', { hasText: 'Pick an emoji' })).toBeVisible();
+  await expect(sheet.locator('button', { hasText: 'Reset to their photo' })).toHaveCount(0);
+
+  // Pick an emoji → the picker modal hosts `emoji-picker`; inject its pick
+  // event. The override lands as B's displayed avatar on A's device (FR-002).
+  await sheet.locator('button', { hasText: 'Pick an emoji' }).click();
+  await a.page.locator('emoji-picker').waitFor({ timeout: 15_000 });
+  await a.page.evaluate(() => {
+    document
+      .querySelector('emoji-picker')!
+      .dispatchEvent(new CustomEvent('emoji-click', { detail: { unicode: '🐙' } }));
+  });
+  await expect
+    .poll(() => a.page.evaluate((id: string) => (window as any).__ringTest.contactAvatarEmoji(id), b.id), {
+      timeout: 15_000,
+    })
+    .toBe('🐙');
+
+  // A also renames B locally — the photo reset must not undo this (FR-005).
+  await a.page.evaluate((id: string) => (window as any).__ringTest.setContactLocalProfile(id, 'Octo Pal'), b.id);
+
+  // With the photo overridden the sheet now ends with the reset entry; using
+  // it reverts the photo to B's own 😎 while the custom name stays.
+  await openPhotoSheet(a.page);
+  await sheet.locator('button', { hasText: 'Reset to their photo' }).click();
+  await expect
+    .poll(() => a.page.evaluate((id: string) => (window as any).__ringTest.contactAvatarEmoji(id), b.id), {
+      timeout: 15_000,
+    })
+    .toBe('😎');
+  expect(await a.page.evaluate((id: string) => (window as any).__ringTest.contactName(id), b.id)).toBe('Octo Pal');
+
+  // Nothing left to reset → the entry is gone again (FR-004).
+  await openPhotoSheet(a.page);
+  await expect(sheet.locator('button', { hasText: 'Pick an emoji' })).toBeVisible();
+  await expect(sheet.locator('button', { hasText: 'Reset to their photo' })).toHaveCount(0);
+  await dismissSheet(a.page);
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/specs/1054-pick-emoji-contact/checklists/requirements.md
+++ b/specs/1054-pick-emoji-contact/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Emoji contact photos + reset to their photo
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The request was specific (menu contents, reset-not-remove semantics, keep-name behavior), so no clarification markers were needed; defaults chosen are recorded under Assumptions.

--- a/specs/1054-pick-emoji-contact/data-model.md
+++ b/specs/1054-pick-emoji-contact/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Emoji contact photos + reset to their photo (spec 1054)
+
+No schema change: no new object store, no new fields, no `DB_VERSION` bump.
+The feature is entirely a new set of transitions over the existing `Contact`
+profile-override fields (`src/db/types.ts`).
+
+## Existing fields involved (Contact, `contacts` store)
+
+| Field | Meaning |
+|---|---|
+| `name` / `avatar` | DISPLAYED values (a local override or the last-adopted remote) |
+| `remoteName` / `remoteAvatar` | latest profile the peer published (change detection + adopt/reset source) |
+| `pendingName` / `pendingAvatar` | staged remote change awaiting the adopt/dismiss prompt |
+| `localProfile` | true when the user set their own name and/or photo override |
+
+An emoji picture is not a new kind of value: it is an ordinary `avatar` string
+that happens to be `emojiAvatar(emoji)`'s SVG data URL (with the recoverable
+`data-emoji` marker `UserAvatar` uses to animate). It must be stored verbatim
+(never through `downscaleAvatar`).
+
+## Transitions
+
+### Set photo/emoji override (existing `setContactLocalProfile`)
+
+```
+avatar ← downscaleAvatar(picked photo)   |  emojiAvatar(picked emoji)
+localProfile ← true
+(chat row mirrored via syncChatFromContact)
+```
+
+At most one override exists: each set replaces `avatar` wholesale.
+
+### NEW: photo-only reset (`resetContactAvatarToRemote(id, freshAvatar?)`)
+
+Preconditions (also the sheet-entry visibility rule): `localProfile` set,
+`remoteAvatar` known, `avatar !== remoteAvatar`.
+
+```
+remoteAvatar ← freshAvatar            (only when a fresher copy is passed in)
+avatar       ← remoteAvatar
+pendingAvatar: cleared IFF it equals the value just applied (moot half-prompt);
+pendingName:   NEVER touched
+localProfile ← (remoteName exists AND name !== remoteName)   // name still overridden?
+updatedAt    ← now; chat row mirrored via syncChatFromContact
+```
+
+Invariants:
+
+- A custom `name` survives unchanged (FR-005).
+- A staged NAME change remains adoptable/dismissable afterwards.
+- When `localProfile` clears, the "Reset to their name & photo" row (gated on
+  it) disappears — consistent, since nothing is overridden anymore.
+
+### NEW: photo-only refresh (`refetchContactAvatar(id)`, directory service)
+
+```
+u ← fetchDirectoryUser(id)        (network; failure → keep optimistic state)
+u.avatar present → resetContactAvatarToRemote(id, u.avatar)
+```
+
+Offline: the caller already applied the optimistic revert from the last-known
+`remoteAvatar`; the refresh silently no-ops (SC-004).
+
+### Unchanged neighbours (for contrast)
+
+- `resetContactToRemote(id)`: reverts BOTH name and avatar, drops
+  `localProfile` and both `pending*` — stays behind "Reset to their name &
+  photo" (FR-009).
+- `updateContactProfile` / `adoptContactProfile` / `dismissContactProfile`:
+  untouched; the staging state machine is not widened.

--- a/specs/1054-pick-emoji-contact/plan.md
+++ b/specs/1054-pick-emoji-contact/plan.md
@@ -1,0 +1,157 @@
+# Implementation Plan: Emoji contact photos + reset to their photo
+
+**Branch**: `feat/1054-pick-emoji-contact` | **Date**: 2026-07-15 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/1054-pick-emoji-contact/spec.md`
+
+## Summary
+
+`ContactDetailPage.vue` replaces its bare hidden `<input type="file">` with the
+same action sheet the own-profile picture uses (`ProfilePage.vue` `editPhoto`):
+Take photo / Choose photo / Pick an emoji / (conditionally) Reset to their photo
+/ Cancel. Photos go through the shared robust picker (`pickImageFile`, which
+handles the Android camera `change` race) and keep the `downscaleAvatar`
+treatment; an emoji is stored verbatim as `emojiAvatar(emoji)` (byte-stable SVG
+disc, never rasterized) via the existing `setContactLocalProfile` override path,
+so `UserAvatar` renders and animates it everywhere automatically. Reset gets a
+new photo-only revert in `queries.ts` (`resetContactAvatarToRemote`) plus a
+photo-only directory re-pull in `services/directory.ts`
+(`refetchContactAvatar`), leaving a local NAME override intact — unlike the
+existing `resetContactToRemote`, which stays as-is behind the "Reset to their
+name & photo" row. Client-only; no server, crypto, or schema changes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Vue 3 `<script setup>` + Ionic 8 (client only)
+
+**Primary Dependencies**: Existing app stack — `actionSheetController` +
+`modalController` (stock Ionic), `EmojiPickerModal` (the `emoji-picker-element`
+sheet the profile/Wall already use), `emojiAvatar`/`emojiOfAvatar`
+(`src/db/avatars.ts`), `pickImageFile`/`fileToDataUrl`
+(`src/utils/pick-image.ts`), `setContactLocalProfile`/`downscaleAvatar`
+(`src/db/queries.ts`), `fetchDirectoryUser` (`src/services/directory.ts`).
+No new dependencies.
+
+**Storage**: Existing `contacts` object store, existing fields only
+(`avatar`, `remoteAvatar`, `localProfile`). No new store, no `DB_VERSION` bump.
+
+**Testing**: Playwright e2e (`e2e/contact-emoji-avatar.spec.ts`, red first):
+emoji override applied via the real action sheet → verified with the existing
+`contactAvatarEmoji` hook; photo-only reset preserves a custom name. The
+emoji pick inside the shadow-DOM `emoji-picker` is driven by dispatching its
+`emoji-click` CustomEvent (the modal's own listener). `npm run build`
+(vue-tsc) as the typecheck gate.
+
+**Target Platform**: Installable PWA, touch + desktop.
+
+**Project Type**: Web app (client half of the monorepo; zero server changes).
+
+**Performance Goals**: None beyond today — the sheet is created on demand;
+avatar rendering paths are unchanged.
+
+**Constraints**: Zero-knowledge unchanged (override never leaves the device;
+reset reuses the existing directory profile GET). Emoji avatars MUST bypass
+`downscaleAvatar` (canvas re-encode would rasterize the SVG and strip the
+recoverable `data-emoji` marker). Photo-only reset MUST NOT disturb
+`pendingName` (a staged name prompt stays answerable).
+
+**Scale/Scope**: One page reworked (`ContactDetailPage.vue`), one new function
+in `queries.ts`, one in `directory.ts`, one new e2e spec. ~150 lines.
+
+## Constitution Check
+
+*GATE: passed before Phase 0; re-checked after design.*
+
+- **I. Zero-Knowledge Boundary** — PASS. Nothing new crosses the wire; the
+  override is device-local; reset reuses the existing directory read. Spec
+  carries the Zero-Knowledge Impact section.
+- **II. Spec-Driven Development** — PASS. Spec 1054 (ad-hoc), this plan, tasks
+  to follow; analyze before implement; issues before PR.
+- **III. TDD** — PASS. New user-facing behavior gets a red-first e2e spec;
+  tasks order it before the implementation. No unit-testable pure module is
+  added (the two new functions are thin IndexedDB/service-layer orchestration,
+  exercised end-to-end like the sibling `resetContactToRemote`).
+- **IV. Crypto Discipline** — N/A (no crypto changes).
+- **V. Offline-First Data Integrity** — PASS. Writes ride `put('contacts', …)`
+  through the existing idb wrapper + change bus; no schema change. Reset is
+  optimistic-local first, network second.
+- **VI. Stateless Server** — N/A (server untouched).
+- **VII. Quality Gates** — PASS. Build + vitest + e2e planned; release-note
+  commit subject ("set an emoji as a contact's photo, and reset back to
+  theirs").
+- **X. Accessibility & i18n** — PASS. Stock action sheet buttons (labelled,
+  focus-managed by Ionic); emoji disc renders through `UserAvatar`, which
+  already carries `role="img"` + `aria-label`.
+- **XI. Ionic-First UI** — PASS. Everything is stock: `ion-action-sheet` via
+  `actionSheetController`, `ion-modal` via `modalController` + the existing
+  `EmojiPickerModal`. No new components.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1054-pick-emoji-contact/
+├── spec.md              # done
+├── plan.md              # this file
+├── research.md          # decisions & alternatives
+├── data-model.md        # contact override fields + reset transitions
+├── quickstart.md        # run/verify locally
+├── checklists/requirements.md
+└── tasks.md             # /speckit-tasks
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── db/
+│   └── queries.ts                    # EXTEND: + resetContactAvatarToRemote(id, freshAvatar?)
+├── services/
+│   ├── directory.ts                  # EXTEND: + refetchContactAvatar(id) (photo-only re-pull)
+│   └── testhook.ts                   # EXTEND: + resetContactAvatar(id) hook for e2e
+└── views/detail/
+    └── ContactDetailPage.vue         # REWORK: photo action sheet (take/choose/emoji/reset),
+                                      #         pickImageFile replaces the hidden <input>
+e2e/
+└── contact-emoji-avatar.spec.ts      # NEW: emoji override via UI + photo-only reset keeps name
+```
+
+**Structure Decision**: mirror the existing pairing — the optimistic local
+revert lives beside its siblings in `queries.ts`; the network refresh lives
+beside `refetchContactProfile` in `directory.ts`; the page only orchestrates.
+No new component: the sheet is `actionSheetController` data, per Principle XI.
+
+## Design Decisions (full trail in research.md)
+
+1. **Sheet composition**: same order as the profile sheet — Take photo, Choose
+   photo, Pick an emoji, then "Reset to their photo" (non-destructive role,
+   `refreshOutline` icon — reset restores something, unlike the profile's
+   destructive Remove), then Cancel. Header: "Edit photo".
+2. **Reset visibility**: only when there is actually something to undo AND a
+   known target — `contact.localProfile && contact.remoteAvatar &&
+   contact.avatar !== contact.remoteAvatar`. A name-only override does not
+   show it; a contact who never published a picture does not show it (FR-004).
+3. **Photo-only reset**: new `resetContactAvatarToRemote(id, freshAvatar?)` —
+   applies `remoteAvatar` (or the passed fresher copy) to `avatar`, keeps
+   `localProfile` when the NAME is still overridden (`name !== remoteName`),
+   clears it otherwise, never touches `pendingName`; clears `pendingAvatar`
+   only when the reset lands on that exact value (the staged photo half is
+   then moot). Syncs the linked 1:1 chat row via `syncChatFromContact`.
+4. **Fresh re-pull**: `refetchContactAvatar(id)` fetches the directory user
+   and re-applies via `resetContactAvatarToRemote(id, u.avatar)`; network
+   errors are swallowed (the optimistic revert already applied) — the same
+   shape as `refetchContactProfile`, but it cannot clobber a local name.
+5. **Emoji storage**: `setContactLocalProfile(id, { avatar: emojiAvatar(emoji) })`
+   — stored verbatim, NEVER through `downscaleAvatar` (FR-007); `UserAvatar`
+   recovers the emoji via `emojiOfAvatar` and animates it, so every surface
+   (contacts list, chat list, chat header, calls) works with zero changes.
+6. **Photo paths**: replace the hidden `<input>` + FileReader with
+   `pickImageFile(capture)` + `fileToDataUrl` (shared, Android-camera-safe),
+   then `downscaleAvatar` as today; failures keep the existing
+   "Couldn't use that image." toast.
+
+## Complexity Tracking
+
+No violations; no bespoke UI; no new moving parts beyond the two thin
+functions the reset semantics require.

--- a/specs/1054-pick-emoji-contact/quickstart.md
+++ b/specs/1054-pick-emoji-contact/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: Emoji contact photos + reset to their photo (spec 1054)
+
+## Run locally
+
+```sh
+make start          # Postgres + ringd (hot reload) + Vite on :5173
+```
+
+Register two accounts (dev invite codes `RINGDEV1`..`RINGDEV9`), pair them
+(Contacts → add by username), or drive it with the `drive/` harness.
+
+## Verify the feature by hand
+
+1. Open a contact → **Contact info** → tap **Change photo**.
+2. The sheet shows **Take photo / Choose photo / Pick an emoji / Cancel**
+   (no reset entry yet — nothing is overridden).
+3. **Pick an emoji** → choose 😎 → the contact's picture becomes the emoji
+   disc on the contact page, Contacts tab, chat list, and chat header —
+   animated where emoji profile pictures animate.
+4. Also give the contact a custom name via **Edit name**.
+5. Reopen **Change photo** → the sheet now ends with **Reset to their photo**.
+6. Tap it: the picture reverts to what the contact set for themselves; the
+   custom name stays. The "Reset to their name & photo" row still resets both.
+7. Offline check: airplane-mode the device, override the photo, reset — the
+   picture still reverts immediately (last-known copy), and refreshes to the
+   contact's current one on reconnect.
+
+## Tests
+
+```sh
+npm run build                                        # typecheck gate
+npx playwright test e2e/contact-emoji-avatar.spec.ts # this feature's e2e (needs `make db-up`)
+npm run test:e2e                                     # full suite
+```

--- a/specs/1054-pick-emoji-contact/research.md
+++ b/specs/1054-pick-emoji-contact/research.md
@@ -1,0 +1,106 @@
+# Research: Emoji contact photos + reset to their photo (spec 1054)
+
+No NEEDS CLARIFICATION items remained after `/speckit-clarify`. This file
+records the design decisions and the alternatives considered.
+
+## D1 — Reuse the profile picture sheet pattern, not a new component
+
+- **Decision**: Build the contact photo menu with `actionSheetController`
+  inline in `ContactDetailPage.vue`, mirroring `ProfilePage.vue`'s `editPhoto`
+  (same buttons, same icons, same `EmojiPickerModal` presentation:
+  `emoji-picker-sheet` class, breakpoints `[0, 0.6, 0.95]`, initial `0.6`).
+- **Rationale**: Principle XI (stock Ionic); the user explicitly asked for
+  the profile-picture approach; two surfaces behaving identically is the
+  feature.
+- **Alternatives**: extracting a shared `useAvatarSheet` composable for both
+  pages — rejected for now: the two flows diverge exactly where it matters
+  (publish-own-profile + Remove vs. local-override + Reset), so the shared
+  part is ~15 declarative lines; a premature abstraction would obscure the
+  divergence.
+
+## D2 — Emoji avatars must bypass `downscaleAvatar`
+
+- **Decision**: store `emojiAvatar(emoji)` verbatim via
+  `setContactLocalProfile`; only camera/library photos go through
+  `downscaleAvatar`.
+- **Rationale**: `downscaleAvatar` is a canvas JPEG re-encode; it would
+  rasterize the SVG disc, strip the recoverable `data-emoji` attribute, and
+  kill the animated upgrade (`emojiOfAvatar` returns null on a JPEG). The
+  profile flow already stores the SVG verbatim, and `emojiAvatar` is
+  deterministic and byte-stable by design.
+- **Alternatives**: none viable.
+
+## D3 — Photo-only reset is a new function, not a flag on `resetContactToRemote`
+
+- **Decision**: add `resetContactAvatarToRemote(id, freshAvatar?)` next to
+  `resetContactToRemote` in `queries.ts`.
+- **Rationale**: the existing function reverts name AND avatar and drops the
+  whole override; the sheet's reset must keep a custom name (FR-005). A
+  boolean parameter (`resetContactToRemote(id, { avatarOnly: true })`) would
+  make one function carry two distinct state machines (when to drop
+  `localProfile`, what to do with `pendingName`); two small functions with
+  clear comments match the file's existing style (`adoptContactProfile` /
+  `dismissContactProfile` are similarly split).
+- **`localProfile` bookkeeping**: after a photo-only reset the flag stays set
+  iff the name is still overridden (`c.remoteName && c.name !== c.remoteName`);
+  otherwise it's cleared so the "Reset to their name & photo" row (gated on
+  `localProfile`) disappears when nothing is overridden anymore.
+- **`pending*` bookkeeping**: `pendingName` is never touched (a staged name
+  change stays answerable, per the spec's edge case). `pendingAvatar` is
+  cleared only when the reset applied that exact value — the photo half of
+  the prompt would otherwise offer a no-op adopt.
+
+## D4 — Fresh copy comes from a photo-only directory re-pull
+
+- **Decision**: `refetchContactAvatar(id)` in `services/directory.ts`:
+  `fetchDirectoryUser(id)` → `resetContactAvatarToRemote(id, u.avatar)` when
+  an avatar is present; errors swallowed.
+- **Rationale**: mirrors the existing optimistic-revert-then-refetch pair
+  (`resetContactToRemote` + `refetchContactProfile`), but the existing
+  refetch force-applies the peer's NAME too (`updateContactProfile(…, true)`),
+  which would clobber a kept name override — hence the photo-only variant.
+  Offline behavior falls out naturally: the optimistic revert already
+  happened from `remoteAvatar` (SC-004).
+- **Alternatives**: parameterizing `updateContactProfile(force)` with a field
+  mask — rejected; that function is the staging brain and is called from
+  sync/ingest paths, so widening its contract for one caller risks the
+  adopt/dismiss machinery.
+
+## D5 — Reset entry visibility
+
+- **Decision**: show "Reset to their photo" iff `contact.localProfile &&
+  contact.remoteAvatar && contact.avatar !== contact.remoteAvatar`.
+- **Rationale**: FR-004 — only when the user overrode the picture and a
+  published target exists. Requiring `localProfile` keeps the entry away
+  from the not-overridden case where `avatar` lags `remoteAvatar` merely
+  because a remote change is STAGED (pending prompt) — reset must not become
+  a hidden "adopt half the prompt" path.
+- **Alternatives**: `avatar !== remoteAvatar` alone — rejected for the
+  staged-change case above.
+
+## D6 — Photo picking moves to the shared `pickImageFile`
+
+- **Decision**: drop the page's hidden `<input type="file">` + FileReader in
+  favour of `pickImageFile(capture)` + `fileToDataUrl`, exactly like the
+  profile page.
+- **Rationale**: gives contacts a true "Take photo" entry (capture attribute)
+  and inherits the documented Android camera `change`-race handling; deletes
+  code instead of adding it.
+- **Alternatives**: keeping the hidden input for "Choose photo" — rejected;
+  one picker path is easier to reason about and already proven on the
+  profile page.
+
+## D7 — e2e drives the real sheet; the emoji pick is event-injected
+
+- **Decision**: the new e2e opens the contact page, taps "Change photo" →
+  "Pick an emoji", then dispatches `emoji-click` (CustomEvent with
+  `detail.unicode`) on the `emoji-picker` element; assertions use the
+  existing `contactAvatarEmoji` / `setContactLocalProfile` test hooks; a new
+  tiny `resetContactAvatar` hook mirrors the UI reset for the offline half.
+- **Rationale**: `emoji-picker-element` renders in shadow DOM with a virtual
+  grid — clicking a specific glyph is flaky; its public event contract
+  (`emoji-click`) is exactly what `EmojiPickerModal` consumes, so injecting
+  it exercises everything from the modal down. The profile-side e2e
+  (`emoji-avatar.spec.ts`) set the precedent of hook-level emoji selection.
+- **Alternatives**: shadow-DOM piercing selectors — rejected (visual-order
+  and locale dependent, flake-prone in CI).

--- a/specs/1054-pick-emoji-contact/spec.md
+++ b/specs/1054-pick-emoji-contact/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Emoji contact photos + reset to their photo
+
+**Feature Branch**: `feat/1054-pick-emoji-contact`
+
+**Created**: 2026-07-15
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "Let's make it possible to set emoji for your contacts as well; right now it is only possible to take a photo or choose from library or pick a file. Prefer the profile-picture approach (Take photo / Choose photo / Pick an emoji), but instead of Remove the option should be Reset to what the contact has set for themselves."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pick an emoji as a contact's picture (Priority: P1)
+
+From a contact's info page, the user taps "Change photo" and — alongside taking
+or choosing a photo — can now pick an emoji. The chosen emoji becomes that
+contact's picture on this device: a colored disc with the emoji, exactly like an
+emoji profile picture, animated on surfaces that support animation.
+
+**Why this priority**: This is the feature being asked for — parity with the own-profile
+picture flow so a contact can be personalized without hunting for a photo.
+
+**Independent Test**: Open a contact's info page, choose "Change photo" → "Pick an
+emoji", select an emoji, and confirm the contact now shows that emoji disc on the
+contact page, the contacts list, the chat list, and the chat header.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contact info page, **When** the user taps "Change photo", **Then** a menu appears with "Take photo", "Choose photo", "Pick an emoji", and "Cancel".
+2. **Given** the picture menu, **When** the user picks an emoji, **Then** the contact's picture becomes that emoji on a colored disc everywhere the contact appears on this device.
+3. **Given** an emoji was set for a contact, **When** the contact appears on a surface that animates emoji pictures, **Then** the emoji animates the same way emoji profile pictures do.
+4. **Given** the emoji picker is open, **When** the user dismisses it without choosing, **Then** the contact's picture is unchanged.
+
+---
+
+### User Story 2 - Reset the picture to what the contact set (Priority: P2)
+
+When the user has personalized a contact's picture (photo or emoji), the picture
+menu offers "Reset to their photo" in place of the profile flow's "Remove photo".
+Choosing it reverts only the picture back to whatever the contact has published
+for themselves, while keeping any custom name the user gave the contact.
+
+**Why this priority**: Personalization needs an undo. A contact picture, unlike an own
+profile picture, always has a natural fallback — what the contact chose — so reset,
+not remove, is the right verb.
+
+**Independent Test**: Override a contact's photo with an emoji, also give them a
+custom name, then use "Reset to their photo" and confirm the picture reverts to the
+contact's own while the custom name stays.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contact whose picture the user has changed, **When** the picture menu opens, **Then** it includes "Reset to their photo".
+2. **Given** a contact whose picture the user has NOT changed, **When** the picture menu opens, **Then** no reset entry is shown.
+3. **Given** a contact with both a custom name and a custom picture, **When** the user resets the photo from the picture menu, **Then** the picture reverts to the contact's own and the custom name is untouched.
+4. **Given** the device is offline, **When** the user resets the photo, **Then** the picture immediately reverts to the last-known picture the contact published, and it refreshes to their current one when the device is next online.
+5. **Given** the existing "Reset to their name & photo" row, **When** the user taps it, **Then** it still resets both, unchanged by this feature.
+
+---
+
+### User Story 3 - Take or choose a photo from the same menu (Priority: P3)
+
+The existing photo paths move into the same menu: "Take photo" opens the camera
+directly, "Choose photo" opens the library/file picker. Both behave as photo
+overrides do today.
+
+**Why this priority**: Pure parity/polish — the capability already exists via the OS
+picker; the menu just makes camera capture explicit and the flow consistent with the
+profile page.
+
+**Independent Test**: Use "Choose photo" to select an image and confirm the contact's
+picture updates; use "Take photo" on a device with a camera and confirm the captured
+photo is applied.
+
+**Acceptance Scenarios**:
+
+1. **Given** the picture menu, **When** the user takes or chooses a photo, **Then** it becomes the contact's picture on this device, with the same size treatment photos get today.
+
+---
+
+### Edge Cases
+
+- The contact has never published a picture: if nothing is known to reset to, the reset entry is not offered.
+- The contact changed their own picture while the user had an override, creating a staged "They updated their profile" prompt: resetting the photo must not silently answer that prompt for their name; the name part of the prompt (if any) remains available.
+- An emoji picture must never be degraded into a static, blurry image by the photo size treatment — it stays crisp and animatable.
+- Setting a new picture (photo or emoji) replaces any previous override; there is at most one override at a time.
+- A contact whose account no longer exists ("ghosted") shows no editing entries at all — unchanged by this feature.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The contact info page MUST present a single picture menu with "Take photo", "Choose photo", "Pick an emoji", a reset entry when applicable, and "Cancel".
+- **FR-002**: Users MUST be able to set any emoji as a contact's picture; it renders as the same colored-disc emoji picture used for profile pictures, animated on capable surfaces.
+- **FR-003**: A contact picture set by the user (photo or emoji) MUST apply everywhere the contact's picture appears on this device (contact page, contacts list, chat list, chat header, calls).
+- **FR-004**: The picture menu MUST offer "Reset to their photo" only when the user has overridden the picture and a picture published by the contact is known.
+- **FR-005**: Resetting from the picture menu MUST revert only the picture; a custom contact name set by the user MUST be preserved.
+- **FR-006**: Reset MUST work offline by reverting to the last-known picture the contact published, then refresh to the contact's current picture when the network allows.
+- **FR-007**: Photos taken or chosen MUST keep today's size treatment; an emoji picture MUST be stored without that treatment so it stays crisp and animatable.
+- **FR-008**: All contact-picture personalization MUST remain on this device only; nothing new is sent to the server or to the contact (zero-knowledge unchanged).
+- **FR-009**: The existing "Reset to their name & photo" row MUST keep its current behavior (resets both name and picture).
+
+### Key Entities
+
+- **Contact picture override**: the user's device-local choice of picture for a contact (photo or emoji disc); at most one per contact; independent of the contact's own published picture.
+- **Contact's published picture**: the picture the contact chose for themselves, as last learned from their profile; the target of "Reset to their photo".
+
+## Zero-Knowledge Impact
+
+- **What crosses the wire**: nothing new. Setting a photo or emoji for a contact is a device-local override that is never uploaded. Resetting re-uses the existing directory profile fetch (the same one contact profiles already use) to read the contact's current published picture.
+- **What is encrypted**: unchanged. The override lives only in the device's local database.
+- **What metadata is unavoidably visible**: at most one already-existing directory profile lookup for the contact when the user resets; the server cannot tell it apart from the routine profile refreshes the app already performs, and it learns nothing about the override (not even that one existed).
+- **Why**: the reset target is "what the contact currently publishes", so the freshest copy comes from the same directory read the app already performs; no new server capability or data is involved.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: From a contact's info page, a user can set an emoji as the contact's picture in 4 taps or fewer.
+- **SC-002**: After picking an emoji, the contact's new picture is visible on every surface listing that contact without reloading the app.
+- **SC-003**: After "Reset to their photo", the contact's picture matches what the contact published, and a custom contact name survives the reset in 100% of cases.
+- **SC-004**: Resetting while offline still visibly reverts the picture immediately (to the last-known published one).
+
+## Assumptions
+
+- This personalization is device-local by design (it does not sync to the user's other devices), matching how custom contact names behave today.
+- Group pictures and the own-profile picture flow are out of scope; the profile page keeps "Remove photo" since one's own picture has no third-party fallback.
+- "Remove photo" (falling back to a generated initials picture) is intentionally not offered for contacts; reset-to-theirs replaces it, per the request.
+- The emoji picker used for profile pictures is reused as-is (same emoji set, same presentation).

--- a/specs/1054-pick-emoji-contact/spec.md
+++ b/specs/1054-pick-emoji-contact/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-15
 
-**Status**: in-progress
+**Status**: in-review
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/1054-pick-emoji-contact/tasks.md
+++ b/specs/1054-pick-emoji-contact/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: Emoji contact photos + reset to their photo
+
+**Input**: Design documents from `specs/1054-pick-emoji-contact/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Included — the constitution mandates TDD (red-first e2e for user-facing behavior).
+
+**Organization**: Tasks are grouped by user story. US1 (emoji) is the MVP; US2 (reset) and US3 (photo paths) build on the same sheet.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 = pick an emoji, US2 = reset to their photo, US3 = take/choose photo via the sheet
+
+## Phase 1: Setup
+
+None — the feature reuses existing infrastructure (no scaffolding, no new stores, no dependencies).
+
+## Phase 2: Foundational
+
+None — all prerequisites (EmojiPickerModal, emojiAvatar, pickImageFile, setContactLocalProfile, test hooks `contactName`/`contactAvatarEmoji`/`setEmojiAvatar`) already exist.
+
+---
+
+## Phase 3: User Story 1 - Pick an emoji as a contact's picture (Priority: P1) 🎯 MVP
+
+**Goal**: "Change photo" on the contact page opens an action sheet whose "Pick an emoji" entry sets an emoji disc as the contact's device-local picture, animated like emoji profile pictures.
+
+**Independent Test**: e2e drives the real sheet → emoji applies; `contactAvatarEmoji` decodes it; visible across surfaces without reload.
+
+- [X] T001 [US1] RED: new e2e `e2e/contact-emoji-avatar.spec.ts` — B sets an emoji profile picture (`setEmojiAvatar('😎')`) BEFORE pairing, then pair A/B, so A's FIRST-learned profile applies directly (`avatar` = `remoteAvatar` = 😎 disc; a post-pair publish would arrive STAGED and never reach `remoteAvatar`-as-displayed without an adopt); poll `contactAvatarEmoji(bId)` → `'😎'` as the baseline; on A, open Contacts → the contact's info page, tap "Change photo", assert the sheet lists "Take photo" / "Choose photo" / "Pick an emoji" (and NOT a reset entry yet), tap "Pick an emoji", dispatch `emoji-click` (CustomEvent, `detail: { unicode: '🐙' }`) on the `emoji-picker` element, then poll `__ringTest.contactAvatarEmoji(bId)` → `'🐙'`. Run it and confirm it FAILS (no sheet exists yet).
+- [X] T002 [US1] Rework `src/views/detail/ContactDetailPage.vue`: replace the "Change photo" item's direct `photoInput?.click()` with an `editPhoto()` action sheet (`actionSheetController`, header "Edit photo") offering "Take photo" / "Choose photo" / "Pick an emoji" / "Cancel"; add `pickEmoji()` presenting `EmojiPickerModal` (cssClass `emoji-picker-sheet`, breakpoints `[0, 0.6, 0.95]`, initial `0.6`, exactly like ProfilePage) and on pick store `setContactLocalProfile(contactId, { avatar: emojiAvatar(data.emoji) })` — verbatim, NEVER through `downscaleAvatar`; dismissal without a pick changes nothing.
+- [X] T003 [US1] GREEN: `npx playwright test e2e/contact-emoji-avatar.spec.ts` passes; `npm run build` typechecks.
+
+**Checkpoint**: emoji contact pictures fully work; ship-able MVP.
+
+---
+
+## Phase 4: User Story 2 - Reset the picture to what the contact set (Priority: P2)
+
+**Goal**: The sheet ends with "Reset to their photo" when (and only when) the photo is locally overridden and a published photo is known; it reverts the photo only, keeps a custom name, works offline optimistically, then re-pulls the current photo.
+
+**Independent Test**: e2e overrides photo + name, resets via the real sheet → avatar decodes back to the contact's own emoji, `contactName` still returns the custom name, reset entry disappears afterwards.
+
+- [X] T004 [US2] RED: extend `e2e/contact-emoji-avatar.spec.ts` — give the contact a custom name (`setContactLocalProfile(bId, 'Cap'\''n B')`) on top of the 🐙 override; reopen "Change photo", assert "Reset to their photo" is now listed, tap it; poll `contactAvatarEmoji(bId)` → `'😎'` (B's own) and `contactName(bId)` → still the custom name; reopen the sheet and assert the reset entry is gone. Confirm it FAILS.
+- [X] T005 [P] [US2] Add `resetContactAvatarToRemote(id, freshAvatar?)` to `src/db/queries.ts` beside `resetContactToRemote`, per data-model.md: apply `freshAvatar` to `remoteAvatar` when passed; `avatar ← remoteAvatar`; clear `pendingAvatar` only if it equals the applied value; never touch `pendingName`; keep `localProfile` iff the name is still overridden (`remoteName && name !== remoteName`); bump `updatedAt`, `put`, `syncChatFromContact`. Carry a why-comment contrasting it with the both-fields reset.
+- [X] T006 [P] [US2] Add `refetchContactAvatar(id)` to `src/services/directory.ts` beside `refetchContactProfile`: `fetchDirectoryUser` → `resetContactAvatarToRemote(id, u.avatar)` when an avatar came back; swallow network errors (optimistic revert already applied; must NOT clobber a kept name override).
+- [X] T007 [US2] Wire the sheet in `src/views/detail/ContactDetailPage.vue`: computed `photoOverridden` (`contact.localProfile && contact.remoteAvatar && contact.avatar !== contact.remoteAvatar`); when true append "Reset to their photo" (icon `refreshOutline`, non-destructive) whose handler runs `resetContactAvatarToRemote(contactId)` then `refetchContactAvatar(contactId)`. The existing "Reset to their name & photo" row stays untouched.
+- [X] T008 [US2] GREEN: the extended e2e passes; `npm run build` typechecks.
+
+**Checkpoint**: US1 + US2 both verifiable through the real UI.
+
+---
+
+## Phase 5: User Story 3 - Take or choose a photo from the same menu (Priority: P3)
+
+**Goal**: "Take photo" opens the camera directly, "Choose photo" the library/file picker; both keep the downscale treatment; the legacy hidden input is gone.
+
+**Independent Test**: Choose a photo via the sheet on the dev stack (drive/ or by hand per quickstart.md) → the contact's picture updates; a broken image shows the existing error toast.
+
+- [X] T009 [US3] In `src/views/detail/ContactDetailPage.vue`, add `pickPhoto(capture)` using `pickImageFile(capture)` + `fileToDataUrl` (from `@/utils/pick-image`) → `downscaleAvatar` → `setContactLocalProfile(contactId, { avatar })`, keeping the "Couldn't use that image." failure toast; wire it to "Take photo" (capture) and "Choose photo"; DELETE the hidden `<input ref="photoInput">`, `photoInput`, and `onPickPhoto`.
+- [X] T010 [US3] Verify the photo path on the live dev stack (`make start` + `drive/`, or quickstart.md steps 1–3 by hand): choose an image file, confirm the avatar updates and the reset entry now appears. Screenshot for the PR. → `drive/scenarios/contact-emoji-1054.mjs` (committed); shots in `.tmp/drive/1054-*.png`. Surfaced + fixed a latent display bug: `UserAvatar` kept rendering the OLD emoji glyph when an emoji avatar changed in place (AnimatedEmoji needs `:key`).
+
+**Checkpoint**: all three stories functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T011 Full gates: `npm run build`, `npm run test:unit` (vitest 1154/1154), and the contact/profile-related e2e specs (`contact-emoji-avatar`, `emoji-avatar`, `directory`, `contact-delete`, `curated-contacts` — 7/7) — all green.
+- [X] T012 Walk quickstart.md end-to-end via the drive scenario (steps 1–6). The offline check (step 7) is left for the user's device pass: headless network-kill is flake-prone, and the offline guarantee is structural (the optimistic local revert commits before the network refetch is attempted; its failure is swallowed).
+- [X] T013 Flip `specs/1054-pick-emoji-contact/spec.md` `**Status**:` to `in-progress` when implementation starts and `in-review` at PR time; run `make roadmap` and commit the regenerated `ROADMAP.md` with the same branch. → in-progress + roadmap regenerated; in-review flip owed at PR time.
+
+---
+
+## Dependencies & Execution Order
+
+- **US1 (T001→T003)**: no dependencies; the MVP. T001 strictly before T002 (red first).
+- **US2 (T004→T008)**: T004 first (red); T005/T006 in parallel (different files); T007 needs T005+T006 and the T002 sheet; T008 last.
+- **US3 (T009→T010)**: T009 needs the T002 sheet; independent of US2.
+- **Polish (T011→T013)**: after all stories.
+
+### Parallel Opportunities
+
+- T005 (`queries.ts`) ∥ T006 (`directory.ts`).
+- US3's T009 can proceed in parallel with US2's T005/T006 once T002 lands (different concerns in the same file — coordinate the merge inside `ContactDetailPage.vue`).
+
+## Implementation Strategy
+
+MVP = Phase 3 alone (emoji picking, sheet in place). Each later phase is an
+independently testable increment; stop-and-validate at every checkpoint. All
+work stays client-side; a single feature branch and one PR into `develop` is
+expected, with commits per task group.

--- a/src/components/UserAvatar.vue
+++ b/src/components/UserAvatar.vue
@@ -7,7 +7,9 @@
        the parent (ion-avatar or a styled container), like the <img> it
        replaces; surfaces not yet swept keep showing the static disc. -->
   <span v-if="emoji" class="ua" :style="{ background: disc }" role="img" :aria-label="alt">
-    <animated-emoji :emoji="emoji" :animate="anim.animate" :plays="anim.plays" class="ua-glyph" />
+    <!-- :key remounts on emoji change — AnimatedEmoji renders a stale glyph if
+         its emoji prop swaps in place (e.g. a contact photo override → reset). -->
+    <animated-emoji :key="emoji" :emoji="emoji" :animate="anim.animate" :plays="anim.plays" class="ua-glyph" />
   </span>
   <img v-else :src="src" :alt="alt" />
 </template>

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4920,6 +4920,29 @@ export async function resetContactToRemote(id: string): Promise<void> {
   await syncChatFromContact(id, c.name, c.avatar);
 }
 
+/** Revert ONLY a locally-overridden photo back to the peer's own (spec 1054's
+ *  "Reset to their photo"), unlike resetContactToRemote above which reverts the
+ *  name too. A custom NAME override must survive, so `localProfile` stays set
+ *  while the name still differs from the peer's; and a STAGED name change
+ *  (`pendingName`) stays untouched so its adopt/dismiss prompt remains
+ *  answerable. `freshAvatar` lets the directory refetch pass in the peer's
+ *  CURRENT photo (the stored `remoteAvatar` may be stale / the reset may run
+ *  offline). */
+export async function resetContactAvatarToRemote(id: string, freshAvatar?: string): Promise<void> {
+  const c = await getContact(id);
+  if (!c) return;
+  if (freshAvatar) c.remoteAvatar = freshAvatar;
+  if (!c.remoteAvatar) return; // nothing known to reset to (UI hides the entry)
+  c.avatar = c.remoteAvatar;
+  // The staged-photo half of a pending prompt is moot once we just applied that
+  // exact picture; a staged NAME (or a different staged photo) is preserved.
+  if (c.pendingAvatar === c.avatar) delete c.pendingAvatar;
+  if (!(c.remoteName && c.name !== c.remoteName)) delete c.localProfile;
+  c.updatedAt = now();
+  await put('contacts', c);
+  await syncChatFromContact(id, c.name, c.avatar);
+}
+
 /** Add a peer by Ring id and send them a friend request (our name + photo).
  *  The chat is created hidden (pending) until they accept. */
 // Open-network model: there is no accept-first friend gate for 1:1 chats, so

--- a/src/services/directory.ts
+++ b/src/services/directory.ts
@@ -18,7 +18,10 @@ import {
 } from './api';
 import { getSelfUserId } from './auth';
 import { get, put } from '@/db/idb';
-import { isPeerBlocked, getSetting, downscaleAvatar, listContacts, updateContactProfile } from '@/db/queries';
+import {
+  isPeerBlocked, getSetting, downscaleAvatar, listContacts, updateContactProfile,
+  resetContactAvatarToRemote,
+} from '@/db/queries';
 import { hasTombstone, clearTombstone } from '@/db/tombstones';
 import { getSecret } from '@/db/secrets';
 import { isUnlockedNow } from '@/services/crypto/identity';
@@ -88,6 +91,19 @@ export async function refetchContactProfile(id: string): Promise<void> {
     const name = (u.displayName || u.username || '').trim();
     const avatar = u.avatar || '';
     await updateContactProfile(id, name, avatar, true); // force-apply the server's current profile
+  } catch {
+    /* offline / not found → keep the optimistic local revert the caller already applied */
+  }
+}
+
+/** Photo-only variant of refetchContactProfile (spec 1054 "Reset to their photo"):
+ *  pull the peer's CURRENT avatar and re-apply it, leaving a local NAME override
+ *  untouched (the force-refetch above would clobber it). */
+export async function refetchContactAvatar(id: string): Promise<void> {
+  try {
+    const u = await fetchDirectoryUser(id);
+    if (!u?.avatar) return;
+    await resetContactAvatarToRemote(id, u.avatar);
   } catch {
     /* offline / not found → keep the optimistic local revert the caller already applied */
   }

--- a/src/views/detail/ContactDetailPage.vue
+++ b/src/views/detail/ContactDetailPage.vue
@@ -48,7 +48,7 @@
             <ion-icon slot="start" :icon="createOutline" />
             <ion-label>Edit name</ion-label>
           </ion-item>
-          <ion-item button :detail="false" @click="photoInput?.click()">
+          <ion-item button :detail="false" @click="editPhoto">
             <ion-icon slot="start" :icon="cameraOutline" />
             <ion-label>Change photo</ion-label>
           </ion-item>
@@ -57,7 +57,6 @@
             <ion-label>Reset to their name &amp; photo</ion-label>
           </ion-item>
         </ion-list>
-        <input ref="photoInput" type="file" accept="image/*" hidden @change="onPickPhoto" />
 
         <ion-list v-if="!contact.ghosted && contact.about" :inset="true">
           <ion-item lines="none">
@@ -167,22 +166,27 @@ import { useRoute, useRouter } from 'vue-router';
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonButtons, IonBackButton,
   IonContent, IonAvatar, IonButton, IonIcon, IonList, IonItem, IonLabel, IonNote, IonToggle,
-  alertController, actionSheetController,
+  alertController, actionSheetController, modalController,
 } from '@ionic/vue';
+import type { ActionSheetButton } from '@ionic/vue';
 import {
   chatbubbleOutline, searchOutline, banOutline, imagesOutline, videocamOutline,
   notificationsOutline, notificationsOffOutline, starOutline, timerOutline, eyeOutline, documentTextOutline,
-  createOutline, cameraOutline, refreshOutline, personOutline, trashOutline,
+  createOutline, cameraOutline, imageOutline, happyOutline, refreshOutline, personOutline, trashOutline,
 } from 'ionicons/icons';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import {
   getContact, startDirectChat, blockContact, unblockContact, listChats, setChatMute, setChatTtl, setChatSendQuality,
   getPresenceOverrides, setPresenceOverride, setChatNotifyPrefs, type ChatNotifyContent,
-  setContactLocalProfile, resetContactToRemote, adoptContactProfile, dismissContactProfile, downscaleAvatar,
+  setContactLocalProfile, resetContactToRemote, resetContactAvatarToRemote,
+  adoptContactProfile, dismissContactProfile, downscaleAvatar,
   deleteContact,
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
-import { refetchContactProfile } from '@/services/directory';
+import { refetchContactProfile, refetchContactAvatar } from '@/services/directory';
+import EmojiPickerModal from '@/components/EmojiPickerModal.vue';
+import { emojiAvatar } from '@/db/avatars';
+import { pickImageFile, fileToDataUrl } from '@/utils/pick-image';
 import { ensureProfile } from '@/composables/useProfileGate';
 import { forceReconnect } from '@/composables/useSync';
 import type { Contact, Chat } from '@/db/types';
@@ -192,7 +196,6 @@ import { peerPresence, presenceLabel } from '@/composables/usePresence';
 const route = useRoute();
 const router = useRouter();
 const contactId = route.params.id as string;
-const photoInput = ref<HTMLInputElement | null>(null);
 
 // ---- local name/photo override + adopt a staged remote change ----
 async function editName(): Promise<void> {
@@ -213,24 +216,69 @@ async function editName(): Promise<void> {
   });
   await a.present();
 }
-async function onPickPhoto(e: Event): Promise<void> {
-  const input = e.target as HTMLInputElement;
-  const file = input.files?.[0];
-  input.value = ''; // allow re-picking the same file
+// Take/choose a photo via the shared robust picker (same as the profile page —
+// it handles the Android camera focus/`change` race so the captured photo isn't
+// dropped). Photos keep the downscale treatment; emoji below must not.
+async function pickPhoto(capture: boolean): Promise<void> {
+  const file = await pickImageFile(capture);
   if (!file) return;
   try {
-    const dataUrl = await new Promise<string>((res, rej) => {
-      const r = new FileReader();
-      r.onload = () => res(r.result as string);
-      r.onerror = () => rej(r.error);
-      r.readAsDataURL(file);
-    });
-    const avatar = await downscaleAvatar(dataUrl);
+    const avatar = await downscaleAvatar(await fileToDataUrl(file));
     await setContactLocalProfile(contactId, { avatar });
   } catch {
     await appToast({ message: "Couldn't use that image.", color: 'danger' });
   }
 }
+
+// Pick an emoji as the contact's photo (spec 1054): stored VERBATIM as
+// emojiAvatar's disc — never through downscaleAvatar, whose canvas re-encode
+// would rasterize the SVG and strip the recoverable emoji (killing the
+// animated rendering in UserAvatar).
+async function pickEmoji(): Promise<void> {
+  const modal = await modalController.create({
+    component: EmojiPickerModal,
+    cssClass: 'emoji-picker-sheet',
+    breakpoints: [0, 0.6, 0.95],
+    initialBreakpoint: 0.6,
+  });
+  await modal.present();
+  const { data } = await modal.onWillDismiss<{ emoji?: string }>();
+  if (!data?.emoji) return;
+  await setContactLocalProfile(contactId, { avatar: emojiAvatar(data.emoji) });
+}
+
+// "Reset to their photo" is offered only when there is actually a local PHOTO
+// override to undo (a name-only override doesn't count) and a published photo
+// is known. Requiring `localProfile` keeps the entry from doubling as a hidden
+// half-adopt when a STAGED remote change is what makes avatar ≠ remoteAvatar.
+const photoOverridden = computed(
+  () =>
+    !!contact.value?.localProfile &&
+    !!contact.value.remoteAvatar &&
+    contact.value.avatar !== contact.value.remoteAvatar,
+);
+
+// Optimistic: revert to the last-known published photo (works offline), then
+// re-pull the peer's CURRENT one. Photo only — a custom name stays.
+async function resetPhoto(): Promise<void> {
+  await resetContactAvatarToRemote(contactId);
+  await refetchContactAvatar(contactId);
+}
+
+async function editPhoto(): Promise<void> {
+  const buttons: ActionSheetButton[] = [
+    { text: 'Take photo', icon: cameraOutline, handler: () => void pickPhoto(true) },
+    { text: 'Choose photo', icon: imageOutline, handler: () => void pickPhoto(false) },
+    { text: 'Pick an emoji', icon: happyOutline, handler: () => void pickEmoji() },
+  ];
+  if (photoOverridden.value) {
+    buttons.push({ text: 'Reset to their photo', icon: refreshOutline, handler: () => void resetPhoto() });
+  }
+  buttons.push({ text: 'Cancel', role: 'cancel' });
+  const sheet = await actionSheetController.create({ header: 'Edit photo', buttons });
+  await sheet.present();
+}
+
 async function resetProfile(): Promise<void> {
   // Optimistic: drop the override + revert to the last-known remote (works offline),
   // then re-pull the peer's CURRENT name/photo from the directory and apply it.


### PR DESCRIPTION
## Summary

"Change photo" on the contact info page now opens the same action sheet as the own-profile picture — **Take photo / Choose photo / Pick an emoji** — and, once the photo is overridden, **Reset to their photo**, which reverts ONLY the picture back to what the contact published while a custom name survives. Reset is optimistic offline (last-known photo) followed by a photo-only directory re-pull. Also fixes a latent stale-glyph render in `UserAvatar` when an emoji avatar changes in place.

Spec: `specs/1054-pick-emoji-contact/` (ad-hoc band; full speckit pipeline, analyze clean).

## Zero-knowledge

Nothing new crosses the wire: the override is device-local; reset reuses the existing directory profile GET.

## Changes

- `ContactDetailPage.vue`: photo action sheet (stock `actionSheetController` + existing `EmojiPickerModal`); emoji discs stored VERBATIM (never `downscaleAvatar` — it would rasterize the SVG and kill animation); photos ride the shared `pickImageFile` (Android camera race handled), replacing the hand-rolled hidden input.
- `queries.ts`: `resetContactAvatarToRemote(id, freshAvatar?)` — photo-only sibling of `resetContactToRemote`; keeps `localProfile` while the name stays overridden; never touches a staged `pendingName`.
- `directory.ts`: `refetchContactAvatar(id)` — photo-only re-pull that cannot clobber a kept name override.
- `UserAvatar.vue`: `:key="emoji"` so `AnimatedEmoji` remounts on in-place emoji change.
- e2e `contact-emoji-avatar.spec.ts` (red-first) + drive scenario `contact-emoji-1054.mjs`.

## Testing

- `npm run build` ✓ · vitest 1154/1154 ✓ · contact/profile e2e suites 7/7 ✓
- Live-stack drive walkthrough with screenshots (file-chooser photo, emoji override, reset)
- User device pass ✓ (incl. the flow by hand)

Closes #1008
Closes #1009
Closes #1010
Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7