### PR TITLE
release: v1.0.6 — older iPhones reliably show notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,5 +281,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/2043-push-zombie-subscriptions/plan.md`
+`specs/2044-older-iphones-show/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -127,3 +127,4 @@ Specs are grouped by category band; status moves
 | [2040](specs/2040-recovered-devices-rebuild/spec.md) | Recovered Devices Rebuild Their Friends Ledger | 🟢 shipped |
 | [2041](specs/2041-video-post-memory/spec.md) | Video Posts Must Not Exhaust iPhone Memory | 🟢 shipped |
 | [2043](specs/2043-push-zombie-subscriptions/spec.md) | Push zombie subscriptions & silent-wake strikes | 🟡 in-progress |
+| [2044](specs/2044-older-iphones-show/spec.md) | Legacy-iOS lite push path — older iPhones always show a notification | 🟡 in-progress |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/2044-older-iphones-show/checklists/zero-knowledge.md
+++ b/specs/2044-older-iphones-show/checklists/zero-knowledge.md
@@ -1,0 +1,41 @@
+# Checklist: Zero-Knowledge Requirements Quality
+
+**Feature**: Legacy-iOS lite push path (`2044`)
+**Created**: 2026-07-19
+**Purpose**: Unit-test the REQUIREMENTS for zero-knowledge quality (Constitution
+Principle I). Checked = the requirement is well-specified; evidence cited.
+
+## Requirement Completeness
+
+- [X] CHK001 Does the spec include a Zero-Knowledge Impact section stating what crosses the wire and what is visible? [Completeness, Spec §Zero-Knowledge Impact]
+- [X] CHK002 Is it specified that the lite path adds NO new endpoints, payloads, fields, logs, or metrics — on either side? [Completeness, Spec §Zero-Knowledge Impact, §FR-008]
+- [X] CHK003 Is the generic notification's content specified as content-free by construction (no sender, no body)? [Completeness, Spec §Zero-Knowledge Impact]
+
+## Requirement Clarity
+
+- [X] CHK004 Is "transmits strictly less" concrete — the lite path reuses the existing content-free tickle and existing authenticated fetch, and never attempts decryption? [Clarity, Spec §FR-008, §Zero-Knowledge Impact]
+- [X] CHK005 Is the single at-risk IDB read (the session token) named, bounded, and sequenced strictly after the show? [Clarity, Spec §FR-003, §Key Entities]
+
+## Requirement Consistency
+
+- [X] CHK006 Do the lite-path requirements stay consistent with the existing preview contract (fetch emits delivered, never acks/dequeues — the page drains durably)? [Consistency, Spec §FR-003, plan §Design decisions]
+- [X] CHK007 Is the modern-path isolation requirement consistent across spec (FR-007), plan (Constitution Check), and tests (isolation pin)? [Consistency]
+
+## Acceptance Criteria Quality
+
+- [X] CHK008 Is there a measurable criterion that no plaintext-bearing surface is added (nothing new crosses the wire at all)? [Measurability, Spec §FR-008, §SC-003]
+- [X] CHK009 Can "visible before any IndexedDB/decrypt work" be objectively verified (ordering requirement + unit/device tests)? [Measurability, Spec §FR-002, §SC-001/004]
+
+## Scenario & Edge-Case Coverage
+
+- [X] CHK010 Is the hung-token-read case specified (no receipts this wake, notification already shown, idempotent recovery)? [Edge Case, Spec §Edge Cases]
+- [X] CHK011 Is the failure direction of the detector specified (unparseable → modern, never a silent downgrade)? [Coverage, Spec §FR-001, §US2]
+
+## Ambiguities & Conflicts
+
+- [X] CHK012 Could any requirement be read as adding content to the push or to the generic on legacy devices? (Resolved: content-free by construction, same tickle.) [Ambiguity, Spec §Zero-Knowledge Impact]
+
+## Result
+
+All 12 items satisfied — the lite path narrows the boundary (less computed, nothing new
+transmitted). No CRITICAL ZK gaps. Cleared against Constitution Principle I.

--- a/specs/2044-older-iphones-show/plan.md
+++ b/specs/2044-older-iphones-show/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Legacy-iOS lite push path
+
+**Branch**: `fix/2044-older-iphones-show` | **Date**: 2026-07-19 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+iPhone 8 (iOS 16.7) proves the failure shape: the SW wakes and fetches (delivered
+receipts fire) but dies silently in the decrypt/store/present stage — SW-context
+IndexedDB on iOS ≤ 16 hangs/throws — and iOS strikes the subscription out. Fix on two
+fronts: (1) an all-device safety fix bounding the IDB read spec 2043 placed inside the
+last-resort `showGeneric` (on a hung DB it could hang the guard's own fallback), and
+(2) a **lite wake path** gated by a pure `isLegacyIOS(ua)` detector (iOS ≤ 16): show a
+visible generic FIRST from IDB-free primitives, then fire delivered receipts via one
+bounded token read + the bounded pending fetch, and skip decrypt/store/ledger/settle/
+badge entirely. Cold open accepted on that tier. Modern devices' path is byte-identical
+apart from the strictly-safer bounded read.
+
+## Technical Context
+
+**Language/Version**: TypeScript (SW context, Workbox injectManifest); no server changes
+
+**Storage**: reuses existing IndexedDB stores read-only-less (the lite path performs at
+most one bounded `keystore` read after the show); no schema/DB_VERSION change
+
+**Testing**: vitest (`sw-legacy.test.ts` UA truth table + `withTimeout` hung-read pin);
+device pass on iPhone 8; modern-corpus isolation pin
+
+**Target Platform**: legacy = installed-PWA WebKit UAs with iOS major ≤ 16
+(`LEGACY_IOS_MAX_MAJOR`); everything else (incl. unparseable UAs) = modern, unchanged
+
+## Constitution Check
+
+- **I. Zero-Knowledge** — PASS. No new wire surface; the lite path transmits strictly
+  less (no decrypt attempted). Spec carries the Zero-Knowledge Impact section.
+- **II. Spec-Driven** — PASS. Hotfix spec 2044, full artifact set, issues + PR traceable.
+- **III. TDD** — PASS. Bug fix starts with the failing detector/bounded-read tests
+  (`sw-legacy.test.ts`) written before the implementation; 1182 tests green.
+- **IV. Crypto** — N/A (the lite path *removes* crypto work on the affected tier; the
+  crypto core is untouched).
+- **V. Offline-First** — PASS. No store changes; the page's durable WS drain on open is
+  unchanged and is exactly the lite tier's source of truth.
+- **VI. Stateless Server** — PASS. Zero server changes.
+- **VII. Quality Gates** — PASS. `npm run build`, vitest 1182, `go build/vet` green.
+- **VIII–XI** — PASS. Roadmap regenerated; no UI besides existing notifications.
+
+**Gate result: PASS.**
+
+## Project Structure
+
+```text
+src/sw.ts                        # bounded showGeneric read; dispatchLiteWake + isLegacyIOS branch
+src/services/sw-inbox.ts         # iosMajorVersion, isLegacyIOS, LEGACY_IOS_MAX_MAJOR, withTimeout
+src/services/sw-legacy.test.ts   # NEW — UA truth table + hung-read bound pin
+specs/2044-older-iphones-show/   # spec, plan, tasks, checklists/zero-knowledge.md
+package.json                     # 1.0.5 → 1.0.6 (new release cycle)
+```
+
+## Design decisions (from research/recon)
+
+- **Show primitive**: `showQuietNote`/`quietNote` is the only fully IDB-free show; the
+  msg lite path uses `showGeneric` (audible) now hang-proofed by the bounded read.
+- **Delivered receipts without decryption**: the server emits `delivered` on
+  `GET /v1/relay/pending` fetch itself (`relay_handlers.go:56-66`), no ack needed — so
+  fetch-only preserves sender ticks.
+- **Detector fails toward modern**: unparseable UA ⇒ rich path; iPadOS-Macintosh UAs
+  undetectable ⇒ keep modern path (documented limit, matches today's behavior).
+- **`stampPushWake` kept** (already 1.5s-bounded): its `push.lastWakeAt` keeps the
+  spec-2043 zombie heal honest; worst case on a hung put is one 2h-capped rotation.
+- **Reminder call tickle re-rings generically** on legacy (no `readRingShown` IDB
+  dedup): an extra ring beats a missed call there.
+
+## Complexity Tracking
+
+> No violations — intentionally empty.

--- a/specs/2044-older-iphones-show/spec.md
+++ b/specs/2044-older-iphones-show/spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: Legacy-iOS lite push path — older iPhones always show a notification
+
+**Feature Branch**: `fix/2044-older-iphones-show`
+
+**Created**: 2026-07-19
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: After spec 2043 (v1.0.5) fixed silent-wake strikes and zombie recovery —
+verified working on iPhone 15 / 15 Pro — the **iPhone 8 (iOS 16.7)** still shows no
+notifications and loses its subscription. Decisive evidence: senders receive **delivered
+receipts for the first 3–4 messages** (the SW wakes and the `/relay/pending` fetch
+succeeds — the server emits `delivered` on fetch), then nothing visible appears and iOS
+kills the subscription on the ~4th silent strike. The failure is *after* the fetch, in
+the decrypt/store/present stage: SW-context IndexedDB on iOS 16.x hangs or throws, and
+the rich pipeline (device unlock, settings reads, decrypt, show) dies silently. Recon
+also found a 2043 regression hazard: `showGeneric` now awaits an IDB read before its
+`showNotification`, so on a hung-IDB device even the timeout generic and the 20s
+last-resort fallback can hang.
+
+## Clarifications
+
+### Session 2026-07-19
+
+- Q: Which iOS versions get the lite path? → A: iOS 16 and older (`LEGACY_IOS_MAX_MAJOR = 16`).
+  iPhone 8 tops out at 16.7; iOS 17+ keeps the rich path (proven butter-smooth on 15/15 Pro).
+  No kill-switch setting — minimal surface.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - An old iPhone always shows a notification and keeps its subscription (Priority: P1)
+
+Someone on an iPhone 8 (iOS 16.x) receives messages while Ring is backgrounded. Every
+push produces a visible generic "New message" immediately, senders still get their
+delivered ticks, and the subscription is never struck out. Opening the app pulls the
+real messages in (cold open accepted on this tier).
+
+**Why this priority**: This tier currently loses push entirely — every burst kills the
+subscription. A guaranteed-visible generic beats rich-but-dead.
+
+**Independent Test**: With a legacy-iOS UA, drive a msg wake: assert the generic shows
+BEFORE any IndexedDB/decrypt work, the pending fetch still fires (delivered receipts),
+and the wake ends shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** a legacy-iOS device with Ring backgrounded, **When** a message push
+   arrives, **Then** a visible generic notification is shown before any IndexedDB or
+   decrypt work is attempted, and the wake ends shown.
+2. **Given** the same device, **When** the SW fetches the pending queue after showing,
+   **Then** senders receive delivered receipts and no frames are acked or dequeued.
+3. **Given** a rapid burst, **Then** the generics collapse onto one self-replacing tag
+   (no stacking) and every wake still ends visibly.
+4. **Given** an incoming call push on legacy iOS, **Then** the generic ring shows
+   without any prior IndexedDB read and the caller's UI flips to "Ringing" (ack fires).
+
+### User Story 2 - Modern devices are completely unaffected (Priority: P1)
+
+Users on iOS 17+ / Android / desktop keep the exact rich-notification behavior shipped
+in v1.0.5 — same code path, same output.
+
+**Why this priority**: The current modern flow is verified working in production; the
+hard requirement is zero risk to it.
+
+**Independent Test**: A UA-corpus unit test pins the legacy detector to `false` for
+every modern UA (iOS 17/26 PWA, Android Chrome, desktop browsers, iPadOS-Macintosh) —
+the lite branch is unreachable for them.
+
+**Acceptance Scenarios**:
+
+1. **Given** any modern UA from the corpus, **When** the detector runs, **Then** it
+   returns false and `dispatchPush` takes the identical pre-2044 path.
+2. **Given** an unparseable or unknown UA, **Then** the detector fails toward modern
+   (never lite).
+
+### User Story 3 - The last-resort generic can never hang on a broken database (Priority: P1)
+
+On ANY device whose SW IndexedDB hangs, the fallback generic still shows: the
+diagnostics-reason read inside `showGeneric` is time-bounded and fails toward plain
+"Tap to open".
+
+**Why this priority**: This is a live 2043 regression hazard — the guard's fallback is
+`showGeneric`, and an unbounded IDB read inside it re-creates the exact silent wake the
+guard exists to prevent.
+
+**Independent Test**: Unit test with a never-resolving settings read: `showGeneric`'s
+show call still happens within the bound.
+
+**Acceptance Scenarios**:
+
+1. **Given** a hung settings read, **When** `showGeneric(reason)` runs, **Then**
+   `showNotification` is still called within ~300ms with the plain body.
+
+### Edge Cases
+
+- Reminder call tickle on legacy iOS re-rings generically (no `readRingShown` dedup) —
+  accepted: an extra audible ring beats a missed call on this tier.
+- Legacy msg wake with a hung `keystore` read: the 3s token race lapses → no fetch this
+  wake (no delivered receipts) — but the notification already showed; receipts arrive on
+  the next successful wake or app open (fetch is idempotent).
+- Old iPads reporting Macintosh UAs are not detected as legacy → they keep the modern
+  path (today's behavior; documented limit, no regression).
+- `stampPushWake` put hangs on legacy: `push.lastWakeAt` stays stale → the page-side
+  zombie heal may rotate that sub at most once per 2h — acceptable churn on a tier iOS
+  was killing anyway.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A pure UA detector MUST classify iOS ≤ 16 devices as legacy and everything
+  else (including unparseable UAs) as modern, with a unit-tested truth table.
+- **FR-002**: On legacy devices, every push wake MUST show its visible notification
+  BEFORE any IndexedDB read/write, decrypt, or unlock attempt (the shared prologue's
+  already-bounded wake stamp excepted).
+- **FR-003**: On legacy devices, the msg wake MUST still fetch the pending queue
+  (bounded token read + bounded fetch) so senders receive delivered receipts, and MUST
+  NOT ack/dequeue frames (the page drains durably on open).
+- **FR-004**: On legacy devices the SW MUST NOT attempt authoritative drain, preview
+  decrypt, shown-ledger writes, settle/straggler upgrades, or badge math.
+- **FR-005**: The page-claim arm (app open, page renders the alert) MUST keep its
+  existing behavior on legacy devices (it is already IDB-free).
+- **FR-006**: `showGeneric`'s diagnostics-reason read MUST be time-bounded (~300ms) on
+  all devices, failing toward the plain body — a hung database can never block the
+  last-resort show.
+- **FR-007**: The legacy branch MUST be reachable only via the pure detector; modern
+  devices' instruction path stays identical to v1.0.5 except FR-006 (strictly safer).
+- **FR-008 (zero-knowledge)**: The lite path adds no new wire surface and transmits
+  strictly less than the rich path (no decrypt attempted, same content-free tickle,
+  same fetch endpoint).
+
+### Key Entities
+
+- **Legacy device**: a WebKit UA whose parsed iOS major version is ≤ 16.
+- **Lite wake**: a push wake that ends visibly using only IDB-free primitives plus at
+  most one bounded `keystore` token read and one bounded network fetch.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a legacy device, 100% of backgrounded pushes produce a visible
+  notification (device test: iPhone 8 burst — no strike-out, subscription survives).
+- **SC-002**: Senders receive delivered receipts for messages pushed to a backgrounded
+  legacy device (observed as receipts before the recipient opens the app).
+- **SC-003**: The detector truth-table test proves every modern-corpus UA takes the
+  unchanged path; full existing test suite stays green.
+- **SC-004**: With a simulated hung settings read, `showGeneric` still shows within its
+  bound (unit-tested).
+- **SC-005**: Prod: `f88bf032` (iPhone 8) stops accumulating stale frames and stops
+  losing/rotating its subscription after test bursts.
+
+## Zero-Knowledge Impact
+
+*What crosses the wire, what is encrypted, what metadata is unavoidably visible, and why.*
+
+- No new endpoints, payloads, or fields. The lite path uses the existing content-free
+  push tickle and the existing authenticated `GET /v1/relay/pending` fetch — and sends
+  strictly LESS than the rich path (it never attempts decryption, so no unlock material
+  is touched in the SW at all on this tier).
+- The generic notification is content-free by construction ("New message" / "Tap to
+  open") — no sender, no body.
+- No new logging, metrics, or storage on either side. Server untouched.
+
+## Assumptions
+
+- iOS 16.x SW-context IndexedDB/decrypt flakiness is an OS-level condition we route
+  around, not fix (out of scope: rich previews on that tier).
+- The `keystore` session-token read works on the affected device class (proven: the
+  delivered receipts observed require it), so the bounded fetch is viable.
+- The existing per-event guard (`runGuardedWake`, spec 2043) remains the backstop for
+  the lite path exactly as for the rich path.

--- a/specs/2044-older-iphones-show/tasks.md
+++ b/specs/2044-older-iphones-show/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: Legacy-iOS lite push path
+
+**Feature**: `fix/2044-older-iphones-show` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+TDD-ordered (Principle III: failing tests precede implementation). Checked = done on
+this branch; unchecked = the owed device/deploy verification.
+
+## Phase 1: Setup
+
+- [X] T001 Create hotfix spec + branch (`make spec CATEGORY=hotfix`), fill spec.md, `make roadmap`, bump `package.json` 1.0.5 → 1.0.6
+
+## Phase 2: Foundational
+
+- [X] T002 Failing tests in `src/services/sw-legacy.test.ts`: `iosMajorVersion`/`isLegacyIOS` UA truth table (legacy corpus true, modern corpus false, unparseable false) + `withTimeout` (resolve/hang/reject → fallback)
+- [X] T003 Implement `iosMajorVersion`, `isLegacyIOS` (`LEGACY_IOS_MAX_MAJOR = 16`), `withTimeout` in `src/services/sw-inbox.ts`
+
+## Phase 3: User Story 3 — last-resort generic can never hang (P1)
+
+- [X] T004 [US3] Bound `showGeneric`'s `diagnostics.pushReasonText` read with `withTimeout(…, 300, false)` in `src/sw.ts` (all devices; fail toward plain body)
+
+## Phase 4: User Story 1 — legacy devices always show + keep their subscription (P1)
+
+- [X] T005 [US1] Add the `isLegacyIOS` branch in `dispatchPush` after the shared prologue in `src/sw.ts`
+- [X] T006 [US1] Implement `dispatchLiteWake` in `src/sw.ts`: call → generic ring (no IDB dedup) + `ackCall`; conn/post/post-activity → nudges + quiet note; version → existing IDB-free show with quiet-note degrade; msg → unchanged page-claim arm, else `showGeneric` FIRST then bounded token read (3s) + bounded `fetchPendingFrames` (delivered receipts), no ack, no decrypt/ledger/settle/badge; `ctx` set at every terminal
+- [ ] T007 [US1] Device pass: iPhone 8 backgrounded burst — every push shows the generic, senders get delivered ticks, subscription survives; prod watch shows `f88bf032` no longer accumulating stale frames or churning endpoints (SC-001/002/005)
+
+## Phase 5: User Story 2 — modern isolation (P1)
+
+- [X] T008 [US2] Modern-corpus isolation pin in `sw-legacy.test.ts` (iOS 17/26, Android, desktop, iPadOS-Macintosh, unparseable → all false)
+- [ ] T009 [US2] iPhone 15 / 15 Pro regression pass after deploy: rich notifications unchanged
+
+## Phase 6: Polish
+
+- [X] T010 Gates: `npm run build` (typecheck+build), full vitest (1182 pass), `go build/vet` (server untouched)
+- [X] T011 Spec artifacts: plan.md, tasks.md, checklists/zero-knowledge.md; roadmap regenerated
+
+## GitHub issues (for the PR's `Closes #N`)
+
+- **#1037** — implementation: lite path + detector + showGeneric hang fix (T002–T006, T008)
+- **#1038** — verification: iPhone 8 burst + modern regression + prod watch (T007, T009)
+
+## Dependencies
+
+T002→T003→(T004 ∥ T005/T006); T007/T009 need the deploy; everything else is done.

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -759,6 +759,43 @@ export function platformTrustsSilence(ua: string): boolean {
   return /\b(?:Chrome|Chromium|HeadlessChrome|Edg)\/\d/.test(ua);
 }
 
+/** (spec 2044) iOS major version from a WebKit UA ("… CPU iPhone OS 16_7_10 like
+ *  Mac OS X …" / iPad "… CPU OS 16_7 …"), or null when the UA isn't an identifiable
+ *  iOS one. The iPhone|iPad|iPod token must precede the version so iPadOS-in-desktop-
+ *  mode UAs (which masquerade as "Macintosh … Mac OS X 10_15_7") parse as null, never
+ *  as a bogus legacy "iOS 10". */
+export function iosMajorVersion(ua: string): number | null {
+  const m = /\b(?:iPhone|iPad|iPod)\b.*?\bOS (\d+)_/.exec(ua);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/** (spec 2044) The ONLY gate into the SW's lite wake path. On iOS <= 16 the
+ *  service-worker context is unreliable past the network layer — IndexedDB
+ *  transactions hang or throw and the decrypt/present pipeline dies silently (the
+ *  iPhone 8 signature: delivered receipts fire, then no visible notification, then
+ *  webpushd strikes the subscription out). Those devices get a guaranteed-visible
+ *  generic-first wake instead of the rich pipeline. Fails toward MODERN: an
+ *  unparseable UA must never downgrade a healthy device to generic-only. */
+export const LEGACY_IOS_MAX_MAJOR = 16;
+export function isLegacyIOS(ua: string): boolean {
+  const major = iosMajorVersion(ua);
+  return major !== null && major <= LEGACY_IOS_MAX_MAJOR;
+}
+
+/** (spec 2044) Bound a promise that may never settle — the shape of a read against a
+ *  wedged SW-context IndexedDB. Falls back on timeout AND on rejection, because both
+ *  must degrade the caller gracefully (a diagnostics read failing must never block
+ *  the last-resort show it decorates). */
+export function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return new Promise<T>((resolve) => {
+    const timer = setTimeout(() => resolve(fallback), ms);
+    p.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      () => { clearTimeout(timer); resolve(fallback); },
+    );
+  });
+}
+
 /** Does any window client's state license a silent outcome? Only one that is
  *  BOTH focused AND visible: a frozen/background PWA still appears in matchAll()
  *  with cached attribute snapshots (the norm on iOS) while showing the user

--- a/src/services/sw-legacy.test.ts
+++ b/src/services/sw-legacy.test.ts
@@ -1,0 +1,75 @@
+// Spec 2044 — the legacy-iOS classifier and the bounded-read helper behind the
+// lite push path. The classifier decides which devices get the guaranteed-visible
+// generic-only wake (iOS <= 16, where SW-context IndexedDB/decrypt is unreliable);
+// everything else — including anything unparseable — MUST stay on the modern rich
+// path, so these tests pin both directions. The bounded-read helper is what keeps
+// showGeneric's diagnostics read from hanging the last-resort show on a wedged DB.
+import { describe, it, expect } from 'vitest';
+import { iosMajorVersion, isLegacyIOS, withTimeout } from './sw-inbox';
+
+// Real-world UA shapes (home-screen PWAs omit Version/Safari tokens; browsers keep them).
+const UA = {
+  iphone8Pwa: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7_10 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+  iphone8Safari: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+  iphoneIos15: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_8 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+  ipadIos16: 'Mozilla/5.0 (iPad; CPU OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1',
+  chromeIos16: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+  iphoneIos17Pwa: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+  iphoneIos26Pwa: 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+  // iPadOS 13+ in desktop mode masquerades as macOS — carries "OS 10_15" but NO iPhone/iPad
+  // token, so it must parse as null (modern), never as legacy iOS 10.
+  ipadOsMacintosh: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+  androidChrome: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.113 Mobile Safari/537.36',
+  winChrome: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+  iphoneNoVersion: 'Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+};
+
+describe('spec 2044: iosMajorVersion', () => {
+  it('parses the major version from iPhone and iPad UAs', () => {
+    expect(iosMajorVersion(UA.iphone8Pwa)).toBe(16);
+    expect(iosMajorVersion(UA.iphone8Safari)).toBe(16);
+    expect(iosMajorVersion(UA.iphoneIos15)).toBe(15);
+    expect(iosMajorVersion(UA.ipadIos16)).toBe(16);
+    expect(iosMajorVersion(UA.chromeIos16)).toBe(16);
+    expect(iosMajorVersion(UA.iphoneIos17Pwa)).toBe(17);
+    expect(iosMajorVersion(UA.iphoneIos26Pwa)).toBe(26);
+  });
+  it('returns null for non-iOS and unparseable UAs (never misreads macOS "OS 10_15")', () => {
+    expect(iosMajorVersion(UA.ipadOsMacintosh)).toBeNull();
+    expect(iosMajorVersion(UA.androidChrome)).toBeNull();
+    expect(iosMajorVersion(UA.winChrome)).toBeNull();
+    expect(iosMajorVersion(UA.iphoneNoVersion)).toBeNull();
+    expect(iosMajorVersion('')).toBeNull();
+  });
+});
+
+describe('spec 2044: isLegacyIOS (the ONLY gate into the lite wake path)', () => {
+  it('iOS <= 16 is legacy, in every skin', () => {
+    for (const ua of [UA.iphone8Pwa, UA.iphone8Safari, UA.iphoneIos15, UA.ipadIos16, UA.chromeIos16]) {
+      expect(isLegacyIOS(ua)).toBe(true);
+    }
+  });
+  it('iOS 17+ and every non-iOS platform stay on the modern path (the isolation pin)', () => {
+    for (const ua of [UA.iphoneIos17Pwa, UA.iphoneIos26Pwa, UA.ipadOsMacintosh, UA.androidChrome, UA.winChrome]) {
+      expect(isLegacyIOS(ua)).toBe(false);
+    }
+  });
+  it('anything unparseable fails toward modern — a fresh device must never be downgraded by accident', () => {
+    for (const ua of [UA.iphoneNoVersion, '', 'Some Future Browser/1.0']) {
+      expect(isLegacyIOS(ua)).toBe(false);
+    }
+  });
+});
+
+describe('spec 2044: withTimeout (bounds reads that may hang on a wedged IndexedDB)', () => {
+  it('resolves with the value when the promise settles in time', async () => {
+    expect(await withTimeout(Promise.resolve(true), 1000, false)).toBe(true);
+  });
+  it('falls back when the promise NEVER settles (the hung-IDB case)', async () => {
+    const hung = new Promise<boolean>(() => {});
+    expect(await withTimeout(hung, 20, false)).toBe(false);
+  });
+  it('falls back on rejection too — a throwing read must not kill the show', async () => {
+    expect(await withTimeout(Promise.reject(new Error('idb dead')), 1000, 'fb')).toBe('fb');
+  });
+});

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -25,11 +25,13 @@ import {
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
   mayEndWakeSilently, quietNote, stampPushWake, countAccepted,
   runGuardedWake, recordWake, type WakeCtx,
+  isLegacyIOS, withTimeout, fetchPendingFrames,
   previewCallRing, recordCallTickle, recordCallOutcome, withdrawCallBadgeUnit, callBadgeCount,
   readRingShown, recordRingShown, clearRingShown,
   type SwNote, type ConnNote,
 } from '@/services/sw-inbox';
 import type { CallEventSignal } from '@/services/crypto/message';
+import { readSessionToken } from '@/services/session';
 import { hasFreshRing, ringReassert, ringAlreadyNamed } from '@/services/call-events';
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { resubscribePush } from '@/services/sw-push';
@@ -154,7 +156,11 @@ async function showGeneric(reason?: string): Promise<void> {
   // (spec 2043) on production when the user opts into the push diagnostics toggle. Content-free:
   // the reason is an internal token (timeout / clean-resolve-no-show / an error message), never
   // sender or message text.
-  const showReason = reason && (DEV_HOST || (await setting('diagnostics.pushReasonText', false)));
+  // (spec 2044) The diagnostics read is BOUNDED: this is the last-resort show, and on iOS-16-class
+  // devices a wedged SW-context IndexedDB leaves a read pending forever — an unbounded await here
+  // would hang the one notification the whole guard chain exists to guarantee (the exact silent
+  // wake that strikes the subscription out). Fail toward the plain body; the show must not wait.
+  const showReason = reason && (DEV_HOST || (await withTimeout(setting('diagnostics.pushReasonText', false), 300, false)));
   await self.registration.showNotification('New message', {
     body: showReason ? reason : 'Tap to open',
     icon: ICON,
@@ -848,6 +854,93 @@ async function pageWillNotify(clients: readonly Client[], timeoutMs: number): Pr
   return acked;
 }
 
+/**
+ * (spec 2044) The LITE wake for legacy iOS (<= 16): show first, decrypt never.
+ *
+ * On that tier the network layer works — the iPhone-8 evidence is delivered receipts
+ * firing for exactly the messages that never produced a banner — but SW-context
+ * IndexedDB transactions hang/throw and the rich pipeline (device unlock, settings
+ * reads, decrypt, ledger writes) dies AFTER the fetch, silently. Every such wake was
+ * a webpushd strike; three strikes killed the subscription. So here the visible
+ * notification comes FIRST, from IDB-free primitives only, and the single IDB read
+ * this path ever risks (the session token, needed to fire delivered receipts) is
+ * time-bounded and happens strictly after the show. Cold open is the accepted cost:
+ * the page WS-drains durably on open, exactly as it already does on this tier.
+ * setAppBadge doesn't exist in the iOS-16 SW, so skipping badge math loses nothing.
+ */
+async function dispatchLiteWake(
+  kind: ReturnType<typeof pushKind>['kind'],
+  clients: readonly Client[],
+  ctx: WakeCtx,
+): Promise<void> {
+  if (kind === 'call') {
+    // Generic ring immediately — no readRingShown dedup (an IDB read that can hang
+    // here). A reminder tickle may re-ring generically; on this tier an extra audible
+    // ring beats a missed call. Ack reachability so the caller flips to "Ringing",
+    // and nudge any live page to reconnect so the buffered call-offer rings in-app.
+    for (const client of clients) client.postMessage({ type: 'ring:drain' });
+    await showCall(undefined, { realert: true });
+    ctx.shown = true;
+    ctx.satisfied = true;
+    void ackCall();
+    return;
+  }
+  if (kind === 'conn' || kind === 'post' || kind === 'post-activity') {
+    // No previews (they read IDB before showing). The content-free quiet generic is
+    // the visible ending; live pages still get their reconcile nudges.
+    const nudge = kind === 'conn' ? 'ring:conn' : 'ring:posts';
+    for (const client of clients) client.postMessage({ type: nudge });
+    await showQuietNote('activity');
+    ctx.shown = true;
+    ctx.satisfied = true;
+    return;
+  }
+  if (kind === 'version') {
+    // Already IDB-free (one network fetch + show); keep the rich "what's new" when
+    // the app is closed, but degrade to the quiet generic if the fetch fails — the
+    // wake must end visibly either way.
+    for (const client of clients) client.postMessage({ type: 'ring:checkupdate' });
+    try {
+      if (!clients.length) await showVersionNotification();
+      else await showQuietNote('activity');
+    } catch {
+      await showQuietNote('activity');
+    }
+    ctx.shown = true;
+    ctx.satisfied = true;
+    return;
+  }
+  // Message. A live, unlocked page may still claim the alert (this arm is IDB-free
+  // and identical to the modern path, preserving the app-open no-double UX); the
+  // platform gate is always untrusted on iOS, so a claimed wake still ends with the
+  // quiet note.
+  if (clients.length && (await pageWillNotify(clients, 2200))) {
+    const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) {
+      await showQuietNote('msg');
+      ctx.shown = true;
+    }
+    ctx.satisfied = true;
+    return;
+  }
+  // Unclaimed: the generic shows NOW (bounded diagnostics read inside, spec 2044),
+  // before any keystore/decrypt work is even attempted.
+  await showGeneric('legacy-lite');
+  ctx.shown = true;
+  ctx.satisfied = true;
+  // Best-effort delivered receipts AFTER the show: one bounded keystore read for the
+  // token, one bounded fetch. The server emits 'delivered' for every queued frame on
+  // fetch (idempotent, no ack/dequeue — the page drains durably on open). A hung
+  // token read just skips this wake's receipts; the next wake or app open recovers
+  // them.
+  try {
+    const token = await withTimeout<string | null>(readSessionToken(), 3000, null);
+    if (token) await fetchPendingFrames(token);
+  } catch {
+    /* receipts are best-effort — the notification already showed */
+  }
+}
+
 async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
       // (spec 1037) Every wake stamps its time FIRST — the page-side zombie
       // detector treats "no wake since a stale message was sent" as the
@@ -858,6 +951,16 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
       await Promise.race([stampPushWake(), new Promise((r) => setTimeout(r, 1500))]);
       const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
       const { kind, post } = pushKind(event);
+      // (spec 2044) Legacy iOS (<= 16) takes the LITE wake: show first, decrypt never.
+      // On that tier the SW's network layer works (delivered receipts prove the queue
+      // fetch succeeds) but IndexedDB transactions and the decrypt/present pipeline
+      // hang or die silently — each such wake was a webpushd strike, and the
+      // subscription was dead within a burst. The gate is a pure UA parse that fails
+      // toward modern, so devices on iOS 17+ never enter this branch.
+      if (isLegacyIOS(self.navigator.userAgent)) {
+        await dispatchLiteWake(kind, clients, ctx);
+        return;
+      }
       if (kind === 'call') {
         // A call is never queued on the relay; the tickle itself is the signal.
         // Show the ring immediately, ack reachability (so the caller's UI flips to


### PR DESCRIPTION
Release **v1.0.6**.

### What's new
- **fix(notifications)**: older iPhones now reliably show notifications instead of losing them (spec 2044, #1039)

iPhones on iOS 16 or older silently lost their push subscription after a few messages (the service worker's storage/decryption layer hangs on that iOS generation mid-notification). Those devices now take a show-first lite path: a visible notification appears immediately, senders still get delivered ticks, and the subscription survives. Also hardens the last-resort fallback notification against a wedged database on every device. Modern devices are untouched (pure, unit-tested gate).

All CI gates passed on the develop PR (#1039). Full detail: `specs/2044-older-iphones-show/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)