### PR TITLE
release: v1.0.7 — no theme flash on app return + notifications for size-limited devices

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,3 +128,4 @@ Specs are grouped by category band; status moves
 | [2041](specs/2041-video-post-memory/spec.md) | Video Posts Must Not Exhaust iPhone Memory | 🟢 shipped |
 | [2043](specs/2043-push-zombie-subscriptions/spec.md) | Push zombie subscriptions & silent-wake strikes | 🟡 in-progress |
 | [2044](specs/2044-older-iphones-show/spec.md) | Legacy-iOS lite push path — older iPhones always show a notification | 🟡 in-progress |
+| [2045](specs/2045-brief-light-theme/spec.md) | No light-theme flash returning to the app | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -129,3 +129,4 @@ Specs are grouped by category band; status moves
 | [2043](specs/2043-push-zombie-subscriptions/spec.md) | Push zombie subscriptions & silent-wake strikes | 🟡 in-progress |
 | [2044](specs/2044-older-iphones-show/spec.md) | Legacy-iOS lite push path — older iPhones always show a notification | 🟡 in-progress |
 | [2045](specs/2045-brief-light-theme/spec.md) | No light-theme flash returning to the app | 🟡 in-progress |
+| [2046](specs/2046-version-announcement-push/spec.md) | Push tickles fit constrained push endpoints | 🟡 in-progress |

--- a/index.html
+++ b/index.html
@@ -23,6 +23,28 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Ring</title>
+    <!-- (spec 2045) Pre-paint theme: apply Ionic's dark palette class synchronously so a
+         cold relaunch (returning from the iOS app switcher after iOS killed the page)
+         never renders a frame in the LIGHT palette before useTheme's async settings read
+         resolves. useTheme mirrors the choice into localStorage on each apply; here we
+         re-resolve it (with 'system' → OS scheme) before first paint. Mirrors
+         resolveDark() in src/composables/useTheme.ts — keep the two in sync. Fails safe to
+         prefers-color-scheme if storage is blocked (private mode). -->
+    <script>
+      (function () {
+        function prefersDark() {
+          try { return window.matchMedia('(prefers-color-scheme: dark)').matches; } catch (e) { return false; }
+        }
+        var dark;
+        try {
+          var pref = localStorage.getItem('appearance.theme') || 'system';
+          dark = pref === 'dark' || (pref === 'system' && prefersDark());
+        } catch (e) {
+          dark = prefersDark();
+        }
+        if (dark) document.documentElement.classList.add('ion-palette-dark');
+      })();
+    </script>
     <!-- Match the app's base background before Vue mounts so there's no white
          flash between the launch screen and the passcode gate. -->
     <style>
@@ -30,6 +52,10 @@
       @media (prefers-color-scheme: dark) {
         html, body { background-color: #000000; }
       }
+      /* When the pre-paint script resolved dark (explicit dark, or system+OS-dark), the
+         raw background must be dark too even on a light-OS device (explicit dark override),
+         so the first frame matches the palette class the script just set. */
+      html.ion-palette-dark, html.ion-palette-dark body { background-color: #000000; }
     </style>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -169,6 +169,22 @@ func NewSender(vapidPublic, vapidPrivate, subject string) *Sender {
 	return &Sender{vapidPublic: vapidPublic, vapidPrivate: vapidPrivate, subject: subject}
 }
 
+// recordSizeOverhead is the aes128gcm framing webpush-go adds around the plaintext
+// inside one record: the content-coding header (salt 16 + rs 4 + keyid-len 1 + the
+// 65-byte ephemeral public key = 86), the 1-byte padding delimiter, and the 16-byte
+// GCM auth tag — 103 bytes. The library requires RecordSize >= payloadLen + 103 or
+// encryption underflows; we add margin on top so the record comfortably holds the
+// payload while staying tiny (a few hundred bytes) for constrained endpoints.
+const recordSizeOverhead = 128
+
+// recordSizeFor returns the smallest safe aes128gcm record size for a tickle payload:
+// large enough that webpush-go never underflows, small enough that constrained push
+// services accept it (vs the library's 4096-byte default padding). Content-free
+// payloads carry no secret whose length needs hiding (see spec 2046 / the Topic note).
+func recordSizeFor(payload []byte) uint32 {
+	return uint32(len(payload)) + recordSizeOverhead
+}
+
 // attempt makes a single delivery and reports the HTTP status, any Retry-After
 // hint, and a transport error (status 0).
 func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p pushParams) (status int, retryAfter time.Duration, body []byte, err error) {
@@ -195,6 +211,15 @@ func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p push
 		TTL:             p.ttl,
 		Urgency:         p.urgency,
 		Topic:           topic,
+		// (spec 2046) Size the aes128gcm record to just fit this content-free tickle.
+		// webpush-go pads every record UP TO RecordSize (default 4096), so a ~15-byte
+		// tickle went out as a ~4 KB body — which some CONSTRAINED push endpoints (a
+		// Firefox/Mozilla autopush subscription observed in prod) reject with 413. The
+		// padding bought no privacy: the tickle TYPE is already visible to the push
+		// service via the cleartext Topic header (sent for collapsing), and every payload
+		// is a fixed content-free marker. recordSizeFor keeps it strictly above the
+		// payload so encryption never underflows.
+		RecordSize: recordSizeFor(p.payload),
 	})
 	if err != nil {
 		return 0, 0, nil, err

--- a/server/internal/push/push_test.go
+++ b/server/internal/push/push_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -92,6 +93,7 @@ type capturedReq struct {
 	ttl     string
 	urgency string
 	topic   string
+	bodyLen int // encrypted aes128gcm body length (spec 2046: must stay small)
 	hits    int32
 }
 
@@ -101,6 +103,8 @@ func (c *capturedReq) record(r *http.Request) {
 	c.ttl = r.Header.Get("TTL")
 	c.urgency = r.Header.Get("Urgency")
 	c.topic = r.Header.Get("Topic")
+	body, _ := io.ReadAll(r.Body)
+	c.bodyLen = len(body)
 	atomic.AddInt32(&c.hits, 1)
 }
 
@@ -324,6 +328,47 @@ func TestSendVersionHeaders(t *testing.T) {
 	}
 	if want := base64.RawURLEncoding.EncodeToString([]byte("ring-version")); cap.topic != want {
 		t.Errorf("version Topic = %q, want %q (base64url of ring-version)", cap.topic, want)
+	}
+}
+
+// TestTickleBodyIsSmall (spec 2046) asserts the encrypted push body is sized to fit the
+// content-free tickle, not padded to webpush-go's 4096-byte default — the padding that made
+// constrained Firefox/Mozilla endpoints reject our sends with 413.
+func TestTickleBodyIsSmall(t *testing.T) {
+	cap := &capturedReq{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.record(r)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	p256dh, auth := newSubKeys(t)
+	n := newNotifier(t, &memSubStore{subs: map[string][]store.PushSubscription{}})
+	n.SendVersion(context.Background(), store.PushSubscription{Endpoint: srv.URL, P256dh: p256dh, Auth: auth})
+
+	if cap.bodyLen == 0 {
+		t.Fatal("no push body captured")
+	}
+	if cap.bodyLen >= 512 {
+		t.Errorf("push body = %d bytes, want < 512 (was ~4096 before the RecordSize fix)", cap.bodyLen)
+	}
+}
+
+// TestRecordSizeFor pins the record-size math: always strictly above the payload (or
+// webpush-go's encryption underflows), and small.
+func TestRecordSizeFor(t *testing.T) {
+	for _, p := range [][]byte{
+		[]byte(`{"t":"version"}`),
+		[]byte(`{"t":"msg"}`),
+		[]byte(`{"t":"post-activity","post":"00000000-0000-0000-0000-000000000000"}`),
+	} {
+		got := recordSizeFor(p)
+		if int(got) <= len(p)+103 { // 103 = aes128gcm framing the library requires
+			t.Errorf("recordSizeFor(%q) = %d, must exceed payload(%d)+103", p, got, len(p))
+		}
+		if got >= 512 {
+			t.Errorf("recordSizeFor(%q) = %d, want < 512", p, got)
+		}
 	}
 }
 

--- a/specs/2045-brief-light-theme/spec.md
+++ b/specs/2045-brief-light-theme/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: No light-theme flash returning to the app
+
+**Feature Branch**: `fix/2045-brief-light-theme`
+
+**Created**: 2026-07-19
+
+**Status**: in-progress
+
+**Input**: On iOS, occasionally (~1% of app-switcher returns / cold relaunches) Ring
+paints in the light theme for one frame before correcting to dark, even though the OS is
+in dark mode and the app resolves the theme correctly the rest of the time. Cause:
+`useTheme` toggles Ionic's `ion-palette-dark` class only AFTER an async IndexedDB read of
+`appearance.theme` (via `useLiveQuery`). On a cold relaunch (iOS silently killed the page,
+switcher relaunch), Ionic's CSS applies its default LIGHT palette for the frames before
+that async read resolves → a light flash. `index.html` already dark-matches the raw
+`html/body` background via `prefers-color-scheme`, but the Ionic component palette (driven
+by the class) is not set until Vue mounts + IDB loads.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Returning to the app never flashes the wrong theme (Priority: P1)
+
+Someone in dark mode switches back to Ring from the app switcher (or relaunches it after
+iOS killed it) and sees dark immediately — no white flash.
+
+**Why this priority**: A jarring flash on a privacy-focused app reads as a glitch; it's a
+visible polish defect on the most common interaction (returning to the app).
+
+**Independent Test**: With `appearance.theme` resolving to dark, the `ion-palette-dark`
+class is present on `<html>` at first paint (before any async read), verified by a unit
+test of the pre-paint resolver + a check that the inline script runs in `<head>`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the resolved theme is dark (explicit `dark`, or `system` + OS dark), **When**
+   the document first paints, **Then** `ion-palette-dark` is already on `<html>` — no
+   frame renders in the light palette.
+2. **Given** the resolved theme is light, **When** the document first paints, **Then** the
+   class is absent (no dark flash on light-mode devices either).
+3. **Given** a fresh install with no stored preference, **When** it first paints, **Then**
+   the palette follows the OS `prefers-color-scheme` (matches today's default behavior).
+
+### Edge Cases
+
+- Stored preference unreadable / localStorage blocked (private mode): fall back to
+  `prefers-color-scheme` — never throw, never block paint.
+- Preference changed in-app then relaunched: the mirror is written on each apply, so the
+  next cold start reads the up-to-date value synchronously.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The resolved dark/light decision MUST be applied to `<html>` as the
+  `ion-palette-dark` class synchronously, before first paint, via an inline script in
+  `index.html` `<head>` (no async, no bundle dependency).
+- **FR-002**: The pre-paint resolver MUST read the persisted `appearance.theme`
+  synchronously — mirrored to `localStorage` by `useTheme` on each apply — and resolve
+  `system` against `prefers-color-scheme`.
+- **FR-003**: The resolver MUST fail safe: any error (blocked storage, missing key) falls
+  back to `prefers-color-scheme`, and never throws or blocks rendering.
+- **FR-004**: `useTheme` MUST keep the `localStorage` mirror in sync whenever it applies
+  the theme (so the next cold start is correct), without changing IndexedDB as the source
+  of truth.
+- **FR-005**: Behavior for the common case (already-correct 99%) MUST be unchanged; this
+  only closes the cold-relaunch first-paint gap.
+
+### Key Entities
+
+- **Theme mirror**: a synchronous `localStorage` copy of `appearance.theme` used only for
+  pre-paint resolution; IndexedDB remains authoritative.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a dark-resolved cold relaunch, zero frames render in the light palette
+  (the class is present at first paint).
+- **SC-002**: Device confirmation: returning to Ring from the iOS app switcher in dark
+  mode shows no light flash across repeated tries.
+- **SC-003**: Existing behavior/tests unaffected; `useTheme` still reacts to the Theme
+  radio and OS changes.
+
+## Zero-Knowledge Impact
+
+Only the appearance preference (`system`/`light`/`dark`) is mirrored to `localStorage` on
+the device — a non-sensitive UI setting, never leaves the device, no server involvement,
+no user content. No wire surface.
+
+## Assumptions
+
+- IndexedDB stays the source of truth; the `localStorage` mirror is a read-optimization
+  for the pre-paint frame only.
+- Ionic's palette is driven by the `ion-palette-dark` class on `<html>` (per `useTheme`
+  and `dark.class.css`).

--- a/specs/2046-version-announcement-push/spec.md
+++ b/specs/2046-version-announcement-push/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Push tickles fit constrained push endpoints
+
+**Feature Branch**: `fix/2046-version-announcement-push`
+
+**Created**: 2026-07-19
+
+**Status**: in-progress
+
+**Input**: Prod logs show `push: non-success status=413 body="…Payload Too Large… Converted
+buffer is too long by 1441 bytes" endpoint=updates.push.services.mozilla.com` — a Firefox
+subscription rejecting our push as too large. Our tickles are tiny and content-free
+(`{"t":"version"}`, `{"t":"msg"}`, …, largest `{"t":"post-activity","post":"<id>"}`), but the
+Web Push library (`webpush-go`) pads every encrypted record UP TO its default `RecordSize`
+of 4096 bytes, so a ~15-byte tickle goes out as a ~4 KB body. Some Mozilla autopush
+subscriptions are flagged "constrained" with a smaller max, so they 413. Affected devices
+never receive that push (e.g. the daily "what's new" announcement). Correctly not pruned
+(413 is an our-request fault, not a dead subscription), so it just silently fails each time.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Every push service accepts our tickles (Priority: P1)
+
+A user on Firefox (or any push service with a small payload limit) receives Ring's pushes —
+messages, calls, and version announcements — instead of the service rejecting them as too
+large.
+
+**Why this priority**: An entire push-service tier silently drops all our notifications; the
+version-announcement daily push never lands for those users.
+
+**Independent Test**: The encrypted POST body for a tickle is small (well under 4 KB and
+under a constrained ~2.6 KB limit), asserted by capturing the request in the push unit test.
+
+**Acceptance Scenarios**:
+
+1. **Given** any tickle payload, **When** it is sent, **Then** the encrypted request body is
+   sized to just fit the payload (hundreds of bytes), not padded to ~4 KB.
+2. **Given** the largest tickle (`post-activity` with a post id), **When** it is sent, **Then**
+   the record size still exceeds the payload (no encryption underflow) and the body stays
+   small.
+3. **Given** a constrained Mozilla endpoint, **When** a version announcement is sent, **Then**
+   it is accepted (no 413).
+
+### Edge Cases
+
+- A future, larger payload: the record size is computed from the payload length plus fixed
+  framing overhead, so it always exceeds the payload and never errors.
+- Other services (Apple/FCM) that accepted the 4 KB body also accept the smaller one (a
+  smaller compliant body is universally accepted).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Web Push send MUST set `RecordSize` so the encrypted record is sized to fit
+  the (content-free) payload plus framing overhead, rather than the library's 4096-byte
+  default padding.
+- **FR-002**: The chosen record size MUST always exceed the payload length by the required
+  aes128gcm framing (header + delimiter + auth tag) so encryption never underflows/errors,
+  for every current and reasonably-sized future tickle.
+- **FR-003**: The resulting body MUST be small enough for constrained push endpoints
+  (comfortably under the observed ~2.6 KB Mozilla limit and the 4 KB Web Push floor).
+- **FR-004 (zero-knowledge)**: Reducing padding MUST NOT increase metadata exposure. The
+  tickle TYPE is already visible to the push service via the cleartext `Topic` header (used
+  for collapsing), so record-length no longer obfuscates anything; payloads remain
+  content-free.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A tickle's encrypted POST body is < 512 bytes (was ~4096), asserted in the push
+  unit test via the captured request Content-Length.
+- **SC-002**: Prod: `updates.push.services.mozilla.com` stops returning 413 for our sends;
+  the Firefox subscription receives version announcements.
+- **SC-003**: No regression for Apple/FCM sends (existing header/TTL/topic tests stay green).
+
+## Zero-Knowledge Impact
+
+No change to what crosses the wire in content terms — payloads stay the fixed content-free
+markers, encrypted end-to-end to the subscription's keys. Padding to 4096 bytes previously
+obscured the payload LENGTH, but the tickle type is already disclosed to the push service by
+the cleartext `Topic` header we send for collapsing, so length obfuscation added nothing;
+removing it leaks nothing new. No new fields, endpoints, logs, or storage.
+
+## Assumptions
+
+- The observed constrained limit (~2.6 KB for that Mozilla endpoint) is representative; a
+  payload-relative record size (~150–250 bytes) clears it and any spec-compliant service.
+- `webpush-go` v1.4.0 `Options.RecordSize` controls the record/padding size (default 4096).

--- a/src/composables/useTheme.test.ts
+++ b/src/composables/useTheme.test.ts
@@ -1,0 +1,26 @@
+// Spec 2045 — the pure dark/light resolver shared between useTheme (runtime, class toggle)
+// and the index.html pre-paint inline script (first frame on a cold relaunch). Pinning it
+// here guards against the two drifting: whatever this asserts is what index.html must do.
+import { describe, it, expect } from 'vitest';
+import { resolveDark, THEME_MIRROR_KEY } from './useTheme';
+
+describe('spec 2045: resolveDark', () => {
+  it('explicit dark is always dark, regardless of OS', () => {
+    expect(resolveDark('dark', false)).toBe(true);
+    expect(resolveDark('dark', true)).toBe(true);
+  });
+  it('explicit light is always light, regardless of OS', () => {
+    expect(resolveDark('light', true)).toBe(false);
+    expect(resolveDark('light', false)).toBe(false);
+  });
+  it('system follows the OS color scheme', () => {
+    expect(resolveDark('system', true)).toBe(true);
+    expect(resolveDark('system', false)).toBe(false);
+  });
+});
+
+describe('spec 2045: the mirror key matches the settings key the pre-paint script reads', () => {
+  it('is exactly appearance.theme', () => {
+    expect(THEME_MIRROR_KEY).toBe('appearance.theme');
+  });
+});

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -14,6 +14,19 @@ import type { Setting } from '@/db/types';
 
 type ThemePref = 'system' | 'light' | 'dark';
 
+// (spec 2045) The one place the dark/light decision is made. Duplicated as a 3-line inline
+// resolver in index.html for the pre-paint frame (it can't import this module before the
+// bundle loads) — keep the two in sync.
+export function resolveDark(pref: ThemePref, prefersDark: boolean): boolean {
+  return pref === 'dark' || (pref === 'system' && prefersDark);
+}
+
+// (spec 2045) localStorage key mirrored from the IndexedDB `appearance.theme` setting, so
+// the index.html pre-paint script can resolve the theme SYNCHRONOUSLY (IDB is async and
+// only resolves after Vue mounts — the window that flashed the light palette on a cold
+// relaunch). IndexedDB stays the source of truth; this is a read-optimization for one frame.
+export const THEME_MIRROR_KEY = 'appearance.theme';
+
 export function useTheme(): void {
   const rows = useLiveQuery(
     () => getAll<Setting>('settings'),
@@ -26,8 +39,14 @@ export function useTheme(): void {
     const pref =
       (rows.value.find((r) => r.key === 'appearance.theme')?.value as ThemePref) ??
       'system';
-    const dark = pref === 'dark' || (pref === 'system' && mql.matches);
+    const dark = resolveDark(pref, mql.matches);
     document.documentElement.classList.toggle('ion-palette-dark', dark);
+    // Keep the synchronous mirror current so the NEXT cold start paints correctly.
+    try {
+      localStorage.setItem(THEME_MIRROR_KEY, pref);
+    } catch {
+      /* storage blocked → pre-paint falls back to prefers-color-scheme */
+    }
   };
 
   // Re-apply when the stored choice changes (settings live query updates) and


### PR DESCRIPTION
Release **v1.0.7** — two notification/UX fixes.

### What's new
- **fix(appearance)**: stop the brief light flash when returning to the app (spec 2045, #1042)
- **fix(notifications)**: deliver notifications to Firefox and other size-limited devices (spec 2046, #1044)

Returning to Ring from the app switcher no longer flashes the light theme for a frame. And push notifications now fit push services with small payload limits (a Firefox subscription was rejecting them), so those devices receive alerts including the daily what's-new.

Both passed all CI gates on their develop PRs (#1042, #1044). Details: `specs/2045-*`, `specs/2046-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)