### PR TITLE
chore: bump version to 1.0.30 and mark 2052/2053 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,8 +138,8 @@ Specs are grouped by category band; status moves
 | [2049](specs/2049-dark-default-flash/spec.md) | Default to dark theme and fix the startup theme flash | 🟢 shipped |
 | [2050](specs/2050-media-interop/spec.md) | Make pasted and sent media interoperable across browsers | 🟢 shipped |
 | [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |
-| [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🔵 in-review |
-| [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🔵 in-review |
+| [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🟢 shipped |
+| [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🟢 shipped |
 | [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |
 | [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🔵 in-review |
 | [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🔵 in-review |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/2052-webm-best-effort/spec.md
+++ b/specs/2052-webm-best-effort/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-26
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2053-media-send-lanes/spec.md
+++ b/specs/2053-media-send-lanes/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-26
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Opens the next release cycle so the `develop → main` release PR clears the version guard.

Also flips specs **2052** (webm best-effort) and **2053** (media send lanes) to `shipped` — both went out in 1.0.29 but their status lines still read `in-review`, so the roadmap was understating what is live.

1.0.30 will carry three bug fixes, all already merged to develop:

- **#1100** (spec 2054) — no delivery tick next to a reaction or call from someone else
- **#1101** (spec 2055) — big animated GIFs and WebPs send instead of sticking on the clock
- **#1102** (spec 2056) — messages from a phone with the wrong clock arrive at the end of the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i