### PR TITLE
Release 1.0.14 — disable the iOS-16 rich attempt (keep the badge + functional fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -141,7 +141,12 @@ const RICH_DEADLINE_LEGACY_MS = 1200;
 // The escape hatch: flip to false to INSTANTLY disable the iOS-16 rich attempt (revert to
 // pure spec-2044 generic lite) without touching anything else — if it ever destabilises
 // iOS ≤16 (SW IDB wedging), one-line change + release and the functional fixes all stay.
-const LEGACY_RICH_ENABLED = true;
+// Device-verified 2026-07-23: iOS ≤16 cannot decrypt the in-push preview inside the SW
+// window (Argon2id unlock + libsodium + IDB too slow), so the attempt always timed out to
+// the generic — zero benefit, but it kept running the fragile SW-context crypto/IDB that
+// spec 2044 avoids. Disabled: the iPhone 8 rides the proven generic-lite path again. The
+// badge fix and the functional fixes stay. Flip back to true only if that constraint changes.
+const LEGACY_RICH_ENABLED = false;
 // The content-upgrade window: after the generic placeholder shows, keep waiting
 // this long for the decrypt to land and replace it with the real sender+text.
 // Restored to a full window (was briefly cut to 3–4s while chasing an iOS-16


### PR DESCRIPTION
## Release 1.0.14

Device testing 1.0.13 confirmed iOS ≤16 can't decrypt the in-push preview inside the SW window, so the rich attempt always fell back to generic — zero benefit while still running the fragile SW crypto/IDB spec 2044 avoids. `LEGACY_RICH_ENABLED = false`: the iPhone 8 returns to the proven generic-lite path.

Kept: the iOS-16 **badge** fix (verified working), the disappearing-timer fix, the Android keyboard fix. Modern iOS unchanged.

1205 tests + full server suite + e2e green on #1068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)