### PR TITLE
ci: generate GitHub release notes to match the in-app "What's new"

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -88,8 +88,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Same grouped, filtered, prettified notes as a GA release (not GitHub's raw
+          # --generate-notes PR dump). Based on the last STABLE tag, so an RC shows the
+          # full set of changes coming in this version.
+          node scripts/release-notes-md.mjs --tag "${{ steps.ver.outputs.tag }}" \
+            --repo "${{ github.repository }}" > release-notes.md
           gh release create "${{ steps.ver.outputs.tag }}" \
-            --title "${{ steps.ver.outputs.tag }}" \
+            --title "Ring ${{ steps.ver.outputs.version }}" \
             --target "${{ github.sha }}" \
             --prerelease \
-            --generate-notes
+            --notes-file release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,34 +122,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Build human-readable notes: the version followed by one bullet per change,
-      # taken from the Conventional-Commit subjects since the previous release tag
-      # (merge commits excluded). This shows the user *what changed*, not a SHA.
+      # Human-readable release notes: user-facing changes since the previous STABLE
+      # release, grouped (New / Fixes / …) and prettified with the same filter + wording
+      # rules the in-app "What's new" uses (scripts/release-notes-md.mjs). ci/docs/chore
+      # noise is dropped; a spec/PR ref is stripped. Basing on the last stable tag (not
+      # the RC) means a GA release shows the whole product delta, not just the RC gap.
       - name: Compose release notes
         if: steps.check.outputs.exists == 'false'
-        id: notes
         run: |
-          set -euo pipefail
-          tag="${{ steps.ver.outputs.tag }}"
-
-          # Highest existing vX.Y.Z tag, excluding the one we're about to create.
-          prev=$(git tag --list 'v*' --sort=-v:refname | grep -vx "$tag" | head -n1 || true)
-
-          {
-            echo "## $tag"
-            echo
-            if [ -n "$prev" ]; then
-              git log "$prev"..HEAD --no-merges --pretty='- %s'
-              echo
-              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/$prev...$tag"
-            else
-              # First release: list everything reachable, still as one-liners.
-              git log --no-merges --pretty='- %s'
-            fi
-          } > release-notes.md
-
-          echo "Generated release notes:"
-          cat release-notes.md
+          node scripts/release-notes-md.mjs --tag "${{ steps.ver.outputs.tag }}" \
+            --repo "${{ github.repository }}" > release-notes.md
+          echo "Generated release notes:"; cat release-notes.md
 
       - name: Create GitHub release
         if: steps.check.outputs.exists == 'false'
@@ -157,7 +140,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.ver.outputs.tag }}" \
-            --title "${{ steps.ver.outputs.tag }}" \
+            --title "Ring ${{ steps.ver.outputs.version }}" \
             --target "${{ github.sha }}" \
             --notes-file release-notes.md
 

--- a/scripts/release-notes-md.mjs
+++ b/scripts/release-notes-md.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Generate a GitHub Release body (Markdown) for a tag: the user-facing changes since
+// the previous STABLE release, filtered and prettified with the SAME rules the in-app
+// "What's new" flow uses — so the release page and the update toast tell one story
+// instead of three (this replaced a raw `git log` on the GA side and GitHub's
+// `--generate-notes` PR-dump on the RC side, both of which leaked ci/docs/chore noise).
+//
+// Filtering + wording are mirrored from src/services/release-notes.ts; the parity
+// test src/services/release-notes-md-parity.test.ts fails if the two ever drift.
+//
+// Base selection: a release's notes are diffed from the previous STABLE tag that is an
+// ANCESTOR of this tag (prerelease `-rc` tags are ignored as a base). So a GA release
+// shows the whole product delta since the last stable — not just the gap since its RC —
+// and it works for regenerating an older tag's notes too (only tags reachable from that
+// tag are considered).
+//
+// Usage: node scripts/release-notes-md.mjs --tag v1.2.3 [--repo owner/name]
+import { execFileSync } from 'node:child_process';
+
+// ── rules mirrored from src/services/release-notes.ts (keep in sync; parity-tested) ──
+export const NOISE_TYPES = new Set(['build', 'chore', 'ci', 'deps', 'docs', 'refactor', 'style', 'test']);
+const CC_TYPE = /^([a-z]+)(\([^)]*\))?!?:/i;
+const CC_PREFIX = /^[a-z]+(\([^)]*\))?!?:\s*/i;
+const TRAILING_REF = /\s*\((?:specs?\s*\d+[^)]*|#\d+|gh-\d+)\)\s*$/i;
+const TRAILING_ASIDE = /\s*\(\+[^)]*\)\s*$/;
+
+/** Conventional-Commit type of a subject in lowercase, or null when there's no prefix. */
+export function commitType(subject) {
+  const m = CC_TYPE.exec(subject.trim());
+  return m ? m[1].toLowerCase() : null;
+}
+
+/** Whether a subject describes a change a regular user cares about. */
+export function isUserFacing(subject) {
+  const t = commitType(subject);
+  return t === null || !NOISE_TYPES.has(t);
+}
+
+/** Drop the `type(scope):` prefix, a trailing `(+ …)` aside and a trailing
+ *  spec/issue/PR reference, then capitalize. Non-conforming subjects pass through. */
+export function prettify(subject) {
+  let stripped = subject.replace(CC_PREFIX, '').trim();
+  // Strip stacked trailing refs — `… (spec 1054) (#1012)` — until neither matches.
+  for (let prev = ''; prev !== stripped; ) {
+    prev = stripped;
+    stripped = stripped.replace(TRAILING_ASIDE, '').replace(TRAILING_REF, '').trim();
+  }
+  const text = stripped || subject.trim();
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+// ─────────────────────────────────────────────────────────────────────────────────────
+
+const STABLE_TAG = /^v\d+\.\d+\.\d+$/;
+
+function arg(name, def = null) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' });
+}
+
+function isAncestor(a, b) {
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', a, b], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Build the Markdown body for `tag`, grouping user-facing changes by kind. */
+export function buildNotes(tag, repo, opts = {}) {
+  const log = opts.log || ((range) => git(['log', range, '--no-merges', '--format=%s']));
+  const tags = opts.tags || git(['tag', '--list', '--sort=-v:refname']).split('\n').map((t) => t.trim()).filter(Boolean);
+  const ancestor = opts.isAncestor || isAncestor;
+
+  // Previous stable tag that is an ancestor of this tag (so regeneration of an older
+  // tag ignores stable tags cut after it).
+  const base = tags.find((t) => t !== tag && STABLE_TAG.test(t) && ancestor(t, tag)) || null;
+  const range = base ? `${base}..${tag}` : tag;
+
+  const subjects = log(range).split('\n').map((s) => s.trim()).filter(Boolean).filter(isUserFacing);
+
+  const buckets = { security: [], feat: [], fix: [], other: [] };
+  for (const s of subjects) {
+    const t = commitType(s);
+    if (t === 'security') buckets.security.push(prettify(s));
+    else if (t === 'feat') buckets.feat.push(prettify(s));
+    else if (t === 'fix') buckets.fix.push(prettify(s));
+    else buckets.other.push(prettify(s)); // perf + non-conforming, still user-facing
+  }
+
+  const sections = [
+    ['🔒 Security', buckets.security],
+    ['✨ New', buckets.feat],
+    ['🐛 Fixes', buckets.fix],
+    ['⚡ Improvements', buckets.other],
+  ];
+
+  let out = '';
+  for (const [title, items] of sections) {
+    if (!items.length) continue;
+    out += `### ${title}\n\n${items.map((i) => `- ${i}`).join('\n')}\n\n`;
+  }
+  if (!out) out += '_Maintenance release — internal changes only, nothing user-facing._\n\n';
+
+  out += base
+    ? `**Full Changelog**: https://github.com/${repo}/compare/${base}...${tag}\n`
+    : `**Full Changelog**: https://github.com/${repo}/commits/${tag}\n`;
+  return out;
+}
+
+function resolveRepo() {
+  const explicit = arg('--repo');
+  if (explicit) return explicit;
+  try {
+    const url = git(['config', '--get', 'remote.origin.url']).trim();
+    const slug = url.replace(/^git@github\.com:/, '').replace(/^https:\/\/github\.com\//, '').replace(/\.git$/, '');
+    if (slug) return slug;
+  } catch {
+    /* fall through */
+  }
+  return 'zuptalo/ring';
+}
+
+function main() {
+  const tag = arg('--tag');
+  if (!tag) {
+    console.error('usage: release-notes-md.mjs --tag <tag> [--repo owner/name]');
+    process.exit(1);
+  }
+  process.stdout.write(buildNotes(tag, resolveRepo()));
+}
+
+// Run only when invoked as a script, not when imported by the parity test.
+if (process.argv[1] && process.argv[1].endsWith('release-notes-md.mjs')) main();

--- a/src/services/release-notes-md-parity.test.ts
+++ b/src/services/release-notes-md-parity.test.ts
@@ -1,0 +1,48 @@
+// Guardrail: the GitHub-release Markdown generator (scripts/release-notes-md.mjs)
+// duplicates the filter + prettify rules from release-notes.ts so it can run in the
+// release workflow without a TS toolchain. This test fails if the two ever diverge,
+// so the release page and the in-app "What's new" always word a change the same way.
+import { describe, it, expect } from 'vitest';
+import { isUserFacing as tsIsUserFacing, prettify as tsPrettify } from './release-notes';
+// @ts-expect-error — plain ESM script, no type declarations by design.
+import { isUserFacing as mdIsUserFacing, prettify as mdPrettify } from '../../scripts/release-notes-md.mjs';
+
+// A corpus that exercises every rule: each Conventional-Commit type, scopes, `!`,
+// non-conforming subjects, and every trailing-reference / aside form prettify strips.
+const CORPUS = [
+  'feat(chat): add reactions to messages',
+  'fix(call): connect the first call as fast as a second one (spec 2008)',
+  'fix(media): sharper thumbnails (#248)',
+  'feat: zero-knowledge social Wall (spec 0003)',
+  'perf(sync): batch idb writes',
+  'security(auth): rotate device tokens on reinstall',
+  'feat(chat)!: drop the quality picker',
+  'fix(wall): honest progress (+ flaky test fix)',
+  'ci: give release tagging a committer identity',
+  'chore: bump version to 1.0.0',
+  'docs(spec): flip 16 shipped specs',
+  'refactor(store): extract repo interface',
+  'test(e2e): cover the Wall',
+  'build(deps): bump vite',
+  'style: gofmt',
+  'deps: update libsodium',
+  'Merge branch develop',
+  'a bare subject with no conventional prefix',
+  'fix(chat): reach you through muted groups (spec 1048 US2/US3)',
+  "feat(contacts): set an emoji as a contact's photo (spec 1054) (#1012)", // stacked refs
+  'feat(wall): efficient videos upload as-is (spec 2038) (#1004)', // stacked refs
+];
+
+describe('release-notes-md.mjs parity with release-notes.ts', () => {
+  it('classifies user-facing vs noise identically', () => {
+    for (const subject of CORPUS) {
+      expect(mdIsUserFacing(subject), subject).toBe(tsIsUserFacing({ sha: 'x', subject }));
+    }
+  });
+
+  it('prettifies subjects identically', () => {
+    for (const subject of CORPUS) {
+      expect(mdPrettify(subject), subject).toBe(tsPrettify(subject));
+    }
+  });
+});

--- a/src/services/release-notes.test.ts
+++ b/src/services/release-notes.test.ts
@@ -98,6 +98,21 @@ describe('prettify', () => {
     expect(prettify('feat: add search (gh-12)')).toBe('Add search');
   });
 
+  it('strips stacked trailing references (a squash-merge leaves both a spec and a PR ref)', () => {
+    expect(prettify("feat(contacts): set an emoji as a contact's photo (spec 1054) (#1012)")).toBe(
+      "Set an emoji as a contact's photo",
+    );
+    expect(prettify('fix(chat): reach you through muted groups (spec 1048) (#993)')).toBe(
+      'Reach you through muted groups',
+    );
+  });
+
+  it('strips a plural "(specs N + M)" reference', () => {
+    expect(prettify('feat(notifications): richer tones and quieter housekeeping (specs 1049 + 1050)')).toBe(
+      'Richer tones and quieter housekeeping',
+    );
+  });
+
   it('strips a trailing reference that carries extra detail', () => {
     // The reported jargon leak: a spec ref with user-story suffix slipped through.
     expect(prettify('feat(chat): visibility-driven Seen + catch-up (spec 1013 US2/US3)')).toBe(

--- a/src/services/release-notes.ts
+++ b/src/services/release-notes.ts
@@ -68,7 +68,7 @@ const CC_PREFIX = /^[a-z]+(\([^)]*\))?!?:\s*/i;
 // `spec\s*\d+[^)]*` form deliberately swallows any suffix after the number (US/FR/task
 // labels) — the leak the iOS user saw — while `(finally)` and other prose parentheticals
 // are left alone because they don't start with `spec`/`#`/`gh-`.
-const TRAILING_REF = /\s*\((?:spec\s*\d+[^)]*|#\d+|gh-\d+)\)\s*$/i;
+const TRAILING_REF = /\s*\((?:specs?\s*\d+[^)]*|#\d+|gh-\d+)\)\s*$/i;
 
 // A trailing `(+ …)` developer aside (e.g. `(+ flaky test fix)`) — a parenthetical the
 // author tacked on, not user-facing. Only strips parens that OPEN with `+`, so genuine
@@ -80,11 +80,14 @@ const TRAILING_ASIDE = /\s*\(\+[^)]*\)\s*$/;
  *  first letter. A non-conforming subject is passed through (just trimmed + capitalized),
  *  never dropped. */
 export function prettify(subject: string): string {
-  const stripped = subject
-    .replace(CC_PREFIX, '')
-    .replace(TRAILING_ASIDE, '')
-    .replace(TRAILING_REF, '')
-    .trim();
+  let stripped = subject.replace(CC_PREFIX, '').trim();
+  // A squash-merge stacks trailing refs — `… (spec 1054) (#1012)` — so strip the aside
+  // and reference repeatedly until neither matches, not just once (a single pass would
+  // leave the inner `(spec 1054)` behind once `(#1012)` is removed).
+  for (let prev = ''; prev !== stripped; ) {
+    prev = stripped;
+    stripped = stripped.replace(TRAILING_ASIDE, '').replace(TRAILING_REF, '').trim();
+  }
   const text = stripped || subject.trim();
   return text.charAt(0).toUpperCase() + text.slice(1);
 }


### PR DESCRIPTION
Follow-up to reviewing the v1.0.0-rc.1 and v1.0.2 release pages, which exposed that release-note generation was three inconsistent, noisy paths.

## The problem
- **RC** used GitHub's `--generate-notes` → a raw 150-PR dump including every `ci:`/`docs:`/`test:` PR.
- **GA** used an unfiltered `git log --pretty='- %s'` → raw commit subjects, noise and all.
- Neither matched the clean, filtered **in-app "What's new"** (`release-notes.ts`).
- Worse: v1.0.2's notes were **four CI lines**, because its diff base was the RC tag (`v1.0.0-rc.1`), not a stable release — so the flagship 1.0 GA page said nothing about the actual product.

## The fix
- **`scripts/release-notes-md.mjs`** renders the GitHub release body: user-facing changes since the previous **stable** tag (prerelease tags ignored as a base; only ancestor tags considered, so regenerating an old tag also works), grouped **✨ New / 🐛 Fixes / ⚡ Improvements**, filtered + prettified with the **same `NOISE_TYPES` + `prettify` rules** as `release-notes.ts`.
- **`release-notes-md-parity.test.ts`** fails if the script and the TS ever drift, so the release page and the update toast always word a change identically.
- **`release.yml`** and **`release-candidate.yml`** now use the script (dropping the raw `git log` and `--generate-notes`) and title releases **"Ring X.Y.Z"**.
- **`prettify()`** now strips *stacked* trailing refs (`… (spec 1054) (#1012)` — a squash-merge leaves both) and the plural `(specs N + M)` form, which the single-pass regex left behind. New unit tests cover both; this also cleans up the in-app "What's new".

## Already applied to the live releases
I regenerated both existing release bodies with this script — **[Ring 1.0.2](https://github.com/zuptalo/ring/releases/tag/v1.0.2)** now shows the full grouped 1.0 changelog (168 New / 134 Fixes / 8 Improvements, zero ref leaks) instead of four CI lines, and rc.1 matches. This PR lands the tooling so every future release renders the same way automatically.

## Test plan
- [x] `npx vitest run` — full suite green (1157), incl. new prettify + parity tests
- [x] `vue-tsc --noEmit` typecheck clean
- [x] Both workflow files parse as valid YAML
- [x] Script run locally against both existing tags; live release bodies regenerated and re-verified (0 ref leaks)