### PR TITLE
fix(notifications): show message notifications on the latest iPhones and iPads

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,3 +130,4 @@ Specs are grouped by category band; status moves
 | [2044](specs/2044-older-iphones-show/spec.md) | Legacy-iOS lite push path — older iPhones always show a notification | 🟡 in-progress |
 | [2045](specs/2045-brief-light-theme/spec.md) | No light-theme flash returning to the app | 🟡 in-progress |
 | [2046](specs/2046-version-announcement-push/spec.md) | Push tickles fit constrained push endpoints | 🟡 in-progress |
+| [2047](specs/2047-modern-iphones-and/spec.md) | Modern iPhones/iPads actually display push notifications | 🟡 in-progress |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/2047-modern-iphones-and/spec.md
+++ b/specs/2047-modern-iphones-and/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: Modern iPhones/iPads actually display push notifications
+
+**Feature Branch**: `fix/2047-modern-iphones-and`
+
+**Created**: 2026-07-19
+
+**Status**: in-progress
+
+**Input**: On modern iOS/iPadOS (iOS 26, iPadOS 27), background push notifications for
+messages **silently fail to appear on the lock screen**, even though the service worker
+wakes and fetches the message (the server logs a "delivered" receipt). Confirmed on two
+different modern devices / two accounts, single clean wake. The failure is invisible
+server-side. The spec-2044 legacy lite path (iOS ≤ 16) works fine — an iPhone 8 shows
+generic notifications reliably. Root cause (investigation): the rich show
+(`showNotes`, `sw.ts`) passes **`renotify: true`**, the one option the working generic
+(`showGeneric`) omits; on the new OS a `renotify: true` `showNotification` is *accepted*
+(the promise resolves) but *not rendered*. Because the spec-2043 guard infers "shown"
+from the promise resolving (`ctx.shown/satisfied = true`), it never fires its last-resort
+visible generic — so nothing appears at all, and diagnostics can't surface it.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A message notification appears on a modern iPhone/iPad (Priority: P1)
+
+Someone on iOS 26 / iPadOS 27 with Ring backgrounded receives a message and sees the
+notification on their lock screen — the same as it already works on older iOS.
+
+**Why this priority**: Background message notifications are silently broken for every
+modern-iOS user; this is the core function of the app's push.
+
+**Independent Test**: On a modern device, a single backgrounded message produces a visible
+notification (device test). Unit: `showNotes` no longer passes `renotify` (the option that
+doesn't render); the rich show's option set matches the proven-working generic's shape.
+
+**Acceptance Scenarios**:
+
+1. **Given** a modern-iOS device with Ring closed/locked, **When** a message push wakes the
+   SW and it shows the rich note, **Then** the notification is visible on the lock screen.
+2. **Given** a per-chat notification already on screen, **When** a new message arrives,
+   **Then** it coalesces onto the same tag and remains visible (updated), not dropped.
+3. **Given** the rich show fails for any reason, **When** the wake ends, **Then** the
+   guard's last-resort generic is visible (the safety net actually displays).
+
+### Edge Cases
+
+- Older iOS (≤ 16) legacy lite path is unchanged (already works; uses `showGeneric`).
+- A burst to one chat coalesces on the shared tag; without `renotify` iOS updates the
+  notification in place rather than re-alerting each — acceptable (visible beats a
+  re-buzz that renders nothing).
+- iOS background-wake budget still throttles very rapid bursts (OS-level, out of scope).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The rich message show (`showNotes`) MUST NOT pass `renotify: true`; it relies
+  on `tag` for per-chat coalescing, matching the option set that reliably renders on iOS
+  (the working generic).
+- **FR-002**: Every other content-carrying rich show that passes `renotify: true`
+  (`showConnNotes`) MUST drop it for the same reason.
+- **FR-003**: The last-resort guard generic and the quiet-note fallback MUST use an option
+  set that iOS reliably displays, so the "always show something" invariant is real on
+  modern iOS (the fallback that should catch everything must actually render).
+- **FR-004**: Behavior on older iOS (≤ 16) and the coalescing/dedup semantics MUST NOT
+  regress; only the non-rendering option is removed.
+
+### Key Entities
+
+- **Rich note show**: the per-chat message/connection notification whose options must stay
+  within the iOS-renderable set.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a modern iOS/iPadOS device, a single backgrounded message produces a
+  visible lock-screen notification (device-verified on the iPad and iPhone 15 Pro).
+- **SC-002**: Unit tests assert no rich show passes `renotify: true`.
+- **SC-003**: The legacy path and existing notification unit/e2e tests stay green.
+
+## Zero-Knowledge Impact
+
+None. This changes only client-side notification *display* options (`renotify`/`silent`);
+no wire surface, no payload, no new data. Notification content is built the same way from
+already-decrypted local data.
+
+## Assumptions
+
+- iOS 26 / iPadOS 27 accept-but-don't-render `renotify: true` (confirmed by contrast: the
+  only option differing between the working generic and the failing rich show; to be
+  device/Web-Inspector-verified).
+- Coalescing via `tag` alone (no `renotify`) still displays and updates the per-chat
+  notification, as the generic path already does.

--- a/specs/2047-modern-iphones-and/tasks.md
+++ b/specs/2047-modern-iphones-and/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Modern iPhones/iPads actually display push notifications
+
+**Spec**: [spec.md](./spec.md) · Branch `fix/2047-modern-iphones-and` · Closes #1046
+
+- [X] T001 Pure `richNoteOptions` helper (no `renotify`) in `src/services/sw-inbox.ts` + failing-first test `src/services/sw-notify-options.test.ts`
+- [X] T002 `showNotes` (`src/sw.ts`) uses `richNoteOptions` — drops `renotify:true`
+- [X] T003 `showConnNotes` (`src/sw.ts`) drops `renotify:true`
+- [X] T004 Page bridge `notifyLocal` (`src/services/push.ts`) drops `renotify:true`
+- [X] T005 Gates: `npm run build`, full vitest (1190) green
+- [ ] T006 Device verify: backgrounded message on iPad + iPhone 15 Pro shows a lock-screen notification (SC-001)

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -367,14 +367,13 @@ export async function notifyLocal(title: string, body: string, url?: string, cha
       badge: '/badge-96.png',
       // Per-chat tag (matching the service worker's preview) so the page- and
       // SW-shown notes for one conversation COLLAPSE into a single notification
-      // instead of stacking, and a follow-up re-alerts (renotify).
+      // instead of stacking.
       tag: chatId ? `ring:${chatId}` : 'ring-incoming',
-      renotify: true,
+      // (spec 2047) NO `renotify`: iOS 26 / iPadOS 27 accept but never render a
+      // renotify:true notification; the per-chat `tag` still coalesces.
       // Deep-link target read by the service worker's notificationclick handler.
       data: url ? { url } : undefined,
-      // `renotify` is valid per the Notifications spec but missing from the DOM lib
-      // type in this TS version (present in the webworker lib the SW uses).
-    } as NotificationOptions & { renotify?: boolean });
+    });
   } catch {
     /* ignore */
   }

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -78,6 +78,28 @@ export interface SwNote {
   silent?: boolean;
 }
 
+/** (spec 2047) The display options for a rich per-chat note. Deliberately OMITS
+ *  `renotify`: iOS 26 / iPadOS 27 ACCEPT a `renotify:true` show (the promise resolves)
+ *  but never RENDER it on the lock screen — a total, silent failure the guard can't
+ *  catch (it infers "shown" from the promise resolving). The working generic and the
+ *  legacy lite path omit `renotify`, which is exactly why they display; coalescing is
+ *  handled by the per-chat `tag` alone. Keep this a pure function so a unit test can
+ *  pin that `renotify` never returns. */
+export function richNoteOptions(
+  n: Pick<SwNote, 'body' | 'tag' | 'url' | 'silent'>,
+  icon: string,
+  badge: string,
+): NotificationOptions {
+  return {
+    body: n.body,
+    icon,
+    badge,
+    tag: n.tag,
+    silent: n.silent === true,
+    data: { url: n.url },
+  };
+}
+
 /** Background-preview result. `notes` are the displayable notifications, `pending`
  *  is the number of queued (undelivered) message frames, known from the fetch
  *  alone (no decryption needed) and used for the app-icon badge. `suppressed` is

--- a/src/services/sw-notify-options.test.ts
+++ b/src/services/sw-notify-options.test.ts
@@ -1,0 +1,35 @@
+// Spec 2047 — the rich per-chat notification's display options MUST NOT carry
+// `renotify`. On iOS 26 / iPadOS 27 a `renotify:true` showNotification resolves but is
+// never rendered on the lock screen — a silent, total failure the wake guard can't
+// detect (it infers "shown" from the promise resolving). The working generic and the
+// legacy lite path omit `renotify`, which is why they display. This pins that it stays
+// gone, and that the per-chat `tag` (the coalescing key) is preserved.
+import { describe, it, expect } from 'vitest';
+import { richNoteOptions } from './sw-inbox';
+
+describe('spec 2047: richNoteOptions', () => {
+  const n = { body: 'hello', tag: 'ring:chat-1', url: '/chat/chat-1', silent: false };
+
+  it('does NOT set renotify (the option iOS 26/iPadOS 27 accepts but never renders)', () => {
+    const opts = richNoteOptions(n, '/icon.png', '/badge.png');
+    expect('renotify' in opts).toBe(false);
+    expect((opts as Record<string, unknown>).renotify).toBeUndefined();
+  });
+
+  it('keeps the per-chat tag so notifications still coalesce', () => {
+    expect(richNoteOptions(n, '/i.png', '/b.png').tag).toBe('ring:chat-1');
+  });
+
+  it('passes icon, badge, body, and the deep-link url through', () => {
+    const opts = richNoteOptions(n, '/icon.png', '/badge.png');
+    expect(opts.body).toBe('hello');
+    expect(opts.icon).toBe('/icon.png');
+    expect(opts.badge).toBe('/badge.png');
+    expect((opts.data as { url: string }).url).toBe('/chat/chat-1');
+  });
+
+  it('honors an explicit silent note (reaction tone None) and defaults silent off', () => {
+    expect(richNoteOptions({ ...n, silent: true }, '/i.png', '/b.png').silent).toBe(true);
+    expect(richNoteOptions({ ...n, silent: undefined }, '/i.png', '/b.png').silent).toBe(false);
+  });
+});

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -25,7 +25,7 @@ import {
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
   mayEndWakeSilently, quietNote, stampPushWake, countAccepted,
   runGuardedWake, recordWake, type WakeCtx,
-  isLegacyIOS, withTimeout, fetchPendingFrames,
+  isLegacyIOS, withTimeout, fetchPendingFrames, richNoteOptions,
   previewCallRing, recordCallTickle, recordCallOutcome, withdrawCallBadgeUnit, callBadgeCount,
   readRingShown, recordRingShown, clearRingShown,
   type SwNote, type ConnNote,
@@ -287,18 +287,10 @@ async function showNotes(notes: SwNote[]): Promise<number> {
       // Center entries instead of collapsing them, so close the ring explicitly
       // before showing its replacement.
       if (n.tag === 'ring-call') await closeByTag('ring-call');
-      await self.registration.showNotification(titleWithCount(n), {
-        body: n.body,
-        icon: ICON,
-        badge: BADGE,
-        tag: n.tag,
-        renotify: true, // a genuinely-new message on this tag should re-alert (a silent re-assert
-        // for "nothing new" uses reassertFromSummary below, which sets renotify:false)
-        // (spec 1048) A reaction note with the tone set to None shows without the
-        // platform sound — visible (the wake still ends visibly), just quiet.
-        silent: n.silent === true,
-        data: { url: n.url },
-      });
+      // (spec 2047) Options via richNoteOptions — deliberately NO `renotify` (iOS 26 /
+      // iPadOS 27 accept but never render a renotify:true show; the per-chat `tag`
+      // still coalesces, exactly as the working generic does).
+      await self.registration.showNotification(titleWithCount(n), richNoteOptions(n, ICON, BADGE));
     } catch (e) {
       console.warn('[sw] showNotification failed', e);
       throw e; // rethrow so countAccepted doesn't count a rejected show
@@ -544,12 +536,13 @@ async function showPostNotification(): Promise<number> {
 async function showConnNotes(notes: ConnNote[]): Promise<number> {
   return countAccepted(notes.map((n) => async () => {
     try {
+      // (spec 2047) NO `renotify` — see showNotes: iOS 26/iPadOS 27 accept but do not
+      // render a renotify:true notification; the per-chat `tag` handles coalescing.
       await self.registration.showNotification(n.title, {
         body: n.body,
         icon: ICON,
         badge: BADGE,
         tag: n.tag,
-        renotify: true,
         data: { url: n.url },
       });
     } catch (e) {


### PR DESCRIPTION
## Spec 2047 — modern iOS/iPadOS silently drop message notifications

Closes #1046

On **iOS 26 / iPadOS 27**, background message notifications silently fail to appear on the lock screen — the service worker wakes and fetches the message (server logs "delivered"), but nothing renders. Confirmed on two modern devices / two accounts; **invisible server-side**. The spec-2044 legacy lite path (iOS ≤ 16) works fine.

**Root cause:** the rich show (`showNotes`) passes **`renotify: true`** — the one option the working generic (`showGeneric`) and legacy lite path omit. The new OS *accepts* a `renotify:true` `showNotification` (the promise resolves) but never *renders* it, and the spec-2043 guard infers "shown" from the promise resolving (`ctx.shown/satisfied = true`), so it never fires its last-resort visible generic → total silent failure that diagnostics can't even surface.

**Fix:** drop `renotify` from `showNotes` + `showConnNotes` (`src/sw.ts`) and the page bridge `notifyLocal` (`src/services/push.ts`). Per-chat coalescing still works via `tag` (exactly how the generic path always did). New pure `richNoteOptions` helper + `sw-notify-options.test.ts` pin that `renotify` never returns. 1190 tests green.

**Owed (device):** confirm a backgrounded message shows a lock-screen notification on the iPad + iPhone 15 Pro once deployed (couldn't Web-Inspector-confirm — no data cable).

Zero-knowledge: none — client display option only, no wire/payload change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)