### PR TITLE
ci: drop auto-bump job, document manual version bump, upgrade actions off Node 20

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,15 +14,15 @@ jobs:
     name: Client (typecheck + build)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       # `npm run build` is `vue-tsc --noEmit && vite build`: typecheck then bundle.
       - run: npm run build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: web-dist
           path: dist
@@ -32,8 +32,8 @@ jobs:
     name: Client (unit tests)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -49,8 +49,8 @@ jobs:
       run:
         working-directory: server
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache-dependency-path: server/go.sum
@@ -77,12 +77,12 @@ jobs:
     name: End-to-end (Playwright)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache-dependency-path: server/go.sum
@@ -96,7 +96,7 @@ jobs:
       # install below still runs --with-deps (apt OS libs) quickly; on a cache hit it
       # finds the browsers present and skips the download.
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -105,7 +105,7 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run e2e
         run: npm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm ci
       # `npm run build` is `vue-tsc --noEmit && vite build`: typecheck then bundle.
       - run: npm run build
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: web-dist
           path: dist
@@ -105,7 +105,7 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run e2e
         run: npm run test:e2e
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # paths-filter needs history to diff a push event
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           # Empty token forces local git-based diffing instead of the GitHub REST
@@ -93,7 +93,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # need main's history + tags to compare against
       - name: Require a version bump for release PRs
@@ -147,7 +147,7 @@ jobs:
     name: Roadmap up to date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Verify ROADMAP.md matches specs/
         run: python3 scripts/roadmap-gen.py --check
 
@@ -203,7 +203,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # release-notes.sh needs tags + history to diff from the last release
       - name: Resolve version
@@ -212,21 +212,21 @@ jobs:
       - name: Compose release notes (base64 JSON)
         id: notes
         run: echo "b64=$(scripts/release-notes.sh | base64 -w0)" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-qemu-action@v3 # arm64 emulation for the final stage
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4 # arm64 emulation for the final stage
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       # Mirror to Docker Hub for discoverability (that's where people `docker pull`).
       # ghcr.io stays the canonical/CI registry; both get the same tags.
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: |
@@ -236,7 +236,7 @@ jobs:
             type=raw,value=develop
             type=sha,format=short,prefix=develop-
             type=raw,value=${{ steps.ver.outputs.version }}-dev.${{ github.run_number }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -255,7 +255,7 @@ jobs:
       # sync — the image itself (the step above) is already pushed. Fix the token to re-enable.
       - name: Sync Docker Hub Overview
         continue-on-error: true
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -37,7 +37,7 @@ jobs:
       contents: write # create the GitHub pre-release
       packages: write # push the RC image to GHCR
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # full history so the pre-release notes can diff from the last tag
 
@@ -49,20 +49,20 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3 # arm64 emulation for the final stage
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4 # arm64 emulation for the final stage
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       # Mirror the RC image to Docker Hub (canonical registry stays ghcr.io).
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: |
@@ -72,7 +72,7 @@ jobs:
           # stable releases and must keep pointing at the last GA build).
           tags: |
             type=raw,value=${{ steps.ver.outputs.version }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,8 @@ jobs:
     permissions:
       contents: write # create the tag + the GitHub release
       packages: write # push the production image to GHCR
-    outputs:
-      exists: ${{ steps.check.outputs.exists }}
-      tag: ${{ steps.ver.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # full history so release notes can diff from the last tag
 
@@ -79,24 +76,24 @@ jobs:
           git tag -a "${{ steps.ver.outputs.tag }}" -m "Release ${{ steps.ver.outputs.tag }}"
           git push origin "${{ steps.ver.outputs.tag }}"
 
-      - uses: docker/setup-qemu-action@v3 # arm64 emulation for the final stage
+      - uses: docker/setup-qemu-action@v4 # arm64 emulation for the final stage
         if: steps.check.outputs.exists == 'false'
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         if: steps.check.outputs.exists == 'false'
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: steps.check.outputs.exists == 'false'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       # Mirror the production image to Docker Hub (canonical registry stays ghcr.io).
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: steps.check.outputs.exists == 'false'
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         if: steps.check.outputs.exists == 'false'
         with:
@@ -108,7 +105,7 @@ jobs:
             type=raw,value=latest
             type=semver,pattern={{version}},value=${{ steps.ver.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.ver.outputs.version }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         if: steps.check.outputs.exists == 'false'
         with:
           context: .
@@ -160,49 +157,3 @@ jobs:
             --title "${{ steps.ver.outputs.tag }}" \
             --target "${{ github.sha }}" \
             --notes-file release-notes.md
-
-  # Open develop for the next release. After X.Y.Z ships, develop still sits at
-  # X.Y.Z, so the release-guard (which requires the next develop -> main PR to be
-  # strictly greater than main) would block the following release until someone
-  # bumps develop by hand. This bumps develop to the next patch (X.Y.Z+1) via an
-  # auto-merged PR, keeping develop one step ahead of main and the next release
-  # unblocked. (A minor/major release just bumps further from there by hand.)
-  #
-  # A real "merge main back into develop" isn't used here on purpose: develop
-  # requires linear history (so main's merge commit can't land on it), and content
-  # only ever flows develop -> main, so there's nothing to merge back — only the
-  # version needs to move forward.
-  open-develop-next:
-    name: Open develop for the next version
-    needs: release
-    if: needs.release.result == 'success' && needs.release.outputs.exists == 'false'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: develop
-          fetch-depth: 0
-      - name: Bump develop to the next patch version (auto-merged PR)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Next patch above whatever develop currently holds (not above the release
-          # tag) — so a manual pre-bump on develop is respected rather than clobbered.
-          next=$(npm version patch --no-git-tag-version | tr -d 'v')
-          branch="chore/open-develop-$next"
-          git checkout -b "$branch"
-          git add package.json package-lock.json
-          git commit -m "chore: open develop for v$next"
-          git push origin "$branch"
-
-          pr_url=$(gh pr create --base develop --head "$branch" \
-            --title "chore: open develop for v$next" \
-            --body "Automated post-release bump: ${{ needs.release.outputs.tag }} shipped, so develop moves to v$next to stay ahead of main and unblock the next release-guard. Bump further by hand if the next release is a minor/major.")
-          gh pr merge --squash --auto --delete-branch "$pr_url"

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -207,6 +207,15 @@ These are project-specific guardrails every relevant spec MUST respect.
   `main` is production. Feature branches merge into `develop`; releases are a
   `develop → main` PR carrying a `package.json` version bump (the release guard
   blocks an un-bumped release PR).
+- **Version is bumped at the START of a release cycle, not automated after one.**
+  After a release ships, `develop` and `main` hold the same `package.json`
+  version, so the next `develop → main` PR would fail the release guard until
+  `develop` is moved forward. The first change of a new cycle MUST bump
+  `develop`'s `package.json` to the next intended version (patch by default;
+  minor/major when the work warrants it). This is a deliberate manual step —
+  GitHub Actions cannot open the bump PR itself (org policy forbids Actions from
+  creating pull requests), and the release guard is the backstop that enforces it
+  at release time.
 - **Spec numbering.** Bands are assigned by category and never reused: planned
   `0001–0999`, ad-hoc `1001–1999`, hotfix/bug `2001+`. The next free number in the
   band is allocated by `.specify/scripts/bash/create-new-feature.sh --category`
@@ -236,4 +245,4 @@ These are project-specific guardrails every relevant spec MUST respect.
 - Runtime engineering guidance that is not constitutional lives in `CLAUDE.md` and
   `CONTRIBUTING.md`; where they conflict with this document, this document wins.
 
-**Version**: 1.2.0 | **Ratified**: 2026-06-15 | **Last Amended**: 2026-06-22
+**Version**: 1.2.1 | **Ratified**: 2026-06-15 | **Last Amended**: 2026-07-17

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,13 +209,23 @@ contributor walkthrough is in `CONTRIBUTING.md`.
 
 GitFlow. **`develop`** is the integration branch; **`main`** is production.
 
-- Every push to `develop` and every PR runs the full build+test suite. A
-  `develop` push also publishes the rolling `ghcr.io/zuptalo/ring:develop` image.
+- Every PR runs the full build+test suite (path-filtered: doc/spec/tooling-only
+  changes skip the heavy jobs). A push to `develop` does NOT re-run the suite —
+  the merged PR already tested the identical tree — it only rebuilds and publishes
+  the rolling `ghcr.io/zuptalo/ring:develop` image.
+- **Bump the version at the start of each release cycle.** After a release ships,
+  `develop` and `main` sit at the same `package.json` version, so the next
+  `develop → main` PR fails the release guard until `develop` moves forward. The
+  first change of a new cycle bumps `develop`'s `version` to the next intended
+  value (patch by default). This is manual on purpose — GitHub Actions can't open
+  the bump PR (org policy blocks Actions from creating PRs), and the release guard
+  enforces it at release time. See constitution "Development Workflow."
 - Releases are driven by `package.json` `version`: bump it on `develop`, open a
-  PR into `main`. On merge, the release pipeline re-verifies the merge commit and,
-  if green and the `vX.Y.Z` tag doesn't already exist, tags `main`, publishes the
-  production image (`latest`, `X.Y.Z`, `X.Y`), and cuts a GitHub release. A merge
-  without a version bump re-runs CI but does not re-release.
+  PR into `main`. That PR **auto-merges** once green (`auto-merge-release.yml`),
+  which then dispatches `release.yml` (a workflow-token push can't trigger it
+  directly). If green and the `vX.Y.Z` tag doesn't already exist, it tags `main`,
+  publishes the production image (`latest`, `X.Y.Z`, `X.Y`), and cuts a GitHub
+  release. A merge without a version bump re-runs CI but does not re-release.
 - Release candidates are cut by pushing a `vX.Y.Z-rc.N` tag (off `develop`):
   `release-candidate.yml` runs the full suite and, if green, publishes a single
   immutable `:X.Y.Z-rc.N` image + a GitHub pre-release. RCs never move `:latest`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,13 @@ npm run test:e2e              # Playwright e2e (needs `make db-up`; spins its ow
 
 Releases are driven by `package.json` `version`:
 
+> **Bump at the start of a cycle.** After a release ships, `develop` and `main`
+> hold the same version, so the *next* `develop → main` PR fails the release guard
+> until `develop` is moved forward. Bump `develop`'s version (with the script below)
+> as the first change of the new cycle. This is manual by design — GitHub Actions
+> can't open the bump PR (org policy forbids Actions from creating PRs), so there's
+> no bot to do it for you; the release guard is the backstop at release time.
+
 - **Release:** bump the version on `develop`, then open a PR into `main`. Bump with
   the one-shot script (no manual editing, no local tag/commit — it just edits
   `package.json` + `package-lock.json` for you to commit):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",


### PR DESCRIPTION
Three related cleanups after v1.0.2 shipped.

## 1. Remove the impossible auto-bump-develop job
The `open-develop-next` job in `release.yml` tried to open a PR bumping develop's version after each release, but **this org forbids GitHub Actions from creating PRs** — it failed every run with `GitHub Actions is not permitted to create or approve pull requests`. Removed the job (and the now-unused `outputs` on the release job).

## 2. Document the manual version-bump convention instead
Since no bot can do it, the rule is now written where contributors and agents will see it:
- **Constitution** (Development Workflow) — new bullet: bump `develop`'s version at the **start** of each release cycle; the release guard is the backstop. Constitution version 1.2.0 → 1.2.1.
- **CLAUDE.md** — added the same to the release section, and fixed a stale line claiming every develop push runs the full suite (it hasn't since #1020 cut `verify` from develop pushes).
- **CONTRIBUTING.md** — a callout at the top of the Releases section.

## 3. Upgrade all actions off the deprecated Node 20 runtime
Silences the `Node.js 20 is deprecated` warnings on every job. Bumped each action to its first Node-24 major (conservative, not bleeding-edge): `checkout@v5`, `setup-node@v5`, `setup-go@v6`, `upload-artifact@v5`, `cache@v5`, `docker/setup-qemu@v4`, `docker/setup-buildx@v4`, `docker/login@v4`, `docker/metadata@v6`, `docker/build-push@v7`, `dorny/paths-filter@v4`, `dockerhub-description@v5`. The inputs we use are unchanged across these majors; every tag was verified to exist. (`dataaxiom/ghcr-cleanup-action@v1` is a Docker action — no Node runtime, no warning — left as-is.)

## Also
Bumps `develop` to **1.0.3**, enacting the newly-documented start-of-cycle bump now that v1.0.2 is out.

## Test plan
- [x] All six workflow files parse as valid YAML
- [x] `npm run build`
- [x] Every pinned action tag confirmed to exist via the GitHub API
- [ ] The Node-20 warnings should be gone from this PR's own CI run — the real confirmation