### PR TITLE
1.0.23 — media that plays everywhere (WebM, HEIC, transparent PNG, SVG)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,5 +281,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/1062-list-status-presence/plan.md`
+`specs/2050-media-interop/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ Specs are grouped by category band; status moves
 | [1053](specs/1053-composer-buttons-transition/spec.md) | Composer Buttons Transition Like WhatsApp | 🟢 shipped |
 | [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🟢 shipped |
 | [1055](specs/1055-ciphertext-push-instant/spec.md) | Instant rich notifications (bounded encrypted preview in push) | 🟡 in-progress |
-| [1062](specs/1062-list-status-presence/spec.md) | Message status and presence on the chat list | 🔵 in-review |
+| [1062](specs/1062-list-status-presence/spec.md) | Message status and presence on the chat list | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -135,3 +135,4 @@ Specs are grouped by category band; status moves
 | [2047](specs/2047-modern-iphones-and/spec.md) | Modern iPhones/iPads actually display push notifications | 🟡 in-progress |
 | [2048](specs/2048-notifications-not-appear/spec.md) | Show-first notifications (work when locked, keep the subscription alive) | 🟡 in-progress |
 | [2049](specs/2049-dark-default-flash/spec.md) | Default to dark theme and fix the startup theme flash | 🟢 shipped |
+| [2050](specs/2050-media-interop/spec.md) | Make pasted and sent media interoperable across browsers | 🔵 in-review |

--- a/drive/scenarios/pin-tick-light.mjs
+++ b/drive/scenarios/pin-tick-light.mjs
@@ -1,0 +1,33 @@
+// spec 1062 light-theme fix — the pinned-tile tick chip + online dot + group count
+// must NOT render as black blobs in light theme (#fff fallback for --ion-background-color).
+import { createAccount, pair, group, chatWith, say, waitForMessage, shot, sweep } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Alice', mobile: true });
+const b = await createAccount({ name: 'Bob', mobile: true });
+const c = await createAccount({ name: 'Carol', mobile: true });
+await pair(a, b);
+await pair(a, c);
+await pair(b, c);
+
+// Force Alice into LIGHT theme.
+await a.page.evaluate(() => window.__ringTest.setSetting('appearance.theme', 'light'));
+
+// 1:1 with Bob: send + have Bob read it (seen tick), Bob online (dot).
+const ab = await say(a, b.id, 'light theme tick');
+await waitForMessage(b, a.id, 'light theme tick');
+await b.page.goto(`/chat/${await chatWith(b, a.id)}`); // Bob reads → seen; Bob online
+
+// A group so the tile shows the online count pill too.
+const gid = await group(a, 'Team', [b, c]);
+await say(b, gid, 'hi', { isGroup: true });
+await waitForMessage(a, gid, 'hi', { isGroup: true });
+
+await a.page.waitForTimeout(3000); // presence settle
+
+// Pin both the 1:1 and the group, then screenshot Alice's light-theme chat list.
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), ab);
+await a.page.evaluate((id) => window.__ringTest.pinChat(id, true), gid);
+await a.page.waitForTimeout(500);
+await shot(a, 'pin-tick-light', { route: '/tabs/chats' });
+
+await sweep([a, b, c]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",
@@ -17,6 +17,7 @@
         "@zxing/browser": "^0.2.0",
         "emoji-picker-element": "^1.29.1",
         "flubber": "^0.4.2",
+        "heic2any": "^0.0.4",
         "ionicons": "^7.4.0",
         "libsodium-wrappers-sumo": "^0.7.16",
         "lottie-web": "^5.13.0",
@@ -5242,6 +5243,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",
@@ -33,6 +33,7 @@
     "@zxing/browser": "^0.2.0",
     "emoji-picker-element": "^1.29.1",
     "flubber": "^0.4.2",
+    "heic2any": "^0.0.4",
     "ionicons": "^7.4.0",
     "libsodium-wrappers-sumo": "^0.7.16",
     "lottie-web": "^5.13.0",

--- a/specs/1062-list-status-presence/checklists/zero-knowledge.md
+++ b/specs/1062-list-status-presence/checklists/zero-knowledge.md
@@ -1,0 +1,49 @@
+# Checklist: Zero-Knowledge & Privacy (spec 1062)
+
+**Purpose**: Validate that the *requirements* for zero-knowledge and privacy are complete, clear, consistent, and measurable — as required by Constitution Principle I. This tests the spec's wording, not the implementation.
+**Created**: 2026-07-24
+**Feature**: [spec.md](../spec.md)
+
+## Boundary — What Crosses the Wire
+
+- [ ] CHK001 Is the requirement that **no new data crosses the client/server boundary** stated explicitly and unambiguously? [Clarity, Spec §ZK-Impact, §FR-018]
+- [ ] CHK002 Is it clearly specified that group presence is composed **client-side from already-received contact-gated presence**, rather than fetched via any new request? [Completeness, Spec §FR-017]
+- [ ] CHK003 Are the existing presence frames the feature relies on (`presence-sub`/`presence`) named as the *only* wire mechanism, with a requirement that no new frame type is introduced? [Clarity, Spec §ZK-Impact]
+- [ ] CHK004 Is the optional bounded open-group subscription bounded in requirements to the *currently-open* group only, with an explicit prohibition on whole-list group-member subscription? [Consistency, Spec §FR-017]
+
+## Server Knowledge & Metadata
+
+- [ ] CHK005 Is there an explicit requirement that the **server gains no knowledge of group membership**? [Completeness, Spec §FR-018, §ZK-Impact]
+- [ ] CHK006 Is the prohibition on **new server endpoint / table / log / metric** stated, not merely implied? [Clarity, Spec §FR-018, §ZK-Impact]
+- [ ] CHK007 Is the "no new server-visible metadata" claim tied to a **verifiable** success criterion? [Measurability, Spec §SC-006]
+- [ ] CHK008 Does the spec state *why* a true "N of M members online" is deliberately **not** attempted (would require server group knowledge)? [Completeness, Spec §ZK-Impact, §Out-of-Scope]
+
+## Ephemerality & Persistence
+
+- [ ] CHK009 Is the requirement that presence stays **ephemeral (never persisted to IndexedDB, never synced)** stated for this feature's new uses, not just assumed from existing behavior? [Completeness, Spec §FR-019]
+- [ ] CHK010 Is the derived group-online view specified as **computed on demand / never stored**, consistent with the ephemerality rule? [Consistency, Spec §Key-Entities, §FR-019]
+- [ ] CHK011 Is the denormalized `Chat.lastTick` field's persistence scope clarified (device-local, derivable, not synced) so it isn't mistaken for synced user data? [Clarity, Data-model]
+
+## Contact-Gating & Counting
+
+- [ ] CHK012 Is it unambiguous that a **non-contact co-member is never counted and never dotted**? [Clarity, Spec §FR-011, §FR-022, §FR-025]
+- [ ] CHK013 Are the "all contacts" vs "mixed group" labeling rules defined precisely enough to be objectively evaluated? [Measurability, Spec §FR-012, §FR-013]
+- [ ] CHK014 Is the zero/unknown case specified to render **nothing** (no "0 online"), consistently across header, row, and tile? [Consistency, Spec §FR-014, §SC-005]
+- [ ] CHK015 Is consistency between the header count and the per-member dots required (dots == counted members)? [Consistency, Spec §FR-022, §SC-007]
+
+## Reciprocity & Privacy Settings
+
+- [ ] CHK016 Is honoring **`privacy.seenReceipts`** reciprocity stated for the list/tile "seen" tier (caps at delivered when off)? [Completeness, Spec §FR-004]
+- [ ] CHK017 Is honoring **`privacy.online` / `privacy.lastSeen`** reciprocity stated for all new presence surfaces (dots, counts)? [Completeness, Spec §FR-020]
+- [ ] CHK018 Are the reciprocity requirements consistent with the existing rule that a user who doesn't share can't see others (no new visibility path)? [Consistency, Spec §FR-020]
+
+## Edge Cases & Ambiguities
+
+- [ ] CHK019 Is the "unknown vs offline" distinction specified so neither contributes to a count nor implies presence the client can't actually see? [Edge Case, Spec §Edge-Cases]
+- [ ] CHK020 Is the inbound-only contact-edge case (someone added you but isn't in your contacts) addressed in requirements without creating a new leak? [Coverage, Spec §FR-017]
+- [ ] CHK021 Is there any residual wording that could be read as requiring server-side group awareness or a broad new subscription (potential conflict to resolve)? [Conflict, Spec §FR-017 vs §FR-018]
+
+## Notes
+
+- Principle I checklist for spec 1062. Items validate that the ZK/privacy *requirements* are well-written and closed — a prerequisite for `/speckit-implement`.
+- CHK021 is the guard against the exact drift that the analyze pass flagged and fixed (FR-017 mechanism reconciled to "compose from existing contact presence"); it should read as resolved.

--- a/specs/1062-list-status-presence/spec.md
+++ b/specs/1062-list-status-presence/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-24
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2050-media-interop/checklists/requirements.md
+++ b/specs/2050-media-interop/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Make pasted and sent media interoperable
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-07-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details leak into requirements (the audit's file/line specifics stay in Context/Assumptions, requirements stay behavioral)
+- [x] Focused on user value (media that actually arrives viewable) and honest failure
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (incl. Zero-Knowledge Impact — Principle I)
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain (scope set by the audit + the user's "full interop pass" choice)
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases identified (Original-quality escape hatch, oversized, transcoder-unavailable, animation, already-portable)
+- [x] Scope is clearly bounded (Out of Scope lists no server validation, no attach-filtering, no audio interop)
+- [x] Dependencies and assumptions identified (client-side ffmpeg/HEIC decoder; portable = MP4/H.264 + JPEG/PNG/WebP/GIF)
+
+## Feature Readiness
+
+- [x] Each functional requirement has clear acceptance criteria
+- [x] User scenarios cover the four format gaps, prioritized (WebM P1 → HEIC P2 → PNG-alpha P3 → SVG P4)
+- [x] Measurable outcomes defined (SC-001..007) including a no-regression criterion for working formats
+- [x] No implementation details leak into requirements
+
+## Notes
+
+- This is a bug fix (2001+): per Constitution III, implementation MUST begin with a **failing regression test** — the natural first test is the pure "is this container/format portable / does it require mandatory conversion?" decision (WebM → must-transcode even at Original quality), before wiring the transcode routing.
+- Principle I applies (media crosses the wire as ciphertext): `/speckit-checklist` is **required** before implement; the Zero-Knowledge Impact section is included.
+- The unifying invariant FR-014 ("interoperable send or visible failure — never a silent broken send") is the acceptance backbone; each format story is one instance of it.

--- a/specs/2050-media-interop/checklists/zero-knowledge.md
+++ b/specs/2050-media-interop/checklists/zero-knowledge.md
@@ -1,0 +1,30 @@
+# Checklist: Zero-Knowledge & Privacy (spec 2050)
+
+**Purpose**: Validate the zero-knowledge/privacy requirements (Constitution Principle I) are met by the media-interop fixes. Tests the design, not pixels.
+**Created**: 2026-07-25
+**Feature**: [spec.md](../spec.md)
+
+## Boundary — what crosses the wire
+
+- [x] CHK001 No new server API, endpoint, or request is added — media stays sealed client-encrypted ciphertext. [Spec §ZK-Impact, §FR-013]
+- [x] CHK002 The server continues to store media as opaque `application/octet-stream`; no media-aware server logic is introduced. [Spec §ZK-Impact]
+- [x] CHK003 Conversion changes the BYTES (MP4/JPEG/alpha-PNG) but adds no new server-visible metadata (size aside, which the server already sees). [Spec §SC-007]
+
+## Where processing happens
+
+- [x] CHK004 All conversion (ffmpeg-wasm transcode, HEIC-wasm decode, canvas re-encode, SVG rasterize) runs on the CLIENT, before encryption. [Spec §ZK-Impact, §FR-013]
+- [x] CHK005 The new HEIC decoder is a local wasm module loaded from the app bundle — no network fetch of media or of a remote decode service. [research D2]
+- [x] CHK006 No media is uploaded to the server for processing under any path (incl. failure). [Spec §FR-013]
+
+## Honest failure (no silent leak of broken data)
+
+- [x] CHK007 A non-portable media that can't be converted fails visibly (`failReason: 'cant-convert'`) and is NOT uploaded raw. [Spec §FR-003, §FR-007, §FR-014, §SC-005]
+- [x] CHK008 No accepted format results in a silent unplayable/unviewable send. [Spec §FR-014]
+
+## No persistence / minimization
+
+- [x] CHK009 Nothing new is persisted to IndexedDB or synced; the portability decision is derived per-send and discarded. [data-model]
+- [x] CHK010 Paste and picker stay equally permissive — the fix is conversion, not new data collection or new gating. [Spec §FR-011]
+
+## Notes
+- Principle I checklist for spec 2050. All items are satisfied by the design (client-side conversion, opaque server blobs, honest failure). The one new dependency (wasm HEIC decoder) is client-side and lazy — no ZK impact.

--- a/specs/2050-media-interop/contracts/README.md
+++ b/specs/2050-media-interop/contracts/README.md
@@ -1,0 +1,47 @@
+# Contracts — Cross-browser media interop (spec 2050)
+
+**No server API and no new wire contract.** Media stays sealed client-encrypted ciphertext,
+stored server-side as opaque `application/octet-stream`; `media-transfer.ts` preserves
+`blob.type` end-to-end for the recipient's player. The server never inspects, validates, or
+transcodes media (it can't — zero-knowledge). The contracts below are the internal client
+interfaces the fixes share.
+
+## Unchanged
+- Media upload/download blob endpoints — used exactly as today; opaque bytes.
+- Composer acceptance — paste (`onComposerPaste`) and the file picker stay permissive
+  (no `accept=` narrowing); the fix is in conversion, not acceptance (FR-011).
+
+## New internal contracts
+
+### `media-portability.ts` (pure, unit-tested)
+- `isPortableVideo(mime): boolean` — mp4/quicktime/m4v.
+- `needsMandatoryTranscode(mime, quality): boolean` — true for any non-portable video
+  container, **independent of quality** (the regression-test target; `('video/webm','original')`→true, `('video/mp4','original')`→false).
+- `isHeic(mime): boolean` — image/heic|heif.
+- `imageNeedsAlphaPreserve(mime, hasAlpha): boolean` — PNG (or other) with transparency.
+
+### `heic-decode.ts` (lazy)
+- `decodeHeicToJpeg(blob): Promise<Blob>` — dynamically imports the wasm decoder on first
+  use; returns a portable JPEG (or throws → honest `'cant-convert'` failure). Client-side
+  only; no network.
+
+### Encode-path integration (existing files)
+- `compressVideoAdaptive` / `runMediaJob` — consult `needsMandatoryTranscode`; a
+  non-portable container is always routed to the ffmpeg transcode (never the mp4-only
+  fast paths, never skipped at `original`), else fails honestly.
+- `media-encode.ts` `compressImage` — HEIC → `decodeHeicToJpeg` first; alpha PNG →
+  preserve (like `PRESERVED_IMAGE_MIME`) instead of JPEG flatten.
+- `media-meta.ts` — SVG → rasterized thumbnail/poster.
+
+### Failure surface
+- `Message.failReason` gains `'cant-convert'`; rendered by the existing failed-send card
+  (Ionic-first, no new widget).
+
+## Consumption map
+
+| Flow | Uses |
+|---|---|
+| Send video (paste/pick/video-note) | `needsMandatoryTranscode` → ffmpeg transcode or honest fail |
+| Send image | `isHeic` → `decodeHeicToJpeg`; `imageNeedsAlphaPreserve` → keep alpha |
+| Send SVG | `media-meta` rasterized thumbnail |
+| Any un-convertible media | `failReason: 'cant-convert'` → failed-send card |

--- a/specs/2050-media-interop/data-model.md
+++ b/specs/2050-media-interop/data-model.md
@@ -1,0 +1,43 @@
+# Data Model — Cross-browser media interop (spec 2050)
+
+No persisted or synced entity is added. This feature adds **client-side decision logic**
+and reuses the existing `Message` failure field. The server keeps storing opaque blobs.
+
+## Portability decision (pure, `media-portability.ts`)
+
+Computed at send time from the media blob's MIME + chosen quality; never stored.
+
+```ts
+// A video container that plays natively on all target browsers (incl. Safari/iOS).
+export function isPortableVideo(mime: string): boolean;      // mp4 / quicktime(mov) / m4v
+
+// A non-portable video MUST transcode to MP4 regardless of quality (incl. 'original').
+export function needsMandatoryTranscode(mime: string, quality: string): boolean;
+
+// HEIC/HEIF still image needing decode→JPEG before send.
+export function isHeic(mime: string): boolean;               // image/heic, image/heif
+
+// A raster image whose transparency must be preserved (don't flatten to JPEG).
+export function imageNeedsAlphaPreserve(mime: string, hasAlpha: boolean): boolean;
+```
+
+## Reused: `Message.failReason`
+
+Extend the existing failure reason set (currently `'too-large'`) with `'cant-convert'`
+for a non-portable media that could not be made interoperable (drives an honest failure
+card). No schema change — `failReason` is already an optional string field on `Message`.
+
+## Media blob (unchanged wire)
+
+An outgoing media item is a blob with a MIME type + chosen quality. This feature changes
+the **bytes** it becomes (MP4 instead of WebM, JPEG instead of HEIC, alpha-preserving PNG/
+WebP instead of flattened JPEG) but not the wire: the server still receives sealed,
+client-encrypted ciphertext stored as `application/octet-stream` (`media-transfer.ts`
+preserves `blob.type` end-to-end for the recipient's player). Nothing new is persisted,
+synced, or made visible to the server.
+
+## State / lifecycle
+
+- The portability decision is derived per send and discarded; it is display/flow logic only.
+- Conversion happens once, on the client, before encryption; a failure marks the message
+  failed (existing lifecycle) with the honest reason — no partial/raw upload.

--- a/specs/2050-media-interop/plan.md
+++ b/specs/2050-media-interop/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Make pasted and sent media interoperable across browsers
+
+**Branch**: `fix/2050-media-interop` | **Date**: 2026-07-25 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/2050-media-interop/spec.md`
+
+## Summary
+
+Everything the composer accepts must arrive viewable on any browser — or fail with a visible message, never a silent broken tile. The composer already accepts every format; the gaps are all in the **client-side encode/convert step** before encryption. Fixes, by priority: (P1) force any non-portable video container (WebM, etc.) to transcode to MP4 regardless of quality, and fail honestly if it can't; (P2) decode HEIC→JPEG when the browser can't natively; (P3) preserve PNG transparency instead of flattening to JPEG; (P4) rasterize an SVG thumbnail. No server change, no new wire contract — the server keeps storing opaque ciphertext.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (Vue 3 + Ionic PWA), client only. No Go changes.
+
+**Primary Dependencies**: existing `@ffmpeg/ffmpeg` (wasm, already used for the video fallback), WebCodecs/mp4box (MP4 fast path), canvas; **one new lazy-loaded wasm HEIC decoder** (see research D2). Encode entry points: `src/services/media-video.ts` (`compressVideoAdaptive`), `src/services/media-video-ffmpeg.ts` (`ffmpegTranscode`), `src/services/media-encode.ts` (`compressImage`, `PRESERVED_IMAGE_MIME`), `src/db/queries.ts` (`runMediaJob`), `src/utils/media-meta.ts` (poster/meta).
+
+**Storage**: none new. Media blobs are opaque ciphertext server-side (`media-transfer.ts` keeps `blob.type`); no IndexedDB store/index added → no `DB_VERSION` bump.
+
+**Testing**: vitest for the new pure `media-portability` decisions (regression-first, Constitution III for 2001+); `drive/` scenarios for visual confirmation of each format; targeted e2e where a send flow changes.
+
+**Target Platform**: installable PWA; the interop target is notably **Safari/iOS** (can't decode VP8/VP9 WebM or raw HEIC) as the worst-case recipient.
+
+**Project Type**: web app, single client project.
+
+**Performance Goals**: transcode/decode run in wasm off the main thread as today; the HEIC decoder is dynamically imported only when a HEIC is actually encountered (no main-bundle bloat).
+
+**Constraints**: client-only; no server validation/transcoding (would break zero-knowledge); paste + picker stay permissive; animated formats (GIF, animated WebP) keep animation; **every accepted format either sends interoperably or fails with a visible message** (no silent broken send).
+
+**Scale/Scope**: four format fixes; bug-fix hotfix (2050).
+
+## Constitution Check
+
+- **I — Zero-Knowledge (NON-NEGOTIABLE)**: PASS. All conversion is client-side, before encryption; the server still stores opaque `application/octet-stream` blobs and gains no endpoint, validation, or metadata. The new HEIC decoder is a local wasm module (no network). Spec carries a Zero-Knowledge Impact section. **`/speckit-checklist` REQUIRED** before implement (tracked).
+- **II — Spec-Driven**: PASS — specify → plan (this) → tasks → analyze → checklist → implement.
+- **III — TDD (bug fix)**: PASS (planned). Begins with a **failing regression test** on the pure portability decision (`needsMandatoryTranscode('video/webm', 'original')` → true; MP4 → false), before touching the routing. Each format fix adds pure-helper tests + a drive/e2e check.
+- **V — Offline-First**: PASS. No store/schema change.
+- **VII — Quality Gates**: PASS (planned). `npm run build` + vitest + drive/e2e; commit subjects as plain-language release notes.
+- **IX — Privacy/Minimization**: PASS. Less broken data leaves the device, nothing new collected.
+- **X/XI — a11y / Ionic-first**: PASS. The "couldn't send" state reuses the existing `failReason` message/card (no bespoke widget); no new iconography.
+
+**Complexity Tracking**: one justified new dependency (HEIC decoder) — see below.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/2050-media-interop/
+├── plan.md · research.md · data-model.md · quickstart.md
+├── contracts/README.md
+├── checklists/requirements.md (done) + zero-knowledge.md (at /speckit-checklist)
+└── tasks.md (Phase 2 — /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── services/
+│   ├── media-portability.ts   # NEW pure: isPortableVideo / needsMandatoryTranscode /
+│   │                          #   isHeic / imageNeedsAlphaPreserve — the tested decisions
+│   ├── media-video.ts         # route non-portable containers to a MANDATORY transcode
+│   │                          #   (bypass the mp4-only as-is/WebCodecs gates), honest fail
+│   ├── media-video-ffmpeg.ts  # transcode entry; keep the honest too-large/unavailable throw
+│   ├── media-encode.ts        # HEIC→JPEG decode (lazy wasm); preserve PNG alpha
+│   ├── heic-decode.ts         # NEW thin lazy wrapper around the wasm HEIC decoder
+│   └── ...
+├── db/queries.ts              # runMediaJob: don't skip encode for non-portable video even
+│                              #   at quality 'original'; surface honest failure card
+├── utils/media-meta.ts        # SVG thumbnail/poster; webm poster moot post-transcode
+└── views/detail/ChatDetailPage.vue  # (only if the failure surface needs a message tweak)
+```
+
+**Structure Decision**: single client project. The load-bearing new piece is a small pure `media-portability.ts` (the decisions, unit-tested) plus a lazy `heic-decode.ts` wrapper; everything else edits existing encode entry points.
+
+## Phase 0 — Research
+
+See [research.md](./research.md). Decisions:
+1. **Mandatory-transcode rule** — a pure `needsMandatoryTranscode(mime, quality)` returning true for any non-MP4/MOV video container regardless of quality; wire it so `compressVideoAdaptive`/`runMediaJob` cannot skip it. Failure is honest (existing `failReason` card / a new `'cant-convert'` reason), never raw bytes.
+2. **HEIC decoder choice** — lazy-loaded wasm (`heic2any`/libheif-wasm), dynamically imported only on encountering HEIC; client-side, no network (ZK-safe). Evaluated vs. relying on native decode (fails off-Safari) — rejected.
+3. **PNG alpha** — detect alpha (PNG IHDR colour-type sniff, cheap) and route alpha PNGs through the preserved/alpha-capable path instead of the JPEG flatten; opaque PNG keeps downscaling.
+4. **SVG thumbnail** — rasterize via `<img>`→canvas at thumbnail size for the poster; keep original SVG for the viewer.
+5. **Honest failure** — reuse the `failReason` surface; keep the ffmpeg input cap but on exceed/unavailable, fail visibly rather than shipping raw.
+
+## Phase 1 — Design & Contracts
+
+- [data-model.md](./data-model.md) — the portability decision inputs/outputs; no persisted entity.
+- [contracts/README.md](./contracts/README.md) — internal contracts (`media-portability` helpers, `heic-decode`), and the unchanged media blob wire (opaque, `blob.type` preserved).
+- [quickstart.md](./quickstart.md) — build/test + per-format drive/e2e verification (incl. the Safari-recipient check).
+
+### Zero-Knowledge Impact
+Bytes change (MP4 instead of WebM, JPEG instead of HEIC) but not what the server sees — still opaque ciphertext, no endpoint/validation/metadata added. All conversion is on the client before encryption; the HEIC decoder is local wasm. Nothing new persisted or synced.
+
+## Complexity Tracking
+
+| Violation | Why needed | Simpler alternative rejected because |
+|-----------|-----------|--------------------------------------|
+| New dependency: wasm HEIC decoder | HEIC/HEIF can't be decoded off-Safari without one; leaving it out is the current silent-break bug | Native `createImageBitmap` fails for HEIC on non-Safari browsers — there is no zero-dependency client-side path. Mitigated: lazy dynamic import (no main-bundle cost), client-side only (ZK-safe). |

--- a/specs/2050-media-interop/quickstart.md
+++ b/specs/2050-media-interop/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart — Cross-browser media interop (spec 2050)
+
+Client-only hotfix; no server/DB change. TDD: the pure portability decision gets a failing
+regression test FIRST (Constitution III for 2001+).
+
+## Build & unit test
+
+```sh
+npm run build                                        # vue-tsc typecheck + vite build
+npx vitest run src/services/media-portability.test.ts   # portability decisions (regression-first)
+```
+
+TDD order:
+1. Write `media-portability.test.ts` — `needsMandatoryTranscode('video/webm','original')`→true,
+   `('video/mp4','original')`→false, `isPortableVideo`, `isHeic`, `imageNeedsAlphaPreserve`.
+2. Implement `media-portability.ts` to pass.
+3. Wire it into `compressVideoAdaptive`/`runMediaJob`, then HEIC/PNG/SVG encode paths.
+
+## Visual verification (drive/ against the live dev stack)
+
+```sh
+make start
+node drive/scenarios/media-interop.mjs
+```
+
+The scenario should send, from a NON-Safari sender, and confirm the delivered blob is portable:
+- **WebM** (P1): send a webm clip at Original quality → delivered as MP4 (`blob.type` video/mp4),
+  plays; force an un-convertible case → a failed-send card, no raw upload. Screenshot.
+- **HEIC** (P2): send a .heic image → delivered as JPEG, renders. Screenshot.
+- **PNG alpha** (P3): send a transparent PNG → received image keeps transparency (checker the
+  alpha, not a black/white fill). Screenshot.
+- **SVG** (P4): send an SVG → a thumbnail shows; original opens in the viewer. Screenshot.
+
+Confirm working formats are unchanged: JPEG, WebP (animation), GIF (animation), MP4, audio, files.
+
+## e2e (where a send flow changes)
+
+```sh
+make db-up
+npm run test:e2e -- e2e/media-interop.spec.ts
+```
+
+At least: a webm send results in a `video/mp4` blob (or an honest failure), asserted via the
+harness — the interop guarantee, not pixel decoding.
+
+## Zero-knowledge sanity
+Confirm no new network: conversion is client-side (ffmpeg-wasm / HEIC-wasm / canvas); the
+server still receives opaque bytes and no group/media-aware request. HEIC decoder loads from
+the app bundle, not the network.
+
+## Definition of done
+- `npm run build` clean; new vitest green; e2e green where a flow changed.
+- Drive screenshots confirm webm/heic/png-alpha/svg in light + dark; working formats un-regressed.
+- No `DB_VERSION` bump, no server change; `/speckit-analyze` clean + `/speckit-checklist` (Principle I) done.

--- a/specs/2050-media-interop/research.md
+++ b/specs/2050-media-interop/research.md
@@ -1,0 +1,43 @@
+# Research — Cross-browser media interop (spec 2050)
+
+## D1. Force non-portable video containers to transcode (WebM)
+
+**Decision**: Introduce a pure `needsMandatoryTranscode(mime, quality)` — true for any video whose container is not MP4/H.264 or MOV, **regardless of quality** (including `original`). Wire it into `compressVideoAdaptive` and `runMediaJob` so the mp4-only "as-is"/WebCodecs fast paths and the `original`-quality encode-skip cannot let a non-portable container through. The transcode target is MP4/H.264 via the existing ffmpeg path.
+
+**Rationale**: MP4/H.264 plays natively on every target browser incl. Safari/iOS; WebM (VP8/VP9) does not. Today `original` quality and the >64 MiB cap and ffmpeg-load-failure all fall back to shipping raw WebM → unplayable. Making portability a *mandatory* condition (not a quality choice) closes all three escape hatches with one rule. Also covers app-recorded WebM video-notes.
+
+**Failure**: when a non-portable video genuinely can't be transcoded (over the input cap, or ffmpeg unavailable), fail honestly via the existing `failReason` card (add a `'cant-convert'` reason distinct from `'too-large'`), never upload raw bytes (SC-005/FR-003).
+
+**Alternatives**: reject WebM at paste (reintroduces the acceptance asymmetry — rejected); server transcode (breaks zero-knowledge — rejected).
+
+## D2. HEIC/HEIF decoder (the one new dependency)
+
+**Decision**: Add a **lazy-loaded, client-side wasm HEIC decoder**, dynamically imported only when a HEIC/HEIF blob is actually encountered, wrapped in a thin `heic-decode.ts` that returns a JPEG/PNG blob. Convert HEIC→JPEG before the normal encode path on **all** senders (not just non-Safari), so the delivered image is portable for every recipient.
+
+**Rationale**: `createImageBitmap` throws for HEIC on non-Safari browsers, so today off-Safari senders ship raw HEIC that only Safari recipients can render. There is **no zero-dependency client-side way** to decode HEIC off-Safari. A wasm decoder (e.g. `heic2any` / libheif-wasm) runs entirely on-device (zero-knowledge intact) and, lazily imported, adds nothing to the main bundle for the common case. Converting on all senders (even Safari, which *can* decode) keeps the delivered format uniform and the code path single.
+
+**Alternatives**: native-only decode (the current bug — rejected); server-side conversion (breaks ZK — rejected); refuse HEIC (hurts the most common iPhone photo format — rejected). Exact package + size to be pinned in implementation; must be MIT/compatible and wasm/client-side.
+
+**Open**: confirm the chosen package's licence + gzip size in the implementing task; if unexpectedly large, gate behind the lazy import (already planned) and note it.
+
+## D3. Preserve PNG transparency
+
+**Decision**: Detect whether a PNG carries an alpha channel (cheap PNG IHDR colour-type byte sniff, or a canvas alpha sample) and route alpha-bearing PNGs through an alpha-preserving path (keep PNG, or re-encode to WebP which the app already preserves) instead of the JPEG flatten. Opaque PNGs keep the existing quality-tier JPEG downscaling.
+
+**Rationale**: `compressImage` currently re-encodes PNG→JPEG, turning transparency into a black/white fill — visible corruption for logos/stickers/alpha screenshots. `media-encode.ts` already has `PRESERVED_IMAGE_MIME` (webp/gif kept as-is); extending the "preserve" decision to alpha PNGs is a small, consistent change.
+
+**Alternatives**: always preserve PNG (loses downscaling on big opaque PNGs — rejected); always WebP (fine but changes format unnecessarily for opaque — only use for the alpha case).
+
+## D4. SVG thumbnail
+
+**Decision**: Rasterize a small poster/thumbnail from the SVG via an `<img>`→`<canvas>` draw at thumbnail dimensions; keep the original SVG blob for the full viewer.
+
+**Rationale**: SVGs already display in `<img>` but produce no preview thumbnail. Rasterizing on the client is trivial and gives the bubble a preview like other images. Lowest priority (polish, not a break).
+
+**Alternatives**: ship no thumbnail (status quo — acceptable but the spec asks for one); server rasterize (breaks ZK — rejected).
+
+## D5. Honest-failure surface
+
+**Decision**: Reuse the existing `Message.failReason` → failure card/toast. Add a `'cant-convert'` reason for a non-portable media that couldn't be made interoperable, distinct from `'too-large'`. No new bespoke UI (Ionic-first).
+
+**Rationale**: FR-014/SC-005 require a *visible* failure instead of a silent broken send; the app already has the failed-send surface — extend its reason set rather than invent UI.

--- a/specs/2050-media-interop/spec.md
+++ b/specs/2050-media-interop/spec.md
@@ -1,0 +1,173 @@
+# Feature Specification: Make pasted and sent media interoperable across browsers
+
+**Feature Branch**: `fix/2050-media-interop`
+
+**Created**: 2026-07-24
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report: "I have experienced not successful sharing of webm — check that, and gif, webp, png, jpeg and other media formats as well. What formats can be pasted into the chat and are we fully handling sending them?"
+
+## Context: why this hotfix exists
+
+The chat composer accepts **every** media format via both paste and the file picker (there is no acceptance filter), but some formats are not made *interoperable* before sending, so they arrive as unplayable/blank tiles on other browsers — with **no error shown**, because the server stores opaque ciphertext and cannot validate media. An audit found:
+
+- **WebM (the reported bug)**: video interoperability depends entirely on the ffmpeg transcode to MP4. The "send as-is" and WebCodecs fast paths are hard-gated to MP4/MOV, so WebM can only reach ffmpeg — and ffmpeg is bypassed when the video quality is "Original", when the clip exceeds the ffmpeg input-size cap, or when ffmpeg fails to load. In those cases the **raw WebM is uploaded** and handed to a bare `<video>` element that **Safari/iOS cannot decode** (VP8/VP9). The sender on Safari also gets no poster/dimensions. Result: a black/broken tile, no error. Ring also records WebM itself (video-notes on Chrome/Android), so this affects recorded clips too, not only pasted ones.
+- **HEIC/HEIF**: on senders whose browser can't natively decode HEIC (non-Safari), the image encode step falls back to uploading the **raw HEIC**, which only Safari recipients can render — a silent break elsewhere.
+- **PNG with transparency**: the image compressor re-encodes to JPEG, **flattening the alpha channel** (transparent areas become black/white).
+- **SVG**: sends and renders in an `<img>`, but produces **no thumbnail/poster**.
+
+Working today (no change needed): JPEG, WebP (animation + alpha preserved), GIF (animation preserved), MP4 (H.264), audio, and generic files.
+
+The unifying principle of this fix: **anything the composer accepts must either send in an interoperable form, or fail honestly with a visible message — never a silent unplayable send.**
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - WebM (and non-portable video) sends playably everywhere (Priority: P1)
+
+A user pastes or picks a WebM clip (or records a video-note on Chrome/Android) and sends it. The recipient — on any browser, including Safari/iOS — sees a playable video with a poster, or, if the clip genuinely cannot be converted, the sender sees a clear "couldn't send this video" message instead of a silently-broken tile.
+
+**Why this priority**: This is the reported defect and the most common interop break (WebM is what browser recorders and many web sources produce). It affects Safari/iOS recipients of every WebM, silently.
+
+**Independent Test**: From a non-Safari sender, send a WebM clip at Original quality and confirm the recipient on Safari/iOS plays it with a poster; force a case that can't transcode and confirm a visible error rather than a broken tile.
+
+**Acceptance Scenarios**:
+
+1. **Given** a WebM clip pasted into the composer, **When** I send it (at any quality, including Original), **Then** it is delivered as a browser-portable video (MP4/H.264) that plays on Safari/iOS recipients, with a poster.
+2. **Given** a WebM I record as a video-note on Chrome/Android, **When** I send it, **Then** the recipient on Safari/iOS can play it.
+3. **Given** a video whose container is not natively portable and that cannot be transcoded (e.g. exceeds limits or the transcoder is unavailable), **When** I try to send it, **Then** I see a clear, honest error and no unplayable tile is delivered.
+4. **Given** an MP4/H.264 clip, **When** I send it, **Then** behavior is unchanged (still plays everywhere, still tiered by quality).
+
+---
+
+### User Story 2 - HEIC/HEIF photos send viewably from any browser (Priority: P2)
+
+A user pastes or picks an iPhone HEIC photo from a non-Safari browser and sends it; the recipient sees the photo regardless of their browser.
+
+**Why this priority**: HEIC is extremely common (default iPhone photo format) and currently breaks silently for any sender not on Safari. Second only to WebM in real-world impact.
+
+**Independent Test**: From a non-Safari sender, send a HEIC image and confirm the recipient on a non-Safari browser sees the photo (not a broken image).
+
+**Acceptance Scenarios**:
+
+1. **Given** a HEIC/HEIF image and a sender whose browser cannot natively decode it, **When** I send it, **Then** it is converted to a browser-portable image (e.g. JPEG) before upload and renders for all recipients.
+2. **Given** a HEIC image and a sender whose browser *can* decode it natively, **When** I send it, **Then** it is converted the same way (a portable image is delivered), with no regression to quality tiers.
+3. **Given** a HEIC that cannot be decoded at all, **When** I try to send it, **Then** I see an honest error rather than a silently broken image.
+
+---
+
+### User Story 3 - PNG transparency is preserved (Priority: P3)
+
+A user pastes or picks a PNG with transparency (logo, sticker, screenshot with alpha) and sends it; the transparent areas stay transparent.
+
+**Why this priority**: A correctness bug (visible corruption — transparent turns to a solid fill), but lower frequency and less severe than an entirely-broken send.
+
+**Independent Test**: Send a PNG with an alpha channel and confirm the received image retains transparency rather than a black/white fill.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PNG image with an alpha channel, **When** I send it, **Then** the delivered image preserves transparency (it is not flattened to an opaque JPEG).
+2. **Given** a fully-opaque PNG or a JPEG, **When** I send it, **Then** behavior is unchanged (still downscaled by quality tier).
+
+---
+
+### User Story 4 - SVG images get a thumbnail (Priority: P4)
+
+A user pastes or picks an SVG and sends it; it shows a proper preview thumbnail in the chat like other images.
+
+**Why this priority**: A polish gap, not a break — SVGs already display in the viewer; they just lack a preview. Lowest priority.
+
+**Independent Test**: Send an SVG and confirm the chat bubble shows a rasterized thumbnail preview.
+
+**Acceptance Scenarios**:
+
+1. **Given** an SVG image, **When** I send it, **Then** a rasterized thumbnail/poster is generated and shown, and the full SVG still opens in the viewer.
+
+---
+
+### Edge Cases
+
+- **Quality = Original for a non-portable container**: interop MUST win — the media is still converted to a portable form (Original must not be an escape hatch that ships unplayable bytes). "Original" continues to mean full-fidelity for already-portable formats (MP4, JPEG, etc.).
+- **Oversized non-portable video** (beyond the transcoder's input cap): fail honestly with a visible message; do not upload raw unplayable bytes.
+- **Transcoder/decoder unavailable** (ffmpeg core or HEIC decoder fails to load): fail honestly with a visible message; do not silently ship raw bytes.
+- **Animated formats** (GIF, animated WebP): unchanged — MUST keep animation; MUST NOT be routed through a flattening path.
+- **A format that is already portable** (JPEG, PNG-opaque, WebP, GIF, MP4/H.264, audio, generic files): unchanged behavior.
+- **Very large images**: existing size/quality handling applies after format conversion.
+- **Sender and recipient on the same capable browser**: still must not regress (conversion is about the *worst-case* recipient, so convert regardless of the sender's own capabilities).
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: unchanged in nature — sealed, client-encrypted media blobs plus their existing capability-style ids. This fix changes the *bytes* (a transcoded MP4 instead of a raw WebM, a JPEG instead of a raw HEIC) but not what the server sees: still opaque ciphertext stored as `application/octet-stream`.
+- **Where processing happens**: entirely **client-side**, before encryption — transcode/decode/rasterize all run in the browser (ffmpeg-wasm / WebCodecs / canvas / an HEIC decoder). No media is ever sent to the server for processing.
+- **Unavoidably-visible metadata**: unchanged — the server already sees blob sizes and relay timing; conversion may change a blob's size but adds no new metadata, endpoint, log, or field.
+- **Why it stays zero-knowledge**: the server neither inspects nor validates media (it cannot — it only holds ciphertext). All format decisions and conversions are made on the client from the plaintext it already holds. No new server capability is added.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Video interop — WebM (Story 1)**
+
+- **FR-001**: Any video whose container is not natively portable across target browsers (i.e. not MP4/H.264 or MOV) MUST be transcoded to a portable form (MP4/H.264) before upload, **regardless of the selected quality** (including "Original").
+- **FR-002**: The "send as-is" and accelerated (WebCodecs) fast paths MUST NOT allow a non-portable container to bypass conversion; a non-portable container MUST always be routed to a working transcode path.
+- **FR-003**: When a non-portable video cannot be transcoded (size/limits/transcoder-unavailable), the app MUST surface a clear, honest failure to the sender and MUST NOT upload the raw unplayable bytes.
+- **FR-004**: This applies to app-produced WebM as well (e.g. video-notes recorded on Chrome/Android), so recorded clips are also delivered playably to Safari/iOS recipients.
+- **FR-005**: Already-portable video (MP4/H.264) MUST keep its current behavior, including quality tiers and poster generation.
+
+**Image interop — HEIC (Story 2)**
+
+- **FR-006**: A HEIC/HEIF image MUST be converted to a browser-portable image (e.g. JPEG) before upload, whether or not the sender's browser can natively decode HEIC, so all recipients can view it.
+- **FR-007**: When a HEIC image cannot be decoded at all, the app MUST surface an honest failure and MUST NOT upload raw HEIC bytes that only some recipients could render.
+
+**Image correctness — PNG alpha (Story 3)**
+
+- **FR-008**: A PNG (or other image) that has an alpha channel MUST be delivered in a format that preserves transparency; it MUST NOT be flattened to an opaque JPEG.
+- **FR-009**: Opaque images MUST retain current quality-tier downscaling behavior.
+
+**Image polish — SVG thumbnail (Story 4)**
+
+- **FR-010**: An SVG image SHOULD have a rasterized thumbnail/poster generated for its chat preview, while the original SVG remains openable in the viewer.
+
+**Cross-cutting**
+
+- **FR-011**: Paste and the file picker MUST remain equally permissive (no acceptance-filter divergence); the fix is in conversion/handling, not in restricting what can be attached.
+- **FR-012**: Animated formats (GIF, animated WebP) MUST retain animation and MUST NOT be routed through a flattening/transcode path that drops frames.
+- **FR-013**: No media is sent to the server for processing; all conversion happens client-side before encryption (zero-knowledge preserved).
+- **FR-014**: Every accepted format MUST either send in an interoperable form or fail with a visible message — there MUST be no silent unplayable/blank send for any format the composer accepts.
+
+### Key Entities *(include if feature involves data)*
+
+- **Outgoing media item**: an attached blob with a MIME type and a chosen quality. This fix adds a *portability decision* (is the container/format natively viewable on target browsers?) that gates whether conversion is mandatory, independent of quality. No new stored or synced entity; the decision is computed client-side at send time.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A WebM sent from a non-Safari browser (at any quality, including Original) plays with a poster on a Safari/iOS recipient in 100% of send attempts that complete, or fails with a visible error — never a silent broken tile.
+- **SC-002**: A HEIC photo sent from a non-Safari browser renders for a non-Safari recipient in 100% of completed sends, or fails visibly.
+- **SC-003**: A PNG with transparency, once received, retains its transparent regions (no black/white fill) in 100% of cases.
+- **SC-004**: An SVG send shows a thumbnail preview in the bubble and still opens full in the viewer.
+- **SC-005**: No format the composer accepts results in a silent unplayable or blank send; any un-sendable media produces a visible, honest error.
+- **SC-006**: Formats that work today (JPEG, WebP, GIF, MP4/H.264, audio, generic files) show no regression in delivery, animation, or quality tiers.
+- **SC-007**: No media is transmitted to the server for processing and no new server-visible metadata is introduced (verified: conversion is client-side, server still stores opaque blobs).
+
+## Assumptions
+
+- A client-side transcode path (ffmpeg-wasm, already in the app) can convert WebM→MP4; the fix routes non-portable containers to it unconditionally and treats "can't transcode" as an honest failure, not a raw-bytes fallback.
+- A client-side HEIC decode capability is available or can be added (browser-native where supported, a wasm decoder otherwise); conversion targets JPEG for broad compatibility.
+- "Portable" targets the browsers Ring supports (notably Safari/iOS for video/HEIC); MP4/H.264 and JPEG/PNG/WebP/GIF are treated as portable.
+- Preserving PNG transparency implies delivering PNG (or another alpha-capable format) rather than JPEG when alpha is present; exact target format is an implementation choice constrained by "keeps transparency + reasonable size".
+- Existing size caps and quality tiers remain; this fix changes *format portability*, not the size/quality policy, except that Original may no longer bypass a mandatory format conversion.
+
+## Out of Scope
+
+- Restricting or filtering which formats can be attached (paste/picker stay permissive).
+- Server-side media validation or transcoding (would break zero-knowledge).
+- New editing/cropping features; changes to the media viewer beyond adding an SVG thumbnail.
+- Re-encoding already-portable formats differently (no change to JPEG/WebP/GIF/MP4 handling beyond the alpha-preservation and thumbnail cases above).
+- Audio format interop beyond current behavior (audio already uploads; playback remains recipient-codec dependent) — noted, not addressed here.

--- a/specs/2050-media-interop/tasks.md
+++ b/specs/2050-media-interop/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Cross-browser media interop (spec 2050)
+
+**Feature**: `specs/2050-media-interop` | **Branch**: `fix/2050-media-interop`
+
+Client-only hotfix (Vue 3 + Ionic). Bug fix (2001+): regression test FIRST. Each story is
+an independently shippable slice. US1 = P1 WebM · US2 = P2 HEIC · US3 = P3 PNG-alpha · US4 = P4 SVG.
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm baseline: `npm run build` + `npx vitest run` green before changes.
+
+## Phase 2: Foundational — the portability decision (blocks US1–US4)
+
+- [ ] T002 [P] Write failing unit tests in `src/services/media-portability.test.ts`: `needsMandatoryTranscode('video/webm','original')`→true, `('video/mp4','original')`→false; `isPortableVideo` (mp4/mov/m4v); `isHeic` (image/heic|heif); `imageNeedsAlphaPreserve` (PNG+alpha→true, opaque→false).
+- [ ] T003 Implement `src/services/media-portability.ts` (pure helpers) to pass T002.
+
+## Phase 3: User Story 1 — WebM (and non-portable video) sends playably (P1) 🎯 MVP
+
+**Independent test**: send a WebM at Original quality from a non-Safari sender → delivered as MP4, plays on Safari/iOS; an un-convertible clip → visible failure, no raw upload.
+
+- [ ] T004 [US1] In `src/services/media-video.ts` `compressVideoAdaptive`: route any container where `needsMandatoryTranscode` is true to the ffmpeg transcode — bypass the mp4-only "as-is" gate (~156) and WebCodecs guard (~178); do NOT return raw bytes for a non-portable container.
+- [ ] T005 [US1] In `src/db/queries.ts` `runMediaJob` (~2273/2409): do not skip the encode phase for a non-portable video even at quality `original`.
+- [ ] T006 [US1] Honest failure: add `'cant-convert'` to `Message.failReason` (`src/db/types.ts`) and set it when a non-portable video can't transcode (over the ffmpeg input cap / ffmpeg unavailable) instead of uploading raw; render via the existing failed-send card.
+- [ ] T007 [US1] Confirm app-recorded WebM video-notes (`VideoNoteRecorder.vue`) flow through the same mandatory transcode (send path reaches `compressVideoAdaptive`/`runMediaJob`).
+- [ ] T008 [P] [US1] Drive scenario `drive/scenarios/media-interop.mjs` (US1): send webm at Original → assert delivered `blob.type` is video/mp4; screenshot.
+- [ ] T009 [P] [US1] e2e `e2e/media-interop.spec.ts` (US1): a webm send yields a video/mp4 blob (or an honest failure).
+
+**Checkpoint**: US1 independently shippable — the reported bug fixed, no new dependency.
+
+## Phase 4: User Story 2 — HEIC sends viewably (P2)
+
+**Independent test**: from a non-Safari sender, send a .heic → recipient on any browser sees the photo.
+
+- [ ] T010 [US2] Add `src/services/heic-decode.ts` — `decodeHeicToJpeg(blob)`, lazy `import()` of a wasm HEIC decoder (pin an MIT/compatible package; note licence + gzip size in the PR). Client-side only, no network.
+- [ ] T011 [US2] In `src/services/media-encode.ts` `compressImage`: when `isHeic(mime)`, decode→JPEG first, then the normal encode; on decode failure set `failReason: 'cant-convert'` (no raw HEIC upload).
+- [ ] T012 [P] [US2] Drive (US2): send .heic → delivered JPEG renders; screenshot.
+
+**Checkpoint**: US2 shippable — HEIC viewable everywhere.
+
+## Phase 5: User Story 3 — PNG transparency preserved (P3)
+
+**Independent test**: send a transparent PNG → received image keeps transparency.
+
+- [ ] T013 [US3] In `src/services/media-encode.ts`: detect PNG alpha (IHDR colour-type sniff or canvas sample); when alpha, route through the preserved/alpha-capable path (keep PNG or re-encode WebP) instead of the JPEG flatten. Opaque images keep quality-tier downscaling.
+- [ ] T014 [P] [US3] Drive (US3): send an alpha PNG → received image retains transparency; screenshot.
+
+**Checkpoint**: US3 shippable — no more flattened alpha.
+
+## Phase 6: User Story 4 — SVG thumbnail (P4)
+
+**Independent test**: send an SVG → a thumbnail shows; original opens in the viewer.
+
+- [ ] T015 [US4] In `src/utils/media-meta.ts`: rasterize an SVG thumbnail/poster via `<img>`→canvas; keep the original SVG for the viewer.
+- [ ] T016 [P] [US4] Drive (US4): send SVG → thumbnail renders; screenshot.
+
+**Checkpoint**: US4 shippable — SVG previews.
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T017 Verify no regression for working formats (JPEG, WebP animation, GIF animation, MP4, audio, files) via drive.
+- [ ] T018 Run `/speckit-checklist` (zero-knowledge, Principle I): all conversion client-side, no server change, no new metadata, honest failures.
+- [ ] T019 Full gate: `npm run build`, new vitest green, `npm run test:e2e -- e2e/media-interop.spec.ts`; drive screenshots reviewed (light + dark).
+- [ ] T020 Update spec `Status` → in-review and `make roadmap` when opening the PR.
+
+## Dependencies & order
+Setup → Foundational (T002–T003 block all) → US1 (MVP, no dep) → US2 (adds the HEIC dep) → US3 → US4 → Polish. US1/US3/US4 need no new dependency; US2 introduces the wasm HEIC decoder.
+
+## MVP
+US1 (WebM) — the reported bug, no new dependency, reuses the existing ffmpeg path.

--- a/src/App.vue
+++ b/src/App.vue
@@ -179,6 +179,13 @@ function failedMessageText(msgs: Message[]): string {
   if (n > 0 && msgs.every((m) => m.failReason === 'too-large')) {
     return n === 1 ? 'A file is too large to send.' : `${n} files are too large to send.`;
   }
+  // spec 2050: a non-portable media (e.g. a webm video) that couldn't be converted to a
+  // format that plays on all devices — not sent (rather than delivered as an unplayable tile).
+  if (n > 0 && msgs.every((m) => m.failReason === 'cant-convert')) {
+    return n === 1
+      ? "A video couldn't be converted to send."
+      : `${n} files couldn't be converted to send.`;
+  }
   return n === 1 ? "A message couldn't be sent." : `${n} messages couldn't be sent.`;
 }
 // Re-run when the set of failed messages changes by COUNT or reason, so the wording

--- a/src/components/PinnedChatsGrid.vue
+++ b/src/components/PinnedChatsGrid.vue
@@ -210,7 +210,7 @@ defineExpose({
   align-items: center;
   padding: 1px 3px;
   border-radius: 999px;
-  background: var(--ion-background-color, #000);
+  background: var(--ion-background-color, #fff);
   color: var(--app-text-muted);
   line-height: 0;
 }
@@ -225,7 +225,7 @@ defineExpose({
   height: 16px;
   border-radius: 50%;
   background: var(--ion-color-success, #2dd36f);
-  border: 2.5px solid var(--ion-background-color, #000);
+  border: 2.5px solid var(--ion-background-color, #fff);
   box-sizing: border-box;
 }
 /* spec 1062: group online count pill at the tile's bottom-right. */
@@ -244,7 +244,7 @@ defineExpose({
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid var(--ion-background-color, #000);
+  border: 2px solid var(--ion-background-color, #fff);
   box-sizing: border-box;
 }
 .pin-name {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -21,6 +21,7 @@ import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryU
 import { recordStaleDrain, recordMissedWakeDrain, STALE_MSG_MS } from '@/services/push';
 import { sealForChat, openPacket } from '@/services/messaging';
 import { lastMessageTick } from '@/services/message-status';
+import { needsMandatoryTranscode, isPortableVideo, isHeic } from '@/services/media-portability';
 import { withInboundLock } from '@/services/cross-lock';
 import { mediaPreview, previewKind, chatListPreview } from '@/services/message-preview';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
@@ -2438,19 +2439,51 @@ async function runMediaJob(messageId: string): Promise<void> {
     try {
       resetJobProgress(messageId);
       let uploadBlob = media.blob;
-      // --- encode phase --- (compression NEVER fails the job → send the original)
-      if (message.compressQuality && (message.kind === 'image' || message.kind === 'video')) {
+      // (spec 2050) A non-portable video container (e.g. webm) MUST transcode to MP4
+      // before send, regardless of quality — even at 'original' (where the encode phase
+      // is otherwise skipped). Raw webm is unplayable on Safari/iOS, so if it can't be
+      // converted we fail honestly rather than ship an unplayable tile.
+      const mustTranscodeVideo =
+        message.kind === 'video' &&
+        needsMandatoryTranscode(media.blob.type, message.compressQuality ?? 'original');
+      // (spec 2050) HEIC/HEIF must be decoded to JPEG before send (viewable everywhere),
+      // even at 'original' quality; if it can't be decoded we fail honestly, never ship raw.
+      const mustConvertImage = message.kind === 'image' && isHeic(media.blob.type);
+      // --- encode phase --- (for portable formats compression NEVER fails the job → send
+      // the original; a mandatory transcode/convert is the exception — see the catch below)
+      if (
+        (message.compressQuality && (message.kind === 'image' || message.kind === 'video')) ||
+        mustTranscodeVideo ||
+        mustConvertImage
+      ) {
         try {
           if (message.kind === 'image') {
-            uploadBlob = await compressImage(media.blob, message.compressQuality);
+            // ?? 'original' satisfies the type; for HEIC at 'original' compressImage still
+            // decodes to JPEG (the decode runs before the quality passthrough).
+            uploadBlob = await compressImage(media.blob, message.compressQuality ?? 'original');
           } else {
-            uploadBlob = await compressVideo(media.blob, message.compressQuality, (p) =>
-              setCompressProgress(messageId, p),
-            );
+            // Force a real transcode for a mandatory case even when quality is 'original'
+            // (compressVideo no-ops on 'original'); 'fhd' preserves the most quality.
+            const q = message.compressQuality ?? 'fhd';
+            uploadBlob = await compressVideo(media.blob, q, (p) => setCompressProgress(messageId, p));
           }
         } catch (e) {
+          if (mustTranscodeVideo || mustConvertImage) {
+            // A non-portable media we couldn't convert must NOT be sent raw (unplayable/
+            // unviewable on other browsers).
+            console.warn('[media-job] mandatory media conversion failed; failing honestly', e);
+            await failMediaPermanently(messageId, 'cant-convert');
+            return;
+          }
           console.warn('[media-job] compression failed; sending original', e);
           uploadBlob = media.blob;
+        }
+        // Defence in depth: if a mandatory transcode somehow returned the original
+        // non-portable bytes (no engine succeeded but didn't throw), fail rather than ship.
+        if (mustTranscodeVideo && !isPortableVideo(uploadBlob.type)) {
+          console.warn('[media-job] mandatory transcode did not yield a portable video; failing honestly');
+          await failMediaPermanently(messageId, 'cant-convert');
+          return;
         }
       }
       setCompressProgress(messageId, 1); // encoding done
@@ -2573,7 +2606,7 @@ async function runMediaJob(messageId: string): Promise<void> {
 
 /** Fail a media send permanently (no retry), recording why so the UI can explain
  *  it (e.g. "too large"). Used for non-transient errors like exceeding the cap. */
-async function failMediaPermanently(messageId: string, reason: 'too-large'): Promise<void> {
+async function failMediaPermanently(messageId: string, reason: 'too-large' | 'cant-convert'): Promise<void> {
   const m = await getMessage(messageId);
   if (!m || m.status !== 'compressing') return;
   m.status = 'failed';

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -334,7 +334,10 @@ export interface Message {
   sentAt?: number; // when the server actually accepted it (shown as the send time)
   compressQuality?: 'sd' | 'hd' | 'fhd'; // the quality to (re)compress at, drives resume
   jobAttempts?: number; // background-job (compress + seal/upload) failure count
-  failReason?: 'too-large'; // why a send failed permanently (drives a specific toast)
+  // why a send failed permanently (drives a specific toast). 'cant-convert' (spec 2050):
+  // a non-portable media (e.g. webm) couldn't be transcoded to a browser-portable form,
+  // so it was NOT sent raw (which would be unplayable on Safari/iOS).
+  failReason?: 'too-large' | 'cant-convert';
   deliveredAt?: number; // 1:1: when the peer's device confirmed delivery
   seenAt?: number; // 1:1: when the peer opened/saw it
   // Spec 1013: when THIS device sent a 'seen' receipt for this INCOMING message (epoch ms).

--- a/src/services/heic-decode.ts
+++ b/src/services/heic-decode.ts
@@ -1,0 +1,20 @@
+/**
+ * (spec 2050) Lazy wrapper around the wasm HEIC/HEIF decoder (heic2any, MIT).
+ *
+ * Dynamically imported so the ~wasm decoder loads ONLY when a HEIC image is actually
+ * sent — no cost to the main bundle for everyone else. Runs entirely on-device (no
+ * network), so the zero-knowledge boundary is intact. Converts to JPEG, which every
+ * target browser can render (raw HEIC renders only on Safari).
+ *
+ * Throws on a genuine decode failure so the caller fails the send honestly rather than
+ * uploading raw HEIC that most recipients couldn't view.
+ */
+export async function decodeHeicToJpeg(blob: Blob, quality = 0.9): Promise<Blob> {
+  const heic2any = (await import('heic2any')).default;
+  const out = await heic2any({ blob, toType: 'image/jpeg', quality });
+  const result = Array.isArray(out) ? out[0] : out;
+  if (!(result instanceof Blob) || result.size === 0) {
+    throw new Error('HEIC decode produced no image');
+  }
+  return result;
+}

--- a/src/services/media-encode.ts
+++ b/src/services/media-encode.ts
@@ -6,6 +6,7 @@
  * send is never blocked by compression.
  */
 import { compressVideoAdaptive } from './media-video';
+import { isHeic } from './media-portability';
 
 export type Quality = 'sd' | 'hd' | 'fhd' | 'original';
 export type Tier = Exclude<Quality, 'original'>;
@@ -81,12 +82,21 @@ export function isPreservedImageMime(mime: string): boolean {
  *  blob for 'original', for animated/efficient formats (GIF/WebP), if the re-encode
  *  would be larger, or on any error. */
 export async function compressImage(blob: Blob, quality: Quality): Promise<Blob> {
-  if (quality === 'original') return blob;
-  if (isPreservedImageMime(blob.type)) return blob; // keep GIF/WebP animation + alpha
+  // (spec 2050) HEIC/HEIF → JPEG first, on ALL senders, so the photo is viewable on every
+  // browser (raw HEIC renders only on Safari). Done BEFORE the quality/preserve checks and
+  // OUTSIDE the fallback try below: a genuine decode failure must propagate so the caller
+  // can fail the send honestly rather than upload raw HEIC.
+  let src = blob;
+  if (isHeic(blob.type)) {
+    const { decodeHeicToJpeg } = await import('./heic-decode');
+    src = await decodeHeicToJpeg(blob);
+  }
+  if (quality === 'original') return src;
+  if (isPreservedImageMime(src.type)) return src; // keep GIF/WebP animation + alpha
   const preset = IMAGE_PRESETS[quality];
-  if (!preset) return blob;
+  if (!preset) return src;
   try {
-    const bitmap = await createImageBitmap(blob);
+    const bitmap = await createImageBitmap(src);
     const longest = Math.max(bitmap.width, bitmap.height);
     const scale = Math.min(1, preset.maxEdge / longest);
     const w = Math.max(1, Math.round(bitmap.width * scale));
@@ -95,16 +105,37 @@ export async function compressImage(blob: Blob, quality: Quality): Promise<Blob>
     canvas.width = w;
     canvas.height = h;
     const ctx = canvas.getContext('2d');
-    if (!ctx) return blob;
+    if (!ctx) return src;
     ctx.drawImage(bitmap, 0, 0, w, h);
     bitmap.close?.();
-    const out = await new Promise<Blob | null>((resolve) =>
-      canvas.toBlob(resolve, 'image/jpeg', preset.quality),
-    );
+    // (spec 2050) Preserve transparency: a PNG with an alpha channel is exported as PNG
+    // (alpha-capable), never flattened to an opaque JPEG. Opaque images (incl. opaque PNGs)
+    // keep the smaller JPEG downscale.
+    const keepAlpha = /png/i.test(src.type) && canvasHasAlpha(ctx, w, h);
+    const out = keepAlpha
+      ? await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
+      : await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/jpeg', preset.quality));
     // Keep whichever is smaller; re-encoding an already-tiny/optimized image can grow it.
-    return out && out.size < blob.size ? out : blob;
+    // For an alpha PNG that grew, we still return the ORIGINAL (which keeps its transparency).
+    return out && out.size < src.size ? out : src;
   } catch {
-    return blob;
+    return src;
+  }
+}
+
+/** (spec 2050) Whether the drawn canvas has any non-opaque pixel. Early-exits on the first
+ *  transparent pixel, so a transparent logo/sticker is detected fast; a fully-opaque image
+ *  scans through (bounded, one-time per send). */
+function canvasHasAlpha(ctx: CanvasRenderingContext2D, w: number, h: number): boolean {
+  try {
+    const data = ctx.getImageData(0, 0, w, h).data;
+    for (let i = 3; i < data.length; i += 4) {
+      if (data[i] < 255) return true;
+    }
+    return false;
+  } catch {
+    // getImageData can throw on a tainted canvas; assume no alpha (fall back to JPEG).
+    return false;
   }
 }
 

--- a/src/services/media-portability.test.ts
+++ b/src/services/media-portability.test.ts
@@ -1,0 +1,53 @@
+// spec 2050 — regression tests for the media-portability decisions (bug fix begins
+// with a failing test, Constitution III). The webm case is the reported bug.
+import { describe, it, expect } from 'vitest';
+import {
+  isPortableVideo,
+  needsMandatoryTranscode,
+  isHeic,
+  imageNeedsAlphaPreserve,
+} from './media-portability';
+
+describe('spec 2050: isPortableVideo', () => {
+  it('mp4/mov/m4v are portable; webm/mkv are not', () => {
+    expect(isPortableVideo('video/mp4')).toBe(true);
+    expect(isPortableVideo('video/quicktime')).toBe(true);
+    expect(isPortableVideo('video/x-m4v')).toBe(true);
+    expect(isPortableVideo('video/webm')).toBe(false);
+    expect(isPortableVideo('video/x-matroska')).toBe(false);
+  });
+});
+
+describe('spec 2050: needsMandatoryTranscode (the webm silent-fail guard)', () => {
+  it('non-portable video must transcode regardless of quality', () => {
+    expect(needsMandatoryTranscode('video/webm', 'original')).toBe(true);
+    expect(needsMandatoryTranscode('video/webm', 'hd')).toBe(true);
+    expect(needsMandatoryTranscode('video/x-matroska', 'original')).toBe(true);
+  });
+  it('portable video never needs a mandatory transcode', () => {
+    expect(needsMandatoryTranscode('video/mp4', 'original')).toBe(false);
+    expect(needsMandatoryTranscode('video/quicktime', 'hd')).toBe(false);
+  });
+  it('non-video inputs are not videos to transcode', () => {
+    expect(needsMandatoryTranscode('image/png', 'original')).toBe(false);
+    expect(needsMandatoryTranscode('image/heic', 'original')).toBe(false);
+    expect(needsMandatoryTranscode('', 'original')).toBe(false);
+  });
+});
+
+describe('spec 2050: isHeic', () => {
+  it('matches heic/heif only', () => {
+    expect(isHeic('image/heic')).toBe(true);
+    expect(isHeic('image/heif')).toBe(true);
+    expect(isHeic('image/jpeg')).toBe(false);
+    expect(isHeic('image/png')).toBe(false);
+  });
+});
+
+describe('spec 2050: imageNeedsAlphaPreserve', () => {
+  it('only a PNG WITH alpha needs preserving', () => {
+    expect(imageNeedsAlphaPreserve('image/png', true)).toBe(true);
+    expect(imageNeedsAlphaPreserve('image/png', false)).toBe(false);
+    expect(imageNeedsAlphaPreserve('image/jpeg', true)).toBe(false);
+  });
+});

--- a/src/services/media-portability.ts
+++ b/src/services/media-portability.ts
@@ -1,0 +1,32 @@
+// (spec 2050) Pure media-portability decisions — dependency-free so they're
+// unit-testable in the Node env and shared across the encode paths. The rule that
+// closes the WebM silent-fail bug: a non-portable video container must transcode to
+// MP4 before send, regardless of the chosen quality (including 'original').
+
+// Containers that play natively on every target browser, incl. Safari/iOS.
+const PORTABLE_VIDEO = /(mp4|quicktime|m4v)/i;
+
+export function isPortableVideo(mime: string): boolean {
+  return PORTABLE_VIDEO.test(mime || '');
+}
+
+/**
+ * True when a video's container is NOT natively portable (e.g. webm/mkv) and therefore
+ * MUST be transcoded to MP4 before sending — independent of quality. This is the guard
+ * that prevents the `original`-quality / oversize / ffmpeg-skip paths from shipping raw
+ * WebM that Safari/iOS can't decode. Non-video inputs return false.
+ */
+export function needsMandatoryTranscode(mime: string, _quality: string): boolean {
+  const m = (mime || '').toLowerCase();
+  if (!m.startsWith('video/')) return false;
+  return !isPortableVideo(m);
+}
+
+export function isHeic(mime: string): boolean {
+  return /(heic|heif)/i.test(mime || '');
+}
+
+/** A raster image whose transparency must be preserved (don't flatten to opaque JPEG). */
+export function imageNeedsAlphaPreserve(mime: string, hasAlpha: boolean): boolean {
+  return hasAlpha && /png/i.test(mime || '');
+}

--- a/src/services/media-video.ts
+++ b/src/services/media-video.ts
@@ -11,6 +11,8 @@
  * their heavy code/wasm only loads when a video is actually compressed.
  */
 
+import { isPortableVideo } from './media-portability';
+
 export interface VideoPreset {
   maxEdge: number; // longest side, px
   bitrate: number; // target video bitrate, bits/s
@@ -227,6 +229,12 @@ export async function compressVideoAdaptive(
  *  same jetsam kill the streaming transcode removed. A clean, explained failure
  *  card beats a crashed app. */
 function originalOrThrow(blob: Blob): Blob {
+  // (spec 2050) A non-portable container (e.g. webm) is unplayable on Safari/iOS as raw
+  // bytes — there is no safe "ship the original". Reaching here for a non-portable
+  // container means conversion failed, so fail honestly rather than send an unplayable tile.
+  if (!isPortableVideo(blob.type)) {
+    throw new Error('This video needs converting to send and converting failed on this device. Try a shorter clip or a different format.');
+  }
   if (blob.size > ORIGINAL_MAX_BYTES) {
     throw new Error('This video is too big to send without converting and converting failed on this device. Try a shorter or smaller clip.');
   }

--- a/src/utils/media-meta.ts
+++ b/src/utils/media-meta.ts
@@ -216,6 +216,12 @@ export async function isAnimatedImage(mime: string, blob: Blob): Promise<boolean
 }
 
 async function generateImageThumbUnlimited(blob: Blob, maxEdge: number): Promise<Blob | undefined> {
+  // (spec 2050) SVG: createImageBitmap on an SVG blob is unreliable across browsers, so
+  // SVGs produced no thumbnail. Rasterize via an <img> (which renders SVG everywhere)
+  // onto a canvas instead. The original SVG is still sent + opens full in the viewer.
+  if (/svg/i.test(blob.type)) {
+    return rasterizeSvgThumb(blob, maxEdge);
+  }
   try {
     const bmp = await createImageBitmap(blob);
     const big = Math.max(bmp.width, bmp.height);
@@ -239,6 +245,35 @@ async function generateImageThumbUnlimited(blob: Blob, maxEdge: number): Promise
     return await jpegBlobUnderBudget(c);
   } catch {
     return undefined;
+  }
+}
+
+/** (spec 2050) Rasterize an SVG blob to a thumbnail via an <img> element (reliable SVG
+ *  rendering) → canvas. SVGs without intrinsic dimensions default to a square canvas. */
+async function rasterizeSvgThumb(blob: Blob, maxEdge: number): Promise<Blob | undefined> {
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('svg load failed'));
+      img.src = url;
+    });
+    const iw = img.naturalWidth || img.width || maxEdge;
+    const ih = img.naturalHeight || img.height || maxEdge;
+    const big = Math.max(iw, ih) || maxEdge;
+    const scale = Math.min(1, maxEdge / big);
+    const c = document.createElement('canvas');
+    c.width = Math.max(1, Math.round(iw * scale));
+    c.height = Math.max(1, Math.round(ih * scale));
+    const cx = c.getContext('2d');
+    if (!cx) return undefined;
+    cx.drawImage(img, 0, 0, c.width, c.height);
+    return await jpegBlobUnderBudget(c);
+  } catch {
+    return undefined;
+  } finally {
+    URL.revokeObjectURL(url);
   }
 }
 

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -5439,7 +5439,10 @@ function cancelRecording() {
   height: 11px;
   border-radius: 50%;
   background: var(--ion-color-success, #2dd36f);
-  border: 2px solid var(--ion-background-color, #000);
+  /* #fff fallback (not #000): Ring only defines --ion-background-color via the dark
+     palette, so in light theme the ring must fall back to the light page colour —
+     matching the list-row .presence-dot. (spec 1062 light-theme fix) */
+  border: 2px solid var(--ion-background-color, #fff);
   box-sizing: border-box;
 }
 .avatar-spacer {


### PR DESCRIPTION
Production release **1.0.23**.

## What's new
- **WebM videos** are converted to MP4 before sending, so they play on iPhone/Safari instead of a black tile (also covers recorded video-notes).
- **iPhone (HEIC) photos** are converted to JPEG, so they display on any browser.
- **Transparent PNGs** keep their transparency instead of a black/white fill.
- **SVG images** get a preview thumbnail.
- If a media can't be converted, you get a clear message instead of a silently-broken send.
- **Pinned chats:** the delivery-tick and presence indicators now render correctly in light mode (were black blobs in 1.0.22).

Client-only; zero-knowledge preserved (all conversion on-device; server stores opaque blobs). Spec 2050. Merged via #1086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i