### PR TITLE
fix(notifications): 1.0.15 — desktop banners every message + badges from push

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -92,8 +92,14 @@ export function richNoteOptions(
   n: Pick<SwNote, 'body' | 'tag' | 'url' | 'silent'>,
   icon: string,
   badge: string,
+  // (desktop fix) renotify RE-ALERTS a same-tag notification (a new banner/sound for the
+  // next message in an already-notified chat). REQUIRED on Chromium — without it a second
+  // same-tag show silently replaces the first, so subsequent messages never banner. MUST
+  // stay off on iOS/WebKit, where renotify:true makes the notification never render at all
+  // (spec 2047). The caller passes platformTrustsSilence(ua): true=Chromium, false=WebKit.
+  renotify = false,
 ): NotificationOptions {
-  return {
+  const opts: NotificationOptions & { renotify?: boolean } = {
     body: n.body,
     icon,
     badge,
@@ -101,6 +107,8 @@ export function richNoteOptions(
     silent: n.silent === true,
     data: { url: n.url },
   };
+  if (renotify) opts.renotify = true; // only when trusted (Chromium); omitted on WebKit
+  return opts;
 }
 
 /** Background-preview result. `notes` are the displayable notifications, `pending`

--- a/src/services/sw-notify-options.test.ts
+++ b/src/services/sw-notify-options.test.ts
@@ -1,19 +1,26 @@
-// Spec 2047 — the rich per-chat notification's display options MUST NOT carry
-// `renotify`. On iOS 26 / iPadOS 27 a `renotify:true` showNotification resolves but is
-// never rendered on the lock screen — a silent, total failure the wake guard can't
-// detect (it infers "shown" from the promise resolving). The working generic and the
-// legacy lite path omit `renotify`, which is why they display. This pins that it stays
-// gone, and that the per-chat `tag` (the coalescing key) is preserved.
+// Spec 2047 + desktop fix — `renotify` is PLATFORM-GATED. On iOS 26 / iPadOS 27 a
+// `renotify:true` show resolves but never renders (a silent total failure the guard can't
+// detect), so it MUST stay omitted on WebKit. But on Chromium it's REQUIRED: without it a
+// second same-tag show silently replaces the first, so subsequent messages in a chat never
+// banner (the desktop bug). The caller passes platformTrustsSilence(ua): the last arg is
+// true on Chromium (renotify on), false/absent on WebKit (renotify omitted).
 import { describe, it, expect } from 'vitest';
 import { richNoteOptions } from './sw-inbox';
 
-describe('spec 2047: richNoteOptions', () => {
+describe('spec 2047 + desktop: richNoteOptions renotify is platform-gated', () => {
   const n = { body: 'hello', tag: 'ring:chat-1', url: '/chat/chat-1', silent: false };
 
-  it('does NOT set renotify (the option iOS 26/iPadOS 27 accepts but never renders)', () => {
-    const opts = richNoteOptions(n, '/icon.png', '/badge.png');
-    expect('renotify' in opts).toBe(false);
-    expect((opts as Record<string, unknown>).renotify).toBeUndefined();
+  it('OMITS renotify by default / on WebKit (iOS 26 never renders a renotify:true show)', () => {
+    for (const opts of [richNoteOptions(n, '/icon.png', '/badge.png'), richNoteOptions(n, '/i.png', '/b.png', false)]) {
+      expect('renotify' in opts).toBe(false);
+      expect((opts as Record<string, unknown>).renotify).toBeUndefined();
+    }
+  });
+
+  it('SETS renotify:true when the platform trusts it (Chromium) so same-tag messages re-banner', () => {
+    const opts = richNoteOptions(n, '/i.png', '/b.png', true) as Record<string, unknown>;
+    expect(opts.renotify).toBe(true);
+    expect(opts.tag).toBe('ring:chat-1'); // tag preserved → still coalesces per chat
   });
 
   it('keeps the per-chat tag so notifications still coalesce', () => {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -23,7 +23,7 @@ import { ExpirationPlugin } from 'workbox-expiration';
 import {
   previewPending, isNothingNew, markShown, unreadCount, ackCall, previewConnections, previewPosts, previewPostActivity, markConnShown,
   coalesceForShow, loadShownSummary, setting, shouldReassert, loadShownSigs, saveShownSig,
-  mayEndWakeSilently, quietNote, stampPushWake, countAccepted,
+  mayEndWakeSilently, platformTrustsSilence, quietNote, stampPushWake, countAccepted,
   runGuardedWake, recordWake, type WakeCtx,
   isLegacyIOS, withTimeout, fetchPendingFrames, richNoteOptions, shouldShowPlaceholderFirst,
   previewCallRing, recordCallTickle, recordCallOutcome, withdrawCallBadgeUnit, callBadgeCount,
@@ -305,6 +305,10 @@ const titleWithCount = (n: SwNote): string => {
  *  quiet/fallback terminal instead of counting this batch as a visible ending. */
 async function showNotes(notes: SwNote[]): Promise<number> {
   const coalesced = await coalesceForShow(notes, Date.now());
+  // (desktop fix) Re-alert same-tag notifications on Chromium so the SECOND+ message in an
+  // already-notified chat still banners; kept off on iOS/WebKit (renotify:true breaks
+  // rendering there, spec 2047). platformTrustsSilence is exactly the Chromium/WebKit split.
+  const renotify = platformTrustsSilence(self.navigator.userAgent);
   return countAccepted(coalesced.map((n) => async () => {
     try {
       // (spec 2026) A missed/cancelled call note REPLACES the ring alert (spec
@@ -312,10 +316,10 @@ async function showNotes(notes: SwNote[]): Promise<number> {
       // Center entries instead of collapsing them, so close the ring explicitly
       // before showing its replacement.
       if (n.tag === 'ring-call') await closeByTag('ring-call');
-      // (spec 2047) Options via richNoteOptions — deliberately NO `renotify` (iOS 26 /
-      // iPadOS 27 accept but never render a renotify:true show; the per-chat `tag`
-      // still coalesces, exactly as the working generic does).
-      await self.registration.showNotification(titleWithCount(n), richNoteOptions(n, ICON, BADGE));
+      // (spec 2047 + desktop fix) renotify ONLY on Chromium (renotify) — re-alerts a
+      // same-tag show so subsequent messages in a chat still banner; on iOS/WebKit it stays
+      // omitted (renotify:true would make the show never render).
+      await self.registration.showNotification(titleWithCount(n), richNoteOptions(n, ICON, BADGE, renotify));
     } catch (e) {
       console.warn('[sw] showNotification failed', e);
       throw e; // rethrow so countAccepted doesn't count a rejected show
@@ -468,6 +472,26 @@ async function updateAppBadge(newCount: number): Promise<void> {
     console.info('[sw] setAppBadge', total);
   } catch (e) {
     console.warn('[sw] setAppBadge failed', e);
+  }
+}
+
+// (badge fix) Set the app badge from the current undelivered backlog, bounded so a slow SW
+// read/fetch can't hang the caller. Used where the authoritative warm CAN'T set it: the
+// legacy lite path (no warm), and multi-device accounts where sw.fullPersist degrades
+// (single-device precondition) so the msgx warm never persists → never badges. The fetch
+// also (idempotently) fires the server's delivered receipts. Best-effort, always AFTER the
+// visible show.
+async function badgeFromPending(): Promise<void> {
+  try {
+    const token = await withTimeout<string | null>(readSessionToken(), 3000, null);
+    if (!token) return;
+    const fetched = await fetchPendingFrames(token);
+    if ('frames' in fetched) {
+      const pending = fetched.frames.filter((f) => f.t === 'msg' && !!f.id).length;
+      await withTimeout(updateAppBadge(pending), 2500, undefined);
+    }
+  } catch {
+    /* badge + receipts are best-effort — the notification already showed */
   }
 }
 
@@ -999,28 +1023,12 @@ async function dispatchLiteWake(
     if (inline) await markShown([inline.id]); // a later fetch/open won't re-notify this id
   }
   ctx.satisfied = true;
-  // Best-effort delivered receipts AFTER the show: one bounded keystore read for the
-  // token, one bounded fetch. The server emits 'delivered' for every queued frame on
-  // fetch (idempotent, no ack/dequeue — the page drains durably on open). A hung
-  // token read just skips this wake's receipts; the next wake or app open recovers
-  // them.
-  try {
-    const token = await withTimeout<string | null>(readSessionToken(), 3000, null);
-    if (token) {
-      const fetched = await fetchPendingFrames(token);
-      // (iOS-16 badge, revertable) setAppBadge IS exposed in the service worker on iOS
-      // 16.4+ (WebKit "Badging for Home Screen Web Apps") — the lite path simply never
-      // called it, so a closed iPhone-8 never badged from a push. Badge the undelivered
-      // backlog now, AFTER the show, bounded so a slow SW-context IDB read can't hang
-      // this best-effort tail. updateAppBadge is feature-checked → a true absence no-ops.
-      if ('frames' in fetched) {
-        const pending = fetched.frames.filter((f) => f.t === 'msg' && !!f.id).length;
-        await withTimeout(updateAppBadge(pending), 2500, undefined);
-      }
-    }
-  } catch {
-    /* receipts + badge are best-effort — the notification already showed */
-  }
+  // Best-effort delivered receipts + app badge AFTER the show (bounded): the fetch emits
+  // the server's 'delivered' for every queued frame (idempotent, no ack — the page drains
+  // durably on open) and its backlog count sets the badge. setAppBadge IS exposed in the SW
+  // on iOS 16.4+ (WebKit) — the lite path just never called it, so a closed iPhone-8 never
+  // badged from a push. A hung read just skips this wake; the next wake / open recovers.
+  await badgeFromPending();
 }
 
 async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
@@ -1108,11 +1116,16 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
         }
         // Warm the DB (persist + ack) so the app opens ready. ctx.shown already true and the
         // id is markShown → the warm adds NO second notification.
+        let warmed = false;
         try {
-          await tryAuthoritativeDrain(ctx);
+          warmed = await tryAuthoritativeDrain(ctx);
         } catch (e) {
           console.warn('[sw] inline warm tail failed (DB warms on open)', e);
         }
+        // (badge fix) The warm sets the badge only when it fully persists — which it can't
+        // on a multi-device account — so the badge never updated from a push there. Set it
+        // directly from the backlog when the warm didn't handle it.
+        if (!warmed) await badgeFromPending();
         return;
       }
       if (kind === 'call') {


### PR DESCRIPTION
Two desktop bugs from device testing:

**① Subsequent messages didn't banner.** `richNoteOptions` had a per-chat `tag` but no `renotify`, so on Chromium a second same-tag show *silently* replaced the first. `renotify` was dropped globally in spec 2047 because iOS 26 never renders a `renotify:true` show — so we fixed iOS and broke desktop. Now platform-gated via `platformTrustsSilence(ua)`: `renotify:true` on Chromium, omitted on WebKit/iOS.

**② Badge never updated from a push.** The msgx path relied on the warm tail's `updateAppBadge`, which degrades on multi-device (`sw.fullPersist` single-device precondition). New `badgeFromPending()` sets the badge from a bounded backlog fetch when the warm can't; the legacy lite path reuses it. After the show → off the critical path.

Modern iOS single-notification path unchanged. 1206 tests + full server suite + build green.