### PR TITLE
Release 1.0.10 — instant rich lock-screen notifications (ciphertext-in-push)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,5 +281,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/2044-older-iphones-show/plan.md`
+`specs/1055-ciphertext-push-instant/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,7 @@ Specs are grouped by category band; status moves
 | [1052](specs/1052-group-adds-you/spec.md) | Group Adds You Can Trust | 🟢 shipped |
 | [1053](specs/1053-composer-buttons-transition/spec.md) | Composer Buttons Transition Like WhatsApp | 🟢 shipped |
 | [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🟢 shipped |
+| [1055](specs/1055-ciphertext-push-instant/spec.md) | Instant rich notifications (bounded encrypted preview in push) | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/server/internal/api/auth_handlers_test.go
+++ b/server/internal/api/auth_handlers_test.go
@@ -256,6 +256,17 @@ func (f *fakeStore) DeleteRelay(_ context.Context, recipient, msgID string) (str
 	return "", false, nil
 }
 
+func (f *fakeStore) StampNotified(_ context.Context, recipient, msgID string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, row := range f.relay[recipient] {
+		if row.msgID == msgID {
+			return row.sender, true, nil // stamp is a no-op in the fake; frame stays queued
+		}
+	}
+	return "", false, nil
+}
+
 func (f *fakeStore) RecordDelivery(_ context.Context, sender, recipient, msgID string) error {
 	if sender == "" || recipient == "" || msgID == "" {
 		return nil

--- a/server/internal/api/connections_handlers_test.go
+++ b/server/internal/api/connections_handlers_test.go
@@ -21,6 +21,7 @@ type fakeConnNotifier struct {
 
 func (f *fakeConnNotifier) Notify(context.Context, string)                     {}
 func (f *fakeConnNotifier) NotifyFrame(context.Context, string, string, string) {}
+func (f *fakeConnNotifier) NotifyFramePreview(context.Context, string, string, string, []byte) {}
 func (f *fakeConnNotifier) NotifyCall(context.Context, string)                 {}
 func (f *fakeConnNotifier) NotifyPost(context.Context, string, string)         {}
 func (f *fakeConnNotifier) NotifyPostActivity(context.Context, string, string) {}

--- a/server/internal/api/posts_handlers_test.go
+++ b/server/internal/api/posts_handlers_test.go
@@ -25,6 +25,7 @@ type recordingNotifier struct {
 
 func (n *recordingNotifier) Notify(context.Context, string)                      {}
 func (n *recordingNotifier) NotifyFrame(context.Context, string, string, string) {}
+func (n *recordingNotifier) NotifyFramePreview(context.Context, string, string, string, []byte) {}
 func (n *recordingNotifier) NotifyCall(context.Context, string) {}
 func (n *recordingNotifier) NotifyConn(context.Context, string) {}
 func (n *recordingNotifier) NotifyPost(_ context.Context, userID, _ string) {

--- a/server/internal/api/relay_handlers.go
+++ b/server/internal/api/relay_handlers.go
@@ -130,6 +130,40 @@ func (h *Handlers) relayAck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// relayNotified (POST /v1/relay/notified) is posted by a recipient's service worker
+// when it shows a bounded PUSH PREVIEW (spec 1055) — the recipient has SEEN the message
+// but not durably downloaded it. It stamps the queued frame's notified_at (so the server
+// knows the frame is seen-but-still-owed) and relays a "notified" receipt to the sender,
+// WITHOUT dequeuing — the full message is delivered + dequeued only on the authoritative
+// ack. To the sender, "notified" renders the same as "delivered" (the recipient was
+// reached). Fires on DECRYPT regardless of the recipient's display prefs, so it never
+// leaks mute/hidden. Idempotent — an already-delivered id simply doesn't match.
+func (h *Handlers) relayNotified(w http.ResponseWriter, r *http.Request) {
+	uid, _ := auth.UserID(r.Context())
+	var req relayAckRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
+		httpx.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	for _, id := range req.IDs {
+		if id == "" {
+			continue
+		}
+		sender, found, err := h.Relay.StampNotified(r.Context(), uid, id)
+		if err != nil {
+			slog.Error("relay notified stamp failed", "err", err, "user", uid, "msg", id)
+			continue
+		}
+		if found && sender != "" {
+			receipt, _ := json.Marshal(map[string]any{
+				"t": "receipt", "messageId": id, "status": "notified", "at": time.Now().UnixMilli(), "from": uid,
+			})
+			h.Hub.Send(sender, receipt)
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // callAck (POST /v1/call/ack) is posted by a callee's service worker when it shows
 // an incoming-call notification. It proves the device is reachable (it received the
 // ring push), so the server flips every caller currently ringing this user from

--- a/server/internal/api/relay_handlers_test.go
+++ b/server/internal/api/relay_handlers_test.go
@@ -58,6 +58,49 @@ func TestRelayPendingAndAck(t *testing.T) {
 	}
 }
 
+// TestRelayNotified (spec 1055) proves POST /v1/relay/notified stamps a queued frame as
+// notified WITHOUT dequeuing it — the recipient showed a push preview but the full
+// message is still owed, so it must remain in the queue until the authoritative ack.
+func TestRelayNotified(t *testing.T) {
+	as := newFakeStore()
+	srv := NewRouter(&Handlers{
+		Store: as, Directory: as, Blocks: as, Relay: as, Hub: ws.NewHub(),
+		Keys: newFakeKeysStore(), Blobs: newFakeBlobStore(),
+		Sync: newFakeSyncStore(), Push: newFakePushStore(), Invites: as,
+		PublicURL: "https://ring.example",
+	}, []string{"http://localhost:5173"})
+
+	tok, uid, code := registerNamed(t, srv, "notifyuser")
+	if code != http.StatusOK {
+		t.Fatalf("register = %d", code)
+	}
+	_ = as.EnqueueRelay(context.Background(), uid, "00000000-0000-0000-0000-000000000999", "m1",
+		[]byte(`{"t":"msg","id":"m1","from":"sndr","ciphertext":{"v":1}}`))
+
+	// Notified → 204, and the frame is STILL queued (unlike ack).
+	if rr := do(t, srv, http.MethodPost, "/v1/relay/notified", tok, `{"ids":["m1"]}`); rr.Code != http.StatusNoContent {
+		t.Fatalf("notified status = %d", rr.Code)
+	}
+	rr := do(t, srv, http.MethodGet, "/v1/relay/pending", tok, "")
+	var got struct {
+		Frames []json.RawMessage `json:"frames"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if len(got.Frames) != 1 {
+		t.Fatalf("after notified frames = %d, want 1 (notified must NOT dequeue)", len(got.Frames))
+	}
+
+	// The authoritative ack still dequeues it.
+	if rr := do(t, srv, http.MethodPost, "/v1/relay/ack", tok, `{"ids":["m1"]}`); rr.Code != http.StatusNoContent {
+		t.Fatalf("ack status = %d", rr.Code)
+	}
+	rr = do(t, srv, http.MethodGet, "/v1/relay/pending", tok, "")
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if len(got.Frames) != 0 {
+		t.Fatalf("after ack frames = %d, want 0", len(got.Frames))
+	}
+}
+
 // TestRelayStatus proves GET /v1/relay/status (spec 2043) reports the queued count
 // and oldest-frame age with NO side effects, and returns a null oldest for an empty
 // queue. It powers the client zombie self-heal without dequeuing or emitting receipts.

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -292,6 +292,7 @@ func NewRouter(h *Handlers, allowedOrigins []string) http.Handler {
 	// self-heal; never dequeues, never emits a receipt, so it's safe to poll.
 	mux.Handle("GET /v1/relay/status", authMW(http.HandlerFunc(h.relayStatus)))
 	mux.Handle("POST /v1/relay/ack", authMW(http.HandlerFunc(h.relayAck)))
+	mux.Handle("POST /v1/relay/notified", authMW(http.HandlerFunc(h.relayNotified)))
 	// Sender-side reconcile: which of my still-'sent' messages were delivered while
 	// I was offline (so a dropped 'delivered' receipt is recovered on reconnect).
 	mux.Handle("POST /v1/deliveries/check", authMW(http.HandlerFunc(h.deliveriesCheck)))

--- a/server/internal/db/migrations/0029_relay_notified_at.sql
+++ b/server/internal/db/migrations/0029_relay_notified_at.sql
@@ -1,0 +1,14 @@
+-- Spec 1055: a per-frame "notified" marker for the ciphertext-in-push preview path.
+--
+-- When a recipient device shows a bounded encrypted PREVIEW from a push (without
+-- yet durably downloading the message), it posts a `notified` receipt. The server
+-- stamps this timestamp on the queued frame so it can tell which still-queued
+-- frames the recipient has SEEN (a preview) but not yet durably downloaded — i.e.
+-- what is still owed to the device. The frame is only ever dequeued on the
+-- authoritative `delivered` ack, never on `notified`.
+--
+-- Zero-knowledge: a nullable timestamp, no message content. It reveals to the
+-- server exactly what a delivery receipt already does (recipient reachability +
+-- timing), nothing readable.
+
+ALTER TABLE relay_queue ADD COLUMN notified_at timestamptz;

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -127,6 +127,10 @@ type pushParams struct {
 	ttl     int
 	urgency webpush.Urgency
 	topic   string
+	// recordSize (spec 1055): fixed aes128gcm record size. 0 = derive from the payload
+	// length (recordSizeFor) — correct for content-free tickles. A preview push sets a
+	// CONSTANT here so its encrypted length reveals nothing about the message size.
+	recordSize uint32
 }
 
 var (
@@ -148,6 +152,22 @@ var (
 		return pushParams{payload: tickleVersion, ttl: versionTTL, urgency: webpush.UrgencyLow, topic: versionTopic}
 	}
 )
+
+// previewMaxPayload (spec 1055) is the largest inline preview push body we send; a
+// larger one falls back to the content-free tickle. previewRecordSize is the CONSTANT
+// aes128gcm record size every preview push is padded to, so its encrypted length is
+// identical regardless of message length (nothing leaks to the push service). It stays
+// well under the ~4 KB constrained-endpoint ceiling (spec 2046).
+const previewMaxPayload = 3072
+
+var previewRecordSize = uint32(previewMaxPayload + recordSizeOverhead)
+
+// previewParams: a message-urgency push carrying the sealed preview body, with NO Topic
+// header (each preview must survive independently — a shared Topic would collapse a
+// burst to only the last) and the constant record size.
+func previewParams(payload []byte) pushParams {
+	return pushParams{payload: payload, ttl: msgTTL, urgency: webpush.UrgencyHigh, topic: "", recordSize: previewRecordSize}
+}
 
 // SubStore is the subscription persistence the notifier needs.
 type SubStore interface {
@@ -185,6 +205,15 @@ func recordSizeFor(payload []byte) uint32 {
 	return uint32(len(payload)) + recordSizeOverhead
 }
 
+// pickRecordSize returns a params' explicit constant record size (spec 1055 preview
+// pushes) or, when unset, the payload-derived size for content-free tickles.
+func pickRecordSize(p pushParams) uint32 {
+	if p.recordSize > 0 {
+		return p.recordSize
+	}
+	return recordSizeFor(p.payload)
+}
+
 // attempt makes a single delivery and reports the HTTP status, any Retry-After
 // hint, and a transport error (status 0).
 func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p pushParams) (status int, retryAfter time.Duration, body []byte, err error) {
@@ -219,7 +248,9 @@ func (s *Sender) attempt(ctx context.Context, sub store.PushSubscription, p push
 		// service via the cleartext Topic header (sent for collapsing), and every payload
 		// is a fixed content-free marker. recordSizeFor keeps it strictly above the
 		// payload so encryption never underflows.
-		RecordSize: recordSizeFor(p.payload),
+		// (spec 1055) A preview push sets a CONSTANT recordSize so its encrypted length
+		// hides the message size; tickles leave it 0 → derive from the payload.
+		RecordSize: pickRecordSize(p),
 	})
 	if err != nil {
 		return 0, 0, nil, err
@@ -299,6 +330,24 @@ func (n *Notifier) NotifyFrame(ctx context.Context, userID, class, prid string) 
 // without racing the debounced network send.
 func (n *Notifier) allowFrame(ctx context.Context, userID, class, prid string) bool {
 	return AllowPush(class, prid, "", n.prefsFor(ctx, userID))
+}
+
+// NotifyFramePreview (spec 1055) inlines a sealed bounded preview in the push so the
+// recipient shows a rich notification without a fetch. It passes the IDENTICAL routing
+// gate as the tickle (a muted prid / classes-off → no push at all), and — unlike the
+// debounced tickle — sends immediately and undebounced, because each preview carries
+// its own unique ciphertext (a trailing debounce would drop distinct previews). An
+// oversized preview (beyond the constant record budget) falls back to the tickle, so
+// the message still notifies without ever sending an unpadded large push.
+func (n *Notifier) NotifyFramePreview(ctx context.Context, userID, class, prid string, preview []byte) {
+	if !n.allowFrame(ctx, userID, class, prid) {
+		return
+	}
+	if len(preview) == 0 || len(preview) > previewMaxPayload {
+		n.msgDeb.hit(userID) // fall back to the content-free tickle
+		return
+	}
+	n.notify(ctx, userID, previewParams(preview))
 }
 
 // NotifyCall pushes a content-free CALL tickle: short-lived (a stale ring is

--- a/server/internal/push/push_test.go
+++ b/server/internal/push/push_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -369,6 +370,29 @@ func TestRecordSizeFor(t *testing.T) {
 		if got >= 512 {
 			t.Errorf("recordSizeFor(%q) = %d, want < 512", p, got)
 		}
+	}
+}
+
+// TestPreviewParamsConstantSize (spec 1055 SC-004 / FR-003) pins that every preview push
+// is padded to the SAME record size regardless of the sealed preview's length — so the
+// push service learns nothing about the message length — and carries NO Topic header
+// (each preview must survive independently; a shared Topic would collapse a burst).
+func TestPreviewParamsConstantSize(t *testing.T) {
+	small := previewParams([]byte(`{"h":{},"p":{"ct":"aa"}}`))
+	large := previewParams([]byte(`{"h":{"dh":"` + strings.Repeat("x", 800) + `"},"p":{"ct":"` + strings.Repeat("y", 1500) + `"}}`))
+	if pickRecordSize(small) != pickRecordSize(large) {
+		t.Errorf("preview record size varies with payload length: %d vs %d (leaks message size)",
+			pickRecordSize(small), pickRecordSize(large))
+	}
+	if pickRecordSize(small) != previewRecordSize {
+		t.Errorf("preview record size = %d, want the constant %d", pickRecordSize(small), previewRecordSize)
+	}
+	if small.topic != "" {
+		t.Errorf("preview push must carry NO Topic header, got %q", small.topic)
+	}
+	// A tickle still derives its size from the payload (spec 2046), unchanged.
+	if got := pickRecordSize(msgParams()); got != recordSizeFor(msgParams().payload) {
+		t.Errorf("tickle record size = %d, want payload-derived %d", got, recordSizeFor(msgParams().payload))
 	}
 }
 

--- a/server/internal/store/relay.go
+++ b/server/internal/store/relay.go
@@ -110,3 +110,21 @@ func (s *Store) DeleteRelay(ctx context.Context, recipient, msgID string) (sende
 	}
 	return sender, true, nil
 }
+
+// StampNotified (spec 1055) marks a queued frame as notified — the recipient showed a
+// push preview but has NOT durably downloaded it — WITHOUT dequeuing it, so the full
+// message is still delivered on the authoritative ack. Returns the sender so a
+// `notified` receipt can be relayed. found=false if nothing matched (already delivered
+// + dequeued, or an unknown id).
+func (s *Store) StampNotified(ctx context.Context, recipient, msgID string) (sender string, found bool, err error) {
+	err = s.pool.QueryRow(ctx,
+		`UPDATE relay_queue SET notified_at = now() WHERE recipient = $1 AND msg_id = $2 RETURNING sender::text`,
+		recipient, msgID).Scan(&sender)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return sender, true, nil
+}

--- a/server/internal/ws/hub.go
+++ b/server/internal/ws/hub.go
@@ -51,6 +51,11 @@ type RelayStore interface {
 	// self-heal, with no payload and no side effects.
 	OldestPendingForRecipient(ctx context.Context, recipient string) (oldestMs int64, count int, err error)
 	DeleteRelay(ctx context.Context, recipient, msgID string) (sender string, found bool, err error)
+	// StampNotified (spec 1055) marks a still-queued frame as notified (the recipient
+	// showed a push preview) WITHOUT dequeuing it — the full message is still owed to the
+	// device. Returns the frame's sender so a `notified` receipt can be relayed. The
+	// frame is dequeued only on the authoritative `delivered` ack.
+	StampNotified(ctx context.Context, recipient, msgID string) (sender string, found bool, err error)
 	// RecordDelivery durably notes msgID (from sender) reached recipient, so the
 	// sender can reconcile a dropped 'delivered' receipt on reconnect.
 	RecordDelivery(ctx context.Context, sender, recipient, msgID string) error
@@ -92,6 +97,11 @@ type Notifier interface {
 	// NotifyFrame is the classed message tickle (spec 1050): class+prid feed the
 	// recipient's per-subscription routing gate; tag-less frames behave as Notify.
 	NotifyFrame(ctx context.Context, userID, class, prid string)
+	// NotifyFramePreview (spec 1055) is NotifyFrame carrying a sealed bounded preview
+	// to inline in the Web Push (rich notification, no fetch). Gated by the SAME routing
+	// as NotifyFrame — a muted prid / classes-off yields no push at all. The preview is
+	// opaque ciphertext, forwarded into the RFC-8291-encrypted push body.
+	NotifyFramePreview(ctx context.Context, userID, class, prid string, preview []byte)
 	NotifyCall(ctx context.Context, userID string)
 	NotifyConn(ctx context.Context, userID string)
 	// NotifyPost carries the post's author so per-friend post overrides apply (spec 1050).
@@ -117,6 +127,11 @@ type frame struct {
 	// Read once at enqueue time to gate the tickle; never persisted.
 	Class string `json:"class,omitempty"`
 	Prid  string `json:"prid,omitempty"`
+	// spec 1055: opaque sealed push preview ({ h: ratchet header, p: preview AEAD }).
+	// Read once at enqueue time and forwarded verbatim into the RFC-8291-encrypted Web
+	// Push so the recipient SW shows a rich notification without a fetch. Never persisted
+	// (the durable/queued `delivered` frame stays content-free); E2EE to the recipient.
+	PushPreview json.RawMessage `json:"pushPreview,omitempty"`
 	Status     string          `json:"status,omitempty"`
 	At         int64           `json:"at,omitempty"`
 	RefID      string          `json:"refId,omitempty"`
@@ -876,6 +891,45 @@ func (c *Client) notifyAsyncFrame(userID string, call bool, class, prid string) 
 	}()
 }
 
+// notifyAsyncFramePreview (spec 1055) is notifyAsyncFrame that inlines a sealed
+// bounded preview in the push (rich notification, no fetch). The preview push carries
+// the frame id + sender inside the (RFC-8291-encrypted) body so the SW can address the
+// notification and peek-decrypt; routing gating is identical to the tickle.
+func (c *Client) notifyAsyncFramePreview(userID, class, prid, msgID, from string, preview []byte) {
+	if c.notifier == nil {
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("push: notify goroutine panicked", "recover", r, "stack", string(debug.Stack()))
+			}
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		c.notifier.NotifyFramePreview(ctx, userID, class, prid, buildPreviewPush(msgID, from, preview))
+	}()
+}
+
+// buildPreviewPush assembles the plaintext preview-push body: the discriminator, the
+// frame id + sender (so the SW can address + peek-decrypt), and the opaque sealed
+// preview ({h,p}). It is encrypted to the browser (RFC 8291) before it leaves the
+// server; the sealed preview inside is additionally E2EE to the recipient device.
+func buildPreviewPush(msgID, from string, preview []byte) []byte {
+	// preview is the client's raw {"h":...,"p":...} JSON, nested under "pv" so the
+	// server never has to parse it (forwarded verbatim).
+	out, err := json.Marshal(struct {
+		T    string          `json:"t"`
+		ID   string          `json:"id"`
+		From string          `json:"from"`
+		PV   json.RawMessage `json:"pv"`
+	}{T: "msgx", ID: msgID, From: from, PV: json.RawMessage(preview)})
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
 // IsActiveFresh reports whether the user has a foregrounded, provably-live
 // connection right now — the same signal the message push decision uses.
 // Exported for spec 1050: connection-event tickles are presence-gated too, so
@@ -1293,7 +1347,14 @@ func (c *Client) handleFrame(data []byte) {
 			if !c.hub.isActiveFresh(f.To) || !sent {
 				// spec 1050: the frame's class/prid gate the tickle against the
 				// recipient's routing prefs (delivery above is already done).
-				c.notifyAsyncFrame(f.To, false, f.Class, f.Prid)
+				// spec 1055: when the sender attached a sealed preview, inline it in the
+				// push so the recipient shows a rich notification with no fetch — gated by
+				// the SAME routing (a muted prid gets no push, preview or tickle).
+				if len(f.PushPreview) > 0 {
+					c.notifyAsyncFramePreview(f.To, f.Class, f.Prid, f.ID, c.userID, f.PushPreview)
+				} else {
+					c.notifyAsyncFrame(f.To, false, f.Class, f.Prid)
+				}
 			}
 		}
 		// Tell the sender the server accepted it.

--- a/server/internal/ws/relay_test.go
+++ b/server/internal/ws/relay_test.go
@@ -109,6 +109,16 @@ func (m *memRelay) DeleteRelay(_ context.Context, recipient, msgID string) (stri
 	return sender, true, nil
 }
 
+func (m *memRelay) StampNotified(_ context.Context, recipient, msgID string) (string, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sender, ok := m.senders[recipient][msgID]
+	if !ok {
+		return "", false, nil
+	}
+	return sender, true, nil // stamp only; frame stays queued (no dequeue)
+}
+
 func (m *memRelay) RecordDelivery(_ context.Context, sender, recipient, msgID string) error {
 	if sender == "" || recipient == "" || msgID == "" {
 		return nil
@@ -425,6 +435,9 @@ type fakeNotifier struct{ ch chan string }
 
 func (f *fakeNotifier) Notify(_ context.Context, userID string)            { f.ch <- userID }
 func (f *fakeNotifier) NotifyFrame(_ context.Context, userID, _, _ string)  { f.ch <- userID }
+func (f *fakeNotifier) NotifyFramePreview(_ context.Context, userID, _, _ string, _ []byte) {
+	f.ch <- userID
+}
 func (f *fakeNotifier) NotifyCall(_ context.Context, userID string)        { f.ch <- userID }
 func (f *fakeNotifier) NotifyConn(_ context.Context, userID string)        { f.ch <- userID }
 func (f *fakeNotifier) NotifyPost(_ context.Context, userID, _ string)     { f.ch <- userID }

--- a/specs/1055-ciphertext-push-instant/checklists/zero-knowledge.md
+++ b/specs/1055-ciphertext-push-instant/checklists/zero-knowledge.md
@@ -1,0 +1,101 @@
+# Checklist: Zero-Knowledge & Privacy (requirements quality)
+
+**Feature**: Instant rich notifications (bounded encrypted preview in push) · spec 1055
+**Created**: 2026-07-20
+**Purpose**: Validate that the spec's requirements pin down the zero-knowledge boundary and privacy
+properties precisely, completely, and testably — BEFORE implementation. These test the requirements, not
+the code. Constitution Principle I (zero-knowledge) is non-negotiable; any CHK that cannot be answered
+"yes" is a spec gap to fix before `/speckit-implement`.
+
+## Preview-key construction & forward secrecy
+
+- [ ] CHK001 Is the preview key derivation fully specified (input, KDF, domain-separation label) rather than
+  left as "a key"? [Clarity, Spec §FR-002]
+- [ ] CHK002 Is it explicitly required that the preview key derive from the per-message ratchet key `mk_N`
+  (not a root key, session key, or standing secret), so forward secrecy is inherited? [Completeness, §FR-002/FR-010]
+- [ ] CHK003 Is the forward-secrecy property stated as a testable outcome — a captured preview push is
+  undecryptable once `mk_N` is consumed on authoritative processing? [Measurability, §FR-010, §SC-006]
+- [ ] CHK004 Does the spec explicitly PROHIBIT any standing/long-lived notification content key? [Completeness, §FR-010]
+- [x] CHK005 Is the associated-data binding (ratchet header bound to the preview AEAD) required, so a preview
+  cannot be swapped/replayed onto a different frame? [Coverage, §FR-002 — now a MUST: header bound as AD, open fails on mismatch]
+- [ ] CHK006 Is the interaction between the outer RFC-8291 push encryption (long-lived subscription keys) and
+  the inner forward-secret preview AEAD described, so the FS claim is not silently defeated by the outer layer?
+  [Consistency, §ZK Impact]
+
+## Peek-decrypt consumes nothing
+
+- [ ] CHK007 Is it required that preview decryption writes NO ratchet state (no `saveSession`), stores no
+  message, and sends no ack — i.e. consumes nothing? [Completeness, §FR-004]
+- [ ] CHK008 Is "operate on a freshly loaded session copy, never a shared live state object" captured as a
+  requirement or only as a plan note? [Ambiguity, plan risks §]
+- [ ] CHK009 Is the single-authoritative-consume invariant stated — exactly one decrypt+store+ack (warm or open)
+  ever advances/persists the ratchet, so session desync is impossible? [Completeness, §FR-006/FR-009]
+
+## What the push provider can observe
+
+- [ ] CHK010 Is payload SIZE named as the ONE new observable versus the constant tickle, and is constant-size
+  padding required to neutralize it? [Completeness, §FR-003, §SC-004]
+- [ ] CHK011 Is "constant byte length across all message lengths AND kinds" a measurable acceptance criterion
+  (not "small" or "bounded")? [Measurability, §SC-004]
+- [ ] CHK012 Is it required that sender/message identifiers (`from`, `id`) live INSIDE the push-encrypted body,
+  never in cleartext headers? [Completeness, §FR-003]
+- [ ] CHK013 Is the removal of the cleartext `Topic` header on preview pushes required, and is the burst-collapse
+  consequence of a shared Topic documented so it is not re-added? [Clarity, plan wire §; is it a requirement?]
+- [ ] CHK014 Are the observables the provider RETAINS (endpoint, timing, constant size) explicitly enumerated so
+  the claim "learns nothing about length/content" is scoped and honest? [Clarity, §ZK Impact]
+
+## What Ring's server can observe / store
+
+- [ ] CHK015 Is it required that the server stores NO new plaintext and adds no readable field — the preview is
+  opaque ciphertext forwarded transiently at push time? [Completeness, §FR-007]
+- [ ] CHK016 Is the `notified_at` addition characterized as a ZK-neutral timestamp (no content), and its purpose
+  (which queued frames are seen-but-not-downloaded) stated? [Clarity, §FR-013, §ZK Impact]
+- [ ] CHK017 Is it required that the preview blob is NOT persisted in the relay row (used transiently), so the
+  "no schema change beyond a timestamp" claim holds? [Consistency, plan server §4/§6]
+- [ ] CHK018 Does the spec confirm the server cannot read the preview any more than it can read the full message
+  (same E2EE trust boundary), i.e. no new decryption capability is implied? [Completeness, §ZK Impact]
+
+## Receipt side-channels (notified / delivered)
+
+- [ ] CHK019 Is it required that the `notified` receipt fires on DECRYPT (device received), NOT on the visible
+  display outcome, so mute/hidden cannot be inferred from receipt presence or timing? [Completeness, §FR-015]
+- [ ] CHK020 Is `notified` vs `delivered` reveal-equivalence stated — `notified` exposes only what `delivered`
+  already does (recipient reachability + timing), no content? [Clarity, §ZK Impact]
+- [x] CHK021 Is the muted-chat receipt path defined so muted deliveries are indistinguishable from "recipient
+  offline" (both flip on open), leaking no mute signal to the sender? [Coverage, edge cases — now explicit: muted stays
+  `sent`, no server-fabricated receipt, WS still delivers when online, offline-indistinguishable]
+- [ ] CHK022 Is the decrypt-failure case specified (no `notified`; later `delivered` covers it) so a gap is not
+  misread as a leak or a lost receipt? [Edge Case, §FR-015]
+
+## Muting, hidden chats, and preferences
+
+- [ ] CHK023 Is server-side drop (spec 1050 `AllowPush` / `MutedPrids`) required as the PRIMARY muting mechanism,
+  with the preview push passing the IDENTICAL gate as the tickle? [Completeness, §FR-016, §SC-011]
+- [ ] CHK024 Is it required that a muted `prid` yields NO push at all (tickle OR preview), so a muted device is
+  never woken and never risks a silent-wake strike? [Completeness, §FR-016]
+- [ ] CHK025 Is the client-side mute suppression scoped as a revocation-safe FALLBACK (mute-sync gap) that on iOS
+  ends with a silent generic — explicitly NOT relied on for true muting? [Clarity, §FR-016, edge cases]
+- [ ] CHK026 Is hidden-chat handling required to render a content-free generic (no sender/avatar/body) via the
+  same `noteForPayload` choke point, with the recipient's local hidden set — never the sealed content? [Completeness, §FR-014]
+- [ ] CHK027 Is it stated that hidden chats are structurally absent from `MutedPrids` (so they DO push and the
+  client generalizes), consistent with spec 1019? [Consistency, edge cases]
+- [ ] CHK028 Is "Show preview" off required to hide BOTH body AND sender, and per-chat content-none / master-off
+  handled, with parity to the fetch path as a measurable criterion? [Measurability, §FR-014, §SC-010]
+- [ ] CHK029 Is it required that `previewInline` SOURCES the recipient's hidden set + prefs (never defaults them
+  empty/permissive), i.e. the privacy defaults fail closed? [Completeness, §FR-014]
+
+## Fallbacks, legacy, and no-silent-wake
+
+- [ ] CHK030 Is every preview-path outcome (rich, generic-fallback on decrypt failure, hidden-generic, silent
+  generic when suppressed) required to end the wake VISIBLY or with licensed silence — never a silent wake? [Coverage, §FR-005/FR-008]
+- [ ] CHK031 Is the legacy-iOS (≤16) path required to NOT attempt preview decryption (lite path stands), so the
+  new crypto never runs where SW IndexedDB is unreliable? [Completeness, §FR-008, edge cases]
+- [ ] CHK032 Is the "notified-but-never-downloaded past 35-day retention" data-loss edge acknowledged and deemed
+  acceptable, so it is a known bounded outcome rather than an unstated risk? [Edge Case, edge cases]
+
+## Scope & consistency
+
+- [ ] CHK033 Are the eligible frame kinds (1:1, reaction, group via pairwise 1:1; post/wall via `K_post`; calls
+  excluded) enumerated consistently across spec and plan, so no unintended frame inlines content? [Consistency, §FR-001]
+- [ ] CHK034 Does the ZK Impact section's "server unchanged / provider strictly-less / FS preserved" claim trace
+  to specific FRs and SCs (not asserted narratively only)? [Traceability, §ZK Impact]

--- a/specs/1055-ciphertext-push-instant/plan.md
+++ b/specs/1055-ciphertext-push-instant/plan.md
@@ -1,0 +1,201 @@
+# Implementation Plan: Instant rich notifications (bounded encrypted preview in push)
+
+**Spec**: `specs/1055-ciphertext-push-instant/spec.md`
+**Branch**: `feat/1055-ciphertext-push-instant`
+**Status**: in-progress
+
+## Summary
+
+The sender seals a small, display-sized **preview** (sender hint + a body truncated to ~256 UTF-8
+bytes, or a kind label like "Photo") under a per-message key derived from the Double-Ratchet message
+key, and attaches it to the Web Push. The service worker peek-decrypts the preview from the push and
+shows a rich notification with no `/relay/pending` fetch. It consumes nothing — no persist, no store,
+no ack; the full message still warms + stores authoritatively over WebSocket on app open. Because the
+preview is bounded and padded to one constant size, the push provider learns nothing about message
+length, and there is no padding ladder and no large-message fallback. Forward secrecy is inherited
+from the ratchet message key.
+
+## Constitution Check (Principle I — zero-knowledge)
+
+- **Server sees nothing new.** The sealed preview travels in the existing WS send frame and is
+  forwarded into the push at enqueue time (`hub.go` msg case, ~`:1262-1300`); it is opaque ciphertext
+  to the server. No plaintext, no new column, no schema change — used transiently at push time. ✅
+- **Push provider: strictly less than full-frame inlining.** RFC-8291 encrypts the push body to the
+  browser; our preview AEAD inside it is double-encrypted. A single constant padding size removes the
+  only new signal (payload length). `from`/`id` are inside the encrypted body; no `Topic` header. ✅
+- **Forward secrecy.** `pk_N = KDF(mk_N, "ring-push-preview")` inherits the ratchet's FS; `mk_N` is
+  deleted on authoritative open, after which captured preview pushes are undecryptable. No standing
+  content key. ✅
+- **`checklists/zero-knowledge.md` gates this spec**, with the preview-key construction + FS property
+  called out for security review before implement.
+
+## Crypto design (the new surface — review target)
+
+Reuses the existing pure ratchet core (`src/services/crypto/ratchet.ts`, `message.ts`); the message
+key derivation is already exercised by `ratchetDecryptPreview` / `openMessagePreview` /
+`previewOpen(persistAdvance=false)` (which "loads a fresh session copy, writes nothing").
+
+- **Sender (has `mk_N` when sealing message N):**
+  - `derivePreviewKey(mk) = KDF(mk, "ring-push-preview")` — new, in `crypto/` (libsodium
+    `crypto_kdf`/HKDF-style; single-purpose, domain-separated string).
+  - `sealPushPreview(mk_N, header, preview) → previewAEAD`: AEAD-seal the bounded preview with
+    `pk_N`, binding the ratchet `header` as associated data (anti-tamper / anti-swap).
+  - `buildPreview(payload) → {kind, body}`: pure — truncate `payload` text to a UTF-8 byte budget on
+    a char boundary, or map a text-less payload (media, reaction, game, call-event) to a kind label.
+    Honors nothing recipient-specific (recipient prefs are applied at render, SW-side).
+- **Recipient SW (peek, no persist):**
+  - `openPushPreview(chatId, header, previewAEAD) → preview`: load a fresh session copy
+    (`loadSession`), peek-derive `mk_N` from `header` (the existing preview derivation path, advancing
+    only the discarded copy — never `saveSession`), `derivePreviewKey`, AEAD-open with `header` as AD.
+    Returns the bounded preview or throws → caller falls back (FR-005).
+- The push carries the ratchet **header** (needed to derive `mk_N`; ~40–100 B, effectively fixed) +
+  the **preview AEAD** (~256 B body + tag). Total padded to one constant size.
+
+## Architecture
+
+### Wire shape
+
+- **Preview push (new):** `{"t":"msgx","id":<msgId>,"from":<senderId>,"h":<b64 header>,"p":<b64 previewAEAD>}`.
+  `from` resolves the session before decrypt; `id` is the dedupe/mark-shown key. **No `Topic` header**
+  (each preview push must survive independently — a shared Topic would collapse a burst to only the last).
+- **Post preview (new):** `{"t":"postx","post":<id>,"p":<b64 sealed engagement/post preview>}` — sealed
+  under `K_post` (non-ratchet, stateless); same no-Topic rule.
+- **Tickle (unchanged):** `{"t":"msg"}` — kept as the fallback when the sender cannot build a preview
+  (rare) and for any path that must degrade; keeps its collapsing `Topic`.
+
+### Sender / send path (`src/`)
+
+1. `src/services/messaging.ts` — where a message is sealed for a peer (`sealForChat` /
+   `openMessage` counterparts): after deriving `mk_N` to seal the body, also `buildPreview(payload)` →
+   `sealPushPreview(mk_N, header, preview)` and return the sealed preview alongside the wire frame.
+2. `src/db/queries.ts` — the send orchestration (incl. group pairwise fan-out `:627-641`): thread the
+   sealed preview through so it is attached to the WS send.
+3. `src/services/api.ts` / WS send — include `pushPreview` (opaque b64) in the `msg` frame sent to the
+   server. Groups: one preview per pairwise recipient (each has its own `mk_N`).
+
+### Server (`server/`)
+
+4. `internal/ws/hub.go` — the `msg` frame gains an optional `PushPreview []byte` (`frame` struct
+   `:109-119`). At the notify point (`:1296`), the preview push MUST pass the SAME `AllowPush(class, prid,
+   sender, prefs)` gate (spec 1050, `push.go:301`) as the tickle — a muted `prid` / classes-off yields NO
+   push at all, tickle OR preview (FR-016; true muting, no silent wake). When the gate permits AND a
+   preview is present, fire a new inline notify variant carrying `id`, sender, header, previewAEAD; when the
+   gate permits but there's no preview (rare), fall back to the tickle. The preview is used transiently here
+   — **not** stored in the relay row.
+5. `internal/push/push.go` — `previewPushPayload(msgId, from string, header, previewAEAD []byte) []byte`
+   builds the `{"t":"msgx",...}` JSON; set `RecordSize` to a single **constant** (replacing the
+   `len+128` of `recordSizeFor` `:184-186`) so every preview push is byte-identical; omit the `Topic`
+   header on the inline path (keep it on tickles).
+6. **`notified` receipt (new state, FR-013):** new `POST /v1/relay/notified` (`relay_handlers.go` +
+   `router.go`) that, per id: looks up the sender from the relay row, stamps `notified_at` on the row, and
+   `Hub.Send(sender, {status:"notified", id})` — **without** `DeleteRelay` (reuses the no-dequeue pattern
+   in `relayPending` `:56-66`). The SW calls it fire-and-forget after a successful preview show. The
+   existing `delivered` (fetch/ack in `relayPending`/`relayAck`) is unchanged and still dequeues on ack.
+   *(Not marked at send time — that would lie if iOS drops the push.)* Migration: one `NNNN_relay_notified_at.sql`
+   adding a nullable `notified_at timestamptz` to the relay queue table (ZK-neutral timestamp).
+
+### Client SW (`src/`)
+
+7. `src/sw.ts` — `pushKind` (`:454-466`) recognizes `msgx`/`postx`. In `dispatchPush` (`:945+`), an
+   inline arm runs under `runGuardedWake` (`sw-inbox.ts:204-236`) so every wake ends visibly.
+8. `src/services/sw-inbox.ts` — `previewInline(frame): SwNote[]`: `sessionKeyForPeer(chats, frame.from)`
+   (`:275`) → `openPushPreview(chatId, frame.h, frame.p)` → render through `noteForPayload` (`:321-687`)
+   **passing the recipient's own hidden set + prefs sourced exactly as `previewPending` does** (FR-014 —
+   hidden chat → content-free generic, "Show preview" off → hide sender+body, muted/content-none/
+   web-push-off/master-off → suppress; never default these to empty/permissive) → `aggregate` (`:692`) →
+   `richNoteOptions` (`:88`, no `renotify`). Fire `postNotified(id)` on successful DECRYPT (FR-015),
+   independent of the display outcome (no mute/hidden leak). Best-effort `markShown(id)` so an on-open warm
+   does not double-notify (a failed write only risks a duplicate, never a desync).
+9. Show + fallback: on success `showNotes(notes)` (`sw.ts:281`) + best-effort `markShown(id)` +
+   fire-and-forget `postNotified(id)` (the new `notified` receipt). On ANY failure →
+   `showGeneric('preview-fallback')` (`sw.ts:151`), rich on open (FR-005). Never silent, never dropped.
+   Legacy iOS (`isLegacyIOS`, spec 2044) short-circuits to the lite path BEFORE any decrypt.
+10. **Best-effort warm tail (FR-011/FR-012).** After the preview show, call the EXISTING
+    `tryAuthoritativeDrain(ctx)` (`sw.ts:605`, spec 1032) — the same fetch+persist+ack path iOS-17+ uses
+    today, now moved OFF the critical display path. It self-gates on 1032 eligibility (returns `'degrade'`
+    → skip, DB warms on open). The only new wiring: the drain must NOT re-notify ids the preview already
+    showed — the preview's `markShown(id)` already feeds the shown ledger (`sw-inbox.ts:308`,
+    `drainPersistPending` filters/`markShown` at `sw.ts:616-619`), so ensure a preview-shown id is
+    persisted + acked but not re-surfaced by `showNotes` (persist/ack silently). The peek (discarded
+    `mk_N`, no lock) and the warm's authoritative open (real `mk_N`, session Web Lock in `sw-drain.ts:215`)
+    are serialized by `serializeNotify` and do not collide. Ordering invariant: **show → warm**, so a
+    suspend/hang in the warm cannot cause a silent wake.
+
+## Padding — constant size (SC-004)
+
+`RecordSize` is set to a single fixed value `PREVIEW_RECORD_SIZE` (header cap + 256 B body + AEAD tag
++ json overhead + record overhead), well under the ~4 KB constrained-endpoint ceiling (spec 2046). The
+webpush library pads every preview record up to it → identical encrypted length for all previews. No
+ladder, no per-message size decision.
+
+## Testing
+
+- **Server (`go test`):** `previewPushPayload` shape; `RecordSize` constant across inputs (identical
+  byte length); inline path omits `Topic`, tickle keeps it; hub attaches preview when present and routing
+  permits, else tickle; **a muted `prid` (in `MutedPrids`) or a classes-off class yields NO push at all —
+  neither tickle nor preview (FR-016)**; `POST /v1/relay/notified` stamps `notified_at`, relays a `notified`
+  receipt to the sender, and does NOT dequeue (relay row survives); `delivered`+ack still dequeues. Fake store.
+- **Client (vitest):** `buildPreview` truncation (UTF-8 byte budget on a char boundary; kind labels for
+  media/reaction/call); `derivePreviewKey` determinism + domain separation; `sealPushPreview`/
+  `openPushPreview` round-trip; `openPushPreview` leaves NO persisted session (assert `saveSession` not
+  called); **FS test** — after the message is opened authoritatively (mk_N gone), `openPushPreview` fails
+  (SC-006); `previewInline` renders rich note with no fetch; decrypt failure → empty → caller shows generic
+  (FR-005); muted chat → quiet downgrade; group frame (groupId in preview) → group note; reaction → reaction
+  note; dedupe id == msg_id; **hidden chat → content-free generic (no sender/body); "Show preview" off →
+  generic title + "New message"; muted/content-none → suppressed (FR-014, parity with fetch path)**;
+  `postNotified` fires on decrypt regardless of shown/generic/suppressed outcome (FR-015, no mute/hidden
+  leak); an incoming `notified` receipt maps a sent message to the same visual as `delivered`; warm tail
+  after a preview show persists+acks but does NOT re-notify an already-shown id (FR-012). New
+  `crypto/push-preview.test.ts`, `sw-inline.test.ts` (+ `sw-quiet.test.ts` edits).
+- **Typecheck:** `npm run build` (vue-tsc).
+- **Device:** locked iPhone 15 Pro, app closed → short 1:1, group, reaction → each shows real
+  sender + preview, no fetch; photo → "Photo" label; open app → full messages present, no dup
+  notification; prod DB → no `410` prune after a locked burst; sender sees "delivered" without the
+  device opening.
+
+## Files to touch
+
+- `src/services/crypto/` — `derivePreviewKey`, `sealPushPreview`, `openPushPreview`, `buildPreview`
+  (new `push-preview.ts` or extend `message.ts`); reuse `ratchet.ts` key derivation
+- `src/services/messaging.ts` — produce the sealed preview alongside the frame
+- `src/db/queries.ts` — thread preview through send + group fan-out
+- `src/services/api.ts` — include `pushPreview` in the WS `msg` frame
+- `src/sw.ts` — `pushKind` `msgx`/`postx`, inline dispatch arm under `runGuardedWake`
+- `src/services/sw-inbox.ts` — `previewInline`, wiring to `openPushPreview` + `noteForPayload`
+- `src/services/push.ts` — `postNotified(id)` fire-and-forget helper (the new `notified` receipt)
+- receipt handling (sender side) — map an incoming `notified` receipt to the same visual as `delivered`
+- `src/sw.ts` — also enable the warm tail by default for non-legacy devices (flip `sw.fullPersist`
+  default on, still gated by 1032 eligibility)
+- `server/internal/ws/hub.go` — `PushPreview` on the msg frame; inline-vs-tickle notify; `notified` receipt relay
+- `server/internal/push/push.go` — `previewPushPayload`, constant `RecordSize`, omit `Topic` on inline
+- `server/internal/api/relay_handlers.go` + `router.go` — `POST /v1/relay/notified` (stamp `notified_at`, no dequeue)
+- `server/internal/store/relay.go` — `notified_at` stamp helper; `internal/db/migrations/NNNN_relay_notified_at.sql`
+- tests: `crypto/push-preview.test.ts`, `sw-inline.test.ts`, `sw-quiet.test.ts`, `push_test.go`,
+  `relay_handlers_test.go`
+- `package.json` — bump 1.0.9 → 1.0.10 (first change of the new cycle; release guard)
+
+## Risks & mitigations
+
+- **New crypto surface (preview key)** → domain-separated KDF from `mk_N`, header bound as AD, no
+  standing key, FS test (SC-006); on the ZK checklist for explicit security review before implement.
+- **Topic collapsing drops burst content** → preview pushes send NO Topic; SW-side per-chat tag still
+  coalesces the notifications.
+- **Sender preview leaks recipient-hidden content?** No — the preview is E2EE to the recipient device;
+  the SW applies the recipient's hide-preview/mute prefs at render, exactly as with a full fetch today.
+- **Peek mutates in-memory state** → always operate on a freshly `loadSession`'d copy, never `saveSession`;
+  never peek against a shared live state object (research caveat).
+- **Double-notify (push shows, open re-shows)** → best-effort `markShown(id)`; worst case a duplicate,
+  never a desync or lost message.
+- **Constant size too large for a constrained endpoint** → `PREVIEW_RECORD_SIZE` is a `go test` constant
+  far under the 2046 ceiling; easy to tune down.
+- **iOS still throttles very rapid bursts** (OS-level) → subscription stays alive, throttled messages
+  arrive on next wake/open, not lost (unchanged from spec 2048).
+
+## Out of scope
+
+- Calls (own fast ring path, spec 2031/2034).
+- Making rich previews work on iOS ≤16 (spec 2044 lite path stands).
+- A user-facing toggle (default-on by decision; no setting).
+- Store-from-push / changing the authoritative open/drain store+ack path (untouched — inline consumes
+  nothing; the full message always warms over WS on open).
+- Any standing/long-lived notification content key (explicitly rejected for FS — FR-010).

--- a/specs/1055-ciphertext-push-instant/spec.md
+++ b/specs/1055-ciphertext-push-instant/spec.md
@@ -1,0 +1,371 @@
+# Feature Specification: Instant rich notifications (bounded encrypted preview in push)
+
+**Feature Branch**: `feat/1055-ciphertext-push-instant`
+
+**Created**: 2026-07-20
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: Follow-on to the 2043–2048 push-reliability arc. Show-first (spec 2048) made locked/idle
+iOS devices show a notification within the OS's tight execution window by displaying a generic
+placeholder BEFORE the `/relay/pending` fetch + decrypt, then upgrading to rich only if the network
+work landed in time. On deeply throttled locked devices it usually did not, leaving the user a
+generic "New message" until they opened the app. This spec removes the fetch from the notification
+hot path: the SENDER seals a small, display-sized **preview** (sender + a truncated body + kind) and
+attaches it to the Web Push, so the service worker can decrypt and show the real sender + preview
+immediately — no network round-trip — while the phone is locked. Because notification UIs truncate to
+~200 characters on every platform, and because the push is peek-decrypted (it stores nothing) with the
+full message still warming over WebSocket on app open, sending the *whole* message would spend bytes on
+content that is never displayed and never stored. A bounded preview is exactly enough. It is also
+near-constant in size, so — unlike inlining the variable-length full frame — it leaks **nothing** about
+message length to the third-party push provider. The preview is sealed under a per-message key derived
+from the Double-Ratchet message key, so decryption is stateless (peek, no persist) and forward secrecy
+is preserved. The server stays zero-knowledge: it forwards an opaque preview blob it cannot read.
+
+## Clarifications
+
+### Session 2026-07-20
+
+- Q: Rollout — default for all eligible pushes, or opt-in setting? → A: Default on, no user toggle.
+- Q: How much of the message goes in the push, given the OS truncates to ~200 chars and we store
+  nothing + warm over WS on open? → A: A bounded, display-sized **preview** only (sender + truncated
+  body + kind), NOT the whole frame. Cap the body by bytes (~256 B of UTF-8, truncated on a character
+  boundary) so the payload is near-constant regardless of script.
+- Q: How is the preview sealed so the SW can decrypt it without advancing/persisting ratchet state? →
+  A: Under a per-message key `pk_N = KDF(mk_N, "ring-push-preview")` derived from the Double-Ratchet
+  message key `mk_N`. The push carries the ratchet header + the preview AEAD; the SW peek-derives `mk_N`
+  from the header against a discarded session copy (no persist), derives `pk_N`, and decrypts. Forward
+  secrecy is inherited from `mk_N` (deleted when the message is later processed authoritatively on open).
+- Q: Which frame kinds get a preview? → A: All text-class frames (1:1 messages, reactions, group —
+  which are pairwise 1:1 fan-out, same ratchet path); plus post/wall activity via its own `K_post` seal.
+  Calls keep their existing fast ring path (out of scope).
+- Q: How does the SW handle ratchet state when it decrypts a preview? → A: Peek only — decrypt against a
+  discarded copy of the session; do NOT persist, store, or ack. The full frame stays in the relay queue;
+  the authoritative decrypt+store+ack happens later (warm tail below, or on app open) exactly as today.
+  The preview decrypt is a pure display accelerator that consumes nothing, so no crypto state is written
+  during it and session desync is impossible. A `delivered` receipt is a small fire-and-forget marker.
+- Q: After showing the preview, should the SW still fetch + persist the full messages to warm the DB, like
+  the iOS-17+ path does today? → A: Yes — best-effort, AFTER the guaranteed show. Once the rich preview is
+  on screen, run the existing spec-1032 authoritative drain (`tryAuthoritativeDrain`: fetch `/relay/pending`
+  → authoritative decrypt → persist → ack), so a device with budget opens already warm. It runs strictly
+  after the visible show, so a suspend/hang cannot cause a silent wake; it self-gates on the existing 1032
+  eligibility (single-device, Web Locks) and degrades harmlessly when it cannot persist. On a throttled
+  locked device the warm is skipped and the DB warms over WS on open, exactly as today. Moving the fetch
+  off the critical display path (the preview now shows without it) makes the warm pure upside. Enabled by
+  default for non-legacy devices as part of this spec (still gated by 1032 eligibility).
+- Q: Are muted chats dropped at the server or the client, given a client that shows nothing risks
+  revocation? → A: SERVER (spec 1050 `AllowPush` Row 6 / `MutedPrids` — opaque prids). The preview push
+  MUST inherit that identical gate, so a muted conversation gets NO push at all (no tickle, no preview, no
+  wake) — the only way to truly mute without a silent-wake strike. The client-side mute suppression is a
+  revocation-safe fallback for the mute-sync gap only; on iOS it ends with a silent generic (not nothing),
+  so it is NOT relied on for true muting. Hidden chats are structurally absent from `MutedPrids`, so they
+  DO push and the client shows a generic note (spec 1019).
+- Q: When should the sender's message flip to "delivered", and how does the server track the gap between
+  "notified" and "durably downloaded"? → A: Introduce a new **`notified`** receipt state, emitted the
+  instant the SW shows the preview (fast sender feedback), which does NOT dequeue the relay frame. The
+  existing **`delivered`** receipt continues to fire when the authoritative warm/open actually fetches +
+  persists the message, and dequeues on ack. To the SENDER, `notified` and `delivered` render identically
+  (the "delivered" tick) — the recipient was reached. The distinction is for the SERVER: a queued frame
+  stamped notified-but-not-delivered is one the recipient has SEEN (preview) but whose full body is not yet
+  durably on their device, so it is still owed. The server stamps `notified_at` on the relay row (a
+  timestamp, no plaintext) to know this; it dequeues only on `delivered` (ack).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A locked phone shows the real sender and preview instantly (Priority: P1)
+
+Someone locks their phone and later receives a message. The lock-screen notification shows the real
+sender name and a message preview immediately — not a generic "New message" that only fills in when they
+next open the app — because a display-sized preview rode inside the push and was decrypted on the device
+with no network fetch. Opening the app warms the full conversation over WebSocket as it does today.
+
+**Why this priority**: This is the core value. Show-first (2048) keeps the subscription alive and
+guarantees *a* notification, but on throttled locked devices the rich upgrade loses the race, so the
+notification stays generic. A preview in the push makes the rich notification the common case on exactly
+the devices that were degraded.
+
+**Independent Test**: With the app closed and the screen locked, a short 1:1 message push produces a
+lock-screen notification bearing the sender and preview with NO `/relay/pending` fetch on the
+notification path (unit: the rich note is built from the push preview, not a fetch; device: the real
+sender/preview appears on the lock screen; and the full message is present after opening the app).
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is closed/backgrounded and the screen is locked, **When** a text-class message push
+   arrives, **Then** the SW peek-decrypts the preview and shows the rich per-chat note without any relay
+   fetch, within iOS's execution window.
+2. **Given** a locked-state burst of messages, **When** each push wakes the SW, **Then** each ends with a
+   visible rich show → no silent-wake strikes → the subscription is not revoked.
+3. **Given** the preview fails to decrypt (out-of-order ratchet the device hasn't caught up to, missing
+   session), **When** the SW cannot render the preview, **Then** it falls back to show-first behavior
+   (generic placeholder now, rich on open) — never a silent wake, never a dropped frame.
+4. **Given** a rich preview was shown from the push, **When** the user opens the app, **Then** the full
+   message is present with no duplicate notification.
+5. **Given** the device has execution budget after the preview show, **When** the best-effort warm tail
+   runs, **Then** the SW fetches + persists + acks the full messages so the app opens already warm; the
+   warm persists + acks silently (no re-notification of the already-shown preview).
+6. **Given** the device is suspended before the warm tail completes, **Then** the frame stays queued and
+   the DB warms over WebSocket on open — no message lost, no silent wake (the preview already showed).
+
+---
+
+### User Story 2 - Messages with no previewable text still notify (Priority: P1)
+
+Someone receives a photo, a voice note, or any message whose body is not plain text. They still get a
+meaningful notification (e.g. "Alice: 📷 Photo"), because the sender puts a kind-based preview in the push
+when there is no text to show.
+
+**Why this priority**: The whole point is that the notification path never needs a fetch; a media message
+with no text must still produce a useful, immediate notification rather than falling back to generic.
+
+**Independent Test**: A media-only message yields a push whose decrypted preview renders a kind-based
+note ("Photo" / "Voice message"), shown without a fetch. Unit: preview generation maps a text-less
+payload to a kind label; device: the labeled notification appears on the lock screen.
+
+**Acceptance Scenarios**:
+
+1. **Given** a media-only message, **When** the sender builds the push preview, **Then** the preview
+   carries a kind label (not raw media) and the SW shows "Sender: <kind>".
+2. **Given** any text-class message, **When** the sender cannot build a useful preview for some reason,
+   **Then** it sends the existing content-free tickle and the SW takes the show-first path (no regression).
+
+---
+
+### User Story 3 - The push provider learns nothing about message length or content (Priority: P1)
+
+The privacy posture is preserved and strengthened: neither Ring's server nor the third-party push service
+(Apple/Mozilla/Google) can read the preview, and the push service cannot infer message length from the
+push it relays — every preview push is the same size.
+
+**Why this priority**: Constitution Principle I (zero-knowledge boundary) is non-negotiable. A bounded
+preview padded to a single constant size removes even the bucket-granular length signal that inlining a
+variable full frame would have exposed.
+
+**Independent Test**: For a range of message lengths and kinds, the encrypted preview push is byte-identical
+in length. Unit: the padded preview payload is a single constant size for every input.
+
+**Acceptance Scenarios**:
+
+1. **Given** two messages of very different lengths, **When** each preview push is built, **Then** the two
+   encrypted payloads have identical byte length.
+2. **Given** a preview push, **When** it is observed at the push provider, **Then** it carries no cleartext
+   `Topic` header and no cleartext sender/message identifiers (those sit inside the push-encrypted body).
+
+---
+
+### Edge Cases
+
+- **Muted**: dropped SERVER-side (spec 1050 `AllowPush` Row 6 / `MutedPrids`), so no preview push is even
+  sent — a muted device is never woken (FR-016). Only in the mute-sync gap can a muted-chat preview reach
+  the SW; then the client downgrades it (silenced) and, on iOS, the 2048 machinery ends the wake with a
+  silent generic (not nothing) to stay revocation-safe — this is a fallback, not true muting.
+- **Muted receipt semantics**: a muted message MUST stay `sent` until the recipient's device actually
+  receives it — the server MUST NOT fabricate `notified`/`delivered` for a dropped push. Because the push
+  was dropped, no `notified` fires (nothing was decrypted); `delivered` fires only when the recipient's
+  device genuinely gets the frame (live over WebSocket if the app is open — mute suppresses only the
+  banner, not WS delivery — or on next open otherwise). A muted-offline recipient is therefore
+  indistinguishable to the sender from any offline recipient (both sit at `sent`), so the receipt never
+  betrays mute. Delivery receipts originate from the recipient's device, never from server optimism.
+- **Notifications-off / content-none (client-side)**: the server cannot always know these, so a push may
+  arrive; the SW suppresses the content, but on iOS the wake still ends with a silent/generic note (2048)
+  rather than silently — showing nothing on iOS would forfeit the subscription. Turning off a whole class
+  server-side (`ClassesOff`) is the way to get no push at all.
+- **Recipient "hide preview" pref on**: the preview still rides the push (E2EE), but the SW renders "New
+  message" AND hides the sender (title "Ring") per the recipient's pref — the device decides display,
+  exactly as today with a full fetch.
+- **Hidden chat (spec 1019)**: the SW resolves the recipient's local hidden set and renders a content-free
+  generic note (no sender/avatar/body, tap → Chats tab); the sealed content is decrypted locally but never
+  displayed. The encrypted preview reaching the device is no different from today's full message over the
+  wire, and the constant-size push means a hidden-chat message is indistinguishable from any other to the
+  server/provider. The `notified` receipt fires on decrypt (FR-015), so a hidden chat does not betray
+  itself to the sender via receipt behavior.
+- **Foreground + focused**: an OS notification is still shown (revocation-safe, spec 2048 FR-005); the live
+  page suppresses its duplicate in-app banner where it can.
+- **Decrypt failure / out-of-order ratchet / missing session**: the SW cannot always derive `mk_N` in the
+  push context. On any failure it MUST fall back to show-first generic + rich-on-open; never silent, never
+  dropped (the full frame is still queued).
+- **Legacy iOS (≤16)**: the lite path (spec 2044) shows generic-first without decrypt where SW-context
+  IndexedDB/decrypt is unreliable; preview decryption is NOT attempted there.
+- **Multi-byte bodies**: the body is truncated by a UTF-8 byte budget on a character boundary, so an
+  emoji/non-Latin message cannot blow the constant payload size.
+- **Replay/dedupe**: a preview-notified message and its later WS-warmed store dedupe on the frame id; the
+  push writes no message, so no dedupe conflict can arise.
+- **Notified but never downloaded**: a recipient who sees the preview but never opens the app (so never
+  durably downloads) keeps only the preview; if the 35-day relay retention lapses first, the full message
+  tail is lost. Acceptable — the preview is the bulk of a short message, the recipient had the retention
+  window to open, and the sender legitimately saw "delivered" (the recipient was reached). The server's
+  `notified_at` stamp is exactly what lets it reason about these still-owed frames.
+- **Sender offline when `notified` fires**: `notified` is a live optimistic receipt; a sender that misses
+  it flips to "delivered" later on the durable `delivered` receipt — no worse than today.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: On every text-class send (1:1 message, reaction, group message; and post/wall activity via
+  its own seal), the SENDER MUST build a bounded preview — sender identity hint + a body truncated to a
+  fixed UTF-8 byte budget (~256 B) or a kind label when there is no previewable text — and seal it for the
+  recipient, attached to the push. The full message is unchanged and still relayed for authoritative
+  delivery.
+- **FR-002**: The preview MUST be sealed under a per-message key `pk_N = KDF(mk_N, "ring-push-preview")`
+  derived from the Double-Ratchet message key `mk_N`, so the recipient SW can peek-derive `mk_N` from the
+  ratchet header against a discarded session copy (no persist), derive `pk_N`, and decrypt — with no
+  ratchet advancement committed and forward secrecy inherited from `mk_N`. The preview AEAD MUST bind the
+  ratchet header as associated data, so a sealed preview cannot be swapped onto, or replayed against, a
+  different frame (open MUST fail if the header does not match the sealed one).
+- **FR-003**: The preview push payload (ratchet header + preview AEAD) MUST be padded to a single constant
+  byte length for all messages, so payload size reveals nothing about message length or kind. The push MUST
+  carry no cleartext `Topic` header and no cleartext sender/message identifiers.
+- **FR-004**: On a preview push, the SW MUST decrypt the preview and show the rich per-chat notification
+  WITHOUT any `/relay/pending` fetch on the notification path, and MUST NOT persist ratchet state, store
+  the message, or ack the frame. The full frame remains in the relay queue for the authoritative
+  open/drain path to consume exactly as today.
+- **FR-005**: On any preview-decrypt failure (out-of-order ratchet, missing session, malformed payload),
+  the SW MUST fall back to spec-2048 show-first behavior (visible placeholder now, rich on open) and MUST
+  NOT end the wake silently or drop the frame.
+- **FR-006**: Because the preview decrypt consumes nothing, delivery-by-push and the later authoritative
+  warm/open MUST converge to a single stored message with correct receipts: the preview show emits a small
+  fire-and-forget **`notified`** receipt off the display path (which does NOT dequeue the relay frame); the
+  warm/open path performs the one authoritative decrypt+store+ack and emits **`delivered`**, dequeuing on
+  ack. No dedupe conflict can arise because the preview never writes a message.
+- **FR-013**: A new **`notified`** delivery state MUST be introduced, distinct on the server from
+  `delivered`: `notified` = the recipient device showed the preview but has not durably downloaded the
+  message (frame still queued); `delivered` = the message was fetched + persisted authoritatively (frame
+  dequeued on ack). To the SENDER's UI, `notified` and `delivered` MUST render identically ("delivered").
+  The server MUST relay `notified` to the sender live and stamp `notified_at` on the relay row so it can
+  distinguish seen-but-not-downloaded frames; it MUST dequeue only on `delivered` (ack). `notified` is an
+  optimistic live receipt (not durably reconciled); a missed `notified` is superseded by `delivered`.
+- **FR-007**: The server MUST NOT be able to read the preview and MUST store no new plaintext or metadata:
+  the sealed preview blob travels in the existing WebSocket send frame and is forwarded into the push at
+  enqueue time; it is opaque ciphertext to the server. No new server-visible field and no schema change is
+  required (the preview is used transiently at push time, not persisted).
+- **FR-008**: Show-first (spec 2048), the legacy lite path (spec 2044), quiet-note downgrade, muted/off
+  suppression, badge, and coalescing semantics MUST NOT regress. The preview path is layered on the
+  existing wake guard, not a replacement for it.
+- **FR-009**: The relay queue's delete-on-ack invariant MUST hold: a preview push MUST NOT ack or dequeue
+  the frame (it only displays); the frame is drained exactly once by the authoritative open/drain path when
+  the device acks, so it neither lingers nor double-delivers.
+- **FR-010**: Forward secrecy MUST be preserved: because `pk_N` derives from `mk_N`, an encrypted preview
+  push captured at the push provider MUST NOT be decryptable once the corresponding message has been
+  processed authoritatively (warm tail or open), which deletes `mk_N`. The preview MUST NOT introduce any
+  standing, long-lived content key.
+- **FR-011**: After the preview is shown, the SW SHOULD run the existing spec-1032 authoritative warm
+  (`tryAuthoritativeDrain`: fetch → authoritative decrypt → persist → ack) on a best-effort basis, so a
+  device with budget opens already warm. It MUST run strictly AFTER the visible show (so a suspend/hang
+  cannot cause a silent wake), MUST respect the existing 1032 eligibility gates (self-degrading when it
+  cannot persist safely), and MUST leave the frame queued for the open path when it does not complete.
+- **FR-012**: The warm tail MUST NOT re-notify a message already shown by the preview: it persists + acks
+  such frames silently (the preview's `markShown(id)` feeds the drain's dedupe), producing no duplicate or
+  re-buzzed notification. It MAY still surface a notification for any NEW frame the preview did not cover.
+
+- **FR-014**: The preview MUST be rendered ONLY through the existing `noteForPayload` choke point, passed
+  the RECIPIENT's own local hidden set (spec 1019) and notification prefs (global "Show notifications",
+  per-chat mute, per-chat web-push, per-chat content level, and global "Show preview"). A hidden chat MUST
+  render a content-free generic note (no sender, no avatar, no body, tap → Chats tab); "Show preview" off
+  MUST hide both body AND sender; muted / content-none / web-push-off / master-off MUST suppress exactly
+  as the fetch path does today. The sender-sealed content MUST NOT be displayed in any way these
+  recipient-local rules forbid. `previewInline` MUST source the hidden set + prefs the same way
+  `previewPending` does — never defaulting them to empty/permissive.
+- **FR-016**: The preview push MUST pass through the identical server-side `AllowPush` gate (spec 1050) as
+  the content-free tickle, evaluated on the SAME frame `class`/`prid`/`sender`. A muted conversation
+  (`prid` ∈ `MutedPrids`), a classes-off class, or any other server-side suppression MUST result in NO
+  push at all — neither tickle nor preview — so a muted device is never woken (true muting, no silent-wake
+  strike). Server-side drop is the PRIMARY muting mechanism; the client-side pref suppression (FR-014) is a
+  revocation-safe fallback for the mute-sync gap only and, on iOS, ends with a silent generic rather than a
+  silent wake — it MUST NOT be relied on as the mechanism for true muting.
+- **FR-015**: The `notified` receipt MUST fire on successful preview DECRYPT (the device received the
+  message), NOT gated on whether a visible notification was shown — so it is identical for shown, generic
+  (hidden), and suppressed (muted) outcomes and cannot reveal the recipient's private mute/hidden/preview
+  prefs via receipt presence or timing (matching today's mute-independent delivery receipt). A preview
+  DECRYPT FAILURE fires no `notified`; the later warm/open `delivered` covers it.
+
+### Key Entities *(include if feature involves data)*
+
+- **Push preview**: a small sealed blob = ratchet header (sender DH pubkey + counters, needed to derive
+  `mk_N`) + AEAD(`pk_N`, {sender hint, truncated body or kind}). Padded to one constant size. Distinct
+  from the full relayed frame; carries only what a notification UI can display.
+- **Preview key `pk_N`**: `KDF(mk_N, "ring-push-preview")`, per message, never persisted, forward-secret.
+- **Constant padding size**: the single fixed payload length every preview push is padded to (via the
+  spec-2046 `RecordSize` mechanism), well under the constrained-endpoint limit.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A locked-state text-class message shows the real sender + preview with NO relay fetch on the
+  notification path (unit: rich note built from the push preview; device: sender/preview on lock screen
+  while closed + locked; and the full message present after opening).
+- **SC-002**: A locked-state burst shows a rich notification per wake and produces **no `410 Unregistered`
+  prune** afterward (device + prod-log verified).
+- **SC-003**: A media-only message notifies with a kind label ("Photo"/"Voice message") from the push, no
+  fetch (unit + device).
+- **SC-004**: Every preview push is byte-identical in length across a range of message lengths and kinds
+  (unit: constant-size truth table).
+- **SC-005**: A preview-notified message and its on-open WS warm dedupe to one stored message with correct
+  receipts and no duplicate notification (unit + drive).
+- **SC-006**: A preview push captured before the message is processed cannot be decrypted after the
+  authoritative open deletes `mk_N` (unit: forward-secrecy property of `pk_N`).
+- **SC-007**: Existing suites (1194+) plus the 2044 legacy path and 2048 show-first path stay green; no
+  server plaintext exposure introduced (checklist-verified).
+- **SC-008**: On an eligible device with budget, after the preview show the warm tail persists + acks the
+  frames so opening the app requires no WS re-fetch; the warm produces no duplicate notification (unit:
+  warm runs after show, dedupes on the shown ledger; device: app opens warm with messages already present).
+- **SC-009**: The sender's message flips to "delivered" as soon as the recipient's device decrypts the
+  preview (via the `notified` receipt), before any download; the relay frame is NOT dequeued until the
+  authoritative `delivered`+ack (unit: `notified` relays to sender + stamps `notified_at` + leaves the
+  frame queued; `delivered` dequeues).
+- **SC-011**: A muted conversation (`prid` ∈ `MutedPrids`) or a classes-off class produces NO push —
+  neither tickle nor preview (unit: `AllowPush` gates the preview identically to the tickle; the muted
+  device is never woken).
+- **SC-010**: Privacy parity with the fetch path (unit, via `noteForPayload`): a hidden chat → content-free
+  generic (no sender/body); "Show preview" off → generic title + "New message"; muted / content-none /
+  web-push-off / master-off → suppressed; and the `notified` receipt fires identically across shown,
+  generic, and suppressed outcomes (no mute/hidden leak).
+
+## Zero-Knowledge Impact
+
+**Server: unchanged and blind.** The sealed preview blob is opaque ciphertext the server forwards from the
+WebSocket send frame into the push at enqueue time; it stores no new plaintext, adds no column, and cannot
+read the preview any more than it can read the message. Constitution Principle I holds.
+
+**Push provider (Apple/Mozilla/Google): strictly less than the full-frame alternative.** The Web Push body
+is separately encrypted to the browser (RFC 8291 aes128gcm — the path spec 2046 tuned via `RecordSize`), so
+the provider cannot read the preview; our AEAD-sealed preview inside it is double-encrypted. Versus today's
+constant tickle, the only theoretical new signal is payload size — which a single constant padding size
+removes entirely (SC-004): every preview push is identical in length, so the provider learns nothing about
+message length or kind. Inline `sender`/`id` live inside the push-encrypted body (invisible to the
+provider), and preview pushes carry **no `Topic` header** — one fewer cleartext field than today's tickle.
+Net: the provider observes only endpoint + timing + a constant size, same as (indeed less than) today.
+
+**Forward secrecy preserved.** The preview key `pk_N = KDF(mk_N, "ring-push-preview")` inherits the
+ratchet's forward secrecy: `mk_N` is deleted when the message is processed authoritatively on open, after
+which a captured encrypted preview push cannot be decrypted (FR-010, SC-006). No standing content key is
+introduced. The outer RFC-8291 layer uses the long-lived subscription keys, but the inner preview AEAD is
+forward-secret, so a compromise of the subscription keys alone does not reveal preview content.
+
+**`notified` receipt + `notified_at`: ZK-neutral.** The new `notified` state reveals to the server exactly
+what `delivered` already does — that the recipient's device was reached (reachability + timing) — and
+carries no message content. `notified_at` is a timestamp on the relay row (no plaintext). Neither widens
+what the server learns beyond the receipt metadata it already handles.
+
+A dedicated **`checklists/zero-knowledge.md`** gates this spec; the preview-key construction and FS
+property are explicitly on it for security review before implement.
+
+## Assumptions
+
+- Notification UIs on every target platform (iOS/iPadOS, Android Chrome, macOS/Windows desktop) truncate
+  the body to a few hundred characters at most; a ~256-byte preview overfills the visible area everywhere,
+  so no display fidelity is lost versus sending the full message.
+- The full message continues to arrive and store authoritatively over WebSocket on app open, so the push
+  storing nothing loses no content — it is a pure display accelerator.
+- The sender can build and seal a preview cheaply at send time (it already has `mk_N` when sealing message
+  N), and the recipient SW can peek-derive `mk_N` from the ratchet header for the common in-order case; the
+  out-of-order/behind cases fall back to rich-on-open (FR-005), which is today's behavior.
+- Push routing (spec 1050) continues to suppress muted/notifications-off pushes server-side.
+- A single constant preview size fits comfortably under the aes128gcm/constrained-endpoint limit that
+  caused the spec-2046 Firefox 413.

--- a/specs/1055-ciphertext-push-instant/tasks.md
+++ b/specs/1055-ciphertext-push-instant/tasks.md
@@ -1,0 +1,145 @@
+# Tasks: Instant rich notifications (bounded encrypted preview in push)
+
+**Spec**: `specs/1055-ciphertext-push-instant/spec.md` · **Plan**: `./plan.md`
+**Branch**: `feat/1055-ciphertext-push-instant`
+
+Constitution: TDD (red → green), zero-knowledge boundary intact, tests against the fake store / vitest.
+Legend: `[P]` = parallelizable (different files, no incomplete-dep). Story labels map to spec user stories.
+
+**GitHub issues** (feature→develop PR must `Closes` each): Phase 1 #1059 · Phase 2 #1052 · Phase 3 #1053 ·
+Phase 4 #1054 · Phase 5 #1055 · Phase 6 #1056 · Phase 7 #1057 · Phase 8 #1058.
+
+## Phase 1: Setup
+
+- [ ] T001 Bump `package.json` version 1.0.9 → 1.0.10 (first change of the new cycle; release guard)
+- [ ] T002 [P] Add embedded migration `server/internal/db/migrations/NNNN_relay_notified_at.sql` — nullable
+  `notified_at timestamptz` on the relay queue table (ZK-neutral timestamp; new DBs create it, existing DBs alter)
+
+## Phase 2: Foundational — crypto primitives (BLOCKS every story)
+
+**Tests first (red):**
+
+- [ ] T003 [P] Write `src/services/crypto/push-preview.test.ts`: `derivePreviewKey(mk)` is deterministic and
+  domain-separated (different label/mk → different key); `sealPushPreview`/`openPushPreview` round-trip;
+  `openPushPreview` throws on a tampered header (AD binding) or wrong key
+- [ ] T004 [P] Add to `push-preview.test.ts` the **forward-secrecy** test (SC-006): after the message is opened
+  authoritatively (its `mk_N` consumed/deleted), `openPushPreview` for that frame fails — a captured preview
+  cannot be decrypted post-processing
+- [ ] T005 [P] Add `buildPreview(payload)` tests: truncate text to a UTF-8 byte budget (~256 B) on a character
+  boundary (multi-byte/emoji cannot overflow); text-less payloads (media, reaction, call-event, game) map to a
+  kind label ("Photo"/"Voice message"/…); output carries no recipient-specific data
+
+**Implementation (green):**
+
+- [ ] T006 Implement `derivePreviewKey(mk) = KDF(mk, "ring-push-preview")` in `src/services/crypto/push-preview.ts`
+  (libsodium KDF; single domain-separated purpose), reusing `ratchet.ts` message-key derivation
+- [ ] T007 Implement `sealPushPreview(mk_N, header, preview) → previewAEAD` (AEAD under `pk_N`, ratchet `header`
+  bound as associated data) and `buildPreview(payload)` (bounded truncation + kind labels) in `push-preview.ts`
+- [ ] T008 Implement `openPushPreview(chatId, header, previewAEAD) → preview` in `push-preview.ts`: `loadSession`
+  a FRESH copy, peek-derive `mk_N` from `header` (existing preview derivation, never `saveSession`),
+  `derivePreviewKey`, AEAD-open with `header` as AD; throw → caller falls back (FR-005). Assert (unit) no
+  `saveSession` call (FR-004 consumes nothing)
+
+## Phase 3: US1 — Locked phone shows real sender + preview instantly (P1) 🎯 MVP
+
+**Sender side (tests → impl):**
+
+- [ ] T009 [P] [US1] Test `src/services/messaging.ts`: sealing message N also produces a sealed push-preview
+  from the same `mk_N` alongside the wire frame (round-trips with `openPushPreview`)
+- [ ] T010 [US1] Implement in `messaging.ts`: after deriving `mk_N` to seal the body, `buildPreview(payload)` →
+  `sealPushPreview(mk_N, header, preview)`; return the sealed preview beside the wire frame
+- [ ] T011 [US1] Thread the sealed preview through send + group pairwise fan-out in `src/db/queries.ts`
+  (`:627-641`) — one preview per pairwise recipient (each has its own `mk_N`)
+- [ ] T012 [US1] Include `pushPreview` (opaque b64) in the WS `msg` frame in `src/services/api.ts` (+ WS send path)
+
+**Server side (tests → impl):**
+
+- [ ] T013 [P] [US1] Test `server/internal/ws/hub.go`: the `msg` frame carries optional `PushPreview`; when
+  `AllowPush` permits and a preview is present → inline notify variant fired; no preview → tickle
+- [ ] T014 [US1] Add `PushPreview []byte` to the `frame` struct (`hub.go:109-119`); at the notify point
+  (`:1296`) fire the inline notify variant (id, sender, header, previewAEAD) transiently — NOT stored in the
+  relay row — gated by `AllowPush` (see T024)
+- [ ] T015 [P] [US1] Test `server/internal/push/push.go`: `previewPushPayload(msgId, from, header, previewAEAD)`
+  builds the `{"t":"msgx",...}` JSON with `from`/`id` inside the (push-encrypted) body
+- [ ] T016 [US1] Implement `previewPushPayload` + the inline `attempt` variant in `push.go` (omit `Topic` on
+  inline — see T022)
+
+**SW side (tests → impl):**
+
+- [ ] T017 [P] [US1] Test `src/services/sw-inbox.ts` `previewInline(frame)`: renders a rich per-chat note from an
+  in-payload frame with NO fetch; decrypt failure → empty (caller shows generic, FR-005); dedupe id == msg_id;
+  group frame (groupId in preview) → group note; reaction → reaction note
+- [ ] T018 [US1] Implement `previewInline(frame)` in `sw-inbox.ts`: `sessionKeyForPeer` → `openPushPreview` →
+  render via `noteForPayload` (recipient's hidden set + prefs — see T027) → `aggregate` → `richNoteOptions`
+- [ ] T019 [US1] In `src/sw.ts`: `pushKind` recognizes `msgx`/`postx` (`:454-466`); add the inline dispatch arm
+  in `dispatchPush` under `runGuardedWake`; on success `showNotes` + `markShown(id)` + `postNotified(id)`; on
+  any failure `showGeneric('preview-fallback')` (FR-005); `isLegacyIOS` short-circuits to the lite path first
+- [ ] T020 [US1] Test + wire the **best-effort warm tail** (FR-011/012): after the show, call
+  `tryAuthoritativeDrain(ctx)` (`sw.ts:605`); ensure a preview-shown id is persisted + acked but NOT re-notified
+  (dedupe via the shown ledger); flip `sw.fullPersist` default ON for non-legacy devices (still gated by 1032
+  eligibility). Test: warm runs after show, no duplicate notification (FR-012, SC-008)
+
+## Phase 4: US2 — Media / no-text messages still notify (P1)
+
+- [ ] T021 [US2] Test + confirm (covered by T005/T007 `buildPreview`): a media-only payload yields a kind-label
+  preview; `previewInline` renders "Sender: Photo"; if no useful preview can be built, the sender omits
+  `pushPreview` and the server sends the tickle (SW show-first) — no regression (SC-003)
+
+## Phase 5: US3 — Push provider learns nothing (constant size) (P1)
+
+- [ ] T022 [P] [US3] Test `push.go`: every preview push is byte-identical in length across message lengths/kinds
+  (constant `PREVIEW_RECORD_SIZE`); inline path omits the `Topic` header, tickle keeps it (SC-004, FR-003)
+- [ ] T023 [US3] Set `RecordSize` to the single constant `PREVIEW_RECORD_SIZE` for the inline path (replacing the
+  `len+128` of `recordSizeFor` `:184-186`), sized under the 2046 constrained-endpoint ceiling; omit `Topic` inline
+
+## Phase 6: Cross-cutting — muting gate, notified/delivered receipts, privacy parity
+
+**Muting (FR-016):**
+
+- [ ] T024 [P] Test `hub.go`/`push.go`: a muted `prid` (∈ `MutedPrids`) or a classes-off class yields NO push at
+  all — neither tickle nor preview (`AllowPush` gates the preview identically to the tickle) (SC-011); and the
+  muted frame gets NO `notified`/`delivered` receipt until it is genuinely received (WS/ack) — the server never
+  fabricates a receipt for a dropped push (muted stays `sent`, indistinguishable from offline)
+- [ ] T025 Wire the preview notify through the SAME `AllowPush(class, prid, sender, prefs)` gate as the tickle
+  (`push.go:301`) so muted/classes-off drop the preview (implements the T024 red)
+
+**`notified` receipt (FR-013/FR-015):**
+
+- [ ] T026 [P] Test `server/internal/api/relay_handlers.go`: `POST /v1/relay/notified` stamps `notified_at`,
+  relays a `notified` receipt to the sender via `Hub.Send`, and does NOT `DeleteRelay` (row survives);
+  `delivered`+ack still dequeues
+- [ ] T027 Implement `POST /v1/relay/notified` (`relay_handlers.go` + `router.go` + `store/relay.go` stamp helper)
+  reusing the no-dequeue pattern (`relayPending:56-66`); `src/services/push.ts` `postNotified(id)` helper
+- [ ] T028 [P] Test + implement sender-side receipt mapping: an incoming `notified` receipt maps a sent message to
+  the SAME visual state as `delivered` (the delivery-status update path); `postNotified` fires on DECRYPT
+  regardless of shown/generic/suppressed outcome (FR-015 — no mute/hidden leak)
+
+**Privacy parity (FR-014, SC-010):**
+
+- [ ] T029 [P] Test in `sw-inline.test.ts` (via `noteForPayload`): hidden chat → content-free generic (no
+  sender/body, tap → Chats); "Show preview" off → generic title + "New message"; muted-sync-gap/content-none →
+  suppressed → on iOS a silent generic (not nothing). Assert `previewInline` sources the recipient's hidden set +
+  prefs (never defaults them permissive) (FR-014)
+
+## Phase 7: Post / wall activity (extends "all text-class")
+
+- [ ] T030 [P] Test + implement `postx` preview for post/wall activity: seal a bounded preview under `K_post`
+  (non-ratchet, stateless — `openReceivedPost`/`openPostEngagement`), `{"t":"postx","post":id,"p":…}`, no `Topic`,
+  same constant size; SW `previewInline` post-branch renders it; gated by `AllowPush("post"/"activity", …)`
+
+## Phase 8: Verify
+
+- [ ] T031 `npm run build` (vue-tsc typecheck) green; full vitest green (existing 1194+ unaffected, SC-007)
+- [ ] T032 `cd server && go build ./... && go vet ./... && go test ./...` green
+- [ ] T033 Update spec `**Status**:` → in-review; `make roadmap`; ride the branch
+- [ ] T034 Device pass (locked iPhone 15 Pro, app closed): short 1:1 / group / reaction → real sender + preview,
+  no fetch; photo → "Photo"; open app → full messages present, no dup notification; muted chat → nothing; hidden
+  chat → generic; prod DB → no `410` prune after a locked burst; sender sees "delivered" without the device opening
+
+## Dependencies
+
+- Phase 2 (crypto) blocks Phase 3–7.
+- T014 (hub notify) depends on T025 (AllowPush gate) — wire the gate first or together.
+- T018 (previewInline) depends on T008 (openPushPreview) and T027 (noteForPayload prefs sourcing).
+- T020 (warm tail) depends on T019 (inline arm shows first).
+- MVP = Phase 1–3 (US1). US2/US3/receipts/parity harden it; Phase 7 extends to posts.

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -550,7 +550,7 @@ async function sealAndEnqueue(
   try {
     const prid = await pridFor(chat);
     const sealed = await sealForChat(chat.id, peerUserId, chat.isGroup, { ...payload, prid });
-    if (sealed) await enqueue({ t: 'msg', id: messageId, to: sealed.to, ciphertext: sealed.packet, class: cls, prid });
+    if (sealed) await enqueue({ t: 'msg', id: messageId, to: sealed.to, ciphertext: sealed.packet, class: cls, prid, pushPreview: sealed.pushPreview });
     else if (!chat.isGroup) await detectTerminated(peerUserId); // no bundle → maybe deleted
   } catch (e) {
     console.warn('[messaging] seal/enqueue failed; message stays pending', e);
@@ -639,6 +639,8 @@ async function sealAndEnqueueGroup(
           // targets, bystander fan-out goes quiet — default 'message' otherwise.
           class: classFor ? classFor(member) : classifyGroupMessage(member, payload),
           prid,
+          // spec 1055: per-pairwise preview (each member's own ratchet seal).
+          pushPreview: sealed.pushPreview,
         });
       }
     } catch (e) {

--- a/src/services/crypto/message.ts
+++ b/src/services/crypto/message.ts
@@ -9,6 +9,7 @@ import {
   ratchetEncrypt,
   ratchetDecrypt,
   ratchetDecryptPreview,
+  ratchetEncryptWithPreview,
   type RatchetState,
   type Header,
 } from './ratchet';
@@ -370,6 +371,28 @@ export function sealMessage(
   ad: Uint8Array = new Uint8Array(0),
 ): WireMessage {
   return ratchetEncrypt(state, utf8ToBytes(JSON.stringify(payload)), ad);
+}
+
+/**
+ * Spec 1055: seal a message AND a bounded display preview in one chain step. The
+ * `previewPayload` (built by buildPreview) is sealed under a domain-separated key
+ * derived from the same message key, header bound as AAD, and rides in the Web Push
+ * so the recipient SW shows a rich notification without a fetch. Advances the ratchet
+ * exactly once — the send path calls THIS or sealMessage, never both.
+ */
+export function sealMessageWithPreview(
+  state: RatchetState,
+  payload: MessagePayload,
+  previewPayload: MessagePayload,
+  ad: Uint8Array = new Uint8Array(0),
+): { wire: WireMessage; previewEnv: Envelope } {
+  const { header, env, previewEnv } = ratchetEncryptWithPreview(
+    state,
+    utf8ToBytes(JSON.stringify(payload)),
+    utf8ToBytes(JSON.stringify(previewPayload)),
+    ad,
+  );
+  return { wire: { header, env }, previewEnv };
 }
 
 /** Decrypt a wire message; mutates `state`. Throws if it doesn't authenticate. */

--- a/src/services/crypto/push-preview.test.ts
+++ b/src/services/crypto/push-preview.test.ts
@@ -1,0 +1,156 @@
+// Spec 1055 — the bounded push-preview crypto: seal a display preview under a
+// per-message key derived from the ratchet message key, peek-decrypt it without
+// consuming ratchet state, and lose the ability to decrypt it once the message is
+// opened authoritatively (forward secrecy). Plus buildPreview's bounding rules.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ready } from './primitives';
+import { utf8ToBytes, bytesToUtf8 } from './envelope';
+import {
+  x3dhInitiator,
+  x3dhResponder,
+  ratchetInitAlice,
+  ratchetInitBob,
+  ratchetEncryptWithPreview,
+  ratchetOpenPreview,
+  sessionRecord,
+  sessionFromRecord,
+  type RatchetState,
+} from './ratchet';
+import { openMessage, type MessagePayload } from './message';
+import { generateIdentityMaterial, type SecretBundle } from './identity';
+import { buildPreview, truncateUtf8, PREVIEW_BODY_BUDGET } from './push-preview';
+import { notifyPreview } from '@/utils/notify-preview';
+
+beforeAll(async () => {
+  await ready();
+});
+
+function setupPair(): { alice: RatchetState; bob: RatchetState; ad: Uint8Array } {
+  const a: SecretBundle = generateIdentityMaterial(2);
+  const b: SecretBundle = generateIdentityMaterial(2);
+  const init = x3dhInitiator(a.x.privateKey, {
+    identityX: b.x.publicKey,
+    signedPreKey: b.signedPreKey.keypair.publicKey,
+    oneTimePreKey: b.oneTimePreKeys[0].keypair.publicKey,
+  });
+  const bobSK = x3dhResponder({
+    identityXPriv: b.x.privateKey,
+    signedPreKeyPriv: b.signedPreKey.keypair.privateKey,
+    oneTimePreKeyPriv: b.oneTimePreKeys[0].keypair.privateKey,
+    initiatorIdentityX: a.x.publicKey,
+    initiatorEphemeral: init.ephemeral.publicKey,
+  });
+  const alice = ratchetInitAlice(init.sk, b.signedPreKey.keypair.publicKey);
+  const bob = ratchetInitBob(bobSK, b.signedPreKey.keypair);
+  return { alice, bob, ad: utf8ToBytes('alice|bob') };
+}
+
+const full = (body: string): MessagePayload => ({ body, kind: 'text', timestamp: 1 });
+const clone = (s: RatchetState) => sessionFromRecord(sessionRecord('c', s)); // fresh, discardable copy
+const sealBoth = (alice: RatchetState, payload: MessagePayload, preview: MessagePayload, ad: Uint8Array) =>
+  ratchetEncryptWithPreview(alice, utf8ToBytes(JSON.stringify(payload)), utf8ToBytes(JSON.stringify(preview)), ad);
+
+describe('spec 1055: ratchet push-preview seal/open', () => {
+  it('peek-decrypts the preview AND opens the full message from one chain step', () => {
+    const { alice, bob, ad } = setupPair();
+    const payload = full('the full message body');
+    const { header, env, previewEnv } = sealBoth(alice, payload, buildPreview(payload), ad);
+    // Peek the preview on a discarded copy — the real bob state is untouched.
+    const preview = JSON.parse(bytesToUtf8(ratchetOpenPreview(clone(bob), header, previewEnv, ad))) as MessagePayload;
+    expect(preview.body).toBe('the full message body');
+    // The full message still opens authoritatively.
+    expect(openMessage(bob, { header, env }, ad).body).toBe('the full message body');
+  });
+
+  it('peek consumes nothing: the same message opens authoritatively afterwards', () => {
+    const { alice, bob, ad } = setupPair();
+    const { header, env, previewEnv } = sealBoth(alice, full('hi'), buildPreview(full('hi')), ad);
+    // Peek repeatedly on copies — bob is never mutated.
+    ratchetOpenPreview(clone(bob), header, previewEnv, ad);
+    ratchetOpenPreview(clone(bob), header, previewEnv, ad);
+    expect(openMessage(bob, { header, env }, ad).body).toBe('hi'); // still decrypts
+  });
+
+  it('a preview sealed for one frame cannot be opened against a different frame (header-bound AAD)', () => {
+    const { alice, bob, ad } = setupPair();
+    const m1 = sealBoth(alice, full('one'), buildPreview(full('one')), ad);
+    const m2 = sealBoth(alice, full('two'), buildPreview(full('two')), ad);
+    // m2's preview envelope opened with m1's header must fail (wrong key AND wrong AAD).
+    expect(() => ratchetOpenPreview(clone(bob), m1.header, m2.previewEnv, ad)).toThrow();
+  });
+
+  it('FORWARD SECRECY (SC-006): once the message is opened authoritatively, the preview is undecryptable', () => {
+    const { alice, bob, ad } = setupPair();
+    const { header, env, previewEnv } = sealBoth(alice, full('secret'), buildPreview(full('secret')), ad);
+    // Before authoritative open: a fresh copy CAN peek the preview.
+    expect(JSON.parse(bytesToUtf8(ratchetOpenPreview(clone(bob), header, previewEnv, ad))).body).toBe('secret');
+    // Authoritative open consumes mk_N and advances the chain past it.
+    openMessage(bob, { header, env }, ad);
+    // A fresh copy of the now-advanced state can no longer derive mk_N → preview is dead.
+    expect(() => ratchetOpenPreview(clone(bob), header, previewEnv, ad)).toThrow();
+  });
+});
+
+describe('spec 1055: truncateUtf8', () => {
+  it('leaves a short string untouched', () => {
+    expect(truncateUtf8('hello', 256)).toBe('hello');
+  });
+  it('truncates a long ASCII string to the byte budget', () => {
+    const long = 'a'.repeat(1000);
+    const out = truncateUtf8(long, 256);
+    expect(new TextEncoder().encode(out).length).toBeLessThanOrEqual(256);
+    expect(out.length).toBe(256); // ASCII: 1 byte per char
+  });
+  it('never splits a multi-byte character (emoji stays whole)', () => {
+    const emoji = '😀'.repeat(200); // 4 bytes each
+    const out = truncateUtf8(emoji, 10); // fits exactly 2 emoji (8 bytes), not a partial 3rd
+    expect(new TextEncoder().encode(out).length).toBeLessThanOrEqual(10);
+    expect([...out].every((c) => c === '😀')).toBe(true); // no mojibake / lone surrogate
+  });
+});
+
+describe('spec 1055: buildPreview', () => {
+  it('truncates the body to the byte budget', () => {
+    const p = buildPreview(full('x'.repeat(1000)));
+    expect(new TextEncoder().encode(p.body).length).toBeLessThanOrEqual(PREVIEW_BODY_BUDGET);
+  });
+
+  it('drops the media reference entirely (no file key, no poster leaks in the push)', () => {
+    const p = buildPreview({
+      body: '',
+      kind: 'image',
+      timestamp: 1,
+      mediaRef: { blobId: 'b', fileKey: 'SECRET_KEY', mime: 'image/jpeg', size: 9, name: 'p.jpg', poster: 'data:...' },
+    });
+    expect(p.mediaRef).toBeUndefined();
+    // The notification still renders a kind label from `kind` alone.
+    expect(notifyPreview(p)).toBe('Photo');
+  });
+
+  it('shrinks structured fields to just what the notification renders', () => {
+    const p = buildPreview({
+      body: '',
+      kind: 'poll',
+      timestamp: 1,
+      poll: { question: 'Lunch?', options: [{ id: '1', text: 'Pizza' }], votes: {} } as unknown as MessagePayload['poll'],
+    });
+    expect(p.poll).toEqual({ question: 'Lunch?' });
+    expect(notifyPreview(p)).toBe('Poll: Lunch?');
+  });
+
+  it('keeps routing + escalation fields the renderer needs', () => {
+    const p = buildPreview({
+      body: 'hey @you',
+      kind: 'text',
+      timestamp: 1,
+      groupId: 'g1',
+      prid: 'route',
+      mentions: ['u2'],
+      reply: { senderId: 'u2', messageId: 'm', body: 'quoted body that should be dropped' } as unknown as MessagePayload['reply'],
+    });
+    expect(p.groupId).toBe('g1');
+    expect(p.prid).toBe('route');
+    expect(p.mentions).toEqual(['u2']);
+    expect(p.reply).toEqual({ senderId: 'u2' }); // quoted body dropped
+  });
+});

--- a/src/services/crypto/push-preview.ts
+++ b/src/services/crypto/push-preview.ts
@@ -1,0 +1,99 @@
+/**
+ * Spec 1055 — bounded encrypted PREVIEW for the ciphertext-in-push notification path.
+ *
+ * The sender builds a small, display-sized preview of a message (buildPreview),
+ * seals it under a per-message key derived from the ratchet message key
+ * (sealMessageWithPreview → ratchetEncryptWithPreview), and attaches it to the Web
+ * Push. The recipient service worker PEEK-decrypts it (openPushPreview) against a
+ * discarded session copy — no persist, no store, no ack — and renders a rich
+ * notification with no /relay/pending fetch. The full message still relays and is
+ * stored authoritatively over WebSocket on app open.
+ *
+ * Bounded by design: notification UIs truncate to ~200 chars on every platform and
+ * the push stores nothing, so the preview carries only what the notification renderer
+ * (notifyPreview / noteForPayload) reads. The free-text body is truncated to a UTF-8
+ * byte budget, and large / sensitive fields — the media reference (incl. the file KEY
+ * and the poster thumbnail), inline link previews, poll options, and game board state
+ * — are dropped entirely. The SW never decrypts media from a push.
+ */
+import type { MessagePayload } from './message';
+import type { Header } from './ratchet';
+import { ratchetOpenPreview, loadSession } from './ratchet';
+import { bytesToUtf8, type Envelope } from './envelope';
+
+/** UTF-8 byte budget for the preview's free text. ~256 B overfills the visible area
+ *  on every platform (iOS/iPadOS ~150–250 chars, Android/desktop less); the constant
+ *  push padding (server-side RecordSize) makes the encrypted payload size uniform. */
+export const PREVIEW_BODY_BUDGET = 256;
+
+/** Truncate a string to at most `budget` UTF-8 bytes, never splitting a character
+ *  (or a surrogate pair) — so an emoji / non-Latin body cannot overflow the budget. */
+export function truncateUtf8(s: string, budget: number): string {
+  const enc = new TextEncoder();
+  if (enc.encode(s).length <= budget) return s;
+  // Trim by code points until it fits; [...s] iterates whole code points (surrogate-safe).
+  const cps = [...s];
+  let out = '';
+  for (const cp of cps) {
+    if (enc.encode(out + cp).length > budget) break;
+    out += cp;
+  }
+  return out;
+}
+
+/**
+ * Build a bounded, display-only preview payload from a full message payload. Keeps
+ * only the fields the notification renderer reads; truncates the free text; drops or
+ * shrinks large / sensitive fields. Pure — applies nothing recipient-specific (the
+ * recipient's mute/hidden/preview prefs are enforced at render, in noteForPayload).
+ */
+export function buildPreview(p: MessagePayload): MessagePayload {
+  const preview: MessagePayload = { ...p };
+
+  // The one unbounded field: truncate to the byte budget on a character boundary.
+  if (typeof preview.body === 'string') preview.body = truncateUtf8(preview.body, PREVIEW_BODY_BUDGET);
+  if (typeof preview.albumName === 'string') preview.albumName = truncateUtf8(preview.albumName, PREVIEW_BODY_BUDGET);
+
+  // Drop large / sensitive fields the notification never needs. notifyPreview reads
+  // only `kind`/`videoNote` for media, so the whole media reference — including the
+  // per-file KEY and the poster thumbnail data-URL — is dropped; the SW never
+  // decrypts media from a push. Inline link previews carry a data-URL image too.
+  delete preview.mediaRef;
+  delete preview.linkPreview;
+
+  // Shrink structured fields to the single string the preview renders (drops poll
+  // options/votes, game board state, location coordinates, full contact/audio detail).
+  // The renderer reads these via optional chaining, so a partial object is safe.
+  if (preview.poll) preview.poll = { question: preview.poll.question } as MessagePayload['poll'];
+  if (preview.game) preview.game = { gameType: preview.game.gameType } as MessagePayload['game'];
+  if (preview.gameChallenge) {
+    preview.gameChallenge = { gameType: preview.gameChallenge.gameType } as MessagePayload['gameChallenge'];
+  }
+  if (preview.location) preview.location = { label: preview.location.label } as MessagePayload['location'];
+  if (preview.contact) preview.contact = { name: preview.contact.name } as MessagePayload['contact'];
+  if (preview.audio) preview.audio = { title: preview.audio.title } as MessagePayload['audio'];
+  // Reply: keep only the quoted author id (reply-to-me detection); drop the quoted body.
+  if (preview.reply) preview.reply = { senderId: preview.reply.senderId } as MessagePayload['reply'];
+
+  return preview;
+}
+
+/**
+ * Recipient PEEK: open a push preview for `chatId` from its ratchet header + preview
+ * envelope. Loads a FRESH session copy and never saves it — advancing the ratchet on
+ * that copy is discarded, so this consumes nothing (no persist, no store, no ack).
+ * Throws on decrypt failure (out-of-order ratchet the device is behind, header
+ * mismatch, missing session) — the SW then falls back to a placeholder. Returns null
+ * if there is no session for the chat.
+ */
+export async function openPushPreview(
+  chatId: string,
+  header: Header,
+  previewEnv: Envelope,
+  ad: Uint8Array = new Uint8Array(0),
+): Promise<MessagePayload | null> {
+  const session = await loadSession(chatId);
+  if (!session) return null;
+  const pt = ratchetOpenPreview(session, header, previewEnv, ad);
+  return JSON.parse(bytesToUtf8(pt)) as MessagePayload;
+}

--- a/src/services/crypto/ratchet.ts
+++ b/src/services/crypto/ratchet.ts
@@ -64,6 +64,16 @@ function msgKey(mk: Uint8Array): Uint8Array {
   return hkdf(mk, KEY_BYTES, new Uint8Array(32), utf8ToBytes('ring/dr/msg'));
 }
 
+// Message key -> AEAD content key for the spec-1055 push PREVIEW. Domain-separated
+// from msgKey ('ring/dr/msg') so the preview and the message never share a content
+// key: the sender seals a bounded display preview under THIS key alongside the full
+// message under msgKey, both from the same chain message key mk. Forward secrecy is
+// inherited — mk is deleted when the message is opened authoritatively, after which a
+// captured preview push (which never persisted anything) can no longer be decrypted.
+function previewKey(mk: Uint8Array): Uint8Array {
+  return hkdf(mk, KEY_BYTES, new Uint8Array(32), utf8ToBytes('ring/push-preview/v1'));
+}
+
 /* ---- X3DH ---- */
 
 export interface PreKeyBundlePub {
@@ -208,29 +218,31 @@ export function ratchetDecrypt(
  * Net effect: forward progress is persisted, but nothing this preview reads becomes
  * undecryptable for the authoritative receiver — it only ever ADDS to the cache.
  */
-export function ratchetDecryptPreview(
-  state: RatchetState,
-  header: Header,
-  env: Envelope,
-  ad: Uint8Array,
-): { plaintext: Uint8Array; advancedDh: boolean } {
+/**
+ * Peek-derive the chain message key `mk` for `header` WITHOUT consuming it: leaves
+ * the key retrievable in the skipped-key cache (the Double Ratchet's normal
+ * out-of-order mechanism) so a later authoritative openMessage of that very message
+ * re-finds it. Shared by ratchetDecryptPreview (message env) and ratchetOpenPreview
+ * (spec-1055 push preview env), which differ only in WHICH envelope they open with
+ * the derived key. Mutates `state` (advances the receiving chain / may DH-ratchet);
+ * callers that must not persist run it on a fresh, discarded session copy.
+ *
+ * `advancedDh` reports whether a DH-ratchet step was taken. A DH ratchet mints a
+ * FRESH sending keypair (DHs); a service-worker caller must NOT persist that, or the
+ * SW becomes a competing writer of the SENDING key and the page↔SW last-write-wins
+ * race can clobber the page's authoritative send-state. So SW callers persist ONLY
+ * same-chain advances (advancedDh === false): those are deterministic and purely
+ * ADDITIVE to the skipped-key cache, hence safe to converge via LWW.
+ */
+function deriveMessageKey(state: RatchetState, header: Header): { mk: Uint8Array; advancedDh: boolean } {
   const skKey = `${header.dh}:${header.n}`;
-  // Already in the cache (skipped over earlier): decrypt WITHOUT deleting, so the
-  // key stays available for the page's authoritative open. No DH step taken.
+  // Already in the cache (skipped over earlier): return WITHOUT deleting, so the key
+  // stays available for the page's authoritative open. No DH step taken.
   const cached = state.skipped.get(skKey);
-  if (cached) return { plaintext: open(msgKey(cached), env, concat(ad, headerBytes(header))), advancedDh: false };
+  if (cached) return { mk: cached, advancedDh: false };
   // Otherwise advance the receiving chain up to AND INCLUDING this message, caching
-  // every key (including this one) via skipMessageKeys. We deliberately reuse the
-  // skip path for header.n+1 so the current message's key lands in `skipped` rather
-  // than being consumed, then read it back from there.
-  //
-  // `advancedDh` reports whether we had to take a DH-ratchet step. A DH ratchet mints
-  // a FRESH sending keypair (DHs); the caller (previewPacket) must NOT persist that
-  // from the service worker, or the SW becomes a competing writer of the SENDING key
-  // and the page↔SW last-write-wins race can clobber the page's authoritative
-  // send-state (permanent outbound divergence — adversarial review). So the caller
-  // persists ONLY same-chain advances (advancedDh === false): those are deterministic
-  // and purely ADDITIVE to the skipped-key cache, hence safe to converge via LWW.
+  // every key (including this one) via skipMessageKeys, then read it back — never
+  // consuming it.
   const headerDh = b64urlToBytes(header.dh);
   let advancedDh = false;
   if (!state.DHr || !equalBytes(headerDh, state.DHr)) {
@@ -241,7 +253,61 @@ export function ratchetDecryptPreview(
   skipMessageKeys(state, header.n + 1); // caches keys Nr..n (incl. this message)
   const mk = state.skipped.get(skKey);
   if (!mk) throw new Error('preview: message key not derivable'); // unreachable in practice
+  return { mk, advancedDh };
+}
+
+export function ratchetDecryptPreview(
+  state: RatchetState,
+  header: Header,
+  env: Envelope,
+  ad: Uint8Array,
+): { plaintext: Uint8Array; advancedDh: boolean } {
+  const { mk, advancedDh } = deriveMessageKey(state, header);
   return { plaintext: open(msgKey(mk), env, concat(ad, headerBytes(header))), advancedDh };
+}
+
+/**
+ * Spec 1055 (sender): seal the full message under the message key AND a bounded
+ * display PREVIEW under a domain-separated key derived from the SAME chain message
+ * key mk — one chain step, two AEADs. Both bind the ratchet header as associated
+ * data, so a sealed preview cannot be swapped onto, or replayed against, a different
+ * frame. Mutates `state` exactly like ratchetEncrypt (advances the sending chain
+ * once); the send path calls THIS or ratchetEncrypt for a message, never both.
+ */
+export function ratchetEncryptWithPreview(
+  state: RatchetState,
+  plaintext: Uint8Array,
+  previewPlaintext: Uint8Array,
+  ad: Uint8Array,
+): { header: Header; env: Envelope; previewEnv: Envelope } {
+  if (!state.CKs) throw new Error('ratchet has no sending chain yet');
+  const [CKs, mk] = kdfCK(state.CKs);
+  state.CKs = CKs;
+  const header: Header = { dh: bytesToB64url(state.DHs.publicKey), pn: state.PN, n: state.Ns };
+  state.Ns += 1;
+  const aad = concat(ad, headerBytes(header));
+  const env = seal(msgKey(mk), plaintext, 'dr', aad);
+  const previewEnv = seal(previewKey(mk), previewPlaintext, 'pp', aad);
+  return { header, env, previewEnv };
+}
+
+/**
+ * Spec 1055 (recipient PEEK): derive mk for `header` and open the push PREVIEW
+ * envelope with the preview key. Consumes nothing durable — like ratchetDecryptPreview
+ * it only ADDS to the skipped-key cache; the caller runs it on a freshly loaded,
+ * to-be-discarded session copy and never persists. Forward secrecy: once the message
+ * is opened authoritatively (mk consumed, chain advanced past it), a fresh copy can
+ * no longer derive mk, so this throws — a captured preview push becomes undecryptable.
+ * Throws on a header mismatch or auth failure; the SW then falls back to a placeholder.
+ */
+export function ratchetOpenPreview(
+  state: RatchetState,
+  header: Header,
+  previewEnv: Envelope,
+  ad: Uint8Array,
+): Uint8Array {
+  const { mk } = deriveMessageKey(state, header);
+  return open(previewKey(mk), previewEnv, concat(ad, headerBytes(header)));
 }
 
 function skipMessageKeys(state: RatchetState, until: number): void {

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -28,7 +28,10 @@ import {
   type RatchetState,
   type PreKeyBundlePub,
 } from './crypto/ratchet';
-import { sealMessage, openMessage, openMessagePreview, type MessagePayload, type WireMessage } from './crypto/message';
+import { sealMessage, sealMessageWithPreview, openMessage, openMessagePreview, type MessagePayload, type WireMessage } from './crypto/message';
+import { buildPreview } from './crypto/push-preview';
+import type { Envelope } from './crypto/envelope';
+import type { Header } from './crypto/ratchet';
 import { sessionRecord, type SerializedSession } from './crypto/ratchet';
 import { withSessionLock, LockTimeoutError } from './cross-lock';
 import {
@@ -113,12 +116,20 @@ export async function clearSession(chatId: string): Promise<void> {
  * the recipient + wire packet to relay. Returns null when the message can't be
  * sent remotely (group chat, or a local-only/demo contact with no account).
  */
+/** Spec 1055: the sealed push preview that rides in the Web Push. Carries the ratchet
+ *  header (so the recipient SW can peek-derive the message key) plus the preview AEAD.
+ *  Opaque to the server, which forwards it verbatim into the (RFC-8291-encrypted) push. */
+export interface PushPreview {
+  h: Header;
+  p: Envelope;
+}
+
 export async function sealForChat(
   chatId: string,
   peerUserId: string,
   isGroup: boolean,
   payload: MessagePayload,
-): Promise<{ to: string; packet: WirePacket } | null> {
+): Promise<{ to: string; packet: WirePacket; pushPreview: PushPreview } | null> {
   if (isGroup) return null; // group messaging (sender keys) is not relay-wired yet
   // Serialize the whole load→advance→save (incl. first-use X3DH bootstrap) per chat so
   // concurrent seals/opens — in THIS context and in the SW — can't corrupt the ratchet.
@@ -159,14 +170,17 @@ export async function sealForChat(
     await setSessionMeta(chatId, meta);
   }
 
-  const wire = sealMessage(session, payload);
+  // Spec 1055: seal the message AND a bounded display preview in one ratchet step.
+  // The preview rides in the Web Push so the recipient shows a rich notification with
+  // no fetch; the full message still relays for the authoritative store on open.
+  const { wire, previewEnv } = sealMessageWithPreview(session, payload, buildPreview(payload));
   await saveSession(chatId, session);
 
   const packet: WirePacket =
     meta?.sendPreamble && meta.preamble
       ? { v: 1, type: 'prekey', ...meta.preamble, msg: wire }
       : { v: 1, type: 'normal', msg: wire };
-  return { to: peerUserId, packet };
+  return { to: peerUserId, packet, pushPreview: { h: wire.header, p: previewEnv } };
   });
 }
 

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -29,6 +29,9 @@ import { attemptDeviceUnlock, getIdentityKeys } from './crypto/identity';
 import { ready as sodiumReady } from './crypto/primitives';
 import { openPostEngagement, openReceivedPost } from './posts';
 import { previewPacket } from './messaging';
+import { openPushPreview } from './crypto/push-preview';
+import type { Header } from './crypto/ratchet';
+import type { Envelope } from './crypto/envelope';
 import { readHiddenSet, readHiddenSetOrNull } from './hidden-chats';
 import { readSessionToken, readSessionUserId } from './session';
 import { get, getAll, put } from '@/db/idb';
@@ -1002,6 +1005,25 @@ export async function ackCall(): Promise<void> {
   }
 }
 
+/** Spec 1055: tell the server this device SHOWED a push preview for `id` (the recipient
+ *  has SEEN it but not durably downloaded). The server stamps notified_at and relays a
+ *  `notified` receipt to the sender — WITHOUT dequeuing (the full message is still owed).
+ *  Fires on decrypt regardless of the display outcome, so it never leaks mute/hidden.
+ *  Best-effort: a dropped notified is superseded by the later `delivered`. */
+export async function postNotified(id: string): Promise<void> {
+  const token = await readSessionToken();
+  if (!token || !id) return;
+  try {
+    await fetch(`${API}/relay/notified`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [id] }),
+    });
+  } catch {
+    /* best-effort: the sender still flips to "delivered" on the durable receipt */
+  }
+}
+
 /** Fetch the queued (undelivered) frames. Fetching is what tells the server the
  *  device received them (→ "delivered" receipts), so callers do it before any
  *  decryption or settings gate. Bounded so a cold-start fetch can't hang the
@@ -1210,6 +1232,94 @@ export async function previewPending(): Promise<PreviewResult> {
     reason,
     ...(callEvents.length ? { callEvents } : {}),
   };
+}
+
+/* ---- spec 1055: inline preview (rich notification from the push, no fetch) ---- */
+
+/** The bounded preview carried in a spec-1055 push: the frame id + sender (to address
+ *  the notification + resolve the session) and the sealed preview ({ h, p }). */
+export interface InlinePreview {
+  id: string;
+  from: string;
+  h: Header;
+  p: Envelope;
+}
+
+export interface InlineResult {
+  notes: SwNote[];
+  suppressed: boolean; // "Show notifications" off → caller shows nothing, no placeholder
+  silenced: boolean; // per-chat mute/off silenced it → caller shows nothing
+  ok: boolean; // decrypt succeeded; false → caller falls back to the show-first placeholder
+}
+
+/**
+ * Render a rich notification from a bounded preview carried IN the push — no
+ * /relay/pending fetch. Peek-decrypts the preview (openPushPreview loads a fresh
+ * session copy and NEVER persists — consumes nothing), then runs the SAME
+ * noteForPayload render as the fetch path, with the recipient's OWN prefs + hidden set
+ * (so a hidden chat → generic, "Show preview" off → hidden sender/body, muted →
+ * silenced — identical to today). `ok:false` (locked / decrypt failure) tells the
+ * caller to fall back to the spec-2048 show-first placeholder; it never ends silently.
+ */
+export async function previewInline(frame: InlinePreview): Promise<InlineResult> {
+  const miss = (ok: boolean): InlineResult => ({ notes: [], suppressed: false, silenced: false, ok });
+  if (!(await attemptDeviceUnlock().catch(() => false))) return miss(false); // PIN-locked → generic
+  const showMessages = await setting<boolean>('notifications.message.show', true);
+  const showGroups = await setting<boolean>('notifications.group.show', true);
+  const showPreview = await setting<boolean>('notifications.showPreview', true);
+  const [chats, contacts, hidden, selfId] = await Promise.all([
+    getAll<Chat>('chats'),
+    getAll<Contact>('contacts'),
+    readHiddenSet(), // spec 1019: hidden chats get a generic, content-free notification
+    readSessionUserId(), // spec 1020: "am I @mentioned?"
+  ]);
+
+  let payload: MessagePayload;
+  try {
+    const decrypted = await openPushPreview(sessionKeyForPeer(chats, frame.from), frame.h, frame.p);
+    if (!decrypted) return miss(false); // no session yet → generic, rich on open
+    payload = decrypted;
+  } catch (e) {
+    console.warn('[sw-inbox] inline preview decrypt failed → show-first fallback', e);
+    return miss(false);
+  }
+
+  const f: MsgFrame = { t: 'msg', id: frame.id, from: frame.from };
+  // Game / reaction context: the same read-only store prefetch previewPending does, so
+  // move/reaction notifications read identically on the inline path. IDB reads are fast
+  // (the slow /relay/pending fetch is what we removed), so a modern device stays inside
+  // its window; an unresolved target just falls back to the generic mover/silent-reaction.
+  const gameTargetId = payload.gameMove?.messageId ?? payload.gameAccept?.messageId;
+  const gameCtx = gameTargetId
+    ? {
+        row: await get<Message>('messages', gameTargetId),
+        prefs: {
+          turn: await setting<boolean>('notifications.games.turn', true),
+          challenges: await setting<boolean>('notifications.games.challenges', true),
+          followMoves: await setting<boolean>('notifications.games.followMoves', true),
+          followResults: await setting<boolean>('notifications.games.followResults', true),
+        },
+        follows: await setting<Record<string, number>>('games.follows', {}),
+      }
+    : undefined;
+  const reactionCtx = payload.reaction
+    ? {
+        row: await get<Message>('messages', payload.reaction.messageId),
+        prefs: {
+          dm: await setting<boolean>('notifications.message.reactions', true),
+          group: await setting<boolean>('notifications.group.reactions', true),
+          tone: await setting<string>('notifications.reactions.sound', 'pop'),
+        },
+      }
+    : undefined;
+
+  const { note, wasMessage, silenced } = noteForPayload(
+    f, payload, chats, contacts, showMessages, showPreview, hidden, selfId ?? '', gameCtx, reactionCtx, { showGroups },
+  );
+  if (note) return { notes: aggregate([note]), suppressed: false, silenced: false, ok: true };
+  if (silenced) return { notes: [], suppressed: false, silenced: true, ok: true }; // muted → nothing
+  if (wasMessage && !showMessages) return { notes: [], suppressed: true, silenced: false, ok: true };
+  return { notes: [], suppressed: false, silenced: false, ok: true }; // side-effect only → nothing to show
 }
 
 /* ---- call-event support for the SW (spec 1040) ---- */

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -110,9 +110,14 @@ async function mutateMessage(
 /** Apply one inbound frame to local storage. */
 export async function handleIncomingFrame(frame: Frame): Promise<void> {
   switch (frame.t) {
-    case 'receipt':
-      await applyReceipt(frame.messageId, frame.status, frame.at, frame.from);
+    case 'receipt': {
+      // (spec 1055) To the sender, a "notified" receipt (the recipient showed a push
+      // preview) means the same as "delivered" (they were reached) — the split exists
+      // only so the server knows the full message is still owed to the device.
+      const status = frame.status === 'notified' ? 'delivered' : frame.status;
+      await applyReceipt(frame.messageId, status, frame.at, frame.from);
       return;
+    }
     case 'records':
       if (frame.store) await mergeRecords(frame.store as StoreName, frame.rows as MergeRow[]);
       if (frame.cursor) await setSyncCursor(frame.cursor);

--- a/src/services/transport.ts
+++ b/src/services/transport.ts
@@ -28,13 +28,22 @@ export interface MsgFrame {
   // blind relay can gate the push tickle; they never affect delivery.
   class?: string;
   prid?: string;
+  // spec 1055: sealed bounded preview ({ h: ratchet header, p: preview AEAD }) for
+  // the ciphertext-in-push notification path. Opaque to the transport and the server
+  // (E2EE to the recipient device); forwarded into the RFC-8291-encrypted Web Push so
+  // the recipient SW shows a rich notification with no fetch. Absent for frames the
+  // sender chose not to preview (e.g. some housekeeping seals).
+  pushPreview?: unknown;
 }
 export interface ReceiptFrame {
   t: 'receipt';
   messageId: string;
   // 'downloaded' is recipient-originated like 'seen', but signals the media bytes are on
   // their device (not a UI tick) so the sender can delete the server blob.
-  status: 'sent' | 'delivered' | 'seen' | 'downloaded';
+  // 'notified' (spec 1055): the recipient showed a push preview but hasn't durably
+  // downloaded yet — to the sender it renders the same as 'delivered' (reached them),
+  // the split is only for the server to know what's still owed.
+  status: 'sent' | 'delivered' | 'seen' | 'downloaded' | 'notified';
   at: number;
   to?: string; // recipient (for client-originated seen receipts; routed by the server)
   from?: string; // server 'sent'/'delivered' receipts: WHICH recipient confirmed it

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -28,7 +28,8 @@ import {
   isLegacyIOS, withTimeout, fetchPendingFrames, richNoteOptions, shouldShowPlaceholderFirst,
   previewCallRing, recordCallTickle, recordCallOutcome, withdrawCallBadgeUnit, callBadgeCount,
   readRingShown, recordRingShown, clearRingShown,
-  type SwNote, type ConnNote,
+  previewInline, loadShown, postNotified,
+  type SwNote, type ConnNote, type InlinePreview,
 } from '@/services/sw-inbox';
 import type { CallEventSignal } from '@/services/crypto/message';
 import { readSessionToken } from '@/services/session';
@@ -451,14 +452,25 @@ async function updateAppBadge(newCount: number): Promise<void> {
  *  payload, is treated as a message). 'post-activity' (spec 1031) is the one tickle
  *  that carries data: the id of OUR post that received engagement — returned as
  *  `post` so the handler can pull exactly that post's engagement. */
-function pushKind(event: PushEvent): { kind: 'call' | 'msg' | 'conn' | 'post' | 'post-activity' | 'version'; post?: string } {
+function pushKind(event: PushEvent): {
+  kind: 'call' | 'msg' | 'msgx' | 'conn' | 'post' | 'post-activity' | 'version';
+  post?: string;
+  inline?: InlinePreview;
+} {
   try {
-    const data = event.data?.json() as { t?: string; post?: string } | undefined;
+    const data = event.data?.json() as
+      | { t?: string; post?: string; id?: string; from?: string; pv?: { h: unknown; p: unknown } }
+      | undefined;
     if (data?.t === 'call') return { kind: 'call' };
     if (data?.t === 'conn') return { kind: 'conn' };
     if (data?.t === 'post') return { kind: 'post' };
     if (data?.t === 'post-activity') return { kind: 'post-activity', post: data.post };
     if (data?.t === 'version') return { kind: 'version' };
+    // (spec 1055) Inline preview: a rich notification is decryptable from the push
+    // body itself — no fetch. Malformed → fall through to the plain message tickle.
+    if (data?.t === 'msgx' && data.id && data.from && data.pv) {
+      return { kind: 'msgx', inline: { id: data.id, from: data.from, h: data.pv.h as InlinePreview['h'], p: data.pv.p as InlinePreview['p'] } };
+    }
   } catch {
     /* not JSON → treat as a message */
   }
@@ -610,8 +622,14 @@ async function tryAuthoritativeDrain(ctx: WakeCtx): Promise<boolean> {
       // path owns the nothing-new / re-assert behavior (spec 2016/2017).
       let accepted = 0;
       if (r.notes.length) {
-        await closeByTag(GENERIC_TAG);
-        accepted = await showNotes(r.notes);
+        // (spec 1055 FR-012) Don't re-notify a message the inline preview already showed
+        // (or a prior wake surfaced): the warm still persists + acks it below, silently.
+        const seen = new Set(await loadShown());
+        const fresh = r.notes.filter((n) => n.ids.some((id) => !seen.has(id)));
+        if (fresh.length) {
+          await closeByTag(GENERIC_TAG);
+          accepted = await showNotes(fresh);
+        }
       }
       // Mark applied frames in the preview ledger too: if the ack below fails they
       // linger in the queue, and the preview path must not re-decrypt them (their
@@ -951,7 +969,7 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
       // background if the DB later frees up).
       await Promise.race([stampPushWake(), new Promise((r) => setTimeout(r, 1500))]);
       const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
-      const { kind, post } = pushKind(event);
+      const { kind, post, inline } = pushKind(event);
       // (spec 2044) Legacy iOS (<= 16) takes the LITE wake: show first, decrypt never.
       // On that tier the SW's network layer works (delivered receipts prove the queue
       // fetch succeeds) but IndexedDB transactions and the decrypt/present pipeline
@@ -959,7 +977,49 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
       // subscription was dead within a burst. The gate is a pure UA parse that fails
       // toward modern, so devices on iOS 17+ never enter this branch.
       if (isLegacyIOS(self.navigator.userAgent)) {
-        await dispatchLiteWake(kind, clients, ctx);
+        // Legacy never decrypts (incl. the inline preview) — the lite path shows a
+        // generic first; a 'msgx' wake is just a message there.
+        await dispatchLiteWake(kind === 'msgx' ? 'msg' : kind, clients, ctx);
+        return;
+      }
+      if (kind === 'msgx' && inline) {
+        // (spec 1055) The rich notification is decryptable from the push itself — show
+        // it WITHOUT any /relay/pending fetch, then best-effort warm the DB. Show first
+        // (the guaranteed, window-fitting part), warm second (pure upside), so a
+        // suspend during the warm can never cause a silent wake.
+        const result = await previewInline(inline);
+        if (result.ok && result.notes.length) {
+          await closeByTag(GENERIC_TAG); // in case a prior wake left a placeholder
+          const accepted = await showNotes(result.notes);
+          if (accepted > 0) {
+            ctx.shown = true;
+            await markShown(allIds(result.notes)); // so the warm/open path won't re-notify (FR-012)
+          }
+        } else if (result.ok && (result.silenced || result.suppressed)) {
+          // Muted / notifications-off: intentionally no content. On iOS the wake must
+          // still end visibly, so show the content-free quiet note unless a page is up.
+          ctx.shown = (await showQuietUnlessVisible('msg')) || ctx.shown;
+        } else {
+          // Locked / decrypt failure → spec-2048 show-first placeholder (rich on open).
+          try {
+            await showGeneric('inline-fallback');
+            ctx.shown = true;
+          } catch (e) {
+            console.warn('[sw] inline fallback placeholder failed', e);
+          }
+        }
+        ctx.satisfied = true;
+        // notified receipt: the device DECRYPTED the preview (regardless of display),
+        // so the sender flips to "delivered" now — fire-and-forget, no mute/hidden leak.
+        if (result.ok) void postNotified(inline.id);
+        // Best-effort warm tail (spec 1032, default-on for non-legacy): persist + ack so
+        // the app opens warm. Runs AFTER the show; self-gates on eligibility; on the
+        // inline path its notify step is deduped by the markShown above (FR-012).
+        try {
+          await tryAuthoritativeDrain(ctx);
+        } catch (e) {
+          console.warn('[sw] inline warm tail failed (DB warms on open)', e);
+        }
         return;
       }
       if (kind === 'call') {


### PR DESCRIPTION
## Release 1.0.10

Ships **spec 1055 — ciphertext-in-push**: the sender seals a bounded, display-sized preview of each message under a per-message key derived from the ratchet message key, and attaches it to the Web Push. The recipient's service worker peek-decrypts it and shows a **rich lock-screen notification with no fetch** — so a locked phone shows the real sender + preview instantly, even when the network fetch would have lost the race. The full message still relays and stores authoritatively over WebSocket on open; the push consumes nothing.

Zero-knowledge preserved and strengthened: constant-size padded pushes (message length hidden from the push service), no `Topic` header, forward-secret preview key, same `AllowPush` muting gate as the tickle, and privacy parity through the existing `noteForPayload` choke point (hidden/preview-off/muted all respected). New `notified` receipt lets the sender see "delivered" the moment the recipient's device shows the preview.

Follow-on to the 2043–2048 push-reliability arc.

Verified: full client suite (1205) + server suite + e2e green on the feature PR (#1060).

**Deferred to follow-up:** wall-post previews `postx` (#1057). **On-device verification** (#1058) happens on the cluster off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)