### PR TITLE
1.0.19 — fix iOS Wall-activity push (BadWebPushTopic) + Android install help

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/server/internal/push/push.go
+++ b/server/internal/push/push.go
@@ -385,15 +385,21 @@ func (n *Notifier) NotifyPost(ctx context.Context, userID, author string) {
 	n.notify(ctx, userID, postParams())
 }
 
-// postActivityTopic derives the per-post Web Push collapse topic. RFC 8030 caps a
-// topic at 32 URL-safe base64 characters and a raw uuid is 36, so use a base64url
-// SHA-256 prefix: bursts on ONE post collapse to a single wake per device while
-// activity on different posts still wakes separately. The hash also keeps the raw
-// post id out of the (push-service-visible) topic header — the payload itself is
-// encrypted, the topic is not.
+// postActivityTopic derives the per-post Web Push collapse label: bursts on ONE post
+// collapse to a single wake per device while activity on different posts still wakes
+// separately. The SHA-256 hash also keeps the raw post id out of the
+// (push-service-visible) topic header — the payload itself is encrypted, the topic is not.
+//
+// This returns the RAW label; notify() base64url-encodes EVERY topic before sending it,
+// because Apple 400s ({"reason":"BadWebPushTopic"}) on a topic that isn't decodable
+// base64. Apple ALSO caps the topic at 32 chars, so the raw label must stay <= 24 bytes
+// (24 * 4/3 = 32 after encoding). "act-" + 16 chars = 20 bytes → 27 chars encoded. A
+// longer prefix here was double-encoded to 38 chars, which WAS the BadWebPushTopic
+// regression that silently dropped every Wall-activity push to iOS post owners (FCM is
+// lenient about topic length, so only Apple endpoints failed).
 func postActivityTopic(postID string) string {
 	sum := sha256.Sum256([]byte(postID))
-	return "act-" + base64.RawURLEncoding.EncodeToString(sum[:])[:24]
+	return "act-" + base64.RawURLEncoding.EncodeToString(sum[:])[:16]
 }
 
 // NotifyPostActivity wakes the POST OWNER's devices for engagement (a reaction or a

--- a/server/internal/push/push_test.go
+++ b/server/internal/push/push_test.go
@@ -332,6 +332,40 @@ func TestSendVersionHeaders(t *testing.T) {
 	}
 }
 
+// TestPostActivityTopicFitsApple guards the BadWebPushTopic regression: the per-post
+// activity topic is base64url-encoded by notify() before it goes on the wire, and Apple
+// 400s ({"reason":"BadWebPushTopic"}) on a topic that isn't decodable base64 OR exceeds 32
+// chars. postActivityTopic once returned a 28-char label that double-encoded to 38 chars,
+// silently dropping every Wall-activity push to iOS post owners (FCM is lenient, so only
+// Apple failed). Pin the FINAL wire topic to Apple's two constraints.
+func TestPostActivityTopicFitsApple(t *testing.T) {
+	cap := &capturedReq{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.record(r)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	p256dh, auth := newSubKeys(t)
+	st := &memSubStore{subs: map[string][]store.PushSubscription{
+		"owner": {{Endpoint: srv.URL, P256dh: p256dh, Auth: auth}},
+	}}
+	n := newNotifier(t, st)
+
+	// A realistic 36-char UUID post id — the worst case for topic length.
+	n.NotifyPostActivity(context.Background(), "owner", "a1b2c3d4-e5f6-7890-abcd-ef0123456789")
+
+	if cap.topic == "" {
+		t.Fatal("post-activity push carried no Topic (want a per-post collapse topic)")
+	}
+	if len(cap.topic) > 32 {
+		t.Errorf("post-activity Topic = %q is %d chars, Apple caps it at 32 (BadWebPushTopic)", cap.topic, len(cap.topic))
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(cap.topic); err != nil {
+		t.Errorf("post-activity Topic = %q is not decodable base64url (Apple rejects with BadWebPushTopic): %v", cap.topic, err)
+	}
+}
+
 // TestTickleBodyIsSmall (spec 2046) asserts the encrypted push body is sized to fit the
 // content-free tickle, not padded to webpush-go's 4096-byte default — the padding that made
 // constrained Firefox/Mozilla endpoints reject our sends with 413.

--- a/src/components/InstallGuard.vue
+++ b/src/components/InstallGuard.vue
@@ -64,6 +64,21 @@
         </div>
       </div>
 
+      <!-- Firefox on Android can't install Ring as a real app (no install prompt, and its
+           "Add to Home screen" only makes a shortcut that reopens in Firefox), so the gate
+           would never clear and notifications stay unreliable. Steer to Chrome / Samsung
+           Internet, where the WebAPK install works. -->
+      <div v-if="platform === 'android' && firefoxAndroid && !installUnavailable" class="ion-padding">
+        <div class="cant-install">
+          <ion-icon :icon="warningOutline" />
+          <span>
+            Firefox on Android can’t install Ring as an app, so notifications won’t work
+            reliably here. Open <strong>ring.zuptalo.com</strong> in Chrome or Samsung
+            Internet, then follow the steps below to install.
+          </span>
+        </div>
+      </div>
+
       <!-- Native install button (Chromium / Android, when available). -->
       <div v-if="canPrompt" class="ion-padding">
         <ion-button expand="block" shape="round" @click="install">
@@ -111,10 +126,10 @@
         <div class="install-help">
           <ion-icon :icon="informationCircleOutline" />
           <span>
-            If Android blocks Ring as “unsafe” or “built for an older version of Android,”
-            that’s a Google Play Protect quirk with installed web apps — not a problem with
-            Ring. Update Chrome and Google Play services, then try again. If it still shows,
-            tap “More details” → “Install anyway.”
+            If Android says Ring is “unsafe” or “built for an older version of Android,”
+            that’s a Google Play Protect quirk with installed web apps, not a problem with
+            Ring. Tap “Install anyway” (not “OK,” which cancels) to continue. If you don’t
+            see that option, update Chrome and Google Play services and try again.
           </span>
         </div>
       </div>
@@ -138,7 +153,7 @@ import {
 import { downloadOutline, shareOutline, warningOutline, informationCircleOutline } from 'ionicons/icons';
 import { useInstallGuard, promptInstall } from '@/composables/useInstallGuard';
 
-const { mustInstall, platform, canPrompt, installUnavailable } = useInstallGuard();
+const { mustInstall, platform, canPrompt, installUnavailable, firefoxAndroid } = useInstallGuard();
 
 const install = (): void => void promptInstall();
 

--- a/src/composables/useInstallGuard.test.ts
+++ b/src/composables/useInstallGuard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isAndroidWebView } from './useInstallGuard';
+import { isAndroidWebView, isFirefoxAndroid } from './useInstallGuard';
 
 // Regression for spec 2003: the install gate must call a browser "can't install" ONLY for a
 // genuinely-incapable surface (an embedded Android WebView), identified from the user agent —
@@ -51,6 +51,33 @@ describe('isAndroidWebView', () => {
       isAndroidWebView(
         'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
       ),
+    ).toBe(false);
+  });
+});
+
+// Firefox on Android can't do a real PWA install (no beforeinstallprompt; "Add to Home"
+// only makes a shortcut), so the guard steers those users to Chrome / Samsung Internet.
+describe('isFirefoxAndroid', () => {
+  it('detects Firefox on Android', () => {
+    expect(isFirefoxAndroid('Mozilla/5.0 (Android 14; Mobile; rv:130.0) Gecko/130.0 Firefox/130.0')).toBe(true);
+  });
+
+  it('does NOT flag Chrome / Samsung / Edge on Android', () => {
+    expect(
+      isFirefoxAndroid('Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36'),
+    ).toBe(false);
+    expect(
+      isFirefoxAndroid('Mozilla/5.0 (Linux; Android 14; SAMSUNG SM-S928B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36'),
+    ).toBe(false);
+  });
+
+  it('does NOT flag Firefox on DESKTOP (no Android token)', () => {
+    expect(isFirefoxAndroid('Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0')).toBe(false);
+  });
+
+  it('does NOT flag iOS "Firefox" (Fx on iOS is WebKit, UA uses FxiOS not Firefox/)', () => {
+    expect(
+      isFirefoxAndroid('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/126.0 Mobile/15E148 Safari/605.1.15'),
     ).toBe(false);
   });
 });

--- a/src/composables/useInstallGuard.ts
+++ b/src/composables/useInstallGuard.ts
@@ -68,6 +68,19 @@ export function isAndroidWebView(ua: string): boolean {
   return /\bVersion\/[\d.]+/i.test(ua) && /\bChrome\/[\d.]+/i.test(ua);
 }
 
+/**
+ * Whether this is Firefox on Android. Firefox there does NOT fire `beforeinstallprompt`
+ * (that's Chromium-only), so Ring can't offer its one-tap install button; worse, its
+ * "Add to Home screen" makes a plain shortcut that reopens in Firefox rather than a
+ * standalone app, so the install gate never clears and Web Push stays unreliable. We
+ * steer those users to Chrome or Samsung Internet, where the WebAPK install works. Pure
+ * (UA-only) so it's unit-testable. Firefox's Gecko UA carries "Firefox/" and no "Chrome/"
+ * token, which cleanly separates it from Chrome / Samsung / Edge.
+ */
+export function isFirefoxAndroid(ua: string): boolean {
+  return /android/i.test(ua) && /\bFirefox\/[\d.]+/i.test(ua);
+}
+
 // Singleton state shared across the (single) guard component.
 const mustInstall = ref(false);
 const platform = ref<InstallPlatform>('desktop');
@@ -78,6 +91,10 @@ const canPrompt = ref(false);
 // (that was a false-negative source on capable Chrome — spec 2003). The guard uses it to
 // show accurate "open in your browser app" guidance instead of steps that won't work.
 const installUnavailable = ref(false);
+// Android only: true for Firefox, which can't install Ring as a real standalone app
+// (no beforeinstallprompt; "Add to Home" only makes a shortcut). The guard steers these
+// users to Chrome / Samsung Internet instead of showing steps that won't stick.
+const firefoxAndroid = ref(false);
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
 let started = false;
 
@@ -91,6 +108,7 @@ function start(): void {
   // browser can (via its menu), even if `beforeinstallprompt` is slow or never auto-fires.
   if (platform.value === 'android' && mustInstall.value) {
     installUnavailable.value = isAndroidWebView(navigator.userAgent || '');
+    firefoxAndroid.value = isFirefoxAndroid(navigator.userAgent || '');
   }
 
   // If the page is ever (re)evaluated as standalone, drop the gate.
@@ -131,5 +149,5 @@ export async function promptInstall(): Promise<void> {
 
 export function useInstallGuard() {
   start();
-  return { mustInstall, platform, canPrompt, installUnavailable };
+  return { mustInstall, platform, canPrompt, installUnavailable, firefoxAndroid };
 }


### PR DESCRIPTION
Two fixes. The first is a live regression caught by the prod push monitor.

**fix(server): deliver Wall post-activity notifications to iPhones again**
Apple Web Push was rejecting every post-activity push with `400 {"reason":"BadWebPushTopic"}` (seen in prod against `web.push.apple.com`), so iPhone post owners stopped getting notified about reactions/comments on their Wall posts. Android was unaffected (FCM is lenient about the topic field). Root cause: `notify()` base64url-encodes every collapse topic before sending (Apple rejects a non-decodable-base64 topic), but `postActivityTopic` was *already* encoded, so it double-encoded to 38 chars and blew past Apple's 32-char cap. Fix returns the raw label and lets the one central encoder handle it (27 chars). Not subscription-killing (`BadWebPushTopic` is on the keep list). Regression test pins the final wire topic ≤32 chars and decodable base64url.

**fix(pwa): clearer install help on Android for Firefox and Play Protect**
- Firefox on Android can't install Ring as a real app (no `beforeinstallprompt`; "Add to Home" only makes a shortcut) so the gate never cleared → now steers to Chrome / Samsung Internet.
- Play Protect note sharpened: when Android flags "unsafe" / "built for an older version of Android" (a WebAPK/Play-Protect quirk, not a Ring problem), tap "Install anyway", not "OK".

Build + 1218 client unit tests + full server suite green. New guards: `TestPostActivityTopicFitsApple`, `isFirefoxAndroid` UA truth table.