### PR TITLE
release: v1.0.5 — restore push notifications and recover silent devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,5 +281,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1054-pick-emoji-contact/plan.md`
+`specs/2043-push-zombie-subscriptions/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,3 +126,4 @@ Specs are grouped by category band; status moves
 | [2039](specs/2039-boot-loop-safe/spec.md) | Boot-Loop Safe Mode | 🟢 shipped |
 | [2040](specs/2040-recovered-devices-rebuild/spec.md) | Recovered Devices Rebuild Their Friends Ledger | 🟢 shipped |
 | [2041](specs/2041-video-post-memory/spec.md) | Video Posts Must Not Exhaust iPhone Memory | 🟢 shipped |
+| [2043](specs/2043-push-zombie-subscriptions/spec.md) | Push zombie subscriptions & silent-wake strikes | 🟡 in-progress |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/server/cmd/ringd/main.go
+++ b/server/cmd/ringd/main.go
@@ -517,6 +517,18 @@ func run() error {
 						break
 					}
 				}
+				// (spec 2043) Zombie-fleet gauge: recipients who hold a push
+				// subscription yet carry unacked relay frames older than a day - the
+				// server-side signature of a subscription the push service still
+				// 201-accepts but never delivers (the device never wakes to drain).
+				// Emitted every sweep as the before/after handle for the client
+				// self-heal; costs one indexed count query.
+				const zombieStaleAge = 24 * time.Hour
+				if zn, zerr := st.CountZombieFleet(sctx, zombieStaleAge); zerr != nil {
+					slog.Error("push: zombie fleet", "err", zerr)
+				} else {
+					slog.Info("push: zombie fleet", "recipients", zn, "staleHours", 24)
+				}
 				cancel()
 				if bn > 0 {
 					slog.Info("blob sweep", "removed", bn)

--- a/server/internal/api/auth_handlers_test.go
+++ b/server/internal/api/auth_handlers_test.go
@@ -202,10 +202,11 @@ func (f *fakeStore) Ping(context.Context) error { return nil }
 // --- RelayStore (in-memory queue for relay-drain handler tests) ---
 
 type relayRow struct {
-	seq     int64
-	sender  string
-	msgID   string
-	payload []byte
+	seq       int64
+	sender    string
+	msgID     string
+	payload   []byte
+	createdMs int64 // 0 unless a test sets it (spec 2043 relay status)
 }
 
 func (f *fakeStore) EnqueueRelay(_ context.Context, recipient, sender, msgID string, payload []byte) error {
@@ -217,6 +218,19 @@ func (f *fakeStore) EnqueueRelay(_ context.Context, recipient, sender, msgID str
 	f.relaySeq++
 	f.relay[recipient] = append(f.relay[recipient], relayRow{seq: f.relaySeq, sender: sender, msgID: msgID, payload: payload})
 	return nil
+}
+
+func (f *fakeStore) OldestPendingForRecipient(_ context.Context, recipient string) (int64, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rows := f.relay[recipient]
+	var oldest int64
+	for _, row := range rows {
+		if row.createdMs > 0 && (oldest == 0 || row.createdMs < oldest) {
+			oldest = row.createdMs
+		}
+	}
+	return oldest, len(rows), nil
 }
 
 func (f *fakeStore) PendingForRecipient(_ context.Context, recipient string) ([]store.RelayItem, error) {

--- a/server/internal/api/relay_handlers.go
+++ b/server/internal/api/relay_handlers.go
@@ -68,6 +68,31 @@ func (h *Handlers) relayPending(w http.ResponseWriter, r *http.Request) {
 	httpx.JSON(w, http.StatusOK, map[string]any{"frames": frames})
 }
 
+// relayStatus (GET /v1/relay/status) returns metadata about the caller's queued
+// frames - the oldest frame's age and the total count - with NO side effects: unlike
+// relayPending it never dequeues and never emits a delivery receipt, so the client
+// can poll it on every foreground. It powers the spec-2043 zombie self-heal: a client
+// whose subscription the push service silently revoked (still 201-accepted upstream,
+// never delivered to the device) sees "the server is holding messages older than any
+// push wake I recorded" and force-rotates to a fresh subscription. Zero-knowledge:
+// only a server timestamp and a count leave the server, never any payload.
+func (h *Handlers) relayStatus(w http.ResponseWriter, r *http.Request) {
+	uid, _ := auth.UserID(r.Context())
+	oldestMs, count, err := h.Relay.OldestPendingForRecipient(r.Context(), uid)
+	if err != nil {
+		slog.Error("relay status failed", "err", err, "user", uid)
+		httpx.Error(w, http.StatusInternalServerError, "could not load relay status")
+		return
+	}
+	// null (not 0) when the queue is empty, so the client never misreads an empty
+	// queue as an epoch-0 timestamp.
+	var oldest any
+	if count > 0 && oldestMs > 0 {
+		oldest = oldestMs
+	}
+	httpx.JSON(w, http.StatusOK, map[string]any{"oldestQueuedAtMs": oldest, "count": count})
+}
+
 type relayAckRequest struct {
 	IDs []string `json:"ids"`
 }

--- a/server/internal/api/relay_handlers_test.go
+++ b/server/internal/api/relay_handlers_test.go
@@ -58,6 +58,67 @@ func TestRelayPendingAndAck(t *testing.T) {
 	}
 }
 
+// TestRelayStatus proves GET /v1/relay/status (spec 2043) reports the queued count
+// and oldest-frame age with NO side effects, and returns a null oldest for an empty
+// queue. It powers the client zombie self-heal without dequeuing or emitting receipts.
+func TestRelayStatus(t *testing.T) {
+	as := newFakeStore()
+	srv := NewRouter(&Handlers{
+		Store: as, Directory: as, Blocks: as, Relay: as, Hub: ws.NewHub(),
+		Keys: newFakeKeysStore(), Blobs: newFakeBlobStore(),
+		Sync: newFakeSyncStore(), Push: newFakePushStore(), Invites: as,
+		PublicURL: "https://ring.example",
+	}, []string{"http://localhost:5173"})
+
+	tok, uid, code := registerNamed(t, srv, "statususer")
+	if code != http.StatusOK {
+		t.Fatalf("register = %d", code)
+	}
+
+	// Empty queue → count 0 and a NULL oldest (never an epoch-0 timestamp).
+	rr := do(t, srv, http.MethodGet, "/v1/relay/status", tok, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var got struct {
+		OldestQueuedAtMs *int64 `json:"oldestQueuedAtMs"`
+		Count            int    `json:"count"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if got.Count != 0 || got.OldestQueuedAtMs != nil {
+		t.Fatalf("empty status = %+v, want count 0 + null oldest (%s)", got, rr.Body.String())
+	}
+
+	// Queue two frames, the older one stamped in the past.
+	as.mu.Lock()
+	as.relay = map[string][]relayRow{
+		uid: {
+			{seq: 1, sender: "00000000-0000-0000-0000-000000000999", msgID: "m1", createdMs: 1_000_000},
+			{seq: 2, sender: "00000000-0000-0000-0000-000000000999", msgID: "m2", createdMs: 2_000_000},
+		},
+	}
+	as.mu.Unlock()
+
+	rr = do(t, srv, http.MethodGet, "/v1/relay/status", tok, "")
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if got.Count != 2 {
+		t.Fatalf("status count = %d, want 2", got.Count)
+	}
+	if got.OldestQueuedAtMs == nil || *got.OldestQueuedAtMs != 1_000_000 {
+		t.Fatalf("status oldest = %v, want 1000000", got.OldestQueuedAtMs)
+	}
+
+	// No side effect: the frames are still queued (relay/status never dequeues).
+	pend := do(t, srv, http.MethodGet, "/v1/relay/pending", tok, "")
+	var pg struct {
+		Frames []json.RawMessage `json:"frames"`
+	}
+	_ = json.Unmarshal(pend.Body.Bytes(), &pg)
+	if len(pg.Frames) != 2 {
+		t.Fatalf("after status, pending = %d, want 2 (status must not dequeue)", len(pg.Frames))
+	}
+}
+
 // TestDeliveriesReconcile proves the WS11 sender-side reconcile: after the recipient
 // acks (recording a durable delivery), the SENDER can recover the 'delivered' state
 // for its still-'sent' messages even though the live receipt may have been dropped.

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -288,6 +288,9 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	// Relay drain over HTTP (for the service worker's background decrypt path; the
 	// live client still drains + acks over the WebSocket).
 	mux.Handle("GET /v1/relay/pending", authMW(http.HandlerFunc(h.relayPending)))
+	// Side-effect-free queue metadata (age + count) for the spec-2043 zombie
+	// self-heal; never dequeues, never emits a receipt, so it's safe to poll.
+	mux.Handle("GET /v1/relay/status", authMW(http.HandlerFunc(h.relayStatus)))
 	mux.Handle("POST /v1/relay/ack", authMW(http.HandlerFunc(h.relayAck)))
 	// Sender-side reconcile: which of my still-'sent' messages were delivered while
 	// I was offline (so a dropped 'delivered' receipt is recovered on reconnect).

--- a/server/internal/store/relay.go
+++ b/server/internal/store/relay.go
@@ -47,6 +47,36 @@ func (s *Store) PendingForRecipient(ctx context.Context, recipient string) ([]Re
 	return out, rows.Err()
 }
 
+// OldestPendingForRecipient returns the age of the oldest queued frame for a
+// recipient and the total queued count - zero-knowledge metadata for the client's
+// zombie self-heal (spec 2043). oldestMs is the oldest frame's created_at in epoch
+// milliseconds, 0 when the queue is empty. No payload ever leaves the server here;
+// only a server timestamp and a count, so the client can tell "the server is holding
+// messages I never woke for" without decrypting anything.
+func (s *Store) OldestPendingForRecipient(ctx context.Context, recipient string) (oldestMs int64, count int, err error) {
+	err = s.pool.QueryRow(ctx,
+		`SELECT COALESCE(EXTRACT(EPOCH FROM min(created_at)) * 1000, 0)::bigint, count(*)
+		   FROM relay_queue WHERE recipient = $1`,
+		recipient).Scan(&oldestMs, &count)
+	return oldestMs, count, err
+}
+
+// CountZombieFleet counts recipients who hold a push subscription yet carry unacked
+// relay frames older than staleAge - the server-side signature of a "zombie"
+// subscription (spec 2043): the upstream push service still 201-accepts every send,
+// but the device never wakes to drain, so frames pile up unacked. Emitted periodically
+// from the sweep loop for operator visibility (and a before/after handle on the fix).
+func (s *Store) CountZombieFleet(ctx context.Context, staleAge time.Duration) (int64, error) {
+	var n int64
+	err := s.pool.QueryRow(ctx,
+		`SELECT count(DISTINCT rq.recipient)
+		   FROM relay_queue rq
+		   JOIN push_subscriptions ps ON ps.user_id = rq.recipient
+		  WHERE rq.created_at < now() - make_interval(secs => $1)`,
+		staleAge.Seconds()).Scan(&n)
+	return n, err
+}
+
 // SweepRelayOlderThan deletes queued frames older than age, returning the number
 // removed. The service worker's preview path never acks (and even the spec-1032
 // authoritative drain acks only what it durably committed, leaving deferred frame

--- a/server/internal/ws/hub.go
+++ b/server/internal/ws/hub.go
@@ -46,6 +46,10 @@ const (
 type RelayStore interface {
 	EnqueueRelay(ctx context.Context, recipient, sender, msgID string, payload []byte) error
 	PendingForRecipient(ctx context.Context, recipient string) ([]store.RelayItem, error)
+	// OldestPendingForRecipient returns the oldest queued frame's age (epoch ms, 0 if
+	// empty) and the total count - zero-knowledge metadata for the spec-2043 zombie
+	// self-heal, with no payload and no side effects.
+	OldestPendingForRecipient(ctx context.Context, recipient string) (oldestMs int64, count int, err error)
 	DeleteRelay(ctx context.Context, recipient, msgID string) (sender string, found bool, err error)
 	// RecordDelivery durably notes msgID (from sender) reached recipient, so the
 	// sender can reconcile a dropped 'delivered' receipt on reconnect.

--- a/server/internal/ws/relay_test.go
+++ b/server/internal/ws/relay_test.go
@@ -83,6 +83,12 @@ func (m *memRelay) PendingForRecipient(_ context.Context, recipient string) ([]s
 	return append([]store.RelayItem(nil), m.queue[recipient]...), nil
 }
 
+func (m *memRelay) OldestPendingForRecipient(_ context.Context, recipient string) (int64, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return 0, len(m.queue[recipient]), nil
+}
+
 func (m *memRelay) DeleteRelay(_ context.Context, recipient, msgID string) (string, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/specs/2043-push-zombie-subscriptions/checklists/zero-knowledge.md
+++ b/specs/2043-push-zombie-subscriptions/checklists/zero-knowledge.md
@@ -1,0 +1,54 @@
+# Checklist: Zero-Knowledge Requirements Quality
+
+**Feature**: Push zombie subscriptions & silent-wake strikes (`2043`)
+**Created**: 2026-07-18
+**Purpose**: Unit-test the REQUIREMENTS for zero-knowledge quality (Constitution Principle I).
+Each item validates whether the spec *specifies* the boundary clearly, completely, and
+measurably — not whether the code works. Checked = the requirement is well-specified; the
+evidence section is cited.
+
+## Requirement Completeness
+
+- [X] CHK001 Does the spec include a dedicated Zero-Knowledge Impact section stating what crosses the wire, what is encrypted, and what metadata is unavoidably visible? [Completeness, Spec §Zero-Knowledge Impact]
+- [X] CHK002 Is every NEW server surface this feature adds enumerated with its exact returned fields for ZK review (status endpoint, fleet log)? [Completeness, Spec §Zero-Knowledge Impact, §FR-003/§FR-006]
+- [X] CHK003 Are the on-device wake ledger's stored fields fully enumerated so it's clear no plaintext is retained? [Completeness, Spec §FR-007, §Zero-Knowledge Impact]
+- [X] CHK004 Is the default state of the production diagnostic (off) specified, and the exact class of content it may surface? [Completeness, Spec §FR-008, §Zero-Knowledge Impact]
+- [X] CHK005 Does the spec state that no new plaintext enters any log, metric, error payload, or migration? [Completeness, Spec §Zero-Knowledge Impact, §FR-009]
+
+## Requirement Clarity
+
+- [X] CHK006 Is "content-free" defined concretely (enum kind, enum outcome, count, timestamp — no sender/body/tag) rather than left as an adjective? [Clarity, Spec §FR-007, §Key Entities]
+- [X] CHK007 Is the `/relay/status` payload specified precisely enough (timestamp + count, null-when-empty) to confirm it carries no capability id or ciphertext? [Clarity, Spec §FR-003, contracts/relay-status.md]
+- [X] CHK008 Is the diagnostic's "reason code" characterized as an internal token set (e.g. timeout, clean-resolve-no-show), distinguishing it from sender/message text? [Clarity, Spec §Zero-Knowledge Impact]
+
+## Requirement Consistency
+
+- [X] CHK009 Is the new status endpoint's metadata exposure justified as ≤ what the existing `/relay/pending` already exposes, so the boundary is not widened? [Consistency, Spec §Zero-Knowledge Impact]
+- [X] CHK010 Do the force-rotation requirements stay consistent with the existing single-subscription-per-user design without introducing a new server-visible identifier? [Consistency, Spec §FR-005, §Assumptions]
+- [X] CHK011 Are the ZK claims in the spec, the plan's Constitution Check, and the contract mutually consistent (no surface described as content-free in one and content-bearing in another)? [Consistency, Spec/Plan/contracts]
+
+## Acceptance Criteria Quality
+
+- [X] CHK012 Is there a measurable success criterion asserting no new surface transmits/stores plaintext, and is it tied to this checklist as its verification? [Measurability, Spec §SC-004]
+- [X] CHK013 Can "side-effect-free" for the status endpoint be objectively verified (no dequeue, no delivery receipt) as written? [Measurability, Spec §FR-003, contracts/relay-status.md]
+
+## Scenario & Edge-Case Coverage
+
+- [X] CHK014 Do the requirements cover the empty-queue case for the status endpoint (null, not an epoch-0 timestamp) so no misleading metadata is emitted? [Edge Case, Spec §Edge Cases, contracts/relay-status.md]
+- [X] CHK015 Is the ledger's bounded size specified so it cannot grow into a large local plaintext-adjacent store? [Coverage, Spec §FR-007]
+- [X] CHK016 Are auth/authorization requirements for the status endpoint specified (authenticated caller IS the recipient) so one device can't read another's queue metadata? [Coverage, contracts/relay-status.md]
+
+## Dependencies & Assumptions
+
+- [X] CHK017 Is the assumption that `relay_queue.created_at` / row count are already server-held (relay-necessary) metadata stated, so the endpoint adds no new collection? [Assumption, Spec §Zero-Knowledge Impact, §Assumptions]
+- [X] CHK018 Is it documented that the feature touches neither crypto primitives nor `SECRETS_KEY`, bounding its ZK/secret-material blast radius? [Assumption, Plan §Constitution Check IV/VI]
+
+## Ambiguities & Conflicts
+
+- [X] CHK019 Is there any requirement whose wording could be read as sending message content to the server for the self-heal? (Resolved: heal reads only queue age/count.) [Ambiguity, Spec §FR-004, §Zero-Knowledge Impact]
+- [X] CHK020 Is the diagnostic toggle unambiguously scoped to reason codes only, with no path to enabling sender/body exposure? [Ambiguity, Spec §FR-008, §Zero-Knowledge Impact]
+
+## Result
+
+All 20 items satisfied — the requirements specify a boundary that stays content-free on every
+new surface. No CRITICAL ZK gaps. Cleared against Constitution Principle I.

--- a/specs/2043-push-zombie-subscriptions/contracts/relay-status.md
+++ b/specs/2043-push-zombie-subscriptions/contracts/relay-status.md
@@ -1,0 +1,46 @@
+# Contract: `GET /v1/relay/status`
+
+Side-effect-free metadata about the authenticated caller's queued relay frames. Powers the
+spec-2043 client zombie self-heal. Distinct from `GET /v1/relay/pending`, which returns the
+ciphertext frames AND emits delivery receipts — `/relay/status` does neither.
+
+## Request
+
+```
+GET /v1/relay/status
+Authorization: Bearer <session token>
+```
+
+- Auth: required (`authMW`). The authenticated user IS the recipient; no path/query params.
+- No body.
+
+## Response — 200 OK
+
+```json
+{ "oldestQueuedAtMs": 1752871200000, "count": 5 }
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `oldestQueuedAtMs` | `number \| null` | Epoch ms of the oldest queued frame's `created_at`; **`null`** when the queue is empty (never `0`). |
+| `count` | `number` | Total queued (unacked) frames for this recipient. |
+
+## Guarantees
+
+- **No side effects**: does not dequeue any frame and does not send any `delivered` receipt.
+  A caller may poll it freely (the client throttles to once / 5 min regardless).
+- **Zero-knowledge**: returns only a server timestamp and an integer count — no payload,
+  ciphertext, sender, or message id. Derived from `relay_queue.created_at` / row count, which
+  the server already holds to relay.
+
+## Errors
+
+- `401 Unauthorized` — missing/invalid bearer token (via `authMW`).
+- `500 Internal Server Error` — query failure (`{"error":"could not load relay status"}`);
+  the client treats any failure as a no-op (no rotation).
+
+## Client usage
+
+`fetchRelayStatus()` (`src/services/api.ts`, 8s AbortController timeout) →
+`healZombieIfLikely()` (`src/services/push.ts`) evaluates `shouldRotateForQueueAge` and, on a
+match, force-rotates the subscription.

--- a/specs/2043-push-zombie-subscriptions/data-model.md
+++ b/specs/2043-push-zombie-subscriptions/data-model.md
@@ -1,0 +1,44 @@
+# Phase 1 Data Model — Push zombie subscriptions & silent-wake strikes
+
+No new IndexedDB object store and no new SQL table/migration. All state reuses existing
+stores/columns; below are the shapes this feature reads and writes.
+
+## Client (IndexedDB `settings` store — key/value)
+
+| Key | Value | Read/Write | Notes |
+|-----|-------|------------|-------|
+| `push.lastWakeAt` | `number` (epoch ms) | existing; read by self-heal | stamped by `stampPushWake` on every SW push wake |
+| `push.lastForceRotateAt` | `number` (epoch ms) | **new** | force-rotate retry-cap stamp (2h) |
+| `push.wakeLedger` | `WakeLedgerEntry[]` (≤50) | **new** | content-free ring buffer |
+| `diagnostics.pushReasonText` | `boolean` (default `false`) | **new** | opt-in production reason surfacing |
+
+`WakeLedgerEntry` (content-free): `{ ts: number; kind: WakeKind; outcome: WakeOutcome; count: number }`
+- `WakeKind`: `'call' | 'conn' | 'post' | 'post-activity' | 'version' | 'msg'`
+- `WakeOutcome`: `'shown' | 'licensed-silent' | 'fallback'`
+
+## Client (in-memory, per push event)
+
+`WakeCtx` — owned by `runGuardedWake`, one per push event, never shared:
+- `shown: boolean` — an OS notification was accepted this event (gates the reject/timeout fallback)
+- `satisfied: boolean` — shown OR silence licensed via `mayEndWakeSilently` (gates the clean-resolve backstop)
+
+`WakeResult` (returned by `runGuardedWake`): `{ shown, satisfied, fellBack }`.
+
+## Server (PostgreSQL — existing tables only)
+
+- `relay_queue(seq, recipient, sender, msg_id, payload, created_at)` — read-only here:
+  - `OldestPendingForRecipient(recipient)` → `(oldestMs int64, count int)` via
+    `min(created_at)` + `count(*)`.
+  - `CountZombieFleet(staleAge)` → `count(DISTINCT recipient)` joined to `push_subscriptions`
+    where `created_at < now() - staleAge`.
+- `push_subscriptions(user_id, endpoint, …)` — read-only join target for the zombie count.
+
+No column added; no state written server-side by this feature.
+
+## Rotation predicate (pure)
+
+`shouldRotateForQueueAge({ oldestQueuedAtMs, lastWakeAt, lastForceRotateAt, now })`:
+1. `!oldestQueuedAtMs` → `false` (empty queue)
+2. `now - oldestQueuedAtMs < 10min` → `false` (too fresh)
+3. `lastWakeAt >= oldestQueuedAtMs` → `false` (a wake since it queued → push path alive)
+4. else `now - lastForceRotateAt >= 2h`

--- a/specs/2043-push-zombie-subscriptions/plan.md
+++ b/specs/2043-push-zombie-subscriptions/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: Push zombie subscriptions & silent-wake strikes
+
+**Branch**: `fix/2043-push-zombie-subscriptions` | **Date**: 2026-07-18 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/2043-push-zombie-subscriptions/spec.md`
+
+## Summary
+
+Web-push notifications fail fleet-wide because subscriptions go "zombie": iOS/Chromium
+silently revoke delivery after ~3 push wakes that don't end in `showNotification`, yet the
+push service keeps returning 201, so the server never prunes and the device never wakes.
+Measured on prod: 13/37 subscriptions (35%) carry relay frames the device never drained; a
+fresh iPhone went zombie within an hour of a 5-message burst.
+
+Two-front fix, all client-side plus one metadata-only server endpoint:
+1. **Stop creating zombies** — replace the module-global "last shown" stamp in the SW push
+   guard with a **per-event** context so one push's notification can't suppress another's
+   fallback (the burst stamp-bleed), and enforce "every wake shows something" as a
+   backstop rather than an assumption.
+2. **Recover existing zombies** — a foreground-triggered, wake-independent self-heal that
+   reads server queue age from a new side-effect-free `GET /v1/relay/status` and
+   force-rotates a subscription the server proves is dead (fires even when the device never
+   woke — the case the existing decrypted-evidence rotation can't handle), with a 10-minute
+   zombie bar and its own 2-hour retry cap.
+3. **Observability** — a server zombie-fleet gauge in the sweep loop, a content-free
+   on-device wake ledger, and an opt-in production diagnostic that surfaces fallback reason
+   codes.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES modules, Vue 3 `<script setup>`); Go 1.26 (stdlib `net/http`)
+
+**Primary Dependencies**: Ionic, libsodium (unchanged here); server `pgx` v5, VAPID Web Push
+
+**Storage**: IndexedDB (client settings store for wake stamps/ledger); PostgreSQL `relay_queue` + `push_subscriptions` (server)
+
+**Testing**: vitest (client unit), Playwright (`e2e/`), `go test` against the in-memory fake store
+
+**Target Platform**: Installable PWA (iOS 16+/WebKit, Chromium engines) + `ringd` container
+
+**Project Type**: Web application (Vue PWA client + Go server, single image)
+
+**Performance Goals**: The push guard stays under iOS's ~30s SW-event budget (existing 20s deadline); `/relay/status` is one indexed count query; the foreground self-heal probe is throttled to once / 5 min
+
+**Constraints**: Zero-knowledge boundary (Principle I) — no new surface may carry plaintext; offline-first; PWA stays `registerType: 'prompt'`
+
+**Scale/Scope**: 37 live subscriptions today (majority iOS); the fix targets the 13 currently-zombie devices and every future one
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Zero-Knowledge Boundary (NON-NEGOTIABLE)** — PASS. See the spec's **Zero-Knowledge
+  Impact** section. `/relay/status` returns only a server timestamp + count (no payload, no
+  sender); the wake ledger stores only enum kind, enum outcome, count, timestamp; the
+  diagnostic surfaces internal reason codes, never sender or body; the force-rotation is a
+  subscribe/unsubscribe dance carrying no message data. No log line, metric, or error
+  payload gains plaintext.
+- **II. Spec-Driven Development** — PASS. Numbered hotfix spec (`2043`, band `2001+`), branch
+  `fix/2043-push-zombie-subscriptions`, pipeline specify → clarify → plan (here) → tasks →
+  analyze → checklist (required, see below) → taskstoissues → implement.
+- **III. Test-Driven Development** — PASS. This is a `2001+` bug fix, so it begins with a
+  failing regression test: `src/services/sw-guard.test.ts` reproduces the burst stamp-bleed
+  (a sibling event's show must not suppress this event's fallback) before the per-event ctx
+  landed. New pure logic is unit-tested (`shouldRotateForQueueAge` in `push.rotate.test.ts`;
+  the `/relay/status` handler + no-side-effect assertion in `relay_handlers_test.go`). The
+  SC-001 burst behavior is covered by a drive/e2e scenario (Phase 2 task).
+- **IV. Crypto Discipline** — N/A. No crypto primitives, key exchange, or ratchet touched;
+  the SW's existing decrypt path is unchanged.
+- **V. Offline-First Data Integrity** — PASS. New settings keys (`push.lastForceRotateAt`,
+  `push.wakeLedger`) live in the existing `settings` object store; no new store, so no
+  `DB_VERSION` bump / `onupgradeneeded` change is required.
+- **VI. Stateless Server & Forward-Only Migrations** — PASS. No schema change (reuses
+  `relay_queue.created_at` and `push_subscriptions`); no new migration. New handler is
+  stdlib `net/http` behind a small interface (`ws.RelayStore`) and tested against the fake
+  store. Does not touch `SECRETS_KEY`.
+- **VII. Quality Gates** — PASS. `npm run build`, `go build/vet/test`, and vitest all green
+  (1174 client + full server unit tests). Commit will be `fix(notifications): …` with
+  plain-language release-note copy.
+- **VIII. Traceable Delivery** — PASS. `ROADMAP.md` regenerated; tasks → issues; the PR will
+  list `Closes #N`.
+- **IX. Privacy & Data Minimization** — PASS. The wake ledger and zombie metric collect the
+  minimum (enums/counts), reveal no identity/contacts/behavior, and the diagnostic is
+  off by default.
+- **X / XI. Accessibility & Ionic-First UI** — PASS. The only UI is one `toggle` added to
+  `src/settings/schema.ts` (a data edit rendered by the stock settings page) — no bespoke
+  component.
+
+**Gate result: PASS — no violations, Complexity Tracking left empty.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/2043-push-zombie-subscriptions/
+├── plan.md              # This file
+├── spec.md              # Feature spec (+ Clarifications, + Zero-Knowledge Impact)
+├── research.md          # Phase 0 — decisions & rationale
+├── data-model.md        # Phase 1 — settings keys + server metadata shapes
+├── quickstart.md        # Phase 1 — how to verify (unit, drive/e2e, prod before/after)
+├── contracts/
+│   └── relay-status.md  # GET /v1/relay/status contract
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── sw.ts                       # per-event WakeCtx threaded through dispatchPush; guardedPush → runGuardedWake; diagnostic reason gate; recordWake
+├── services/
+│   ├── sw-inbox.ts             # runGuardedWake + WakeCtx/WakeResult; wake ledger (recordWake/readWakeLedger)
+│   ├── push.ts                 # shouldRotateForQueueAge, healZombieIfLikely, ensurePushSubscription({forceRotate})
+│   ├── api.ts                  # fetchRelayStatus
+│   ├── testhook.ts             # pushWakeLedger() accessor (dev-only)
+│   ├── sw-guard.test.ts        # NEW — per-event guard regression tests
+│   └── push.rotate.test.ts     # + shouldRotateForQueueAge truth table
+├── composables/useSync.ts      # wire healZombieIfLikely() into online + visibilitychange
+└── settings/schema.ts          # diagnostics.pushReasonText toggle
+
+server/
+├── internal/store/relay.go            # OldestPendingForRecipient, CountZombieFleet
+├── internal/api/relay_handlers.go     # relayStatus handler
+├── internal/api/router.go             # GET /v1/relay/status route
+├── internal/api/relay_handlers_test.go# TestRelayStatus
+├── internal/ws/hub.go                 # RelayStore interface += OldestPendingForRecipient
+└── cmd/ringd/main.go                  # "push: zombie fleet" gauge in the sweep loop
+```
+
+**Structure Decision**: Existing Vue-PWA-client + Go-server layout; no new top-level
+directories. Changes are localized to the push/notification path on both sides.
+
+## Complexity Tracking
+
+> No Constitution Check violations — table intentionally empty.

--- a/specs/2043-push-zombie-subscriptions/quickstart.md
+++ b/specs/2043-push-zombie-subscriptions/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart — verifying spec 2043
+
+## Automated gates (all currently green)
+
+```sh
+# Client typecheck + build
+npm run build
+
+# Focused unit suites
+npx vitest run src/services/sw-guard.test.ts \
+               src/services/push.rotate.test.ts \
+               src/services/sw-quiet.test.ts
+# (full suite: npx vitest run — 1174 tests)
+
+# Server
+cd server && go build ./... && go vet ./... && go test ./...
+```
+
+What they prove:
+- `sw-guard.test.ts` — the burst stamp-bleed regression (a sibling event's show does NOT
+  suppress this event's fallback), the clean-resolve backstop, and that licensed silence is
+  still exempt.
+- `push.rotate.test.ts` — `shouldRotateForQueueAge` truth table (empty / too-fresh /
+  `lastWakeAt>=oldest` / `lastWakeAt==0` with old queue / within-vs-over the 2h cap).
+- `relay_handlers_test.go` `TestRelayStatus` — count + null-when-empty, and that it does NOT
+  dequeue (no side effects).
+
+## Behavioral — the 5-message burst (SC-001)
+
+Drive a backgrounded recipient through a rapid burst and assert every wake ended visibly,
+via the dev test hook:
+
+```js
+// after pairing A→B and backgrounding B, A sends 5 messages fast, then:
+const ledger = await window.__ringTest.pushWakeLedger();
+// assert: no entry has outcome === 'fallback' beyond the expected, and none is silently
+// dropped — every push wake produced 'shown' or 'licensed-silent'.
+```
+
+Run against the live `make start` stack with the `drive/` harness (real push wakes are not
+reproducible headlessly; the ledger is the observable proxy).
+
+## Prod before/after (SC-002) — measured via k3s
+
+Baseline captured 2026-07-18: **`zombie_devices_24h = 13`**; fresh iPhone `1d0ca925` holds
+**5** unacked frames.
+
+```sh
+kubectl exec -n ring ring-postgres-0 -- psql -U ring -d ring -tA -c \
+ "select count(distinct rq.recipient) from relay_queue rq \
+    join push_subscriptions ps on ps.user_id = rq.recipient \
+   where rq.created_at < now() - interval '24 hours';"
+```
+
+After deploy, as devices foreground: the count should fall from 13 toward 0 (force-rotations
+replace dead endpoints; the fresh subs wake and drain), and `1d0ca925`'s 5 frames should
+clear. Watch the new `push: zombie fleet` log line in the `ringd` pod for the same trend.
+
+## On-device diagnosis
+
+Settings → Notifications → "Show notification diagnostics" (default off). When on, a generic
+fallback notification shows a content-free reason token (`timeout`, `clean-resolve-no-show`,
+…) so a real production device can report WHY it fell back — never sender or message content.

--- a/specs/2043-push-zombie-subscriptions/research.md
+++ b/specs/2043-push-zombie-subscriptions/research.md
@@ -1,0 +1,57 @@
+# Phase 0 Research — Push zombie subscriptions & silent-wake strikes
+
+No open `NEEDS CLARIFICATION` remained after `/speckit-clarify` (the two self-heal timing
+values were resolved). This records the decisions that shaped the design.
+
+## Decision: the failure is a client-side "zombie", not a server revocation
+
+- **Rationale**: Live prod evidence — `push: delivered endpoint=web.push.apple.com` (Apple
+  201) 102× / 26h with **zero** `push: pruning`; `relay_queue` rows delete on ack
+  (`store/relay.go` `DeleteRelay`), so leftover rows == frames never drained; 13/37 subs held
+  stale unacked backlog. The upstream push service accepts every send but the device never
+  wakes. This is the documented WebKit/Chromium behavior: repeated push wakes without
+  `showNotification` revoke delivery while the push service still returns 201.
+- **Alternatives considered**: server VAPID/config fault (ruled out — deliveries succeed,
+  config endpoint serves a valid key); not-installed PWA / permission (ruled out — the
+  subscription exists and is installed, iOS `installed_version 1.0.4`).
+
+## Decision: per-event WakeCtx instead of a module-global stamp
+
+- **Rationale**: The pre-fix guard tracked "did we show" in a module global
+  (`lastNotificationAt`). In an overlapping burst a later event's accepted show bled past an
+  earlier event's start and suppressed its fallback → a silent wake → an iOS strike. A
+  per-event context (`{ shown, satisfied }`) threaded through `dispatchPush` attributes each
+  show to exactly its event, eliminating cross-event bleed. Extracted into a pure,
+  injectable `runGuardedWake` so it is unit-testable outside the `self`-bound SW module.
+- **Alternatives considered**: (a) a per-event counter derived from a global monotonic show
+  count — still cross-contaminated by sibling events; (b) `getNotifications()` at fallback
+  time — already rejected historically (counts stale prior-push notifications). Per-event
+  ctx is the only attribution that is correct under concurrency.
+
+## Decision: server-truth self-heal reading queue age, wake-independent
+
+- **Rationale**: The existing rotation (`shouldRotateForStaleness`,
+  `shouldRotateForMissedWakes`) keys on the *decrypted* send time of drained messages, so it
+  needs the app to receive+decrypt and can match neither a fresh-burst zombie (<10 min,
+  <3 drain sessions) nor a subscription that never woke. Reading the server's oldest-queued
+  age directly lets the client decide from ground truth, and the `lastWakeAt >= oldest` guard
+  is the only wake check — so it fires even at `lastWakeAt == 0`, exactly the un-healable
+  case. A side-effect-free endpoint (no dequeue, no receipt) makes it safe to poll on
+  foreground.
+- **Timing** (from `/speckit-clarify`): 10-minute zombie bar (a held push to a live sub has
+  landed by then, so a merely-offline device won't false-rotate; matches `STALE_MSG_MS`);
+  2-hour retry cap, separate from the 24h drain cap, so a rotation onto another dead endpoint
+  can retry within the day without thrashing.
+- **Alternatives considered**: extending `/relay/pending` to expose `created_at` (rejected —
+  it emits delivery receipts as a side effect, unsafe to poll); lowering the existing 24h cap
+  (rejected — it also governs the decrypted-evidence path and would increase churn there).
+
+## Decision: observability is content-free and opt-in
+
+- **Rationale**: This bug class has recurred across 6+ specs because it is invisible on real
+  iOS devices. A server aggregate gauge + a content-free on-device ledger + an opt-in reason
+  diagnostic give measurement and on-device root-cause without crossing the zero-knowledge
+  boundary. Reuses the spec-2014 dev-host reason-gate pattern.
+- **Alternatives considered**: richer per-terminal outcome enums (deferred — coarse
+  shown/licensed-silent/fallback already distinguishes the failure modes we act on);
+  always-on production reason text (rejected — noise for normal users; gated behind a toggle).

--- a/specs/2043-push-zombie-subscriptions/spec.md
+++ b/specs/2043-push-zombie-subscriptions/spec.md
@@ -1,0 +1,197 @@
+# Feature Specification: Push zombie subscriptions & silent-wake strikes
+
+**Feature Branch**: `fix/2043-push-zombie-subscriptions`
+
+**Created**: 2026-07-18
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: A brand-new iPhone 15 (iOS 26.5.2, installed PWA, backgrounded) received a
+burst of messages but showed **no notification at all**. Live investigation on prod
+(`ring.zuptalo.com`) found this is fleet-wide: **13 of 37 push subscriptions (35%)** carry
+`relay_queue` frames the device never acked (some stacked since mid-June) while the push
+service keeps 201-accepting every send. The subscriptions are **zombies** — iOS/Chromium
+silently revoked delivery after ~3 push wakes that didn't end in `showNotification`, but the
+push service still returns 201, so the server sees "delivered" and never prunes.
+
+## Clarifications
+
+### Session 2026-07-18
+
+- Q: How old must the oldest queued frame be (no push wake since) before force-rotating as a zombie? → A: 10 minutes (matches the existing stale-drain bar; a held push to a live sub has landed by then, so a merely-offline device won't false-rotate).
+- Q: What retry cap should the force-rotate self-heal use, separate from the existing 24h drain-rotation cap? → A: 2 hours (a device that rotates onto another dead endpoint retries within the day, while a single foreground can't thrash subscriptions).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - New device keeps receiving notifications through a burst (Priority: P1)
+
+A person installs Ring on a fresh phone and a friend sends several messages in quick
+succession while the app is backgrounded. Every message produces a visible notification, so
+the subscription never accrues a silent-wake strike and is never revoked.
+
+**Why this priority**: This is the acute regression — a rapid burst to a cold device is the
+exact shape that strikes out a fresh subscription within its first hour (confirmed on device
+`1d0ca925`). If the burst still produces silent wakes, every new device keeps going dark.
+
+**Independent Test**: Drive overlapping `push` events into the SW (5-message burst,
+recipient backgrounded) and assert **every** event ends with an accepted `showNotification`
+— no event completes silently.
+
+**Acceptance Scenarios**:
+
+1. **Given** two overlapping push events where the later event's notification resolves before
+   the earlier event times out, **When** the earlier event's handler ends, **Then** it still
+   shows its own notification (its fallback is not suppressed by the sibling's show).
+2. **Given** a push handler that resolves cleanly without showing anything and without a
+   licensed-silence outcome, **When** the wake ends, **Then** a backstop notification is
+   shown.
+3. **Given** a wake on a platform/state where silence is licensed (`mayEndWakeSilently`),
+   **When** the wake ends silently, **Then** no backstop fires (the exemption is preserved).
+
+### User Story 2 - An already-zombie device heals itself on next open (Priority: P1)
+
+A device whose subscription was silently revoked in the past (the push service still 201s,
+but nothing ever wakes it) recovers automatically the next time the person opens the app: it
+detects that the server holds messages it never woke for and rotates to a fresh
+subscription, after which notifications resume.
+
+**Why this priority**: 35% of the live fleet is currently in this state and cannot recover
+today (the existing evidence-based rotation can't match a never-woken or fresh-burst
+subscription). Without this, the 13 stuck devices stay dark forever.
+
+**Independent Test**: Seed a device with `lastWakeAt=0` and a server queue whose oldest frame
+is >10 min old; on foreground, assert it force-rotates the subscription (fresh endpoint
+registered) exactly once, then respects the short retry cap.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server reports queued frames older than the zombie bar and no push wake
+   since they queued, **When** the app foregrounds, **Then** the client unsubscribes and
+   re-subscribes to a fresh endpoint and registers it.
+2. **Given** a merely-offline device whose held push lands and stamps a fresh wake, **When**
+   it foregrounds, **Then** it does **not** rotate (no false positive).
+3. **Given** a device that just force-rotated, **When** it foregrounds again within the cap,
+   **Then** it does not rotate again.
+
+### User Story 3 - We can see why a device fell silent (Priority: P2)
+
+Operators can measure the zombie-fleet size over time, and a person debugging on a real
+production device can turn on a diagnostic that reveals *why* a notification fell back to
+generic — without any message content leaving the zero-knowledge boundary.
+
+**Why this priority**: This class of bug has recurred across 6+ specs precisely because it is
+invisible on real iOS devices. Measurement + on-device reason codes let us confirm the fix
+and catch regressions.
+
+**Independent Test**: Run the server sweep and assert a `push: zombie fleet` count is logged;
+enable the diagnostic setting and assert the on-device wake ledger records content-free
+outcome entries and the generic body surfaces a reason code.
+
+**Acceptance Scenarios**:
+
+1. **Given** the hourly sweep runs, **When** it completes, **Then** it logs the count of
+   recipients holding a subscription plus stale unacked backlog.
+2. **Given** the diagnostic setting is on, **When** a wake falls back to generic, **Then** the
+   notification body shows a content-free reason code and the wake ledger records
+   `{ts,kind,outcome,count}` only.
+
+### Edge Cases
+
+- Queue age is reported but `lastWakeAt` is newer (offline phone caught up) → no rotation.
+- `/relay/status` fetch fails or times out → heal is a no-op (best-effort), never blocks UI.
+- Rotation lands on another dead endpoint → the 2h cap (not 24h) allows a retry next session.
+- Every frame in a burst is muted/hidden/badge-only → each wake still ends visibly (quiet
+  note) or with licensed silence; never a bare silent completion.
+- Reassigning `showNotification` is blocked by the platform → per-event tracking still works
+  (attribution moved off the global wrapper).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A push wake MUST NOT complete without either an accepted `showNotification` or a
+  `mayEndWakeSilently`-licensed silent outcome — tracked **per event**, so one event's show
+  can never suppress another event's fallback.
+- **FR-002**: When a push handler resolves cleanly having neither shown nor licensed silence,
+  the system MUST show a backstop notification.
+- **FR-003**: The server MUST expose queued-frame age + count for the authenticated recipient
+  via a side-effect-free endpoint that emits no delivery receipts and returns no payload.
+- **FR-004**: On foreground/reconnect, the client MUST detect a likely-zombie subscription
+  from server queue age (oldest queued frame older than the **10-minute** zombie bar with no
+  push wake since) independent of decryption, WS drain, or a push wake, and force-rotate the
+  subscription, bounded by a **2-hour** retry cap distinct from the existing 24h drain cap.
+- **FR-005**: The force-rotation MUST reuse the existing unsubscribe→subscribe→register path
+  and carry no message data.
+- **FR-006**: The server MUST periodically log the count of recipients holding a push
+  subscription plus stale unacked relay backlog (zombie-fleet size).
+- **FR-007**: The client MUST keep a bounded on-device wake ledger of content-free entries
+  (enum kind, enum outcome, count, timestamp) — no sender, body, or tag.
+- **FR-008**: A production device MUST be able to opt into surfacing content-free fallback
+  reason codes for diagnosis, off by default.
+- **FR-009 (zero-knowledge)**: Every new surface MUST remain content-free — `/relay/status`
+  returns a timestamp + count only; the ledger and diagnostic carry no plaintext.
+
+### Key Entities
+
+- **Zombie subscription**: a push subscription the upstream service still 201-accepts but the
+  device never wakes for; observable server-side as a recipient with a subscription plus
+  stale unacked `relay_queue` frames.
+- **Wake ledger entry**: `{ ts, kind, outcome, count }` — content-free record of one push
+  wake's outcome, capped ring buffer in device settings.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a 5-message burst to a backgrounded fresh device, **100%** of push events end
+  with an accepted `showNotification` (zero silent completions in the unit/e2e harness).
+- **SC-002**: The prod zombie-fleet count (recipients with a subscription + unacked backlog
+  older than 24h) drops from **13** toward 0 as devices foreground after the fix.
+- **SC-003**: A device seeded with `lastWakeAt=0` and an old server queue force-rotates
+  exactly once per retry-cap window, and a caught-up offline device never rotates.
+- **SC-004**: No new surface transmits or stores message plaintext (verified by the required
+  zero-knowledge checklist).
+
+## Zero-Knowledge Impact
+
+*What crosses the wire, what is encrypted, what metadata is unavoidably visible, and why.*
+
+- **New endpoint `GET /v1/relay/status`** returns only `{ oldestQueuedAtMs, count }` — a
+  server-side timestamp and an integer. No payload, ciphertext, sender, or message id leaves
+  the server. Both values derive from `relay_queue` columns the server already holds
+  (`created_at`, row count) to relay at all; this exposes no new metadata beyond what queuing
+  inherently requires, and strictly less than the existing `GET /v1/relay/pending` (which
+  returns the ciphertext frames). It is side-effect-free (no dequeue, no delivery receipt).
+- **Server zombie-fleet log** (`push: zombie fleet`, recipients=N) is an aggregate count of
+  distinct recipients with stale unacked backlog. No user id, endpoint, or content is logged.
+- **On-device wake ledger** (`push.wakeLedger`) stores only `{ ts, kind, outcome, count }` —
+  an enum tickle kind, an enum outcome, an integer, a timestamp. It never records sender,
+  message body, chat id, or tag, and never leaves the device (surfaced only in the local
+  diagnostics view / dev test hook).
+- **Production diagnostic** (`diagnostics.pushReasonText`, off by default) surfaces the
+  existing content-free fallback reason token (e.g. `timeout`, `clean-resolve-no-show`, an
+  error message) in the generic notification body — the same class the spec-2014 dev-host
+  reason gate already showed. It never reveals who messaged or what was said.
+- **Force-rotation** is a `pushManager` unsubscribe→subscribe→register round trip carrying no
+  message data; the server row is replaced under the existing single-subscription-per-user
+  design.
+- **Nothing decrypts on the server**, and no plaintext enters any log, metric, error payload,
+  or migration. The push tickle itself remains the existing content-free type; this spec adds
+  no plaintext to it.
+
+## Assumptions
+
+- iOS/WebKit and Chromium both revoke `userVisibleOnly` subscriptions after repeated
+  no-`showNotification` wakes, and continue to return 201 afterward (zombie) — cured only by
+  a client-side re-subscribe.
+- `relay_queue` rows are deleted on ack (with a 35-day sweep backstop), so remaining rows
+  represent frames the recipient never drained.
+- The single-active-subscription-per-user server design (one row, upsert on rotate) is
+  retained; a fresh endpoint replaces the prior row.
+- Existing SW hardening (specs 1034/2016/2017/2023) and the `push.ts` rotate/unsubscribe
+  machinery are reused, not replaced.

--- a/specs/2043-push-zombie-subscriptions/tasks.md
+++ b/specs/2043-push-zombie-subscriptions/tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Push zombie subscriptions & silent-wake strikes
+
+**Feature**: `fix/2043-push-zombie-subscriptions` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+TDD is mandated (Principle III — a `2001+` bug fix begins with a failing regression test).
+Test tasks precede the implementation they cover. `[P]` marks tasks touching different files
+with no incomplete dependency. Checked boxes reflect work already completed on this branch;
+unchecked tasks are the owed behavioral/deploy verification.
+
+## Phase 1: Setup
+
+- [X] T001 Create hotfix spec + branch via `make spec CATEGORY=hotfix` (branch `fix/2043-push-zombie-subscriptions`, `specs/2043-push-zombie-subscriptions/`), and run `make roadmap`
+
+## Phase 2: Foundational (blocking prerequisites)
+
+- [X] T002 Add per-event guard primitives `WakeCtx`, `WakeResult`, `runGuardedWake`, and `PUSH_DEADLINE_MESSAGE` in `src/services/sw-inbox.ts` (pure, injectable — the seam every story's SW change builds on)
+
+## Phase 3: User Story 1 — New device keeps receiving notifications through a burst (P1)
+
+**Goal**: No push wake completes silently; a burst can't make one event's show suppress
+another's fallback. **Independent test**: overlapping `push` events each end with an accepted
+`showNotification` (sw-guard unit + drive/e2e burst).
+
+- [X] T003 [US1] Write failing guard regression tests in `src/services/sw-guard.test.ts`: burst isolation (sibling show must not suppress this event's fallback), clean-resolve backstop, licensed-silence exemption, timeout fallback
+- [X] T004 [US1] Thread a per-event `WakeCtx` through `dispatchPush(event, ctx)` in `src/sw.ts`, setting `shown`/`satisfied` at every terminal (call, conn, post, post-activity, version, page-claim, drain, message); make `showQuietUnlessVisible` return did-show
+- [X] T005 [US1] Rewrite `guardedPush` to use `runGuardedWake` and DELETE the module-global `lastNotificationAt` + the `showNotification` monkeypatch in `src/sw.ts`
+- [X] T006 [US1] Update `tryAuthoritativeDrain(ctx)` and `showMessageNotification(ctx)` in `src/sw.ts` to report their outcome into the ctx
+- [ ] T007 [US1] Add a drive/e2e burst scenario (5 rapid messages to a backgrounded recipient) asserting via `window.__ringTest.pushWakeLedger()` that no wake is silent (SC-001)
+
+## Phase 4: User Story 2 — An already-zombie device heals itself on next open (P1)
+
+**Goal**: A subscription the server proves is dead (old queued frames, no wake since)
+force-rotates on foreground, even at `lastWakeAt==0`. **Independent test**: seeded
+`lastWakeAt=0` + old queue → rotates once, respects the 2h cap; a caught-up offline device
+does not.
+
+- [X] T008 [P] [US2] Write failing `shouldRotateForQueueAge` truth-table tests in `src/services/push.rotate.test.ts` (empty / too-fresh / `lastWakeAt>=oldest` / `lastWakeAt==0` old queue / within-vs-over 2h cap)
+- [X] T009 [P] [US2] Write failing `TestRelayStatus` in `server/internal/api/relay_handlers_test.go` (count + null-when-empty + NO dequeue side effect)
+- [X] T010 [US2] Add `OldestPendingForRecipient` to `server/internal/store/relay.go` and to the `RelayStore` interface in `server/internal/ws/hub.go`; implement in the fakes (`auth_handlers_test.go`, `ws/relay_test.go`)
+- [X] T011 [US2] Add the side-effect-free `relayStatus` handler in `server/internal/api/relay_handlers.go` and register `GET /v1/relay/status` behind `authMW` in `server/internal/api/router.go`
+- [X] T012 [P] [US2] Add `fetchRelayStatus()` (bearer auth, 8s timeout) in `src/services/api.ts`
+- [X] T013 [US2] Add the pure `shouldRotateForQueueAge` predicate (10-min bar, 2h cap, `push.lastForceRotateAt`) and `healZombieIfLikely()` (throttled probe → force-rotate) in `src/services/push.ts`
+- [X] T014 [US2] Add the `ensurePushSubscription({ forceRotate })` hook reusing the unsubscribe→subscribe→register path in `src/services/push.ts`
+- [X] T015 [US2] Wire `void healZombieIfLikely()` into `src/composables/useSync.ts` on transport `online` and on `visibilitychange`→visible
+
+## Phase 5: User Story 3 — We can see why a device fell silent (P2)
+
+**Goal**: Server zombie-fleet gauge + content-free on-device wake ledger + opt-in production
+reason diagnostic. **Independent test**: sweep logs a `push: zombie fleet` count; with the
+toggle on, a fallback shows a content-free reason and the ledger records enum entries.
+
+- [X] T016 [P] [US3] Add `CountZombieFleet(staleAge)` in `server/internal/store/relay.go`
+- [X] T017 [US3] Emit `slog.Info("push: zombie fleet", ...)` from the ringd hourly sweep loop in `server/cmd/ringd/main.go`
+- [X] T018 [P] [US3] Add the content-free wake ledger (`recordWake`/`readWakeLedger`, `push.wakeLedger`) in `src/services/sw-inbox.ts`; record one entry per wake in `guardedPush` (`src/sw.ts`)
+- [X] T019 [US3] Extend `showGeneric`'s reason gate with the opt-in `diagnostics.pushReasonText` setting in `src/sw.ts`
+- [X] T020 [P] [US3] Add the `diagnostics.pushReasonText` toggle to `src/settings/schema.ts` and expose `pushWakeLedger()` on the dev test hook in `src/services/testhook.ts`
+
+## Phase 6: Polish & Cross-Cutting
+
+- [X] T021 Verify all gates: `npm run build`, `go build/vet/test`, full vitest (1174 pass), full `go test ./...`
+- [X] T022 Capture the prod before-baseline (`zombie_devices_24h = 13`; `1d0ca925` = 5 frames) for the SC-002 before/after
+- [ ] T023 Deploy, then confirm SC-002: the zombie count falls from 13 and `1d0ca925`'s frames drain as devices foreground; watch the `push: zombie fleet` log
+- [ ] T024 Real-device pass on iOS 26.5.2 with the diagnostics toggle on: confirm burst notifications land and the wake ledger populates (the owed device verification)
+
+## GitHub issues (task groups → for the feature→develop PR's `Closes #N`)
+
+- **#1031** — US1: per-event push guard (T002–T007)
+- **#1032** — US2: server `/relay/status` + client zombie self-heal (T008–T015)
+- **#1033** — US3: observability — zombie metric + wake ledger + diagnostic (T016–T020)
+- **#1034** — Verification & rollout (T021–T024)
+
+## Dependencies & order
+
+- Setup (T001) → Foundational (T002) → then stories.
+- **US1** (T003–T007) depends only on T002; it is the acute fix and the MVP.
+- **US2** (T008–T015): T010→T011 (handler needs the store method + interface); T012→T013→T014→T015 (client heal needs the fetch, predicate, rotate hook, then wiring). Server tasks and client `fetchRelayStatus` (T012) are `[P]` relative to each other.
+- **US3** (T016–T020) depends on T002 (ledger records via the guard) but is otherwise independent of US1/US2.
+- Polish (T021–T024) after the stories; T023/T024 require a deploy + device (owed).
+
+## Parallel execution examples
+
+- US2 kick-off in parallel: T008 (client predicate test) ∥ T009 (server handler test) ∥ T012 (client fetch helper) — different files, no shared dependency.
+- US3 in parallel: T016 (server count) ∥ T018 (client ledger) ∥ T020 (settings toggle + test hook).
+
+## Implementation strategy
+
+MVP = **US1** (stops new zombies — the acute fresh-device strike-out). Then **US2** (recovers
+the existing 35% fleet). Then **US3** (measurement + on-device root-cause). US1 and US3 are
+independently shippable; US2 is the highest-impact recovery and depends on its own server
+endpoint only.

--- a/src/composables/useSync.ts
+++ b/src/composables/useSync.ts
@@ -29,7 +29,7 @@ import { deferNotificationsFor } from '@/services/notify';
 import { publishOwnPreKeysOnce, replenishPreKeysIfLow } from '@/services/messaging';
 import { runOwnSync, ownSyncQuiet } from '@/services/ownsync';
 import { publishOwnProfile, syncContactEdges, refreshContactProfiles } from '@/services/directory';
-import { applyPushPreference, disablePush, revalidatePushSubscription } from '@/services/push';
+import { applyPushPreference, disablePush, healZombieIfLikely, revalidatePushSubscription } from '@/services/push';
 import { checkForUpdate } from '@/composables/useAppUpdate';
 import { refreshConnections, onConnectionAccepted } from '@/services/connections';
 import { notifyIncoming } from '@/services/notify';
@@ -303,6 +303,10 @@ function start(): void {
       // outcome marker lands before the stale judgement.
       if (isUnlocked.value) void reconcilePendingCallEvents();
       void applyPushPreference(true); // (re)register or drop push per the notification prefs
+      // (spec 2043) On reconnect, check whether the server is holding frames this
+      // device never woke for — the zombie signature — and force-rotate if so. This
+      // is wake-independent, so it recovers a subscription that silently went dark.
+      void healZombieIfLikely();
       void sendPresencePrefs(); // upload our sharing booleans
       void sendPresenceSub(); // watch our contacts' presence
       void sendPresenceSelf(selfActive()); // correct the server's connect-default if we're locked
@@ -518,6 +522,9 @@ function start(): void {
         // whose subscription silently lapsed while closed heals on foreground.
         // Throttled internally, so this is cheap to run every time.
         void revalidatePushSubscription();
+        // (spec 2043) And on a warm reopen, force-rotate a subscription the server
+        // proves is a zombie (holding frames older than any wake). Throttled too.
+        void healZombieIfLikely();
         void sweepExpiredMessages(); // drop anything that expired while backgrounded
         // Spec 1032: the SW may have PERSISTED messages while this page sat frozen
         // (iOS freezes JS but keeps the page alive), and a frozen page can miss the

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -608,6 +608,28 @@ export async function subscribePush(sub: {
   if (!res.ok) throw new Error(`push subscribe failed: ${res.status}`);
 }
 
+/**
+ * (spec 2043) Fetch the caller's queued-frame status: the oldest queued frame's age
+ * (epoch ms, null when the queue is empty) and the total count. Side-effect-free on
+ * the server (no dequeue, no delivery receipt), so it is safe to poll on foreground.
+ * Powers the client zombie self-heal: a subscription the push service silently
+ * revoked still 201-accepts upstream but never wakes the device, so the server holds
+ * frames older than any push wake this device recorded. Bounded so a hung request
+ * can't stall the foreground path.
+ */
+export async function fetchRelayStatus(): Promise<{ oldestQueuedAtMs: number | null; count: number }> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 8000);
+  let res: Response;
+  try {
+    res = await fetch(`${apiBaseUrl()}/v1/relay/status`, { headers: authHeaders(), signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!res.ok) throw new Error(`relay status failed: ${res.status}`);
+  return (await res.json()) as { oldestQueuedAtMs: number | null; count: number };
+}
+
 /** Mint a single-use invitation code (owned by the current user) to share. */
 export async function createInvitation(): Promise<{ code: string; publicUrl: string }> {
   const res = await fetch(`${apiBaseUrl()}/v1/invitations`, {

--- a/src/services/push.rotate.test.ts
+++ b/src/services/push.rotate.test.ts
@@ -67,3 +67,44 @@ describe('weak zombie signature: shouldRotateForMissedWakes', () => {
     expect(shouldRotateForMissedWakes({ ...weakBase, lastRotateAt: NOW - 23 * H })).toBe(false);
   });
 });
+
+// Spec 2043 — the server-truth zombie signature: the server holds queued frames
+// older than the bar with NO push wake since they queued. Unlike the two decrypted-
+// evidence signatures above, this reads directly from /relay/status, so it fires even
+// on a device whose lastWakeAt is 0 (never woke) or a fresh-burst zombie that matches
+// neither the ≥10-min-stale nor the streak-of-3 signature. Its OWN short (2h) cap,
+// separate from the 24h drain cap, lets a device that rotated into a still-dead
+// endpoint retry next session.
+import { shouldRotateForQueueAge } from './push';
+
+const M = 60 * 1000;
+const queueBase = {
+  oldestQueuedAtMs: NOW - 30 * M, // oldest frame queued 30min ago (well past the 10min bar)
+  lastWakeAt: 0, // never woke — the exact case the decrypted-evidence signatures can't heal
+  lastForceRotateAt: 0,
+  now: NOW,
+};
+
+describe('spec 2043: shouldRotateForQueueAge', () => {
+  it('fires when the server holds old frames and this device never woke', () => {
+    expect(shouldRotateForQueueAge(queueBase)).toBe(true);
+  });
+  it('empty queue (null) → never', () => {
+    expect(shouldRotateForQueueAge({ ...queueBase, oldestQueuedAtMs: null })).toBe(false);
+  });
+  it('a queue younger than the 10min bar → wait (a held push to a live sub may still be in flight)', () => {
+    expect(shouldRotateForQueueAge({ ...queueBase, oldestQueuedAtMs: NOW - 3 * M })).toBe(false);
+  });
+  it('a wake since the oldest frame queued → not a zombie (offline phone caught up)', () => {
+    expect(shouldRotateForQueueAge({ ...queueBase, lastWakeAt: queueBase.oldestQueuedAtMs + 1000 })).toBe(false);
+  });
+  it('a wake BEFORE the oldest frame keeps the signature (that wake proves nothing about these frames)', () => {
+    expect(shouldRotateForQueueAge({ ...queueBase, lastWakeAt: queueBase.oldestQueuedAtMs - 1000 })).toBe(true);
+  });
+  it('force-rotated within the 2h cap → wait', () => {
+    expect(shouldRotateForQueueAge({ ...queueBase, lastForceRotateAt: NOW - 1 * H })).toBe(false);
+  });
+  it('force-rotated over 2h ago → allowed again (retry a still-dead endpoint)', () => {
+    expect(shouldRotateForQueueAge({ ...queueBase, lastForceRotateAt: NOW - 3 * H })).toBe(true);
+  });
+});

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -9,7 +9,7 @@
  * Requires notification permission to already be granted (the onboarding wizard
  * handles the prompt); these functions are safe no-ops otherwise.
  */
-import { fetchServerConfig, savePushPrefs, subscribePush, unsubscribePushServer } from './api';
+import { fetchRelayStatus, fetchServerConfig, savePushPrefs, subscribePush, unsubscribePushServer } from './api';
 import { get, getAll, put, remove, subscribe as subscribeBus } from '@/db/idb';
 import { readHiddenSetOrNull } from './hidden-chats';
 import { derivePushPrefs, type PrefsChatSnap } from './push-prefs';
@@ -176,6 +176,65 @@ async function consumeRotationDecision(): Promise<boolean> {
 
 export { STALE_MSG_MS };
 
+/* ---- (spec 2043) The SERVER-TRUTH zombie signature. The two signatures above key
+ * on the DECRYPTED send time of a drained message, so they need the app to actually
+ * receive + decrypt frames, and they can't match a fresh-burst zombie (<10min old,
+ * <3 drain sessions) or a subscription that NEVER woke. This one reads /relay/status
+ * directly: if the server is holding frames older than the bar and this device has no
+ * push wake since they queued, the subscription is a zombie (still 201-accepted
+ * upstream, never delivered) — rotate. It fires even when lastWakeAt is 0, which is
+ * the whole point. Its own SHORT cap (2h, not the 24h drain cap) lets a device that
+ * rotated into a still-dead endpoint retry on the next session. ---- */
+const ZOMBIE_QUEUE_AGE_MS = 10 * 60 * 1000; // a frame this old must have woken a live sub by now
+const FORCE_ROTATE_MIN_INTERVAL_MS = 2 * 60 * 60 * 1000; // retry cap for the force-rotate signal
+const FORCE_ROTATED_KEY = 'push.lastForceRotateAt';
+
+/** The pure server-truth rotation decision (unit-tested). */
+export function shouldRotateForQueueAge(args: {
+  oldestQueuedAtMs: number | null;
+  lastWakeAt: number;
+  lastForceRotateAt: number;
+  now: number;
+}): boolean {
+  const { oldestQueuedAtMs, lastWakeAt, lastForceRotateAt, now } = args;
+  if (!oldestQueuedAtMs) return false; // empty queue (null / 0)
+  if (now - oldestQueuedAtMs < ZOMBIE_QUEUE_AGE_MS) return false; // too fresh — a held push may still be in flight
+  if (lastWakeAt >= oldestQueuedAtMs) return false; // a wake since it queued → the push path works
+  return now - lastForceRotateAt >= FORCE_ROTATE_MIN_INTERVAL_MS;
+}
+
+// Throttle the /relay/status probe so healZombieIfLikely is cheap to call on every
+// foreground and reconnect (mirrors revalidatePushSubscription's throttle).
+let lastZombieProbe = 0;
+const ZOMBIE_PROBE_THROTTLE_MS = 5 * 60_000;
+
+/**
+ * (spec 2043) Detect a likely-zombie subscription from SERVER queue age and, if
+ * found, force-rotate to a fresh endpoint — the only client-side cure for a
+ * subscription the push service silently revoked (it still 201-accepts, so the
+ * server never prunes and the browser hands back the same dead object forever).
+ * Foreground/reconnect-driven and wake-independent: this is what recovers a device
+ * that went dark without ever waking. Best-effort and throttled; a probe failure
+ * or a not-yet-zombie result is a silent no-op.
+ */
+export async function healZombieIfLikely(): Promise<void> {
+  if (!pushReady()) return;
+  const now = Date.now();
+  if (now - lastZombieProbe < ZOMBIE_PROBE_THROTTLE_MS) return;
+  lastZombieProbe = now;
+  try {
+    const { oldestQueuedAtMs } = await fetchRelayStatus();
+    const lastWakeAt = (await get<Setting<number>>('settings', WAKE_KEY))?.value ?? 0;
+    const lastForceRotateAt = (await get<Setting<number>>('settings', FORCE_ROTATED_KEY))?.value ?? 0;
+    if (!shouldRotateForQueueAge({ oldestQueuedAtMs, lastWakeAt, lastForceRotateAt, now })) return;
+    console.warn('[push] server-truth zombie signature — force-rotating the subscription');
+    await put<Setting<number>>('settings', { key: FORCE_ROTATED_KEY, value: now });
+    await ensurePushSubscription({ forceRotate: true });
+  } catch {
+    /* probe/rotate is best-effort — the next foreground retries after the throttle */
+  }
+}
+
 /** Whether an existing subscription was created with the given VAPID key. If not,
  *  the server's key rotated (or differs across envs) and pushes to it would
  *  silently fail, so it must be replaced. */
@@ -196,7 +255,7 @@ function subMatchesKey(sub: PushSubscription, desired: Uint8Array): boolean {
  * re-subscribes, so a rotated/mismatched key can't silently kill delivery. Returns
  * true only when a subscription was successfully registered (so callers can retry).
  */
-export async function ensurePushSubscription(): Promise<boolean> {
+export async function ensurePushSubscription(opts?: { forceRotate?: boolean }): Promise<boolean> {
   if (!pushReady()) return false;
   try {
     const reg = await navigator.serviceWorker.ready;
@@ -207,6 +266,17 @@ export async function ensurePushSubscription(): Promise<boolean> {
     const key = urlBase64ToUint8Array(vapidPublicKey);
     let sub = await reg.pushManager.getSubscription();
     if (sub && !subMatchesKey(sub, key)) {
+      try {
+        await sub.unsubscribe();
+      } catch {
+        /* ignore, we resubscribe below regardless */
+      }
+      sub = null;
+    }
+    // (spec 2043) Caller-forced rotation: the server-truth zombie heal decided this
+    // endpoint is dead (queued frames older than any wake). Drop it and mint a fresh
+    // one — the browser object is not trustworthy evidence the push service delivers.
+    if (sub && opts?.forceRotate) {
       try {
         await sub.unsubscribe();
       } catch {

--- a/src/services/sw-guard.test.ts
+++ b/src/services/sw-guard.test.ts
@@ -1,0 +1,121 @@
+// Spec 2043 — the per-event guard around a push wake. The pre-2043 bug was a
+// MODULE-GLOBAL "last notification shown" stamp: in an overlapping burst, a later
+// event's accepted show bled past an earlier event's start and suppressed the
+// earlier event's fallback → a silent push → an iOS subscription strike. The fix
+// is a per-event context: one WakeCtx per wake, never shared. These tests pin the
+// two decisions (reject/timeout → fall back unless THIS event showed; clean resolve
+// → fall back unless THIS event was satisfied) and the burst-isolation invariant.
+import { describe, it, expect } from 'vitest';
+import { runGuardedWake, type WakeCtx } from './sw-inbox';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('spec 2043: runGuardedWake', () => {
+  it('a wake that shows and is satisfied fires no fallback', async () => {
+    const reasons: string[] = [];
+    await runGuardedWake(
+      async (ctx: WakeCtx) => { ctx.shown = true; ctx.satisfied = true; },
+      async (r) => { reasons.push(r); },
+      1000,
+    );
+    expect(reasons).toEqual([]);
+  });
+
+  it('a CLEAN resolve that showed nothing and was not satisfied trips the backstop', async () => {
+    const reasons: string[] = [];
+    await runGuardedWake(
+      async () => { /* resolves without touching ctx — the un-backstopped regression */ },
+      async (r) => { reasons.push(r); },
+      1000,
+    );
+    expect(reasons).toEqual(['clean-resolve-no-show']);
+  });
+
+  it('a clean resolve with LICENSED silence (satisfied, not shown) fires no backstop', async () => {
+    const reasons: string[] = [];
+    await runGuardedWake(
+      async (ctx: WakeCtx) => { ctx.satisfied = true; /* focused+visible Chromium: silence is licensed */ },
+      async (r) => { reasons.push(r); },
+      1000,
+    );
+    expect(reasons).toEqual([]);
+  });
+
+  it('a wake that THROWS having shown nothing fires the fallback', async () => {
+    const reasons: string[] = [];
+    await runGuardedWake(
+      async () => { throw new Error('idb wedged'); },
+      async (r) => { reasons.push(r); },
+      1000,
+    );
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain('idb wedged');
+  });
+
+  it('a wake that throws AFTER an accepted show does NOT double up a fallback', async () => {
+    const reasons: string[] = [];
+    await runGuardedWake(
+      async (ctx: WakeCtx) => { ctx.shown = true; throw new Error('straggler blew up post-show'); },
+      async (r) => { reasons.push(r); },
+      1000,
+    );
+    expect(reasons).toEqual([]);
+  });
+
+  it('burst isolation: a sibling event\'s show never suppresses THIS event\'s fallback (the 2043 regression)', async () => {
+    // Two overlapping wakes. Wake B is fast and shows; wake A is slow and throws
+    // having shown nothing. With the old global stamp, B's show would satisfy A's
+    // suppression check and A would end SILENTLY. With per-event ctx, A still falls
+    // back. Order the timing so B resolves BEFORE A rejects.
+    const aReasons: string[] = [];
+    const bReasons: string[] = [];
+    const a = runGuardedWake(
+      async () => { await sleep(30); throw new Error('A failed'); },
+      async (r) => { aReasons.push(r); },
+      1000,
+    );
+    const b = runGuardedWake(
+      async (ctx: WakeCtx) => { ctx.shown = true; ctx.satisfied = true; },
+      async (r) => { bReasons.push(r); },
+      1000,
+    );
+    await Promise.all([a, b]);
+    expect(bReasons).toEqual([]);           // B showed → no fallback
+    expect(aReasons).toHaveLength(1);       // A still falls back despite B's show
+    expect(aReasons[0]).toContain('A failed');
+  });
+
+  it('a dispatch that never resolves falls back after the deadline', async () => {
+    const reasons: string[] = [];
+    await runGuardedWake(
+      () => new Promise<void>(() => { /* never settles */ }),
+      async (r) => { reasons.push(r); },
+      20,
+    );
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain('deadline');
+  });
+
+  it('a fallback that itself rejects is swallowed (the platform denied even the generic)', async () => {
+    // Still resolves; the attempt is recorded as fellBack so the ledger sees it.
+    await expect(
+      runGuardedWake(
+        async () => { throw new Error('boom'); },
+        async () => { throw new Error('platform denied the fallback too'); },
+        1000,
+      ),
+    ).resolves.toMatchObject({ fellBack: true, shown: false });
+  });
+
+  it('reports the outcome: shown wakes never fall back; silent primary paths do', async () => {
+    const shownRes = await runGuardedWake(
+      async (ctx: WakeCtx) => { ctx.shown = true; ctx.satisfied = true; },
+      async () => {},
+      1000,
+    );
+    expect(shownRes).toEqual({ shown: true, satisfied: true, fellBack: false });
+
+    const backstopRes = await runGuardedWake(async () => {}, async () => {}, 1000);
+    expect(backstopRes).toEqual({ shown: false, satisfied: false, fellBack: true });
+  });
+});

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -137,6 +137,110 @@ export async function stampPushWake(): Promise<void> {
   }
 }
 
+/** (spec 2043) The per-event outcome of a single push wake. Both bits are scoped
+ *  to ONE event — never a module global — which is the whole fix: pre-2043 a shared
+ *  "last shown" stamp let a later event's accepted show bleed past an earlier
+ *  event's start and suppress its fallback, ending that earlier wake silently (an
+ *  iOS subscription strike). */
+export interface WakeCtx {
+  /** An OS notification was actually accepted DURING this event. Gates the
+   *  reject/timeout fallback: fall back unless this specific event showed. */
+  shown: boolean;
+  /** Shown, OR silence was licensed for this wake (`mayEndWakeSilently`). Gates the
+   *  clean-resolve backstop: a wake that resolves neither shown nor licensed is a
+   *  silent push and must show a backstop generic. */
+  satisfied: boolean;
+}
+
+/** (spec 2043) The deadline message; also the reason token the guard surfaces so a
+ *  hung handler is distinguishable from a thrown one in the fallback body/ledger. */
+export const PUSH_DEADLINE_MESSAGE = 'push handler exceeded deadline';
+
+/** (spec 2043) The coarse, content-free outcome of a guarded wake. */
+export interface WakeResult {
+  /** An OS notification was accepted this event. */
+  shown: boolean;
+  /** Shown or licensed-silent — the wake ended acceptably (no backstop needed). */
+  satisfied: boolean;
+  /** The last-resort backstop generic fired (the primary path showed nothing). */
+  fellBack: boolean;
+}
+
+/** (spec 2043) Run one push wake under a per-event guard. `dispatch` mutates its
+ *  own `WakeCtx` as it shows / licenses silence; `showFallback` is the last-resort
+ *  visible generic. The Web Push `userVisibleOnly` contract is unforgiving on iOS —
+ *  a push event that resolves without a visible notification is a silent push, and
+ *  a few of those revoke the subscription — so this guarantees EVERY wake ends
+ *  either shown or with licensed silence:
+ *    - clean resolve, not satisfied → backstop generic (the always-visible invariant
+ *      becomes enforced, not merely assumed by each terminal).
+ *    - reject / deadline, not shown → last-resort generic (per-event, so a sibling
+ *      wake's show can't suppress it — the 2043 stamp-bleed regression).
+ *  A fallback that itself fails is swallowed (the platform denied even the generic;
+ *  nothing more we can do). Kept pure + injectable here so it is unit-testable
+ *  without the `self`-bound service-worker module. */
+export async function runGuardedWake(
+  dispatch: (ctx: WakeCtx) => Promise<void>,
+  showFallback: (reason: string) => Promise<void>,
+  deadlineMs: number,
+): Promise<WakeResult> {
+  const ctx: WakeCtx = { shown: false, satisfied: false };
+  let fellBack = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const fallback = async (reason: string): Promise<void> => {
+    fellBack = true;
+    try {
+      await showFallback(reason);
+    } catch {
+      /* the platform denied even the bare fallback — nothing more we can do */
+    }
+  };
+  try {
+    await Promise.race([
+      dispatch(ctx),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(PUSH_DEADLINE_MESSAGE)), deadlineMs);
+      }),
+    ]);
+    if (!ctx.satisfied) await fallback('clean-resolve-no-show');
+  } catch (err) {
+    if (!ctx.shown) await fallback(`fallback: ${String((err as Error)?.message ?? err)}`);
+  } finally {
+    // Clear the loser of the race so a still-pending deadline reject can't surface
+    // as an unhandled rejection after dispatch already settled.
+    if (timer !== undefined) clearTimeout(timer);
+  }
+  return { shown: ctx.shown, satisfied: ctx.satisfied, fellBack };
+}
+
+/* ---- (spec 2043) On-device push-wake ledger. A bounded, ZERO-KNOWLEDGE ring buffer
+ * of what each push wake did — enum kind, enum outcome, a count, a timestamp. NO
+ * sender, body, or tag ever enters it, so it is safe to surface on a real production
+ * device (behind the diagnostics toggle) to see WHY notifications fell silent, which
+ * is otherwise invisible on iOS. ---- */
+export type WakeKind = 'call' | 'conn' | 'post' | 'post-activity' | 'version' | 'msg';
+export type WakeOutcome = 'shown' | 'licensed-silent' | 'fallback';
+export interface WakeLedgerEntry { ts: number; kind: WakeKind; outcome: WakeOutcome; count: number }
+const WAKE_LEDGER_KEY = 'push.wakeLedger';
+const WAKE_LEDGER_MAX = 50;
+
+/** Append one content-free wake outcome, capped at the newest WAKE_LEDGER_MAX.
+ *  Best-effort telemetry — never blocks or fails the alert. */
+export async function recordWake(kind: WakeKind, outcome: WakeOutcome, count = 0): Promise<void> {
+  try {
+    const prev = (await get<Setting<WakeLedgerEntry[]>>('settings', WAKE_LEDGER_KEY))?.value ?? [];
+    const next = [...prev, { ts: Date.now(), kind, outcome, count }].slice(-WAKE_LEDGER_MAX);
+    await put<Setting<WakeLedgerEntry[]>>('settings', { key: WAKE_LEDGER_KEY, value: next });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Read the wake ledger (newest last) for the diagnostics view. */
+export async function readWakeLedger(): Promise<WakeLedgerEntry[]> {
+  return (await get<Setting<WakeLedgerEntry[]>>('settings', WAKE_LEDGER_KEY))?.value ?? [];
+}
+
 export async function setting<T>(key: string, fallback: T): Promise<T> {
   const s = await get<Setting<T>>('settings', key);
   return s ? s.value : fallback;

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -9,7 +9,7 @@
  */
 import { register, getSelfUserId, getSelfUsername } from '@/services/auth';
 import { syncDirectory, importDirectoryUser, searchDirectory, publishOwnProfile, refetchContactProfile } from '@/services/directory';
-import { previewPending } from '@/services/sw-inbox';
+import { previewPending, readWakeLedger } from '@/services/sw-inbox';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { disconnectTransport, nudgeReconnect, forceReconnect, sendDownloadedReceipts, sendSeenReceipts, applySeenPref } from '@/composables/useSync';
 import {
@@ -352,6 +352,10 @@ export function installTestHook(): void {
       const ackOk = r.mode === 'applied' ? await ackFrames(r.ackIds) : false;
       return { ...r, ackOk };
     },
+    /** (spec 2043) The content-free push-wake ledger — one entry per push wake
+     *  ({ ts, kind, outcome, count }). Lets the burst e2e assert every wake ended
+     *  shown/licensed and none fell to the backstop. */
+    pushWakeLedger: () => readWakeLedger(),
     /** Drop the WebSocket so the server queues messages (simulate app closed). */
     disconnect: () => disconnectTransport(),
     /** Reconnect the WebSocket (drains the queue for real). */

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -568,6 +568,11 @@ export const SETTINGS: Record<string, SettingNode> = {
         items: [{ type: 'toggle', title: 'Show preview', key: 'notifications.showPreview', default: true }],
         footer: 'Preview message text inside new message notifications.',
       },
+      {
+        header: 'Troubleshooting',
+        items: [{ type: 'toggle', title: 'Show notification diagnostics', key: 'diagnostics.pushReasonText', default: false }],
+        footer: 'If a notification arrives as a plain "New message", show a short reason for it. Turn this on only if we ask you to help track down missing notifications. It never reveals who messaged you or what they said.',
+      },
     ],
   },
   'notifications-message-sound': {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -23,7 +23,8 @@ import { ExpirationPlugin } from 'workbox-expiration';
 import {
   previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, previewPosts, previewPostActivity, markConnShown,
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
-  mayEndWakeSilently, quietNote, stampPushWake, stampedShow, countAccepted,
+  mayEndWakeSilently, quietNote, stampPushWake, countAccepted,
+  runGuardedWake, recordWake, type WakeCtx,
   previewCallRing, recordCallTickle, recordCallOutcome, withdrawCallBadgeUnit, callBadgeCount,
   readRingShown, recordRingShown, clearRingShown,
   type SwNote, type ConnNote,
@@ -148,10 +149,14 @@ const DEV_HOST = /(^|\.)ring-dev\./.test(self.location.hostname) || self.locatio
 async function showGeneric(reason?: string): Promise<void> {
   // (spec 2014 US1) Title is the STATUS, not the literal app name: iOS already shows "Ring" as its
   // forced app-name header, so titling this "Ring" too rendered the app name twice
-  // ("Ring › Ring › New message"). (US2) On the dev host only, the body carries why we fell back to
-  // generic so the "generic after a while" cause can be confirmed on a real device.
+  // ("Ring › Ring › New message"). (US2) The body carries WHY we fell back to generic so the
+  // "generic after a while" cause can be confirmed on a real device — on the dev host always, and
+  // (spec 2043) on production when the user opts into the push diagnostics toggle. Content-free:
+  // the reason is an internal token (timeout / clean-resolve-no-show / an error message), never
+  // sender or message text.
+  const showReason = reason && (DEV_HOST || (await setting('diagnostics.pushReasonText', false)));
   await self.registration.showNotification('New message', {
-    body: DEV_HOST && reason ? reason : 'Tap to open',
+    body: showReason ? reason : 'Tap to open',
     icon: ICON,
     badge: BADGE,
     tag: GENERIC_TAG,
@@ -330,10 +335,15 @@ async function showQuietNote(kind: 'msg' | 'activity'): Promise<void> {
  *  WebKit — where webpushd's cumulative three-strike counter has NO on-screen
  *  exemption — plus Firefox and anything unrecognized, every wake ends visibly
  *  no matter what the client list claims. */
-async function showQuietUnlessVisible(kind: 'msg' | 'activity'): Promise<void> {
+// (spec 2043) Returns whether it actually SHOWED the quiet note. `false` means
+// silence was licensed (trusted platform + focused & visible window) — the caller
+// treats that as satisfied-but-not-shown, so a clean wake doesn't trip the backstop
+// yet a reject/timeout still falls back (the wake produced no OS notification).
+async function showQuietUnlessVisible(kind: 'msg' | 'activity'): Promise<boolean> {
   const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
-  if (mayEndWakeSilently(self.navigator.userAgent, clients)) return; // licensed: trusted platform + focused & visible window
+  if (mayEndWakeSilently(self.navigator.userAgent, clients)) return false; // licensed: trusted platform + focused & visible window
   await showQuietNote(kind);
+  return true;
 }
 
 /** Close any lingering notifications with a given tag (used to clear the generic
@@ -593,7 +603,7 @@ async function showConnNotification(): Promise<number> {
  * an ack is only ever sent for a durably-committed frame, and the notification
  * is shown before the ack so a kill can't consume a frame silently.
  */
-async function tryAuthoritativeDrain(): Promise<boolean> {
+async function tryAuthoritativeDrain(ctx: WakeCtx): Promise<boolean> {
   try {
     return await serializeNotify(async () => {
       const r = await drainPersistPending();
@@ -609,7 +619,12 @@ async function tryAuthoritativeDrain(): Promise<boolean> {
       // message keys are consumed — it would misread them as decrypt failures).
       await markShown(r.ackIds);
       await ackFrames(r.ackIds); // strictly after commit + notifications
-      if (r.deferred > 0) return false; // preview flow handles the deferred remainder
+      if (r.deferred > 0) {
+        // Preview flow handles the deferred remainder AND sets ctx there. Any notes
+        // we accepted above still count toward this wake having shown.
+        if (accepted > 0) ctx.shown = true;
+        return false;
+      }
       // Fully handled: applied rows are already in unreadCount(), nothing pending.
       await updateAppBadge(0);
       // (spec 1034/2023) Persisted + acked but nothing made it on screen — every
@@ -619,7 +634,11 @@ async function tryAuthoritativeDrain(): Promise<boolean> {
       // owed. A failure of the quiet note itself is contained by this function's
       // catch, which degrades to the preview flow — whose own quiet terminal
       // propagates (FR-005 carve-out).
-      if (!r.notes.length || accepted === 0) await showQuietUnlessVisible('msg');
+      let shown = accepted > 0;
+      if (!r.notes.length || accepted === 0) shown = (await showQuietUnlessVisible('msg')) || shown;
+      // (spec 2043) A fully-handled drain always ends satisfied (shown or licensed).
+      ctx.shown = shown;
+      ctx.satisfied = true;
       return true;
     });
   } catch (e) {
@@ -634,7 +653,7 @@ async function tryAuthoritativeDrain(): Promise<boolean> {
  * *some* notification (iOS requires one per push). A generic placeholder shown on
  * timeout is UPGRADED to the rich preview when the full decrypt settles.
  */
-async function showMessageNotification(): Promise<void> {
+async function showMessageNotification(ctx: WakeCtx): Promise<void> {
   // (spec 2017) Serialize only the critical read→show→markShown sections (NOT the straggler's sleeps),
   // so overlapping burst wakes can't interleave and duplicate a notification or bounce the per-pass
   // count — while a queued wake still gets the lock during another wake's sleep gaps and is never
@@ -695,7 +714,11 @@ async function showMessageNotification(): Promise<void> {
   // off (`silenced`), the master-toggle race (`suppressed`), and a nothing-new
   // wake with nothing to re-assert all still consumed a push — end them with the
   // content-free quiet generic unless Ring is actually on screen.
-  if (!shownAny) await showQuietUnlessVisible('msg');
+  if (!shownAny) shownAny = await showQuietUnlessVisible('msg');
+  // (spec 2043) Record the wake's per-event outcome for the guard: a real show or
+  // a licensed-silent quiet skip both satisfy it; only an actual show sets `shown`.
+  ctx.shown = shownAny;
+  ctx.satisfied = true;
 
   // Settle the full preview (bounded) so its /relay/pending fetch lands (→ delivery)
   // even after a generic fallback, we learn the accurate backlog for the badge, and
@@ -825,7 +848,7 @@ async function pageWillNotify(clients: readonly Client[], timeoutMs: number): Pr
   return acked;
 }
 
-async function dispatchPush(event: PushEvent): Promise<void> {
+async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
       // (spec 1037) Every wake stamps its time FIRST — the page-side zombie
       // detector treats "no wake since a stale message was sent" as the
       // rotate-the-subscription signature. It's best-effort telemetry though, so
@@ -847,6 +870,10 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         const sig = await readRingShown();
         const reassert = ringReassert(sig, Date.now());
         await showCall(reassert ?? undefined, { realert: true });
+        // (spec 2043) The ring alert is up; any later naming upgrade is a bonus. If
+        // showCall threw, ctx stays unshown → the guard's fallback fires.
+        ctx.shown = true;
+        ctx.satisfied = true;
         if (reassert && sig) {
           await recordRingShown({ ...sig, ts: Date.now() });
         } else if (!ringReassert(await readRingShown(), Date.now())) {
@@ -905,10 +932,13 @@ async function dispatchPush(event: PushEvent): Promise<void> {
           // the conn path previously never touched the badge, so a friend request didn't count.
           const pendingIncoming = await showConnNotification();
           await updateAppBadge(pendingIncoming);
+          ctx.shown = true;
+          ctx.satisfied = true; // showConnNotification always ends with a visible show
         } else {
           // (spec 1034) A client EXISTS but may be a frozen background PWA (the norm
           // on iOS) that will never render the page-side alert — end visibly anyway.
-          await showQuietUnlessVisible('activity');
+          ctx.shown = await showQuietUnlessVisible('activity');
+          ctx.satisfied = true;
         }
         return;
       }
@@ -924,10 +954,13 @@ async function dispatchPush(event: PushEvent): Promise<void> {
           // Name the author AND bump the app-icon badge (the post path previously did neither).
           const newCount = await showPostNotification();
           await updateAppBadge(newCount);
+          ctx.shown = true;
+          ctx.satisfied = true; // showPostNotification always ends with a visible show
         } else {
           // (spec 1034) Toggle off, or a (possibly frozen) client exists: the wake
           // still consumed a push — end it with the content-free quiet generic.
-          await showQuietUnlessVisible('activity');
+          ctx.shown = await showQuietUnlessVisible('activity');
+          ctx.satisfied = true;
         }
         return;
       }
@@ -951,7 +984,9 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         // (spec 1034) Toggle off, frozen client, or a removal that previews to zero
         // notes: still a consumed push — end visibly (content-free; a removal shows
         // the neutral "New activity", never who or what).
-        if (!shownActivity) await showQuietUnlessVisible('activity');
+        if (!shownActivity) shownActivity = await showQuietUnlessVisible('activity');
+        ctx.shown = shownActivity;
+        ctx.satisfied = true;
         return;
       }
       if (kind === 'version') {
@@ -963,9 +998,12 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         for (const client of clients) client.postMessage({ type: 'ring:checkupdate' });
         if (!clients.length) {
           await showVersionNotification();
+          ctx.shown = true;
+          ctx.satisfied = true; // showVersionNotification always ends with a visible show
         } else {
           // (spec 1034) A frozen background client can't show the update toast.
-          await showQuietUnlessVisible('activity');
+          ctx.shown = await showQuietUnlessVisible('activity');
+          ctx.satisfied = true;
         }
         return;
       }
@@ -999,14 +1037,20 @@ async function dispatchPush(event: PushEvent): Promise<void> {
         // Chrome window that stays focused+visible still skips exactly as before (the user
         // saw the in-app banner, so no OS duplicate).
         const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
-        if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) await showQuietNote('msg');
+        if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) {
+          await showQuietNote('msg');
+          ctx.shown = true;
+        }
+        // Either we showed the quiet note, or silence is licensed here (focused +
+        // visible Chromium). Both are satisfied; only the show sets ctx.shown.
+        ctx.satisfied = true;
         return;
       }
       // Spec 1032: with sw.fullPersist on (and no page claiming the wake), persist
       // + ack eligible frames right now so the app opens warm. Any degrade — and
       // any deferred remainder — falls through to today's preview flow.
-      if (await tryAuthoritativeDrain()) return;
-      await showMessageNotification();
+      if (await tryAuthoritativeDrain(ctx)) return;
+      await showMessageNotification(ctx);
 }
 
 // The Web Push `userVisibleOnly` contract is unforgiving on iOS: a push event
@@ -1021,50 +1065,25 @@ async function dispatchPush(event: PushEvent): Promise<void> {
 // broken device finally says WHY on-screen).
 const PUSH_DEADLINE_MS = 20000; // under iOS's ~30s SW-event budget, over our own straggler+settle window
 
-// Whether a notification was actually shown DURING the current push event — the
-// only correct gate for the fallback. (An earlier version checked
-// getNotifications(), but that also counts a STALE notification from a PRIOR
-// push still on screen, so when a later push failed with an old notification
-// visible, the fallback was wrongly suppressed → a SILENT push → the exact
-// subscription revocation this guard exists to prevent.) Wrapping the one
-// registration method that every show* path funnels through centralizes the
-// tracking without threading a flag through all of them. If the platform blocks
-// reassigning the native method, the flag simply never flips → the guard always
-// shows on failure, which is the safe direction (a rare double beats a silent).
-let lastNotificationAt = 0;
-try {
-  const rawShow = self.registration.showNotification.bind(self.registration);
-  // (spec 2023 FR-006) Stamp on FULFILLMENT, never at call time: a show the OS
-  // rejects (or hangs) was never shown, and stamping it early would suppress the
-  // guarded fallback below — the exact silent wake it exists to prevent.
-  self.registration.showNotification = stampedShow(rawShow, () => {
-    lastNotificationAt = Date.now();
-  }) as ServiceWorkerRegistration['showNotification'];
-} catch {
-  /* reassignment blocked — fallback stays maximally safe (always shows on failure) */
-}
-
+// (spec 2043) Guard one push wake with a PER-EVENT context. dispatchPush threads a
+// WakeCtx and marks it `shown` the instant an OS notification is accepted and
+// `satisfied` when the wake ends shown OR with licensed silence. runGuardedWake then:
+//   - reject/deadline → last-resort generic UNLESS this event already showed
+//     (ctx.shown). Because the flag is per-event, a sibling wake's show can no longer
+//     suppress this one's fallback — the module-global stamp that did exactly that
+//     (a later push's show bleeding past an earlier push's start → a silent wake →
+//     an iOS subscription strike) is GONE.
+//   - clean resolve, not satisfied → backstop generic. The "every iOS wake shows
+//     something" invariant every terminal used to assume is now ENFORCED here.
+// `showGeneric` is the registration's native showNotification path (no monkeypatch);
+// the reason is surfaced only on the dev host / when the diagnostic toggle is on.
 async function guardedPush(event: PushEvent): Promise<void> {
-  const startedAt = Date.now();
-  try {
-    await Promise.race([
-      dispatchPush(event),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('push handler exceeded deadline')), PUSH_DEADLINE_MS),
-      ),
-    ]);
-  } catch (err) {
-    // Only skip the fallback if THIS event already produced a notification (a
-    // stale one from an earlier push must NOT suppress it — that's what caused
-    // the silent pushes). On any doubt, show: a double beats a revocation.
-    if (lastNotificationAt < startedAt) {
-      try {
-        await showGeneric(`fallback: ${String((err as Error)?.message ?? err)}`);
-      } catch {
-        /* the platform denied even the bare fallback — nothing more we can do */
-      }
-    }
-  }
+  const { kind } = pushKind(event);
+  const res = await runGuardedWake((ctx) => dispatchPush(event, ctx), (reason) => showGeneric(reason), PUSH_DEADLINE_MS);
+  // (spec 2043) Content-free ledger entry: which tickle kind, and did the wake end
+  // shown / licensed-silent / on the backstop generic. Surfaced (behind the
+  // diagnostics toggle) so a real device can finally say WHY it fell silent.
+  void recordWake(kind, res.fellBack ? 'fallback' : res.shown ? 'shown' : 'licensed-silent');
 }
 
 self.addEventListener('push', (event) => {


### PR DESCRIPTION
Release **v1.0.5**.

### What's new
- **fix(notifications)**: restore push notifications and recover devices that stopped alerting (spec 2043, #1035)

Some devices — new iPhones especially — had stopped showing notifications entirely (zombie push subscriptions the service kept accepting but the phone never woke for). This ships the per-event push guard that stops it happening and a self-heal that recovers already-affected devices on next open, plus content-free diagnostics.

Full detail: `specs/2043-push-zombie-subscriptions/`. All CI gates passed on the develop PR (#1035).

🤖 Generated with [Claude Code](https://claude.com/claude-code)