### PR TITLE
Release 1.0.16 — fix constrained-endpoint 413 (preview push too large)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -156,9 +156,15 @@ var (
 // previewMaxPayload (spec 1055) is the largest inline preview push body we send; a
 // larger one falls back to the content-free tickle. previewRecordSize is the CONSTANT
 // aes128gcm record size every preview push is padded to, so its encrypted length is
-// identical regardless of message length (nothing leaks to the push service). It stays
-// well under the ~4 KB constrained-endpoint ceiling (spec 2046).
-const previewMaxPayload = 3072
+// identical regardless of message length (nothing leaks to the push service).
+//
+// Sized to fit CONSTRAINED endpoints: a Mozilla autopush "constrained device" subscription
+// rejected the original 3200-byte record with 413 ("too long by 246 bytes" → a ~2954-byte
+// ceiling), so that device received no notifications at all. 1920 leaves a wide margin
+// below the observed ceiling (and below smaller constrained limits) while still comfortably
+// holding a real bounded preview (~1.3 KB) — so normal previews keep inlining; only an
+// unusually large one (e.g. a heavily-@mentioned group message) falls back to the tickle.
+const previewMaxPayload = 1792
 
 var previewRecordSize = uint32(previewMaxPayload + recordSizeOverhead)
 

--- a/server/internal/push/push_test.go
+++ b/server/internal/push/push_test.go
@@ -396,6 +396,22 @@ func TestPreviewParamsConstantSize(t *testing.T) {
 	}
 }
 
+// TestPreviewRecordSizeFitsConstrained pins the constant preview record size below the
+// constrained-endpoint ceiling. A Mozilla autopush "constrained device" rejected a 3200-byte
+// record with 413 (~2954-byte ceiling), leaving that device with no notifications; the record
+// size must stay well under that so preview pushes reach constrained subscriptions.
+func TestPreviewRecordSizeFitsConstrained(t *testing.T) {
+	const constrainedCeiling = 2954 // observed in prod (413 "too long by 246" at record size 3200)
+	if previewRecordSize > constrainedCeiling {
+		t.Errorf("previewRecordSize = %d exceeds the observed constrained-endpoint ceiling %d — constrained devices will 413 and get no pushes",
+			previewRecordSize, constrainedCeiling)
+	}
+	// And it must still hold a real bounded preview (body ~256B + fields + header, ~1.3KB).
+	if previewMaxPayload < 1536 {
+		t.Errorf("previewMaxPayload = %d is too small to inline a normal bounded preview", previewMaxPayload)
+	}
+}
+
 // TestVersionPayloadContentFree asserts the version tickle carries ONLY the type marker —
 // no version string, notes, or any content (NFR-ZK-001). The device fetches the public
 // "what's new" itself; nothing about the release rides through the push service.


### PR DESCRIPTION
## Release 1.0.16

A Mozilla autopush constrained-device subscription was rejecting the spec-1055 preview push with 413 (~2954-byte ceiling vs our 3200-byte record) — so that device got no notifications. Caught live by the push-regression monitor.

Lowered the constant preview record size 3200 → 1920 (`previewMaxPayload` 3072 → 1792): fits constrained endpoints with margin, still holds a real bounded preview (~1.3 KB). Normal previews unaffected; constant-size/privacy preserved; regression test added.

Server build + push tests + full suite + e2e green on #1072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)