### PR TITLE
Release 1.0.4

### DIFF
--- a/deploy/k8s/20-ringd.yaml
+++ b/deploy/k8s/20-ringd.yaml
@@ -5,8 +5,10 @@
 # roll deploys with a brief 2-pod overlap rather than a hard stop-then-start, so
 # updates don't take the app down - see the strategy block below.
 #
-# Keel auto-updates this Deployment: it polls ghcr.io/zuptalo/ring:develop and,
-# when the tag's digest changes (a new develop build), forces a rolling redeploy.
+# Keel auto-updates this Deployment: it polls ghcr.io/zuptalo/ring:latest and,
+# when the tag's digest changes (a new production release moves :latest), forces a
+# rolling redeploy. So this cluster always tracks the newest stable release. To
+# follow the rolling dev build instead, point the image tag below at :develop.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -58,7 +60,7 @@ metadata:
   name: ringd
   namespace: ring
   annotations:
-    # Keel: watch the mutable :develop tag and force a redeploy on a new digest.
+    # Keel: watch the mutable :latest tag and force a redeploy on a new digest.
     keel.sh/policy: force
     keel.sh/trigger: poll
     keel.sh/pollSchedule: "@every 2m"
@@ -87,7 +89,7 @@ spec:
     spec:
       containers:
         - name: ringd
-          image: ghcr.io/zuptalo/ring:develop
+          image: ghcr.io/zuptalo/ring:latest
           imagePullPolicy: Always
           ports:
             - { name: http, containerPort: 8080 }

--- a/deploy/k8s/40-keel.yaml
+++ b/deploy/k8s/40-keel.yaml
@@ -1,7 +1,7 @@
 # Keel - the cluster-wide image auto-updater - installed as plain manifests (no
 # Helm needed). Keel watches Deployments annotated with keel.sh/* (see 20-ringd.yaml:
 # policy=force, trigger=poll, pollSchedule=@every 2m), polls their image tag in the
-# registry and, when the :develop digest changes, forces a rolling redeploy. The
+# registry and, when the :latest digest changes, forces a rolling redeploy. The
 # ghcr.io/zuptalo/ring image is public, so Keel needs no registry credentials.
 #
 # Pinned to a concrete tag (not :latest) so the updater itself is reproducible.

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,7 +1,8 @@
 # Ring on k3s (with auto-deploy)
 
 Deploys Ring to a fresh k3s cluster with **voice/video calls** and **automatic
-image updates** from `ghcr.io/zuptalo/ring:develop`. Everything stays in the
+image updates** from `ghcr.io/zuptalo/ring:latest` (the newest production release).
+Everything stays in the
 cluster: in-cluster PostgreSQL, ringd terminating its own TLS, and **Keel**
 rolling the deployment whenever a new image is published.
 
@@ -11,7 +12,7 @@ rolling the deployment whenever a new image is published.
   (HTTPS +       (TCP/SNI               │   :8443 app HTTPS                        │
    TURNS)         passthrough)          │   :3478 TURN-over-TLS (call media)       │
                                         │   ACME certs + secrets stored in PG      │
-   Keel (ns: keel) ── polls GHCR ──────►│   redeploys on a new :develop digest    │
+   Keel (ns: keel) ── polls GHCR ──────►│   redeploys on a new :latest digest     │
                                         └──────────────────────────────────────────┘
 ```
 
@@ -71,9 +72,10 @@ keel.sh/trigger: poll
 keel.sh/pollSchedule: "@every 2m"
 ```
 
-Keel polls `ghcr.io/zuptalo/ring:develop` every ~2 min; when CI publishes a new
-`develop` build, Keel forces a rolling (Recreate) redeploy that pulls the new
-digest and re‑runs migrations on boot. Nothing else to do.
+Keel polls `ghcr.io/zuptalo/ring:latest` every ~2 min; when a new production
+release moves `:latest`, Keel forces a rolling redeploy that pulls the new
+digest and re‑runs migrations on boot. Nothing else to do. (To track the rolling
+dev build instead, point the image tag at `:develop`.)
 
 **Track stable releases instead of develop:** in `20-ringd.yaml` change the image
 tag to `:latest` (published on each version release) and re‑apply. Keel `force`

--- a/deploy/k8s/install.sh
+++ b/deploy/k8s/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Idempotent installer for Ring on a fresh k3s cluster (calls enabled, Keel
-# auto-updates from ghcr.io/zuptalo/ring:develop). Re-runnable: it never rotates
-# the existing SECRETS_KEY / DB password.
+# auto-updates from ghcr.io/zuptalo/ring:latest — the newest production release).
+# Re-runnable: it never rotates the existing SECRETS_KEY / DB password.
 #
 #   APP_HOST=ring.example.com ACME_EMAIL=you@example.com ./install.sh
 #
@@ -82,6 +82,6 @@ Done. Next:
   3. First-run invite code:   kubectl -n ring logs deploy/ringd | grep FIRST-RUN
   4. Open https://${APP_HOST}, install the PWA, register with that code.
 
-New :develop images now auto-deploy within ~2 minutes (Keel). To track stable
-releases instead, edit 20-ringd.yaml: image tag -> :latest and keep keel policy force.
+New production releases (:latest) now auto-deploy within ~2 minutes (Keel). To track
+the rolling dev build instead, edit 20-ringd.yaml: image tag -> :develop, keep policy force.
 EOF

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4579,7 +4579,15 @@ async function resendRecentOutgoing(chatId: string): Promise<void> {
 
 /* ---- delivery reconcile (recover a 'delivered' receipt dropped while we were offline) ---- */
 
-const RECONCILE_WINDOW_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+// Must stay <= the server's relay/deliveries retention (relayRetention, 35d in
+// cmd/ringd/main.go): the server durably records a delivery for that long, so we
+// keep re-asking about a still-unconfirmed outgoing message for the same span. A
+// shorter window (was 3d) stranded messages whose recipient only came online — or
+// whose service worker only drained the backlog — days after we sent, leaving our
+// copy stuck at 'sent' forever even though the delivery WAS recorded (and the live
+// receipt was dropped because we were offline at that instant). Going beyond 35d
+// buys nothing: the record has already been swept server-side.
+const RECONCILE_WINDOW_MS = 35 * 24 * 60 * 60 * 1000; // 35 days — matches server relayRetention
 const RECONCILE_ID_CAP = 500;
 
 /**
@@ -4593,19 +4601,27 @@ const RECONCILE_ID_CAP = 500;
 export async function collectUnconfirmedOutgoing(): Promise<string[]> {
   const since = now() - RECONCILE_WINDOW_MS;
   const all = await getAll<Message>('messages');
-  const ids: string[] = [];
+  const unconfirmed: Message[] = [];
   for (const m of all) {
     if (!m.outgoing || m.timestamp < since) continue;
     const recs = m.receipts;
     if (recs && recs.length) {
       // Group: any member not yet delivered (→ checkDeliveries) or not yet seen
       // (→ checkSeen) keeps this message in the reconcile set.
-      if (recs.some((r) => !r.deliveredAt || !r.seenAt)) ids.push(m.id);
+      if (recs.some((r) => !r.deliveredAt || !r.seenAt)) unconfirmed.push(m);
     } else if (m.status === 'sent') {
-      ids.push(m.id);
+      unconfirmed.push(m);
     }
   }
-  return ids.slice(-RECONCILE_ID_CAP);
+  // Message ids are random UUIDs, so getAll returns them in an arbitrary (but
+  // stable) order — a plain cap would re-check the SAME arbitrary subset every
+  // reconnect and never cover the rest, which the widened 35d window makes reachable.
+  // Order by send time and keep the OLDEST RECONCILE_ID_CAP: those are closest to the
+  // server's 35d sweep (most urgent to recover before their record is gone), while
+  // newer unconfirmed messages have many more reconnects ahead to be picked up as
+  // confirmed ones drop out of the set. The server bounds its query at 500 too.
+  unconfirmed.sort((a, b) => a.timestamp - b.timestamp);
+  return unconfirmed.slice(0, RECONCILE_ID_CAP).map((m) => m.id);
 }
 
 /** Set (or clear) a chat's per-kind media send-quality override. null = fall back to the global


### PR DESCRIPTION
Release **1.0.4** — promotes `develop` to production.

## What's in this release

- **fix(messaging): update delivery status when a message reaches someone days later** (#1029)
  Widens the sender's delivery reconcile window from 3 to 35 days so it matches the server's relay/deliveries retention. Messages that a recipient only received days later — common for people who open the app infrequently, or whose service worker drained the backlog late — no longer stay stuck at "sent" once the delivery was actually recorded. Also orders the reconcile set by send time so the oldest unconfirmed messages (closest to the server's sweep) are always covered.

## Release mechanics

Per the GitFlow release flow, this PR auto-merges once green (`auto-merge-release.yml`), which dispatches `release.yml` to tag `v1.0.4`, publish the production images (`latest`, `1.0.4`, `1.0`), and cut the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)