### PR TITLE
fix(chats): no delivery tick next to a reaction or call from someone else (spec 2054)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -140,3 +140,4 @@ Specs are grouped by category band; status moves
 | [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |
 | [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🔵 in-review |
 | [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🔵 in-review |
+| [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |

--- a/drive/scenarios/incoming-tick-2054.mjs
+++ b/drive/scenarios/incoming-tick-2054.mjs
@@ -1,0 +1,56 @@
+/**
+ * Spec 2054 — no delivery tick beside an INCOMING activity preview.
+ *
+ * Reproduces the report: Alice sends a message (her row shows a tick), Bob reacts to it, and
+ * Alice's chat-list row preview becomes "Bob reacted 👍 to …". That preview describes BOB's
+ * activity, so the row must NOT keep the tick from Alice's outgoing message.
+ *
+ *   node drive/scenarios/incoming-tick-2054.mjs
+ *   HEADED=1 node drive/scenarios/incoming-tick-2054.mjs
+ */
+import {
+  createAccount, pair, chatWith, say, waitForMessage, messageId, react, shot, poll, sweep, done,
+} from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice', mobile: true });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+// Alice sends → her row gets a real outgoing tick.
+await say(alice, bob.id, 'Finally done bowwo');
+await waitForMessage(bob, alice.id, 'Finally done bowwo');
+
+const aliceChat = await chatWith(alice, bob.id);
+const tickAfterSend = await alice.page.evaluate(
+  (c) => window.__ringTest.chatRow(c).then((r) => r?.lastTick),
+  aliceChat,
+);
+console.log('[2054] Alice lastTick after her own send:', tickAfterSend);
+if (tickAfterSend === 'none') throw new Error('setup FAIL: expected a tick on her own outgoing message');
+
+// Bob reacts to it → Alice's row preview becomes Bob's activity.
+const bobChat = await chatWith(bob, alice.id);
+const mid = await messageId(bob, bobChat, 'Finally done bowwo');
+await react(bob, mid, '👍');
+
+// The preview must flip to the reaction AND the tick must clear.
+await poll(
+  () => alice.page.evaluate((c) => window.__ringTest.chatRow(c), aliceChat),
+  (row) => !!row && /reacted/.test(row.lastMessage ?? ''),
+  { timeout: 20_000, label: "Alice's row preview shows Bob's reaction" },
+);
+
+const row = await alice.page.evaluate(
+  (c) => window.__ringTest.chatRow(c),
+  aliceChat,
+);
+console.log('[2054] preview:', JSON.stringify(row.lastMessage), '| lastTick:', row.lastTick);
+if ((row.lastTick ?? 'none') !== 'none') {
+  throw new Error(`FAIL: incoming reaction preview still carries a tick (${row.lastTick})`);
+}
+console.log('[2054] PASS — no tick beside the incoming reaction ✓');
+
+await shot(alice, 'incoming-reaction-no-tick', { route: '/tabs/chats' });
+
+await sweep([alice, bob]);
+await done();

--- a/specs/2054-incoming-tick/spec.md
+++ b/specs/2054-incoming-tick/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: No delivery tick beside an incoming activity in the chats list
+
+**Feature Branch**: `fix/2054-incoming-tick`
+
+**Created**: 2026-07-27
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report (with screenshot): "Why do we see a sent status mark next to the incoming reaction!? Please make sure the message status is only shown on the outgoing messages and not incoming ones!"
+
+## Context: why this hotfix exists
+
+A Chats-list row read **"✓ Kambiz reacted 👍 to 'Finally done bowwo 😁'"** — a delivery tick beside an activity that belongs to *the other person*. A tick means "this is my message and here is how far it got", so putting one next to someone else's reaction is simply wrong.
+
+The row's tick is driven by a denormalized `Chat.lastTick` (spec 1062), kept in step with the newest message so the list can show delivery progress without scanning history. `lastMessageTick` itself is correct — it returns `none` for anything incoming. The defect is that the sites which **replace the row preview with a non-message activity** update `lastMessage` / `lastKind` / `lastMessageTime` but never touch `lastTick`. The row therefore keeps the tick of the *outgoing message it just stopped describing*.
+
+That affects every activity preview, not just the reported one:
+
+- an **incoming reaction** ("Kambiz reacted 👍 to …") — the reported bug,
+- your **own** reaction ("You reacted 👍 to …") — a tick belonging to a different message,
+- **game** activity ("made a move 🎲", both directions),
+- a **call** entry — stored as a message for the timeline but explicitly informational (never enqueued, no receipts), so it can inherit a blue double tick it never earned,
+- a **cleared** chat — preview wiped, tick left behind.
+
+The unifying rule: **the row tick describes a receipt-tracked outgoing message. Anything else shows no tick.**
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - An incoming reaction shows no delivery mark (Priority: P1)
+
+Someone reacts to my message; my chats list shows their reaction as the latest activity, with no tick beside it.
+
+**Why this priority**: The reported defect, and the most visible — reactions are frequent, so the wrong mark shows up constantly.
+
+**Independent Test**: Send a message (row shows a tick), have the peer react, and confirm the row preview becomes their reaction with no tick.
+
+**Acceptance Scenarios**:
+
+1. **Given** my outgoing message is the newest and its row shows a tick, **When** the peer reacts to it, **Then** the row preview becomes their reaction and the tick disappears.
+2. **Given** that reaction preview is showing, **When** a late receipt for my earlier message arrives, **Then** no tick reappears beside the reaction.
+3. **Given** I then send a new message, **Then** the tick returns and tracks that message normally.
+
+---
+
+### User Story 2 - Other non-message activity carries no tick either (Priority: P2)
+
+Game moves, calls, my own reactions and cleared chats show their preview without a stale delivery mark.
+
+**Why this priority**: Same defect class and the same wrong impression, but less frequent than reactions.
+
+**Independent Test**: Trigger each activity preview and confirm no tick renders.
+
+**Acceptance Scenarios**:
+
+1. **Given** a chat whose latest activity is a game move (mine or theirs), **Then** the row shows no tick.
+2. **Given** a chat whose latest entry is a call, **Then** the row shows no tick, in either direction.
+3. **Given** I react to someone's message, **Then** my row shows "You reacted …" with no tick.
+4. **Given** I clear a chat's history, **Then** the emptied row carries no tick.
+
+---
+
+### Edge Cases
+
+- **A late receipt** for the message an activity replaced MUST NOT restore the tick (the existing "only if it is still the newest" guard covers this — the activity moved `lastMessageTime`).
+- **Pinned tiles** read the same `lastTick`, so they must behave identically to list rows.
+- **An ordinary outgoing message** MUST be unaffected: pending → sent → delivered → seen still climbs live.
+- **A failed send** keeps its existing failed treatment.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: nothing new. This changes only a locally-derived display field.
+- **Where processing happens**: entirely on-device, from data already held.
+- **Unavoidably-visible metadata**: unchanged — no new endpoint, field, or receipt is sent.
+- **Why it stays zero-knowledge**: `lastTick` is a local denormalization of local state; the server has no part in it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The chats-list row / pinned-tile delivery tick MUST only ever describe a receipt-tracked **outgoing message**.
+- **FR-002**: When a row preview is replaced by a **reaction** (incoming or own), the tick MUST be cleared.
+- **FR-003**: When a row preview is replaced by **game** activity (incoming or own), the tick MUST be cleared.
+- **FR-004**: A **call** entry MUST never render a tick, in either direction, including when the row summary is recomputed from history.
+- **FR-005**: Clearing a chat's history MUST clear its tick.
+- **FR-006**: A late receipt MUST NOT restore a tick beside an activity preview.
+- **FR-007**: Ordinary outgoing messages MUST keep their existing tick behaviour (pending/sent/delivered/seen, group roster tiers, failed, and the seen-reciprocity gate).
+
+### Key Entities *(include if feature involves data)*
+
+- **Chat summary**: the denormalized row fields (`lastMessage`, `lastKind`, `lastMessageTime`, `lastTick`). This fix makes `lastTick` a first-class part of every summary update rather than something only the message paths maintain. No schema change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An incoming reaction preview never renders a delivery tick.
+- **SC-002**: No activity preview (reaction, game, call, cleared) renders a tick, in either direction.
+- **SC-003**: Ordinary outgoing messages show no regression in tick behaviour.
+- **SC-004**: A late receipt cannot reintroduce a tick beside an activity preview.
+
+## Assumptions
+
+- A call entry carries no delivery semantics — the code already records it as informational with no receipts — so it should never show a tick even though an outgoing call is flagged outgoing.
+- Clearing the tick (rather than recomputing it from the newest real outgoing message) is the right behaviour: the row is describing the activity, so a tick for some other message would be misleading regardless of accuracy.
+
+## Out of Scope
+
+- The in-conversation bubble ticks (already correct — they render per message).
+- Changing reaction, game, or call previews themselves (wording, ordering, notifications).
+- Any change to receipt collection or the seen-reciprocity policy.

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -315,6 +315,7 @@ export async function clearChat(chatId: string): Promise<void> {
   if (chat) {
     chat.lastMessage = '';
     chat.lastKind = undefined;
+    chat.lastTick = 'none'; // (spec 2054) history wiped → no message left to carry a tick
     chat.unread = 0;
     delete chat.manualUnread;
     chat.updatedAt = now();
@@ -753,6 +754,11 @@ export async function reactToMessage(
     chat.lastMessage = `You reacted ${emoji} to "${previewText(message)}"`;
     chat.lastKind = 'reaction';
     chat.lastMessageTime = at;
+    // (spec 2054) The row preview is now an ACTIVITY, not the outgoing message it replaced, so
+    // drop that message's delivery tick — otherwise the row keeps a stale ✓/✓✓ beside a preview
+    // it doesn't describe. A reaction rides its own signal and carries no receipts of its own,
+    // so there is no tick to show for it. Same reasoning at every activity-preview site below.
+    chat.lastTick = 'none';
     chat.updatedAt = at;
     await put('chats', chat);
   }
@@ -791,6 +797,10 @@ async function handleReaction(from: string, signal: ReactionSignal): Promise<voi
       chat.lastMessage = `${name.split(' ')[0]} reacted ${signal.emoji} to "${previewText(message)}"`;
       chat.lastKind = 'reaction';
       chat.lastMessageTime = signal.at;
+      // (spec 2054) THE reported bug: an INCOMING reaction left the previous outgoing message's
+      // tick in place, so the row read "✓ Kambiz reacted 👍 to …" — a delivery mark on someone
+      // else's activity. Incoming activity never shows a tick.
+      chat.lastTick = 'none';
       chat.updatedAt = signal.at;
       await put('chats', chat);
 
@@ -1106,6 +1116,7 @@ async function bumpOwnGamePreview(m: Message, action: 'move' | 'resign', at: num
   chat.lastMessage = text;
   chat.lastKind = 'game';
   chat.lastMessageTime = at;
+  chat.lastTick = 'none'; // (spec 2054) game activity, not a receipt-tracked message → no tick
   chat.updatedAt = at;
   await put('chats', chat);
 }
@@ -1488,6 +1499,7 @@ async function handleGameMove(from: string, signal: GameMoveSignal): Promise<voi
   chat.lastMessage = text;
   chat.lastKind = 'game';
   chat.lastMessageTime = signal.at;
+  chat.lastTick = 'none'; // (spec 2054) incoming game activity → never a delivery tick
   chat.updatedAt = signal.at;
   await put('chats', chat);
 
@@ -1641,7 +1653,13 @@ async function refreshChatPreview(chatId: string): Promise<void> {
   const seenOn = await getSetting<boolean>('privacy.seenReceipts', true);
   chat.lastTick = lastMessageTick(
     newest
-      ? { outgoing: newest.outgoing, status: newest.status, receipts: newest.receipts, isGroup: chat.isGroup }
+      ? {
+          outgoing: newest.outgoing,
+          status: newest.status,
+          receipts: newest.receipts,
+          isGroup: chat.isGroup,
+          callLog: newest.callLog, // (spec 2054) call entries are informational → no tick
+        }
       : undefined,
     seenOn,
   );
@@ -6832,6 +6850,7 @@ export async function logCallToChat(chatId: string, log: CallLog): Promise<void>
   chat.lastMessage = preview;
   chat.lastKind = 'call';
   chat.lastMessageTime = ts;
+  chat.lastTick = 'none'; // (spec 2054) a call is informational — no receipts, so no tick
   chat.updatedAt = ts;
   await put('chats', chat);
 }

--- a/src/services/message-status.test.ts
+++ b/src/services/message-status.test.ts
@@ -282,6 +282,16 @@ describe('spec 1062: lastMessageTick (shared list/tile tick tier)', () => {
     expect(lastMessageTick(msg({ status: 'failed' }))).toBe('failed');
   });
 
+  // (spec 2054) A call entry is stored as a message so it appears in the timeline, but it is
+  // informational — never enqueued, no receipts — so it must never render a delivery tick,
+  // even though an outgoing call is flagged outgoing with status 'seen'.
+  it('a call-log entry never shows a tick, even when outgoing', () => {
+    expect(lastMessageTick({ ...msg({ status: 'seen' }), callLog: { direction: 'outgoing' } })).toBe('none');
+    expect(lastMessageTick({ ...msg({ status: 'delivered' }), callLog: {} })).toBe('none');
+    // …while an ordinary outgoing message is unaffected.
+    expect(lastMessageTick(msg({ status: 'seen' }))).toBe('seen');
+  });
+
   it('pre-send states map to pending (clock)', () => {
     expect(lastMessageTick(msg({ status: 'pending' }))).toBe('pending');
     expect(lastMessageTick(msg({ status: 'compressing' }))).toBe('pending');

--- a/src/services/message-status.ts
+++ b/src/services/message-status.ts
@@ -170,15 +170,20 @@ export function applyDownloadedReceipt(
  *     reciprocity-gated by `seenReceiptsOn` (seen tier suppressed → caps at delivered)
  *   - 1:1 → status maps straight through, with 'seen' capped to 'delivered' when
  *     `seenReceiptsOn` is false (the reciprocity DISPLAY gate, spec 1010 FR-009).
+ *  (spec 2054) A call-log entry is stored as a message for the timeline but is purely
+ *  informational — never enqueued, no receipts — so it carries NO tick, even though it is
+ *  flagged outgoing for an outgoing call. Without this, a "Call · 0:06" row rendered a blue
+ *  double tick it never earned.
+ *
  *  Pure: no Vue/IDB — unit-testable, and reused by the summary maintenance in queries.ts. */
 export function lastMessageTick(
   msg:
-    | (Pick<Message, 'outgoing' | 'status' | 'receipts'> & { isGroup?: boolean })
+    | (Pick<Message, 'outgoing' | 'status' | 'receipts'> & { isGroup?: boolean; callLog?: unknown })
     | null
     | undefined,
   seenReceiptsOn = true,
 ): LastTick {
-  if (!msg || !msg.outgoing) return 'none';
+  if (!msg || !msg.outgoing || msg.callLog) return 'none';
   const { status, receipts, isGroup } = msg;
   if (status === 'failed') return 'failed';
   if (status === 'compressing' || status === 'pending') return 'pending';

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -516,6 +516,13 @@ export function installTestHook(): void {
     hiddenReset: () => hcReset(),
     /** Visible chat ids right now (what `listChats` returns) — for exclusion asserts. */
     visibleChatIds: async (): Promise<string[]> => (await listChats()).map((c) => c.id),
+    /** (spec 2054) A chat's denormalized list-row summary — the preview text/kind plus the
+     *  delivery tick tier the Chats row and pinned tile render. Lets a test assert that an
+     *  INCOMING activity preview (a reaction, a game move, a call) carries no tick. */
+    chatRow: async (chatId: string): Promise<{ lastMessage?: string; lastKind?: string; lastTick?: string } | null> => {
+      const c = (await listChats()).find((x) => x.id === chatId);
+      return c ? { lastMessage: c.lastMessage, lastKind: c.lastKind, lastTick: c.lastTick } : null;
+    },
     /** The unread badge total (countUnread) — for hidden-chat badge-mode asserts. */
     unreadBadge: (): Promise<number> => dbCountUnread(),
 


### PR DESCRIPTION
## The bug

A chats-list row read **"✓ Kambiz reacted 👍 to 'Finally done bowwo 😁'"** — a delivery mark beside activity belonging to *the other person*. A tick means "this is my message and here is how far it got", so showing one next to someone else's reaction is wrong.

## Root cause

The row tick comes from the denormalized `Chat.lastTick` (spec 1062). `lastMessageTick` is correct — it returns `none` for anything incoming. The defect is that the sites which replace the row preview with a **non-message activity** update `lastMessage` / `lastKind` / `lastMessageTime` but never touch `lastTick`, so the row keeps the tick of the outgoing message it just stopped describing.

It was a class of bug, not one case:

- **incoming reaction** ("Kambiz reacted …") — the reported one
- **own reaction** ("You reacted …") — a tick belonging to a different message
- **game** activity ("made a move 🎲"), both directions
- a **call** entry — stored as a message for the timeline but explicitly informational (never enqueued, no receipts), so it could inherit a blue double tick it never earned
- a **cleared** chat — preview wiped, tick left behind

## Fix

Clear `lastTick` at every activity-preview site, and make `lastMessageTick` itself return `none` for a call-log entry so a recomputed summary can't put the tick back. A late receipt already can't restore it — the activity moved `lastMessageTime`, so the existing "only if it is still the newest" guard declines.

The invariant, now held in one place: **the row tick describes a receipt-tracked outgoing message; anything else shows no tick.** Ordinary outgoing messages are untouched and still climb pending → sent → delivered → seen.

## Verification

- `npm run build` clean; **1252 unit tests pass**, including a new case pinning that a call-log entry never ticks while an ordinary outgoing message still does.
- `drive/scenarios/incoming-tick-2054.mjs` reproduces the report: the sender's row shows `delivered` for her own message, then clears to `none` the moment the peer's reaction becomes the preview. Screenshot confirms the row renders with no tick.

## Zero-knowledge

Unchanged — `lastTick` is a local denormalization of local state. Nothing new crosses the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i