### PR TITLE
chore: issue triage — close #921/#680/#523/#524/#525

### DIFF
--- a/e2e/tap-entities.spec.ts
+++ b/e2e/tap-entities.spec.ts
@@ -2,10 +2,11 @@ import { test, expect } from '@playwright/test';
 import { createAccount, pair } from './helpers';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// Spec 1029 — a phone number and an email in a received message render as tappable
-// entities; tapping opens the OS-handoff action sheet; Copy places the value on the
-// clipboard (native tel:/sms:/mailto: launch itself isn't invocable headless, so we
-// assert the rendered hrefs + the action menu + the copy confirmation).
+// Spec 1029 — a phone number and an email in a received message (or a Wall post body,
+// US1/US2) render as tappable entities; tapping opens the OS-handoff action sheet; Copy
+// places the value on the clipboard (native tel:/sms:/mailto: launch itself isn't
+// invocable headless, so we assert the rendered hrefs + the action menu + the copy
+// confirmation).
 
 test('phone + email in a message render tappable with the right actions (US1/US2)', async ({ browser }) => {
   test.setTimeout(90_000);
@@ -57,4 +58,30 @@ test('phone + email in a message render tappable with the right actions (US1/US2
   await expect(emailSheet).toBeVisible({ timeout: 10_000 });
   await expect(emailSheet.locator('.action-sheet-button', { hasText: 'Email' })).toBeVisible();
   await expect(emailSheet.locator('.action-sheet-button', { hasText: 'Call' })).toHaveCount(0);
+});
+
+test('phone + email in a Wall post render tappable (US1/US2)', async ({ browser }) => {
+  test.setTimeout(90_000);
+  const a = await createAccount(await browser.newContext(), 'ENT03');
+  const b = await createAccount(await browser.newContext(), 'ENT04');
+  await pair(a, b); // a friends-audience post needs an audience to post to
+
+  const body = 'reach me on +1 415 555 0134 or hi@example.com anytime';
+  const id = await a.page.evaluate((t) => (window as any).__ringTest.post({ body: t, audience: 'friends' }), body);
+
+  await a.page.goto(`/wall/post/${id}`);
+  const phone = a.page.locator('.wrap .body a.entity-link[href^="tel:"]');
+  const email = a.page.locator('.wrap .body a.entity-link[href^="mailto:"]');
+  await expect(phone).toBeVisible({ timeout: 20_000 });
+  await expect(email).toBeVisible();
+  await expect(phone).toHaveAttribute('href', 'tel:+14155550134');
+  await expect(email).toHaveAttribute('href', 'mailto:hi@example.com');
+
+  // Tapping either opens the same OS-handoff action sheet as in messages.
+  await phone.click();
+  const sheet = a.page.locator('ion-action-sheet');
+  await expect(sheet).toBeVisible({ timeout: 10_000 });
+  for (const label of ['Call', 'Message', 'Copy']) {
+    await expect(sheet.locator('.action-sheet-button', { hasText: label })).toBeVisible();
+  }
 });

--- a/specs/1019-hidden-chats-pin/tasks.md
+++ b/specs/1019-hidden-chats-pin/tasks.md
@@ -155,9 +155,9 @@ tab; incoming call shows a generic caller.
 **Independent test**: Enable biometrics → reveal without typing the PIN; on
 failure/unsupported, PIN still works.
 
-- [ ] T034 [P] [US6] Unit test `src/composables/useHiddenChats.test.ts`: `revealWithBiometric()` reveals when enabled+available, falls back to PIN on failure/cancel, and the option is inert when unsupported (US6 AC1–AC3); biometrics never replace the PIN (FR-011).
-- [ ] T035 [US6] **Spike first** (resolves analyze finding U1): determine whether the app already has a device-auth/biometric primitive (e.g., used by app-lock / `useAutoLock`). Then implement `revealWithBiometric()` in `src/composables/useHiddenChats.ts` reusing it if present, else the platform credential prompt (WebAuthn), gated by `privacy.hiddenChatsBiometric`; PIN fallback always works (FR-011). Makes T034 pass.
-- [ ] T036 [US6] Add the biometric toggle row (`privacy.hiddenChatsBiometric`, default false) to `src/settings/schema.ts`, disabled/hidden when the device lacks support (FR-011/FR-013).
+- [~] T034 [P] [US6] WON'T DO — biometric unlock isn't a priority for hidden chats; PIN-only stays the permanent design (#523).
+- [~] T035 [US6] WON'T DO (#524).
+- [~] T036 [US6] WON'T DO (#525).
 
 **Checkpoint**: Biometric convenience layer works; PIN remains authoritative.
 

--- a/specs/1029-tap-phone-and-email/tasks.md
+++ b/specs/1029-tap-phone-and-email/tasks.md
@@ -26,7 +26,7 @@ correctness); the render/action integration gets a lean e2e. No crypto/ZK checkl
 ## Phase 4: User Story 1 & 2 — Wall posts (P1)
 
 - [x] T007 (#679) [US1][US2] Add `segmentContacts` detection to `src/components/EmojiText.vue` (before emoji segmentation) so posts + comments render tappable phone/email → `presentEntityActions`; keep emoji-only rendering otherwise unchanged
-- [ ] T008 (#680) [P] [US1][US2] Extend the e2e (or a drive scenario) to cover a Wall post body with a phone + email rendering tappable
+- [x] T008 (#680) [P] [US1][US2] Extend the e2e (or a drive scenario) to cover a Wall post body with a phone + email rendering tappable
 
 ## Phase 5: Polish & gates
 

--- a/specs/2023-push-wakes-always/tasks.md
+++ b/specs/2023-push-wakes-always/tasks.md
@@ -173,7 +173,7 @@ closed, each pinned by a unit test on its pure half.
       per the plan's documented Principle-III deviation (Playwright cannot
       deliver Web Push to the SW); the existing notification e2e suites run
       in CI on push and must stay green
-- [ ] T014 Real-device validation per quickstart.md on the dev iPhone
+- [X] T014 Real-device validation per quickstart.md on the dev iPhone
       (SC-004): foreground + severed socket, 5+ pushes, every wake visible,
       subscription alive afterward — MANUAL, requires the physical device;
       may complete after the PR opens


### PR DESCRIPTION
## Summary
- Spec 2023 T014 (real-device push validation, SC-004): confirmed done on the dev iPhone — closes #921.
- Spec 1029 T008: adds the missing e2e coverage for tappable phone/email in a Wall post body — closes #680.
- Spec 1019 US6 (biometric unlock for hidden chats, T034-T036): marked won't-do — PIN-only stays the permanent design — closes #523, closes #524, closes #525.

## Test plan
- [x] `npm run build`
- [x] `npx playwright test e2e/tap-entities.spec.ts` (both cases green, including the new Wall post case)