### PR TITLE
1.0.22 — see message status and who's online from the chats list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,5 +281,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1055-ciphertext-push-instant/plan.md`
+`specs/1062-list-status-presence/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,6 +81,7 @@ Specs are grouped by category band; status moves
 | [1053](specs/1053-composer-buttons-transition/spec.md) | Composer Buttons Transition Like WhatsApp | 🟢 shipped |
 | [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🟢 shipped |
 | [1055](specs/1055-ciphertext-push-instant/spec.md) | Instant rich notifications (bounded encrypted preview in push) | 🟡 in-progress |
+| [1062](specs/1062-list-status-presence/spec.md) | Message status and presence on the chat list | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -133,4 +134,4 @@ Specs are grouped by category band; status moves
 | [2046](specs/2046-version-announcement-push/spec.md) | Push tickles fit constrained push endpoints | 🟡 in-progress |
 | [2047](specs/2047-modern-iphones-and/spec.md) | Modern iPhones/iPads actually display push notifications | 🟡 in-progress |
 | [2048](specs/2048-notifications-not-appear/spec.md) | Show-first notifications (work when locked, keep the subscription alive) | 🟡 in-progress |
-| [2049](specs/2049-dark-default-flash/spec.md) | Default to dark theme and fix the startup theme flash | 🟡 in-progress |
+| [2049](specs/2049-dark-default-flash/spec.md) | Default to dark theme and fix the startup theme flash | 🟢 shipped |

--- a/drive/scenarios/list-status-group.mjs
+++ b/drive/scenarios/list-status-group.mjs
@@ -1,0 +1,36 @@
+// spec 1062 US3+US4 — group online count (header, list row, pinned tile) and
+// per-member online dots on avatars in the conversation. Alice is in a group with
+// Bob + Carol (both her contacts, both foregrounded → online), so she should see
+// "2 online" and dots on Bob's and Carol's avatars.
+import { createAccount, pair, group, say, waitForMessage, shot, sweep } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Alice', mobile: true });
+const b = await createAccount({ name: 'Bob', mobile: true });
+const c = await createAccount({ name: 'Carol', mobile: true });
+await pair(a, b);
+await pair(a, c);
+await pair(b, c);
+
+const gid = await group(a, 'Team', [b, c]);
+
+// Bob and Carol both post, so both their avatars (with dots) appear in Alice's view.
+await say(b, gid, 'Bob here', { isGroup: true });
+await say(c, gid, 'Carol here', { isGroup: true });
+await waitForMessage(a, gid, 'Bob here', { isGroup: true });
+await waitForMessage(a, gid, 'Carol here', { isGroup: true });
+
+// Let presence propagate (Bob + Carol are foregrounded contacts → online to Alice).
+await a.page.waitForTimeout(3500);
+
+// US4 + US3-header: inside the group — header "2 online" + dots on member avatars.
+await shot(a, 'us4-group-convo', { route: `/chat/${gid}` });
+
+// US3: group row in the chat list shows the compact count.
+await shot(a, 'us3-group-list', { route: '/tabs/chats' });
+
+// US3: pinned group tile shows the count pill.
+await a.page.evaluate((g) => window.__ringTest.pinChat(g, true), gid);
+await a.page.waitForTimeout(500);
+await shot(a, 'us3-group-tile', { route: '/tabs/chats' });
+
+await sweep([a, b, c]);

--- a/drive/scenarios/list-status-presence.mjs
+++ b/drive/scenarios/list-status-presence.mjs
@@ -1,0 +1,36 @@
+// spec 1062 — visual check that the Chats-list row shows the outgoing message's
+// delivery tick (US1). Alice DMs Bob; once Bob receives, Alice's list row shows the
+// grey double-check; once Bob opens the chat, it climbs to the blue "seen" tick.
+import { createAccount, pair, chatWith, say, waitForMessage, shot, sweep, poll } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Alice', mobile: true });
+const b = await createAccount({ name: 'Bob', mobile: true });
+await pair(a, b);
+
+const aChat = await say(a, b.id, 'Ticks on the list now');
+await waitForMessage(b, a.id, 'Ticks on the list now');
+
+const statusIs = (...want) => (msgs) =>
+  Array.isArray(msgs) &&
+  msgs.some((m) => (m.body ?? '').includes('Ticks on the list') && want.includes(m.status));
+const aMsgs = () => a.page.evaluate((c) => window.__ringTest.messages(c), aChat);
+
+// delivered (double check)
+await poll(aMsgs, statusIs('delivered', 'seen'), { label: 'Alice → delivered', timeout: 20000 });
+await shot(a, 'us1-list-tick-delivered', { route: '/tabs/chats' });
+
+// Bob opens the chat → visibility-driven seen receipt → Alice's tick goes blue.
+const bChat = await chatWith(b, a.id);
+await b.page.goto(`/chat/${bChat}`);
+await poll(aMsgs, statusIs('seen'), { label: 'Alice → seen', timeout: 20000 }).catch(() =>
+  console.log('[note] seen not reached; delivered screenshot still proves US1'),
+);
+await shot(a, 'us1-list-tick-seen', { route: '/tabs/chats' });
+
+// US2: pin the chat → the tile shows the tick (bottom-left) + online dot (bottom-right).
+// Bob is still on the chat page (foregrounded → online), so his dot should show.
+await a.page.evaluate((c) => window.__ringTest.pinChat(c, true), aChat);
+await a.page.waitForTimeout(500);
+await shot(a, 'us2-pinned-tile', { route: '/tabs/chats' });
+
+await sweep([a, b]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/1062-list-status-presence/checklists/requirements.md
+++ b/specs/1062-list-status-presence/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Message status and presence on the chat list
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The one genuine open design decision (how to word a group's partial online count under the zero-knowledge boundary) was resolved with the user before drafting: "N online" for all-contact groups, "N online contacts" for mixed groups, nothing when zero/unknown. No [NEEDS CLARIFICATION] markers remain.
+- Exact pixel placement, sizing, and micro-copy format are intentionally deferred to plan/implementation per the user's explicit design latitude; the spec fixes behavior and labeling rules only. This is recorded in Assumptions, not left ambiguous.
+- The spec deliberately names existing conventions (tick stages, presence dot, contact-gated presence) as reuse constraints without prescribing code-level implementation — kept at the behavioral level.

--- a/specs/1062-list-status-presence/contracts/README.md
+++ b/specs/1062-list-status-presence/contracts/README.md
@@ -1,0 +1,61 @@
+# Contracts — Message status and presence on the chat list
+
+This feature adds **no server API and no new wire contract**. The only external
+contract it touches — the presence WebSocket — is used exactly as today. The
+contracts below are the internal client interfaces the four UI slices share, so
+list, tile, and conversation stay consistent.
+
+## Unchanged: presence WebSocket (existing)
+
+- Client → server: `presence-sub { ids }`, `presence-prefs {...}`, `presence-self {active}`.
+- Server → client: `presence { user, online?, lastSeen? }`, gated by the 1:1
+  contact graph.
+
+This feature issues **no new frame types**. The client already subscribes to all
+contacts; an optional, bounded `subscribePresence(openGroupMemberIds)` reuses the
+existing `presence-sub` frame for the currently-open group only. The server
+behaves identically and remains blind to group membership.
+
+## New internal contracts
+
+### `lastMessageTick(input, seenReceiptsOn): LastTick` — `src/services/message-status.ts`
+
+Pure. Given the chat's last message (direction + `status` for 1:1, or the
+`receipts[]`/`groupProgress` tier for a group) and whether seen-receipts are
+reciprocally enabled, returns the display tier (`none | pending | sent |
+delivered | seen | failed`). Single source of truth for the tick everywhere.
+
+- Incoming or absent last message → `none`.
+- `failed` → `failed` (callers render nothing, no success glyph).
+- `seen` is only reachable when `seenReceiptsOn` is true; otherwise caps at
+  `delivered` (mirrors the in-conversation gate).
+
+### `MessageTick.vue` — `src/components/MessageTick.vue`
+
+Ionic-first presentational component. Props: `{ tier: LastTick }` (and optional
+`size`). Renders the matching `ion-icon` (`timeOutline` / `checkmark` /
+`checkmarkDone`) with the `.tick` / `.tick.seen` (blue `#34b7f1`) styling already
+used in the conversation. Renders nothing for `none`/`failed`. Reused by
+`ChatDetailPage`, `ChatListItem`, and `PinnedChatsGrid` so the glyphs never drift.
+
+### `useGroupPresence(chat): ComputedRef<GroupOnline>` — `src/composables/useGroupPresence.ts`
+
+Reactive. Given a group Chat, returns the `GroupOnline` view (see data-model):
+`{ count, onlineIds, allContacts, label }`. Reads `participantIds`, the contact
+set, and `peerPresence()`. Recomputes when presence or roster changes. Returns an
+empty label at `count === 0`. Non-group chats return `count: 0` / empty label
+(callers fall back to the existing 1:1 dot).
+
+### Presence dot (existing `.presence-dot`, reused)
+
+The green dot CSS in `ChatListItem.vue` is reused for: pinned-tile bottom-right
+(1:1) and per-member group avatars (Story 4), the latter sized proportionally via
+an `em`/CSS-variable tweak. No new colours — the success token drives it.
+
+## Consumption map
+
+| Surface | Uses |
+|---|---|
+| `ChatListItem.vue` (row) | `lastMessageTick` + `MessageTick` (1:1 & group); `useGroupPresence` label for group rows |
+| `PinnedChatsGrid.vue` (tile) | `MessageTick` bottom-left; `.presence-dot` bottom-right (1:1); `useGroupPresence` compact label (group) |
+| `ChatDetailPage.vue` (conversation) | `MessageTick` (dedupe existing inline logic); `useGroupPresence` in the group header; `.presence-dot` on member avatars, `activityFor` overriding |

--- a/specs/1062-list-status-presence/data-model.md
+++ b/specs/1062-list-status-presence/data-model.md
@@ -1,0 +1,84 @@
+# Data Model — Message status and presence on the chat list
+
+Nothing new is persisted server-side and nothing new is synced. Two client-side
+shapes are introduced: one tiny denormalized field on the existing Chat summary,
+and one purely-derived view computed on demand.
+
+## 1. `LastTick` — denormalized onto the Chat summary
+
+A compact display tier for the chat's most recent message, used to render the
+list-row / pinned-tile tick without a per-row message lookup.
+
+```ts
+// src/db/types.ts
+export type LastTick =
+  | 'none'        // last message is incoming, or there is no message → render nothing
+  | 'pending'     // outgoing, still sending (clock)
+  | 'sent'        // outgoing, single check
+  | 'delivered'   // outgoing, grey double check
+  | 'seen'        // outgoing, blue double check (only when seen-receipts reciprocal)
+  | 'failed';     // outgoing send failed → render nothing (no success glyph)
+
+export interface Chat {
+  // ...existing fields (lastMessage, lastKind, lastMessageTime, ...)
+  lastTick?: LastTick;   // optional: legacy records compute it lazily on read
+}
+```
+
+**Derivation** (pure, in `message-status.ts`): from the chat's last message —
+`none` if incoming/absent; otherwise map the message's `status` (1:1) or
+`groupProgress` tier (group) to the tier above, capping at `delivered` when
+`seenReceipts` is off. This is the same logic the conversation view already uses,
+extracted so both share it.
+
+**Maintenance** (`queries.ts`):
+- Set alongside `lastMessage`/`lastKind`/`lastMessageTime` whenever the chat's
+  last message changes (send, receive).
+- When an inbound receipt advances the status of the chat's **current last
+  outgoing** message, recompute and write `lastTick` on that Chat so the list
+  advances live (pending→sent→delivered→seen) via the existing `chats` live query.
+- Legacy Chat records without `lastTick`: computed on read from the last message,
+  so **no `DB_VERSION` bump / migration** (additive, index-free field).
+
+**Reactivity**: writing the Chat record fires the idb change bus → the Chats-list
+`useLiveQuery` re-renders. No new subscription.
+
+## 2. `GroupOnline` — derived, never stored
+
+Computed on demand for a group from local roster + the in-memory presence map.
+
+```ts
+// returned by useGroupPresence(chat)
+export interface GroupOnline {
+  count: number;            // members who are my contacts AND online AND sharing
+  onlineIds: string[];      // that member set (drives per-member dots, Story 4)
+  allContacts: boolean;     // true → every member is my contact ("N online")
+                            // false → mixed group ("N online contacts")
+  label: string;            // '' when count === 0; else "N online" / "N online contacts"
+}
+```
+
+**Derivation** (pure over inputs):
+- `members = chat.participantIds`
+- `contacts = ` your contact-id set
+- `onlineIds = members.filter(id => contacts.has(id) && peerPresence(id)?.online)`
+- `allContacts = members.every(id => contacts.has(id))`
+- `count = onlineIds.length`; `label` per the rules above (empty at 0/unknown).
+
+**Zero-knowledge**: a member not in `contacts` is never counted and never gets a
+dot; the server already withholds their presence, so the client cannot and does
+not infer it. Purely a set intersection over data already received.
+
+**Inputs already available**: `participantIds` (local), the contact set
+(`listContacts()` / a `Set`), and `peerPresence()` (already populated for all
+contacts via the existing subscription). No new persistence, no new network for
+the common case; an optional bounded `subscribePresence(members)` for the open
+group only (see research D3).
+
+## State & lifecycle
+
+- `LastTick` lives as long as the Chat summary; it is display-only and derivable,
+  so it is safe to drop/recompute at any time.
+- `GroupOnline` is ephemeral per render (recomputed reactively from the presence
+  map); it is never written to IndexedDB and never sent to the server, matching
+  the existing ephemeral-presence rule.

--- a/specs/1062-list-status-presence/plan.md
+++ b/specs/1062-list-status-presence/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Message status and presence on the chat list
+
+**Branch**: `feat/1062-list-status-presence` | **Date**: 2026-07-24 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/1062-list-status-presence/spec.md`
+
+## Summary
+
+Surface information Ring already computes but only shows inside a conversation onto the Chats list, pinned tiles, and group headers: the last outgoing message's delivery tick, the online presence dot, and — for groups — an honest online count plus per-member dots. The work is **client-only**: no server change, no new wire contract. Every piece reuses an existing primitive (the conversation's tick glyphs, the `.presence-dot`, the contact-gated presence map, the typing/recording activity override). The one new data touch is a small computed "last outgoing tick" denormalized onto the existing Chat summary; the one design refinement is that group online counts are composed from presence the client **already** has (contacts are already subscribed), so no meaningful new subscription traffic is introduced.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (Vue 3 `<script setup>` + Ionic), client only. No Go changes.
+
+**Primary Dependencies**: Vue 3, Ionic, `ionicons`; existing modules — `src/services/message-status.ts` (pure status reducers, `groupProgress`), `src/composables/usePresence.ts`, `src/composables/useLiveQuery.ts`, `src/composables/useSync.ts` (presence subscription), `src/db/queries.ts` (chat-summary maintenance).
+
+**Storage**: IndexedDB `chats` store. One additive, computed field on the Chat summary (`lastTick`). IndexedDB records are schemaless per-record, and no new object store or index is introduced, so **no `DB_VERSION` bump and no migration** (Principle V): the field is populated by the same code paths that already maintain `lastMessage`, and is computed on read for any legacy record that predates it.
+
+**Testing**: vitest for the new pure helpers (tick tier + group-count derivation); `drive/` scenarios for visual confirmation (list ticks, tile corners, group dots); Playwright `e2e/` for behavioral coverage of a status advancing on the list and a member's dot matching the header count (Principle III — user-facing behavior extends e2e).
+
+**Target Platform**: Installable PWA (iOS/Android/desktop).
+
+**Project Type**: Web app, single client project (repo root `src/`).
+
+**Performance Goals**: Chat list stays smooth (no per-row async lookups — the tick is denormalized, not queried per row); group count/dots are O(members) pure reads over the in-memory presence map, recomputed reactively.
+
+**Constraints**: Zero-knowledge preserved (no server group knowledge, no new server primitive); presence stays ephemeral (never persisted/synced); reciprocity honored (`privacy.seenReceipts`, `privacy.online`, `privacy.lastSeen`); Ionic-first (reuse `ion-icon`, `.presence-dot`, `--ring-*` tokens).
+
+**Scale/Scope**: Chat list of tens of rows; groups up to Ring's realistic member counts. Four independently shippable UI slices (P1–P4).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I — Zero-Knowledge (NON-NEGOTIABLE)**: PASS. No client/server boundary change. Group presence is composed entirely client-side from the existing per-user, contact-gated presence map; the server never learns group membership and gains no new endpoint. A non-contact co-member is never counted (the server won't reveal their presence and the client won't invent it). A dedicated **Zero-Knowledge Impact** section is added to the spec. Because this spec touches Principle I, **`/speckit-checklist` is REQUIRED** before `/speckit-implement` (tracked below).
+- **II — Spec-Driven**: PASS. Following specify → clarify(pre-done) → plan (this) → tasks → analyze → checklist → taskstoissues → implement.
+- **III — TDD**: PASS (planned). Pure helpers (`lastMessageTick`, `groupOnline`) get failing vitest first; the four UI slices each extend an e2e/drive scenario for the user-facing behavior. No crypto/store/HTTP logic changes.
+- **V — Offline-First**: PASS. Additive computed Chat field, no store/index addition → no `DB_VERSION` bump, no migration; reactivity rides the existing `chats` live query.
+- **VII — Quality Gates**: PASS (planned). `npm run build` + vitest + e2e where behavior changed; commit subjects written as plain-language release-note copy.
+- **IX — Privacy/Data-Minimization**: PASS. Uses strictly less than the server already gates; no new data collected or transmitted.
+- **X — Accessibility/i18n**: PASS. Count strings ("N online" / "N online contacts") are short, bidi-safe text; dots/ticks carry `aria-hidden` like the existing ones; contrast via `--ring-*`/success token.
+- **XI — Ionic-First**: PASS. Ticks render through `ion-icon` (a shared `MessageTick` composed from it); presence dots reuse the existing `.presence-dot` styling; group count lives in existing text slots (`ion-note`, the conversation subtitle). No bespoke widgets.
+
+**No violations → Complexity Tracking is empty.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1062-list-status-presence/
+├── plan.md              # This file
+├── research.md          # Phase 0 — key decisions (denormalized tick, no-new-subscription count)
+├── data-model.md        # Phase 1 — Chat.lastTick, derived group-online view
+├── quickstart.md        # Phase 1 — how to build/verify each slice
+├── contracts/
+│   └── README.md        # Internal UI/helper contracts + the (unchanged) presence WS usage
+├── checklists/
+│   └── requirements.md   # Spec quality checklist (done); ZK checklist added at /speckit-checklist
+└── tasks.md             # Phase 2 (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── services/
+│   └── message-status.ts        # + pure lastMessageTick() tier helper (extract the ChatDetailPage
+│                                 #   tickInfo/statusIcon logic here so all surfaces share one source)
+├── composables/
+│   ├── usePresence.ts           # (unchanged) contact-gated presence map
+│   ├── useGroupPresence.ts      # NEW small composable: online count + labeling + per-member set
+│   │                            #   for a group, derived from participantIds ∩ online contacts
+│   └── useSync.ts               # (optional) bounded subscribePresence for an open group's members
+├── components/
+│   ├── MessageTick.vue          # NEW tiny ion-icon wrapper (tier → glyph + .seen blue); reused by
+│   │                            #   ChatDetailPage, ChatListItem, PinnedChatsGrid
+│   ├── ChatListItem.vue         # + tick in preview row (outgoing last msg); + group online text
+│   └── PinnedChatsGrid.vue      # + tick bottom-left, presence dot bottom-right; + group count
+├── views/
+│   └── detail/
+│       └── ChatDetailPage.vue   # use MessageTick (dedupe); group header shows online count;
+│                                #   per-member online dot on sender avatars (activity overrides)
+└── db/
+    ├── types.ts                 # + Chat.lastTick?: LastTick (computed, optional)
+    └── queries.ts               # maintain lastTick where lastMessage is maintained; bump it when a
+                                 #   receipt advances the last outgoing message's status
+```
+
+**Structure Decision**: Single client project at repo root `src/`. This is a presentation-layer feature: one pure-helper extraction (`message-status.ts`), one tiny shared component (`MessageTick.vue`), one small composable (`useGroupPresence.ts`), and edits to the three surfaces that render chats (`ChatListItem`, `PinnedChatsGrid`, `ChatDetailPage`). The only data-layer touch is denormalizing a computed tick onto the Chat summary in `queries.ts`.
+
+## Phase 0 — Research
+
+See [research.md](./research.md). Decisions resolved:
+
+1. **Last-message tick data path** — denormalize a compact `lastTick` onto the Chat summary (updated where `lastMessage` is maintained, and bumped when a receipt advances the last outgoing message), rather than per-row message lookups. Keeps the list render synchronous and reactive via the existing `chats` live query.
+2. **Tick logic reuse** — extract the inline `tickInfo`/`statusIcon` from `ChatDetailPage.vue` into a pure `lastMessageTick()` in `message-status.ts` returning a tier (`pending|sent|delivered|seen|failed|none`), with a shared `MessageTick.vue` doing the `ion-icon` rendering. One source of truth for all four surfaces.
+3. **Group online count needs (almost) no new subscription** — the server reveals presence only for your contacts, and the client already subscribes to all contacts, so presence for every group member you are *permitted* to see is already in the map. The count is `participantIds ∩ {online contacts}`; "all contacts" vs "mixed" wording is decided by whether every member is in your contact set. Optional, bounded `subscribePresence(openGroupMemberIds)` only to catch the rare inbound-only contact edge — scoped to the open conversation, never the whole list.
+4. **Labeling** — `N online` when every member is a contact; `N online contacts` for mixed; render nothing when N is 0/unknown. Compact form on tile/row, fuller form in the header.
+5. **Per-member dots (Story 4)** — reuse `.presence-dot` scaled to the in-conversation avatar; `activityFor(member)` already overrides presence, satisfying "when none are interacting with the composer".
+
+## Phase 1 — Design & Contracts
+
+- [data-model.md](./data-model.md) — the `LastTick` shape and the derived `GroupOnline` view (both computed; nothing new persisted server-side, nothing new synced).
+- [contracts/README.md](./contracts/README.md) — internal contracts for `lastMessageTick()`, `useGroupPresence()`, and `MessageTick.vue`, plus a note that the presence WebSocket usage (`presence-sub`/`presence`) is unchanged.
+- [quickstart.md](./quickstart.md) — build/typecheck/test and the drive + e2e verification recipe per slice.
+
+### Zero-Knowledge Impact (added to spec)
+
+What crosses the wire: nothing new. Group membership stays client-only (sender keys); presence stays the existing per-user, contact-gated `presence-sub`/`presence` frames. The group count and dots are pure client-side composition over presence the client already receives. No server endpoint, table, log, or metric is added or changed. A co-member who is not your contact is invisible to you by construction, so the "honest partial count" cannot leak more than the 1:1 contact graph already does.
+
+## Complexity Tracking
+
+No constitutional violations — no entries.

--- a/specs/1062-list-status-presence/quickstart.md
+++ b/specs/1062-list-status-presence/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart — Message status and presence on the chat list
+
+How to build, test, and verify each slice. Client-only feature; no server or DB
+migration.
+
+## Build & unit test
+
+```sh
+npm run build      # vue-tsc typecheck + vite build (the CI typecheck gate)
+npx vitest run src/services/message-status.test.ts   # pure tick-tier helper
+npx vitest run src/composables/useGroupPresence.test.ts  # pure group-online derivation
+```
+
+TDD order (Principle III): write the failing pure-helper tests first —
+`lastMessageTick(...)` tier mapping (incoming→none, failed→failed, seen-gate caps
+at delivered, group tier via `groupProgress`) and `useGroupPresence` derivation
+(contacts-only counting, allContacts vs mixed label, empty at zero) — then make
+them pass, then wire the UI.
+
+## Visual verification (drive/ against the live dev stack)
+
+```sh
+make start                                   # dev stack: Vite :5173 → ringd :8080
+node drive/scenarios/list-status-presence.mjs   # NEW scenario for this feature
+```
+
+The scenario should, using the `window.__ringTest` hook:
+- **P1**: two accounts DM; sender checks that its Chats-list row shows the tick
+  advance sent→delivered→seen (and none when the peer replies last). Screenshot.
+- **P2**: pin the chat; confirm the tile shows the tick bottom-left and the online
+  dot bottom-right when the peer is online; both visible together with the unread
+  badge. Screenshot.
+- **P3**: a 3+ member group where all are contacts → header + row show "N online";
+  add a non-contact member → wording becomes "N online contacts"; take everyone
+  offline → nothing shown. Screenshot.
+- **P4**: inside the group, online members' avatars show the dot; a member typing
+  shows the activity indicator instead; dotted avatars == header count. Screenshot.
+
+Screenshots land in `.tmp/drive/*.png` — read them to confirm placement in light
+and dark themes.
+
+## Behavioral coverage (e2e)
+
+```sh
+make db-up
+npm run test:e2e -- e2e/list-status-presence.spec.ts   # NEW e2e for user-facing behavior
+```
+
+Cover at least: a list-row tick advancing to seen after the recipient reads
+(reciprocity on), and the group header count matching the number of online member
+dots. Follow the existing e2e presence/status patterns; poll via the harness
+helpers (never `page.waitForFunction(() => promise.then(...))`).
+
+## Manual sanity (zero-knowledge)
+
+Confirm no new network traffic: with a group open, the only presence frames are
+the existing `presence-sub`/`presence` for contacts (plus, if implemented, one
+bounded `presence-sub` for the open group's members). No new endpoint is called,
+nothing group-aware is sent, and a non-contact co-member never appears online.
+
+## Definition of done (this feature)
+
+- `npm run build` clean; new vitest green; e2e green where behavior changed.
+- Drive screenshots confirm all four slices in light + dark (+ RTL sanity).
+- No `DB_VERSION` bump, no server change, no new synced/persisted data.
+- `/speckit-analyze` clean and `/speckit-checklist` (Principle I) completed.

--- a/specs/1062-list-status-presence/research.md
+++ b/specs/1062-list-status-presence/research.md
@@ -1,0 +1,56 @@
+# Research — Message status and presence on the chat list
+
+Phase 0 decisions. Each resolves a design fork the plan depends on.
+
+## D1. How the list learns the last message's tick
+
+**Decision**: Denormalize a compact `lastTick` onto the Chat summary, maintained in `queries.ts` (a) wherever `lastMessage`/`lastKind`/`lastMessageTime` are already set, and (b) when an incoming receipt advances the status of the chat's *last outgoing* message.
+
+**Rationale**: The Chats list is driven by a single `useLiveQuery` over the `chats` store. Denormalizing keeps every row's tick available synchronously (no per-row message lookup on render) and reactive (updating the Chat record re-fires the live query, so the tick advances pending→sent→delivered→seen without reopening the chat — SC-002/FR-005). It mirrors how `lastMessage` is already maintained.
+
+**Alternatives considered**:
+- *Per-row lookup of the last message at render time* — N async reads on every list paint; janky and harder to keep reactive. Rejected.
+- *Store only `lastMessageId` + `lastOutgoing`, look up reactively* — still a per-row reactive read; more moving parts than a denormalized tier. Rejected.
+
+**Cost acknowledged**: the receipt-handling path must, when it advances a message that is a chat's last outgoing message, also update that chat's `lastTick`. This is the one new write coupling and is called out as a task. Legacy Chat records with no `lastTick` compute it lazily from the last message on first read (no migration).
+
+## D2. Reuse the conversation's tick logic
+
+**Decision**: Extract the inline `tickInfo`/`statusIcon` logic from `ChatDetailPage.vue` into a pure `lastMessageTick(...)` in `src/services/message-status.ts` returning a **tier** enum (`'pending' | 'sent' | 'delivered' | 'seen' | 'failed' | 'none'`), and add a tiny `MessageTick.vue` that maps a tier to the `ion-icon` glyph + `.seen` blue. `ChatDetailPage`, `ChatListItem`, and `PinnedChatsGrid` all consume the same helper + component.
+
+**Rationale**: One source of truth prevents the list and the conversation from drifting (the spec's whole premise is "same states as inside the chat"). `message-status.ts` is already the pure reducer home (`STATUS_ORDER`, `groupProgress`), so the tier logic belongs there; the glyph/`ion-icon` rendering stays in a component (Principle XI). The reciprocity gate (`seenReceipts`) is an input to the helper so "seen" caps at "delivered" identically everywhere (FR-004).
+
+**Alternatives considered**: leaving the logic inline and copying it into the list — guarantees drift, rejected.
+
+## D3. Group online count — no meaningful new subscription
+
+**Decision**: Compute a group's online set as `participantIds ∩ { userId : peerPresence(userId)?.online }`, i.e. intersect the local roster with contacts the client already sees as online. Do **not** add broad group-member presence subscriptions. Optionally issue a **bounded** `subscribePresence(members)` for the *currently open* group only, to catch the rare inbound-only contact edge.
+
+**Rationale (the key finding)**: The server gates presence strictly by the 1:1 contact graph (`store.PresenceAudience`), and the client already subscribes to *all* contacts (`useSync.sendPresenceSub` → `listContacts()`). Therefore presence for **every group member the client is permitted to see is already in the presence map** — a non-contact member would be gated to offline/unknown by the server even if subscribed, so subscribing to them yields nothing. This dissolves the spec's assumed scaling cost (the spec deliberately left the mechanism to the plan) while producing exactly the specified behavior: strangers never counted, honest partial count. The optional open-group subscription is a small, bounded safety net for the asymmetric case where someone added you (server would share) but you haven't added them (so they're not in `listContacts()`); scoped to one open conversation it is negligible.
+
+**Alternatives considered**:
+- *Subscribe to all members of all groups on connect* — potentially large sub set for no gain in the common case (contacts already covered). Rejected as the default; folded into the optional bounded open-group case only.
+- *Server-side group presence aggregate* — breaks Principle I outright. Rejected.
+
+**Zero-knowledge check**: unchanged wire; the count is a client-side set intersection over data already received. No new metadata leaves the device.
+
+## D4. Labeling rule
+
+**Decision**: Let `M` = group members, `online` = the D3 set, `contacts` = your contact set.
+- If `M ⊆ contacts` → `"{online.size} online"`.
+- Else (mixed) → `"{online.size} online contacts"`.
+- If `online.size === 0` → render nothing (no header line, no tile/row badge).
+
+Compact form on the pinned tile / list row (`N online`); fuller form in the group header where there's room.
+
+**Rationale**: The word "contacts" makes a partial count honest without a disclaimer (the user's chosen wording). Staying silent at zero matches how a 1:1 shows nothing when offline/unknown (FR-014), keeping surfaces quiet.
+
+## D5. Per-member dots inside a group (Story 4)
+
+**Decision**: On the member avatars already rendered on group messages (the collapsed sender-group avatars in `ChatDetailPage.vue`), render the existing `.presence-dot` scaled to the smaller avatar, shown for members in the D3 online set. `activityFor(member)` (typing/recording) already takes precedence over presence in the header logic — reuse that so a composing member shows the activity affordance instead of the plain dot (FR-024).
+
+**Rationale**: Reuses the exact presence source and dot styling; guarantees the dotted avatars equal the header count (SC-007) because both read the same D3 set. Sizing in proportion to the in-conversation avatar (FR-023) is a CSS-variable/`em`-based tweak on the shared dot, not a new element.
+
+## D6. Placement & styling latitude
+
+Exact corner offsets, dot diameter at tile vs. conversation avatar size, and whether the list-row group count sits in the preview row or the meta column are left to implementation, constrained to: reuse `.presence-dot` and `--ring-*`/success tokens, keep the unread badge legible alongside new indicators (FR-009), and work in light+dark + RTL (Principle X/XI). No new palette values.

--- a/specs/1062-list-status-presence/spec.md
+++ b/specs/1062-list-status-presence/spec.md
@@ -1,0 +1,198 @@
+# Feature Specification: Message status and presence on the chat list
+
+**Feature Branch**: `feat/1062-list-status-presence`
+
+**Created**: 2026-07-24
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User description: "In WhatsApp you can see the state of the last message right from the Chats list without going inside to see if it is sent, delivered or seen — please add that to Ring. For pinned chats there is no last-message preview, so if there is an outgoing message and nothing has arrived after it, show the pending/single/double/double-seen state at the bottom-left of the avatar, and show the online status at the bottom-right where the green dot already lives in the chats list. In group chats, if more than one other member is online, show an online count, and show the online count inside group chats too (where 1:1 shows the online status) — Online × N or whatever has a better UX/UI design."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See my last message's delivery status from the Chats list (Priority: P1)
+
+A user sends a message and returns to the Chats list. Without opening the conversation, they can see whether their most recent message is still pending, has been sent, delivered, or seen — the same tick states shown inside the conversation, surfaced on the list row.
+
+**Why this priority**: This is the core of the request and the highest-frequency payoff — every user checks "did it go through / did they read it?" many times a day. It reuses Ring's existing message-status model and tick glyphs, so it delivers the most value for the least new surface area, and it stands alone as a shippable slice.
+
+**Independent Test**: Send a message in a 1:1 chat, go to the Chats list, and confirm the row shows a pending clock; after the recipient's device acknowledges, confirm it advances to a single check (sent), then a double check (delivered), then the "seen" state once read. Confirm the tick disappears/does not apply when the most recent activity in the chat is an incoming message.
+
+**Acceptance Scenarios**:
+
+1. **Given** my last message in a chat is outgoing and still sending, **When** I view the Chats list, **Then** that chat's row shows the pending (clock) indicator.
+2. **Given** my last message was delivered but not yet read, **When** I view the Chats list, **Then** the row shows the delivered (grey double-check) indicator.
+3. **Given** my last message has been seen and seen-receipts are mutually enabled, **When** I view the Chats list, **Then** the row shows the seen (blue double-check) indicator.
+4. **Given** the most recent message in a chat is incoming (the other person replied after my last message), **When** I view the Chats list, **Then** no outgoing status indicator is shown for that chat (the incoming preview stands on its own).
+5. **Given** I have disabled seen-receipts (so I do not share mine), **When** my delivered message is read by the recipient, **Then** the list row does not advance past the delivered state (the seen state stays suppressed, matching in-conversation behavior).
+
+---
+
+### User Story 2 - See status and presence on pinned chat tiles (Priority: P2)
+
+A user pins their most important chats. Pinned chats render as avatar tiles with no message preview, so the tick and presence information has nowhere to appear today. This story places the last-outgoing-message status at the bottom-left corner of the tile avatar and the online presence dot at the bottom-right corner, so a pinned tile communicates both "state of my last message" and "are they online" at a glance.
+
+**Why this priority**: Pinned chats are the user's highest-value conversations but currently the most information-poor surface (avatar + name only). This directly addresses the user's specific request and reuses the exact indicators built in Story 1 and the existing presence-dot pattern. It depends on Story 1's derived last-message status, so it comes second.
+
+**Independent Test**: Pin a 1:1 chat, send a message, and confirm the tile shows the corresponding tick at the avatar's bottom-left. Have the peer come online (sharing presence) and confirm the green dot appears at the avatar's bottom-right; have them go offline and confirm it disappears. Confirm both corners can be shown at once without overlapping.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pinned 1:1 chat whose most recent message is outgoing, **When** I view the pinned grid, **Then** the tile shows the last message's tick state at the avatar's bottom-left corner.
+2. **Given** the pinned chat's peer is online and sharing their online status with me, **When** I view the pinned grid, **Then** the tile shows the green online dot at the avatar's bottom-right corner.
+3. **Given** the pinned chat's most recent message is incoming, **When** I view the pinned grid, **Then** no outgoing tick is shown at the bottom-left corner (the corner stays empty).
+4. **Given** a pinned chat's peer is offline or hides their presence, **When** I view the pinned grid, **Then** no online dot is shown.
+5. **Given** a pinned tile already shows an unread badge, **When** the tick and/or presence indicators also apply, **Then** all indicators remain legible and do not visually collide.
+
+---
+
+### User Story 3 - See how many people are online in a group (Priority: P3)
+
+A user wants to know, at a glance, how many people are around in a group conversation — both from the chat list/pinned surface and from inside the group. Because Ring is zero-knowledge and the server has no knowledge of group membership, the count reflects only the members the user can actually see presence for (their own contacts who share their online status). The wording makes this honest: a full-contact group reads "N online"; a mixed group reads "N online contacts" so a partial number is never mistaken for the whole roster.
+
+**Why this priority**: This is the most valuable-but-constrained slice: it needs new presence subscriptions for group members and careful wording to stay honest under the zero-knowledge boundary. It is genuinely useful but not required for Stories 1–2 to ship, so it is sequenced last.
+
+**Independent Test**: In a group where every member is the user's contact and two of them are online, confirm the group shows "2 online" in the header and a compact "2 online" on the list/pinned surface. In a group containing at least one member who is not the user's contact, confirm the wording becomes "N online contacts". With nobody visibly online, confirm no presence line/badge is shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** a group where every member is my contact and 3 of them are currently online and sharing presence, **When** I open the group, **Then** the header shows "3 online".
+2. **Given** a group that includes at least one member who is not my contact, and 2 members I can see are online, **When** I open the group, **Then** the header shows "2 online contacts".
+3. **Given** a group where nobody I can see is currently online, **When** I view the group (header, list row, or pinned tile), **Then** no online count is shown at all.
+4. **Given** a group with a visible online count, **When** I view its Chats-list row or pinned tile, **Then** a compact form of the count is shown (space-appropriate) consistent with the header count.
+5. **Given** a member of the group who is not my contact comes online, **When** I view the group, **Then** the count does not increase for them (strangers never contribute to the count), preserving the zero-knowledge boundary.
+
+---
+
+### User Story 4 - See which specific members are online inside a group (Priority: P4)
+
+Inside a group conversation, a member's avatar shows the same green online dot (sized in proportion to the in-conversation avatar) when that member is online and visible to the user. This makes the header count concrete — instead of only knowing "3 online", the user can see *which* three people the dots belong to. When a member is actively typing or recording, the existing activity indicator takes precedence over the plain online dot for that member.
+
+**Why this priority**: This enriches the group online count (Story 3) from an aggregate into per-person visibility, so it depends on Story 3's member presence subscriptions being in place. It is a refinement rather than a prerequisite for the count, so it is sequenced last. It reuses the exact same contact-gated presence set as Story 3, so the dots and the count are always mutually consistent.
+
+**Independent Test**: In a group with several members that are the user's contacts, bring two of them online (sharing presence) and confirm their avatars inside the conversation show the green dot at a proportionate size while offline members show none; have one of the online members start typing and confirm the activity indicator takes over from the plain dot for that member; confirm the number of dotted avatars equals the header count.
+
+**Acceptance Scenarios**:
+
+1. **Given** a group member who is my contact and is online sharing presence, **When** I view the group conversation, **Then** that member's avatar shows the green online dot, proportioned to the in-conversation avatar size.
+2. **Given** a group member who is offline, hides presence, or is not my contact, **When** I view the group conversation, **Then** that member's avatar shows no online dot.
+3. **Given** an online group member who begins typing or recording, **When** I view the group conversation, **Then** the existing activity indicator takes precedence over the plain online dot for that member.
+4. **Given** a group with a visible online count of N in the header, **When** I look at the member avatars in the conversation, **Then** exactly the members counted in N show the online dot (dots and count agree).
+5. **Given** a member's online state changes while I am viewing the group, **When** they come online or go offline, **Then** their avatar's dot appears or disappears live without reloading the conversation.
+
+---
+
+### Edge Cases
+
+- **Last message is a reaction / system marker, not a chat message**: the status indicator reflects the most recent *outgoing chat message*, consistent with how the conversation view derives ticks; non-message markers do not produce a tick.
+- **Failed outgoing message**: a failed send shows no success tick (matching in-conversation behavior, which suppresses ticks for `failed`); the row/tile should not imply delivery.
+- **Group message partial delivery**: for a group, the last-outgoing-message status uses the same roster-based derivation as the conversation view (delivered/seen only when the whole roster reaches that tier). The list surfaces the resulting tier; the detailed "X/N" fraction remains an in-conversation detail, not required on the list.
+- **Presence unknown vs. offline**: "unknown" (never received a presence frame / hidden) and "offline" both render as no dot and do not contribute to a group count — the surface stays quiet rather than showing "0 online".
+- **Reciprocity**: a user who does not share their own online status cannot see others' online status (existing rule); in that case no dots and no group counts appear for them.
+- **Large groups**: subscribing to presence for group members must scale to Ring's largest realistic groups without noticeable UI or battery cost; the count updates live as members come and go.
+- **A member is in multiple of my chats**: presence for a person is consistent everywhere they appear (1:1 row, group count, pinned tile) — the same underlying online state drives all surfaces.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: nothing new. Message delivery/seen state already
+  rides the existing sealed receipt frames; presence already rides the existing
+  per-user, contact-gated `presence`/`presence-sub` frames. This feature only
+  *renders* that existing data on more surfaces.
+- **What is encrypted / client-only**: group membership stays entirely client-side
+  (sender keys); the last-message tick is derived on-device from local messages;
+  the group online count and per-member dots are composed on-device by intersecting
+  the local group roster with the presence the client already receives for its
+  contacts. None of it is sent to or stored by the server.
+- **Unavoidably-visible metadata**: unchanged from today — the server already sees
+  which sealed envelopes are relayed and gates presence by the 1:1 contact graph.
+  This feature adds no new metadata: no group-aware request, no new endpoint, no
+  new stored field, no new log or metric.
+- **Why it stays zero-knowledge**: a co-member who is not the user's contact is
+  invisible to the client by construction (the server withholds their presence),
+  so the honest partial count cannot reveal more than the 1:1 contact graph already
+  does. No server capability is added; a true "N of M" is deliberately *not*
+  attempted because it would require the server to learn group membership.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Last-message status on the Chats list (Story 1)**
+
+- **FR-001**: The system MUST display, on a chat's Chats-list row, the delivery status of that chat's most recent message when that message is outgoing (sent by the user) — using the same status stages already shown inside a conversation: pending, sent, delivered, and seen.
+- **FR-002**: The system MUST NOT display an outgoing status indicator on a row when the chat's most recent message is incoming.
+- **FR-003**: The system MUST NOT display a success indicator for a most-recent outgoing message that has failed to send.
+- **FR-004**: The seen stage on the list MUST respect the existing seen-receipts reciprocity rule — if the user does not share seen-receipts, the list indicator MUST NOT advance to "seen" (it caps at delivered), identical to the in-conversation behavior.
+- **FR-005**: The list status indicator MUST update live as the underlying message status advances (pending → sent → delivered → seen) without the user re-opening or manually refreshing the list.
+- **FR-006**: For group chats, the most-recent-outgoing-message status on the list MUST be derived from the group's per-member receipt roster using the same rules as the conversation view (a tier is reached only when the whole roster reaches it).
+
+**Pinned tile indicators (Story 2)**
+
+- **FR-007**: On a pinned chat tile, the system MUST show the last-outgoing-message status indicator at the bottom-left corner of the tile's avatar, under the same conditions as FR-001–FR-006 (only when the most recent message is an outgoing, non-failed message).
+- **FR-008**: On a pinned chat tile, the system MUST show the online presence dot at the bottom-right corner of the tile's avatar when the tile's peer is online and visible to the user, reusing the existing presence-dot visual.
+- **FR-009**: The bottom-left status indicator and the bottom-right presence dot MUST be able to appear simultaneously on the same tile without overlapping each other, the unread badge, or the name.
+- **FR-010**: Pinned-tile indicators MUST update live as message status and presence change.
+
+**Group online count (Story 3)**
+
+- **FR-011**: The system MUST compute a group's visible online count as the number of that group's members who are (a) the user's own contacts, (b) currently online, and (c) sharing their online status with the user. Members who are not the user's contacts MUST NEVER be counted.
+- **FR-012**: When every member of a group is the user's contact, the system MUST label the count as "N online".
+- **FR-013**: When a group includes at least one member who is not the user's contact (a mixed group), the system MUST label the count as "N online contacts" so a partial number cannot be mistaken for the full roster.
+- **FR-014**: When a group's visible online count is zero or unknown, the system MUST show no online count on any surface (header, list row, pinned tile) — staying quiet rather than showing "0 online".
+- **FR-015**: The system MUST show the group online count inside the group conversation header (where a 1:1 conversation header shows the peer's online/last-seen status, groups currently show nothing).
+- **FR-016**: The system MUST show a space-appropriate form of the group online count on the group's Chats-list row and pinned tile, consistent with the header value.
+- **FR-017**: The group count MUST be composed from presence the client already receives. Because the server reveals presence only for the user's contacts and the client already subscribes to all contacts, every group member the user is permitted to see is already present in the local presence map; the count is that set intersected with the group roster. The client MAY additionally issue a bounded presence subscription for the members of the currently-open group only (to catch an inbound-only contact edge), but MUST NOT broadly subscribe to group members across the whole list. The server MUST continue to gate each member's presence by the 1:1 contact graph, so a non-contact member always resolves to offline/unknown and never contributes to the count.
+
+**Per-member online dots inside a group (Story 4)**
+
+- **FR-022**: Inside a group conversation, the system MUST show the online presence dot on a member's avatar when that member is online and visible to the user, using the same contact-gated presence set that feeds the group online count (FR-011) — so the dotted avatars and the header count are always consistent.
+- **FR-023**: The in-conversation member online dot MUST be sized in proportion to the in-conversation avatar (not the larger list/tile avatar), remaining legible without overwhelming the avatar.
+- **FR-024**: When a group member is actively typing or recording, the existing activity indicator MUST take precedence over that member's plain online dot; when no member is composing, the plain online dots are what is shown.
+- **FR-025**: A member who is offline, hides presence, or is not the user's contact MUST show no online dot, and the dot MUST update live as a member's online state changes.
+
+**Cross-cutting / invariants**
+
+- **FR-018**: The feature MUST NOT introduce any server knowledge of group membership and MUST NOT add a new server-side presence primitive; group presence is composed entirely on the client from existing per-user, contact-gated presence.
+- **FR-019**: Presence used by this feature MUST remain ephemeral — never persisted to the device database and never synced.
+- **FR-020**: All new indicators MUST respect the existing presence privacy settings (online-status sharing, last-seen sharing, and their reciprocity), showing nothing where the user or the peer has opted out.
+- **FR-021**: The visual language for the status ticks and presence dot MUST reuse the existing in-app conventions (the conversation's tick glyphs and colors, including the blue "seen" tick, and the existing green presence dot) rather than introducing new iconography.
+
+### Key Entities *(include if feature involves data)*
+
+- **Chat last-message status**: a derived, read-only view of a chat summary that answers "is the most recent message outgoing, and if so what stage is it at (pending/sent/delivered/seen/failed)?". Derived from existing message and receipt data; not a new stored user record.
+- **Peer presence**: an existing ephemeral, per-user online/last-seen state, contact-gated and server-authoritative; this feature consumes it for additional surfaces (pinned tiles, group members) but does not change its nature.
+- **Group visible-online count**: a derived, read-only aggregate over a group's members — the count of members who are the user's contacts, online, and sharing presence — plus a flag for whether the group is "all contacts" or "mixed" (which selects the wording). Computed live on the client; never stored or sent to the server.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: From the Chats list alone, a user can correctly determine whether their most recent outgoing message in a chat is pending, sent, delivered, or seen, without opening the conversation, for 100% of chats whose latest message is outgoing.
+- **SC-002**: The list/tile status indicator reflects a status change (e.g., delivered → seen) within the same time budget as the in-conversation indicator — no additional user action required — in at least 95% of observed transitions.
+- **SC-003**: A pinned tile simultaneously communicates last-message status (bottom-left) and peer online state (bottom-right) with both indicators fully legible and non-overlapping across supported screen sizes and both light and dark themes.
+- **SC-004**: For a group where every member is the user's contact, the displayed count exactly equals the number of those members who are online and sharing presence; for a mixed group, the count never includes any non-contact member and is labeled "online contacts".
+- **SC-005**: In no scenario does any surface display a "0 online" (or equivalent empty) count; groups with no visible online members show nothing.
+- **SC-006**: No plaintext, group-membership, or presence data crosses the client/server boundary beyond the existing per-user, contact-gated presence mechanism — verified by confirming the server receives no new group-aware requests and stores nothing new.
+- **SC-007**: Inside a group conversation, the set of member avatars showing the online dot exactly matches the members counted in the header's online count, and each dot appears/disappears live within the same time budget as the header count when a member's online state changes.
+
+## Assumptions
+
+- The existing message-status model and the conversation's tick derivation are correct and are the single source of truth reused here; this feature surfaces that state on new UI, it does not redefine delivery/seen semantics.
+- The existing presence mechanism (contact-gated, server-authoritative, ephemeral) is the only source of online state; "online" for the group count means exactly what it means for a 1:1 today.
+- "The user's contact" means a member with whom the user has the mutual 1:1 relationship that already gates presence visibility; group co-members without that relationship are treated as strangers for counting/wording purposes.
+- Subscribing to presence for group members is acceptable additional signalling and is expected to stay within reasonable cost for Ring's realistic group sizes; if a hard scaling limit is discovered during planning, it will be bounded there.
+- The precise pixel placement, sizing, and exact micro-copy/format of the indicators and counts are delegated to the plan/implementation phase (the user explicitly invited design latitude); this spec fixes the behavior and the labeling rules, not the styling.
+- Last-seen text for groups is out of scope; only a live online *count* is specified for groups (1:1 last-seen behavior is unchanged).
+
+## Out of Scope
+
+- Changing 1:1 presence or last-seen behavior, or the existing in-conversation tick rendering.
+- Any server-side awareness of group membership, or a new server presence/aggregation primitive.
+- A dedicated "who's online" roster screen or members list for a group. Per-member online *dots on existing avatars* inside the conversation are in scope (Story 4); a separate roster UI is not.
+- Typing/recording activity indicators (an existing, separate feature) — unchanged here.
+- Persisting or syncing presence or derived counts.

--- a/specs/1062-list-status-presence/tasks.md
+++ b/specs/1062-list-status-presence/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Message status and presence on the chat list
+
+**Feature**: `specs/1062-list-status-presence` | **Branch**: `feat/1062-list-status-presence`
+
+**Input**: plan.md, research.md, data-model.md, contracts/README.md, quickstart.md
+
+Client-only feature (Vue 3 + Ionic PWA). No server, no DB migration. TDD: pure-helper
+tests precede their implementations; each user story is an independently shippable slice.
+
+**Story → priority**: US1 = P1 list-row ticks · US2 = P2 pinned-tile corners ·
+US3 = P3 group online count · US4 = P4 per-member group dots.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm baseline green before changes: run `npm run build` and `npx vitest run` from repo root; note any pre-existing failures so new work is distinguishable.
+- [ ] T002 Add the `LastTick` type and optional `Chat.lastTick?: LastTick` field in `src/db/types.ts` (additive, index-free — no `DB_VERSION` bump), per data-model.md.
+
+## Phase 2: Foundational (blocking prerequisites)
+
+**These unblock every story — the shared tick source of truth.**
+
+- [ ] T003 [P] Write failing unit tests for the pure tick helper in `src/services/message-status.test.ts`: `lastMessageTick(input, seenReceiptsOn)` returns `none` for incoming/absent, `failed` for failed sends, `pending|sent|delivered` mapping for 1:1, caps at `delivered` when `seenReceiptsOn` is false, `seen` only when true, and derives the group tier via `groupProgress`.
+- [ ] T004 Implement `lastMessageTick(input, seenReceiptsOn): LastTick` in `src/services/message-status.ts` (extract/lift the tier logic from `ChatDetailPage.vue` `tickInfo`/`statusIcon`) to make T003 pass.
+- [ ] T005 Create `src/components/MessageTick.vue` — Ionic-first `ion-icon` wrapper: prop `tier: LastTick` (+ optional `size`), renders `timeOutline`/`checkmark`/`checkmarkDone` with `.tick`/`.tick.seen` (blue `#34b7f1`) styling; renders nothing for `none`/`failed`. Reuse existing tick CSS tokens.
+- [ ] T006 Refactor `src/views/detail/ChatDetailPage.vue` to render `MessageTick` (driven by `lastMessageTick`) instead of the inline `tickInfo`/`statusIcon` glyph markup — dedupe to one source of truth; confirm the conversation ticks are visually unchanged (`npm run build`).
+- [ ] T007 Maintain `Chat.lastTick` in `src/db/queries.ts`: compute via `lastMessageTick` wherever `lastMessage`/`lastKind`/`lastMessageTime` are set (send/receive), AND when an inbound receipt advances the chat's current last-outgoing message; compute lazily on read for legacy records lacking the field. No new store/index.
+
+**Checkpoint**: shared tick helper + component exist and the conversation view uses them; `Chat.lastTick` is populated reactively.
+
+## Phase 3: User Story 1 — Last-message ticks on Chats list rows (P1) 🎯 MVP
+
+**Goal**: The chat's row shows the outgoing last message's tick (pending→sent→delivered→seen), respecting the seen-receipts gate; nothing when the last message is incoming/failed.
+
+**Independent test**: Send in a 1:1, view the list, watch the row tick advance; confirm no tick when the peer replies last.
+
+- [ ] T008 [US1] Render `MessageTick` in the preview row of `src/components/ChatListItem.vue`, driven by `chat.lastTick`; show only for outgoing (`lastTick` not `none`/`failed`); keep it clear of the unread badge/mention/mute icons.
+- [ ] T009 [US1] Ensure reciprocity: the list `seen` tier follows `privacy.seenReceipts` exactly as the conversation does (already encoded in `lastMessageTick` input; wire the flag through where the summary tick is computed in `queries.ts`).
+- [ ] T010 [P] [US1] Add a drive scenario `drive/scenarios/list-status-presence.mjs` (US1 section): two accounts DM, assert the sender's list row tick advances sent→delivered→seen and shows none when incoming is last; screenshot light + dark.
+- [ ] T011 [P] [US1] Add e2e `e2e/list-status-presence.spec.ts` (US1 case): a list-row tick reaches `seen` after the recipient reads with reciprocity on.
+
+**Checkpoint**: US1 is independently shippable — list rows show live outgoing status.
+
+## Phase 4: User Story 2 — Pinned-tile corners (P2)
+
+**Goal**: Pinned 1:1 tiles show the last-outgoing tick bottom-left and the online dot bottom-right, coexisting with the unread badge.
+
+**Independent test**: Pin a 1:1; tile shows the tick bottom-left; peer comes online → green dot bottom-right; both visible with the unread badge.
+
+- [ ] T012 [US2] Render `MessageTick` at the avatar bottom-left in `src/components/PinnedChatsGrid.vue` (driven by `chat.lastTick`; hidden for `none`/`failed`), positioned on the `position:relative` `.pin-avatar`.
+- [ ] T013 [US2] Add the online `.presence-dot` at the avatar bottom-right of the pinned tile for 1:1 chats (reuse the exact CSS from `ChatListItem.vue`; gated on `peerPresence(participantIds[0])?.online`).
+- [ ] T014 [US2] Ensure the bottom-left tick, bottom-right dot, and existing unread badge/dot do not overlap and stay legible in light + dark + RTL (CSS only, existing tokens).
+- [ ] T015 [P] [US2] Extend `drive/scenarios/list-status-presence.mjs` (US2 section): pin a chat, assert tile tick + online dot render together; screenshot light + dark. AND extend `e2e/list-status-presence.spec.ts` (US2 case) to assert the pinned tile's tick + presence-dot DOM appear together (Constitution III: user-facing behavior gets e2e).
+
+**Checkpoint**: US2 independently shippable — pinned tiles convey status + presence.
+
+## Phase 5: User Story 3 — Group online count (P3)
+
+**Goal**: Groups show "N online" (all-contacts) or "N online contacts" (mixed), nothing at zero, in the group header and a compact form on the list/tile.
+
+**Independent test**: All-contact group with 2 online → "2 online"; add a non-contact member → "2 online contacts"; everyone offline → nothing.
+
+- [ ] T016 [US3] Write failing unit tests for `useGroupPresence` derivation in `src/composables/useGroupPresence.test.ts`: count = members ∩ online-contacts; `allContacts` flips label between "N online" and "N online contacts"; empty label at count 0; non-group → count 0.
+- [ ] T017 [US3] Implement `useGroupPresence(chat): ComputedRef<GroupOnline>` in `src/composables/useGroupPresence.ts` (participantIds ∩ contact set ∩ `peerPresence().online`; `allContacts`; label rules) to pass T016. Pure derivation over already-received presence — no new subscription in the common case.
+- [ ] T018 [US3] Show the group online count in the group header of `src/views/detail/ChatDetailPage.vue` (the slot that currently renders no presence line for groups), using `useGroupPresence().label`; render nothing when empty.
+- [ ] T019 [US3] Show the compact group count on group rows in `src/components/ChatListItem.vue` and group tiles in `src/components/PinnedChatsGrid.vue` (space-appropriate `N online`), consistent with the header.
+- [ ] T020 [US3] (Optional, bounded) In `src/composables/useSync.ts` usage, `subscribePresence(openGroupMemberIds)` for the currently-open group only, to catch inbound-only contact edges; never subscribe whole-list group members. Document that strangers still resolve offline (server-gated).
+- [ ] T021 [P] [US3] Extend `drive/scenarios/list-status-presence.mjs` (US3 section): all-contact group count vs mixed-group "online contacts" wording vs empty; screenshot header + row.
+- [ ] T022 [P] [US3] Extend `e2e/list-status-presence.spec.ts` (US3 case): group header count matches the number of online members.
+
+**Checkpoint**: US3 independently shippable — honest group online counts everywhere.
+
+## Phase 6: User Story 4 — Per-member group dots (P4)
+
+**Goal**: Inside a group, online members' avatars show a proportional dot; typing/recording overrides it; dotted avatars equal the header count.
+
+**Independent test**: Two online contact-members show dots; one starts typing → activity indicator instead; dotted count == header count.
+
+- [ ] T023 [US4] Render `.presence-dot` on group member (sender) avatars in `src/views/detail/ChatDetailPage.vue`, shown for members in `useGroupPresence().onlineIds`; size proportionally to the in-conversation avatar via an `em`/CSS-var tweak (no new colour).
+- [ ] T024 [US4] Make `activityFor(member)` (typing/recording) take precedence over the plain dot for that member, mirroring the header activity-override logic.
+- [ ] T025 [P] [US4] Extend `drive/scenarios/list-status-presence.mjs` (US4 section): assert online member avatars show dots, a typing member shows activity instead, and dotted count == header count; screenshot. AND extend `e2e/list-status-presence.spec.ts` (US4 case) to assert member-avatar presence-dot DOM matches the header count (Constitution III).
+
+**Checkpoint**: US4 independently shippable — per-member presence visible in-group.
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T026 Run `/speckit-checklist` for zero-knowledge/privacy (Principle I requires it): verify no new wire data, no server group knowledge, presence stays ephemeral, reciprocity honored; record in `specs/1062-list-status-presence/checklists/`.
+- [ ] T027 [P] Accessibility/i18n pass: `aria-hidden` on new dots/ticks (matching existing), count strings bidi-safe, contrast via `--ring-*`/success token; verify light + dark + RTL.
+- [ ] T028 Full gate: `npm run build` clean, all new vitest green, `npm run test:e2e -- e2e/list-status-presence.spec.ts` green; drive screenshots reviewed for all four slices.
+- [ ] T029 Update spec `Status` to `in-review` and regenerate `ROADMAP.md` (`make roadmap`) when opening the feature PR.
+
+---
+
+## Dependencies & order
+
+- **Setup (T001–T002)** → **Foundational (T003–T007)** blocks all stories (shared tick helper/component + `lastTick` maintenance; `useGroupPresence` is created in US3).
+- **US1 (T008–T011)** depends only on Foundational — the MVP.
+- **US2 (T012–T015)** depends on Foundational (uses `MessageTick` + `.presence-dot`); independent of US1.
+- **US3 (T016–T022)** introduces `useGroupPresence`; independent of US1/US2.
+- **US4 (T023–T025)** depends on US3 (`useGroupPresence.onlineIds`).
+- **Polish (T026–T029)** last.
+
+## Parallel opportunities
+
+- T003 (test) ∥ nothing before it; T004 after T003.
+- Within a story, the `[P]` drive/e2e tasks (T010/T011, T015, T021/T022, T025) run parallel to each other once the story's UI task lands.
+- US1, US2, and US3 can be built in parallel by different contributors after Foundational; US4 waits on US3.
+
+## Implementation strategy
+
+- **MVP = US1** (list-row ticks): highest-frequency payoff, smallest surface, reuses everything from Foundational.
+- Ship incrementally US1 → US2 → US3 → US4; each checkpoint is demoable and testable on its own.
+- Total: 29 tasks (Setup 2, Foundational 5, US1 4, US2 4, US3 7, US4 3, Polish 4).

--- a/specs/2049-dark-default-flash/spec.md
+++ b/specs/2049-dark-default-flash/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-24
 
-**Status**: in-progress
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -49,6 +49,10 @@
             <span class="preview draft-text">{{ draft ? ': ' + draft : '' }}</span>
           </template>
           <template v-else>
+            <!-- spec 1062: WhatsApp-style delivery tick for our own last message,
+                 leading the preview. Renders nothing when the last message is
+                 incoming/failed (tier 'none'/'failed'). -->
+            <message-tick :tier="chat.lastTick ?? 'none'" size="15px" class="preview-tick" />
             <ion-icon
               v-if="previewIcon"
               :icon="previewIcon"
@@ -64,6 +68,15 @@
       <div class="meta" slot="end">
         <ion-note :class="{ unread: unread }">{{ formatTime(chat.lastMessageTime) }}</ion-note>
         <div class="meta-icons">
+          <!-- spec 1062: compact honest online count for group rows ("3 online" /
+               "3 online contacts"); nothing when no visible member is online. -->
+          <span
+            v-if="chat.isGroup && groupOnline.count"
+            class="group-online"
+            :aria-label="groupOnline.label"
+          >
+            <span class="go-dot" aria-hidden="true" />{{ groupOnline.count }}
+          </span>
           <ion-icon v-if="isHidden" :icon="eyeOffOutline" class="meta-ico hidden-ico" aria-label="Hidden chat" />
           <ion-icon v-if="muted" :icon="notificationsOffOutline" class="meta-ico" aria-hidden="true" />
           <ion-icon v-if="chat.locked" :icon="lockClosedOutline" class="meta-ico" aria-hidden="true" />
@@ -110,8 +123,10 @@ import {
 } from '@/db/queries';
 import { appToast } from '@/services/toast';
 import EmojiText from '@/components/EmojiText.vue';
+import MessageTick from '@/components/MessageTick.vue';
 import { isHiddenId } from '@/services/hidden-state';
 import { peerPresence } from '@/composables/usePresence';
+import { useGroupPresence } from '@/composables/useGroupPresence';
 import { activityFor, activityKindLabel } from '@/composables/useTyping';
 import { formatTime } from '@/utils/time';
 import type { Chat } from '@/db/types';
@@ -154,6 +169,8 @@ const muted = computed(() => !!props.chat.mutedUntil && props.chat.mutedUntil > 
 const isOnline = computed(
   () => !props.chat.isGroup && !!peerPresence(props.chat.participantIds?.[0] ?? '')?.online,
 );
+// spec 1062: honest group online count for a compact indicator on group rows.
+const groupOnline = useGroupPresence(() => props.chat);
 // While the 1:1 peer is composing, the row shows their activity ("typing…",
 // "recording audio…", …) in place of the last-message preview (spec 1009).
 // Group rows keep the preview (per-sender group activity is US5).
@@ -287,6 +304,28 @@ ion-item-option ion-icon {
   font-size: 16px;
   margin-top: 2px;
   color: var(--app-text-muted);
+}
+/* spec 1062: leading delivery tick on the preview row. Muted like the kind icon for
+   pending/sent/delivered; the seen tier tints itself blue (MessageTick .tick.seen). */
+.preview-tick {
+  flex: none;
+  margin-top: 3px;
+  color: var(--app-text-muted);
+}
+/* spec 1062: compact group online count in the meta row — a small green dot + number. */
+.group-online {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ion-color-success, #2dd36f);
+}
+.go-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ion-color-success, #2dd36f);
 }
 .preview.activity {
   color: var(--ion-color-primary, #10b981);

--- a/src/components/MessageTick.vue
+++ b/src/components/MessageTick.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+/**
+ * (spec 1062) The WhatsApp-style delivery tick, factored out of ChatDetailPage's
+ * inline `tickInfo`/`statusIcon` so the Chats-list row, the pinned tile, and the
+ * conversation all render the same glyph set from one source of truth.
+ *
+ * Driven by a `LastTick` tier (see lastMessageTick in message-status.ts):
+ *   pending → clock · sent → single check · delivered → grey double check ·
+ *   seen → blue double check. `none`/`failed` render nothing (no idle/failure glyph
+ *   on the list — a failed send simply shows no success tick).
+ *
+ * Ionic-first: a stock `ion-icon` styled only with the existing tick tokens.
+ */
+import { computed } from 'vue';
+import { IonIcon } from '@ionic/vue';
+import { timeOutline, checkmark, checkmarkDone } from 'ionicons/icons';
+import type { LastTick } from '@/db/types';
+
+const props = defineProps<{
+  tier: LastTick;
+  /** Optional icon size (e.g. '13px' on a pinned tile). Defaults to the 16px used in-conversation. */
+  size?: string;
+}>();
+
+const icon = computed(() => {
+  switch (props.tier) {
+    case 'pending':
+      return timeOutline;
+    case 'sent':
+      return checkmark;
+    case 'delivered':
+    case 'seen':
+      return checkmarkDone;
+    default:
+      return null; // 'none' | 'failed' → render nothing
+  }
+});
+
+const seen = computed(() => props.tier === 'seen');
+</script>
+
+<template>
+  <ion-icon
+    v-if="icon"
+    class="tick"
+    :class="{ seen }"
+    :icon="icon"
+    :style="size ? { fontSize: size } : undefined"
+    aria-hidden="true"
+  />
+</template>
+
+<style scoped>
+.tick {
+  font-size: 16px;
+  /* Inherit the surrounding text colour for pending/sent/delivered (matches the
+     conversation footer); the seen tier overrides to the WhatsApp blue below. */
+  color: currentColor;
+}
+/* WhatsApp-style blue "seen" double-check — identical to the in-conversation tick. */
+.tick.seen {
+  color: #34b7f1;
+}
+</style>

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -29,6 +29,18 @@
           <user-avatar :src="byId[id].avatar" :alt="byId[id].name" :attention="byId[id].unread > 0" />
           <ion-badge v-if="byId[id].unread" color="primary" class="pin-badge">{{ byId[id].unread }}</ion-badge>
           <span v-else-if="byId[id].manualUnread" class="pin-dot" aria-hidden="true" />
+          <!-- spec 1062: last-outgoing-message tick at the avatar's bottom-left (a pinned
+               tile has no preview row), and the online presence dot at the bottom-right. -->
+          <span v-if="(byId[id].lastTick ?? 'none') !== 'none'" class="pin-tick">
+            <message-tick :tier="byId[id].lastTick ?? 'none'" size="13px" />
+          </span>
+          <span v-if="isOnline(byId[id])" class="pin-presence" aria-hidden="true" />
+          <!-- spec 1062: groups show a compact online count instead of a single dot. -->
+          <span
+            v-else-if="byId[id].isGroup && groupOnlineCount(byId[id])"
+            class="pin-online-count"
+            aria-label="online"
+          >{{ groupOnlineCount(byId[id]) }}</span>
         </div>
         <span class="pin-name" dir="auto">{{ byId[id].name }}</span>
       </button>
@@ -46,7 +58,31 @@
 import { computed, ref } from 'vue';
 import { IonBadge } from '@ionic/vue';
 import UserAvatar from '@/components/UserAvatar.vue';
-import type { Chat } from '@/db/types';
+import MessageTick from '@/components/MessageTick.vue';
+import { peerPresence } from '@/composables/usePresence';
+import { groupOnline } from '@/composables/group-online';
+import { useLiveQuery } from '@/composables/useLiveQuery';
+import { listAllContacts } from '@/db/queries';
+import { getSelfUserId } from '@/services/auth';
+import type { Chat, Contact } from '@/db/types';
+
+// spec 1062: 1:1 online presence for the tile's bottom-right dot (groups get an
+// online count instead — see groupOnlineCount). Reactive via the presence map.
+function isOnline(chat: Chat): boolean {
+  return !chat.isGroup && !!peerPresence(chat.participantIds[0])?.online;
+}
+
+// Shared contact set for group counts (one liveQuery for the whole grid — the tiles
+// are one component, so we can't call useGroupPresence per tile). Pure groupOnline()
+// keeps the zero-knowledge rule: only members who are my contacts + online are counted.
+const selfId = getSelfUserId() ?? '';
+const contacts = useLiveQuery(() => listAllContacts(), ['contacts', 'chats'], [] as Contact[]);
+const contactIds = computed(() => new Set(contacts.value.map((c) => c.id)));
+function groupOnlineCount(chat: Chat): number {
+  if (!chat.isGroup) return 0;
+  const members = chat.participantIds.filter((id) => id !== selfId);
+  return groupOnline(members, contactIds.value, (id) => !!peerPresence(id)?.online).count;
+}
 
 const props = defineProps<{
   /** Pinned chats in the user's (rank) order. */
@@ -163,6 +199,53 @@ defineExpose({
   height: 10px;
   border-radius: 50%;
   background: var(--ion-color-primary);
+}
+/* spec 1062: last-outgoing tick at the avatar's bottom-left, in a small chip that
+   backs it against the app background so it reads over any avatar. */
+.pin-tick {
+  position: absolute;
+  bottom: -1px;
+  inset-inline-start: -1px;
+  display: flex;
+  align-items: center;
+  padding: 1px 3px;
+  border-radius: 999px;
+  background: var(--ion-background-color, #000);
+  color: var(--app-text-muted);
+  line-height: 0;
+}
+/* spec 1062: online dot at the avatar's bottom-right — the list-row .presence-dot
+   pattern, scaled up for the 88px tile with a background-coloured ring to separate
+   it from the avatar edge. */
+.pin-presence {
+  position: absolute;
+  bottom: 3px;
+  inset-inline-end: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--ion-color-success, #2dd36f);
+  border: 2.5px solid var(--ion-background-color, #000);
+  box-sizing: border-box;
+}
+/* spec 1062: group online count pill at the tile's bottom-right. */
+.pin-online-count {
+  position: absolute;
+  bottom: 2px;
+  inset-inline-end: 2px;
+  min-width: 19px;
+  height: 19px;
+  padding: 0 4px;
+  border-radius: 10px;
+  background: var(--ion-color-success, #2dd36f);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--ion-background-color, #000);
+  box-sizing: border-box;
 }
 .pin-name {
   max-width: 100%;

--- a/src/composables/group-online.ts
+++ b/src/composables/group-online.ts
@@ -1,0 +1,35 @@
+/**
+ * (spec 1062) Pure group-online derivation — kept in its own module (no Vue/IDB/`.vue`
+ * imports) so it stays exhaustively unit-testable in the Node test env. `useGroupPresence`
+ * wraps this with the reactive contact list + presence map.
+ *
+ * Zero-knowledge: a member who is not one of my contacts is NEVER counted — the server
+ * withholds their presence and the client does not infer it. Wording stays honest: an
+ * all-contact group reads "N online"; a mixed group reads "N online contacts".
+ */
+export interface GroupOnline {
+  /** Members who are my contacts AND online AND sharing presence. */
+  count: number;
+  /** That member set — drives the per-member dots (Story 4). */
+  onlineIds: string[];
+  /** True when every member is my contact → "N online"; else mixed → "N online contacts". */
+  allContacts: boolean;
+  /** '' when count is 0/unknown (render nothing); else the labelled count. */
+  label: string;
+}
+
+export const EMPTY_GROUP_ONLINE: GroupOnline = { count: 0, onlineIds: [], allContacts: true, label: '' };
+
+/** `members` excludes self; `contactIds` is my contact id set; `isOnline` reports visible
+ *  online-ness. A member not in `contactIds` is never counted, even if `isOnline` is true. */
+export function groupOnline(
+  members: string[],
+  contactIds: Set<string>,
+  isOnline: (id: string) => boolean,
+): GroupOnline {
+  const onlineIds = members.filter((id) => contactIds.has(id) && isOnline(id));
+  const allContacts = members.every((id) => contactIds.has(id));
+  const count = onlineIds.length;
+  const label = count === 0 ? '' : allContacts ? `${count} online` : `${count} online contacts`;
+  return { count, onlineIds, allContacts, label };
+}

--- a/src/composables/useGroupPresence.test.ts
+++ b/src/composables/useGroupPresence.test.ts
@@ -1,0 +1,42 @@
+// spec 1062 — the pure group-online derivation (zero-knowledge honest count).
+import { describe, it, expect } from 'vitest';
+import { groupOnline } from './group-online';
+
+const onlineOf = (ids: string[]) => (id: string) => ids.includes(id);
+
+describe('spec 1062: groupOnline', () => {
+  it('counts only members who are contacts AND online', () => {
+    const r = groupOnline(['a', 'b', 'c'], new Set(['a', 'b', 'c']), onlineOf(['a', 'b']));
+    expect(r.count).toBe(2);
+    expect(r.onlineIds).toEqual(['a', 'b']);
+  });
+
+  it('all-contact group is labelled "N online"', () => {
+    const r = groupOnline(['a', 'b'], new Set(['a', 'b']), onlineOf(['a']));
+    expect(r.allContacts).toBe(true);
+    expect(r.label).toBe('1 online');
+  });
+
+  it('mixed group (a non-contact member) is labelled "N online contacts"', () => {
+    const r = groupOnline(['a', 'stranger'], new Set(['a']), onlineOf(['a']));
+    expect(r.allContacts).toBe(false);
+    expect(r.label).toBe('1 online contacts');
+  });
+
+  it('a non-contact member is NEVER counted, even if reported online (zero-knowledge)', () => {
+    const r = groupOnline(['a', 'stranger'], new Set(['a']), onlineOf(['a', 'stranger']));
+    expect(r.count).toBe(1);
+    expect(r.onlineIds).toEqual(['a']);
+  });
+
+  it('zero visible-online → empty label (render nothing)', () => {
+    const r = groupOnline(['a', 'b'], new Set(['a', 'b']), onlineOf([]));
+    expect(r.count).toBe(0);
+    expect(r.label).toBe('');
+  });
+
+  it('empty roster → empty, all-contacts vacuously true', () => {
+    const r = groupOnline([], new Set<string>(), onlineOf([]));
+    expect(r).toEqual({ count: 0, onlineIds: [], allContacts: true, label: '' });
+  });
+});

--- a/src/composables/useGroupPresence.ts
+++ b/src/composables/useGroupPresence.ts
@@ -1,0 +1,37 @@
+/**
+ * (spec 1062) Honest group online presence, composed entirely client-side.
+ *
+ * Zero-knowledge: the server reveals presence ONLY for the user's contacts, and the
+ * client already subscribes to all contacts, so every group member we're permitted to
+ * see is already in the presence map. The count is the group roster intersected with
+ * "my online contacts" — a non-contact co-member is never counted (we can't and don't
+ * infer their presence). Wording stays honest: an all-contact group reads "N online";
+ * a mixed group reads "N online contacts" so a partial count is never mistaken for the
+ * whole roster. Nothing new crosses the wire; nothing is persisted or synced.
+ */
+import { computed, toValue, type ComputedRef, type MaybeRefOrGetter } from 'vue';
+import type { Chat, Contact } from '@/db/types';
+import { peerPresence } from '@/composables/usePresence';
+import { useLiveQuery } from '@/composables/useLiveQuery';
+import { listAllContacts } from '@/db/queries';
+import { getSelfUserId } from '@/services/auth';
+import { groupOnline, EMPTY_GROUP_ONLINE, type GroupOnline } from '@/composables/group-online';
+
+export { groupOnline, type GroupOnline };
+
+/** Reactive `GroupOnline` for a group chat. Non-group (or absent) chats yield the empty
+ *  view so callers fall back to the existing 1:1 presence dot / no count. */
+export function useGroupPresence(
+  chat: MaybeRefOrGetter<Chat | undefined | null>,
+): ComputedRef<GroupOnline> {
+  const self = getSelfUserId() ?? '';
+  // Same contact source as the rest of the app; re-runs when contacts change.
+  const contacts = useLiveQuery(() => listAllContacts(), ['contacts', 'chats'], [] as Contact[]);
+  return computed(() => {
+    const c = toValue(chat);
+    if (!c || !c.isGroup) return EMPTY_GROUP_ONLINE;
+    const contactIds = new Set(contacts.value.map((x) => x.id));
+    const members = c.participantIds.filter((id) => id !== self);
+    return groupOnline(members, contactIds, (id) => !!peerPresence(id)?.online);
+  });
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -20,6 +20,7 @@ import { initialsAvatar, groupAvatar, ghostAvatar } from '@/db/avatars';
 import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryUser, cancelInvitation, connectLink, fetchPeerBundle, createPost as apiCreatePost, listPosts as apiListPosts, deletePost as apiDeletePost, keepAlivePost as apiKeepAlivePost, addPostEnvelopes as apiAddPostEnvelopes, removePostRecipient as apiRemovePostRecipient, submitEngagement as apiSubmitEngagement, listEngagement as apiListEngagement, recordPostView as apiRecordPostView, listPostViews as apiListPostViews, type ServerPost } from '@/services/api';
 import { recordStaleDrain, recordMissedWakeDrain, STALE_MSG_MS } from '@/services/push';
 import { sealForChat, openPacket } from '@/services/messaging';
+import { lastMessageTick } from '@/services/message-status';
 import { withInboundLock } from '@/services/cross-lock';
 import { mediaPreview, previewKind, chatListPreview } from '@/services/message-preview';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
@@ -473,6 +474,7 @@ export async function sendMessage(
     chat.lastMessage = body;
     chat.lastKind = 'text';
     chat.lastMessageTime = ts;
+    chat.lastTick = 'pending'; // spec 1062: our new outgoing message → clock; receipts advance it
     chat.unread = 0;
     chat.interactions = (chat.interactions ?? 0) + 1;
     chat.updatedAt = ts;
@@ -878,6 +880,7 @@ async function bumpOutgoing(chat: Chat | undefined, kind: Chat['lastKind'], prev
   chat.lastMessage = preview;
   chat.lastKind = kind;
   chat.lastMessageTime = ts;
+  chat.lastTick = 'pending'; // spec 1062: outgoing (location/poll/contact/game) → clock, advanced by receipts
   chat.unread = 0;
   chat.interactions = (chat.interactions ?? 0) + 1;
   chat.updatedAt = ts;
@@ -1632,6 +1635,35 @@ async function refreshChatPreview(chatId: string): Promise<void> {
       : previewKind(newest.kind, newest.albumName, newest.videoNote);
     chat.lastMessageTime = newest.timestamp;
   }
+  // spec 1062: keep the denormalized list/tile tick in sync with the newest message.
+  const seenOn = await getSetting<boolean>('privacy.seenReceipts', true);
+  chat.lastTick = lastMessageTick(
+    newest
+      ? { outgoing: newest.outgoing, status: newest.status, receipts: newest.receipts, isGroup: chat.isGroup }
+      : undefined,
+    seenOn,
+  );
+  chat.updatedAt = now();
+  await put('chats', chat);
+}
+
+/** (spec 1062) Advance a chat's denormalized `lastTick` when a receipt changed the
+ *  status of its NEWEST message — so the Chats-list row / pinned tile tick climbs
+ *  pending→sent→delivered→seen live, without reopening the chat. Lean by design:
+ *  no full message scan — it only acts when the changed message IS the newest (its
+ *  timestamp matches the summary) and the tier actually moved, so receipts on older
+ *  messages and duplicate/late frames write nothing (no spurious list re-render). */
+export async function refreshChatTickFor(m: Message): Promise<void> {
+  if (!m.outgoing) return;
+  const chat = await getChat(m.chatId);
+  if (!chat || m.timestamp !== chat.lastMessageTime) return; // not the newest → tick unaffected
+  const seenOn = await getSetting<boolean>('privacy.seenReceipts', true);
+  const tick = lastMessageTick(
+    { outgoing: m.outgoing, status: m.status, receipts: m.receipts, isGroup: chat.isGroup },
+    seenOn,
+  );
+  if (chat.lastTick === tick) return; // no change → skip the write + notification
+  chat.lastTick = tick;
   chat.updatedAt = now();
   await put('chats', chat);
 }
@@ -2317,6 +2349,7 @@ export async function sendMediaMessage(
         : caption || mediaPreview(kind, durationSec, name, opts?.videoNote);
     chat.lastKind = previewKind(kind, opts?.albumName, opts?.videoNote);
     chat.lastMessageTime = ts;
+    chat.lastTick = 'pending'; // spec 1062: outgoing media starts compressing/pending → clock
     chat.unread = 0;
     chat.interactions = (chat.interactions ?? 0) + 1;
     chat.updatedAt = ts;
@@ -6362,6 +6395,7 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
     chat.lastMessage = isGroupMsg ? `${contact.name.split(' ')[0]}: ${preview}` : preview;
     chat.lastKind = previewKind(kind, payload.albumName, payload.videoNote);
     chat.lastMessageTime = ts;
+    chat.lastTick = 'none'; // spec 1062: newest is an incoming message → no outgoing tick
     chat.interactions = (chat.interactions ?? 0) + 1;
     // If the user is actively viewing this chat, the message is seen on arrival
     // (the open chat sends the read receipt), so don't grow the unread badge.

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -47,6 +47,14 @@ export interface Contact {
   updatedAt: number;
 }
 
+// spec 1062: the display tier of a chat's LAST message, denormalized onto the Chat
+// summary so the Chats list / pinned tiles can show the WhatsApp-style tick without a
+// per-row message lookup. 'none' = the last message is incoming/absent or a failed send
+// (render nothing). Derived on the client (see lastMessageTick in message-status.ts);
+// device-local + recomputable, never synced. Defined here (not in message-status.ts) so
+// Chat can reference it without a circular import.
+export type LastTick = 'none' | 'pending' | 'sent' | 'delivered' | 'seen' | 'failed';
+
 export interface Chat {
   id: string;
   name: string;
@@ -76,6 +84,10 @@ export interface Chat {
     | 'game'
     | 'call';
   lastMessageTime: number; // epoch ms
+  // spec 1062: display tier of the last message when it is our own outgoing message
+  // (pending/sent/delivered/seen), else 'none'. Drives the list-row / pinned-tile tick.
+  // Optional: legacy records without it fall back to 'none'/lazy recompute on read.
+  lastTick?: LastTick;
   unread: number;
   interactions?: number; // messages sent/received, drives "Frequently contacted"
   updatedAt: number;

--- a/src/services/message-status.test.ts
+++ b/src/services/message-status.test.ts
@@ -8,6 +8,7 @@ import {
   applyStatusReceipt,
   applyDownloadedReceipt,
   groupProgress,
+  lastMessageTick,
 } from './message-status';
 
 // Minimal outgoing-message factory. The reducers only read status/receipts/*At/
@@ -258,5 +259,64 @@ describe('groupProgress (complete-the-tier counter, spec 1010 FR-004/005)', () =
     // delivered → plain), never a "Seen X/N".
     const partial = msg({ receipts: roster([{ d: true, s: true }, { d: true }]) });
     expect(groupProgress(partial, false)).toEqual({ tier: 'delivered', label: null });
+  });
+});
+
+describe('spec 1062: lastMessageTick (shared list/tile tick tier)', () => {
+  // Local receipt roster: {d,s} → deliveredAt/seenAt set. (The identically-named
+  // helper above is scoped to another describe block, so we define our own here.)
+  const roster = (rs: { d?: boolean; s?: boolean }[]): Receipt[] =>
+    rs.map((r, i) => ({
+      contactId: `u${i}`,
+      deliveredAt: r.d ? 1 : undefined,
+      seenAt: r.s ? 1 : undefined,
+    }));
+
+  it('renders nothing for an incoming or absent last message', () => {
+    expect(lastMessageTick(undefined)).toBe('none');
+    expect(lastMessageTick(null)).toBe('none');
+    expect(lastMessageTick(msg({ outgoing: false, status: 'seen' }))).toBe('none');
+  });
+
+  it('failed outgoing sends show no success tick', () => {
+    expect(lastMessageTick(msg({ status: 'failed' }))).toBe('failed');
+  });
+
+  it('pre-send states map to pending (clock)', () => {
+    expect(lastMessageTick(msg({ status: 'pending' }))).toBe('pending');
+    expect(lastMessageTick(msg({ status: 'compressing' }))).toBe('pending');
+  });
+
+  it('1:1 maps status straight through', () => {
+    expect(lastMessageTick(msg({ status: 'sent' }))).toBe('sent');
+    expect(lastMessageTick(msg({ status: 'delivered' }))).toBe('delivered');
+    expect(lastMessageTick(msg({ status: 'seen' }))).toBe('seen');
+  });
+
+  it('1:1 seen caps at delivered when seen-receipts are off (reciprocity)', () => {
+    expect(lastMessageTick(msg({ status: 'seen' }), false)).toBe('delivered');
+    // sent/delivered are unaffected by the gate
+    expect(lastMessageTick(msg({ status: 'delivered' }), false)).toBe('delivered');
+  });
+
+  // isGroup is a lastMessageTick input flag, not a Message field — attach it to the
+  // spread message rather than the Partial<Message> factory.
+  const group = (over: Partial<Message>) => ({ ...msg(over), isGroup: true });
+
+  it('groups derive the tier from the receipt roster (via groupProgress)', () => {
+    const allDelivered = group({ status: 'delivered', receipts: roster([{ d: true }, { d: true }]) });
+    expect(lastMessageTick(allDelivered)).toBe('delivered');
+
+    const partialDelivered = group({ status: 'sent', receipts: roster([{ d: true }, {}]) });
+    // partial delivery still shows the delivered tier (fraction is a bubble-only detail)
+    expect(lastMessageTick(partialDelivered)).toBe('delivered');
+
+    const allSeen = group({ status: 'seen', receipts: roster([{ d: true, s: true }, { d: true, s: true }]) });
+    expect(lastMessageTick(allSeen)).toBe('seen');
+  });
+
+  it('group seen tier is suppressed when seen-receipts are off', () => {
+    const allSeen = group({ status: 'seen', receipts: roster([{ d: true, s: true }, { d: true, s: true }]) });
+    expect(lastMessageTick(allSeen, false)).toBe('delivered');
   });
 });

--- a/src/services/message-status.ts
+++ b/src/services/message-status.ts
@@ -15,7 +15,7 @@
 // `updatedAt` is intentionally NOT touched here — that's the persistence layer's
 // job (it stamps it only when a write actually happens).
 
-import type { Message, Receipt } from '@/db/types';
+import type { LastTick, Message, Receipt } from '@/db/types';
 
 /** Monotonic rank of each displayed status. Pre-send states (compressing/pending/
  *  failed) sit below `sent` so a server ack advances them; status never regresses
@@ -158,6 +158,39 @@ export function applyDownloadedReceipt(
   if (already) return { msg, allDownloaded: true };
   const downloadedBy = [...new Set([...(msg.downloadedBy ?? []), recipient])];
   return { msg: { ...msg, downloadedBy }, allDownloaded: true };
+}
+
+/** (spec 1062) The display tier of a chat's LAST message, for the Chats list row and
+ *  pinned tile — the single source of truth shared with the in-conversation `tickInfo`.
+ *  `none` when the last message is incoming/absent or a failed send (render nothing).
+ *
+ *  Mirrors `tickInfo`/`statusIcon` in ChatDetailPage.vue exactly:
+ *   - pre-send (compressing/pending) → 'pending' (clock)
+ *   - group → the roster-derived `groupProgress` tier (sent/delivered/seen), already
+ *     reciprocity-gated by `seenReceiptsOn` (seen tier suppressed → caps at delivered)
+ *   - 1:1 → status maps straight through, with 'seen' capped to 'delivered' when
+ *     `seenReceiptsOn` is false (the reciprocity DISPLAY gate, spec 1010 FR-009).
+ *  Pure: no Vue/IDB — unit-testable, and reused by the summary maintenance in queries.ts. */
+export function lastMessageTick(
+  msg:
+    | (Pick<Message, 'outgoing' | 'status' | 'receipts'> & { isGroup?: boolean })
+    | null
+    | undefined,
+  seenReceiptsOn = true,
+): LastTick {
+  if (!msg || !msg.outgoing) return 'none';
+  const { status, receipts, isGroup } = msg;
+  if (status === 'failed') return 'failed';
+  if (status === 'compressing' || status === 'pending') return 'pending';
+  if (isGroup && receipts && receipts.length) {
+    // groupProgress already caps the seen tier when seenReceiptsOn is false.
+    const p = groupProgress({ receipts }, seenReceiptsOn);
+    return p ? p.tier : 'sent';
+  }
+  if (status === 'sent') return 'sent';
+  if (status === 'delivered') return 'delivered';
+  if (status === 'seen') return seenReceiptsOn ? 'seen' : 'delivered';
+  return 'none';
 }
 
 /** Which tier's icon/colour a group bubble shows. `sent` = single tick; `delivered`

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -7,7 +7,7 @@
  * Today it runs against MockTransport (see services/transport.ts); the same
  * code drives the real WebSocket transport later. The cursor API is preserved.
  */
-import { getSetting, setSetting, getMessage, receiveIncoming, markSendFailed } from '@/db/queries';
+import { getSetting, setSetting, getMessage, receiveIncoming, markSendFailed, refreshChatTickFor } from '@/db/queries';
 import { get, bulkPut, remove, type StoreName } from '@/db/idb';
 import { listOutbox, removeOutbox, removeOutboxByFrameId, markOutboxSent } from '@/db/outbox';
 import { recordTombstone, isTombstoned } from '@/db/tombstones';
@@ -189,7 +189,12 @@ async function applyReceipt(
   // mutateMessage serializes the read-modify-write so a concurrent cleanup or local
   // write can't clobber it. The reducer no-ops (same reference) on a duplicate/late
   // frame, so no spurious write/notification happens.
-  await mutateMessage(messageId, (m) => applyStatusReceipt(m, status as ReceiptStatus, at, recipient));
+  const updated = await mutateMessage(messageId, (m) =>
+    applyStatusReceipt(m, status as ReceiptStatus, at, recipient),
+  );
+  // spec 1062: if that receipt advanced the chat's NEWEST outgoing message, climb the
+  // denormalized list/tile tick so it updates live (no-op when it wasn't the newest).
+  if (updated) await refreshChatTickFor(updated);
 }
 
 /** A recipient confirmed they hold our media's bytes. Once EVERY recipient has, delete the

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -171,14 +171,22 @@
           <!-- Group chats: the sender's avatar next to their messages (shown once
                per consecutive run; a spacer keeps continuation bubbles aligned). -->
           <template v-if="chat?.isGroup && !m.outgoing">
-            <img
+            <!-- spec 1062: the sender's online dot on their avatar (proportional to the
+                 34px avatar), shown when they're a visible-online contact and NOT
+                 currently composing (activity takes precedence, FR-024). -->
+            <span
               v-if="groupRunStart(i) && senderAvatar(m.senderId)"
-              class="msg-avatar"
-              :src="senderAvatar(m.senderId)"
-              :alt="m.senderName"
-              role="button"
-              @click.stop="openSenderProfile(m.senderId)"
-            />
+              class="msg-avatar-wrap"
+            >
+              <img
+                class="msg-avatar"
+                :src="senderAvatar(m.senderId)"
+                :alt="m.senderName"
+                role="button"
+                @click.stop="openSenderProfile(m.senderId)"
+              />
+              <span v-if="memberOnline(m.senderId)" class="msg-presence-dot" aria-hidden="true" />
+            </span>
             <span v-else class="msg-avatar avatar-spacer" aria-hidden="true" />
           </template>
           <!-- Send failed (3 retries) → a red retry button in front of the bubble. -->
@@ -1284,6 +1292,7 @@ import {
 import { isUnlocked, isUnlockedNow } from '@/services/crypto/identity';
 import { reportSeenUpTo, sendDownloadedReceipts, sendActivity, sendGroupActivity, useSync } from '@/composables/useSync';
 import { peerPresence, presenceLabel } from '@/composables/usePresence';
+import { useGroupPresence } from '@/composables/useGroupPresence';
 import { activityFor, activityKindLabel, coalescedActivityLabel } from '@/composables/useTyping';
 import { ACTIVITY, type ActivityKind, type ActivityState } from '@/services/transport';
 import { startDirectCall, startGroupCall } from '@/composables/useCall';
@@ -1297,15 +1306,32 @@ const router = useRouter();
 const chatId = route.params.id as string;
 
 // Online / last-seen line under the contact name (1:1 only; '' when unknown).
+// spec 1062: honest group online count for the header + per-member dots (US3/US4).
+// Getter form (not the ref directly) — `chat` is declared later; the closure defers
+// access until the computed runs, matching how statusLine references it.
+const groupPresence = useGroupPresence(() => chat.value);
+
+// A group member's avatar shows the online dot when they're in the visible-online set
+// AND not currently composing — the typing/recording activity takes precedence (FR-024).
+function memberOnline(id: string): boolean {
+  return groupPresence.value.onlineIds.includes(id) && activityFor(id).length === 0;
+}
+
 // While the peer is composing, a transient activity indicator ("typing…",
 // "recording audio…", "recording video…") OVERRIDES the presence line (spec 1009).
 const statusLine = computed(() => {
   const c = chat.value;
   if (!c) return '';
   if (c.isGroup) {
-    // Groups have no presence line; show per-sender activity only while someone's
-    // composing — "Alice is typing…" / "Alice, Bob…" / "several people…" (US5).
-    return coalescedActivityLabel(c.id, (id) => contactsMap.value.get(id)?.name ?? 'Someone');
+    // Per-sender activity overrides everything while someone's composing —
+    // "Alice is typing…" / "Alice, Bob…" / "several people…" (US5).
+    const activity = coalescedActivityLabel(c.id, (id) => contactsMap.value.get(id)?.name ?? 'Someone');
+    if (activity) return activity;
+    // spec 1062: otherwise show the honest online count ("N online" / "N online
+    // contacts"), or nothing when no one visible is online. Reactive to presence;
+    // the 30s tick keeps parity with the 1:1 branch (harmless for a bare count).
+    void nowMs.value;
+    return groupPresence.value.label;
   }
   const peer = c.participantIds[0];
   if (!peer) return '';
@@ -5393,6 +5419,28 @@ function cancelRecording() {
   align-self: flex-start;
   background: var(--app-bubble-in);
   cursor: pointer;
+}
+/* spec 1062: wrapper so the sender's online dot can pin to the avatar's bottom-right.
+   The wrapper carries the avatar's spacing; the img inside drops its own margin. */
+.msg-avatar-wrap {
+  position: relative;
+  display: inline-flex;
+  margin: 2px 7px 0 0;
+  align-self: flex-start;
+}
+.msg-avatar-wrap .msg-avatar {
+  margin: 0;
+}
+.msg-presence-dot {
+  position: absolute;
+  bottom: 0;
+  inset-inline-end: 0;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--ion-color-success, #2dd36f);
+  border: 2px solid var(--ion-background-color, #000);
+  box-sizing: border-box;
 }
 .avatar-spacer {
   visibility: hidden;


### PR DESCRIPTION
Production release **1.0.22**.

## What's new
- **Message delivery status on the Chats list** — see whether your last message was sent, delivered, or read, right from the list (blue double-check when read).
- **Pinned tiles** show your last message's status and the contact's online dot.
- **Group online counts** — "N online" (or "N online contacts" in a mixed group) in the group header, chat-list row, and pinned tile, plus a green dot on each online member's avatar in the conversation.

## Notes
Client-only, zero-knowledge preserved: group presence is composed from the presence you already receive for your contacts (a stranger in a group is never counted). Spec `1062`. Merged via #1084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i