### PR TITLE
1.0.25 — snappier swipe-to-reply on received messages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,4 +136,4 @@ Specs are grouped by category band; status moves
 | [2048](specs/2048-notifications-not-appear/spec.md) | Show-first notifications (work when locked, keep the subscription alive) | 🟡 in-progress |
 | [2049](specs/2049-dark-default-flash/spec.md) | Default to dark theme and fix the startup theme flash | 🟢 shipped |
 | [2050](specs/2050-media-interop/spec.md) | Make pasted and sent media interoperable across browsers | 🔵 in-review |
-| [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🔵 in-review |
+| [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/2051-reply-swipe-responsive/spec.md
+++ b/specs/2051-reply-swipe-responsive/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-25
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category
@@ -40,7 +40,7 @@ A user swipes right on an incoming message to reply; the gesture engages across 
 
 ## Requirements *(mandatory)*
 
-- **FR-001**: The inert (non-reply) region of an **incoming** bubble MUST be the left 35% of that bubble's width (was 55%); the right 65% MUST engage the reply-swipe.
+- **FR-001**: The inert (non-reply) region of an **incoming** bubble MUST be the left 25% of that bubble's width (tuned on-device 55% → 35% → 25%); the right 75% MUST engage the reply-swipe. 0.25 is the practical floor for the fraction approach.
 - **FR-002**: Outgoing bubbles MUST remain fully swipeable (unchanged).
 - **FR-003**: A right-swipe that begins in the reserved left region MUST NOT arm a reply, preserving the OS back-swipe (no stray draft on back-navigation).
 - **FR-004**: The reply fire threshold, max travel, direction lock, and delete-swipe behavior are unchanged.
@@ -57,5 +57,5 @@ None. This is a client-only touch-gesture threshold change; nothing crosses the 
 
 ## Assumptions
 
-- 0.35 is a first, low-risk step chosen for on-device tuning; the exact safe value depends on iOS's back-swipe lane width, which can only be confirmed on a real iPhone.
-- The screen-edge-lane alternative remains available as a follow-up if 0.35 proves too aggressive on narrow left-edge bubbles.
+- On-device tuning: 0.55 → 0.35 (1.0.24, confirmed no back-swipe interference) → 0.25 (1.0.25). The exact safe value depends on iOS's back-swipe lane width, confirmable only on a real iPhone.
+- 0.25 is the practical floor for the fraction approach; the screen-edge-lane alternative remains available if even more responsiveness is wanted on narrow left-edge bubbles.

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -2481,12 +2481,12 @@ const SWIPE_TRIGGER = 70; // release past this fires the action
 // drop a stray draft as the page navigates away). Only the bubble's right portion
 // starts a reply. Outgoing bubbles hug the right edge, clear of the back-swipe
 // lane, so they stay fully swipeable.
-// (spec 2050 follow-up) Left fraction of an incoming bubble that ignores swipe-right, so
-// an edge back-swipe never arms a reply. Reduced 0.55 → 0.35 to make incoming bubbles more
-// responsive to reply-swipes (active zone grows from the right 45% to the right 65%) while
-// still keeping the left third — the part most likely to sit in the OS back-swipe lane —
-// inert. If a back-swipe ever leaks into a reply on a narrow left-edge bubble, nudge back up.
-const REPLY_DEAD_ZONE_FRAC = 0.35;
+// (spec 2051) Left fraction of an incoming bubble that ignores swipe-right, so an edge
+// back-swipe never arms a reply. Tuned on-device 0.55 → 0.35 → 0.25: the reply-active zone
+// is now the right 75% of an incoming bubble, keeping only the left quarter inert. 0.25 is
+// the practical floor for this fraction approach — going lower risks narrow left-edge 1:1
+// bubbles overlapping the OS back-swipe lane, at which point a screen-edge lane is the move.
+const REPLY_DEAD_ZONE_FRAC = 0.25;
 const swipeId = ref<string | null>(null); // the message currently being dragged
 const swipeDx = ref(0); // its current x offset
 const swipeReleasing = ref(false); // animate the snap-back


### PR DESCRIPTION
Production release **1.0.25**.

## What's new
- Swipe-to-reply on messages you receive is a little snappier — it now engages across more of the bubble, with the left edge still reserved for back-swipe.

On-device tuning of spec 2051 (right 75% active). Merged via #1090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i