### PR TITLE
fix(notifications+chat): 1.0.11 — device-test fixes for inline previews + chat timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -651,8 +651,13 @@ async function tryAuthoritativeDrain(ctx: WakeCtx): Promise<boolean> {
       // owed. A failure of the quiet note itself is contained by this function's
       // catch, which degrades to the preview flow — whose own quiet terminal
       // propagates (FR-005 carve-out).
-      let shown = accepted > 0;
-      if (!r.notes.length || accepted === 0) shown = (await showQuietUnlessVisible('msg')) || shown;
+      // (spec 1055) If this wake ALREADY ended visibly — the inline-preview path showed
+      // a placeholder/rich note before running the warm as a tail — do NOT add a second
+      // (quiet) notification: that produced a rich + generic double on modern devices.
+      // The warm still persisted + acked above; only the extra visible note is dropped.
+      const already = ctx.shown;
+      let shown = accepted > 0 || already;
+      if (!already && (!r.notes.length || accepted === 0)) shown = (await showQuietUnlessVisible('msg')) || shown;
       // (spec 2043) A fully-handled drain always ends satisfied (shown or licensed).
       ctx.shown = shown;
       ctx.satisfied = true;
@@ -983,38 +988,51 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
         return;
       }
       if (kind === 'msgx' && inline) {
-        // (spec 1055) The rich notification is decryptable from the push itself — show
-        // it WITHOUT any /relay/pending fetch, then best-effort warm the DB. Show first
-        // (the guaranteed, window-fitting part), warm second (pure upside), so a
-        // suspend during the warm can never cause a silent wake.
-        const result = await previewInline(inline);
-        if (result.ok && result.notes.length) {
-          await closeByTag(GENERIC_TAG); // in case a prior wake left a placeholder
-          const accepted = await showNotes(result.notes);
-          if (accepted > 0) {
+        // (spec 1055) The rich notification is decryptable from the push itself, but the
+        // ORDER matters (device-tested): decrypting on a cold/locked SW (device unlock +
+        // session read + context) can be slow or fail, so we MUST show a placeholder
+        // FIRST (spec 2048 ordering) — a fast, guaranteed visible ending — then UPGRADE
+        // it to the rich preview in place when the in-push decrypt lands, and warm last.
+        //
+        // A focused+visible page owns the in-app alert — defer to it (no OS notification),
+        // mirroring the plain message path below.
+        if (!shouldShowPlaceholderFirst(clients) && (await pageWillNotify(clients, 2200))) {
+          const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+          if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) {
+            await showQuietNote('msg');
             ctx.shown = true;
-            await markShown(allIds(result.notes)); // so the warm/open path won't re-notify (FR-012)
           }
-        } else if (result.ok && (result.silenced || result.suppressed)) {
-          // Muted / notifications-off: intentionally no content. On iOS the wake must
-          // still end visibly, so show the content-free quiet note unless a page is up.
-          ctx.shown = (await showQuietUnlessVisible('msg')) || ctx.shown;
-        } else {
-          // Locked / decrypt failure → spec-2048 show-first placeholder (rich on open).
-          try {
-            await showGeneric('inline-fallback');
-            ctx.shown = true;
-          } catch (e) {
-            console.warn('[sw] inline fallback placeholder failed', e);
-          }
+          ctx.satisfied = true;
+          void postNotified(inline.id); // the device received it → sender sees "delivered"
+          return;
         }
-        ctx.satisfied = true;
-        // notified receipt: the device DECRYPTED the preview (regardless of display),
-        // so the sender flips to "delivered" now — fire-and-forget, no mute/hidden leak.
-        if (result.ok) void postNotified(inline.id);
-        // Best-effort warm tail (spec 1032, default-on for non-legacy): persist + ack so
-        // the app opens warm. Runs AFTER the show; self-gates on eligibility; on the
-        // inline path its notify step is deduped by the markShown above (FR-012).
+        // No focused page: show the generic placeholder NOW (before the decrypt), and tell
+        // the sender we received it — fired REGARDLESS of decrypt, so a locked device that
+        // cannot decrypt in the background still flips the sender to "delivered" (parity
+        // with the legacy lite path, which reports delivered on the buzz).
+        for (const client of clients) client.postMessage({ type: 'ring:drain' });
+        try {
+          await showGeneric('show-first');
+          ctx.shown = ctx.satisfied = true;
+        } catch (e) {
+          console.warn('[sw] inline show-first placeholder failed', e);
+        }
+        void postNotified(inline.id);
+        // UPGRADE: peek-decrypt the in-push preview and REPLACE the placeholder with the
+        // rich note (fast — no fetch). If the SW cannot decrypt in the background (locked,
+        // key unavailable), the generic placeholder already shown stands.
+        try {
+          const result = await previewInline(inline);
+          if (result.ok && result.notes.length) {
+            await closeByTag(GENERIC_TAG);
+            const accepted = await showNotes(result.notes);
+            if (accepted > 0) await markShown(allIds(result.notes)); // warm/open won't re-notify (FR-012)
+          }
+        } catch (e) {
+          console.warn('[sw] inline preview upgrade failed (placeholder stands)', e);
+        }
+        // Warm the DB (persist + ack) so the app opens ready. ctx.shown is already true,
+        // so the warm adds NO second notification (fixed in tryAuthoritativeDrain).
         try {
           await tryAuthoritativeDrain(ctx);
         } catch (e) {

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1311,6 +1311,11 @@ const statusLine = computed(() => {
   if (!peer) return '';
   const active = activityFor(peer); // reactive: peer's current activity (1:1 keyed by peer id)
   if (active.length) return activityKindLabel(active[0].kind);
+  // Re-evaluate on the 30s clock tick so the relative "last seen …" label stays current
+  // while the chat sits open (otherwise "just now" never becomes "2 minutes ago" until you
+  // leave and re-enter). peerPresence itself is reactive to actual presence changes; this
+  // adds the passage-of-time dependency the relative formatter needs.
+  void nowMs.value;
   return presenceLabel(peerPresence(peer));
 });
 
@@ -2725,14 +2730,19 @@ onMounted(() => {
 onUnmounted(() => clearInterval(ttlTick));
 
 // Compact "time left before this disappears" for a message's expiresAt (e.g. "1d", "3h", "5m", "9s").
+// The window counts DOWN, so the label rounds UP (ceil) on the hour/day so it reads the time
+// remaining honestly and never jumps early: a fresh 24h timer shows "1d" for its whole first hour
+// and only becomes "23h" once an hour has actually elapsed; "2h" holds until exactly 1h is left;
+// below an hour it counts whole minutes down (59, 58, …), and seconds only in the last minute.
 function ttlLeft(expiresAt: number): string {
-  const s = Math.max(0, Math.floor((expiresAt - nowMs.value) / 1000));
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  return `${Math.floor(h / 24)}d`;
+  const ms = Math.max(0, expiresAt - nowMs.value);
+  const DAY = 24 * HOUR;
+  if (ms < MIN) return `${Math.floor(ms / 1000)}s`; // last minute: seconds
+  if (ms < HOUR) return `${Math.floor(ms / MIN)}m`; // last hour: whole minutes counting down
+  const ceilHours = Math.ceil(ms / HOUR);
+  if (ceilHours <= 23) return `${ceilHours}h`; // 23h … 1h (rounded up)
+  if (ceilHours === 24) return '1d'; // the first hour of a 1-day window (23h < left ≤ 24h)
+  return `${Math.ceil(ms / DAY)}d`; // more than a day
 }
 const msgTtlShort = computed(() => (effectiveTtlMs.value ? fmtTtl(effectiveTtlMs.value) : ''));
 const msgTtlLabel = computed(() => {


### PR DESCRIPTION
## 1.0.11 — fixes from device-testing 1.0.10 on real hardware

### Notifications (spec 1055 inline-preview path) — three ordering bugs
1. **Show-first restored:** the wake awaited the decrypt before showing anything, delaying the lock-screen alert on cold/locked devices. Now shows the placeholder immediately, then upgrades to the rich preview in place.
2. **Delivered even when locked:** the `notified` receipt only fired on a successful decrypt, so a locked device (generic shown) stayed stuck at "sent". Now fires whenever the push is received — parity with the legacy lite path (delivered on the buzz).
3. **No more double notification:** after the rich preview showed, the warm tail added a second generic note. Now suppressed when the wake already ended visibly; placeholder is closed before the rich note replaces it.

Confirmed on device: subscription survives a locked burst, correct count, readable decrypted text on unlock. These fix the delay, stuck-at-sent, and rich+generic double.

### Chat time displays — two stale-render bugs
4. **"last seen" ticks:** was frozen ("just now") for hours until you left/re-entered; now re-evaluates on the existing 30s clock.
5. **Disappearing timer counts down right:** a 1-day timer dropped to "23h" after a minute (floored hours); now rounds up — "1d" for the first hour, "2h" until exactly 1h left, then minutes.

1205 client tests + full server suite + build green.