### PR TITLE
feat(chats): new messages glide in with a playful pop, and uploads show progress right on the media

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,7 @@ Specs are grouped by category band; status moves
 | [1051](specs/1051-message-bubble-grows/spec.md) | Message Bubble Grows to Hold Its Reactions | 🟡 in-progress |
 | [1052](specs/1052-group-adds-you/spec.md) | Group Adds You Can Trust | 🟡 in-progress |
 | [1053](specs/1053-composer-buttons-transition/spec.md) | Composer Buttons Transition Like WhatsApp | 🟡 in-progress |
-| [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🔵 in-review |
+| [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/arrival-glide-composer.mjs
+++ b/drive/scenarios/arrival-glide-composer.mjs
@@ -1,0 +1,62 @@
+/**
+ * Arrival glide via the REAL composer (the path the user exercises on the phone):
+ * type into ion-textarea and tap the send button, then sample .msg-list's computed
+ * transform per frame. The testhook `say()` bypasses ChatDetailPage's send(), which
+ * also calls scrollToNewest() explicitly — this covers the real path.
+ *
+ *   node drive/scenarios/arrival-glide-composer.mjs
+ */
+import { createAccount, pair, chatWith, say, waitForMessage, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'GlideCA', mobile: true });
+const b = await createAccount({ name: 'GlideCB' });
+await pair(a, b);
+
+// Seed history so the chat overflows on A's phone viewport.
+for (let i = 1; i <= 12; i++) await say(b, a.id, `seed message number ${i} — some extra words for bubble height`);
+await waitForMessage(a, b.id, 'seed message number 12');
+
+await a.page.goto(`/chat/${await chatWith(a, b.id)}`);
+await a.page.waitForTimeout(1500);
+
+// Sampler: per frame for 2.5s, record .msg-list translateY (glide) AND the newest
+// bubble's scale + transform-origin (pop).
+await a.page.evaluate(() => {
+  window.__glideSamples = [];
+  const t0 = performance.now();
+  const parse = (s) => (s && s.startsWith('matrix') ? new DOMMatrixReadOnly(s) : new DOMMatrixReadOnly());
+  const tick = () => {
+    const el = document.querySelector('.msg-list');
+    const bubbles = document.querySelectorAll('.bubble[data-mid]');
+    const nb = bubbles[bubbles.length - 1];
+    if (el) {
+      const m = parse(getComputedStyle(el).transform);
+      const bm = nb ? parse(getComputedStyle(nb).transform) : null;
+      window.__glideSamples.push({
+        t: Math.round(performance.now() - t0),
+        ty: Math.round(m.m42 * 10) / 10,
+        scale: bm ? Math.round(bm.a * 100) / 100 : null,
+        origin: nb ? getComputedStyle(nb).transformOrigin : null,
+      });
+    }
+    if (performance.now() - t0 < 2500) requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+});
+
+// Real composer interaction: type, then tap the round send button.
+const ta = a.page.locator('ion-textarea.composer textarea');
+await ta.click();
+await ta.fill('typed through the real composer — glide me');
+await a.page.locator('button[aria-label="Send"]').click();
+await a.page.waitForTimeout(2600);
+
+const samples = await a.page.evaluate(() => window.__glideSamples);
+const active = samples.filter((s) => s.ty !== 0 || (s.scale !== null && s.scale !== 1));
+console.log('[composer send] samples:', samples.length, 'animating:', JSON.stringify(active));
+const peak = Math.max(...samples.map((s) => s.scale ?? 0));
+console.log('[composer send] peak scale:', peak, 'origin during pop:', active.find((s) => s.origin)?.origin);
+
+await shot(a, 'glide-composer-final');
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/arrival-glide.mjs
+++ b/drive/scenarios/arrival-glide.mjs
@@ -1,0 +1,59 @@
+/**
+ * Arrival glide (WhatsApp-style): a new bottom message — incoming while the chat is
+ * open, or your own send — should translate .msg-list down by the new row's height
+ * and ease it back to 0 (~260ms), instead of popping in with a jump.
+ *
+ * Verifies by sampling getComputedStyle(.msg-list).transform per frame around the
+ * send on BOTH sides: expect a nonzero translateY that decays to 0.
+ *
+ *   node drive/scenarios/arrival-glide.mjs
+ */
+import { createAccount, pair, chatWith, say, waitForMessage, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'GlideA' });
+const b = await createAccount({ name: 'GlideB', mobile: true });
+await pair(a, b);
+
+// Seed enough history that B's chat overflows (exercises the pinned/scrollTop path).
+for (let i = 1; i <= 12; i++) await say(a, b.id, `seed message number ${i} — some extra words for bubble height`);
+await waitForMessage(b, a.id, 'seed message number 12');
+
+// Open the chat on both sides and let the initial pin settle.
+await a.page.goto(`/chat/${await chatWith(a, b.id)}`);
+await b.page.goto(`/chat/${await chatWith(b, a.id)}`);
+await a.page.waitForTimeout(1500);
+await b.page.waitForTimeout(1500);
+
+// Per-frame transform sampler on .msg-list for ~1.8s.
+const startSampler = (c) =>
+  c.page.evaluate(() => {
+    window.__glideSamples = [];
+    const t0 = performance.now();
+    const tick = () => {
+      const el = document.querySelector('.msg-list');
+      if (el) {
+        const m = new DOMMatrixReadOnly(getComputedStyle(el).transform);
+        window.__glideSamples.push({ t: Math.round(performance.now() - t0), ty: Math.round(m.m42 * 10) / 10 });
+      }
+      if (performance.now() - t0 < 1800) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+const nonzero = (c) => c.page.evaluate(() => window.__glideSamples.filter((s) => s.ty !== 0));
+
+// 1) Incoming on B: A sends while B has the chat open.
+await startSampler(b);
+await say(a, b.id, 'incoming glide test — watch me slide in smoothly');
+await waitForMessage(b, a.id, 'incoming glide test');
+await b.page.waitForTimeout(1900);
+console.log('[B incoming] nonzero ty samples:', JSON.stringify(await nonzero(b)));
+
+// 2) Outgoing on A: A's own send should glide on A's screen too.
+await startSampler(a);
+await say(a, b.id, 'outgoing glide test — my own bubble slides in');
+await a.page.waitForTimeout(1900);
+console.log('[A outgoing] nonzero ty samples:', JSON.stringify(await nonzero(a)));
+
+await shot(b, 'glide-b-final');
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/pin-after-send.mjs
+++ b/drive/scenarios/pin-after-send.mjs
@@ -1,0 +1,75 @@
+/**
+ * Repro: "every other message doesn't fully come up when composing and sending" —
+ * send several messages back-to-back through the real composer and, after each
+ * settles (past the 280ms pop + 260ms glide + 600ms backstop), measure:
+ *   - gap: scroll distance still left below (scrollHeight - scrollTop - clientHeight)
+ *   - cut: how far the newest bubble's bottom sticks BELOW the scroll viewport
+ *   - listTy / bubScale: any transform left stuck from the glide/pop
+ *
+ *   node drive/scenarios/pin-after-send.mjs
+ */
+import { createAccount, pair, chatWith, say, waitForMessage, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'PinA', mobile: true });
+const b = await createAccount({ name: 'PinB' });
+await pair(a, b);
+
+for (let i = 1; i <= 8; i++) await say(b, a.id, `seed ${i} — filler so the chat scrolls`);
+await waitForMessage(a, b.id, 'seed 8');
+await a.page.goto(`/chat/${await chatWith(a, b.id)}`);
+await a.page.waitForTimeout(1500);
+
+const ta = a.page.locator('ion-textarea.composer textarea');
+const send = a.page.locator('button[aria-label="Send"]');
+
+// Phase 1: rapid burst — no settle between sends (animations overlap mid-send).
+for (let i = 1; i <= 5; i++) {
+  await ta.fill(`burst ${i} quick fire`);
+  await send.click();
+  await a.page.waitForTimeout(120); // next send lands mid-pop/mid-glide
+}
+await a.page.waitForTimeout(1200);
+const burst = await a.page.evaluate(() => {
+  const content = document.querySelector('.chat-content');
+  const el = content?.shadowRoot?.querySelector('.inner-scroll') ?? content;
+  const list = document.querySelector('.msg-list');
+  const bubbles = document.querySelectorAll('.bubble[data-mid]');
+  const nb = bubbles[bubbles.length - 1];
+  const er = el.getBoundingClientRect();
+  const br = nb?.getBoundingClientRect();
+  const parse = (s) => (s && s.startsWith('matrix') ? new DOMMatrixReadOnly(s) : new DOMMatrixReadOnly());
+  return {
+    gap: Math.round(el.scrollHeight - el.scrollTop - el.clientHeight),
+    cut: br ? Math.round(br.bottom - er.bottom) : null,
+    listTy: Math.round(parse(getComputedStyle(list).transform).m42 * 10) / 10,
+  };
+});
+console.log('[after burst]', JSON.stringify(burst));
+
+// Phase 2: paced sends.
+for (let i = 1; i <= 6; i++) {
+  await ta.click();
+  await ta.fill(`composer send number ${i} with a little bit of length to it`);
+  await send.click();
+  await a.page.waitForTimeout(1000); // past pop+glide+backstop
+  const m = await a.page.evaluate(() => {
+    const content = document.querySelector('.chat-content');
+    const el = content?.shadowRoot?.querySelector('.inner-scroll') ?? content;
+    const list = document.querySelector('.msg-list');
+    const bubbles = document.querySelectorAll('.bubble[data-mid]');
+    const nb = bubbles[bubbles.length - 1];
+    const er = el.getBoundingClientRect();
+    const br = nb?.getBoundingClientRect();
+    const parse = (s) => (s && s.startsWith('matrix') ? new DOMMatrixReadOnly(s) : new DOMMatrixReadOnly());
+    return {
+      gap: Math.round(el.scrollHeight - el.scrollTop - el.clientHeight),
+      cut: br ? Math.round(br.bottom - er.bottom) : null, // >0 = newest bubble sticks below the viewport
+      listTy: Math.round(parse(getComputedStyle(list).transform).m42 * 10) / 10,
+      bubScale: nb ? Math.round(parse(getComputedStyle(nb).transform).a * 100) / 100 : null,
+    };
+  });
+  console.log(`[after send ${i}]`, JSON.stringify(m));
+}
+await shot(a, 'pin-after-send');
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/play-triangle.mjs
+++ b/drive/scenarios/play-triangle.mjs
@@ -1,0 +1,13 @@
+/** Quick look at the video play overlay proportions (custom triangle on 48px disc). */
+import { createAccount, pair, chatWith, sendVideo, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'TriA', mobile: true });
+const b = await createAccount({ name: 'TriB' });
+await pair(a, b);
+const chat = await chatWith(a, b.id);
+await sendVideo(a, chat, 'clip.mp4', 'original');
+await a.page.goto(`/chat/${chat}`);
+await a.page.waitForTimeout(1800);
+await shot(a, 'play-triangle');
+await sweep([a, b]);
+await done();

--- a/drive/scenarios/upload-cloud-progress.mjs
+++ b/drive/scenarios/upload-cloud-progress.mjs
@@ -1,0 +1,97 @@
+/**
+ * In-media upload progress: photos/videos show a cloud waterline in the thumbnail
+ * centre, voice fills its waveform left→right, music fills over the cover, files fill
+ * in the icon slot — and NOTHING about the bubble reflows when the upload completes
+ * (the old bottom bar row used to snap the bubble shorter, spoiling the arrival pop).
+ *
+ * Sends real media, then flips the messages into the uploading state directly (Vite
+ * serves the app's OWN module instances to the page, so media-jobs/idb pokes hit the
+ * live app) at fixed fractions for deterministic screenshots, and asserts bubble rects
+ * are identical in-flight vs done.
+ *
+ *   node drive/scenarios/upload-cloud-progress.mjs
+ */
+import { createAccount, pair, chatWith, poll, sendImage, sendAudio, shot, sweep, done } from '../driver.mjs';
+
+const a = await createAccount({ name: 'CloudA', mobile: true });
+const b = await createAccount({ name: 'CloudB' });
+await pair(a, b);
+const chat = await chatWith(a, b.id);
+
+// One of each media kind through the real send pipeline (tiny fixtures upload instantly,
+// so the flow settles to status 'sent' before we stage the in-flight state ourselves).
+await sendImage(a, chat, 'photo.png', 'hd');
+await sendAudio(a, chat, 'song.mp3', 'Test Song', 'Test Artist');
+await a.page.evaluate((id) => window.__ringTest.seedMedia(id, 'voice', 4096), chat);
+await a.page.evaluate((id) => window.__ringTest.seedMedia(id, 'file', 4096), chat);
+await poll(
+  () => a.page.evaluate((id) => window.__ringTest.listMessages?.(id).then((m) => m.length).catch(() => null) ?? null, chat),
+  () => true, // listMessages may not exist; the real wait is the DOM below
+  { timeout: 1000, every: 300, label: 'settle' },
+).catch(() => {});
+
+await a.page.goto(`/chat/${chat}`);
+await a.page.waitForTimeout(1500);
+
+// Stage the in-flight state: distinct fractions per kind so the screenshot shows the
+// waterline at different levels, and capture each bubble's rect while uploading.
+const during = await a.page.evaluate(async () => {
+  const jobs = await import('/src/services/media-jobs.ts');
+  const idb = await import('/src/db/idb.ts');
+  const msgs = (await idb.getAll('messages')).filter((m) => m.mediaId);
+  const frac = { image: 0.35, audio: 0.6, voice: 0.5, file: 0.8 };
+  for (const m of msgs) {
+    jobs.setUploadProgress(m.id, frac[m.kind] ?? 0.5);
+    m.status = 'compressing';
+    m.updatedAt = Date.now();
+    await idb.put('messages', m);
+  }
+  await new Promise((r) => setTimeout(r, 600)); // let liveQuery + render settle
+  const rects = {};
+  for (const m of msgs) {
+    const el = document.querySelector(`.bubble[data-mid="${CSS.escape(m.id)}"]`);
+    if (el) {
+      const r = el.getBoundingClientRect();
+      rects[m.kind] = { w: Math.round(r.width), h: Math.round(r.height) };
+    }
+  }
+  return {
+    rects,
+    clouds: document.querySelectorAll('.upload-cloud, .chip-cloud, .audio-play .cloud-fill').length,
+    waveFilled: document.querySelectorAll('.vp-bar.played').length,
+    waveTotal: document.querySelectorAll('.vp-bar').length,
+  };
+});
+console.log('[during upload]', JSON.stringify(during));
+await shot(a, 'upload-cloud-during');
+
+// Complete the uploads: clear progress, back to sent — bubbles must not move.
+const after = await a.page.evaluate(async () => {
+  const jobs = await import('/src/services/media-jobs.ts');
+  const idb = await import('/src/db/idb.ts');
+  const msgs = (await idb.getAll('messages')).filter((m) => m.mediaId);
+  for (const m of msgs) {
+    jobs.clearJobProgress(m.id);
+    m.status = 'sent';
+    m.updatedAt = Date.now();
+    await idb.put('messages', m);
+  }
+  await new Promise((r) => setTimeout(r, 600));
+  const rects = {};
+  for (const m of msgs) {
+    const el = document.querySelector(`.bubble[data-mid="${CSS.escape(m.id)}"]`);
+    if (el) {
+      const r = el.getBoundingClientRect();
+      rects[m.kind] = { w: Math.round(r.width), h: Math.round(r.height) };
+    }
+  }
+  return { rects, clouds: document.querySelectorAll('.upload-cloud, .chip-cloud, .audio-play .cloud-fill').length };
+});
+console.log('[after upload]', JSON.stringify(after));
+await shot(a, 'upload-cloud-after');
+
+const same = JSON.stringify(during.rects) === JSON.stringify(after.rects);
+console.log(same ? 'PASS: bubble sizes identical in-flight vs done' : 'FAIL: bubble sizes changed!');
+
+await sweep([a, b]);
+await done();

--- a/specs/1054-pick-emoji-contact/spec.md
+++ b/specs/1054-pick-emoji-contact/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-15
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/components/AudioCard.vue
+++ b/src/components/AudioCard.vue
@@ -3,7 +3,10 @@
     <button type="button" class="audio-cover" :aria-label="playing ? 'Pause' : 'Play'" @click.stop="$emit('toggle')">
       <img v-if="coverUrl" :src="coverUrl" alt="" />
       <ion-icon v-else class="audio-note" :icon="musicalNotes" />
-      <span class="audio-play"><ion-icon :icon="playing ? pause : play" /></span>
+      <!-- Send in flight: the play scrim shows the cloud waterline instead of the glyph;
+           same overlay box, so nothing about the card moves when the upload ends. -->
+      <span v-if="uploadProgress !== undefined" class="audio-play"><cloud-fill :progress="uploadProgress" /></span>
+      <span v-else class="audio-play"><ion-icon :icon="playing ? pause : play" /></span>
     </button>
     <div class="audio-meta">
       <span class="audio-title">{{ title }}</span>
@@ -24,6 +27,7 @@ import { computed } from 'vue';
 import { IonIcon } from '@ionic/vue';
 import { play, pause, musicalNotes } from 'ionicons/icons';
 import SpeedPill from '@/components/SpeedPill.vue';
+import CloudFill from '@/components/CloudFill.vue';
 
 const props = withDefaults(
   defineProps<{
@@ -35,6 +39,7 @@ const props = withDefaults(
     playing?: boolean;
     progress?: number; // 0..1 (only meaningful when active)
     rate?: number; // playback speed of the shared player (only meaningful when active)
+    uploadProgress?: number; // send in flight (sender side): 0..1, undefined = not uploading
   }>(),
   { progress: 0, rate: 1 },
 );

--- a/src/components/CloudFill.vue
+++ b/src/components/CloudFill.vue
@@ -1,0 +1,96 @@
+<template>
+  <!-- Upload progress as a cloud silhouette filling bottom-up: the outline is the empty
+       state, the filled glyph on top is clipped to the progressed fraction. It lives IN
+       the media visual (thumbnail centre, chip icon slot, cover corner) rather than in a
+       bar row of its own, so nothing reflows when the upload finishes and the indicator
+       unmounts — the bubble keeps its exact size throughout (the arrival pop stays put). -->
+  <span
+    class="cloud-fill"
+    role="progressbar"
+    aria-label="Uploading"
+    :aria-valuenow="Math.round(progress * 100)"
+    aria-valuemin="0"
+    aria-valuemax="100"
+  >
+    <ion-icon class="cf-outline" :icon="cloudOutline" aria-hidden="true" />
+    <ion-icon class="cf-fill" :icon="cloud" aria-hidden="true" :style="{ clipPath: clip }" />
+    <!-- Indeterminate orbit around the cloud: slow encodes/uploads can sit at the same
+         waterline for a while, and a static cloud reads as stuck — the spinning arc says
+         "still working" independent of the fill level. -->
+    <svg class="cf-ring" viewBox="0 0 40 40" aria-hidden="true">
+      <circle cx="20" cy="20" r="18.5" pathLength="100" />
+    </svg>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { IonIcon } from '@ionic/vue';
+import { cloud, cloudOutline } from 'ionicons/icons';
+
+const props = defineProps<{ progress: number }>(); // 0..1
+
+// The waterline is relative to the CLOUD SHAPE, not the icon's square box: the ionicons
+// cloud path spans y 80..432 of the 512 viewBox (top 15.6%, height 68.8%). Clipping by raw
+// box percentage would show a 35% upload as a near-full cloud (most of the glyph's ink sits
+// in the lower half of the box); mapping into the glyph band makes the fill read true.
+const GLYPH_TOP = 80 / 512;
+const GLYPH_H = (432 - 80) / 512;
+const clip = computed(() => {
+  const p = Math.max(0, Math.min(1, props.progress));
+  return `inset(${(GLYPH_TOP + (1 - p) * GLYPH_H) * 100}% 0 0 0)`;
+});
+</script>
+
+<style scoped>
+/* Sized by the host's font-size: both glyphs stack in the same 1em box (the filled and
+   outlined ionicons clouds share their geometry, so the fill registers exactly). */
+.cloud-fill {
+  position: relative;
+  display: inline-flex;
+  width: 1em;
+  height: 1em;
+  flex: none;
+}
+.cloud-fill ion-icon {
+  position: absolute;
+  inset: 0;
+  font-size: 1em;
+}
+/* The empty state stays a faint silhouette so the bright fill rising through it reads as
+   a waterline even at chip sizes — same-color outline+fill just looks like a full cloud. */
+.cf-outline {
+  opacity: 0.45;
+}
+/* Progress arrives in bursts from the uploader; a short linear glide between values keeps
+   the waterline rising smoothly instead of stepping. */
+.cf-fill {
+  transition: clip-path 200ms linear;
+}
+/* The orbit circumscribes the cloud at 1.5em — with the standard 28px cloud that's a 42px
+   ring, the diameter the play button's circle used to occupy. Kept spinning even under
+   reduced motion: it's the "still working" status itself, not decoration. */
+.cf-ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1.5em;
+  height: 1.5em;
+  margin: -0.75em 0 0 -0.75em;
+  overflow: visible;
+  animation: cf-spin 1.1s linear infinite;
+}
+.cf-ring circle {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-dasharray: 30 70; /* a ~30% arc orbiting the cloud */
+  opacity: 0.9;
+}
+@keyframes cf-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/components/VoicePlayer.vue
+++ b/src/components/VoicePlayer.vue
@@ -12,7 +12,7 @@
         v-for="(h, i) in bars"
         :key="i"
         class="vp-bar"
-        :class="{ played: (i + 0.5) / bars.length <= progress }"
+        :class="{ played: (i + 0.5) / bars.length <= paint }"
         :style="{ height: barHeight(h) }"
       />
     </div>
@@ -50,6 +50,10 @@ const props = defineProps<{
   // Wall feed: hide the floating controller while THIS inline player is on screen, and reveal it
   // the moment the post is swiped/scrolled out of view (so you don't see both at once).
   floatWhenAway?: boolean;
+  // Send in flight (sender side): 0..1 upload fraction. While defined, the waveform paints
+  // it left→right — the wave itself is the progress indicator — so the bubble needs no
+  // extra progress row (nothing appears/disappears around the player when the send ends).
+  uploadProgress?: number;
 }>();
 
 const BAR_COUNT = 44;
@@ -63,6 +67,8 @@ const total = ref(props.durationSec ?? 0);
 const isActive = computed(() => audioCurId.value === props.mid);
 const playing = computed(() => isActive.value && audioPlaying.value);
 const progress = computed(() => (isActive.value ? audioProgress.value : 0)); // 0..1
+// What the wave paints: the upload waterline while the send is in flight, playback after.
+const paint = computed(() => props.uploadProgress ?? progress.value);
 const elapsed = computed(() => progress.value * total.value);
 const rate = computed(() => audioRate.value);
 

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -159,6 +159,7 @@
             downloadProgress[m.id],
             groupRunStart(i),
             senderAvatar(m.senderId),
+            m.status === 'compressing' ? Math.round(uploadFrac(m) * 50) : -1,
           ]"
           @click="selecting && toggleSelect([m.id])"
         >
@@ -258,7 +259,10 @@
                   alt="gif"
                 />
                 <img v-else-if="mediaInfo[m.mediaId]?.posterUrl" class="bubble-image" :src="mediaInfo[m.mediaId]!.posterUrl" alt="photo" loading="lazy" decoding="async" />
-                <ion-skeleton-text v-else :animated="true" class="media-skel" />              </div>
+                <ion-skeleton-text v-else :animated="true" class="media-skel" />
+                <!-- Send in flight: the cloud waterline in the thumbnail centre (see CloudFill). -->
+                <span v-if="m.status === 'compressing'" class="upload-cloud"><cloud-fill :progress="uploadFrac(m)" /></span>
+              </div>
               <!-- Video: a still thumbnail with a play button. Tapping the poster opens the
                    action menu (whole bubble is the hit target); the play button is the
                    direct affordance to the full-screen viewer. The sender-embedded
@@ -274,8 +278,16 @@
                 />
                 <ion-skeleton-text v-else :animated="true" class="media-skel" />
                 <!-- Visual play affordance only; a tap anywhere on the poster opens
-                     the viewer via the bubble's tap handler. -->
-                <ion-icon class="play-overlay" :icon="playCircle" aria-hidden="true" />              </div>
+                     the viewer via the bubble's tap handler. While the send is in
+                     flight the same centre spot shows the cloud waterline instead. -->
+                <span v-if="m.status === 'compressing'" class="upload-cloud"><cloud-fill :progress="uploadFrac(m)" /></span>
+                <!-- Custom triangle rather than the ionicons glyph: that one is taller than
+                     wide with heavy corner rounding, which reads as a blob at this size.
+                     Near-equilateral, gently rounded corners, optically centred. -->
+                <span v-else class="play-overlay" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M7.5 5.14 19 12 7.5 18.86Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" /></svg>
+                </span>
+              </div>
 
               <!-- Non-square media (round note / voice / audio card / file chip) stays gated
                    on mediaInfo: these are text-height cards with no fixed-square frame, so
@@ -300,6 +312,7 @@
                   :outgoing="m.outgoing"
                   :avatar="!m.outgoing && !chat?.isGroup ? chat?.avatar : undefined"
                   :duration-sec="m.durationSec"
+                  :upload-progress="m.status === 'compressing' ? uploadFrac(m) : undefined"
                 />
                 <!-- Shared audio file (music): track card with cover/title/artist. -->
                 <audio-card
@@ -312,6 +325,7 @@
                   :playing="audioCurId === m.id && audioPlaying"
                   :progress="audioCurId === m.id ? audioProgress : 0"
                   :rate="audioRate"
+                  :upload-progress="m.status === 'compressing' ? uploadFrac(m) : undefined"
                   @toggle="toggleAudio(m.id)"
                   @seek="(f) => seekAudio(m.id, f)"
                   @cycle-speed="cycleAudioRate"
@@ -323,7 +337,9 @@
                   :download="mediaInfo[m.mediaId].name"
                   @click.stop
                 >
-                  <ion-icon :icon="documentOutline" />
+                  <!-- Send in flight: the document glyph gives its slot to the cloud waterline. -->
+                  <cloud-fill v-if="m.status === 'compressing'" class="chip-cloud" :progress="uploadFrac(m)" />
+                  <ion-icon v-else :icon="documentOutline" />
                   <span>{{ mediaInfo[m.mediaId].name }}</span>
                 </a>
               </template>
@@ -481,19 +497,9 @@
                   :animate="animEmoji"
                   :large="emojiBig(m.body)"
                 /><template v-else>{{ p.text }}</template></template></span>
-              <!-- Background job: separate encode + upload progress bars. -->
-              <div v-if="m.status === 'compressing'" class="job-progress">
-                <div v-if="m.mediaQuality && m.mediaQuality !== 'original'" class="job-row">
-                  <span class="job-label">Encoding</span>
-                  <span class="job-track"><span class="job-fill" :style="{ width: jobPct(m.id, 'compress') }" /></span>
-                  <span class="job-num">{{ jobPct(m.id, 'compress') }}</span>
-                </div>
-                <div class="job-row">
-                  <span class="job-label">Uploading</span>
-                  <span class="job-track"><span class="job-fill" :style="{ width: jobPct(m.id, 'upload') }" /></span>
-                  <span class="job-num">{{ jobPct(m.id, 'upload') }}</span>
-                </div>
-              </div>
+              <!-- In-flight send progress lives INSIDE each media visual (cloud waterline on
+                   thumbnails/chips, the waveform fill for voice) — never as a bar row below,
+                   which would grow the bubble and then snap it shorter when the upload ends. -->
               <!-- Media facts (quality · resolution · size) live in Message info now
                    (long-press → Message info), not on the bubble. -->
               <!-- Direction-aware foot: react button opposite the timestamp; sent →
@@ -1205,6 +1211,7 @@ import PollComposer from '@/components/PollComposer.vue';
 import ContactPicker from '@/components/ContactPicker.vue';
 import LocationComposer from '@/components/LocationComposer.vue';
 import AudioCard from '@/components/AudioCard.vue';
+import CloudFill from '@/components/CloudFill.vue';
 import SpeedPill from '@/components/SpeedPill.vue';
 import { nextRate, playWhenReady } from '@/utils/playback';
 import AudioReview from '@/components/AudioReview.vue';
@@ -1381,9 +1388,13 @@ function dlSizeLabel(m: Message): string {
 }
 
 
-// Encode / upload progress as a "42%" string for the in-flight bars.
-function jobPct(id: string, phase: 'compress' | 'upload'): string {
-  return `${Math.round((jobProgress[id]?.[phase] ?? 0) * 100)}%`;
+// One 0..1 for the whole in-flight job, driving the cloud/waveform fill: when this media
+// gets transcoded first, encoding occupies the first half and upload the second (a single
+// monotonic waterline, no reset halfway); upload-only media map 1:1.
+function uploadFrac(m: Message): number {
+  const j = jobProgress[m.id];
+  if (!j) return 0;
+  return m.mediaQuality && m.mediaQuality !== 'original' ? (j.compress + j.upload) / 2 : j.upload;
 }
 
 function statusIcon(status: MessageStatus) {
@@ -3025,6 +3036,19 @@ function observeScroll(): void {
     setupWindowSentinels(el);
     setupBubbleObserver(el); // spec 1013: per-bubble ≥50% visibility → Seen
   });
+  // iOS PWA keyboard hole: the on-screen keyboard often shrinks only the VISUAL viewport —
+  // no layout resize, so the ResizeObserver above never fires — and the pinned bottom
+  // (newest messages) ends up behind the keyboard. The visualViewport resize is the one
+  // signal that always accompanies the keyboard; re-pin on it under the same
+  // momentum-quiet guard. Registration is idempotent (named handler, add after remove).
+  if (window.visualViewport) {
+    window.visualViewport.removeEventListener('resize', onVisualViewportResize);
+    window.visualViewport.addEventListener('resize', onVisualViewportResize);
+  }
+}
+function onVisualViewportResize(): void {
+  if (stickBottom && !shouldDeferScrollWrite(Date.now(), lastScrollAt, MOMENTUM_QUIET_MS))
+    void scrollToNewest();
 }
 
 // Look-ahead prefetch: an IntersectionObserver rooted on the scroll element with
@@ -3139,6 +3163,7 @@ onMounted(() => {
 onUnmounted(() => {
   void persistDraft(); // leaving the chat → keep the unsent message for next time
   document.removeEventListener('visibilitychange', onVisibilityChange);
+  window.visualViewport?.removeEventListener('resize', onVisualViewportResize);
   clearTimeout(headerReadyFallback);
   clearTimeout(listReadyFallback);
   resizeObs?.disconnect();
@@ -3293,9 +3318,23 @@ function reseedTopPad(): void {
 // already pinned there (stickBottom) or it's our own send, never while reading history. The
 // first populated load reveals the list once scrolled to newest (no flash of the oldest).
 let didInitialLoad = false;
+// The on-screen top of a rendered bubble, for the arrival-glide shift measurement. Rect-based so
+// it reflects exactly what the user sees (spacer rebases and window trims cancel out of the
+// before/after difference).
+function bubbleTop(id: string | undefined): number | undefined {
+  if (!id) return undefined;
+  return listEl.value
+    ?.querySelector<HTMLElement>(`.bubble[data-mid="${CSS.escape(id)}"]`)
+    ?.getBoundingClientRect().top;
+}
 watch(
   () => rows.value[rows.value.length - 1]?.id,
   async (newestId, prevId) => {
+    // Captured synchronously, before this pre-flush watcher yields and the new row renders:
+    // where the previous newest bubble sat, and whether the window even holds the true bottom.
+    // The arrival glide below needs the before/after difference.
+    const prevTopBefore = bubbleTop(prevId);
+    const hadNewer = history.hasNewer.value;
     markChatSeenIfVisible();
     if (!didInitialLoad) {
       didInitialLoad = true;
@@ -3324,7 +3363,19 @@ watch(
     if (search.value || !newestId || newestId === prevId) return; // not a new bottom message
     if (seeking) return; // a seek is swapping the window — don't yank back to the newest
     const newest = rows.value[rows.value.length - 1];
-    if (newest?.outgoing || stickBottom) await scrollToNewest();
+    if (newest?.outgoing || stickBottom) {
+      await scrollToNewest();
+      // The new bubble pops in from the corner nearest its side; independent of the glide
+      // below so it also runs when there's no previous bubble to measure (first message).
+      popNewestIn(newestId, !!newest?.outgoing);
+      // Arrival glide: how far did the previous newest bubble jump up? (New row + any day
+      // divider, and in the pinned case the scrollTop snap — the rect difference captures it
+      // all.) Skip when the window was swapped in from elsewhere (hadNewer): that's a jump to
+      // the bottom of the chat, not an arrival.
+      const prevTopAfter = bubbleTop(prevId);
+      if (!hadNewer && prevTopBefore !== undefined && prevTopAfter !== undefined)
+        glideNewestIn(prevTopBefore - prevTopAfter);
+    }
   },
 );
 // Search reloads the run; re-seed the spacer for the fresh result set.
@@ -3799,6 +3850,84 @@ async function scrollToNewest(): Promise<void> {
   // We're at the newest now → hide the control (the count clears itself as the now-visible bottom
   // messages get reported Seen by the visibility observer).
   jumpVisible.value = false;
+}
+
+// ---- arrival glide ----
+// When a new bottom message lands while we're following the newest (an incoming message with the
+// chat open, or our own send), the append + scrollToNewest snap repaints the conversation shifted
+// up by the new row's height in a single frame — the bubble pops in with a visible jump. To make
+// it glide instead (the WhatsApp arrival animation), translate the list back DOWN by exactly the
+// measured shift right after the snap — that frame paints pixel-identical to the pre-append one —
+// then ease the transform to 0: the whole conversation slides up together and the new bubble
+// emerges from behind the composer. Works for short (bottom-anchored) chats too, where the same
+// append pushes the previous bubbles up with no scrollTop involved. Transform-only and composited:
+// layout, scroll metrics, and the spacer/anchor machinery never see it.
+let glideCleanup: (() => void) | null = null;
+function glideNewestIn(delta: number): void {
+  const list = listEl.value;
+  const el = scrollEl;
+  if (!list || !el || !(delta > 2) || document.hidden) return;
+  if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  // Tall media can add most of a screen; cap the travel so the glide reads as a beat, not a tour.
+  const cap = Math.round(el.clientHeight * 0.85);
+  let from = Math.min(Math.round(delta), cap);
+  // Burst of messages mid-glide: the list is still translated — start from the current offset
+  // plus the new shift so consecutive arrivals stack into one continuous motion (no teleport).
+  const ty = new DOMMatrixReadOnly(getComputedStyle(list).transform).m42;
+  if (ty > 0) from = Math.min(from + Math.round(ty), cap);
+  glideCleanup?.();
+  list.style.transition = 'none';
+  list.style.transform = `translateY(${from}px)`;
+  list.style.willChange = 'transform';
+  void list.offsetHeight; // commit the start frame, so the transition below actually runs
+  list.style.transition = 'transform 260ms cubic-bezier(0.2, 0.85, 0.3, 1)';
+  list.style.transform = 'translateY(0)';
+  const done = (e?: TransitionEvent) => {
+    if (e && (e.target !== list || e.propertyName !== 'transform')) return; // a child's transition bubbling up
+    clearTimeout(backstop);
+    list.removeEventListener('transitionend', done);
+    list.style.transition = '';
+    list.style.transform = '';
+    list.style.willChange = '';
+    if (glideCleanup === done) glideCleanup = null;
+    // Assurance pin: if the keyboard/composer resized mid-glide, the snap we took before
+    // animating may be stale — re-assert the bottom now that the transform is gone.
+    if (stickBottom && scrollEl) scrollEl.scrollTop = scrollEl.scrollHeight;
+  };
+  // transitionend is lossy (backgrounded tab, display flip mid-run) — always settle.
+  const backstop = setTimeout(done, 600);
+  list.addEventListener('transitionend', done);
+  glideCleanup = done;
+}
+onUnmounted(() => glideCleanup?.());
+
+// The bubble pop: the new bubble grows from the corner it "comes from" — scale 0 up to a
+// slight overshoot past full size, then settles back to 1 (the overshoot is in the easing
+// curve). Own sends grow from their bottom-RIGHT corner (out of the composer); incoming
+// mirrors from the bottom-LEFT. Runs alongside the list glide: the glide carries the
+// vertical shift of the conversation, the pop is the new bubble's arrival. WAAPI, so it
+// never touches Vue-managed style state and self-cleans on unmount/re-render.
+function popNewestIn(id: string, outgoing: boolean): void {
+  const bubble = listEl.value?.querySelector<HTMLElement>(`.bubble[data-mid="${CSS.escape(id)}"]`);
+  if (!bubble || document.hidden) return;
+  if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  bubble.style.transformOrigin = outgoing ? 'bottom right' : 'bottom left';
+  // The overshoot is a fixed ~12px of edge travel, not a fixed percentage: 10% past full
+  // size feels right on a 40px text bubble but lurches a 340px photo by 30+px. Deriving
+  // the peak from the bubble's height keeps the bounce ENERGY constant across sizes
+  // (small bubbles pop ~1.1, a full-width photo barely ~1.03).
+  const peak = 1 + Math.min(0.1, 12 / Math.max(1, bubble.getBoundingClientRect().height));
+  const anim = bubble.animate(
+    [
+      { transform: 'scale(0)', easing: 'cubic-bezier(0.2, 0.9, 0.3, 1)' },
+      { transform: `scale(${peak})`, offset: 0.72, easing: 'cubic-bezier(0.33, 0, 0.67, 1)' },
+      { transform: 'scale(1)' },
+    ],
+    { duration: 280 },
+  );
+  anim.onfinish = anim.oncancel = () => {
+    bubble.style.transformOrigin = '';
+  };
 }
 // Within ~120px of the bottom counts as "pinned to newest". Defaults to true before
 // the scroll element resolves (a fresh chat opens pinned to newest).
@@ -5216,43 +5345,34 @@ function cancelRecording() {
   font-size: 24px;
   cursor: pointer;
 }
-/* Background job: labelled encode + upload progress bars. */
-.job-progress {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  margin: 4px 0 2px;
-}
-.job-row {
+/* Send-in-flight cloud waterline, centred on a photo/video thumbnail: the same dark
+   48px disc as the download button (.dl-btn) so upload and download read as one family.
+   Purely indicative — taps pass through to the bubble as usual. */
+.upload-cloud {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.42);
+  color: #fff;
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 11px;
-  color: var(--app-text-muted);
+  justify-content: center;
+  font-size: 24px;
+  pointer-events: none;
 }
-.job-label {
+/* The compact variant living in a file chip's icon slot. Both the document glyph and
+   the cloud get the SAME fixed box so the swap between them never moves the chip. */
+.file-chip > ion-icon,
+.chip-cloud {
+  font-size: 18px;
   flex: none;
-  width: 56px;
 }
-.job-track {
-  flex: 1;
-  height: 4px;
-  border-radius: 2px;
-  background: rgba(0, 0, 0, 0.14);
-  overflow: hidden;
-}
-.job-fill {
-  display: block;
-  height: 100%;
-  border-radius: 2px;
-  background: var(--ion-color-primary);
-  transition: width 0.2s ease;
-}
-.job-num {
-  flex: none;
-  width: 34px;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
+.chip-cloud {
+  color: var(--ion-color-primary);
 }
 /* Wrapper so a photo can overlay its quality/size badge. */
 /* Fixed media frame: image/video bubbles are a constant square, so every media row
@@ -5927,18 +6047,26 @@ function cancelRecording() {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 56px;
-  height: 56px;
+  width: 48px;
+  height: 48px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 40px;
   color: #fff;
   background: rgba(0, 0, 0, 0.42);
   border-radius: 50%;
   filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.5));
   /* Visual only — the whole poster is the tap target (handled on the bubble). */
   pointer-events: none;
+}
+/* The triangle, proportioned like the media viewer's centre play (VideoPlayer .vid-play:
+   ~21px of glyph ink on a 64px disc): the path's ink spans 11.5/24 of this box, so 33px
+   yields ~16×19px of ink on the 48px disc — the same disc:triangle ratio. Nudged right
+   onto the optical centre (a right-pointing triangle's mass sits left of its box centre). */
+.play-overlay svg {
+  width: 33px;
+  height: 33px;
+  margin-inline-start: 3px;
 }
 .bubble-audio {
   width: 240px;


### PR DESCRIPTION
## What

**Arrival animation** (outgoing + incoming): when a new message lands while the chat is open, the conversation glides up smoothly and the new bubble scales in from the corner nearest the composer — bottom-right for own sends, mirrored bottom-left for incoming — overshooting slightly past full size before settling. The overshoot is a constant ~12px of edge travel (derived from bubble height), so a full-width photo lands as calmly as a one-line text. Everything is transform-only: a translate on the list cancels the scroll snap and a WAAPI scale animates the bubble, so the spacer/anchor machinery, iOS momentum, and Seen reporting are untouched. Skipped under `prefers-reduced-motion`.

**In-media upload progress** — the old encode/upload bar rows grew the bubble and snapped it shorter on completion, spoiling the arrival:
- Photos/videos: a cloud waterline (new `CloudFill.vue`) filling bottom-up in the thumbnail centre, with an orbiting arc so slow encodes/uploads still visibly work; the fill is calibrated to the cloud glyph's ink, and transcoded sends map encoding to the first half (one monotonic fill)
- Voice: the waveform itself paints left→right with the upload
- Music: the cloud fills over the cover art; files: in the document icon's slot
- Bubble geometry is pixel-identical in-flight vs done (drive-verified rects)

**Video play affordance**: crisp custom triangle on the 48px disc, proportioned like the media viewer's centre play button.

**Keyboard pin fixes** so no message ever rests behind the composer/keyboard:
- Re-pin on `visualViewport` resize — iOS keyboards often shrink only the visual viewport, so the existing layout ResizeObserver never fired
- Re-assert the bottom pin when the arrival glide settles, in case the composer resized mid-animation

## Testing

- `npm run build` green (typecheck + build)
- Scroll-sensitive e2e suites (`chat-media-scroll`, `seen-on-view`, `all-media-goto`) pass locally
- New drive scenarios: frame-by-frame transform sampling of glide + pop (test-hook and real-composer send paths), upload-state rendering for all four media kinds with no-reflow rect assertions, and post-send pin integrity incl. rapid bursts
- Verified on-device (iPhone, ring-dev) across nine iteration rounds: text/location/contact/poll/media arrivals, upload cloud + waveform, play-button proportions, and keyboard-open composing

Also rides along: spec 1054 status flipped to shipped + regenerated ROADMAP (housekeeping from PR #1012).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQh9a1XQWPXf4XdHdLk4w7