### PR TITLE
fix(chat): big animated GIFs and WebPs send instead of sticking on the clock (spec 2055)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -140,3 +140,4 @@ Specs are grouped by category band; status moves
 | [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |
 | [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🔵 in-review |
 | [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🔵 in-review |
+| [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🔵 in-review |

--- a/drive/scenarios/oversize-poster-repro.mjs
+++ b/drive/scenarios/oversize-poster-repro.mjs
@@ -1,0 +1,81 @@
+/**
+ * REPRO: a small-DIMENSION but large-BYTE image (the shape of an animated GIF/WebP) gets
+ * stuck on the sending clock forever.
+ *
+ * Mechanism under test (queries.ts runMediaJob):
+ *   let bubble = await makeImageThumb(uploadBlob, THUMB_TIERS.bubble);   // undefined when big <= 512
+ *   if (!bubble && big > 0 && big <= THUMB_TIERS.bubble) bubble = uploadBlob;  // <-- whole file!
+ *   message.posterData = await blobToDataUrl(bubble);                    // base64, ~1.37x
+ * The poster rides INSIDE the sealed message (MediaRef.poster), and the server caps a
+ * websocket frame at 1 MiB (ws/hub.go maxMessageSize). A multi-MB GIF at 480x480 therefore
+ * ships a multi-MB poster → the frame is over the limit → never acked → 'pending' forever.
+ *
+ * This uses a 512x512 RANDOM-NOISE PNG because that hits the SAME branch (it is mime-agnostic)
+ * and is reproducible without a binary fixture: noise doesn't compress, so 512x512 lands well
+ * over the budget while staying within the 512px bubble tier.
+ *
+ *   node drive/scenarios/oversize-poster-repro.mjs
+ */
+import { createAccount, pair, chatWith, poll, sweep, done } from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+const aliceChat = await chatWith(alice, bob.id);
+
+// 512x512 noise → within the bubble tier (512) but far over the 40KB poster budget.
+const info = await alice.page.evaluate(async (chatId) => {
+  const N = 512;
+  const c = document.createElement('canvas');
+  c.width = N; c.height = N;
+  const cx = c.getContext('2d');
+  const img = cx.createImageData(N, N);
+  for (let i = 0; i < img.data.length; i += 4) {
+    img.data[i] = (Math.random() * 256) | 0;
+    img.data[i + 1] = (Math.random() * 256) | 0;
+    img.data[i + 2] = (Math.random() * 256) | 0;
+    img.data[i + 3] = 255;
+  }
+  cx.putImageData(img, 0, 0);
+  const blob = await new Promise((res) => c.toBlob(res, 'image/png'));
+  const b64 = await new Promise((res) => {
+    const r = new FileReader();
+    r.onload = () => res(String(r.result).split(',')[1]);
+    r.readAsDataURL(blob);
+  });
+  await window.__ringTest.sendImageData(chatId, b64, 'image/png', 'noise.png', 'original');
+  return { bytes: blob.size };
+}, aliceChat);
+
+console.log('[repro] source image bytes:', info.bytes, `(${(info.bytes / 1024).toFixed(0)} KB)`);
+
+// Watch the send state + how big the embedded poster ended up.
+let last = null;
+for (let i = 0; i < 20; i++) {
+  const snap = await alice.page.evaluate(async (c) => {
+    const ms = await window.__ringTest.messages(c);
+    const m = ms.filter((x) => x.kind === 'image').pop();
+    return m ? { status: m.status, hasPoster: m.hasPoster } : null;
+  }, aliceChat);
+  if (snap && JSON.stringify(snap) !== JSON.stringify(last)) {
+    console.log(`[repro] t+${i * 2}s status=${snap.status} hasPoster=${snap.hasPoster}`);
+    last = snap;
+  }
+  if (snap && ['sent', 'delivered', 'seen'].includes(snap.status)) break;
+  await new Promise((r) => setTimeout(r, 2000));
+}
+
+const finalState = last?.status;
+const gotThere = ['sent', 'delivered', 'seen'].includes(finalState ?? '');
+console.log(gotThere ? `[repro] delivered OK (${finalState})` : `[repro] STUCK at '${finalState}' — reproduced`);
+
+// Did the recipient ever see it?
+const bobChat = await chatWith(bob, alice.id);
+const bobHas = await bob.page.evaluate(
+  async (c) => (await window.__ringTest.messages(c)).filter((m) => m.kind === 'image').length,
+  bobChat,
+);
+console.log('[repro] recipient image count:', bobHas);
+
+await sweep([alice, bob]);
+await done();

--- a/specs/2055-poster-budget/spec.md
+++ b/specs/2055-poster-budget/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: An oversized preview must never block a send
+
+**Feature Branch**: `fix/2055-poster-budget`
+
+**Created**: 2026-07-27
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report, after spec 2053 shipped in 1.0.29: "some gif images still can be sent and get stuck, didn't you say we send gif and animated webp and images as they are without any conversion?"
+
+## Context: why this hotfix exists
+
+Spec 2053 fixed media sends that hung in the **`compressing`** phase. This is a **second, independent** stuck-forever bug one stage later, which 2053 could not have caught — and it is why GIFs still stick. Both render the same clock icon, which is why they looked like one bug: `ChatDetailPage` shows the clock for `compressing` **and** `pending`.
+
+The sender embeds a small preview (the "bubble tier") **inside the sealed message** as `MediaRef.poster`, so the recipient sees something before downloading the full file. Generating that tier had a shortcut: if the image is already within the 512px tier, don't make a second copy — **use the original as its own thumbnail**.
+
+That shortcut tested **pixels only**. For an **animated** GIF or WebP the assumption is false: size lives in the *frame count*, not the frame size, so a 480×480 GIF is routinely several megabytes. Such a file became its own multi-megabyte "poster", was base64-encoded (~1.37×) into the sealed message, and the resulting websocket frame exceeded the server's **1 MiB** read limit (`ws/hub.go maxMessageSize`). The frame was never acked, so the message sat at `pending` — the sending clock — **forever**, and because the durable outbox retries at-least-once, every retry re-sent the same doomed frame.
+
+Reproduced deterministically (`drive/scenarios/oversize-poster-repro.mjs`): an 882 KB, 512×512 image went `compressing → pending` and stopped; the recipient received **nothing**. With the fix, the same input reaches `delivered` in ~2s and the recipient gets it.
+
+This also explains the user's puzzlement about conversion: nothing was converting the GIF (2050/2053 are correct that GIF/WebP pass through untouched). The blocker was the *preview* generated alongside it.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A large animated GIF or WebP sends (Priority: P1)
+
+A user sends a multi-megabyte animated GIF or WebP with modest pixel dimensions. It delivers, still animated, instead of sitting on the sending clock.
+
+**Why this priority**: The reported defect. It silently loses messages — the sender believes it is sending and the recipient never receives anything.
+
+**Independent Test**: Send an image whose long edge is within the bubble tier but whose bytes are far above the preview budget; confirm it reaches delivered and the recipient has it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a small-dimension, large-byte animated image, **When** I send it, **Then** it is delivered and the recipient can view it, animated.
+2. **Given** that same send, **When** it completes, **Then** the embedded preview is within the wire budget (a re-encoded still frame), not the whole file.
+3. **Given** an image small in both pixels and bytes, **When** I send it, **Then** behaviour is unchanged (it still serves as its own preview — no second copy).
+
+---
+
+### User Story 2 - A preview can never block delivery (Priority: P1)
+
+However a preview was produced, an oversized one is dropped rather than allowed to prevent the message being delivered.
+
+**Why this priority**: The invariant that makes this class of failure impossible, not just this instance. A preview is an optimisation; delivery is the product.
+
+**Independent Test**: Force an over-budget preview and confirm the message still delivers, without the preview.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message whose preview exceeds the wire ceiling, **When** it is sent, **Then** the preview is dropped and the message is delivered.
+2. **Given** that delivery, **When** the recipient opens it, **Then** they still get the full media by downloading it.
+
+---
+
+### Edge Cases
+
+- **Animation MUST be preserved**: the preview is a still frame, but the delivered file is the untouched original (specs 2050/2052 unchanged) and renders animated.
+- **A small-but-heavy source MUST NOT be upscaled** when re-encoded for the preview.
+- **Unknown/degenerate dimensions** must not be treated as "small enough" to skip the check.
+- Existing images small in both pixels and bytes must keep the no-second-copy optimisation (no storage or bandwidth regression).
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: strictly less. The preview rides inside the same sealed envelope as before, now bounded; no new field, endpoint or metadata.
+- **Where processing happens**: entirely client-side, before encryption.
+- **Unavoidably-visible metadata**: unchanged, and marginally reduced — sealed media messages get smaller.
+- **Why it stays zero-knowledge**: a purely local decision about how large a locally-generated preview may be.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: An image may serve as its own preview tier only when it is small in **both** pixel dimensions and bytes.
+- **FR-002**: A source within the tier's pixel size but over the byte budget MUST have a preview generated (re-encoded to fit) rather than being reused whole.
+- **FR-003**: Preview generation MUST NOT upscale a small source.
+- **FR-004**: An embedded preview exceeding a hard wire ceiling MUST be dropped and the message delivered without it, never blocked.
+- **FR-005**: The rule in FR-001 MUST be shared by the preview generator and the send path, so the two cannot disagree.
+- **FR-006**: Media format handling is unchanged — GIF and animated WebP still send as-is, animation intact.
+- **FR-007**: An image small in both dimensions and bytes MUST keep serving as its own preview (no extra copy stored or sent).
+
+### Key Entities *(include if feature involves data)*
+
+- **Bubble-tier preview** (`MediaRef.poster`): the small still image embedded in the sealed message. This fix makes its size bounded by construction and, as a backstop, at the point it is put on the wire. No schema change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A small-dimension, multi-megabyte animated image delivers successfully instead of stalling on the clock.
+- **SC-002**: The embedded preview of any sent image is within the wire budget.
+- **SC-003**: No send is ever blocked by its preview — an over-budget preview is dropped, the media still delivers.
+- **SC-004**: Images small in both dimensions and bytes keep the existing no-second-copy behaviour.
+- **SC-005**: Animated media still arrives animated (no conversion regression from specs 2050/2052/2053).
+
+## Assumptions
+
+- A still-frame preview is acceptable for animated media: the recipient downloads and renders the full animation regardless, so the preview only has to look right before download.
+- Dropping a preview is always preferable to failing delivery.
+- The server's 1 MiB frame limit is a fixed constraint to design within, not something to raise — a bigger limit would only move the threshold.
+
+## Out of Scope
+
+- Changing which media formats are converted (specs 2050 / 2052).
+- The media-job lane/timeout work (spec 2053) — this is the next stage of the same pipeline.
+- Raising or renegotiating the server frame limit, or chunking large previews across frames.
+- Animated (multi-frame) previews.

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -39,7 +39,7 @@ import { compressImage, compressVideo, achievedQuality } from '@/services/media-
 import { setCompressProgress, setUploadProgress, resetJobProgress, clearJobProgress } from '@/services/media-jobs';
 import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deriveTiers, blobToDataUrl } from '@/utils/media-meta';
 import { createLimiter, createByteBudget, raceTimeout } from '@/utils/concurrency';
-import { THUMB_TIERS } from '@/utils/thumbs';
+import { THUMB_TIERS, isOwnThumbnail } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview, shouldBuildLinkPreview } from '@/services/link-preview';
 import { inSafeMode } from '@/services/boot-guard';
@@ -2400,6 +2400,22 @@ async function sealMediaAndEnqueue(
   if (!chat || !peerUserId) throw new Error('no chat/peer for media send');
   const media = message.mediaId ? await get<Media>('media', message.mediaId) : undefined;
   const name = media?.name ?? 'attachment';
+  // (spec 2055) LAST-RESORT wire guard. The poster travels INSIDE the sealed message, and the
+  // server drops a websocket frame over 1 MiB — an oversized poster therefore never gets acked
+  // and the send sits on the clock forever, with retry re-sending the same doomed frame. The
+  // tiering above already keeps posters within THUMB_MAX_BYTES; this is the backstop that makes
+  // "a poster can never block a send" true no matter how the poster was produced. Dropping the
+  // preview is always better than not delivering: the recipient still downloads the full media.
+  const poster =
+    message.posterData && message.posterData.length > POSTER_WIRE_MAX_BYTES
+      ? undefined
+      : message.posterData;
+  if (message.posterData && !poster) {
+    console.warn('[media-job] poster too large for the wire; sending without a preview', {
+      id: message.id,
+      posterBytes: message.posterData.length,
+    });
+  }
   const mediaRef = await prepareOutgoingMedia(
     uploadBlob,
     name,
@@ -2407,7 +2423,7 @@ async function sealMediaAndEnqueue(
     {
       width: message.mediaWidth,
       height: message.mediaHeight,
-      poster: message.posterData,
+      poster,
       quality: message.mediaQuality,
     },
     onUploadProgress,
@@ -2439,6 +2455,14 @@ async function sealMediaAndEnqueue(
 }
 
 /* ---- background media jobs (compress → upload), with retry + resume ---- */
+
+// (spec 2055) Hard ceiling for an embedded poster (the data-URL string length) before it is
+// dropped from the wire. The server closes a websocket frame over 1 MiB (ws/hub.go
+// maxMessageSize), and the poster is the only unbounded-by-construction part of a sealed media
+// message. 128 KiB leaves the sealed envelope far under that limit while comfortably clearing
+// the ~40 KiB tier budget, so this only ever fires on a genuinely pathological poster.
+const POSTER_WIRE_MAX_BYTES = 128 * 1024;
+
 const MAX_JOB_ATTEMPTS = 3;
 const jobsInFlight = new Set<string>();
 
@@ -2623,7 +2647,14 @@ async function runMediaJob(messageId: string): Promise<void> {
           if (!message.posterData && message.mediaId) {
             const big = Math.max(meta.width ?? 0, meta.height ?? 0);
             let bubble = await makeImageThumb(uploadBlob, THUMB_TIERS.bubble);
-            if (!bubble && big > 0 && big <= THUMB_TIERS.bubble) bubble = uploadBlob;
+            // (spec 2055) Reuse the original as its own bubble tier ONLY when it is small in
+            // BYTES as well as pixels — see isOwnThumbnail. Without the size half of that test, a
+            // small-dimension/large-byte animated GIF or WebP became its own multi-MB "poster"
+            // and rode the sealed message over the server's 1 MiB frame cap, so the send sat on
+            // the clock forever.
+            if (!bubble && isOwnThumbnail(big, uploadBlob.size, THUMB_TIERS.bubble)) {
+              bubble = uploadBlob;
+            }
             if (bubble) {
               message.posterData = await blobToDataUrl(bubble);
               await put('messages', message);

--- a/src/utils/media-meta.ts
+++ b/src/utils/media-meta.ts
@@ -5,7 +5,7 @@
  * hang the send pipeline, so each call resolves on a timeout with whatever it has.
  */
 import { createLimiter, withTimeout } from '@/utils/concurrency';
-import { THUMB_TIERS, THUMB_MAX_BYTES, chooseJpegQuality, dataUrlBytes } from '@/utils/thumbs';
+import { THUMB_TIERS, THUMB_MAX_BYTES, chooseJpegQuality, dataUrlBytes, isOwnThumbnail } from '@/utils/thumbs';
 
 // A hard cap on any single image decode. On WebKit, `createImageBitmap` on certain animated
 // WebPs never settles (neither resolves nor rejects) — the send pipeline's thumbnail step
@@ -236,11 +236,19 @@ async function generateImageThumbUnlimited(blob: Blob, maxEdge: number): Promise
     const bmp = await withTimeout(createImageBitmap(blob), IMAGE_DECODE_TIMEOUT_MS, undefined);
     if (!bmp) return undefined; // decode timed out
     const big = Math.max(bmp.width, bmp.height);
-    if (big <= maxEdge) {
+    // (spec 2055) "Already small" must mean small in BOTH dimensions AND bytes. The old check
+    // looked at pixels only and told the caller to reuse the original — but an ANIMATED GIF or
+    // WebP is typically small-dimension and very large-byte (many frames), so a multi-MB file
+    // was handed back as the "thumbnail" and embedded in the sealed message, blowing the
+    // server's 1 MiB frame limit and wedging the send. When the bytes are over budget we
+    // re-encode (a flat JPEG still frame) even at unchanged dimensions, so the poster always
+    // fits the wire budget. Animation is not lost: the poster is only the preview; the full
+    // original is downloaded separately and rendered animated.
+    if (isOwnThumbnail(big, blob.size, maxEdge)) {
       bmp.close?.();
-      return undefined; // already small — no point storing a second copy
+      return undefined; // small in pixels and bytes — the original IS its own thumbnail
     }
-    const scale = maxEdge / big;
+    const scale = Math.min(1, maxEdge / big); // never upscale a small-but-heavy source
     const c = document.createElement('canvas');
     c.width = Math.max(1, Math.round(bmp.width * scale));
     c.height = Math.max(1, Math.round(bmp.height * scale));

--- a/src/utils/thumbs.test.ts
+++ b/src/utils/thumbs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { THUMB_TIERS, thumbDims, THUMB_MAX_BYTES, JPEG_QUALITY_STEPS, dataUrlBytes, chooseJpegQuality } from './thumbs';
+import { THUMB_TIERS, thumbDims, THUMB_MAX_BYTES, JPEG_QUALITY_STEPS, dataUrlBytes, chooseJpegQuality, isOwnThumbnail } from './thumbs';
 
 // Pure tier-size math for spec 1014's three image thumbnail tiers (bubble/grid/strip).
 // The actual downscaling (canvas/createImageBitmap) lives in media-meta.ts (needs the DOM);
@@ -75,5 +75,32 @@ describe('thumbnail size budget (spec 1018)', () => {
   it('chooseJpegQuality falls back to the lowest (smallest) step when nothing fits', () => {
     const pick = chooseJpegQuality(() => 500_000, 40 * 1024); // everything over budget
     expect(pick.quality).toBe(JPEG_QUALITY_STEPS[JPEG_QUALITY_STEPS.length - 1]);
+  });
+});
+
+describe('isOwnThumbnail (spec 2055) — an image may stand in as its own bubble tier', () => {
+  const MAX = THUMB_TIERS.bubble; // 512
+
+  it('accepts an image small in BOTH dimensions and bytes', () => {
+    expect(isOwnThumbnail(400, 20 * 1024, MAX)).toBe(true);
+    expect(isOwnThumbnail(MAX, THUMB_MAX_BYTES, MAX)).toBe(true); // exactly at both limits
+  });
+
+  it('REJECTS a small-dimension but large-byte image (the animated GIF/WebP trap)', () => {
+    // The shape that wedged sends: 480x480 but multi-megabyte, because an animation's size
+    // lives in its frame COUNT. Treating this as its own thumbnail embedded the whole file in
+    // the sealed message and blew the server's 1 MiB frame limit.
+    expect(isOwnThumbnail(480, 3 * 1024 * 1024, MAX)).toBe(false);
+    expect(isOwnThumbnail(100, THUMB_MAX_BYTES + 1, MAX)).toBe(false);
+  });
+
+  it('rejects an image larger than the tier, however small its bytes', () => {
+    expect(isOwnThumbnail(MAX + 1, 1024, MAX)).toBe(false);
+    expect(isOwnThumbnail(4000, 10 * 1024, MAX)).toBe(false);
+  });
+
+  it('rejects degenerate/unknown dimensions rather than guessing', () => {
+    expect(isOwnThumbnail(0, 1024, MAX)).toBe(false);
+    expect(isOwnThumbnail(-5, 1024, MAX)).toBe(false);
   });
 });

--- a/src/utils/thumbs.ts
+++ b/src/utils/thumbs.ts
@@ -37,6 +37,24 @@ export const THUMB_MAX_BYTES = 40 * 1024;
 export const JPEG_QUALITY_STEPS = [0.82, 0.72, 0.62, 0.5] as const;
 
 /**
+ * (spec 2055) Whether a source image can serve as its OWN bubble-tier thumbnail, so we skip
+ * generating (and storing, and transmitting) a second copy.
+ *
+ * It qualifies only when it is small in BOTH dimensions and BYTES. The dimension test alone —
+ * which is what this used to be — is a trap for **animated** formats: a GIF or animated WebP is
+ * routinely 480x480 but several MB, because the size is in the frame count, not the frame size.
+ * Treating such a file as its own thumbnail embedded the whole animation in the sealed message's
+ * `MediaRef.poster`, which blew the server's 1 MiB websocket frame limit — the message was never
+ * acked and sat on the sending clock forever, with retry re-sending the same doomed frame.
+ *
+ * Pure so the rule is unit-testable and shared by the generator (media-meta) and the send path
+ * (queries), which must agree — if they disagree, the oversize poster comes back.
+ */
+export function isOwnThumbnail(longEdge: number, bytes: number, maxEdge: number): boolean {
+  return longEdge > 0 && longEdge <= maxEdge && bytes <= THUMB_MAX_BYTES;
+}
+
+/**
  * Estimate the decoded byte length of a base64 `data:` URL (e.g. a JPEG produced by
  * canvas.toDataURL) WITHOUT allocating the bytes — base64 encodes 3 bytes per 4 chars, minus any
  * `=` padding. Returns 0 for a string that isn't a data URL. Pure (DOM-free) so it's unit-testable.


### PR DESCRIPTION
## Why GIFs still stuck after 1.0.29

Spec 2053 fixed media hanging in the **`compressing`** phase. This is a **second, independent** stall one stage later. They looked like one bug because the clock icon renders for `compressing` *and* `pending`.

**Nothing was converting the GIF** — 2050/2052/2053 are right that GIF and animated WebP pass through untouched. The blocker was the **preview generated alongside** the file.

## Root cause

The sender embeds a small preview inside the sealed message (`MediaRef.poster`) so the recipient sees something before downloading. Generating it had a shortcut: if the image already fits the 512px tier, don't make a second copy — use the original as its own thumbnail.

That test looked at **pixels only**. For an **animated** GIF/WebP the assumption is false — size lives in the frame **count**, not the frame size — so a 480×480 GIF is routinely several MB. It became its own multi-MB "poster", base64-encoded (~1.37×) into the sealed message, and the frame blew past the server's **1 MiB** websocket read limit (`ws/hub.go maxMessageSize`). Never acked → message sat at `pending` forever → and the durable outbox re-sent the same doomed frame on every retry, which is why Retry never helped.

## Reproduced, then fixed

`drive/scenarios/oversize-poster-repro.mjs`, an 882 KB 512×512 image:

| | before | after |
|---|---|---|
| sender status | `compressing → pending`, stuck | `compressing → delivered` (~2s) |
| recipient images | **0** | **1** |

## Fix — three layers

1. **`isOwnThumbnail`** (new, pure): an image is its own preview only when small in **both** dimensions and bytes. Shared by the generator and the send path so they can't drift — if they disagree, the oversize poster comes back.
2. Over-budget sources get a **real re-encoded preview** instead of being reused whole, and are never upscaled.
3. A **last-resort wire guard** drops a preview that still exceeds a hard ceiling. A preview is an optimisation; delivery is the product — ship the message without it rather than not at all.

Animation is not lost: the preview is a still frame, the delivered file is the untouched original and renders animated.

## Verification

- `npm run build` clean; **1255 unit tests pass**, including new `isOwnThumbnail` cases pinning the animated-format trap (small dimensions + large bytes → must NOT be reused).
- Repro scenario now delivers (table above).
- `media-lanes-2053.mjs` still passes — no regression to the 1.0.29 fix.

## Zero-knowledge

Strictly less data on the wire, in the same sealed envelope. No new field, endpoint, or metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i