### PR TITLE
1.0.20 — group message notification opens the group, not a 1:1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,7 +72,7 @@ import { useNotificationNudge } from '@/composables/useNotificationNudge';
 import { useAppUpdate, checkForUpdate } from '@/composables/useAppUpdate';
 import { countPendingRequests, listChats, listFailedMessages, retryAllFailed, syncPosts } from '@/db/queries';
 import { takePendingNav } from '@/services/pending-nav';
-import { parseRelevantNav } from '@/services/nav-intent';
+import { isRelevantNav } from '@/services/nav-intent';
 import { recoverInterruptedPosts } from '@/services/pending-posts';
 import { setAutoplayGifsEnabled } from '@/directives/autoplay-visible';
 import { useAnimationPrefs } from '@/composables/useAnimationPrefs';
@@ -238,21 +238,13 @@ async function routeRelevant(url?: string, coldStart = false): Promise<void> {
   let target = url;
   // (notify-nav fix) A generic notification can't name the chat, so it hands us a "route to
   // the relevant chat" intent instead of a dead-end /tabs/chats. Resolve it HERE, where we
-  // have full DB access (the SW couldn't, on a locked device): land on the sender's 1:1 chat
-  // when we know them AND it's not hidden (listChats excludes hidden), else the newest unread
-  // chat, else the list. A group's id needs the decrypt we never had, so a group message
-  // resolves via newest-unread.
-  const intent = parseRelevantNav(url);
-  if (intent.relevant) {
-    target = undefined; // fall through to the resolvers below
-    if (intent.from) {
-      const chats = await listChats();
-      const direct = chats.find(
-        (c) => !c.isGroup && c.participantIds.length === 1 && c.participantIds[0] === intent.from,
-      );
-      if (direct) target = `/chat/${direct.id}`;
-    }
-  }
+  // have full DB access (the SW couldn't, on a locked device). Route to the newest UNREAD
+  // chat — the one that just received the triggering message, whether that's a 1:1 or a
+  // GROUP. We must NOT resolve by the push sender id: for a group message the sender is a
+  // group member, and landing on their 1:1 chat sent the tap to the wrong conversation.
+  // The newest-unread chat is correct for both kinds (hidden chats are excluded by
+  // listChats, so a hidden chat is never revealed by this route).
+  if (isRelevantNav(url)) target = undefined; // fall through to the newest-unread resolver
   if (!target) {
     if ((await countPendingRequests()) > 0) target = '/tabs/contacts';
     else {

--- a/src/services/nav-intent.test.ts
+++ b/src/services/nav-intent.test.ts
@@ -1,45 +1,35 @@
 // (notify-nav fix) A generic notification can't name the chat, so it encodes a
 // "route me to the relevant chat" intent instead of the dead-end /tabs/chats. The SW
-// builds it; the app parses it after unlock (with full DB access) to land on the
-// sender's 1:1 chat, or the newest unread chat. These are the pure build/parse
-// contracts both sides depend on.
+// builds it; the app resolves it after unlock (with full DB access) to the newest
+// unread chat — the one that just received the triggering message, 1:1 OR group. A
+// rich note's real /chat/<id> deep-link must NOT be intercepted.
 import { describe, it, expect } from 'vitest';
-import { relevantNav, parseRelevantNav } from './nav-intent';
+import { relevantNav, isRelevantNav } from './nav-intent';
 
 describe('nav-intent: relevant-chat notification routing', () => {
-  it('builds a bare intent when the sender is unknown', () => {
+  it('builds the relevant-chat intent', () => {
     expect(relevantNav()).toBe('ring-relevant');
-    expect(relevantNav(undefined)).toBe('ring-relevant');
   });
 
-  it('encodes the sender id when known', () => {
-    expect(relevantNav('user-42')).toBe('ring-relevant:user-42');
-  });
-
-  it('round-trips the sender id through parse', () => {
-    const { relevant, from } = parseRelevantNav(relevantNav('user-42'));
-    expect(relevant).toBe(true);
-    expect(from).toBe('user-42');
-  });
-
-  it('parses the bare intent as relevant with no sender', () => {
-    expect(parseRelevantNav('ring-relevant')).toEqual({ relevant: true, from: undefined });
+  it('recognizes the intent it builds', () => {
+    expect(isRelevantNav(relevantNav())).toBe(true);
   });
 
   it('does NOT treat a real deep-link route as a relevant intent', () => {
-    // A rich note carries /chat/<id> — it must route verbatim, never be intercepted.
-    expect(parseRelevantNav('/chat/abc123')).toEqual({ relevant: false });
-    expect(parseRelevantNav('/tabs/chats')).toEqual({ relevant: false });
-    expect(parseRelevantNav('/tabs/contacts')).toEqual({ relevant: false });
+    // A rich note carries /chat/<id> (1:1 or group) — it must route verbatim.
+    expect(isRelevantNav('/chat/abc123')).toBe(false);
+    expect(isRelevantNav('/chat/group-xyz')).toBe(false);
+    expect(isRelevantNav('/tabs/chats')).toBe(false);
+    expect(isRelevantNav('/tabs/contacts')).toBe(false);
   });
 
   it('treats an absent url as not-relevant (no crash)', () => {
-    expect(parseRelevantNav(undefined)).toEqual({ relevant: false });
-    expect(parseRelevantNav('')).toEqual({ relevant: false });
+    expect(isRelevantNav(undefined)).toBe(false);
+    expect(isRelevantNav('')).toBe(false);
   });
 
   it('does not false-match a route that merely starts with the word', () => {
-    // Defensive: only the exact sentinel or `sentinel:` prefix count.
-    expect(parseRelevantNav('/ring-relevant-lookalike').relevant).toBe(false);
+    expect(isRelevantNav('/ring-relevant-lookalike')).toBe(false);
+    expect(isRelevantNav('ring-relevant:from=x')).toBe(false);
   });
 });

--- a/src/services/nav-intent.ts
+++ b/src/services/nav-intent.ts
@@ -10,25 +10,26 @@
  *
  * This encodes a "route me to the RELEVANT chat" intent that the APP resolves after
  * unlock, where it has full IndexedDB access (the SW must not do that work on a
- * locked iOS device — that's exactly the window it's too slow for). The optional
- * `from` (the push sender id) lets the app land precisely on a 1:1 chat; without it
- * (or for a group, whose id needs the decrypt we don't have) the app falls back to
- * the newest unread chat, then the list. A tiny leaf module so both the SW bundle
- * and the app can import it without pulling in heavy deps or creating a cycle.
+ * locked iOS device — that's exactly the window it's too slow for). The app routes
+ * to the newest UNREAD chat, which is the one that just received the triggering
+ * message — 1:1 OR group. We deliberately do NOT encode the push sender id: for a
+ * GROUP message the sender is a group member, and resolving them to their 1:1 chat
+ * sent the tap to the wrong conversation (a member you also DM). The newest-unread
+ * chat is right for both kinds without needing the decrypt we don't have. A tiny
+ * leaf module so both the SW bundle and the app can import it without pulling in
+ * heavy deps or creating a cycle.
  */
 
 // A sentinel that can never be mistaken for a real route (routes start with '/').
 const PREFIX = 'ring-relevant';
 
-/** Build the intent url for a generic notification. `from` = the push sender id, when known. */
-export function relevantNav(from?: string): string {
-  return from ? `${PREFIX}:${from}` : PREFIX;
+/** Build the intent url for a generic notification. */
+export function relevantNav(): string {
+  return PREFIX;
 }
 
-/** Parse a notification's stored url. `relevant` is true for the sentinel; `from` is the
- *  sender id when one was encoded. A normal `/…` deep-link parses as not-relevant. */
-export function parseRelevantNav(url?: string): { relevant: boolean; from?: string } {
-  if (!url || (url !== PREFIX && !url.startsWith(`${PREFIX}:`))) return { relevant: false };
-  const from = url.length > PREFIX.length + 1 ? url.slice(PREFIX.length + 1) : undefined;
-  return { relevant: true, from };
+/** Whether a notification's stored url is the "route to the relevant chat" intent.
+ *  A normal `/…` deep-link (a rich note's chat link) is not-relevant and routes verbatim. */
+export function isRelevantNav(url?: string): boolean {
+  return url === PREFIX;
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -37,7 +37,7 @@ import { hasFreshRing, ringReassert, ringAlreadyNamed } from '@/services/call-ev
 import { drainPersistPending, ackFrames } from '@/services/sw-drain';
 import { resubscribePush } from '@/services/sw-push';
 import { setPendingNav } from '@/services/pending-nav';
-import { relevantNav, parseRelevantNav } from '@/services/nav-intent';
+import { relevantNav, isRelevantNav } from '@/services/nav-intent';
 import { userFacing, prettify, displayVersion } from '@/services/release-notes';
 
 declare const self: ServiceWorkerGlobalScope & {
@@ -174,7 +174,7 @@ const STRAGGLER_INTERVAL_MS = 4500;
 // notification for on-device diagnosis; production (same build) never shows internal reason text.
 const DEV_HOST = /(^|\.)ring-dev\./.test(self.location.hostname) || self.location.hostname === 'localhost' || self.location.hostname === '127.0.0.1';
 
-async function showGeneric(reason?: string, navFrom?: string): Promise<void> {
+async function showGeneric(reason?: string): Promise<void> {
   // (spec 2014 US1) Title is the STATUS, not the literal app name: iOS already shows "Ring" as its
   // forced app-name header, so titling this "Ring" too rendered the app name twice
   // ("Ring › Ring › New message"). (US2) The body carries WHY we fell back to generic so the
@@ -194,9 +194,9 @@ async function showGeneric(reason?: string, navFrom?: string): Promise<void> {
     tag: GENERIC_TAG,
     // (notify-nav fix) A generic note can't name the chat, but tapping it should still
     // land on the conversation, not the list. Encode a "route to the relevant chat"
-    // intent the app resolves after unlock (with full DB access); when we know the push
-    // sender (the msgx fallback passes it) the app can target their 1:1 chat precisely.
-    data: { url: relevantNav(navFrom) },
+    // intent the app resolves after unlock (with full DB access) to the newest unread
+    // chat — the one that just received this message, 1:1 or group.
+    data: { url: relevantNav() },
   });
 }
 
@@ -350,7 +350,7 @@ async function showNotes(notes: SwNote[]): Promise<number> {
  *  where the wake is already visibly ended or re-routed (the settle downgrade of
  *  an accepted loud generic; the authoritative-drain degrade) contain it locally
  *  via their own existing catches. */
-async function showQuietNote(kind: 'msg' | 'activity', navFrom?: string): Promise<void> {
+async function showQuietNote(kind: 'msg' | 'activity'): Promise<void> {
   const n = quietNote(kind);
   await self.registration.showNotification(n.title, {
     ...n.options,
@@ -358,7 +358,7 @@ async function showQuietNote(kind: 'msg' | 'activity', navFrom?: string): Promis
     badge: BADGE,
     // (notify-nav fix) A msg quiet note routes to the relevant chat (see showGeneric);
     // 'activity' stays on the app root.
-    data: { url: kind === 'msg' ? relevantNav(navFrom) : '/' },
+    data: { url: kind === 'msg' ? relevantNav() : '/' },
   });
 }
 
@@ -373,10 +373,10 @@ async function showQuietNote(kind: 'msg' | 'activity', navFrom?: string): Promis
 // silence was licensed (trusted platform + focused & visible window) — the caller
 // treats that as satisfied-but-not-shown, so a clean wake doesn't trip the backstop
 // yet a reject/timeout still falls back (the wake produced no OS notification).
-async function showQuietUnlessVisible(kind: 'msg' | 'activity', navFrom?: string): Promise<boolean> {
+async function showQuietUnlessVisible(kind: 'msg' | 'activity'): Promise<boolean> {
   const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
   if (mayEndWakeSilently(self.navigator.userAgent, clients)) return false; // licensed: trusted platform + focused & visible window
-  await showQuietNote(kind, navFrom);
+  await showQuietNote(kind);
   return true;
 }
 
@@ -997,7 +997,7 @@ async function dispatchLiteWake(
   if (clients.length && (await pageWillNotify(clients, 2200))) {
     const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
     if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) {
-      await showQuietNote('msg', inline?.from);
+      await showQuietNote('msg');
       ctx.shown = true;
     }
     ctx.satisfied = true;
@@ -1025,7 +1025,7 @@ async function dispatchLiteWake(
   // The generic shows NOW (bounded diagnostics read inside, spec 2044) when rich didn't
   // win — before any further keystore/decrypt work.
   if (!claimed) {
-    await showGeneric('legacy-lite', inline?.from);
+    await showGeneric('legacy-lite');
     ctx.shown = true;
     if (inline) await markShown([inline.id]); // a later fetch/open won't re-notify this id
   }
@@ -1075,7 +1075,7 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
         if (!shouldShowPlaceholderFirst(clients) && (await pageWillNotify(clients, 2200))) {
           const nowClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
           if (!mayEndWakeSilently(self.navigator.userAgent, nowClients)) {
-            await showQuietNote('msg', inline.from);
+            await showQuietNote('msg');
             ctx.shown = true;
           }
           ctx.satisfied = true;
@@ -1112,12 +1112,12 @@ async function dispatchPush(event: PushEvent, ctx: WakeCtx): Promise<void> {
         } else if (!raced.deadline && raced.r?.ok && (raced.r.silenced || raced.r.suppressed)) {
           // Muted / notifications-off (rare — usually dropped server-side): end visibly
           // with the quiet note, no loud generic.
-          if (claim() && (await showQuietUnlessVisible('msg', inline.from))) { ctx.shown = true; await markShown([inline.id]); }
+          if (claim() && (await showQuietUnlessVisible('msg'))) { ctx.shown = true; await markShown([inline.id]); }
         } else {
           // Deadline hit (rich too slow / still decrypting) OR decrypt failed → the single
           // generic SAFETY note.
           if (claim()) {
-            try { await showGeneric(raced.deadline ? 'rich-too-slow' : 'inline-fallback', inline.from); ctx.shown = true; await markShown([inline.id]); }
+            try { await showGeneric(raced.deadline ? 'rich-too-slow' : 'inline-fallback'); ctx.shown = true; await markShown([inline.id]); }
             catch (e) { console.warn('[sw] safety generic failed', e); }
           }
         }
@@ -1407,7 +1407,7 @@ self.addEventListener('notificationclick', (event) => {
       if (data.url) await setPendingNav(data.url);
       // The "relevant chat" intent is a sentinel, not a real path — openWindow can't load it,
       // so open the app root and let the stashed intent route after unlock.
-      const openTarget = !data.url || parseRelevantNav(data.url).relevant ? '/' : data.url;
+      const openTarget = !data.url || isRelevantNav(data.url) ? '/' : data.url;
       return self.clients.openWindow(openTarget);
     })(),
   );


### PR DESCRIPTION
Fixes a misroute introduced by the 1.0.18 notification-tap work.

**Symptom:** tapping a *group* message notification sometimes opened the 1:1 chat with the member who sent it, instead of the group. (Rich notifications were fine — they carry the exact `/chat/<groupId>`; only the generic fallback misrouted.)

**Cause:** the generic fallback encoded the push sender id and the app resolved it to a 1:1 chat. For a group message the sender is a group member, so that landed on the wrong conversation (a member you also DM).

**Fix:** a generic notification can't distinguish a 1:1 from a group message (no decrypt), so the tap now routes to the **newest unread chat** — the conversation that just received the triggering message, 1:1 or group. Dropped the sender-id plumbing entirely. Hidden chats remain excluded (listChats).

Also verified (no change needed): **group reaction pushes work** — `classifyReactionRecipient` wakes the reacted-to author and prior co-reactors (`reaction` class → server AllowPush Row 8 → push); bystanders and every un-react are silent housekeeping, by design (spec 1050).

Build + 1216 client unit tests green.