### PR TITLE
1.0.27 — full-size photos in chat at their real aspect ratio

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,6 +82,7 @@ Specs are grouped by category band; status moves
 | [1054](specs/1054-pick-emoji-contact/spec.md) | Emoji contact photos + reset to their photo | 🟢 shipped |
 | [1055](specs/1055-ciphertext-push-instant/spec.md) | Instant rich notifications (bounded encrypted preview in push) | 🟡 in-progress |
 | [1062](specs/1062-list-status-presence/spec.md) | Message status and presence on the chat list | 🟢 shipped |
+| [1063](specs/1063-full-size-media/spec.md) | Full-size aspect-preserving media thumbnails in chat | 🟡 in-progress |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/drive/scenarios/full-size-media.mjs
+++ b/drive/scenarios/full-size-media.mjs
@@ -1,0 +1,23 @@
+// spec 1063 — verify full-size, aspect-preserving media bubbles. Send a wide 16:9 and a
+// tall 9:16 so both extremes show in one view: 16:9 is width-driven (short); 9:16 is
+// height-driven (capped ~60vh, never runs off-screen). Alice holds the full media → tests
+// layout + retina crispness.
+import { createAccount, pair, chatWith, shot, sweep, poll } from '../driver.mjs';
+
+const a = await createAccount({ name: 'Alice', mobile: true });
+const b = await createAccount({ name: 'Bob', mobile: true });
+await pair(a, b);
+const aChat = await chatWith(a, b.id);
+
+for (const [w, h, n] of [[1280, 720, 'wide-16x9'], [720, 1280, 'tall-9x16']]) {
+  await a.page.evaluate(([c, w, h, nm]) => window.__ringTest.sendImage(c, w, h, nm), [aChat, w, h, `${n}.png`]);
+  await a.page.waitForTimeout(500);
+}
+await poll(
+  () => a.page.evaluate((c) => window.__ringTest.messages(c), aChat),
+  (msgs) => (msgs || []).filter((m) => m.kind === 'image').length >= 2,
+  { label: 'images sent', timeout: 60000 },
+);
+await a.page.waitForTimeout(1500);
+await shot(a, 'fullsize-wide-tall', { route: `/chat/${aChat}` });
+await sweep([a, b]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/1063-full-size-media/spec.md
+++ b/specs/1063-full-size-media/spec.md
@@ -1,0 +1,82 @@
+# Feature Specification: Full-size aspect-preserving media thumbnails in chat
+
+**Feature Branch**: `feat/1063-full-size-media`
+
+**Created**: 2026-07-26
+
+**Status**: in-progress
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User request: "See the full-size media thumbnail in chat — any reasonable aspect ratio (3:4, 4:3, 16:9, 9:16, …) should use the max width of the media and render based on that, unless it gets too tall to fit the visible chat area, in which case height drives; if too wide, width drives. Thumbnails should be crystal clear on retina."
+
+## Context
+
+Today every photo/video in the chat renders in a fixed **240×240 square** frame with `object-fit: cover`, so all media is **center-cropped to a square** regardless of its real aspect ratio, and the shown image is the **512px on-wire poster** — fine for a 240px square but soft on a full-size retina bubble. This spec makes media render at its **true aspect ratio**, sized to a max width but height-capped so a tall clip never runs off the visible chat area, and **crystal-clear on retina** by rendering the full downloaded media (poster only as a pre-download placeholder).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Media shows at its real aspect ratio, full size (Priority: P1)
+
+A user views photos/videos of any reasonable aspect ratio (3:4, 4:3, 16:9, 9:16, square). Each renders uncropped at its true ratio: width-driven up to a max width; if that would be too tall, height-driven capped at a max height so it stays within the visible chat area.
+
+**Independent Test**: Send images of 3:4, 4:3, 16:9, 9:16, and 1:1 → each shows uncropped at its ratio; the tall 9:16 is capped in height (not running off-screen), the wide 16:9 is capped in width; none are square-cropped.
+
+**Acceptance Scenarios**:
+
+1. **Given** a landscape (e.g. 16:9) image, **When** it renders, **Then** it uses the max width and its height follows the ratio (short), uncropped.
+2. **Given** a portrait (e.g. 9:16) image, **When** it would be taller than the height cap, **Then** height drives (capped) and width follows the ratio — it fits the visible chat area, uncropped.
+3. **Given** any media, **When** it renders, **Then** it is NOT center-cropped to a square.
+4. **Given** a very small image, **When** it renders, **Then** it still shows at full bubble width (visible and tappable), not as a tiny sliver.
+
+### User Story 2 - Retina-crisp media (Priority: P1)
+
+Media in the bubble is crisp on retina/high-DPI screens.
+
+**Independent Test**: On a 2–3× DPI display, a full-size photo bubble looks sharp (not the soft 512px poster) once the media has downloaded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a downloaded image, **When** it renders in the bubble, **Then** the full-resolution media is shown (browser downscales it) — crisp at any DPI.
+2. **Given** an image not yet downloaded, **When** it renders, **Then** the poster shows as a placeholder until the full media resolves, then upgrades to crisp.
+3. **Given** a video, **When** its bubble renders, **Then** its still preview is crisp at full size (a higher-resolution poster than the 512px on-wire one).
+
+### Edge Cases
+
+- **Unknown dimensions** (legacy messages without stored width/height): fall back to a sensible frame (square) rather than breaking layout.
+- **Extreme ratios** (very wide panorama / very tall): clamped by the width and height caps respectively; still uncropped.
+- **Off-screen / long media-heavy chats**: full-res rendering is bounded to near/visible items (existing media windowing), so memory stays controlled; off-screen items use the poster and lazy-load.
+- **Albums / grid / viewer**: unchanged (this spec is the single-media chat bubble).
+
+## Requirements *(mandatory)*
+
+- **FR-001**: A single-media (image/video) chat bubble MUST render at the media's true aspect ratio (from the stored width/height), never center-cropped to a square.
+- **FR-002**: Sizing MUST be width-driven up to a max width, and switch to height-driven (capped) when the aspect-preserving height would exceed a max height, so a tall clip fits the visible chat area.
+- **FR-003**: The max width MUST make media feel full-size (wider than today's 240px) while remaining responsive on narrow screens; the max height MUST be viewport-relative so tall media never runs off the visible chat content.
+- **FR-004**: Media MUST render at the computed max width (never a tiny, untappable sliver); a small/degenerate image is shown at full bubble width rather than at its native pixel size.
+- **FR-005**: The bubble MUST render the full downloaded media for retina crispness, using the poster only as a placeholder until the full media resolves.
+- **FR-006**: Video bubbles MUST show a crisp still at full size (a higher-resolution local poster than the ~512px on-wire poster), with the play affordance and tap-to-open-viewer unchanged.
+- **FR-007**: Full-res rendering MUST stay bounded to near/visible items (reuse the existing media windowing) so long media-heavy chats don't blow up memory.
+- **FR-008**: The on-wire poster (sealed in the message) MUST remain small (~40KB) — crispness comes from the locally-held full media / local hi-res poster, not a larger wire payload.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+None. This is a client-side rendering/layout change over media the device already holds; nothing new crosses the client/server boundary, the on-wire poster stays as-is, and no new data is persisted or synced.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Images of 3:4, 4:3, 16:9, 9:16, and 1:1 all render uncropped at their true ratio; tall media is height-capped within the visible chat area; wide media is width-capped.
+- **SC-002**: A downloaded photo bubble is visibly crisp on a 2–3× DPI display (clearly better than the 512px poster).
+- **SC-003**: No square center-cropping remains for single-media bubbles.
+- **SC-004**: Small/degenerate media still renders at full bubble width (visible and tappable), never a tiny sliver.
+- **SC-005**: The sealed message poster size is unchanged (~40KB); no new wire/persisted data.
+- **SC-006**: No regression to albums, the media grid, the full-screen viewer, or scroll/perf in long chats.
+
+## Assumptions
+
+- `mediaWidth`/`mediaHeight` are already stored on messages (set during the media job) and are sufficient for the aspect ratio; legacy messages without them fall back to square.
+- `mediaInfo[mediaId].url` (the full downloaded media) is already resolved for near/visible items and is the crisp source to render.
+- Exact max width/height values (≈ min(75vw, 330px) width, ≈ 60vh height) are tuned on-device via screenshots across aspect ratios; the spec fixes the behavior, not the pixel constants.

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -211,7 +211,7 @@
               class="bubble"
               :class="{ out: m.outgoing, 'bubble-plain': m.videoNote && !m.deleted, 'bubble-media': mediaBubble(m), 'bubble-unseen': !m.outgoing && !m.deleted && m.seenReportedAt == null }"
               :data-mid="m.id"
-              :style="swipeStyle(m.id)"
+              :style="[swipeStyle(m.id), mediaVars(m)]"
               @touchstart.passive="onSwipeStart($event, m)"
               @touchmove.passive="onSwipeMove($event)"
               @touchend.passive="onSwipeEnd()"
@@ -266,7 +266,9 @@
                   :poster-url="mediaInfo[m.mediaId]!.posterUrl"
                   alt="gif"
                 />
-                <img v-else-if="mediaInfo[m.mediaId]?.posterUrl" class="bubble-image" :src="mediaInfo[m.mediaId]!.posterUrl" alt="photo" loading="lazy" decoding="async" />
+                <!-- spec 1063: render the FULL downloaded media (crisp on retina) once its
+                     window is resolved; the poster is the pre-download placeholder. -->
+                <img v-else-if="mediaInfo[m.mediaId]?.url || mediaInfo[m.mediaId]?.posterUrl" class="bubble-image" :src="mediaInfo[m.mediaId]?.url || mediaInfo[m.mediaId]!.posterUrl" alt="photo" loading="lazy" decoding="async" />
                 <ion-skeleton-text v-else :animated="true" class="media-skel" />
                 <!-- Send in flight: the cloud waterline in the thumbnail centre (see CloudFill). -->
                 <span v-if="m.status === 'compressing'" class="upload-cloud"><cloud-fill :progress="uploadFrac(m)" /></span>
@@ -2501,6 +2503,36 @@ function swipeStyle(id: string): Record<string, string> | undefined {
     transform: `translateX(${swipeDx.value}px)`,
     transition: swipeReleasing.value ? 'transform 0.2s ease' : 'none',
   };
+}
+
+// (spec 1063) Reactive viewport size so media sizing recomputes on resize/rotate.
+const vpW = ref(typeof window !== 'undefined' ? window.innerWidth : 393);
+const vpH = ref(typeof window !== 'undefined' ? window.innerHeight : 852);
+function onViewportResize(): void {
+  vpW.value = window.innerWidth;
+  vpH.value = window.innerHeight;
+}
+onMounted(() => window.addEventListener('resize', onViewportResize));
+onUnmounted(() => window.removeEventListener('resize', onViewportResize));
+
+// (spec 1063) Per-message CSS vars for full-size, aspect-preserving media.
+//  --ar     = width/height → the frame's true aspect ratio (frame is width:100%, height from --ar).
+//  --media-w = the DEFINITE px bubble/media width: width-driven up to min(75vw, 330px), switched to
+//             height-driven (capped 60vh → maxH*ar) for tall clips. A plain px value (not a
+//             vw/min() expression) so it caps the bubble's intrinsic width and a long caption wraps
+//             at the photo edge (spec 2027). The frame always fills this width — small media is
+//             shown at full size (a tiny/degenerate image is not rendered as a 1px, untappable
+//             sliver). Undefined for non-media / dimension-less legacy messages → CSS 246px fallback.
+function mediaVars(m: Message): Record<string, string> | undefined {
+  if (!mediaBubble(m)) return undefined;
+  const w = m.mediaWidth ?? 0;
+  const h = m.mediaHeight ?? 0;
+  if (w <= 0 || h <= 0) return undefined;
+  const ar = w / h;
+  const maxW = Math.min(vpW.value * 0.75, 330);
+  const maxH = vpH.value * 0.6;
+  const width = Math.max(1, Math.round(Math.min(maxW, maxH * ar)));
+  return { '--ar': String(ar), '--media-w': `${width}px` };
 }
 function onSwipeStart(e: TouchEvent, m: Message): void {
   if (m.deleted || selecting.value) return;
@@ -5386,9 +5418,16 @@ function cancelRecording() {
    floating quick-forward button ~100px off the bubble (spec 2028). The separate
    max-width keeps narrow viewports working: media and bubble shrink together. */
 .bubble-media {
+  /* spec 1063: the media (and therefore the bubble) width. --media-w is a DEFINITE px value
+     computed in JS (mediaVars) from the media's real ratio + the viewport (width-driven up to
+     min(75vw,330px), height-driven & capped at 60vh for tall clips, never upscaled past native).
+     It MUST be a plain px length, not a min()/vw expression: only a definite width caps the
+     bubble's intrinsic max-content, so a long caption wraps at the photo edge instead of
+     stretching the bubble (spec 2027/2028). Falls back to 246px until dimensions are known
+     (also prevents a 0-width collapse before the media resolves). */
   padding: 3px;
   gap: 0;
-  width: 246px;
+  width: var(--media-w, 246px);
   max-width: 100%;
 }
 .bubble-media .bubble-image {
@@ -5622,9 +5661,12 @@ function cancelRecording() {
 .media-wrap,
 .video-poster {
   position: relative;
-  width: 240px;
+  /* spec 1063: full-size, aspect-preserving. Fill the bubble's media width (--media-w, set
+     on .bubble-media from the media's real ratio) and take the height from the true ratio
+     (--ar = width/height). No more fixed 240px square / object-fit crop. */
+  width: 100%;
   max-width: 100%;
-  aspect-ratio: 1;
+  aspect-ratio: var(--ar, 1);
   border-radius: 12px;
   overflow: hidden;
   background: rgba(127, 127, 127, 0.15);


### PR DESCRIPTION
Production release **1.0.27**.

## What's new
- **Photos show full-size at their real aspect ratio** (3:4, 4:3, 16:9, 9:16, …) instead of a small square crop — width-driven, or height-capped so a tall photo never runs off the screen — and rendered full-resolution, so they're crisp on retina.

spec 1063 (photos). Video shows the correct aspect ratio too; a crisper video still is a tracked follow-up. Merged via #1094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i