### PR TITLE
chore: bump version to 1.0.31 and mark 2054-2056 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -140,7 +140,7 @@ Specs are grouped by category band; status moves
 | [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |
 | [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🟢 shipped |
 | [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🟢 shipped |
-| [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |
-| [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🔵 in-review |
-| [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🔵 in-review |
+| [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🟢 shipped |
+| [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🟢 shipped |
+| [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🟢 shipped |
 | [2057](specs/2057-signal-clock/spec.md) | Reactions and game moves still trust the sender's clock | 🔵 in-review |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/2054-incoming-tick/spec.md
+++ b/specs/2054-incoming-tick/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-27
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2055-poster-budget/spec.md
+++ b/specs/2055-poster-budget/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-27
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2056-sender-clock-skew/spec.md
+++ b/specs/2056-sender-clock-skew/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-27
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Opens the next release cycle so the `develop → main` release PR clears the version guard.

Also flips specs **2054**, **2055** and **2056** to `shipped` — all three went out in 1.0.30 but their status lines still read `in-review`, so the roadmap understated what is live.

1.0.31 will carry one fix, already merged to develop:

- **#1105** (spec 2057) — a reaction now lifts the chat to the top of the list whatever the sender's clock says, plus the intro-montage gamepad sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i