### PR TITLE
ops(k8s): track :latest (production releases) instead of :develop

### DIFF
--- a/deploy/k8s/20-ringd.yaml
+++ b/deploy/k8s/20-ringd.yaml
@@ -5,8 +5,10 @@
 # roll deploys with a brief 2-pod overlap rather than a hard stop-then-start, so
 # updates don't take the app down - see the strategy block below.
 #
-# Keel auto-updates this Deployment: it polls ghcr.io/zuptalo/ring:develop and,
-# when the tag's digest changes (a new develop build), forces a rolling redeploy.
+# Keel auto-updates this Deployment: it polls ghcr.io/zuptalo/ring:latest and,
+# when the tag's digest changes (a new production release moves :latest), forces a
+# rolling redeploy. So this cluster always tracks the newest stable release. To
+# follow the rolling dev build instead, point the image tag below at :develop.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -58,7 +60,7 @@ metadata:
   name: ringd
   namespace: ring
   annotations:
-    # Keel: watch the mutable :develop tag and force a redeploy on a new digest.
+    # Keel: watch the mutable :latest tag and force a redeploy on a new digest.
     keel.sh/policy: force
     keel.sh/trigger: poll
     keel.sh/pollSchedule: "@every 2m"
@@ -87,7 +89,7 @@ spec:
     spec:
       containers:
         - name: ringd
-          image: ghcr.io/zuptalo/ring:develop
+          image: ghcr.io/zuptalo/ring:latest
           imagePullPolicy: Always
           ports:
             - { name: http, containerPort: 8080 }

--- a/deploy/k8s/40-keel.yaml
+++ b/deploy/k8s/40-keel.yaml
@@ -1,7 +1,7 @@
 # Keel - the cluster-wide image auto-updater - installed as plain manifests (no
 # Helm needed). Keel watches Deployments annotated with keel.sh/* (see 20-ringd.yaml:
 # policy=force, trigger=poll, pollSchedule=@every 2m), polls their image tag in the
-# registry and, when the :develop digest changes, forces a rolling redeploy. The
+# registry and, when the :latest digest changes, forces a rolling redeploy. The
 # ghcr.io/zuptalo/ring image is public, so Keel needs no registry credentials.
 #
 # Pinned to a concrete tag (not :latest) so the updater itself is reproducible.

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,7 +1,8 @@
 # Ring on k3s (with auto-deploy)
 
 Deploys Ring to a fresh k3s cluster with **voice/video calls** and **automatic
-image updates** from `ghcr.io/zuptalo/ring:develop`. Everything stays in the
+image updates** from `ghcr.io/zuptalo/ring:latest` (the newest production release).
+Everything stays in the
 cluster: in-cluster PostgreSQL, ringd terminating its own TLS, and **Keel**
 rolling the deployment whenever a new image is published.
 
@@ -11,7 +12,7 @@ rolling the deployment whenever a new image is published.
   (HTTPS +       (TCP/SNI               │   :8443 app HTTPS                        │
    TURNS)         passthrough)          │   :3478 TURN-over-TLS (call media)       │
                                         │   ACME certs + secrets stored in PG      │
-   Keel (ns: keel) ── polls GHCR ──────►│   redeploys on a new :develop digest    │
+   Keel (ns: keel) ── polls GHCR ──────►│   redeploys on a new :latest digest     │
                                         └──────────────────────────────────────────┘
 ```
 
@@ -71,9 +72,10 @@ keel.sh/trigger: poll
 keel.sh/pollSchedule: "@every 2m"
 ```
 
-Keel polls `ghcr.io/zuptalo/ring:develop` every ~2 min; when CI publishes a new
-`develop` build, Keel forces a rolling (Recreate) redeploy that pulls the new
-digest and re‑runs migrations on boot. Nothing else to do.
+Keel polls `ghcr.io/zuptalo/ring:latest` every ~2 min; when a new production
+release moves `:latest`, Keel forces a rolling redeploy that pulls the new
+digest and re‑runs migrations on boot. Nothing else to do. (To track the rolling
+dev build instead, point the image tag at `:develop`.)
 
 **Track stable releases instead of develop:** in `20-ringd.yaml` change the image
 tag to `:latest` (published on each version release) and re‑apply. Keel `force`

--- a/deploy/k8s/install.sh
+++ b/deploy/k8s/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Idempotent installer for Ring on a fresh k3s cluster (calls enabled, Keel
-# auto-updates from ghcr.io/zuptalo/ring:develop). Re-runnable: it never rotates
-# the existing SECRETS_KEY / DB password.
+# auto-updates from ghcr.io/zuptalo/ring:latest — the newest production release).
+# Re-runnable: it never rotates the existing SECRETS_KEY / DB password.
 #
 #   APP_HOST=ring.example.com ACME_EMAIL=you@example.com ./install.sh
 #
@@ -82,6 +82,6 @@ Done. Next:
   3. First-run invite code:   kubectl -n ring logs deploy/ringd | grep FIRST-RUN
   4. Open https://${APP_HOST}, install the PWA, register with that code.
 
-New :develop images now auto-deploy within ~2 minutes (Keel). To track stable
-releases instead, edit 20-ringd.yaml: image tag -> :latest and keep keel policy force.
+New production releases (:latest) now auto-deploy within ~2 minutes (Keel). To track
+the rolling dev build instead, edit 20-ringd.yaml: image tag -> :develop, keep policy force.
 EOF


### PR DESCRIPTION
Points the k3s deployment at `ghcr.io/zuptalo/ring:latest` so Keel follows the newest **production release** instead of the rolling `develop` build.

## What changed
- `20-ringd.yaml`: image tag `:develop` → `:latest` (+ comment).
- `40-keel.yaml`, `README.md`, `install.sh`: docs/comments updated to match; the opt-out (point at `:develop` for the dev build) is noted.

## Already applied to the live cluster
`kubectl set image deploy/ringd ringd=ghcr.io/zuptalo/ring:latest` — rolled zero-downtime; prod (ring.zuptalo.com) now serves **1.0.3** (the security release), `/healthz` green. This PR makes the committed manifest match so a cluster rebuild or `install.sh` re-run won't regress to `:develop`.

## Effect going forward
Keel (force/poll @2m) redeploys prod whenever a new production release moves `:latest`. Every `develop → main` release now auto-ships to prod within ~2 minutes.

## Test plan
- [x] `kubectl apply --dry-run=client` on the manifest — valid
- [x] Live rollout succeeded; prod healthy on 1.0.3
- [ ] N/A — deploy config only (not in the image; CI treats as tooling-only)