### PR TITLE
Release 1.0.31

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -140,7 +140,7 @@ Specs are grouped by category band; status moves
 | [2051](specs/2051-reply-swipe-responsive/spec.md) | Make incoming messages more responsive to swipe-to-reply | 🟢 shipped |
 | [2052](specs/2052-webm-best-effort/spec.md) | Send webm best-effort instead of hard-failing when it can't transcode | 🟢 shipped |
 | [2053](specs/2053-media-send-lanes/spec.md) | Stuck media sends no longer block every later send | 🟢 shipped |
-| [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |
-| [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🔵 in-review |
-| [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🔵 in-review |
+| [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🟢 shipped |
+| [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🟢 shipped |
+| [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🟢 shipped |
 | [2057](specs/2057-signal-clock/spec.md) | Reactions and game moves still trust the sender's clock | 🔵 in-review |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,3 +143,4 @@ Specs are grouped by category band; status moves
 | [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🔵 in-review |
 | [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🔵 in-review |
 | [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🔵 in-review |
+| [2057](specs/2057-signal-clock/spec.md) | Reactions and game moves still trust the sender's clock | 🔵 in-review |

--- a/drive/scenarios/reaction-list-order-2057.mjs
+++ b/drive/scenarios/reaction-list-order-2057.mjs
@@ -1,0 +1,75 @@
+/**
+ * Spec 2057 — with a realistic multi-chat list, a reaction from a SKEWED-clock contact must lift
+ * that chat to the TOP and refresh its row live.
+ *
+ * Before the fix the reaction wrote the sender's own (hour-behind) clock into the chat summary,
+ * so the chat sank down the list — the row did change, but not where the reader was looking,
+ * which reads as "the list didn't update".
+ *
+ *   node drive/scenarios/reaction-list-order-2057.mjs
+ */
+import { createAccount, pair, chatWith, say, waitForMessage, messageId, react, shot, sweep, done } from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice', mobile: true });
+const bob = await createAccount({ name: 'Bob' });      // the skewed-clock contact
+const carol = await createAccount({ name: 'Carol' });
+const dave = await createAccount({ name: 'Dave' });
+await pair(alice, bob);
+await pair(alice, carol);
+await pair(alice, dave);
+
+// Alice talks to Bob FIRST, so his chat starts at the BOTTOM of the list…
+const bobChatA = await chatWith(alice, bob.id);
+await say(alice, bob.id, 'ping bob');
+await waitForMessage(bob, alice.id, 'ping bob');
+// …then Carol and Dave chat more recently, pushing Bob down.
+await say(carol, alice.id, 'hi from carol');
+await waitForMessage(alice, carol.id, 'hi from carol');
+await say(dave, alice.id, 'hi from dave');
+await waitForMessage(alice, dave.id, 'hi from dave');
+
+const order = async () =>
+  alice.page.evaluate(() =>
+    Array.from(document.querySelectorAll('ion-item h2, .chat-name, .row-name'))
+      .map((e) => e.textContent?.trim())
+      .filter(Boolean),
+  );
+
+await alice.page.goto('http://localhost:5173/tabs/chats');
+await alice.page.waitForTimeout(3000);
+console.log('[2057] list BEFORE reaction:', JSON.stringify(await order()));
+
+// Bob's clock runs an hour slow, then he reacts to Alice's message.
+await bob.page.evaluate(() => { const r = Date.now.bind(Date); Date.now = () => r() - 3600000; });
+const bobChatB = await chatWith(bob, alice.id);
+const mid = await messageId(bob, bobChatB, 'ping bob');
+await react(bob, mid, '👍');
+
+// Watch the list WITHOUT navigating.
+let seen = false;
+for (let i = 0; i < 15; i++) {
+  await alice.page.waitForTimeout(1000);
+  const previews = await alice.page.evaluate(() =>
+    Array.from(document.querySelectorAll('.preview')).map((e) => e.textContent?.trim() ?? ''),
+  );
+  if (previews.some((t) => /reacted/.test(t))) { seen = true; break; }
+}
+
+const row = await alice.page.evaluate((c) => window.__ringTest.chatRow(c), bobChatA);
+const all = await alice.page.evaluate(async () => {
+  const ids = await window.__ringTest.chatOrder();
+  return ids;
+});
+const pos = all.indexOf(bobChatA);
+
+console.log('[2057] list AFTER  reaction:', JSON.stringify(await order()));
+console.log(`[2057] preview refreshed live: ${seen}; Bob's chat position: ${pos} (0 = top of ${all.length})`);
+console.log('[2057] Bob row preview:', JSON.stringify(row?.lastMessage));
+
+if (!seen) throw new Error('FAIL: the row preview never refreshed while sitting on the list');
+if (pos !== 0) throw new Error(`FAIL: the reacted chat is at position ${pos}, not the top`);
+console.log('[2057] PASS — reaction lifted the chat to the top and the row refreshed live ✓');
+
+await shot(alice, 'reaction-list-order-2057', { route: '/tabs/chats' });
+await sweep([alice, bob, carol, dave]);
+await done();

--- a/drive/scenarios/reaction-list-refresh.mjs
+++ b/drive/scenarios/reaction-list-refresh.mjs
@@ -1,0 +1,79 @@
+/**
+ * REPRO: a reaction arriving while you are sitting on the Chats LIST does not refresh that
+ * chat's preview row — you have to navigate away and back to see "X reacted …".
+ *
+ * The DB write clearly lands (it shows on return), so this checks the RENDERED row, not the
+ * stored row, and reports both so we can tell a write problem from a re-render problem.
+ *
+ *   node drive/scenarios/reaction-list-refresh.mjs
+ */
+import { createAccount, pair, chatWith, say, waitForMessage, messageId, react, shot, sweep, done } from '../driver.mjs';
+
+const alice = await createAccount({ name: 'Alice', mobile: true });
+const bob = await createAccount({ name: 'Bob' });
+await pair(alice, bob);
+
+const aliceChat = await chatWith(alice, bob.id);
+await say(alice, bob.id, 'ping from alice');
+await waitForMessage(bob, alice.id, 'ping from alice');
+
+// Realistic flow: Alice OPENS the conversation first, then goes BACK to the list via the
+// router (Ionic keeps the detail page mounted), instead of a fresh page load.
+await alice.page.goto(`http://localhost:5173/chat/${aliceChat}`);
+await alice.page.waitForTimeout(2500);
+await alice.page.evaluate(() => window.history.back());
+await alice.page.waitForTimeout(2500);
+
+const rowText = async () =>
+  alice.page.evaluate(() => {
+    const els = Array.from(document.querySelectorAll('.preview'));
+    return els.map((e) => e.textContent?.trim() ?? '').filter(Boolean);
+  });
+const dbRow = async () => alice.page.evaluate((c) => window.__ringTest.chatRow(c), aliceChat);
+
+console.log('[repro] BEFORE  rendered:', JSON.stringify(await rowText()));
+console.log('[repro] BEFORE  stored  :', JSON.stringify((await dbRow())?.lastMessage));
+
+// Bob's device clock runs an hour SLOW (the stale-tzdata phone from spec 2056).
+await bob.page.evaluate(() => { const r = Date.now.bind(Date); Date.now = () => r() - 3600000; });
+// Bob reacts while Alice sits on the list.
+const bobChat = await chatWith(bob, alice.id);
+const mid = await messageId(bob, bobChat, 'ping from alice');
+await react(bob, mid, '👍');
+
+// Watch for up to ~15s WITHOUT navigating.
+let renderedSaw = false;
+for (let i = 0; i < 15; i++) {
+  await alice.page.waitForTimeout(1000);
+  const rendered = await rowText();
+  if (rendered.some((t) => /reacted/.test(t))) {
+    console.log(`[repro] rendered updated after ~${i + 1}s:`, JSON.stringify(rendered));
+    renderedSaw = true;
+    break;
+  }
+}
+
+const stored = await dbRow();
+const times = await alice.page.evaluate(async (c) => {
+  const ms = await window.__ringTest.messages(c);
+  const row = await window.__ringTest.chatRow(c);
+  const mine = ms.filter((m) => m.body === 'ping from alice')[0];
+  return { myMsg: mine?.timestamp, rowTime: row?.lastMessageTime };
+}, aliceChat);
+const drift = Math.round((times.rowTime - times.myMsg) / 60000);
+console.log(`[repro] chat row lastMessageTime vs my own message: ${drift} min (negative = went BACKWARDS)`);
+console.log('[repro] AFTER   rendered:', JSON.stringify(await rowText()));
+console.log('[repro] AFTER   stored  :', JSON.stringify(stored?.lastMessage));
+
+if (!renderedSaw && /reacted/.test(stored?.lastMessage ?? '')) {
+  console.log('[repro] REPRODUCED — the row was written but the list never re-rendered');
+} else if (renderedSaw) {
+  console.log('[repro] list refreshed live ✓');
+} else {
+  console.log('[repro] INCONCLUSIVE — the reaction never reached the stored row either');
+}
+
+await shot(alice, 'reaction-list-refresh');
+
+await sweep([alice, bob]);
+await done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/2054-incoming-tick/spec.md
+++ b/specs/2054-incoming-tick/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-27
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2055-poster-budget/spec.md
+++ b/specs/2055-poster-budget/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-27
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2056-sender-clock-skew/spec.md
+++ b/specs/2056-sender-clock-skew/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-27
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2057-signal-clock/spec.md
+++ b/specs/2057-signal-clock/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: Reactions and game moves still trust the sender's clock
+
+**Feature Branch**: `fix/2057-signal-clock`
+
+**Created**: 2026-07-28
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report after 1.0.30: "There is a glitch when a new reaction happens in a chat and I am in the Chats list, the in app notification shows correctly, but that chat's last interaction preview is not updated unless I change from the chats to something else and come back to the list." Plus: "in the intro animation, the game pad height is too little compared to the other elements."
+
+## Context: why this hotfix exists
+
+**Spec 2056 reconciled MESSAGE timestamps against the relay's receive time, but not SIGNALS.** A reaction, game move, edit or poll vote carries its own `at` stamped by the sender's device, and two of those paths write it straight into the chat summary (`lastMessageTime`, `updatedAt`). The Chats list sorts on `lastMessageTime`.
+
+So a reaction from the very device 2056 was written for — a phone whose clock runs an hour behind — drives the chat's `lastMessageTime` an hour **backwards**. Measured against a live pair with the reactor's clock shifted −1h: `chat row lastMessageTime vs my own message: -60 min`. Instead of rising to the top on a brand-new interaction, the chat **sinks down the list**, so the list does not show the interaction where the reader looks for it, even though the notification fired correctly.
+
+This is the same class of defect as 2056 and the same fix: reconcile the sender's claim against when the relay accepted the frame.
+
+**This also explains the reported symptom, which is not a rendering bug at all.** The report reads as "the preview doesn't update until I leave the list and come back", and no re-render fault could be found — the row's text updates within ~1s in every flow tried. An A/B run on a realistic three-chat list settles it:
+
+| | list order after the reaction | reacted chat's position |
+|---|---|---|
+| before the fix | Dave, Carol, **Bob** | 2 (bottom) |
+| after the fix | **Bob**, Dave, Carol | 0 (top) |
+
+The row's preview text refreshed live in **both** runs. What failed was the chat's POSITION: with its summary time pushed an hour into the past, the chat stayed where it was — near the bottom — instead of jumping to the top on a new interaction. To a reader scanning the top of the Chats list, an updated row sitting far down the list is indistinguishable from a row that never updated.
+
+**Rider (visual):** in the launch montage, every intermediate silhouette is uniform-scaled so its LONGEST edge hits one shared box. That punishes a wide, short shape: the controller is 90×49 raw, so fitting its width to 66 left it ~36 tall — the shortest symbol in the montage, against the camera's ~41 and the resolved shield's ~70. That is the "game pad height is too little" report.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A reaction lifts the chat to the top of the list (Priority: P1)
+
+Someone reacts to my message; that chat moves to the top of the Chats list as the most recent interaction, whatever their device thinks the time is.
+
+**Why this priority**: The reported defect. A new interaction that sorts into the past is effectively invisible in the list.
+
+**Independent Test**: On a multi-chat list, have a reactor whose clock is an hour behind react to an older conversation, and confirm that chat jumps to the top rather than staying put.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reactor whose clock runs an hour behind, **When** they react to my message, **Then** the chat's last-interaction time does not go backwards and the chat sorts as the newest interaction.
+2. **Given** a correctly-clocked reactor, **When** they react, **Then** behaviour is unchanged.
+3. **Given** a game move from a skewed-clock player, **When** it arrives, **Then** the same holds.
+4. **Given** my OWN reaction, **When** I make it, **Then** it continues to use my own clock (unchanged).
+
+---
+
+### User Story 2 - The game pad reads at the same weight as the other intro symbols (Priority: P3)
+
+The controller in the launch montage looks the same visual size as the phone, chat bubble and camera rather than squat.
+
+**Why this priority**: Cosmetic polish on the first-run animation, no functional impact.
+
+**Independent Test**: Compare the normalized height of each montage silhouette; the controller should no longer be the outlier.
+
+**Acceptance Scenarios**:
+
+1. **Given** the launch montage, **When** the controller is shown, **Then** its height is comparable to the other intermediate symbols.
+2. **Given** the same montage, **When** it resolves, **Then** the final shield/ring app icon is unchanged.
+
+---
+
+### Edge Cases
+
+- **A genuinely old queued reaction** (sent while the recipient was offline) must keep its real time — same reconciliation rule as 2056, not a blind re-stamp.
+- **Per-user reaction last-write-wins** compares one user's own successive stamps and stays on the raw sender value, which is self-consistent; only the chat SUMMARY is reconciled.
+- **Own reactions/moves** already use the local clock and must not change.
+- **Wide silhouettes** may exceed the shared width box once a height floor applies; they must stay within the drawing viewBox and keep their own aspect ratio.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: nothing new. It reuses the relay-receive time already added by spec 2056.
+- **Where processing happens**: client-side, after decryption.
+- **Unavoidably-visible metadata**: unchanged.
+- **Why it stays zero-knowledge**: a local decision about which of two already-held timestamps to store.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: An incoming reaction's contribution to the chat summary (`lastMessageTime`, `updatedAt`) MUST be reconciled against the relay's receive time, exactly as message timestamps are.
+- **FR-002**: An incoming game move MUST do the same.
+- **FR-003**: Locally-originated reactions and moves MUST keep using the local clock.
+- **FR-004**: Per-signal last-write-wins comparisons MUST keep their existing semantics.
+- **FR-005**: A genuinely queued-while-offline signal MUST retain its real time.
+- **FR-006**: The launch montage MUST NOT let a wide silhouette collapse below a minimum normalized height; uniform scaling and the resolved app icon MUST be preserved.
+
+### Key Entities *(include if feature involves data)*
+
+- **Signal (`at`)**: the sender-stamped time on a reaction/move. Its use for the chat summary becomes a reconciled value. No schema change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reaction from a device an hour behind does not move the chat's last-interaction time backwards.
+- **SC-002**: The chat sorts as the newest interaction after such a reaction.
+- **SC-003**: Correctly-clocked reactions and own reactions are unchanged.
+- **SC-004**: The controller silhouette is no longer the shortest symbol in the montage, and the final icon is unchanged.
+
+## Assumptions
+
+- Reactions and game moves are the signals whose sender time reaches the chat summary; other signals (edits, poll votes) affect their target message's own bookkeeping rather than list ordering, so they are left alone here.
+- Equalising the controller's height with the camera's is the right visual target; the shield finale stays taller by design because it is the resolved app icon.
+
+## Out of Scope
+
+- Reconciling signal times used purely for per-signal last-write-wins.
+- Redrawing any montage silhouette; this only changes how they are scaled.

--- a/src/components/LaunchReveal.vue
+++ b/src/components/LaunchReveal.vue
@@ -96,6 +96,14 @@ const MARK = 84; // px, the morphing symbol inside the 128px tile
 // is deliberately left as-is: it already matches the real app icon.
 const NCENTER = { x: 50, y: 49 };
 const NSIZE = 66; // target max( width, height ) in the 0–100 viewBox
+// (spec 2057) …but scaling by the LONGEST edge alone punishes a wide, short silhouette: the
+// controller is 90×49 raw, so fitting its width to 66 left it only ~36 tall — visibly squat
+// next to the camera (~41) and half the resolved shield (~70), which is what "the game pad
+// height is too little" refers to. Floor the normalized HEIGHT so a wide shape is allowed to
+// exceed NSIZE in width rather than collapse vertically. It only affects shapes that would
+// land under the floor (the controller, and the camera by a hair); the bubble and handset are
+// already well above it, and the shield finale is untouched as ever.
+const NMIN_H = 44;
 const round2 = (n: number): number => Math.round(n * 100) / 100;
 function pathBox(d: string): { cx: number; cy: number; w: number; h: number } {
   const n = (d.match(/-?\d*\.?\d+/g) ?? []).map(Number);
@@ -126,7 +134,10 @@ function mapPath(d: string, fn: (x: number, y: number) => [number, number]): str
 }
 function normScale(d: string): number {
   const b = pathBox(d);
-  return NSIZE / Math.max(b.w, b.h);
+  const s = NSIZE / Math.max(b.w, b.h);
+  // Raise a shape that would end up shorter than the floor, keeping its own aspect (it simply
+  // grows wider too) — uniform scale is preserved, only the fitted dimension changes.
+  return b.h > 0 && b.h * s < NMIN_H ? NMIN_H / b.h : s;
 }
 function normalize(d: string): string {
   const b = pathBox(d), s = normScale(d);

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -785,7 +785,7 @@ export async function reactToMessage(
  *  notifyIncoming so mute / per-chat prefs / hidden / settle all apply and the
  *  alert can NEVER escalate (a reaction is not a mention). Deliberately no unread
  *  or badge change: a reaction is not a message (spec 1048 clarification). */
-async function handleReaction(from: string, signal: ReactionSignal): Promise<void> {
+async function handleReaction(from: string, signal: ReactionSignal, relayedAt?: number): Promise<void> {
   const message = await getMessage(signal.messageId);
   if (!message) return; // we don't have that message (yet), drop it
   applyReaction(message, from, signal.emoji, !!signal.remove, signal.at);
@@ -797,12 +797,18 @@ async function handleReaction(from: string, signal: ReactionSignal): Promise<voi
       const name = (await getContact(from))?.name ?? 'Someone';
       chat.lastMessage = `${name.split(' ')[0]} reacted ${signal.emoji} to "${previewText(message)}"`;
       chat.lastKind = 'reaction';
-      chat.lastMessageTime = signal.at;
+      // (spec 2057) `signal.at` is the REACTOR's clock. Spec 2056 reconciled message timestamps
+      // against the relay's receive time but not signals, so a reaction from a device running an
+      // hour behind drove this chat's lastMessageTime an hour BACKWARDS — and since the chats
+      // list sorts on it, the chat sank down the list instead of rising to the top on a brand-new
+      // interaction. Reconcile it the same way.
+      const reactedAt = resolveIncomingTimestamp(signal.at, relayedAt);
+      chat.lastMessageTime = reactedAt;
       // (spec 2054) THE reported bug: an INCOMING reaction left the previous outgoing message's
       // tick in place, so the row read "✓ Kambiz reacted 👍 to …" — a delivery mark on someone
       // else's activity. Incoming activity never shows a tick.
       chat.lastTick = 'none';
-      chat.updatedAt = signal.at;
+      chat.updatedAt = reactedAt; // (spec 2057) same reconciled time — this drives own-sync LWW
       await put('chats', chat);
 
       const selfId = getSelfUserId() ?? '';
@@ -1419,7 +1425,7 @@ export async function resignGame(chatId: string, messageId: string): Promise<voi
  *  (data-model rule 1). 1:1 sessions: only the conversation's peer plays.
  *  Explicit-players sessions (spec 0009 challenges): seats map by userId and
  *  non-players are dropped, never out-of-sync. */
-async function handleGameMove(from: string, signal: GameMoveSignal): Promise<void> {
+async function handleGameMove(from: string, signal: GameMoveSignal, relayedAt?: number): Promise<void> {
   const message = await getMessage(signal.messageId);
   if (!message?.game) return;
   const chat = await getChat(message.chatId);
@@ -1499,9 +1505,12 @@ async function handleGameMove(from: string, signal: GameMoveSignal): Promise<voi
             : `${by}made a move 🎲`;
   chat.lastMessage = text;
   chat.lastKind = 'game';
-  chat.lastMessageTime = signal.at;
+  // (spec 2057) Reconciled against the relay's receive time, like every other incoming
+  // activity: a mover whose clock runs behind must not drag this chat down the list.
+  const movedAt = resolveIncomingTimestamp(signal.at, relayedAt);
+  chat.lastMessageTime = movedAt;
   chat.lastTick = 'none'; // (spec 2054) incoming game activity → never a delivery tick
-  chat.updatedAt = signal.at;
+  chat.updatedAt = movedAt;
   await put('chats', chat);
 
   // NOTIFICATIONS (spec 0009 FR-005/FR-006/FR-009): players get their turn and
@@ -6372,7 +6381,7 @@ async function receiveIncomingInner(
   // Emoji reactions → mutate the target message, never a stored message. (A group
   // reaction also carries groupId; the messageId lookup handles either case.)
   if (payload.reaction) {
-    await handleReaction(from, payload.reaction);
+    await handleReaction(from, payload.reaction, relayedAt);
     if (remoteId) await markInboundSeen(remoteId);
     return;
   }
@@ -6384,7 +6393,7 @@ async function receiveIncomingInner(
   }
   // Game moves/resignations → mutate the target game bubble, never a stored message.
   if (payload.gameMove) {
-    await handleGameMove(from, payload.gameMove);
+    await handleGameMove(from, payload.gameMove, relayedAt);
     if (remoteId) await markInboundSeen(remoteId);
     return;
   }

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -519,9 +519,13 @@ export function installTestHook(): void {
     /** (spec 2054) A chat's denormalized list-row summary — the preview text/kind plus the
      *  delivery tick tier the Chats row and pinned tile render. Lets a test assert that an
      *  INCOMING activity preview (a reaction, a game move, a call) carries no tick. */
-    chatRow: async (chatId: string): Promise<{ lastMessage?: string; lastKind?: string; lastTick?: string } | null> => {
+    chatRow: async (
+      chatId: string,
+    ): Promise<{ lastMessage?: string; lastKind?: string; lastTick?: string; lastMessageTime?: number } | null> => {
       const c = (await listChats()).find((x) => x.id === chatId);
-      return c ? { lastMessage: c.lastMessage, lastKind: c.lastKind, lastTick: c.lastTick } : null;
+      return c
+        ? { lastMessage: c.lastMessage, lastKind: c.lastKind, lastTick: c.lastTick, lastMessageTime: c.lastMessageTime }
+        : null;
     },
     /** The unread badge total (countUnread) — for hidden-chat badge-mode asserts. */
     unreadBadge: (): Promise<number> => dbCountUnread(),


### PR DESCRIPTION
## Ring 1.0.31

### Fixed

**A reaction now lifts the chat to the top of the list, whatever the sender's clock says** (spec 2057)

Reported as "when a reaction arrives while I'm on the Chats list, the notification shows but that chat's preview doesn't update until I switch away and come back".

It was never a rendering fault — the row's text refreshes within about a second in every flow. What failed was the chat's **position**. An A/B run on a three-chat list, with the reactor's clock an hour behind:

| | list order after the reaction | reacted chat's position |
|---|---|---|
| before | Dave, Carol, **Bob** | 2 (bottom) |
| after | **Bob**, Dave, Carol | 0 (top) |

The preview refreshed live in *both* runs. To a reader scanning the top of the list, an updated row sitting far down is indistinguishable from a row that never updated.

Cause: 1.0.30 (spec 2056) reconciled *message* timestamps against the relay's receive time, but not *signals*. A reaction carries its own time from the sender's device and that goes straight into the chat's last-interaction time, which the list sorts on — so a reaction from the same hour-behind phone pushed the chat an hour into the past (`-60 min` → `0 min`). Now reconciled the same way, for reactions and game moves. Own reactions and per-signal last-write-wins are unchanged.

**Intro animation: the game pad no longer reads squat**

Every montage silhouette is uniform-scaled so its *longest* edge fits one shared box, which punishes a wide, short shape. The controller is 90×49 raw, so fitting its width left it ~36 tall — the shortest symbol in the sequence. Normalized heights:

| symbol | before | after |
|---|---|---|
| bubble | 61.9 | 61.9 |
| handset | 63.5 | 63.5 |
| camera | 40.8 | 44.0 |
| **controller** | **35.9** | **44.0** |
| shield (finale) | 70.5 | 70.5 — untouched |

### Verification

Full CI green on #1105 including the Playwright e2e suite; 1268 unit tests; server build + vet. The A/B scenario fails on the pre-fix tree and passes after. Spec 2056's scenario re-run and still passing.

### Zero-knowledge

Nothing new on the wire — reuses the relay-receive time already added in 1.0.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i