### PR TITLE
ci: fix release trigger + develop sync-back, and cut redundant develop-push e2e

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: write # github-actions[bot] performs the eventual merge
   pull-requests: write # enable auto-merge on the PR
+  actions: write # dispatch release.yml after the merge (see below)
 
 jobs:
   enable-auto-merge:
@@ -38,3 +39,30 @@ jobs:
           gh pr merge "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --auto --merge
+
+      # GitHub deliberately does not let a push made with the run's own GITHUB_TOKEN
+      # trigger other workflows (anti-infinite-loop safeguard) — so once GitHub's
+      # platform completes the auto-merge above, release.yml's `push: branches:
+      # [main]` never fires. workflow_dispatch IS exempt from that suppression even
+      # when called with GITHUB_TOKEN, so: poll until the PR actually merges, then
+      # explicitly dispatch release.yml. (First hit + full writeup: the v1.0.0 cut.)
+      - name: Wait for the merge, then dispatch the release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # ~60 minutes at 20s/poll — comfortably past the slowest observed e2e run.
+          for i in $(seq 1 180); do
+            state=$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json state -q .state)
+            if [ "$state" = "MERGED" ]; then
+              echo "PR merged — dispatching release.yml on main"
+              gh workflow run release.yml --repo "${{ github.repository }}" --ref main
+              exit 0
+            fi
+            if [ "$state" = "CLOSED" ]; then
+              echo "PR closed without merging — nothing to dispatch"
+              exit 0
+            fi
+            sleep 20
+          done
+          echo "::warning::Timed out waiting for the PR to merge; release.yml was not dispatched. Run it manually: gh workflow run release.yml --ref main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,17 +66,18 @@ jobs:
               - '.dockerignore'
               - '.github/workflows/**'
 
-  # The full build + test suite. Path-filtering gates it on BOTH PRs and develop
-  # pushes: a doc/spec/tooling-only change (markdown, specs/, .specify/, ROADMAP.md,
-  # scripts/) skips the heavy suite — and, because the develop image job chains off
-  # `verify`, also skips the image rebuild — since the built app is byte-identical to
-  # the previous commit. The always-on roadmap guard is the real gate for those.
-  # Anything in app/server/e2e/deps/configs/Dockerfile/workflows still runs the full
-  # suite. `workflow_dispatch` ALWAYS runs it, so a manual run reliably republishes
-  # the develop image even when nothing code-relevant changed.
+  # The full build + test suite. It runs where its result actually GATES something:
+  # on PRs (it must pass before the PR can merge) and on manual workflow_dispatch.
+  # It deliberately does NOT run on a push to develop: `develop` requires "branches
+  # up to date" + a PR to merge, so the PR just tested `latest-develop + changes`,
+  # and the post-merge develop tip is the identical tree — re-running the ~33-min
+  # e2e suite there would produce a known result and gate nothing. (The develop
+  # image still publishes on that push; see develop-image below, which now builds
+  # from source directly rather than waiting on this re-run.) Path-filtering still
+  # skips even the PR run for doc/spec/tooling-only changes.
   verify:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.changes.outputs.code == 'true') }}
     uses: ./.github/workflows/build-test.yml
 
   # Gate the one merge that actually ships: a PR into main must carry a version
@@ -185,12 +186,18 @@ jobs:
 
   develop-image:
     name: Publish develop image
-    needs: verify
+    needs: changes
     # On a real push to develop, or a manual dispatch, never on PRs (no image from
-    # untrusted forks, and PRs only need the green checks above).
+    # untrusted forks, and PRs only need the green checks above). Depends on `changes`
+    # (not `verify`) so publishing the develop image no longer waits on a redundant
+    # e2e re-run — the merged code already passed the suite on its PR. The docker
+    # build below still compiles client + server, so a broken tree can't publish.
+    # A docs-only push (code == false) skips this: the built app is byte-identical.
+    # A manual dispatch always republishes (even docs-only), the escape hatch for a
+    # stale :develop tag.
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ name: Release
 on:
   push:
     branches: [main]
+  # A GITHUB_TOKEN-authored push (e.g. auto-merge-release.yml's auto-merge) doesn't
+  # trigger the push event above (anti-infinite-loop safeguard) — workflow_dispatch
+  # is exempt from that, so auto-merge-release.yml calls this explicitly once a
+  # release PR actually merges. Also handy for a manual re-run.
+  workflow_dispatch:
 
 concurrency:
   group: release-main
@@ -31,6 +36,9 @@ jobs:
     permissions:
       contents: write # create the tag + the GitHub release
       packages: write # push the production image to GHCR
+    outputs:
+      exists: ${{ steps.check.outputs.exists }}
+      tag: ${{ steps.ver.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -148,3 +156,60 @@ jobs:
             --title "${{ steps.ver.outputs.tag }}" \
             --target "${{ github.sha }}" \
             --notes-file release-notes.md
+
+  # GitFlow's usual "merge main back into develop" after a release — main's tip is
+  # a merge commit that only exists on main, so without this, develop never gets
+  # the release folded into its own ancestry (the tag stays unreachable from it,
+  # and the two branches' merge-base drifts a little further apart every release).
+  # develop requires linear history, so a real merge commit can't land there
+  # directly; this goes through a normal squash-merged PR instead.
+  #
+  # In this repo's flow main NEVER carries content develop doesn't already have
+  # (everything reaches main only via a develop -> main release PR), so the diff
+  # is expected to be empty — auto-merge only fires in that verified-empty case.
+  # If main ever does carry something new (e.g. a future direct hotfix), the PR
+  # is still opened but left for manual review rather than auto-merged blind.
+  sync-develop:
+    name: Sync develop with main
+    needs: release
+    if: needs.release.result == 'success' && needs.release.outputs.exists == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Open (and auto-merge, if empty) a develop sync PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch origin develop main --quiet
+
+          if git diff --quiet origin/develop origin/main; then
+            empty=true
+          else
+            empty=false
+          fi
+
+          branch="chore/sync-develop-post-${{ needs.release.outputs.tag }}"
+          git push origin "refs/remotes/origin/main:refs/heads/$branch"
+
+          body="Automated post-release sync so develop's ancestry includes the ${{ needs.release.outputs.tag }} release merge commit."
+          if [ "$empty" = "true" ]; then
+            body="$body Content-empty (the expected case) — auto-merging."
+          else
+            body="$body This PR has REAL file changes, meaning main has content develop doesn't. Needs manual review before merging."
+          fi
+
+          pr_url=$(gh pr create --base develop --head "$branch" \
+            --title "chore: sync develop with main after ${{ needs.release.outputs.tag }}" \
+            --body "$body")
+
+          if [ "$empty" = "true" ]; then
+            gh pr merge --squash --auto --delete-branch "$pr_url"
+          else
+            echo "::warning::$pr_url is non-empty — left open for manual review, not auto-merged."
+          fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",


### PR DESCRIPTION
Three release-pipeline fixes plus the v1.0.1 bump, all surfaced by (or discussed during) the first-ever v1.0.0 cut.

## 1. release.yml never fired after auto-merge
The `develop -> main` release PR auto-merged fine, but `release.yml` (tag + image + GitHub release) never ran — a push authored by a workflow's own `GITHUB_TOKEN` can't trigger another workflow (GitHub's anti-infinite-loop safeguard). So v1.0.0's code landed on `main` but no tag/image/release was ever published.

**Fix:** `auto-merge-release.yml` now waits for the PR to actually merge, then explicitly `gh workflow run release.yml --ref main`. `workflow_dispatch` IS exempt from the token-suppression rule, so this works. `release.yml` gains a `workflow_dispatch` trigger (also useful for a manual re-run).

## 2. develop never got main's release merge commit back
After a release, `main`'s tip is a merge commit that only exists on `main` — `develop`'s ancestry never included it, so the release tag stayed unreachable from `develop` and the branches' merge-base drifted a little further apart each release.

**Fix:** a new `sync-develop` job in `release.yml` opens a post-release PR (`main -> develop`) and, in the expected content-empty case, auto-merges it (squash, since `develop` requires linear history). If `main` ever carries content `develop` doesn't (e.g. a future direct hotfix), the PR is opened but **left for manual review**, not auto-merged blind.

## 3. Redundant full e2e on every develop push
`develop` requires "branches up to date" + a PR to merge, so a merged PR already tested `latest-develop + changes`, and the post-merge `develop` tip is the identical tree. Re-running the ~33-min e2e suite on that push gated nothing.

**Fix:** `verify` no longer runs on `develop` pushes (still runs on PRs, releases, RCs, and manual dispatch). The `:develop` image now publishes off a direct source build (which still compiles client + server, so a broken tree can't publish) instead of chaining off the redundant re-run. Net: ~one full suite saved per merge, no coverage lost.

## 4. Version bump to 1.0.1
v1.0.0's artifacts were never published (bug #1). `main`'s branch protection requires a version bump on every incoming PR, so this ships as `1.0.1` — the first fully-published release, identical app code plus these CI fixes.

## Test plan
- [x] All three workflow files parse as valid YAML
- [x] `npm run build` (version bump baked into `__APP_VERSION__`)
- [ ] Real end-to-end proof comes when this merges and the next `develop -> main` release PR exercises the full corrected pipeline