### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",


### PR DESCRIPTION
## Summary
- Bumps `package.json`/`package-lock.json` version 0.3.0 -> 1.0.0.
- RC1 (`ghcr.io/zuptalo/ring:1.0.0-rc.1`) has soaked cleanly on the production k3s cluster (confirmed working).
- Once this merges into `develop`, the follow-up is a `develop -> main` PR to actually cut the v1.0.0 release.

## Test plan
- [x] `npm run build`