### PR TITLE
fix(messaging): 1.0.17 — recover 'seen' on delivered-but-unseen 1:1 messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4611,7 +4611,14 @@ export async function collectUnconfirmedOutgoing(): Promise<string[]> {
       // Group: any member not yet delivered (→ checkDeliveries) or not yet seen
       // (→ checkSeen) keeps this message in the reconcile set.
       if (recs.some((r) => !r.deliveredAt || !r.seenAt)) unconfirmed.push(m);
-    } else if (m.status === 'sent') {
+    } else if (m.status === 'sent' || m.status === 'delivered') {
+      // 1:1 message. 'sent' → checkDeliveries recovers a dropped 'delivered'; 'delivered'
+      // → checkSeen recovers a dropped 'seen' (the recipient opened the chat while WE were
+      // offline, so the live seen receipt was lost). Previously only 'sent' was re-checked,
+      // so a 1:1 message that reached 'delivered' NEVER reconciled its seen state — it sat
+      // at 'delivered' forever even though the peer saw it and the server durably recorded
+      // it. Both reconcileDeliveries and reconcileSeen consume this set, so a 'delivered'
+      // message is harmlessly re-confirmed by the former and correctly advanced by the latter.
       unconfirmed.push(m);
     }
   }


### PR DESCRIPTION
Older 1:1 messages the recipient read while the sender was offline stayed stuck at **delivered** and never advanced to **seen**, while newer messages (seen live) showed correctly.

**Root cause:** `collectUnconfirmedOutgoing` — the reconnect reconcile set consumed by *both* `reconcileDeliveries` and `reconcileSeen` — included 1:1 messages only at status `'sent'`, never `'delivered'`. So `reconcileSeen` never asked `checkSeen` about a delivered-but-unseen message; the dropped seen receipt was never recovered. (The server already records seen durably via `RecordSeen`/`SeenFor` for the 35-day window — the client just never queried.)

**Fix:** include `'delivered'` 1:1 messages in the reconcile set. `checkDeliveries` harmlessly re-confirms; `checkSeen` advances it to `seen`. Bounded by the same 35d window + 500-id cap.

Client-only. 1206 tests + full server suite + build green. The 6 stuck messages should flip to 'seen' on the sender's next reconnect.