### PR TITLE
fix(messaging): update delivery status when a message reaches someone days later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4579,7 +4579,15 @@ async function resendRecentOutgoing(chatId: string): Promise<void> {
 
 /* ---- delivery reconcile (recover a 'delivered' receipt dropped while we were offline) ---- */
 
-const RECONCILE_WINDOW_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+// Must stay <= the server's relay/deliveries retention (relayRetention, 35d in
+// cmd/ringd/main.go): the server durably records a delivery for that long, so we
+// keep re-asking about a still-unconfirmed outgoing message for the same span. A
+// shorter window (was 3d) stranded messages whose recipient only came online — or
+// whose service worker only drained the backlog — days after we sent, leaving our
+// copy stuck at 'sent' forever even though the delivery WAS recorded (and the live
+// receipt was dropped because we were offline at that instant). Going beyond 35d
+// buys nothing: the record has already been swept server-side.
+const RECONCILE_WINDOW_MS = 35 * 24 * 60 * 60 * 1000; // 35 days — matches server relayRetention
 const RECONCILE_ID_CAP = 500;
 
 /**
@@ -4593,19 +4601,27 @@ const RECONCILE_ID_CAP = 500;
 export async function collectUnconfirmedOutgoing(): Promise<string[]> {
   const since = now() - RECONCILE_WINDOW_MS;
   const all = await getAll<Message>('messages');
-  const ids: string[] = [];
+  const unconfirmed: Message[] = [];
   for (const m of all) {
     if (!m.outgoing || m.timestamp < since) continue;
     const recs = m.receipts;
     if (recs && recs.length) {
       // Group: any member not yet delivered (→ checkDeliveries) or not yet seen
       // (→ checkSeen) keeps this message in the reconcile set.
-      if (recs.some((r) => !r.deliveredAt || !r.seenAt)) ids.push(m.id);
+      if (recs.some((r) => !r.deliveredAt || !r.seenAt)) unconfirmed.push(m);
     } else if (m.status === 'sent') {
-      ids.push(m.id);
+      unconfirmed.push(m);
     }
   }
-  return ids.slice(-RECONCILE_ID_CAP);
+  // Message ids are random UUIDs, so getAll returns them in an arbitrary (but
+  // stable) order — a plain cap would re-check the SAME arbitrary subset every
+  // reconnect and never cover the rest, which the widened 35d window makes reachable.
+  // Order by send time and keep the OLDEST RECONCILE_ID_CAP: those are closest to the
+  // server's 35d sweep (most urgent to recover before their record is gone), while
+  // newer unconfirmed messages have many more reconnects ahead to be picked up as
+  // confirmed ones drop out of the set. The server bounds its query at 500 too.
+  unconfirmed.sort((a, b) => a.timestamp - b.timestamp);
+  return unconfirmed.slice(0, RECONCILE_ID_CAP).map((m) => m.id);
 }
 
 /** Set (or clear) a chat's per-kind media send-quality override. null = fall back to the global


### PR DESCRIPTION
## Problem

Some users — especially those who open the app infrequently — see messages stay stuck at **sent** even though the recipient actually received them.

A `delivered` receipt is normally pushed to the sender the instant the recipient's device pulls the message. But if the sender is offline at that moment the live receipt is dropped, and the sender relies on **reconnect reconciliation** (`POST /v1/deliveries/check`) to recover it.

That reconcile only re-asked about outgoing messages **younger than 3 days** (`RECONCILE_WINDOW_MS`), while the server durably retains the delivery record for **35 days** (`relayRetention` in `cmd/ringd/main.go`). So when a recipient came online — or their service worker only drained the backlog — more than 3 days after we sent, the delivery was recorded server-side but the sender had already stopped asking. Its copy stayed at `sent` forever.

This is the exact profile of a rarely-active recipient (slow/suspended push wakes, late first touch of the frame) or a rarely-active sender (doesn't reconnect within its own 3-day window).

## Fix

- **Widen `RECONCILE_WINDOW_MS` from 3 → 35 days** so the sender's ask window matches the server's relay/deliveries retention. A comment now ties the two constants together across the client/server boundary.
- **Harden the 500-id cap.** Message ids are random UUIDs, so `getAll('messages')` returns them in an arbitrary (but stable) order — the old `.slice(-500)` kept an arbitrary 500. Harmless at a 3-day window that rarely hit the cap, but once the window can exceed 500 unconfirmed messages it would re-check the *same* arbitrary subset every reconnect and never cover the rest. Candidates are now ordered by send time, keeping the **oldest** 500 (closest to the server's sweep, so most urgent to recover); newer unconfirmed messages have many more reconnects ahead to be picked up as the set drains.

## Scope / not included

This is the root-cause fix (Gap 1). A separate amplifier — the 50-frame cap on the service worker's `GET /v1/relay/pending` preview fetch, which makes the *oldest* backlog frames report delivery latest — is left as a follow-on. Push/subscription safety is unaffected: delivery recording is a side effect of the same fetch that builds the notification preview, so nothing here changes the userVisibleOnly contract.

## Testing

- `npm run build` (typecheck + vite + service-worker build) passes clean.
- No tests pinned the 3-day window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)