### PR TITLE
ci: fix release-guard crash and paths-filter 404 on the first release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # Empty token forces local git-based diffing instead of the GitHub REST
+          # API's listFiles endpoint. The API path 404s on a PR with a very large
+          # diff (seen on the first-ever develop -> main release PR, 1000+ files
+          # since main starts nearly empty) — git diff has no such limit and we
+          # already have full history via fetch-depth: 0 above.
+          token: ''
           # `code` is true when ANY path the heavy jobs cover changed. If nothing
           # here matched, the change is docs/specs/tooling-only and verify is skipped.
           filters: |
@@ -102,7 +108,13 @@ jobs:
 
           head_ver=$(node -p "require('./package.json').version")
           git fetch --quiet origin main
-          base_ver=$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync(0)).version")
+          # main won't have a package.json at all before the very first release —
+          # treat that as version 0.0.0 rather than letting `git show` fail the job.
+          if git cat-file -e origin/main:package.json 2>/dev/null; then
+            base_ver=$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync(0)).version")
+          else
+            base_ver="0.0.0"
+          fi
           echo "head (this PR) version: $head_ver"
           echo "base (main) version:    $base_ver"
 


### PR DESCRIPTION
## Summary
The open v1.0.0 release PR (#1018) is the first-ever develop -> main merge, and it exposed two bugs that only a truly first release triggers:

- `release-guard`'s version check crashed (`git show origin/main:package.json` is fatal) because `main` has no `package.json` yet (it's the untouched `chore: initialize repository` scaffold). Now treats a missing `package.json` on `main` as version `0.0.0`.
- `dorny/paths-filter`'s default GitHub-API-based diff 404s on #1018 specifically because `main` starts nearly empty, so the diff looks like 1,376 new files to the API (confirmed by hitting `GET /repos/zuptalo/ring/pulls/1018/files` directly — it 404s with GitHub's generic error page, reproducibly, not transient). Setting `token: ''` forces local git-based diffing instead, which has no such limit.

Both are permanent, reusable fixes to the CI scripts, not one-off workarounds — they'll only matter for this one release going forward (every later release PR is a small incremental diff against a populated `main`), but they belong in the workflow rather than being special-cased away.

## Test plan
- [x] Reasoned through the shell logic locally (`sort -V` comparison against `base_ver=0.0.0` correctly passes for `1.0.0`)
- [x] Confirmed the `pulls/1018/files` API 404 independently via `gh api`
- [ ] Once merged into `develop`, PR #1018 (head = `develop`) picks up the fix automatically and its checks re-run