### PR TITLE
fix(notifications): notifications now arrive reliably when your phone is locked

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -131,3 +131,4 @@ Specs are grouped by category band; status moves
 | [2045](specs/2045-brief-light-theme/spec.md) | No light-theme flash returning to the app | 🟡 in-progress |
 | [2046](specs/2046-version-announcement-push/spec.md) | Push tickles fit constrained push endpoints | 🟡 in-progress |
 | [2047](specs/2047-modern-iphones-and/spec.md) | Modern iPhones/iPads actually display push notifications | 🟡 in-progress |
+| [2048](specs/2048-notifications-not-appear/spec.md) | Show-first notifications (work when locked, keep the subscription alive) | 🟡 in-progress |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/2048-notifications-not-appear/spec.md
+++ b/specs/2048-notifications-not-appear/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Show-first notifications (work when locked, keep the subscription alive)
+
+**Feature Branch**: `fix/2048-notifications-not-appear`
+
+**Created**: 2026-07-19
+
+**Status**: in-progress
+
+**Input**: Methodical device testing isolated the real failure: on modern iOS/iPadOS,
+message notifications work fine while the **screen is on** (even backgrounded/closed), but
+once the **screen is locked and some time passes**, pushes are accepted and the service
+worker wakes + fetches (server logs "delivered") yet **no notification renders** — and after
+~4 such silent wakes iOS **revokes the subscription** (confirmed: `push: pruning dead
+subscription status=410 reason="Unregistered"`; the 5th message never woke the device). Root
+cause: when locked/idle, iOS gives the SW a very tight execution window; Ring's rich path is
+too slow to call `showNotification` in time — it waits up to 2200ms for a live page to claim
+(`pageWillNotify`), then fetches `/relay/pending` (bounded 8s), then decrypts, then shows.
+The spec-2044 legacy path works because it shows FIRST. Extend show-first to the modern path.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A locked phone still shows notifications and keeps its subscription (Priority: P1)
+
+Someone locks their phone, sets it down, and later receives messages. Each one shows a
+notification on the lock screen (rich when there's time, a generic "New message" when deeply
+throttled), and the subscription is never revoked.
+
+**Why this priority**: This is the core failure — locked-phone notifications silently break
+and then the subscription dies, cutting the user off entirely.
+
+**Independent Test**: With the app not foreground-visible, a message push shows a
+notification IMMEDIATELY (before the fetch/decrypt); a locked-state burst produces a visible
+notification per wake (device test) and no `410 Unregistered` prune follows.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is backgrounded/closed and the screen is locked, **When** a message
+   push wakes the SW, **Then** a placeholder notification is shown before any network fetch
+   or decrypt, so the wake ends visibly within iOS's window.
+2. **Given** the SW has time (screen on / generous budget), **When** the fetch+decrypt lands,
+   **Then** the placeholder is upgraded to the rich "Sender: message" note.
+3. **Given** a locked-state sequence of messages, **When** each push wakes the SW, **Then**
+   each ends with a visible show → no silent-wake strikes → the subscription is not revoked.
+4. **Given** a per-chat notification already shown, **When** more arrive, **Then** they
+   coalesce (close-generic-then-show-rich / per-chat tag) without stacking noise.
+
+### User Story 2 - Muted/notifications-off are still respected (Priority: P1)
+
+Show-first must not turn a muted chat or a notifications-off account into a buzzing "New
+message."
+
+**Why this priority**: A fix that over-notifies muted chats trades one bug for another.
+
+**Independent Test**: A muted chat's push (if it reaches the SW) ends as the quiet note, not
+a loud generic; a notifications-off account suppresses the placeholder.
+
+**Acceptance Scenarios**:
+
+1. **Given** push routing suppresses muted/off pushes server-side, **Then** the SW never
+   wakes for them and no placeholder is shown.
+2. **Given** a muted-chat push still reaches the SW, **When** the decrypt settles and reports
+   silenced, **Then** the loud placeholder is downgraded in place to the quiet note.
+
+### Edge Cases
+
+- App genuinely foreground + focused: the OS notification is shown anyway (revocation-safe);
+  iOS suppresses the foreground app's own banner, and such an app usually gets no push at all
+  (WS delivery). The page suppresses its duplicate in-app banner where it can.
+- Deeply throttled: the placeholder stays generic until the app opens (rich content needs the
+  fetch+decrypt, which the OS didn't allow time for) — acceptable; visible beats invisible.
+- iOS wake-budget still throttles very rapid bursts (OS-level); show-first keeps the
+  subscription alive so throttled messages arrive on the next wake/open, not lost.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: On a message push wake, the SW MUST call `showNotification` (a placeholder)
+  BEFORE the page-claim wait, the `/relay/pending` fetch, and decryption — so a
+  locked/low-power device shows within iOS's execution window.
+- **FR-002**: The SW MUST NOT block the initial show on `pageWillNotify`'s wait when there is
+  no focused+visible client; it may still nudge clients to drain without awaiting.
+- **FR-003**: When the fetch+decrypt lands in time, the placeholder MUST be upgraded to the
+  rich note (close generic tag, show per-chat rich note); when it reports silenced/muted, the
+  placeholder MUST be downgraded to the quiet note; when notifications are off (suppressed),
+  no placeholder is shown.
+- **FR-004**: Every message wake MUST end visibly (or with licensed silence) so no wake
+  counts as a silent push — preventing subscription revocation.
+- **FR-005**: Show-first applies regardless of app foreground state (no on-screen exemption),
+  because iOS revokes on silent wakes even when a window is visible.
+- **FR-006**: The legacy lite path (iOS ≤ 16) and existing coalescing/dedup/badge semantics
+  MUST NOT regress.
+
+### Key Entities
+
+- **Placeholder → rich upgrade**: an immediate generic notification (`GENERIC_TAG`) replaced
+  by the per-chat rich note once decryption completes; downgraded to quiet if the chat is
+  silenced.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A backgrounded/locked message push shows a notification before the fetch (unit:
+  the show is issued before `previewPending`/fetch; device: a locked-state message appears).
+- **SC-002**: A locked-state burst produces a visible notification per wake and **no `410
+  Unregistered` prune** for the device afterward (device + prod-log verified).
+- **SC-003**: Muted chats end quiet, notifications-off shows nothing (unit).
+- **SC-004**: Existing suites (1190+) and the legacy path stay green.
+
+## Zero-Knowledge Impact
+
+None. Ordering/timing of client-side notification display only; no wire, payload, or metadata
+change. The push stays the existing content-free tickle; content is still fetched over the
+authenticated relay and decrypted locally. (A future ciphertext-in-push optimization is a
+separate spec with its own metadata trade-off analysis.)
+
+## Assumptions
+
+- iOS grants a much shorter SW execution window when locked/idle; showing before the network
+  fetch fits it, showing after does not (device-confirmed).
+- The existing generic→rich upgrade and generic→quiet downgrade settle machinery (specs
+  1034/2016/2017) can be driven from an earlier placeholder.
+- Push routing (spec 1050) suppresses notifications-off/muted pushes server-side to the
+  extent configured; the SW-side downgrade covers any that still arrive.

--- a/specs/2048-notifications-not-appear/tasks.md
+++ b/specs/2048-notifications-not-appear/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Show-first notifications (spec 2048)
+
+**Spec**: [spec.md](./spec.md) · Branch `fix/2048-notifications-not-appear` · Closes https://github.com/zuptalo/ring/issues/1049
+
+- [X] T001 Pure `shouldShowPlaceholderFirst` gate in `src/services/sw-inbox.ts` + unit tests in `src/services/sw-quiet.test.ts`
+- [X] T002 `dispatchPush` msg path (`src/sw.ts`): gate the pageWillNotify claim-wait on `anyClientVisible` (not `clients.length`); when not foreground-visible, nudge clients (no await) + `showGeneric('show-first')` immediately, set ctx; then drain/preview upgrade
+- [X] T003 `showMessageNotification(ctx, placeholderShown)`: seed `shownGeneric=placeholderShown`; clear after rich upgrade; skip duplicate `showGeneric` in the timeout branch when placeholder up
+- [X] T004 Verified server AllowPush already suppresses muted/off pushes (mentions pierce); loud→quiet same-tag downgrade covers the stale-prefs race — no server change
+- [X] T005 Gates: `npm run build`, full vitest (1194) green
+- [ ] T006 Device verify: LOCKED-state burst on iPhone 15 Pro / iPad shows a notification per wake; no `410 Unregistered` prune follows (SC-002)

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -830,6 +830,19 @@ export function anyClientVisible(clients: readonly { visibilityState?: string; f
   return clients.some((c) => c.focused === true && c.visibilityState === 'visible');
 }
 
+/** (spec 2048) Show-first gate. Put a visible placeholder up IMMEDIATELY unless a
+ *  focused+visible window is present to render the rich in-app banner itself — only
+ *  then is it worth spending the tight iOS wake window awaiting that page's claim.
+ *  With no such window (locked / backgrounded / frozen-PWA / closed — the norm on
+ *  iOS), waiting or fetching first lets iOS suspend the SW before ANY showNotification,
+ *  which it counts as a silent push and, after a few, revokes the subscription. So
+ *  there we show first. Same fail-closed semantics as anyClientVisible. */
+export function shouldShowPlaceholderFirst(
+  clients: readonly { visibilityState?: string; focused?: boolean }[],
+): boolean {
+  return !anyClientVisible(clients);
+}
+
 /** The ONE license to end a push wake silently (spec 2023, amending 1034 FR-001):
  *  the platform must tolerate silence AND a Ring window must be focused+visible.
  *  On WebKit, Firefox, and unknown engines this is always false — every wake ends

--- a/src/services/sw-quiet.test.ts
+++ b/src/services/sw-quiet.test.ts
@@ -2,7 +2,7 @@
 // gate and visible-client test that together license a silent outcome, and the
 // content-free quiet note shown when the rich path has nothing it may display.
 import { describe, it, expect } from 'vitest';
-import { anyClientVisible, quietNote, platformTrustsSilence, mayEndWakeSilently, stampedShow, countAccepted } from './sw-inbox';
+import { anyClientVisible, quietNote, platformTrustsSilence, mayEndWakeSilently, stampedShow, countAccepted, shouldShowPlaceholderFirst } from './sw-inbox';
 
 // Real-world user agents for the platform gate's truth table (spec 2023 FR-002).
 const UA = {
@@ -79,6 +79,23 @@ describe('spec 1034: anyClientVisible', () => {
     // visibilityState present but `focused` absent must NOT fall back to the old
     // visibility-only license — this pins the fail-closed default.
     expect(anyClientVisible([{ visibilityState: 'visible' }])).toBe(false);
+  });
+});
+
+describe('spec 2048: shouldShowPlaceholderFirst (show-first gate)', () => {
+  it('no clients (app closed) → show first (locked/closed is the norm on iOS)', () => {
+    expect(shouldShowPlaceholderFirst([])).toBe(true);
+  });
+  it('a frozen/background PWA (visible but NOT focused) → show first — it will not render the banner', () => {
+    expect(shouldShowPlaceholderFirst([{ visibilityState: 'visible', focused: false }])).toBe(true);
+    expect(shouldShowPlaceholderFirst([{ visibilityState: 'hidden', focused: true }])).toBe(true);
+  });
+  it('a focused+visible window → do NOT show first (that page renders the in-app banner; await its claim)', () => {
+    expect(shouldShowPlaceholderFirst([{ visibilityState: 'visible', focused: true }])).toBe(false);
+  });
+  it('missing fields fail closed → show first (never assume a page will render)', () => {
+    expect(shouldShowPlaceholderFirst([{}])).toBe(true);
+    expect(shouldShowPlaceholderFirst([{ visibilityState: 'visible' }])).toBe(true);
   });
 });
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -25,7 +25,7 @@ import {
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
   mayEndWakeSilently, quietNote, stampPushWake, countAccepted,
   runGuardedWake, recordWake, type WakeCtx,
-  isLegacyIOS, withTimeout, fetchPendingFrames, richNoteOptions,
+  isLegacyIOS, withTimeout, fetchPendingFrames, richNoteOptions, shouldShowPlaceholderFirst,
   previewCallRing, recordCallTickle, recordCallOutcome, withdrawCallBadgeUnit, callBadgeCount,
   readRingShown, recordRingShown, clearRingShown,
   type SwNote, type ConnNote,
@@ -652,7 +652,7 @@ async function tryAuthoritativeDrain(ctx: WakeCtx): Promise<boolean> {
  * *some* notification (iOS requires one per push). A generic placeholder shown on
  * timeout is UPGRADED to the rich preview when the full decrypt settles.
  */
-async function showMessageNotification(ctx: WakeCtx): Promise<void> {
+async function showMessageNotification(ctx: WakeCtx, placeholderShown = false): Promise<void> {
   // (spec 2017) Serialize only the critical read→show→markShown sections (NOT the straggler's sleeps),
   // so overlapping burst wakes can't interleave and duplicate a notification or bounce the per-pass
   // count — while a queued wake still gets the lock during another wake's sleep gaps and is never
@@ -676,7 +676,10 @@ async function showMessageNotification(ctx: WakeCtx): Promise<void> {
     console.warn('[sw] preview slow/failed → generic fallback');
   }
 
-  let shownGeneric = false;
+  // (spec 2048) The show-first placeholder (if dispatchPush already put one up) IS a
+  // generic on GENERIC_TAG, so seed shownGeneric with it: the settle's upgrade
+  // (rich)/downgrade (quiet) machinery gates on shownGeneric.
+  let shownGeneric = placeholderShown;
   let shownAny = false; // spec 1034: track whether THIS wake produced anything visible
   if (result.notes.length) {
     await closeByTag(GENERIC_TAG); // clear any earlier generic before the rich note
@@ -685,13 +688,18 @@ async function showMessageNotification(ctx: WakeCtx): Promise<void> {
     // (spec 2023 FR-007) an all-rejected batch is NOT a visible ending — leaving
     // shownAny false routes this wake to the quiet terminal below.
     shownAny = accepted > 0;
+    // (spec 2048) The rich note REPLACED the placeholder (closeByTag above), so the
+    // settle must not re-show/re-buzz the generic for it.
+    if (accepted > 0) shownGeneric = false;
   } else if (timedOut || (!result.suppressed && !result.silenced && result.newUnshown)) {
     // Show the generic placeholder ONLY when there's a genuinely-new message we couldn't render: a
     // slow cold-start decrypt still in flight at the deadline (timedOut), a fetched-but-undecryptable
     // frame, a PIN-locked device with pending frames, or a failed relay fetch (all → newUnshown). The
     // settle below upgrades it to the rich note if the decrypt lands. `suppressed` (notifications off)
     // and `silenced` (mute / web-push-off / badge-only, spec 1015 FR-022/FR-024) show no placeholder.
-    await showGeneric(timedOut ? 'timeout' : result.reason);
+    // (spec 2048) Skip if the show-first placeholder is already up — a same-tag re-show re-buzzes on
+    // iOS (spec 2020); the placeholder is this branch's visible ending.
+    if (!placeholderShown) await showGeneric(timedOut ? 'timeout' : result.reason);
     shownGeneric = true;
     shownAny = true;
   } else if (isNothingNew(result)) {
@@ -1110,43 +1118,52 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
       // 1200ms — comfortably above the page's own DRAIN_ACK_WINDOW so a page that will
       // show a banner reliably claims it, while a hidden/locked/frozen page (which
       // never acks) still falls through to the SW promptly enough.
-      if (clients.length && (await pageWillNotify(clients, 2200))) {
-        // (spec 2023 FR-003) The page owns the RICH alert, but an in-app banner is
-        // invisible to the OS push service: a claimed wake that shows no OS
-        // notification is a SILENT push, and every userVisibleOnly push service
-        // revokes the subscription after a few of those — not just WebKit's webpushd.
-        // Chromium does too, exempting ONLY a push handled while a window is open AND
-        // focused (its documented "site is visible" carve-out). This skip used to gate
-        // on the platform ALONE, trusting Chromium unconditionally — but the page acks
-        // when it CAN render a banner, and Chromium samples window visibility at event
-        // RESOLUTION, so a page that was visible when it acked and then backgrounded
-        // during the up-to-2200ms wait produced a silent push Chromium counted. Enough
-        // of those and Android's subscription got revoked "after several messages".
-        //
-        // So re-sample the clients HERE (start-of-wake `clients` is now stale) and end
-        // silently only when `mayEndWakeSilently` holds: the platform tolerates silence
-        // AND a window is focused+visible right now. Otherwise show the content-free
-        // quiet note — which is also the only visible ending for the one claim arm that
-        // shows nothing anywhere (a locked hidden chat on a visible page: notify.ts, the
-        // spec-1027 FR-012 zero-trace claim). iOS is unaffected: platformTrustsSilence is
-        // already false there, so this always showed the quiet note and still does; and a
-        // Chrome window that stays focused+visible still skips exactly as before (the user
-        // saw the in-app banner, so no OS duplicate).
+      // (spec 2048) SHOW-FIRST. Only a FOCUSED+VISIBLE page renders the rich in-app
+      // banner itself, so ONLY then may we spend the tight iOS wake window awaiting its
+      // claim (via pageWillNotify). With no such window — locked / backgrounded /
+      // frozen-PWA / closed, the norm on iOS — waiting up to 2200ms and THEN fetching
+      // /relay/pending and decrypting is too slow: iOS suspends the SW before any
+      // showNotification lands (the fetch fires, so the server logs "delivered", but
+      // nothing renders), counts the wake as a SILENT push, and after ~4 REVOKES the
+      // subscription (status=410 Unregistered). So there we put a visible placeholder up
+      // IMMEDIATELY, before the drain/preview, and let the durable work upgrade it.
+      if (!shouldShowPlaceholderFirst(clients) && (await pageWillNotify(clients, 2200))) {
+        // (spec 2023 FR-003) A focused+visible page claimed the RICH in-app alert, but
+        // an in-app banner is invisible to the OS push service, so a claimed wake that
+        // shows no OS notification is a SILENT push. Re-sample and end silently ONLY
+        // when mayEndWakeSilently holds (trusted platform + focused+visible); otherwise
+        // show the content-free quiet note. iOS is unaffected (platformTrustsSilence
+        // false → always the quiet note).
         const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
         if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) {
           await showQuietNote('msg');
           ctx.shown = true;
         }
-        // Either we showed the quiet note, or silence is licensed here (focused +
-        // visible Chromium). Both are satisfied; only the show sets ctx.shown.
         ctx.satisfied = true;
         return;
       }
-      // Spec 1032: with sw.fullPersist on (and no page claiming the wake), persist
-      // + ack eligible frames right now so the app opens warm. Any degrade — and
-      // any deferred remainder — falls through to today's preview flow.
+      // No focused+visible client to own the alert. Still nudge any (frozen/background)
+      // client to reconnect + drain durably — but DON'T await it; that 2200ms wait was
+      // the window-burn we are removing (the page-side handler drains on a bare
+      // 'ring:drain' without a reqId, just skipping the ack). Then show the placeholder
+      // NOW, before the fetch + decrypt.
+      for (const client of clients) client.postMessage({ type: 'ring:drain' });
+      try {
+        await showGeneric('show-first');
+        ctx.shown = true;
+        ctx.satisfied = true;
+      } catch (e) {
+        // The platform denied even the placeholder — the drain/preview below (or the
+        // guard's last-resort generic) still owns the visible ending; leave ctx unset.
+        console.warn('[sw] show-first placeholder failed', e);
+      }
+      // Spec 1032: with sw.fullPersist on, persist + ack eligible frames right now so
+      // the app opens warm; either way the durable work UPGRADES the placeholder in
+      // place (closeByTag(GENERIC_TAG) + rich note, or same-tag quiet downgrade when
+      // the batch is muted/suppressed/nothing-new). placeholderShown=true tells
+      // showMessageNotification the generic is already up so it doesn't re-buzz it.
       if (await tryAuthoritativeDrain(ctx)) return;
-      await showMessageNotification(ctx);
+      await showMessageNotification(ctx, true /* placeholderShown */);
 }
 
 // The Web Push `userVisibleOnly` contract is unforgiving on iOS: a push event


### PR DESCRIPTION
## Spec 2048 — show-first notifications (fix locked-state silent failure + revocation)

Closes #1049

**Your device testing isolated it:** screen-on works (even backgrounded/closed), but once the **screen is locked and idle**, message pushes wake the SW and fetch (server logs "delivered") yet **nothing renders** — and after ~4 silent wakes iOS **revokes the subscription** (confirmed `push: pruning dead subscription status=410 reason="Unregistered"`; the 5th message never woke the device).

**Root cause:** locked/low-power gives the SW a very tight execution window. The rich path is too slow to fit: it waits up to 2200ms for a live page to claim (`pageWillNotify`), then fetches `/relay/pending` (up to 8s), then decrypts, then shows. iOS suspends the worker before `showNotification` lands. The spec-2044 legacy path works precisely because it shows *first*.

**Fix — show-first (extends the legacy principle to modern):**
- When there's no focused+visible window to render the in-app banner, **nudge clients without awaiting** and **`showGeneric` immediately** — before the fetch/decrypt — so the wake always ends visibly within iOS's window.
- **Upgrade** the placeholder to the rich "Sender: message" note when the decrypt lands (existing `closeByTag(GENERIC_TAG)` + rich settle); **downgrade** to the quiet note if the chat turns out muted (existing same-tag settle).
- Gate the 2200ms `pageWillNotify` wait on `anyClientVisible` so it no longer burns the window when locked/backgrounded.
- Every wake now shows → **no more silent-wake strikes → no revocation.**

Muted/notifications-off stay respected: the server's `AllowPush` already suppresses those pushes (mentions pierce, intentionally); the rare stale-prefs race is downgraded to quiet after decrypt. New pure `shouldShowPlaceholderFirst` gate + tests; **1194 green**.

**Owed (device):** locked-state burst on the 15 Pro / iPad shows a notification per wake and no `410 Unregistered` follows.

Zero-knowledge: none — client-side display timing only; the push stays the content-free tickle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)