### PR TITLE
fix(media): send WebM even when it can't be converted, instead of blocking it

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,5 +135,6 @@ Specs are grouped by category band; status moves
 | [2047](specs/2047-modern-iphones-and/spec.md) | Modern iPhones/iPads actually display push notifications | 🟡 in-progress |
 | [2048](specs/2048-notifications-not-appear/spec.md) | Show-first notifications (work when locked, keep the subscription alive) | 🟡 in-progress |
 | [2049](specs/2049-dark-default-flash/spec.md) | Default to dark theme and fix the startup theme flash | 🟢 shipped |
-| [2050](specs/2050-media-interop/spec.md) | Make pasted and sent media interoperable across browsers | 🔵 in-review |
+| [2050](specs/2050-media-interop/spec.md) | Make pasted and sent media interoperable across browsers | 🟢 shipped |
 | [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |
+| [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🔵 in-review |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/2050-media-interop/spec.md
+++ b/specs/2050-media-interop/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-24
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2052-webm-best-effort/spec.md
+++ b/specs/2052-webm-best-effort/spec.md
@@ -1,0 +1,66 @@
+# Feature Specification: Send webm best-effort instead of hard-failing when it can't transcode
+
+**Feature Branch**: `fix/2052-webm-best-effort`
+
+**Created**: 2026-07-26
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report: "Sending a webm fails with 'video couldn't be converted to send.' Why do we need to convert a webm? Browsers support webm."
+
+## Context: regression from spec 2050
+
+Spec 2050 made non-portable video containers (webm) **mandatorily** transcode to MP4 and, if the transcode couldn't run, **hard-fail** the send (`failReason: 'cant-convert'`). Intent: Safari/iOS can't decode VP8/VP9 webm, so an un-transcoded webm shows a black tile there.
+
+But that hard-fail is too aggressive. Diagnosis on a real 1920p/~25s VP8 webm: the single-threaded ffmpeg-wasm core **decodes and re-encodes the whole clip, then `Aborted()` (OOM) at the mux/finalize step** — so a legitimate, ordinary webm can't be transcoded on-device and was **blocked entirely**, even though it plays fine on Chrome/Firefox/Android. Being unable to send at all is worse than the pre-existing Safari limitation.
+
+This hotfix makes webm **best-effort**: attempt the MP4 transcode (so Safari recipients benefit when it succeeds), but if it can't, **send the raw webm** rather than blocking. Also drops `-movflags +faststart` (its in-memory moov relocation contributed to the finalize OOM, and progressive-start buys nothing for chat videos that are fully downloaded before playback), and keeps the transcoded MP4 for a non-portable source even when it isn't smaller (portability beats size there).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A webm always sends (Priority: P1)
+
+A user sends a webm; it goes through. If it can be transcoded to MP4 it is (best for all recipients); if it can't, the raw webm is sent (plays on Chrome/Firefox/Android) — never a "couldn't convert" block.
+
+**Independent Test**: On macOS, send a large (1920p/~25s) VP8 webm → it delivers (as raw webm when the wasm transcode OOMs); send a small/short webm → it delivers as MP4. Neither shows the "couldn't convert" failure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a webm the on-device transcoder can convert, **When** I send it, **Then** it is delivered as MP4 (playable on Safari/iOS too).
+2. **Given** a webm the on-device transcoder can NOT convert (e.g. too heavy for wasm), **When** I send it, **Then** the raw webm is delivered (no "couldn't convert" failure).
+3. **Given** an MP4/H.264 video, **When** I send it, **Then** behavior is unchanged.
+4. **Given** a webm that genuinely exceeds the send size cap, **When** I send it, **Then** it fails with the existing "too large" reason (not "couldn't convert").
+
+### Edge Cases
+
+- **Raw webm to a Safari/iOS recipient** when the transcode couldn't run: it won't play there (pre-existing VP8/VP9 limitation) — accepted, since blocking the send is worse and most recipients can play it. Smaller webms still transcode to MP4 and play everywhere.
+- **HEIC images** keep failing honestly if they can't be decoded (raw HEIC is unviewable on most browsers, unlike webm) — unchanged from 2050.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: A non-portable video container (webm, etc.) MUST be sent best-effort: transcode to MP4 when possible, otherwise send the raw file. It MUST NOT hard-fail the send solely because the transcode couldn't run.
+- **FR-002**: When the transcode succeeds for a non-portable source, the MP4 MUST be used even if it is not smaller than the source (portability over size).
+- **FR-003**: `-movflags +faststart` MUST NOT be used (avoids the finalize OOM; unnecessary for fully-downloaded chat playback).
+- **FR-004**: A genuinely too-large original MUST still fail with the existing "too large" reason (memory-safety / server cap), not "couldn't convert".
+- **FR-005**: HEIC image conversion behavior is unchanged (still fails honestly if undecodable). MP4 video behavior is unchanged.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+None new. All transcoding remains client-side before encryption; the server still stores opaque blobs. This change only affects the client-side fallback decision (send raw vs. block).
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: A 1920p/~25s VP8 webm that OOMs the wasm transcoder is delivered (as raw webm), not blocked — verified end-to-end.
+- **SC-002**: A webm small enough to transcode is delivered as MP4.
+- **SC-003**: No "couldn't convert" failure occurs for any webm within the send size cap.
+- **SC-004**: MP4 and HEIC behavior show no regression.
+
+## Assumptions
+
+- The single-threaded ffmpeg-wasm core has a hard memory ceiling that some ordinary large webms exceed; a multi-threaded core (needs COOP/COEP) is deliberately not used, so best-effort + raw fallback is the pragmatic behavior.
+- webm plays natively on Chrome/Firefox/Android; only Safari/iOS lacks VP8/VP9 — so raw webm is a reasonable fallback for the majority.

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -21,7 +21,7 @@ import { fetchUserStatuses, blockUser, unblockUser, fetchBlocks, fetchDirectoryU
 import { recordStaleDrain, recordMissedWakeDrain, STALE_MSG_MS } from '@/services/push';
 import { sealForChat, openPacket } from '@/services/messaging';
 import { lastMessageTick } from '@/services/message-status';
-import { needsMandatoryTranscode, isPortableVideo, isHeic } from '@/services/media-portability';
+import { needsMandatoryTranscode, isHeic } from '@/services/media-portability';
 import { withInboundLock } from '@/services/cross-lock';
 import { mediaPreview, previewKind, chatListPreview } from '@/services/message-preview';
 import { prepareOutgoingMedia, receiveIncomingMedia, getMaxBlobBytes, BlobUploadError, deleteBlob, uploadBlob, downloadBlob } from '@/services/media-transfer';
@@ -2443,17 +2443,21 @@ async function runMediaJob(messageId: string): Promise<void> {
       // before send, regardless of quality — even at 'original' (where the encode phase
       // is otherwise skipped). Raw webm is unplayable on Safari/iOS, so if it can't be
       // converted we fail honestly rather than ship an unplayable tile.
-      const mustTranscodeVideo =
+      // (spec 2050 revised) Best-effort transcode for a non-portable video container (webm):
+      // attempt it even at 'original' quality so Safari/iOS recipients get a playable MP4 when
+      // it works — but if the transcode can't run, send the RAW file rather than blocking (a
+      // webm still plays on Chrome/Firefox/Android; a blocked send helps no one). The video
+      // fallback is handled inside compressVideoAdaptive, which returns the original on failure.
+      const attemptVideoTranscode =
         message.kind === 'video' &&
         needsMandatoryTranscode(media.blob.type, message.compressQuality ?? 'original');
-      // (spec 2050) HEIC/HEIF must be decoded to JPEG before send (viewable everywhere),
-      // even at 'original' quality; if it can't be decoded we fail honestly, never ship raw.
+      // HEIC/HEIF: decode to JPEG before send (raw HEIC is unviewable on most browsers), even
+      // at 'original'. This one DOES fail honestly if it truly can't be decoded.
       const mustConvertImage = message.kind === 'image' && isHeic(media.blob.type);
-      // --- encode phase --- (for portable formats compression NEVER fails the job → send
-      // the original; a mandatory transcode/convert is the exception — see the catch below)
+      // --- encode phase ---
       if (
         (message.compressQuality && (message.kind === 'image' || message.kind === 'video')) ||
-        mustTranscodeVideo ||
+        attemptVideoTranscode ||
         mustConvertImage
       ) {
         try {
@@ -2462,28 +2466,21 @@ async function runMediaJob(messageId: string): Promise<void> {
             // decodes to JPEG (the decode runs before the quality passthrough).
             uploadBlob = await compressImage(media.blob, message.compressQuality ?? 'original');
           } else {
-            // Force a real transcode for a mandatory case even when quality is 'original'
-            // (compressVideo no-ops on 'original'); 'fhd' preserves the most quality.
+            // Attempt a real transcode even at 'original' (compressVideo no-ops on 'original');
+            // 'fhd' preserves the most quality. On failure it returns the original best-effort.
             const q = message.compressQuality ?? 'fhd';
             uploadBlob = await compressVideo(media.blob, q, (p) => setCompressProgress(messageId, p));
           }
         } catch (e) {
-          if (mustTranscodeVideo || mustConvertImage) {
-            // A non-portable media we couldn't convert must NOT be sent raw (unplayable/
-            // unviewable on other browsers).
-            console.warn('[media-job] mandatory media conversion failed; failing honestly', e);
+          if (mustConvertImage) {
+            // A HEIC we couldn't decode would be unviewable for most recipients — fail honestly.
+            console.warn('[media-job] HEIC decode failed; failing honestly', e);
             await failMediaPermanently(messageId, 'cant-convert');
             return;
           }
+          // Video/other: best-effort — send the original rather than blocking the send.
           console.warn('[media-job] compression failed; sending original', e);
           uploadBlob = media.blob;
-        }
-        // Defence in depth: if a mandatory transcode somehow returned the original
-        // non-portable bytes (no engine succeeded but didn't throw), fail rather than ship.
-        if (mustTranscodeVideo && !isPortableVideo(uploadBlob.type)) {
-          console.warn('[media-job] mandatory transcode did not yield a portable video; failing honestly');
-          await failMediaPermanently(messageId, 'cant-convert');
-          return;
         }
       }
       setCompressProgress(messageId, 1); // encoding done

--- a/src/services/media-video-ffmpeg.ts
+++ b/src/services/media-video-ffmpeg.ts
@@ -54,6 +54,10 @@ export async function ffmpegTranscode(
   blob: Blob,
   preset: VideoPreset,
   onProgress?: (p: number) => void,
+  // (spec 2050) For a non-portable source (e.g. webm) we want the MP4 for interop even if
+  // it isn't smaller than the source — portability beats size there. Portable re-encodes
+  // keep the "only if smaller" rule so we never grow an already-fine mp4.
+  opts?: { keepEvenIfLarger?: boolean },
 ): Promise<Blob> {
   // Refuse oversize inputs BEFORE loading the 30 MB core or decoding a frame — a 4K
   // decode here would OOM-crash the tab (see FFMPEG_MAX_INPUT_BYTES). Throwing lets the
@@ -83,7 +87,11 @@ export async function ffmpegTranscode(
       // spec 1018 FR-014: drop all source container metadata (GPS location, device id, creation
       // time) — ffmpeg copies it by default. The re-encoded clip carries only what's needed to play.
       '-map_metadata', '-1',
-      '-movflags', '+faststart',
+      // (spec 2050) NO -movflags +faststart: relocating the moov atom over the whole output at
+      // finalize is a second in-memory pass that OOM-`Aborted()` the single-threaded wasm core on
+      // larger clips (observed on a 1920p/~25s webm — full encode, then abort at mux). Chat videos
+      // are fully downloaded before playback, so progressive-start buys nothing here; dropping it
+      // makes the transcode actually complete.
       output,
     ], FFMPEG_TIMEOUT_MS);
     // (spec 2038) ffmpeg.wasm's exec RESOLVES with an exit code — it never
@@ -96,8 +104,11 @@ export async function ffmpegTranscode(
     }
     const data = (await ff.readFile(output)) as Uint8Array;
     const out = new Blob([data.buffer as ArrayBuffer], { type: 'video/mp4' });
-    // Keep whichever is smaller (re-encoding a small clip can grow it).
-    return out.size > 0 && out.size < blob.size ? out : blob;
+    if (out.size === 0) return blob;
+    // Non-portable source: keep the mp4 for interop regardless of size. Portable source:
+    // keep whichever is smaller (re-encoding a small clip can grow it).
+    if (opts?.keepEvenIfLarger) return out;
+    return out.size < blob.size ? out : blob;
   } finally {
     if (onProgress) ff.off('progress', onProg);
     await ff.deleteFile(input).catch(() => {});

--- a/src/services/media-video.ts
+++ b/src/services/media-video.ts
@@ -206,7 +206,10 @@ export async function compressVideoAdaptive(
   // 2. ffmpeg.wasm universal path.
   try {
     const { ffmpegTranscode } = await import('./media-video-ffmpeg');
-    const out = await ffmpegTranscode(blob, preset, onProgress);
+    // Non-portable source (webm): keep the mp4 for interop even if not smaller.
+    const out = await ffmpegTranscode(blob, preset, onProgress, {
+      keepEvenIfLarger: !isPortableVideo(blob.type),
+    });
     console.info('[video] ffmpeg output', { bytes: out.size, vs: blob.size });
     if (out !== blob && !(await transcodeOutputPlayable(out))) {
       console.warn('[video] ffmpeg output unreadable; sending original');
@@ -229,14 +232,12 @@ export async function compressVideoAdaptive(
  *  same jetsam kill the streaming transcode removed. A clean, explained failure
  *  card beats a crashed app. */
 function originalOrThrow(blob: Blob): Blob {
-  // (spec 2050) A non-portable container (e.g. webm) is unplayable on Safari/iOS as raw
-  // bytes — there is no safe "ship the original". Reaching here for a non-portable
-  // container means conversion failed, so fail honestly rather than send an unplayable tile.
-  if (!isPortableVideo(blob.type)) {
-    throw new Error('This video needs converting to send and converting failed on this device. Try a shorter clip or a different format.');
-  }
+  // (spec 2050 revised) Best-effort: if conversion couldn't run, still SEND the original
+  // rather than blocking. A raw webm plays on Chrome/Firefox/Android (only Safari/iOS can't
+  // decode VP8/VP9) — not being able to send at all is worse. We only refuse an original
+  // that is too large to seal without risking an OOM crash (unchanged memory-safety guard).
   if (blob.size > ORIGINAL_MAX_BYTES) {
-    throw new Error('This video is too big to send without converting and converting failed on this device. Try a shorter or smaller clip.');
+    throw new Error('This video is too big to send. Try a shorter or smaller clip.');
   }
   return blob;
 }


### PR DESCRIPTION
Fixes a regression from 2050: a WebM the on-device transcoder can't convert to MP4 (e.g. a large 1080p/~25s clip that OOM-`Aborted()`s the single-threaded ffmpeg-wasm core at mux/finalize) was **hard-failing the send** ("couldn't convert"). Now it's **best-effort** — transcode to MP4 when possible (so Safari/iOS recipients get a playable video), otherwise **send the raw WebM** (plays on Chrome/Firefox/Android). Being unable to send at all was worse than the pre-existing Safari limitation.

- `originalOrThrow` no longer hard-fails a non-portable container; `runMediaJob` falls back to the raw file on transcode failure (HEIC still fails honestly — raw HEIC is unviewable on most browsers).
- Dropped `-movflags +faststart` (its in-memory moov relocation contributed to the finalize OOM; unneeded for fully-downloaded chat playback).
- Keep the transcoded MP4 for a non-portable source even if it isn't smaller (portability > size).

Diagnosed + verified end-to-end with the reported real 1920p VP8 webm — now delivers. Client-only; zero-knowledge unchanged. Spec 2052; also marks 2050 shipped. Ships as **1.0.26**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i