### PR TITLE
1.0.18 — notification tap opens the chat, follow-system flash, pinned-name colour

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,13 +23,17 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Ring</title>
-    <!-- (spec 2045) Pre-paint theme: apply Ionic's dark palette class synchronously so a
-         cold relaunch (returning from the iOS app switcher after iOS killed the page)
-         never renders a frame in the LIGHT palette before useTheme's async settings read
-         resolves. useTheme mirrors the choice into localStorage on each apply; here we
-         re-resolve it (with 'system' → OS scheme) before first paint. Mirrors
-         resolveDark() in src/composables/useTheme.ts — keep the two in sync. Fails safe to
-         prefers-color-scheme if storage is blocked (private mode). -->
+    <!-- (spec 2045 + follow-system flash fix) Pre-paint theme: apply Ionic's dark palette
+         class synchronously so a cold relaunch (returning from the iOS app switcher after
+         iOS killed the page) never renders a frame in the LIGHT palette before useTheme's
+         async settings read resolves. useTheme mirrors BOTH the choice and the already-
+         RESOLVED dark decision into localStorage on each apply. We trust the resolved
+         mirror first: for 'system', re-deriving from matchMedia here is unreliable on an
+         iOS PWA cold launch (it briefly reports LIGHT before the OS scheme settles, which
+         WAS the every-launch bright flash) — the last resolved value has no such
+         dependency. Only when that mirror is absent (first-ever launch) do we fall back to
+         pref + matchMedia, and to prefers-color-scheme if storage is blocked (private
+         mode). Mirrors resolveDark() in src/composables/useTheme.ts — keep in sync. -->
     <script>
       (function () {
         function prefersDark() {
@@ -37,8 +41,13 @@
         }
         var dark;
         try {
-          var pref = localStorage.getItem('appearance.theme') || 'system';
-          dark = pref === 'dark' || (pref === 'system' && prefersDark());
+          var resolved = localStorage.getItem('appearance.theme.dark');
+          if (resolved === '1' || resolved === '0') {
+            dark = resolved === '1';
+          } else {
+            var pref = localStorage.getItem('appearance.theme') || 'system';
+            dark = pref === 'dark' || (pref === 'system' && prefersDark());
+          }
         } catch (e) {
           dark = prefersDark();
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.9",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.9",
+      "version": "1.0.18",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,6 +72,7 @@ import { useNotificationNudge } from '@/composables/useNotificationNudge';
 import { useAppUpdate, checkForUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
 import { takePendingNav } from '@/services/pending-nav';
+import { parseRelevantNav } from '@/services/nav-intent';
 import { recoverInterruptedPosts } from '@/services/pending-posts';
 import { setAutoplayGifsEnabled } from '@/directives/autoplay-visible';
 import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
@@ -235,6 +236,23 @@ const settleFrames = (): Promise<void> =>
 // push behaviour.
 async function routeRelevant(url?: string, coldStart = false): Promise<void> {
   let target = url;
+  // (notify-nav fix) A generic notification can't name the chat, so it hands us a "route to
+  // the relevant chat" intent instead of a dead-end /tabs/chats. Resolve it HERE, where we
+  // have full DB access (the SW couldn't, on a locked device): land on the sender's 1:1 chat
+  // when we know them AND it's not hidden (listChats excludes hidden), else the newest unread
+  // chat, else the list. A group's id needs the decrypt we never had, so a group message
+  // resolves via newest-unread.
+  const intent = parseRelevantNav(url);
+  if (intent.relevant) {
+    target = undefined; // fall through to the resolvers below
+    if (intent.from) {
+      const chats = await listChats();
+      const direct = chats.find(
+        (c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === intent.from,
+      );
+      if (direct) target = `/chat/${direct.id}`;
+    }
+  }
   if (!target) {
     if ((await countPendingRequests()) > 0) target = '/tabs/contacts';
     else {

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -170,6 +170,11 @@ defineExpose({
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 13px;
-  color: var(--ion-text-color);
+  /* A pin tile is a bare <button>, which inherits Ionic's primary (blue) text
+     color. --ion-text-color is only defined by the dark palette, so on LIGHT it
+     was empty and the name fell through to that blue. --app-text is defined in
+     BOTH themes (black on light, white on dark) — the same var the rest of this
+     component uses — so the name matches the list rows on either theme. */
+  color: var(--app-text);
 }
 </style>

--- a/src/composables/useTheme.test.ts
+++ b/src/composables/useTheme.test.ts
@@ -2,7 +2,7 @@
 // and the index.html pre-paint inline script (first frame on a cold relaunch). Pinning it
 // here guards against the two drifting: whatever this asserts is what index.html must do.
 import { describe, it, expect } from 'vitest';
-import { resolveDark, THEME_MIRROR_KEY } from './useTheme';
+import { resolveDark, THEME_MIRROR_KEY, THEME_RESOLVED_KEY } from './useTheme';
 
 describe('spec 2045: resolveDark', () => {
   it('explicit dark is always dark, regardless of OS', () => {
@@ -22,5 +22,15 @@ describe('spec 2045: resolveDark', () => {
 describe('spec 2045: the mirror key matches the settings key the pre-paint script reads', () => {
   it('is exactly appearance.theme', () => {
     expect(THEME_MIRROR_KEY).toBe('appearance.theme');
+  });
+});
+
+describe('follow-system flash fix: the resolved-dark mirror the pre-paint trusts first', () => {
+  // index.html reads localStorage['appearance.theme.dark'] ('1'/'0') BEFORE consulting
+  // matchMedia, so a system-mode cold relaunch never flashes the light palette while iOS's
+  // cold-start prefers-color-scheme is still settling. If this key drifts, the pre-paint
+  // silently falls back to the flaky matchMedia path — keep them identical.
+  it('is exactly appearance.theme.dark', () => {
+    expect(THEME_RESOLVED_KEY).toBe('appearance.theme.dark');
   });
 });

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -27,6 +27,17 @@ export function resolveDark(pref: ThemePref, prefersDark: boolean): boolean {
 // relaunch). IndexedDB stays the source of truth; this is a read-optimization for one frame.
 export const THEME_MIRROR_KEY = 'appearance.theme';
 
+// (follow-system flash fix) The RESOLVED dark/light decision, mirrored as '1'/'0'.
+// The pref mirror above isn't enough for 'system': the pre-paint has to re-derive
+// dark from matchMedia('(prefers-color-scheme: dark)'), and on an iOS PWA cold
+// relaunch that query briefly reports LIGHT before the OS scheme settles — so a
+// system-mode user saw a bright frame flash before useTheme corrected it (explicit
+// light/dark never flashed because they don't consult matchMedia). Storing the LAST
+// resolved value lets the pre-paint paint the correct palette with zero matchMedia
+// dependency; if the OS theme changed while the app was closed, the first frame is
+// one-frame stale and useTheme fixes it — far rarer than the every-launch flash.
+export const THEME_RESOLVED_KEY = 'appearance.theme.dark';
+
 export function useTheme(): void {
   const rows = useLiveQuery(
     () => getAll<Setting>('settings'),
@@ -41,9 +52,13 @@ export function useTheme(): void {
       'system';
     const dark = resolveDark(pref, mql.matches);
     document.documentElement.classList.toggle('ion-palette-dark', dark);
-    // Keep the synchronous mirror current so the NEXT cold start paints correctly.
+    // Keep the synchronous mirrors current so the NEXT cold start paints correctly:
+    // the pref (for reference) and the already-resolved dark decision (the one the
+    // pre-paint actually trusts, so it never re-consults the flaky cold-start
+    // matchMedia for 'system').
     try {
       localStorage.setItem(THEME_MIRROR_KEY, pref);
+      localStorage.setItem(THEME_RESOLVED_KEY, dark ? '1' : '0');
     } catch {
       /* storage blocked → pre-paint falls back to prefers-color-scheme */
     }

--- a/src/services/nav-intent.test.ts
+++ b/src/services/nav-intent.test.ts
@@ -1,0 +1,45 @@
+// (notify-nav fix) A generic notification can't name the chat, so it encodes a
+// "route me to the relevant chat" intent instead of the dead-end /tabs/chats. The SW
+// builds it; the app parses it after unlock (with full DB access) to land on the
+// sender's 1:1 chat, or the newest unread chat. These are the pure build/parse
+// contracts both sides depend on.
+import { describe, it, expect } from 'vitest';
+import { relevantNav, parseRelevantNav } from './nav-intent';
+
+describe('nav-intent: relevant-chat notification routing', () => {
+  it('builds a bare intent when the sender is unknown', () => {
+    expect(relevantNav()).toBe('ring-relevant');
+    expect(relevantNav(undefined)).toBe('ring-relevant');
+  });
+
+  it('encodes the sender id when known', () => {
+    expect(relevantNav('user-42')).toBe('ring-relevant:user-42');
+  });
+
+  it('round-trips the sender id through parse', () => {
+    const { relevant, from } = parseRelevantNav(relevantNav('user-42'));
+    expect(relevant).toBe(true);
+    expect(from).toBe('user-42');
+  });
+
+  it('parses the bare intent as relevant with no sender', () => {
+    expect(parseRelevantNav('ring-relevant')).toEqual({ relevant: true, from: undefined });
+  });
+
+  it('does NOT treat a real deep-link route as a relevant intent', () => {
+    // A rich note carries /chat/<id> — it must route verbatim, never be intercepted.
+    expect(parseRelevantNav('/chat/abc123')).toEqual({ relevant: false });
+    expect(parseRelevantNav('/tabs/chats')).toEqual({ relevant: false });
+    expect(parseRelevantNav('/tabs/contacts')).toEqual({ relevant: false });
+  });
+
+  it('treats an absent url as not-relevant (no crash)', () => {
+    expect(parseRelevantNav(undefined)).toEqual({ relevant: false });
+    expect(parseRelevantNav('')).toEqual({ relevant: false });
+  });
+
+  it('does not false-match a route that merely starts with the word', () => {
+    // Defensive: only the exact sentinel or `sentinel:` prefix count.
+    expect(parseRelevantNav('/ring-relevant-lookalike').relevant).toBe(false);
+  });
+});

--- a/src/services/nav-intent.ts
+++ b/src/services/nav-intent.ts
@@ -1,0 +1,34 @@
+/**
+ * Notification-tap navigation intent.
+ *
+ * A RICH notification carries the exact chat deep-link (`/chat/<id>`) because the
+ * SW decrypted the frame and resolved the conversation. A GENERIC notification —
+ * shown when the sender's app is pre-preview (< 1.0.10, no ciphertext-in-push) or
+ * the recipient's phone was locked+off and the decrypt missed the show deadline —
+ * has NO decrypted payload, so the SW can't name the chat. It used to fall back to
+ * `/tabs/chats`, which dumped the tap on the chat LIST instead of the conversation.
+ *
+ * This encodes a "route me to the RELEVANT chat" intent that the APP resolves after
+ * unlock, where it has full IndexedDB access (the SW must not do that work on a
+ * locked iOS device — that's exactly the window it's too slow for). The optional
+ * `from` (the push sender id) lets the app land precisely on a 1:1 chat; without it
+ * (or for a group, whose id needs the decrypt we don't have) the app falls back to
+ * the newest unread chat, then the list. A tiny leaf module so both the SW bundle
+ * and the app can import it without pulling in heavy deps or creating a cycle.
+ */
+
+// A sentinel that can never be mistaken for a real route (routes start with '/').
+const PREFIX = 'ring-relevant';
+
+/** Build the intent url for a generic notification. `from` = the push sender id, when known. */
+export function relevantNav(from?: string): string {
+  return from ? `${PREFIX}:${from}` : PREFIX;
+}
+
+/** Parse a notification's stored url. `relevant` is true for the sentinel; `from` is the
+ *  sender id when one was encoded. A normal `/…` deep-link parses as not-relevant. */
+export function parseRelevantNav(url?: string): { relevant: boolean; from?: string } {
+  if (!url || (url !== PREFIX && !url.startsWith(`${PREFIX}:`))) return { relevant: false };
+  const from = url.length > PREFIX.length + 1 ? url.slice(PREFIX.length + 1) : undefined;
+  return { relevant: true, from };
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -37,6 +37,7 @@ import { hasFreshRing, ringReassert, ringAlreadyNamed } from '@/services/call-ev
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { resubscribePush } from '@/services/sw-push';
 import { setPendingNav } from '@/services/pending-nav';
+import { relevantNav, parseRelevantNav } from '@/services/nav-intent';
 import { userFacing, prettify, displayVersion } from '@/services/release-notes';
 
 declare const self: ServiceWorkerGlobalScope & {
@@ -173,7 +174,7 @@ const STRAGGLER_INTERVAL_MS = 4500;
 // notification for on-device diagnosis; production (same build) never shows internal reason text.
 const DEV_HOST = /(^|\.)ring-dev\./.test(self.location.hostname) || self.location.hostname === 'localhost' || self.location.hostname === '127.0.0.1';
 
-async function showGeneric(reason?: string): Promise<void> {
+async function showGeneric(reason?: string, navFrom?: string): Promise<void> {
   // (spec 2014 US1) Title is the STATUS, not the literal app name: iOS already shows "Ring" as its
   // forced app-name header, so titling this "Ring" too rendered the app name twice
   // ("Ring › Ring › New message"). (US2) The body carries WHY we fell back to generic so the
@@ -191,7 +192,11 @@ async function showGeneric(reason?: string): Promise<void> {
     icon: ICON,
     badge: BADGE,
     tag: GENERIC_TAG,
-    data: { url: '/tabs/chats' },
+    // (notify-nav fix) A generic note can't name the chat, but tapping it should still
+    // land on the conversation, not the list. Encode a "route to the relevant chat"
+    // intent the app resolves after unlock (with full DB access); when we know the push
+    // sender (the msgx fallback passes it) the app can target their 1:1 chat precisely.
+    data: { url: relevantNav(navFrom) },
   });
 }
 
@@ -345,13 +350,15 @@ async function showNotes(notes: SwNote[]): Promise<number> {
  *  where the wake is already visibly ended or re-routed (the settle downgrade of
  *  an accepted loud generic; the authoritative-drain degrade) contain it locally
  *  via their own existing catches. */
-async function showQuietNote(kind: 'msg' | 'activity'): Promise<void> {
+async function showQuietNote(kind: 'msg' | 'activity', navFrom?: string): Promise<void> {
   const n = quietNote(kind);
   await self.registration.showNotification(n.title, {
     ...n.options,
     icon: ICON,
     badge: BADGE,
-    data: { url: kind === 'msg' ? '/tabs/chats' : '/' },
+    // (notify-nav fix) A msg quiet note routes to the relevant chat (see showGeneric);
+    // 'activity' stays on the app root.
+    data: { url: kind === 'msg' ? relevantNav(navFrom) : '/' },
   });
 }
 
@@ -366,10 +373,10 @@ async function showQuietNote(kind: 'msg' | 'activity'): Promise<void> {
 // silence was licensed (trusted platform + focused & visible window) — the caller
 // treats that as satisfied-but-not-shown, so a clean wake doesn't trip the backstop
 // yet a reject/timeout still falls back (the wake produced no OS notification).
-async function showQuietUnlessVisible(kind: 'msg' | 'activity'): Promise<boolean> {
+async function showQuietUnlessVisible(kind: 'msg' | 'activity', navFrom?: string): Promise<boolean> {
   const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
   if (mayEndWakeSilently(self.navigator.userAgent, clients)) return false; // licensed: trusted platform + focused & visible window
-  await showQuietNote(kind);
+  await showQuietNote(kind, navFrom);
   return true;
 }
 
@@ -990,7 +997,7 @@ async function dispatchLiteWake(
   if (clients.length && (await pageWillNotify(clients, 2200))) {
     const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
     if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) {
-      await showQuietNote('msg');
+      await showQuietNote('msg', inline?.from);
       ctx.shown = true;
     }
     ctx.satisfied = true;
@@ -1018,7 +1025,7 @@ async function dispatchLiteWake(
   // The generic shows NOW (bounded diagnostics read inside, spec 2044) when rich didn't
   // win — before any further keystore/decrypt work.
   if (!claimed) {
-    await showGeneric('legacy-lite');
+    await showGeneric('legacy-lite', inline?.from);
     ctx.shown = true;
     if (inline) await markShown([inline.id]); // a later fetch/open won't re-notify this id
   }
@@ -1068,7 +1075,7 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
         if (!shouldShowPlaceholderFirst(clients) && (await pageWillNotify(clients, 2200))) {
           const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
           if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) {
-            await showQuietNote('msg');
+            await showQuietNote('msg', inline.from);
             ctx.shown = true;
           }
           ctx.satisfied = true;
@@ -1105,12 +1112,12 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
         } else if (!raced.deadline && raced.r?.ok && (raced.r.silenced || raced.r.suppressed)) {
           // Muted / notifications-off (rare — usually dropped server-side): end visibly
           // with the quiet note, no loud generic.
-          if (claim() && (await showQuietUnlessVisible('msg'))) { ctx.shown = true; await markShown([inline.id]); }
+          if (claim() && (await showQuietUnlessVisible('msg', inline.from))) { ctx.shown = true; await markShown([inline.id]); }
         } else {
           // Deadline hit (rich too slow / still decrypting) OR decrypt failed → the single
           // generic SAFETY note.
           if (claim()) {
-            try { await showGeneric(raced.deadline ? 'rich-too-slow' : 'inline-fallback'); ctx.shown = true; await markShown([inline.id]); }
+            try { await showGeneric(raced.deadline ? 'rich-too-slow' : 'inline-fallback', inline.from); ctx.shown = true; await markShown([inline.id]); }
             catch (e) { console.warn('[sw] safety generic failed', e); }
           }
         }
@@ -1398,7 +1405,10 @@ self.addEventListener('notificationclick', (event) => {
       // and routes there. On platforms where openWindow honors the path it's a harmless no-op
       // (the app is already there; the consume just re-routes to the same place).
       if (data.url) await setPendingNav(data.url);
-      return self.clients.openWindow(data.url || '/');
+      // The "relevant chat" intent is a sentinel, not a real path — openWindow can't load it,
+      // so open the app root and let the stashed intent route after unlock.
+      const openTarget = !data.url || parseRelevantNav(data.url).relevant ? '/' : data.url;
+      return self.clients.openWindow(openTarget);
     })(),
   );
 });


### PR DESCRIPTION
Device-testing fixes (v1.0.18). Three independently-revertable commits.

**fix(chats): pinned chat names match the theme instead of blue in light mode**
`.pin-name` used `--ion-text-color`, which only the dark palette defines; on light it was empty and the bare `<button>` fell through to Ionic's primary blue. Switched to `--app-text` (defined in both themes), matching the list rows.

**fix(appearance): no bright flash when following the device theme**
A cold relaunch on "follow system" flashed light before settling to dark. The pre-paint re-derived dark/light from `prefers-color-scheme`, which on an iOS PWA cold launch briefly reports light before the OS scheme settles. `useTheme` now mirrors the *resolved* dark decision to localStorage and the pre-paint trusts that first — no `matchMedia` dependency. Explicit light/dark were never affected.

**fix(notifications): tapping a notification opens the conversation, not the chats list**
Rich notes already deep-link; generic ones (older sender, or locked device that couldn't decrypt in time) dumped the tap on the list. Generic notes now carry a "relevant chat" intent + sender id; the app resolves it after unlock with full DB access — the sender's 1:1 chat when known (never hidden), else the newest unread chat, else the list. Group messages resolve to newest-unread (their id needs the decrypt the generic path lacks).

Not a code change but confirmed: the "random rich vs generic per user/group" is expected — preview-in-push shipped in 1.0.10, so pre-1.0.10 senders send content-free tickles → generic. Self-heals as the fleet updates.

Build + 1213 unit tests green. New tests: `nav-intent.test.ts`, resolved-mirror key guard in `useTheme.test.ts`.