### PR TITLE
fix(notifications): deliver notifications to Firefox and other size-limited devices

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -129,3 +129,4 @@ Specs are grouped by category band; status moves
 | [2043](specs/2043-push-zombie-subscriptions/spec.md) | Push zombie subscriptions & silent-wake strikes | 🟡 in-progress |
 | [2044](specs/2044-older-iphones-show/spec.md) | Legacy-iOS lite push path — older iPhones always show a notification | 🟡 in-progress |
 | [2045](specs/2045-brief-light-theme/spec.md) | No light-theme flash returning to the app | 🟡 in-progress |
+| [2046](specs/2046-version-announcement-push/spec.md) | Push tickles fit constrained push endpoints | 🟡 in-progress |

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -169,6 +169,22 @@ func NewSender(vapidPublic, vapidPrivate, subject string) *Sender {
 	return &Sender{vapidPublic: vapidPublic, vapidPrivate: vapidPrivate, subject: subject}
 }
 
+// recordSizeOverhead is the aes128gcm framing webpush-go adds around the plaintext
+// inside one record: the content-coding header (salt 16 + rs 4 + keyid-len 1 + the
+// 65-byte ephemeral public key = 86), the 1-byte padding delimiter, and the 16-byte
+// GCM auth tag — 103 bytes. The library requires RecordSize >= payloadLen + 103 or
+// encryption underflows; we add margin on top so the record comfortably holds the
+// payload while staying tiny (a few hundred bytes) for constrained endpoints.
+const recordSizeOverhead = 128
+
+// recordSizeFor returns the smallest safe aes128gcm record size for a tickle payload:
+// large enough that webpush-go never underflows, small enough that constrained push
+// services accept it (vs the library's 4096-byte default padding). Content-free
+// payloads carry no secret whose length needs hiding (see spec 2046 / the Topic note).
+func recordSizeFor(payload []byte) uint32 {
+	return uint32(len(payload)) + recordSizeOverhead
+}
+
 // attempt makes a single delivery and reports the HTTP status, any Retry-After
 // hint, and a transport error (status 0).
 func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p pushParams) (status int, retryAfter time.Duration, body []byte, err error) {
@@ -195,6 +211,15 @@ func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p push
 		TTL:             p.ttl,
 		Urgency:         p.urgency,
 		Topic:           topic,
+		// (spec 2046) Size the aes128gcm record to just fit this content-free tickle.
+		// webpush-go pads every record UP TO RecordSize (default 4096), so a ~15-byte
+		// tickle went out as a ~4 KB body — which some CONSTRAINED push endpoints (a
+		// Firefox/Mozilla autopush subscription observed in prod) reject with 413. The
+		// padding bought no privacy: the tickle TYPE is already visible to the push
+		// service via the cleartext Topic header (sent for collapsing), and every payload
+		// is a fixed content-free marker. recordSizeFor keeps it strictly above the
+		// payload so encryption never underflows.
+		RecordSize: recordSizeFor(p.payload),
 	})
 	if err != nil {
 		return 0, 0, nil, err

--- a/server/internal/push/push_test.go
+++ b/server/internal/push/push_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -92,6 +93,7 @@ type capturedReq struct {
 	ttl     string
 	urgency string
 	topic   string
+	bodyLen int // encrypted aes128gcm body length (spec 2046: must stay small)
 	hits    int32
 }
 
@@ -101,6 +103,8 @@ func (c *capturedReq) record(r *http.Request) {
 	c.ttl = r.Header.Get("TTL")
 	c.urgency = r.Header.Get("Urgency")
 	c.topic = r.Header.Get("Topic")
+	body, _ := io.ReadAll(r.Body)
+	c.bodyLen = len(body)
 	atomic.AddInt32(&c.hits, 1)
 }
 
@@ -324,6 +328,47 @@ func TestSendVersionHeaders(t *testing.T) {
 	}
 	if want := base64.RawURLEncoding.EncodeToString([]byte("ring-version")); cap.topic != want {
 		t.Errorf("version Topic = %q, want %q (base64url of ring-version)", cap.topic, want)
+	}
+}
+
+// TestTickleBodyIsSmall (spec 2046) asserts the encrypted push body is sized to fit the
+// content-free tickle, not padded to webpush-go's 4096-byte default — the padding that made
+// constrained Firefox/Mozilla endpoints reject our sends with 413.
+func TestTickleBodyIsSmall(t *testing.T) {
+	cap := &capturedReq{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.record(r)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	p256dh, auth := newSubKeys(t)
+	n := newNotifier(t, &memSubStore{subs: map[string][]store.PushSubscription{}})
+	n.SendVersion(context.Background(), store.PushSubscription{Endpoint: srv.URL, P256dh: p256dh, Auth: auth})
+
+	if cap.bodyLen == 0 {
+		t.Fatal("no push body captured")
+	}
+	if cap.bodyLen >= 512 {
+		t.Errorf("push body = %d bytes, want < 512 (was ~4096 before the RecordSize fix)", cap.bodyLen)
+	}
+}
+
+// TestRecordSizeFor pins the record-size math: always strictly above the payload (or
+// webpush-go's encryption underflows), and small.
+func TestRecordSizeFor(t *testing.T) {
+	for _, p := range [][]byte{
+		[]byte(`{"t":"version"}`),
+		[]byte(`{"t":"msg"}`),
+		[]byte(`{"t":"post-activity","post":"00000000-0000-0000-0000-000000000000"}`),
+	} {
+		got := recordSizeFor(p)
+		if int(got) <= len(p)+103 { // 103 = aes128gcm framing the library requires
+			t.Errorf("recordSizeFor(%q) = %d, must exceed payload(%d)+103", p, got, len(p))
+		}
+		if got >= 512 {
+			t.Errorf("recordSizeFor(%q) = %d, want < 512", p, got)
+		}
 	}
 }
 

--- a/specs/2046-version-announcement-push/spec.md
+++ b/specs/2046-version-announcement-push/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Push tickles fit constrained push endpoints
+
+**Feature Branch**: `fix/2046-version-announcement-push`
+
+**Created**: 2026-07-19
+
+**Status**: in-progress
+
+**Input**: Prod logs show `push: non-success status=413 body="…Payload Too Large… Converted
+buffer is too long by 1441 bytes" endpoint=updates.push.services.mozilla.com` — a Firefox
+subscription rejecting our push as too large. Our tickles are tiny and content-free
+(`{"t":"version"}`, `{"t":"msg"}`, …, largest `{"t":"post-activity","post":"<id>"}`), but the
+Web Push library (`webpush-go`) pads every encrypted record UP TO its default `RecordSize`
+of 4096 bytes, so a ~15-byte tickle goes out as a ~4 KB body. Some Mozilla autopush
+subscriptions are flagged "constrained" with a smaller max, so they 413. Affected devices
+never receive that push (e.g. the daily "what's new" announcement). Correctly not pruned
+(413 is an our-request fault, not a dead subscription), so it just silently fails each time.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Every push service accepts our tickles (Priority: P1)
+
+A user on Firefox (or any push service with a small payload limit) receives Ring's pushes —
+messages, calls, and version announcements — instead of the service rejecting them as too
+large.
+
+**Why this priority**: An entire push-service tier silently drops all our notifications; the
+version-announcement daily push never lands for those users.
+
+**Independent Test**: The encrypted POST body for a tickle is small (well under 4 KB and
+under a constrained ~2.6 KB limit), asserted by capturing the request in the push unit test.
+
+**Acceptance Scenarios**:
+
+1. **Given** any tickle payload, **When** it is sent, **Then** the encrypted request body is
+   sized to just fit the payload (hundreds of bytes), not padded to ~4 KB.
+2. **Given** the largest tickle (`post-activity` with a post id), **When** it is sent, **Then**
+   the record size still exceeds the payload (no encryption underflow) and the body stays
+   small.
+3. **Given** a constrained Mozilla endpoint, **When** a version announcement is sent, **Then**
+   it is accepted (no 413).
+
+### Edge Cases
+
+- A future, larger payload: the record size is computed from the payload length plus fixed
+  framing overhead, so it always exceeds the payload and never errors.
+- Other services (Apple/FCM) that accepted the 4 KB body also accept the smaller one (a
+  smaller compliant body is universally accepted).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Web Push send MUST set `RecordSize` so the encrypted record is sized to fit
+  the (content-free) payload plus framing overhead, rather than the library's 4096-byte
+  default padding.
+- **FR-002**: The chosen record size MUST always exceed the payload length by the required
+  aes128gcm framing (header + delimiter + auth tag) so encryption never underflows/errors,
+  for every current and reasonably-sized future tickle.
+- **FR-003**: The resulting body MUST be small enough for constrained push endpoints
+  (comfortably under the observed ~2.6 KB Mozilla limit and the 4 KB Web Push floor).
+- **FR-004 (zero-knowledge)**: Reducing padding MUST NOT increase metadata exposure. The
+  tickle TYPE is already visible to the push service via the cleartext `Topic` header (used
+  for collapsing), so record-length no longer obfuscates anything; payloads remain
+  content-free.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A tickle's encrypted POST body is < 512 bytes (was ~4096), asserted in the push
+  unit test via the captured request Content-Length.
+- **SC-002**: Prod: `updates.push.services.mozilla.com` stops returning 413 for our sends;
+  the Firefox subscription receives version announcements.
+- **SC-003**: No regression for Apple/FCM sends (existing header/TTL/topic tests stay green).
+
+## Zero-Knowledge Impact
+
+No change to what crosses the wire in content terms — payloads stay the fixed content-free
+markers, encrypted end-to-end to the subscription's keys. Padding to 4096 bytes previously
+obscured the payload LENGTH, but the tickle type is already disclosed to the push service by
+the cleartext `Topic` header we send for collapsing, so length obfuscation added nothing;
+removing it leaks nothing new. No new fields, endpoints, logs, or storage.
+
+## Assumptions
+
+- The observed constrained limit (~2.6 KB for that Mozilla endpoint) is representative; a
+  payload-relative record size (~150–250 bytes) clears it and any spec-compliant service.
+- `webpush-go` v1.4.0 `Options.RecordSize` controls the record/padding size (default 4096).


### PR DESCRIPTION
## Spec 2046 — push tickles fit constrained push endpoints

Closes #1043

Prod logs: `push: non-success status=413 …Payload Too Large… endpoint=updates.push.services.mozilla.com`. Our tickles are tiny and content-free, but `webpush-go` pads every encrypted record up to its 4096-byte default `RecordSize`, so a ~15-byte tickle went out as a ~4 KB body — which some Mozilla autopush subscriptions (flagged "constrained") reject. Those devices never received our pushes (e.g. the daily version announcement). Correctly not pruned (413 is our-fault, not a dead sub), so it silently failed each time.

**Fix**: set `RecordSize = len(payload) + 128` (payload-relative, so it always exceeds the payload and never underflows), producing a ~150-byte body that clears constrained limits and every push service. `push_test.go` now captures the request body and asserts it's < 512 bytes (was ~4096); `recordSizeFor` is unit-pinned.

**Zero-knowledge**: unchanged. Padding to 4 KB obscured the payload *length*, but the tickle *type* is already disclosed to the push service via the cleartext `Topic` header (sent for collapsing), so length obfuscation added nothing — removing it leaks nothing new. Payloads stay content-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)