### PR TITLE
Release 1.0.30

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -142,3 +142,4 @@ Specs are grouped by category band; status moves
 | [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🔵 in-review |
 | [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |
 | [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🔵 in-review |
+| [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -140,3 +140,4 @@ Specs are grouped by category band; status moves
 | [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |
 | [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🔵 in-review |
 | [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🔵 in-review |
+| [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,3 +141,4 @@ Specs are grouped by category band; status moves
 | [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🔵 in-review |
 | [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🔵 in-review |
 | [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |
+| [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,8 +138,8 @@ Specs are grouped by category band; status moves
 | [2049](specs/2049-dark-default-flash/spec.md) | Default to dark theme and fix the startup theme flash | 🟢 shipped |
 | [2050](specs/2050-media-interop/spec.md) | Make pasted and sent media interoperable across browsers | 🟢 shipped |
 | [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |
-| [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🔵 in-review |
-| [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🔵 in-review |
+| [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🟢 shipped |
+| [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🟢 shipped |
 | [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |
 | [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🔵 in-review |
 | [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🔵 in-review |

--- a/drive/scenarios/incoming-tick-2054.mjs
+++ b/drive/scenarios/incoming-tick-2054.mjs
@@ -1,0 +1,56 @@
+/**
+ * Spec 2054 — no delivery tick beside an INCOMING activity preview.
+ *
+ * Reproduces the report: Alice sends a message (her row shows a tick), Bob reacts to it, and
+ * Alice's chat-list row preview becomes "Bob reacted 👍 to …". That preview describes BOB's
+ * activity, so the row must NOT keep the tick from Alice's outgoing message.
+ *
+ *   node drive/scenarios/incoming-tick-2054.mjs
+ *   HEADED=1 node drive/scenarios/incoming-tick-2054.mjs
+ */
+import {
+  createAccount, pair, chatWith, say, waitForMessage, messageId, react, shot, poll, sweep, done,
+} from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice', mobile: true });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+// Alice sends → her row gets a real outgoing tick.
+await say(alice, bob.id, 'Finally done bowwo');
+await waitForMessage(bob, alice.id, 'Finally done bowwo');
+
+const aliceChat = await chatWith(alice, bob.id);
+const tickAfterSend = await alice.page.evaluate(
+  (c) => window.__ringTest.chatRow(c).then((r) => r?.lastTick),
+  aliceChat,
+);
+console.log('[2054] Alice lastTick after her own send:', tickAfterSend);
+if (tickAfterSend === 'none') throw new Error('setup FAIL: expected a tick on her own outgoing message');
+
+// Bob reacts to it → Alice's row preview becomes Bob's activity.
+const bobChat = await chatWith(bob, alice.id);
+const mid = await messageId(bob, bobChat, 'Finally done bowwo');
+await react(bob, mid, '👍');
+
+// The preview must flip to the reaction AND the tick must clear.
+await poll(
+  () => alice.page.evaluate((c) => window.__ringTest.chatRow(c), aliceChat),
+  (row) => !!row && /reacted/.test(row.lastMessage ?? ''),
+  { timeout: 20_000, label: "Alice's row preview shows Bob's reaction" },
+);
+
+const row = await alice.page.evaluate(
+  (c) => window.__ringTest.chatRow(c),
+  aliceChat,
+);
+console.log('[2054] preview:', JSON.stringify(row.lastMessage), '| lastTick:', row.lastTick);
+if ((row.lastTick ?? 'none') !== 'none') {
+  throw new Error(`FAIL: incoming reaction preview still carries a tick (${row.lastTick})`);
+}
+console.log('[2054] PASS — no tick beside the incoming reaction ✓');
+
+await shot(alice, 'incoming-reaction-no-tick', { route: '/tabs/chats' });
+
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/oversize-poster-repro.mjs
+++ b/drive/scenarios/oversize-poster-repro.mjs
@@ -1,0 +1,81 @@
+/**
+ * REPRO: a small-DIMENSION but large-BYTE image (the shape of an animated GIF/WebP) gets
+ * stuck on the sending clock forever.
+ *
+ * Mechanism under test (queries.ts runMediaJob):
+ *   let bubble = await makeImageThumb(uploadBlob, THUMB_TIERS.bubble);   // undefined when big <= 512
+ *   if (!bubble && big > 0 && big <= THUMB_TIERS.bubble) bubble = uploadBlob;  // <-- whole file!
+ *   message.posterData = await blobToDataUrl(bubble);                    // base64, ~1.37x
+ * The poster rides INSIDE the sealed message (MediaRef.poster), and the server caps a
+ * websocket frame at 1 MiB (ws/hub.go maxMessageSize). A multi-MB GIF at 480x480 therefore
+ * ships a multi-MB poster → the frame is over the limit → never acked → 'pending' forever.
+ *
+ * This uses a 512x512 RANDOM-NOISE PNG because that hits the SAME branch (it is mime-agnostic)
+ * and is reproducible without a binary fixture: noise doesn't compress, so 512x512 lands well
+ * over the budget while staying within the 512px bubble tier.
+ *
+ *   node drive/scenarios/oversize-poster-repro.mjs
+ */
+import { createAccount, pair, chatWith, poll, sweep, done } from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+const aliceChat = await chatWith(alice, bob.id);
+
+// 512x512 noise → within the bubble tier (512) but far over the 40KB poster budget.
+const info = await alice.page.evaluate(async (chatId) => {
+  const N = 512;
+  const c = document.createElement('canvas');
+  c.width = N; c.height = N;
+  const cx = c.getContext('2d');
+  const img = cx.createImageData(N, N);
+  for (let i = 0; i < img.data.length; i += 4) {
+    img.data[i] = (Math.random() * 256) | 0;
+    img.data[i + 1] = (Math.random() * 256) | 0;
+    img.data[i + 2] = (Math.random() * 256) | 0;
+    img.data[i + 3] = 255;
+  }
+  cx.putImageData(img, 0, 0);
+  const blob = await new Promise((res) => c.toBlob(res, 'image/png'));
+  const b64 = await new Promise((res) => {
+    const r = new FileReader();
+    r.onload = () => res(String(r.result).split(',')[1]);
+    r.readAsDataURL(blob);
+  });
+  await window.__ringTest.sendImageData(chatId, b64, 'image/png', 'noise.png', 'original');
+  return { bytes: blob.size };
+}, aliceChat);
+
+console.log('[repro] source image bytes:', info.bytes, `(${(info.bytes / 1024).toFixed(0)} KB)`);
+
+// Watch the send state + how big the embedded poster ended up.
+let last = null;
+for (let i = 0; i < 20; i++) {
+  const snap = await alice.page.evaluate(async (c) => {
+    const ms = await window.__ringTest.messages(c);
+    const m = ms.filter((x) => x.kind === 'image').pop();
+    return m ? { status: m.status, hasPoster: m.hasPoster } : null;
+  }, aliceChat);
+  if (snap && JSON.stringify(snap) !== JSON.stringify(last)) {
+    console.log(`[repro] t+${i * 2}s status=${snap.status} hasPoster=${snap.hasPoster}`);
+    last = snap;
+  }
+  if (snap && ['sent', 'delivered', 'seen'].includes(snap.status)) break;
+  await new Promise((r) => setTimeout(r, 2000));
+}
+
+const finalState = last?.status;
+const gotThere = ['sent', 'delivered', 'seen'].includes(finalState ?? '');
+console.log(gotThere ? `[repro] delivered OK (${finalState})` : `[repro] STUCK at '${finalState}' — reproduced`);
+
+// Did the recipient ever see it?
+const bobChat = await chatWith(bob, alice.id);
+const bobHas = await bob.page.evaluate(
+  async (c) => (await window.__ringTest.messages(c)).filter((m) => m.kind === 'image').length,
+  bobChat,
+);
+console.log('[repro] recipient image count:', bobHas);
+
+await sweep([alice, bob]);
+await done();

--- a/drive/scenarios/skewed-clock-2056.mjs
+++ b/drive/scenarios/skewed-clock-2056.mjs
@@ -1,0 +1,62 @@
+/**
+ * Spec 2056 — a sender whose device clock is wrong must not sort into the recipient's past.
+ *
+ * Reproduces the report: an Android phone with stale timezone data reports a wall clock that
+ * looks right to its owner while its UTC is an hour behind, so every message it sends claimed a
+ * time an hour earlier and landed ABOVE older messages instead of at the end of the chat.
+ *
+ * Bob's page has Date.now() shifted -1h to stand in for that device.
+ *
+ *   node drive/scenarios/skewed-clock-2056.mjs
+ */
+import { createAccount, pair, chatWith, say, waitForMessage, poll, shot, sweep, done } from '../driver.mjs';
+
+const HOUR = 3600_000;
+
+const alice = await createAccount({ name: 'Alice' });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+const aliceChat = await chatWith(alice, bob.id);
+
+// Alice (correct clock) speaks first.
+await say(alice, bob.id, 'alice-first');
+await waitForMessage(bob, alice.id, 'alice-first');
+
+// Bob's device clock now runs an hour SLOW (stale-tzdata phone).
+await bob.page.evaluate((h) => {
+  const realNow = Date.now.bind(Date);
+  // eslint-disable-next-line no-extend-native
+  Date.now = () => realNow() - h;
+}, HOUR);
+
+await say(bob, alice.id, 'bob-from-a-skewed-clock');
+await waitForMessage(alice, bob.id, 'bob-from-a-skewed-clock');
+
+// The decisive check: on ALICE's device Bob's reply must come LAST, not an hour into the past.
+const rows = await poll(
+  () => alice.page.evaluate((c) => window.__ringTest.messages(c), aliceChat),
+  (ms) => ms.some((m) => m.body === 'bob-from-a-skewed-clock') && ms.some((m) => m.body === 'alice-first'),
+  { timeout: 20_000, label: "both messages present on Alice's device" },
+);
+
+const ordered = [...rows].sort((a, b) => a.timestamp - b.timestamp).map((m) => m.body);
+const first = rows.find((m) => m.body === 'alice-first');
+const reply = rows.find((m) => m.body === 'bob-from-a-skewed-clock');
+const gapMin = Math.round((reply.timestamp - first.timestamp) / 60000);
+
+console.log('[2056] order by timestamp:', ordered.join('  →  '));
+console.log(`[2056] reply is ${gapMin} min after Alice's message (negative = sorted into the past)`);
+
+if (reply.timestamp < first.timestamp) {
+  throw new Error(`FAIL: the skewed sender's reply sorted BEFORE the message it answers (${gapMin} min)`);
+}
+if (ordered[ordered.length - 1] !== 'bob-from-a-skewed-clock') {
+  throw new Error(`FAIL: the reply is not last — order was ${ordered.join(', ')}`);
+}
+console.log('[2056] PASS — the reply sits at the end of the chat, where it belongs ✓');
+
+await shot(alice, 'skewed-clock-order', { route: `/chat/${aliceChat}` });
+
+await sweep([alice, bob]);
+await done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/server/internal/ws/hub.go
+++ b/server/internal/ws/hub.go
@@ -135,6 +135,10 @@ type frame struct {
 	Status     string          `json:"status,omitempty"`
 	At         int64           `json:"at,omitempty"`
 	RefID      string          `json:"refId,omitempty"`
+	// (spec 2056) t:"msg" only — epoch ms at which the relay accepted this frame. The
+	// recipient compares it with the sender's own claimed timestamp to spot a skewed sender
+	// clock; see the stamping site in the "msg" case for why this is the neutral reference.
+	RelayedAt int64 `json:"relayedAt,omitempty"`
 	// Presence fields. For outbound t:"presence", Online is omitted (→ false on
 	// the client) when not shared, and LastSeen is omitted (→ null) when not
 	// shared or never set. For inbound prefs/self the bools default to false.
@@ -1327,7 +1331,22 @@ func (c *Client) handleFrame(data []byte) {
 		if b, err := c.store.IsBlocked(ctx, f.To, c.userID); err == nil {
 			blocked = b
 		}
-		delivered := frame{T: "msg", ID: f.ID, From: c.userID, Ciphertext: f.Ciphertext}
+		// (spec 2056) Stamp when the RELAY received this frame. The recipient uses it as a
+		// neutral reference to detect a sender whose device clock is wrong: message order and
+		// timestamps come from the sender's own clock, so a phone with stale timezone data (an
+		// old Android still applying an abolished DST rule, say) made its messages sort an hour
+		// into the past on every recipient's screen — new messages landed above older ones
+		// instead of at the end. Comparing the sender's claimed time against this one separates
+		// "genuinely old, queued while you were offline" from "the sender's clock is wrong",
+		// which the recipient cannot tell apart on its own.
+		//
+		// Stamped HERE, where the frame is built, so the identical value reaches both the live
+		// socket below and the durable copy replayed by flushPending — no schema change, and a
+		// queued frame keeps the time it actually arrived rather than the time it was drained.
+		// Zero-knowledge: the relay already knows when it accepted a frame (it stores created_at
+		// and the ciphertext stays opaque); this only hands the recipient a fact the server
+		// already had, and no new plaintext or metadata is derived.
+		delivered := frame{T: "msg", ID: f.ID, From: c.userID, Ciphertext: f.Ciphertext, RelayedAt: time.Now().UnixMilli()}
 		payload, err := json.Marshal(delivered)
 		if err != nil {
 			return

--- a/specs/2052-webm-best-effort/spec.md
+++ b/specs/2052-webm-best-effort/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-26
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2053-media-send-lanes/spec.md
+++ b/specs/2053-media-send-lanes/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-26
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2054-incoming-tick/spec.md
+++ b/specs/2054-incoming-tick/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: No delivery tick beside an incoming activity in the chats list
+
+**Feature Branch**: `fix/2054-incoming-tick`
+
+**Created**: 2026-07-27
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report (with screenshot): "Why do we see a sent status mark next to the incoming reaction!? Please make sure the message status is only shown on the outgoing messages and not incoming ones!"
+
+## Context: why this hotfix exists
+
+A Chats-list row read **"✓ Kambiz reacted 👍 to 'Finally done bowwo 😁'"** — a delivery tick beside an activity that belongs to *the other person*. A tick means "this is my message and here is how far it got", so putting one next to someone else's reaction is simply wrong.
+
+The row's tick is driven by a denormalized `Chat.lastTick` (spec 1062), kept in step with the newest message so the list can show delivery progress without scanning history. `lastMessageTick` itself is correct — it returns `none` for anything incoming. The defect is that the sites which **replace the row preview with a non-message activity** update `lastMessage` / `lastKind` / `lastMessageTime` but never touch `lastTick`. The row therefore keeps the tick of the *outgoing message it just stopped describing*.
+
+That affects every activity preview, not just the reported one:
+
+- an **incoming reaction** ("Kambiz reacted 👍 to …") — the reported bug,
+- your **own** reaction ("You reacted 👍 to …") — a tick belonging to a different message,
+- **game** activity ("made a move 🎲", both directions),
+- a **call** entry — stored as a message for the timeline but explicitly informational (never enqueued, no receipts), so it can inherit a blue double tick it never earned,
+- a **cleared** chat — preview wiped, tick left behind.
+
+The unifying rule: **the row tick describes a receipt-tracked outgoing message. Anything else shows no tick.**
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - An incoming reaction shows no delivery mark (Priority: P1)
+
+Someone reacts to my message; my chats list shows their reaction as the latest activity, with no tick beside it.
+
+**Why this priority**: The reported defect, and the most visible — reactions are frequent, so the wrong mark shows up constantly.
+
+**Independent Test**: Send a message (row shows a tick), have the peer react, and confirm the row preview becomes their reaction with no tick.
+
+**Acceptance Scenarios**:
+
+1. **Given** my outgoing message is the newest and its row shows a tick, **When** the peer reacts to it, **Then** the row preview becomes their reaction and the tick disappears.
+2. **Given** that reaction preview is showing, **When** a late receipt for my earlier message arrives, **Then** no tick reappears beside the reaction.
+3. **Given** I then send a new message, **Then** the tick returns and tracks that message normally.
+
+---
+
+### User Story 2 - Other non-message activity carries no tick either (Priority: P2)
+
+Game moves, calls, my own reactions and cleared chats show their preview without a stale delivery mark.
+
+**Why this priority**: Same defect class and the same wrong impression, but less frequent than reactions.
+
+**Independent Test**: Trigger each activity preview and confirm no tick renders.
+
+**Acceptance Scenarios**:
+
+1. **Given** a chat whose latest activity is a game move (mine or theirs), **Then** the row shows no tick.
+2. **Given** a chat whose latest entry is a call, **Then** the row shows no tick, in either direction.
+3. **Given** I react to someone's message, **Then** my row shows "You reacted …" with no tick.
+4. **Given** I clear a chat's history, **Then** the emptied row carries no tick.
+
+---
+
+### Edge Cases
+
+- **A late receipt** for the message an activity replaced MUST NOT restore the tick (the existing "only if it is still the newest" guard covers this — the activity moved `lastMessageTime`).
+- **Pinned tiles** read the same `lastTick`, so they must behave identically to list rows.
+- **An ordinary outgoing message** MUST be unaffected: pending → sent → delivered → seen still climbs live.
+- **A failed send** keeps its existing failed treatment.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: nothing new. This changes only a locally-derived display field.
+- **Where processing happens**: entirely on-device, from data already held.
+- **Unavoidably-visible metadata**: unchanged — no new endpoint, field, or receipt is sent.
+- **Why it stays zero-knowledge**: `lastTick` is a local denormalization of local state; the server has no part in it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The chats-list row / pinned-tile delivery tick MUST only ever describe a receipt-tracked **outgoing message**.
+- **FR-002**: When a row preview is replaced by a **reaction** (incoming or own), the tick MUST be cleared.
+- **FR-003**: When a row preview is replaced by **game** activity (incoming or own), the tick MUST be cleared.
+- **FR-004**: A **call** entry MUST never render a tick, in either direction, including when the row summary is recomputed from history.
+- **FR-005**: Clearing a chat's history MUST clear its tick.
+- **FR-006**: A late receipt MUST NOT restore a tick beside an activity preview.
+- **FR-007**: Ordinary outgoing messages MUST keep their existing tick behaviour (pending/sent/delivered/seen, group roster tiers, failed, and the seen-reciprocity gate).
+
+### Key Entities *(include if feature involves data)*
+
+- **Chat summary**: the denormalized row fields (`lastMessage`, `lastKind`, `lastMessageTime`, `lastTick`). This fix makes `lastTick` a first-class part of every summary update rather than something only the message paths maintain. No schema change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An incoming reaction preview never renders a delivery tick.
+- **SC-002**: No activity preview (reaction, game, call, cleared) renders a tick, in either direction.
+- **SC-003**: Ordinary outgoing messages show no regression in tick behaviour.
+- **SC-004**: A late receipt cannot reintroduce a tick beside an activity preview.
+
+## Assumptions
+
+- A call entry carries no delivery semantics — the code already records it as informational with no receipts — so it should never show a tick even though an outgoing call is flagged outgoing.
+- Clearing the tick (rather than recomputing it from the newest real outgoing message) is the right behaviour: the row is describing the activity, so a tick for some other message would be misleading regardless of accuracy.
+
+## Out of Scope
+
+- The in-conversation bubble ticks (already correct — they render per message).
+- Changing reaction, game, or call previews themselves (wording, ordering, notifications).
+- Any change to receipt collection or the seen-reciprocity policy.

--- a/specs/2055-poster-budget/spec.md
+++ b/specs/2055-poster-budget/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: An oversized preview must never block a send
+
+**Feature Branch**: `fix/2055-poster-budget`
+
+**Created**: 2026-07-27
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report, after spec 2053 shipped in 1.0.29: "some gif images still can be sent and get stuck, didn't you say we send gif and animated webp and images as they are without any conversion?"
+
+## Context: why this hotfix exists
+
+Spec 2053 fixed media sends that hung in the **`compressing`** phase. This is a **second, independent** stuck-forever bug one stage later, which 2053 could not have caught — and it is why GIFs still stick. Both render the same clock icon, which is why they looked like one bug: `ChatDetailPage` shows the clock for `compressing` **and** `pending`.
+
+The sender embeds a small preview (the "bubble tier") **inside the sealed message** as `MediaRef.poster`, so the recipient sees something before downloading the full file. Generating that tier had a shortcut: if the image is already within the 512px tier, don't make a second copy — **use the original as its own thumbnail**.
+
+That shortcut tested **pixels only**. For an **animated** GIF or WebP the assumption is false: size lives in the *frame count*, not the frame size, so a 480×480 GIF is routinely several megabytes. Such a file became its own multi-megabyte "poster", was base64-encoded (~1.37×) into the sealed message, and the resulting websocket frame exceeded the server's **1 MiB** read limit (`ws/hub.go maxMessageSize`). The frame was never acked, so the message sat at `pending` — the sending clock — **forever**, and because the durable outbox retries at-least-once, every retry re-sent the same doomed frame.
+
+Reproduced deterministically (`drive/scenarios/oversize-poster-repro.mjs`): an 882 KB, 512×512 image went `compressing → pending` and stopped; the recipient received **nothing**. With the fix, the same input reaches `delivered` in ~2s and the recipient gets it.
+
+This also explains the user's puzzlement about conversion: nothing was converting the GIF (2050/2053 are correct that GIF/WebP pass through untouched). The blocker was the *preview* generated alongside it.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A large animated GIF or WebP sends (Priority: P1)
+
+A user sends a multi-megabyte animated GIF or WebP with modest pixel dimensions. It delivers, still animated, instead of sitting on the sending clock.
+
+**Why this priority**: The reported defect. It silently loses messages — the sender believes it is sending and the recipient never receives anything.
+
+**Independent Test**: Send an image whose long edge is within the bubble tier but whose bytes are far above the preview budget; confirm it reaches delivered and the recipient has it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a small-dimension, large-byte animated image, **When** I send it, **Then** it is delivered and the recipient can view it, animated.
+2. **Given** that same send, **When** it completes, **Then** the embedded preview is within the wire budget (a re-encoded still frame), not the whole file.
+3. **Given** an image small in both pixels and bytes, **When** I send it, **Then** behaviour is unchanged (it still serves as its own preview — no second copy).
+
+---
+
+### User Story 2 - A preview can never block delivery (Priority: P1)
+
+However a preview was produced, an oversized one is dropped rather than allowed to prevent the message being delivered.
+
+**Why this priority**: The invariant that makes this class of failure impossible, not just this instance. A preview is an optimisation; delivery is the product.
+
+**Independent Test**: Force an over-budget preview and confirm the message still delivers, without the preview.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message whose preview exceeds the wire ceiling, **When** it is sent, **Then** the preview is dropped and the message is delivered.
+2. **Given** that delivery, **When** the recipient opens it, **Then** they still get the full media by downloading it.
+
+---
+
+### Edge Cases
+
+- **Animation MUST be preserved**: the preview is a still frame, but the delivered file is the untouched original (specs 2050/2052 unchanged) and renders animated.
+- **A small-but-heavy source MUST NOT be upscaled** when re-encoded for the preview.
+- **Unknown/degenerate dimensions** must not be treated as "small enough" to skip the check.
+- Existing images small in both pixels and bytes must keep the no-second-copy optimisation (no storage or bandwidth regression).
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: strictly less. The preview rides inside the same sealed envelope as before, now bounded; no new field, endpoint or metadata.
+- **Where processing happens**: entirely client-side, before encryption.
+- **Unavoidably-visible metadata**: unchanged, and marginally reduced — sealed media messages get smaller.
+- **Why it stays zero-knowledge**: a purely local decision about how large a locally-generated preview may be.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: An image may serve as its own preview tier only when it is small in **both** pixel dimensions and bytes.
+- **FR-002**: A source within the tier's pixel size but over the byte budget MUST have a preview generated (re-encoded to fit) rather than being reused whole.
+- **FR-003**: Preview generation MUST NOT upscale a small source.
+- **FR-004**: An embedded preview exceeding a hard wire ceiling MUST be dropped and the message delivered without it, never blocked.
+- **FR-005**: The rule in FR-001 MUST be shared by the preview generator and the send path, so the two cannot disagree.
+- **FR-006**: Media format handling is unchanged — GIF and animated WebP still send as-is, animation intact.
+- **FR-007**: An image small in both dimensions and bytes MUST keep serving as its own preview (no extra copy stored or sent).
+
+### Key Entities *(include if feature involves data)*
+
+- **Bubble-tier preview** (`MediaRef.poster`): the small still image embedded in the sealed message. This fix makes its size bounded by construction and, as a backstop, at the point it is put on the wire. No schema change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A small-dimension, multi-megabyte animated image delivers successfully instead of stalling on the clock.
+- **SC-002**: The embedded preview of any sent image is within the wire budget.
+- **SC-003**: No send is ever blocked by its preview — an over-budget preview is dropped, the media still delivers.
+- **SC-004**: Images small in both dimensions and bytes keep the existing no-second-copy behaviour.
+- **SC-005**: Animated media still arrives animated (no conversion regression from specs 2050/2052/2053).
+
+## Assumptions
+
+- A still-frame preview is acceptable for animated media: the recipient downloads and renders the full animation regardless, so the preview only has to look right before download.
+- Dropping a preview is always preferable to failing delivery.
+- The server's 1 MiB frame limit is a fixed constraint to design within, not something to raise — a bigger limit would only move the threshold.
+
+## Out of Scope
+
+- Changing which media formats are converted (specs 2050 / 2052).
+- The media-job lane/timeout work (spec 2053) — this is the next stage of the same pipeline.
+- Raising or renegotiating the server frame limit, or chunking large previews across frames.
+- Animated (multi-frame) previews.

--- a/specs/2056-sender-clock-skew/spec.md
+++ b/specs/2056-sender-clock-skew/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Messages from a device with a wrong clock must not sort into the past
+
+**Feature Branch**: `fix/2056-sender-clock-skew`
+
+**Created**: 2026-07-27
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report (with screenshots from both devices): "when chatting with someone in a different time zone on android, their messages get incorrect timestamp and even when they were sending me a new message it wouldn't just show up in the end, I had to leave the chat and come back in and scroll up to actually see the message they have sent … since they were showing up 1 hour before my time! I have not had this issue with iphone users in different time zone."
+
+## Context: why this hotfix exists
+
+A message carries the timestamp its **sender's** device stamped on it, and that timestamp decides both the displayed time and **where the message sits in the conversation**. Conversation order is therefore hostage to every participant's clock.
+
+The reported pair, read off the two screenshots:
+
+| message | sender's screen | recipient's screen | implied offset |
+|---|---|---|---|
+| "Salam 👋" (recipient → Android) | 14:03 | 15:33 | **+1:30** ✓ consistent |
+| "Tt" (Android → recipient) | 15:35 | 13:05 | **−2:30** ✗ should be −1:30 |
+
+The timezone difference is a genuine +1:30. Messages *to* the Android device convert correctly; messages *from* it arrive exactly **one hour early**. So the Android device's wall clock displays correctly to its owner while its actual UTC time is an hour behind — the signature of **stale timezone data** (the phone in the screenshot is on Android 11 / MIUI 12.0.3 with a 2021 security patch level, predating that region dropping DST). Its messages then sorted an hour into the recipient's past: they appeared **above** older messages instead of at the end, so a new message never showed up where the reader was looking — exactly the "leave the chat, come back, scroll up to find it" symptom.
+
+This is not Android-specific in the code. It is "any sender whose clock is wrong" — a stale-tzdata phone, a manually-set clock, a device that lost its battery. iPhones ship timezone updates with the OS, which is why the reporter never saw it from them.
+
+The recipient cannot detect this from the sender's timestamp alone, because "timestamp well in the past" is *also* exactly what a legitimate message queued while the recipient was offline looks like. The discriminator is a reference both sides already share and neither controls: **when the relay accepted the frame**. A genuinely-queued message's claimed time agrees with the relay's; a skewed sender's does not.
+
+A secondary harm: the receive path feeds this untrusted timestamp into the push-zombie heuristics, which infer "this sat queued for ages" from a message's age. A sender running an hour behind forged that evidence on every message, pushing the recipient toward needless push-subscription rotation.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A new message always arrives at the end of the chat (Priority: P1)
+
+Whoever sends it, and whatever their device thinks the time is, a newly-received message appears at the bottom of the conversation.
+
+**Why this priority**: The reported defect. Messages effectively go missing — the reader has no reason to scroll up, so a conversation silently stops working.
+
+**Independent Test**: Send from a device whose clock is an hour slow and confirm the message lands last on the recipient's screen, after the message it replies to.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sender whose clock is an hour behind, **When** they reply to my message, **Then** their reply appears after mine, at the end of the chat.
+2. **Given** that same sender, **When** they send several messages, **Then** those keep their relative order.
+3. **Given** a sender whose clock runs fast, **When** they message me, **Then** it does not sort into the future.
+4. **Given** correctly-clocked participants in different timezones, **When** we chat, **Then** nothing changes — times still render in each reader's local zone.
+
+---
+
+### User Story 2 - A genuinely old message stays old (Priority: P1)
+
+A message that really was sent hours ago while I was offline still shows its real time and its historical position.
+
+**Why this priority**: The guard that keeps Story 1 from becoming a worse bug. Naively re-stamping every late message to "now" would collapse an offline backlog to the present and break the delivery-reliability signals that depend on honest message ages.
+
+**Independent Test**: Receive a backlog after being offline and confirm the messages keep their original times and order.
+
+**Acceptance Scenarios**:
+
+1. **Given** messages sent while I was offline, **When** I reconnect, **Then** they appear with their original times, in their original order.
+2. **Given** such a backlog, **When** it is applied, **Then** the queued-message reliability signals still see the real ages.
+
+---
+
+### User Story 3 - A skewed sender cannot trip my push-recovery heuristics (Priority: P2)
+
+Another person's wrong clock does not cause my device to churn its push subscription.
+
+**Why this priority**: Silent, self-inflicted damage — invisible to the user but it degrades notification reliability, the area specs 2043–2048 were spent stabilising.
+
+**Independent Test**: Receive messages from a skewed sender and confirm no stale-drain / missed-wake signal is recorded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sender whose clock is an hour behind, **When** their messages arrive promptly, **Then** no "this sat queued" signal is recorded.
+2. **Given** genuinely delayed messages from a correctly-clocked sender, **Then** those signals still fire as before.
+
+---
+
+### Edge Cases
+
+- **A recipient whose OWN clock is wrong** must still order the conversation correctly — the comparison must not involve the reader's clock.
+- **No reference available** (a server that does not supply one): behave exactly as today, trusting the sender.
+- **Composed offline, sent much later**: the claim and the reference legitimately diverge, so the message is placed when it reached the conversation. Accepted trade-off — see Assumptions.
+- **Half-hour timezone offsets** (+3:30, +5:45) must be caught as readily as whole-hour ones.
+- **The sender's own copy** keeps the sender's own time; only the receiving side reconciles.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: one extra integer on a delivered frame — the epoch ms at which the relay accepted it. No message content, and the ciphertext stays opaque.
+- **Where processing happens**: the reconciliation is entirely client-side, on the recipient's device, after decryption.
+- **Unavoidably-visible metadata**: none added. The relay already records when it accepted each frame (`relay_queue.created_at`, used today for retention and queue-age reporting). This hands the recipient — who is already receiving that very frame — a fact the server already had, and tells the server nothing new.
+- **Why it stays zero-knowledge**: no new endpoint, no new stored field, no inspection of plaintext. The server does not learn the sender's clock, the correction, or anything about the message.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A delivered message frame MUST carry the time the relay accepted it, on both live delivery and replay of a queued frame.
+- **FR-002**: That value MUST be identical for both paths for a given message (a queued frame keeps the time it arrived, not the time it was drained).
+- **FR-003**: On receive, the sender's claimed timestamp MUST be kept when it is consistent with the relay's time, and replaced by the relay's time when it is not.
+- **FR-004**: The consistency tolerance MUST absorb ordinary latency and drift while remaining well below the smallest timezone offset (30 minutes).
+- **FR-005**: The reconciliation MUST NOT consult the receiving device's clock, so a reader with a wrong clock still orders correctly.
+- **FR-006**: Messages from a skewed sender MUST retain their relative order.
+- **FR-007**: When no relay time is available, behaviour MUST be unchanged (trust the sender).
+- **FR-008**: Queued-message reliability signals (stale-drain / missed-wake) MUST be skipped for a sender detected as skewed, and unchanged otherwise.
+- **FR-009**: Both writers of received messages — the page and the service-worker drain — MUST apply the same reconciliation, so a message sorts identically whichever committed it.
+
+### Key Entities *(include if feature involves data)*
+
+- **Delivered frame**: gains a relay-receive timestamp (transport-level only; not persisted as a message field).
+- **Received message**: its stored timestamp becomes a reconciled value rather than the sender's raw claim. No schema change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A message from a sender whose clock is an hour off appears at the end of the recipient's chat, never above older messages.
+- **SC-002**: Messages from a skewed sender preserve their relative order.
+- **SC-003**: A genuinely queued backlog keeps its original timestamps and order.
+- **SC-004**: A recipient with a wrong clock still orders conversations correctly.
+- **SC-005**: No stale-drain / missed-wake signal is recorded for a skewed sender; behaviour is unchanged for real delays.
+- **SC-006**: Correctly-clocked participants across timezones see no change.
+
+## Assumptions
+
+- The relay's clock is a reasonable shared reference. It is already the sequencing authority for the queue, and the server is a single deployment with normal time sync.
+- Placing an offline-composed message at the time it reached the conversation is acceptable, and is the safe direction: it can never sort a message into the distant past, which is the failure being fixed. The sender's own copy keeps their compose time.
+- A 90-second tolerance separates the two cases cleanly: it far exceeds real latency and drift, and is far below the 30-minute minimum timezone quantum.
+
+## Out of Scope
+
+- Correcting the sending device's clock, or warning its owner that it is wrong.
+- Showing timezone information in the UI, or rendering times in the sender's zone.
+- Reordering or re-timestamping messages already stored from before this fix.
+- Replacing timestamp-based ordering with a server sequence number (a larger change; this keeps timestamps as the ordering key and makes them trustworthy).

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -39,6 +39,7 @@ import { compressImage, compressVideo, achievedQuality } from '@/services/media-
 import { setCompressProgress, setUploadProgress, resetJobProgress, clearJobProgress } from '@/services/media-jobs';
 import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deriveTiers, blobToDataUrl } from '@/utils/media-meta';
 import { createLimiter, createByteBudget, raceTimeout } from '@/utils/concurrency';
+import { resolveIncomingTimestamp, senderClockIsSkewed } from '@/utils/message-time';
 import { THUMB_TIERS, isOwnThumbnail } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview, shouldBuildLinkPreview } from '@/services/link-preview';
@@ -6209,8 +6210,18 @@ async function markInboundSeen(id: string): Promise<void> {
 // timeout (only the SW side must degrade rather than stall its push budget), and
 // where Web Locks don't exist the helper is just this chain again.
 let inboundSerial: Promise<void> = Promise.resolve();
-export function receiveIncoming(from: string, remoteId: string, ciphertext: unknown): Promise<void> {
-  const run = inboundSerial.then(() => withInboundLock(() => receiveIncomingInner(from, remoteId, ciphertext)));
+export function receiveIncoming(
+  from: string,
+  remoteId: string,
+  ciphertext: unknown,
+  // (spec 2056) When the relay accepted this frame (epoch ms). Optional: the service-worker
+  // drain and older servers don't supply it, and without it we simply keep trusting the
+  // sender's own timestamp exactly as before.
+  relayedAt?: number,
+): Promise<void> {
+  const run = inboundSerial.then(() =>
+    withInboundLock(() => receiveIncomingInner(from, remoteId, ciphertext, relayedAt)),
+  );
   inboundSerial = run.then(
     () => undefined,
     () => undefined,
@@ -6218,7 +6229,12 @@ export function receiveIncoming(from: string, remoteId: string, ciphertext: unkn
   return run;
 }
 
-async function receiveIncomingInner(from: string, remoteId: string, ciphertext: unknown): Promise<void> {
+async function receiveIncomingInner(
+  from: string,
+  remoteId: string,
+  ciphertext: unknown,
+  relayedAt?: number,
+): Promise<void> {
   if (!from) return;
   // Drop anything from a peer we've blocked, a backstop for frames that slipped
   // through before the server-side block took effect (or were already queued).
@@ -6435,17 +6451,33 @@ async function receiveIncomingInner(from: string, remoteId: string, ciphertext: 
   const targetChatId = payload.groupId ?? chatId;
   if (payload.groupId) await ensureGroupChat(payload.groupId, from);
 
-  const ts = payload.timestamp || now();
+  // (spec 2056) The sender's own clock decides both the displayed time and where the message
+  // sorts in the conversation, so a device with a wrong clock (stale timezone data on an old
+  // phone, say) made its messages land an hour into the past — above older messages instead of
+  // at the end, easy to miss entirely. Reconcile the sender's claim against when the RELAY
+  // accepted the frame, which separates "genuinely queued while we were offline" (claim agrees
+  // with the relay → keep it old) from "the sender's clock is wrong" (they disagree → use the
+  // relay's time). Falls back to the old behaviour when no relay time is available.
+  const claimedTs = payload.timestamp || now();
+  const ts = resolveIncomingTimestamp(claimedTs, relayedAt);
   // (spec 1037) A message that sat queued past the staleness bar means a push
   // SHOULD have woken this device while it was away — record the signature so
   // the next subscription check can detect a zombie and rotate. Harmless for a
   // merely-offline phone: its held pushes arrive on reconnect and stamp a
   // fresh wake, which invalidates the marker.
-  if (now() - ts > STALE_MSG_MS) void recordStaleDrain(ts);
-  // The WEAK signature too (iOS 16.x zombies dodge the 10-min bar on a
-  // frequently-checked phone): every drained message that should have woken us
-  // counts toward a streak; three no-wake sessions rotate the subscription.
-  void recordMissedWakeDrain(ts);
+  //
+  // (spec 2056) Skip both signals when the sender's clock is the thing that's wrong: these
+  // heuristics infer "this sat queued for ages" from the message's age, so a sender running an
+  // hour behind would otherwise forge that evidence on every message and push this device
+  // toward a needless subscription rotation. `ts` is corrected above, but the skew check is
+  // what tells us the age was never real.
+  if (!senderClockIsSkewed(claimedTs, relayedAt)) {
+    if (now() - ts > STALE_MSG_MS) void recordStaleDrain(ts);
+    // The WEAK signature too (iOS 16.x zombies dodge the 10-min bar on a
+    // frequently-checked phone): every drained message that should have woken us
+    // counts toward a streak; three no-wake sessions rotate the subscription.
+    void recordMissedWakeDrain(ts);
+  }
   const kind = (payload.kind as MessageKind) || 'text';
 
   // If the message carries media, download + decrypt the ciphertext and store

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -315,6 +315,7 @@ export async function clearChat(chatId: string): Promise<void> {
   if (chat) {
     chat.lastMessage = '';
     chat.lastKind = undefined;
+    chat.lastTick = 'none'; // (spec 2054) history wiped → no message left to carry a tick
     chat.unread = 0;
     delete chat.manualUnread;
     chat.updatedAt = now();
@@ -753,6 +754,11 @@ export async function reactToMessage(
     chat.lastMessage = `You reacted ${emoji} to "${previewText(message)}"`;
     chat.lastKind = 'reaction';
     chat.lastMessageTime = at;
+    // (spec 2054) The row preview is now an ACTIVITY, not the outgoing message it replaced, so
+    // drop that message's delivery tick — otherwise the row keeps a stale ✓/✓✓ beside a preview
+    // it doesn't describe. A reaction rides its own signal and carries no receipts of its own,
+    // so there is no tick to show for it. Same reasoning at every activity-preview site below.
+    chat.lastTick = 'none';
     chat.updatedAt = at;
     await put('chats', chat);
   }
@@ -791,6 +797,10 @@ async function handleReaction(from: string, signal: ReactionSignal): Promise<voi
       chat.lastMessage = `${name.split(' ')[0]} reacted ${signal.emoji} to "${previewText(message)}"`;
       chat.lastKind = 'reaction';
       chat.lastMessageTime = signal.at;
+      // (spec 2054) THE reported bug: an INCOMING reaction left the previous outgoing message's
+      // tick in place, so the row read "✓ Kambiz reacted 👍 to …" — a delivery mark on someone
+      // else's activity. Incoming activity never shows a tick.
+      chat.lastTick = 'none';
       chat.updatedAt = signal.at;
       await put('chats', chat);
 
@@ -1106,6 +1116,7 @@ async function bumpOwnGamePreview(m: Message, action: 'move' | 'resign', at: num
   chat.lastMessage = text;
   chat.lastKind = 'game';
   chat.lastMessageTime = at;
+  chat.lastTick = 'none'; // (spec 2054) game activity, not a receipt-tracked message → no tick
   chat.updatedAt = at;
   await put('chats', chat);
 }
@@ -1488,6 +1499,7 @@ async function handleGameMove(from: string, signal: GameMoveSignal): Promise<voi
   chat.lastMessage = text;
   chat.lastKind = 'game';
   chat.lastMessageTime = signal.at;
+  chat.lastTick = 'none'; // (spec 2054) incoming game activity → never a delivery tick
   chat.updatedAt = signal.at;
   await put('chats', chat);
 
@@ -1641,7 +1653,13 @@ async function refreshChatPreview(chatId: string): Promise<void> {
   const seenOn = await getSetting<boolean>('privacy.seenReceipts', true);
   chat.lastTick = lastMessageTick(
     newest
-      ? { outgoing: newest.outgoing, status: newest.status, receipts: newest.receipts, isGroup: chat.isGroup }
+      ? {
+          outgoing: newest.outgoing,
+          status: newest.status,
+          receipts: newest.receipts,
+          isGroup: chat.isGroup,
+          callLog: newest.callLog, // (spec 2054) call entries are informational → no tick
+        }
       : undefined,
     seenOn,
   );
@@ -6832,6 +6850,7 @@ export async function logCallToChat(chatId: string, log: CallLog): Promise<void>
   chat.lastMessage = preview;
   chat.lastKind = 'call';
   chat.lastMessageTime = ts;
+  chat.lastTick = 'none'; // (spec 2054) a call is informational — no receipts, so no tick
   chat.updatedAt = ts;
   await put('chats', chat);
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -39,7 +39,7 @@ import { compressImage, compressVideo, achievedQuality } from '@/services/media-
 import { setCompressProgress, setUploadProgress, resetJobProgress, clearJobProgress } from '@/services/media-jobs';
 import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deriveTiers, blobToDataUrl } from '@/utils/media-meta';
 import { createLimiter, createByteBudget, raceTimeout } from '@/utils/concurrency';
-import { THUMB_TIERS } from '@/utils/thumbs';
+import { THUMB_TIERS, isOwnThumbnail } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview, shouldBuildLinkPreview } from '@/services/link-preview';
 import { inSafeMode } from '@/services/boot-guard';
@@ -2418,6 +2418,22 @@ async function sealMediaAndEnqueue(
   if (!chat || !peerUserId) throw new Error('no chat/peer for media send');
   const media = message.mediaId ? await get<Media>('media', message.mediaId) : undefined;
   const name = media?.name ?? 'attachment';
+  // (spec 2055) LAST-RESORT wire guard. The poster travels INSIDE the sealed message, and the
+  // server drops a websocket frame over 1 MiB — an oversized poster therefore never gets acked
+  // and the send sits on the clock forever, with retry re-sending the same doomed frame. The
+  // tiering above already keeps posters within THUMB_MAX_BYTES; this is the backstop that makes
+  // "a poster can never block a send" true no matter how the poster was produced. Dropping the
+  // preview is always better than not delivering: the recipient still downloads the full media.
+  const poster =
+    message.posterData && message.posterData.length > POSTER_WIRE_MAX_BYTES
+      ? undefined
+      : message.posterData;
+  if (message.posterData && !poster) {
+    console.warn('[media-job] poster too large for the wire; sending without a preview', {
+      id: message.id,
+      posterBytes: message.posterData.length,
+    });
+  }
   const mediaRef = await prepareOutgoingMedia(
     uploadBlob,
     name,
@@ -2425,7 +2441,7 @@ async function sealMediaAndEnqueue(
     {
       width: message.mediaWidth,
       height: message.mediaHeight,
-      poster: message.posterData,
+      poster,
       quality: message.mediaQuality,
     },
     onUploadProgress,
@@ -2457,6 +2473,14 @@ async function sealMediaAndEnqueue(
 }
 
 /* ---- background media jobs (compress → upload), with retry + resume ---- */
+
+// (spec 2055) Hard ceiling for an embedded poster (the data-URL string length) before it is
+// dropped from the wire. The server closes a websocket frame over 1 MiB (ws/hub.go
+// maxMessageSize), and the poster is the only unbounded-by-construction part of a sealed media
+// message. 128 KiB leaves the sealed envelope far under that limit while comfortably clearing
+// the ~40 KiB tier budget, so this only ever fires on a genuinely pathological poster.
+const POSTER_WIRE_MAX_BYTES = 128 * 1024;
+
 const MAX_JOB_ATTEMPTS = 3;
 const jobsInFlight = new Set<string>();
 
@@ -2641,7 +2665,14 @@ async function runMediaJob(messageId: string): Promise<void> {
           if (!message.posterData && message.mediaId) {
             const big = Math.max(meta.width ?? 0, meta.height ?? 0);
             let bubble = await makeImageThumb(uploadBlob, THUMB_TIERS.bubble);
-            if (!bubble && big > 0 && big <= THUMB_TIERS.bubble) bubble = uploadBlob;
+            // (spec 2055) Reuse the original as its own bubble tier ONLY when it is small in
+            // BYTES as well as pixels — see isOwnThumbnail. Without the size half of that test, a
+            // small-dimension/large-byte animated GIF or WebP became its own multi-MB "poster"
+            // and rode the sealed message over the server's 1 MiB frame cap, so the send sat on
+            // the clock forever.
+            if (!bubble && isOwnThumbnail(big, uploadBlob.size, THUMB_TIERS.bubble)) {
+              bubble = uploadBlob;
+            }
             if (bubble) {
               message.posterData = await blobToDataUrl(bubble);
               await put('messages', message);

--- a/src/services/message-status.test.ts
+++ b/src/services/message-status.test.ts
@@ -282,6 +282,16 @@ describe('spec 1062: lastMessageTick (shared list/tile tick tier)', () => {
     expect(lastMessageTick(msg({ status: 'failed' }))).toBe('failed');
   });
 
+  // (spec 2054) A call entry is stored as a message so it appears in the timeline, but it is
+  // informational — never enqueued, no receipts — so it must never render a delivery tick,
+  // even though an outgoing call is flagged outgoing with status 'seen'.
+  it('a call-log entry never shows a tick, even when outgoing', () => {
+    expect(lastMessageTick({ ...msg({ status: 'seen' }), callLog: { direction: 'outgoing' } })).toBe('none');
+    expect(lastMessageTick({ ...msg({ status: 'delivered' }), callLog: {} })).toBe('none');
+    // …while an ordinary outgoing message is unaffected.
+    expect(lastMessageTick(msg({ status: 'seen' }))).toBe('seen');
+  });
+
   it('pre-send states map to pending (clock)', () => {
     expect(lastMessageTick(msg({ status: 'pending' }))).toBe('pending');
     expect(lastMessageTick(msg({ status: 'compressing' }))).toBe('pending');

--- a/src/services/message-status.ts
+++ b/src/services/message-status.ts
@@ -170,15 +170,20 @@ export function applyDownloadedReceipt(
  *     reciprocity-gated by `seenReceiptsOn` (seen tier suppressed → caps at delivered)
  *   - 1:1 → status maps straight through, with 'seen' capped to 'delivered' when
  *     `seenReceiptsOn` is false (the reciprocity DISPLAY gate, spec 1010 FR-009).
+ *  (spec 2054) A call-log entry is stored as a message for the timeline but is purely
+ *  informational — never enqueued, no receipts — so it carries NO tick, even though it is
+ *  flagged outgoing for an outgoing call. Without this, a "Call · 0:06" row rendered a blue
+ *  double tick it never earned.
+ *
  *  Pure: no Vue/IDB — unit-testable, and reused by the summary maintenance in queries.ts. */
 export function lastMessageTick(
   msg:
-    | (Pick<Message, 'outgoing' | 'status' | 'receipts'> & { isGroup?: boolean })
+    | (Pick<Message, 'outgoing' | 'status' | 'receipts'> & { isGroup?: boolean; callLog?: unknown })
     | null
     | undefined,
   seenReceiptsOn = true,
 ): LastTick {
-  if (!msg || !msg.outgoing) return 'none';
+  if (!msg || !msg.outgoing || msg.callLog) return 'none';
   const { status, receipts, isGroup } = msg;
   if (status === 'failed') return 'failed';
   if (status === 'compressing' || status === 'pending') return 'pending';

--- a/src/services/sw-drain.ts
+++ b/src/services/sw-drain.ts
@@ -31,6 +31,7 @@ import { readSessionToken, readSessionUserId } from './session';
 import { readHiddenSetOrNull } from './hidden-chats';
 import { resolveInboundDirectChat } from './hidden-pair';
 import { fetchPendingFrames, noteForPayload, aggregate, setting, loadShown, type MsgFrame, type SwNote } from './sw-inbox';
+import { resolveIncomingTimestamp } from '@/utils/message-time';
 import { chatListPreview, previewKind } from './message-preview';
 import { transact, getAll, get } from '@/db/idb';
 import type { Chat, Contact, Message, Setting } from '@/db/types';
@@ -229,7 +230,9 @@ async function applyOne(f: MsgFrame, ctx: ApplyCtx): Promise<ApplyOutcome> {
       if (cls.verdict === 'defer') return { kind: 'defer' as const, why: cls.why };
       const targetChatId = cls.targetChatId ?? direct.id;
 
-      const ts = payload.timestamp || Date.now();
+      // (spec 2056) Same clock reconciliation the page path does, so a message committed here
+      // by the service worker sorts identically to one committed by the page.
+      const ts = resolveIncomingTimestamp(payload.timestamp || Date.now(), f.relayedAt);
       const kind = (payload.kind as Message['kind']) || 'text';
       const isGroupMsg = !!payload.groupId;
       // Media bytes are NEVER downloaded in the SW (no canvas pipeline, tight

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -60,6 +60,10 @@ export interface MsgFrame {
   id?: string;
   from?: string;
   ciphertext?: unknown;
+  // (spec 2056) Epoch ms at which the relay accepted the frame. Stamped into the stored payload
+  // at enqueue, so it rides both the websocket delivery and this REST replay. The authoritative
+  // SW drain uses it to correct a skewed sender clock exactly as the page does.
+  relayedAt?: number;
 }
 
 /** A ready-to-show notification. `ids` are the relay frame ids this note covers

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -130,7 +130,9 @@ export async function handleIncomingFrame(frame: Frame): Promise<void> {
       // (so seen receipts we send back correlate on their side). The ack (which
       // clears the server queue and triggers the sender's delivered receipt) is
       // sent by useSync after this resolves.
-      await receiveIncoming(frame.from ?? '', frame.id, frame.ciphertext);
+      // (spec 2056) Pass the relay's receive time through: receiveIncoming uses it to tell a
+      // genuinely-old queued message from one sent by a device whose clock is wrong.
+      await receiveIncoming(frame.from ?? '', frame.id, frame.ciphertext, frame.relayedAt);
       return;
     case 'presence':
       applyPresenceFrame(frame);

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -516,6 +516,13 @@ export function installTestHook(): void {
     hiddenReset: () => hcReset(),
     /** Visible chat ids right now (what `listChats` returns) — for exclusion asserts. */
     visibleChatIds: async (): Promise<string[]> => (await listChats()).map((c) => c.id),
+    /** (spec 2054) A chat's denormalized list-row summary — the preview text/kind plus the
+     *  delivery tick tier the Chats row and pinned tile render. Lets a test assert that an
+     *  INCOMING activity preview (a reaction, a game move, a call) carries no tick. */
+    chatRow: async (chatId: string): Promise<{ lastMessage?: string; lastKind?: string; lastTick?: string } | null> => {
+      const c = (await listChats()).find((x) => x.id === chatId);
+      return c ? { lastMessage: c.lastMessage, lastKind: c.lastKind, lastTick: c.lastTick } : null;
+    },
     /** The unread badge total (countUnread) — for hidden-chat badge-mode asserts. */
     unreadBadge: (): Promise<number> => dbCountUnread(),
 

--- a/src/services/transport.ts
+++ b/src/services/transport.ts
@@ -23,6 +23,10 @@ export interface MsgFrame {
   to?: string; // recipient user id (set when sending)
   from?: string; // sender user id (set by the server on delivery)
   ciphertext?: unknown; // sealed wire packet, opaque to the transport
+  // (spec 2056) Epoch ms at which the RELAY accepted this frame, stamped by the server on both
+  // live and queued delivery. The recipient checks the sender's own timestamp against it to
+  // catch a skewed sender clock (see utils/message-time). Absent from an older server.
+  relayedAt?: number;
   // spec 1050: sender-set coarse push class + opaque conversation route id.
   // Plaintext BY DESIGN (the user-approved routing leak): they exist so the
   // blind relay can gate the push tickle; they never affect delivery.

--- a/src/utils/media-meta.ts
+++ b/src/utils/media-meta.ts
@@ -5,7 +5,7 @@
  * hang the send pipeline, so each call resolves on a timeout with whatever it has.
  */
 import { createLimiter, withTimeout } from '@/utils/concurrency';
-import { THUMB_TIERS, THUMB_MAX_BYTES, chooseJpegQuality, dataUrlBytes } from '@/utils/thumbs';
+import { THUMB_TIERS, THUMB_MAX_BYTES, chooseJpegQuality, dataUrlBytes, isOwnThumbnail } from '@/utils/thumbs';
 
 // A hard cap on any single image decode. On WebKit, `createImageBitmap` on certain animated
 // WebPs never settles (neither resolves nor rejects) — the send pipeline's thumbnail step
@@ -236,11 +236,19 @@ async function generateImageThumbUnlimited(blob: Blob, maxEdge: number): Promise
     const bmp = await withTimeout(createImageBitmap(blob), IMAGE_DECODE_TIMEOUT_MS, undefined);
     if (!bmp) return undefined; // decode timed out
     const big = Math.max(bmp.width, bmp.height);
-    if (big <= maxEdge) {
+    // (spec 2055) "Already small" must mean small in BOTH dimensions AND bytes. The old check
+    // looked at pixels only and told the caller to reuse the original — but an ANIMATED GIF or
+    // WebP is typically small-dimension and very large-byte (many frames), so a multi-MB file
+    // was handed back as the "thumbnail" and embedded in the sealed message, blowing the
+    // server's 1 MiB frame limit and wedging the send. When the bytes are over budget we
+    // re-encode (a flat JPEG still frame) even at unchanged dimensions, so the poster always
+    // fits the wire budget. Animation is not lost: the poster is only the preview; the full
+    // original is downloaded separately and rendered animated.
+    if (isOwnThumbnail(big, blob.size, maxEdge)) {
       bmp.close?.();
-      return undefined; // already small — no point storing a second copy
+      return undefined; // small in pixels and bytes — the original IS its own thumbnail
     }
-    const scale = maxEdge / big;
+    const scale = Math.min(1, maxEdge / big); // never upscale a small-but-heavy source
     const c = document.createElement('canvas');
     c.width = Math.max(1, Math.round(bmp.width * scale));
     c.height = Math.max(1, Math.round(bmp.height * scale));

--- a/src/utils/message-time.test.ts
+++ b/src/utils/message-time.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { resolveIncomingTimestamp, senderClockIsSkewed, CLOCK_SKEW_TOLERANCE_MS } from './message-time';
+
+const NOW = 1_800_000_000_000; // fixed epoch ms; these helpers are pure
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+describe('resolveIncomingTimestamp (spec 2056)', () => {
+  it('keeps the sender timestamp when it agrees with the relay (the normal case)', () => {
+    expect(resolveIncomingTimestamp(NOW, NOW)).toBe(NOW);
+    expect(resolveIncomingTimestamp(NOW - 5_000, NOW)).toBe(NOW - 5_000); // ordinary latency
+    expect(resolveIncomingTimestamp(NOW - CLOCK_SKEW_TOLERANCE_MS, NOW)).toBe(NOW - CLOCK_SKEW_TOLERANCE_MS);
+  });
+
+  it('keeps a genuinely OLD message old when it was queued while we were offline', () => {
+    // Sent 6h ago and queued 6h ago: the sender's clock is fine, the message really is old.
+    // It must stay old — the chat shows it in the past AND the push-zombie staleness signal
+    // relies on this being honest.
+    const sixHoursAgo = NOW - 6 * HOUR;
+    expect(resolveIncomingTimestamp(sixHoursAgo, sixHoursAgo)).toBe(sixHoursAgo);
+  });
+
+  it('corrects a sender whose clock runs an hour SLOW (the reported timezone bug)', () => {
+    // Stale tzdata: the device shows the right wall clock but its UTC is an hour behind, so
+    // every message it sends claims to be an hour older than it is. Relayed just now.
+    const claimed = NOW - HOUR;
+    expect(resolveIncomingTimestamp(claimed, NOW)).toBe(NOW);
+  });
+
+  it('corrects a sender whose clock runs FAST (would sort into the future)', () => {
+    expect(resolveIncomingTimestamp(NOW + 2 * HOUR, NOW)).toBe(NOW);
+  });
+
+  it('corrects the half-hour timezone offsets too (well above tolerance)', () => {
+    expect(resolveIncomingTimestamp(NOW - 30 * MIN, NOW)).toBe(NOW);
+  });
+
+  it('trusts the sender when the relay time is unknown (older server, no regression)', () => {
+    const claimed = NOW - HOUR;
+    expect(resolveIncomingTimestamp(claimed, undefined)).toBe(claimed);
+    expect(resolveIncomingTimestamp(claimed, 0)).toBe(claimed);
+  });
+
+  it('falls back to the relay time when the sender sent no timestamp at all', () => {
+    expect(resolveIncomingTimestamp(0, NOW)).toBe(NOW);
+  });
+
+  it('never consults the local clock, so a skewed RECIPIENT still orders correctly', () => {
+    // Both inputs are independent of Date.now(); ordering is decided purely between the
+    // sender's claim and the relay's stamp.
+    const a = resolveIncomingTimestamp(NOW - HOUR, NOW);
+    const b = resolveIncomingTimestamp(NOW - HOUR + 1_000, NOW + 1_000);
+    expect(b).toBeGreaterThan(a); // relative order of two skewed messages is preserved
+  });
+
+  it('keeps successive messages from a skewed sender in the order they were relayed', () => {
+    const skew = -HOUR;
+    const relayTimes = [NOW, NOW + 30_000, NOW + 90_000];
+    const out = relayTimes.map((r) => resolveIncomingTimestamp(r + skew, r));
+    expect(out).toEqual(relayTimes); // monotonic, matching send order
+  });
+});
+
+describe('senderClockIsSkewed', () => {
+  it('is false for agreeing clocks and unknown references', () => {
+    expect(senderClockIsSkewed(NOW, NOW)).toBe(false);
+    expect(senderClockIsSkewed(NOW - 5_000, NOW)).toBe(false);
+    expect(senderClockIsSkewed(NOW, undefined)).toBe(false);
+    expect(senderClockIsSkewed(0, NOW)).toBe(false);
+  });
+
+  it('is true once the disagreement exceeds tolerance, in either direction', () => {
+    expect(senderClockIsSkewed(NOW - HOUR, NOW)).toBe(true);
+    expect(senderClockIsSkewed(NOW + HOUR, NOW)).toBe(true);
+  });
+
+  it('does NOT flag a genuinely queued-while-offline message', () => {
+    const old = NOW - 6 * HOUR;
+    expect(senderClockIsSkewed(old, old)).toBe(false);
+  });
+});

--- a/src/utils/message-time.ts
+++ b/src/utils/message-time.ts
@@ -1,0 +1,56 @@
+// (spec 2056) Deciding what time an INCOMING message really happened.
+//
+// A message carries the timestamp its SENDER's device put on it, and that timestamp drives both
+// the displayed time and the message's position in the conversation. That makes conversation
+// order hostage to every participant's clock: a phone with stale timezone data — an old Android
+// still applying a DST rule its country abolished, for instance — reports a wall clock that looks
+// right to its owner while its actual UTC time is an hour off. Every message it sends then sorts
+// an hour into the past on the recipient's screen, so new messages appear ABOVE older ones
+// instead of at the end of the chat, and can be missed entirely.
+//
+// The recipient cannot judge this from the sender's timestamp alone, because "timestamp well in
+// the past" is also exactly what a legitimate message queued while the recipient was offline
+// looks like. The discriminator is the RELAY's own receive time, which the server now stamps on
+// every delivered frame:
+//
+//   • queued-while-offline → the sender sent it when they said, so their claim and the relay
+//     time agree; the message is genuinely old and must stay old (Ring's push-zombie detection
+//     depends on that being honest).
+//   • skewed sender clock → the claim and the relay time disagree by the skew, even though the
+//     message was relayed seconds ago.
+//
+// So: trust the sender's own timestamp while it is consistent with when the relay saw the frame,
+// and fall back to the relay's time when it is not. The comparison never involves OUR clock, so a
+// recipient whose own clock is wrong still orders the conversation correctly.
+
+/** How far a sender's claimed time may sit from the relay's receive time before we stop
+ *  believing it. Generous enough to absorb ordinary network latency, brief queuing and modest
+ *  clock drift, far below the smallest timezone error (30 minutes). */
+export const CLOCK_SKEW_TOLERANCE_MS = 90_000;
+
+/**
+ * The timestamp to store for an incoming message.
+ *
+ * @param claimedTs   the sender's own timestamp for the message (epoch ms)
+ * @param relayedAtMs when the relay accepted the frame (epoch ms); 0/undefined when unknown
+ *                    (a server older than spec 2056), in which case the claim is kept as-is.
+ *
+ * Note the deliberate trade-off when a sender composes while offline and sends much later: the
+ * claim and the relay time diverge, so we use the relay time — the message shows when it reached
+ * the conversation rather than when it was typed. That is the safe direction: it can never sort a
+ * message into the distant past, which is the failure being fixed. The sender's own copy keeps
+ * their compose time.
+ */
+export function resolveIncomingTimestamp(claimedTs: number, relayedAtMs?: number): number {
+  if (!claimedTs) return relayedAtMs || Date.now();
+  if (!relayedAtMs) return claimedTs; // no reference to check against → take the sender's word
+  return Math.abs(claimedTs - relayedAtMs) <= CLOCK_SKEW_TOLERANCE_MS ? claimedTs : relayedAtMs;
+}
+
+/** Whether the sender's clock disagrees with the relay beyond tolerance — i.e. we corrected it.
+ *  Split out so callers can skip clock-dependent heuristics (the stale-drain / missed-wake push
+ *  signals) that a skewed sender would otherwise trip falsely. */
+export function senderClockIsSkewed(claimedTs: number, relayedAtMs?: number): boolean {
+  if (!claimedTs || !relayedAtMs) return false;
+  return Math.abs(claimedTs - relayedAtMs) > CLOCK_SKEW_TOLERANCE_MS;
+}

--- a/src/utils/thumbs.test.ts
+++ b/src/utils/thumbs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { THUMB_TIERS, thumbDims, THUMB_MAX_BYTES, JPEG_QUALITY_STEPS, dataUrlBytes, chooseJpegQuality } from './thumbs';
+import { THUMB_TIERS, thumbDims, THUMB_MAX_BYTES, JPEG_QUALITY_STEPS, dataUrlBytes, chooseJpegQuality, isOwnThumbnail } from './thumbs';
 
 // Pure tier-size math for spec 1014's three image thumbnail tiers (bubble/grid/strip).
 // The actual downscaling (canvas/createImageBitmap) lives in media-meta.ts (needs the DOM);
@@ -75,5 +75,32 @@ describe('thumbnail size budget (spec 1018)', () => {
   it('chooseJpegQuality falls back to the lowest (smallest) step when nothing fits', () => {
     const pick = chooseJpegQuality(() => 500_000, 40 * 1024); // everything over budget
     expect(pick.quality).toBe(JPEG_QUALITY_STEPS[JPEG_QUALITY_STEPS.length - 1]);
+  });
+});
+
+describe('isOwnThumbnail (spec 2055) — an image may stand in as its own bubble tier', () => {
+  const MAX = THUMB_TIERS.bubble; // 512
+
+  it('accepts an image small in BOTH dimensions and bytes', () => {
+    expect(isOwnThumbnail(400, 20 * 1024, MAX)).toBe(true);
+    expect(isOwnThumbnail(MAX, THUMB_MAX_BYTES, MAX)).toBe(true); // exactly at both limits
+  });
+
+  it('REJECTS a small-dimension but large-byte image (the animated GIF/WebP trap)', () => {
+    // The shape that wedged sends: 480x480 but multi-megabyte, because an animation's size
+    // lives in its frame COUNT. Treating this as its own thumbnail embedded the whole file in
+    // the sealed message and blew the server's 1 MiB frame limit.
+    expect(isOwnThumbnail(480, 3 * 1024 * 1024, MAX)).toBe(false);
+    expect(isOwnThumbnail(100, THUMB_MAX_BYTES + 1, MAX)).toBe(false);
+  });
+
+  it('rejects an image larger than the tier, however small its bytes', () => {
+    expect(isOwnThumbnail(MAX + 1, 1024, MAX)).toBe(false);
+    expect(isOwnThumbnail(4000, 10 * 1024, MAX)).toBe(false);
+  });
+
+  it('rejects degenerate/unknown dimensions rather than guessing', () => {
+    expect(isOwnThumbnail(0, 1024, MAX)).toBe(false);
+    expect(isOwnThumbnail(-5, 1024, MAX)).toBe(false);
   });
 });

--- a/src/utils/thumbs.ts
+++ b/src/utils/thumbs.ts
@@ -37,6 +37,24 @@ export const THUMB_MAX_BYTES = 40 * 1024;
 export const JPEG_QUALITY_STEPS = [0.82, 0.72, 0.62, 0.5] as const;
 
 /**
+ * (spec 2055) Whether a source image can serve as its OWN bubble-tier thumbnail, so we skip
+ * generating (and storing, and transmitting) a second copy.
+ *
+ * It qualifies only when it is small in BOTH dimensions and BYTES. The dimension test alone —
+ * which is what this used to be — is a trap for **animated** formats: a GIF or animated WebP is
+ * routinely 480x480 but several MB, because the size is in the frame count, not the frame size.
+ * Treating such a file as its own thumbnail embedded the whole animation in the sealed message's
+ * `MediaRef.poster`, which blew the server's 1 MiB websocket frame limit — the message was never
+ * acked and sat on the sending clock forever, with retry re-sending the same doomed frame.
+ *
+ * Pure so the rule is unit-testable and shared by the generator (media-meta) and the send path
+ * (queries), which must agree — if they disagree, the oversize poster comes back.
+ */
+export function isOwnThumbnail(longEdge: number, bytes: number, maxEdge: number): boolean {
+  return longEdge > 0 && longEdge <= maxEdge && bytes <= THUMB_MAX_BYTES;
+}
+
+/**
  * Estimate the decoded byte length of a base64 `data:` URL (e.g. a JPEG produced by
  * canvas.toDataURL) WITHOUT allocating the bytes — base64 encodes 3 bytes per 4 chars, minus any
  * `=` padding. Returns 0 for a string that isn't a data URL. Pure (DOM-free) so it's unit-testable.


### PR DESCRIPTION
## Ring 1.0.30

Three bug fixes, all reported from real use and each verified end-to-end.

### Fixed

**Big animated GIFs and WebPs send instead of sticking on the clock** (spec 2055)

The follow-on to 1.0.29's fix, and the reason GIFs *still* stuck: a second, independent stall one stage later. Both wear the same clock icon, which is why they looked like one bug.

Nothing was converting the GIF — the blocker was the small **preview** generated alongside it. Generating that preview had a shortcut: if the image already fits the 512px tier, reuse the original rather than make a second copy. That test looked at **pixels only**, but an animated GIF/WebP is routinely 480×480 and several MB, because its size lives in the frame *count*. So the whole animation was embedded inside the sealed message, blowing the server's 1 MiB frame limit — never acked, stuck at pending forever, and every retry re-sent the same doomed frame.

Now the "is it its own preview" rule checks bytes as well as pixels (one shared function, so the two places applying it cannot drift), over-budget images get a properly re-encoded preview, and a final guard drops any preview still too large — a preview is an optimisation, delivery is not.

**Messages from a phone with the wrong clock now arrive at the end of the chat** (spec 2056)

Messages from a contact's Android phone showed an hour early and sorted into the *past*, appearing above older messages, so a new message never showed up where the reader was looking.

The phone had stale timezone data: its wall clock looked right to its owner while its UTC ran an hour behind. Since a message's position comes from the sender's own clock, that skew reordered the conversation for everyone it talked to. The recipient can't tell that from the timestamp alone — "an hour old" is also what a message queued while you were offline looks like — so the relay's own receive time is now used as the neutral reference that separates the two. Genuinely old messages stay old; a skewed sender is corrected. The check never consults the reader's clock, so it works even if theirs is wrong too.

Also stops a skewed sender from forging the "this sat queued" evidence that nudges the recipient's device into needless push-subscription churn.

**No delivery tick next to a reaction or call from someone else** (spec 2054)

A chats-list row read "✓ Kambiz reacted 👍 to …" — a delivery mark beside activity belonging to someone else. Any preview replaced by a non-message activity (a reaction either way, a game move, a call, a cleared chat) kept the tick of the message it stopped describing. The row tick now only ever describes a receipt-tracked outgoing message.

### Verification

Full CI green on every PR (#1100, #1101, #1102), including the Playwright e2e suite. 1268 unit tests. Each fix additionally carries a drive scenario reproducing the reported symptom and demonstrating the fix, all re-run together on the combined tree.

### Zero-knowledge

Preserved. 2055 puts strictly *less* on the wire. 2056 adds one integer to a delivered frame — the relay's own receive time, a fact the server already recorded (`relay_queue.created_at`) and now shares with the recipient who is already receiving that frame. No new endpoint, stored field, or plaintext exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i