### PR TITLE
Release 1.0.17 — recover 'seen' on delivered-but-unseen 1:1 messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4611,7 +4611,14 @@ export async function collectUnconfirmedOutgoing(): Promise<string[]> {
       // Group: any member not yet delivered (→ checkDeliveries) or not yet seen
       // (→ checkSeen) keeps this message in the reconcile set.
       if (recs.some((r) => !r.deliveredAt || !r.seenAt)) unconfirmed.push(m);
-    } else if (m.status === 'sent') {
+    } else if (m.status === 'sent' || m.status === 'delivered') {
+      // 1:1 message. 'sent' → checkDeliveries recovers a dropped 'delivered'; 'delivered'
+      // → checkSeen recovers a dropped 'seen' (the recipient opened the chat while WE were
+      // offline, so the live seen receipt was lost). Previously only 'sent' was re-checked,
+      // so a 1:1 message that reached 'delivered' NEVER reconciled its seen state — it sat
+      // at 'delivered' forever even though the peer saw it and the server durably recorded
+      // it. Both reconcileDeliveries and reconcileSeen consume this set, so a 'delivered'
+      // message is harmlessly re-confirmed by the former and correctly advanced by the latter.
       unconfirmed.push(m);
     }
   }


### PR DESCRIPTION
## Release 1.0.17

Older 1:1 messages the recipient read while the sender was offline stayed stuck at **delivered** and never advanced to **seen**. The reconnect reconcile set (`collectUnconfirmedOutgoing`, consumed by both `reconcileDeliveries` and `reconcileSeen`) only included 1:1 messages at `sent`, never `delivered` — so `reconcileSeen` never queried `checkSeen` for them, even though the server durably recorded the seen (`RecordSeen`/`SeenFor`, 35-day window).

Fix: include `delivered`-but-unseen 1:1 messages in the reconcile set. Stuck messages advance to `seen` on the sender's next reconnect. Client-only.

1206 tests + full server suite + e2e green on #1074.

🤖 Generated with [Claude Code](https://claude.com/claude-code)