### PR TITLE
Release 1.0.32

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,6 +83,7 @@ Specs are grouped by category band; status moves
 | [1055](specs/1055-ciphertext-push-instant/spec.md) | Instant rich notifications (bounded encrypted preview in push) | 🟡 in-progress |
 | [1062](specs/1062-list-status-presence/spec.md) | Message status and presence on the chat list | 🟢 shipped |
 | [1063](specs/1063-full-size-media/spec.md) | Full-size aspect-preserving media thumbnails in chat | 🟡 in-progress |
+| [1064](specs/1064-mention-names/spec.md) | Mentions show the name you know someone by, and stay readable | 🔵 in-review |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 
@@ -143,4 +144,4 @@ Specs are grouped by category band; status moves
 | [2054](specs/2054-incoming-tick/spec.md) | No delivery tick beside an incoming activity in the chats list | 🟢 shipped |
 | [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🟢 shipped |
 | [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🟢 shipped |
-| [2057](specs/2057-signal-clock/spec.md) | Reactions and game moves still trust the sender's clock | 🔵 in-review |
+| [2057](specs/2057-signal-clock/spec.md) | Reactions and game moves still trust the sender's clock | 🟢 shipped |

--- a/drive/driver.mjs
+++ b/drive/driver.mjs
@@ -126,17 +126,19 @@ export async function newClient({ mobile = false, label = '?' } = {}) {
  * context and return the Client. Always mints a fresh dev invite code, so reruns
  * never collide. Optionally sets a display name (+ a blank avatar).
  */
-export async function createAccount({ mobile = false, name, label } = {}) {
+export async function createAccount({ mobile = false, name, label, username } = {}) {
   const c = await newClient({ mobile, label: label ?? name ?? 'acct' });
   await c.page.goto('/');
   await c.page.waitForFunction(() => !!window.__ringTest, null, { timeout: 30_000 }); // sync predicate → OK
-  await c.page.evaluate(async (nm) => {
+  await c.page.evaluate(async ([nm, un]) => {
     const t = window.__ringTest;
     const code = await t.freshCode();
-    await t.register(code);
+    // `username` lets a scenario pin the directory handle — e.g. one containing a DOT, which
+    // is legal but was mishandled by the mention parser (spec 1064).
+    await t.register(code, un ?? undefined);
     await t.createAuto();
     if (nm) await t.setProfile(nm, 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>');
-  }, name);
+  }, [name, username]);
   await poll(() => c.page.evaluate(() => window.__ringTest.isUnlocked()), (v) => v === true, { label: `${c.label} unlocked` });
   c.id = await c.page.evaluate(() => window.__ringTest.selfId());
   if (!c.id) throw new Error(`${c.label}: no self id after registration`);

--- a/drive/scenarios/mention-names-1064.mjs
+++ b/drive/scenarios/mention-names-1064.mjs
@@ -1,0 +1,95 @@
+/**
+ * Spec 1064 — an @mention of a DOTTED handle must resolve: render as the person's name, be
+ * tappable, and (the part that actually matters) register in the message's `mentions` array so
+ * the mention notification fires at all.
+ *
+ * Before the fix the handle charset stopped at the dot, so `@parham.hoseini` matched only
+ * `parham`, resolved to nobody, rendered as raw text — and stored an EMPTY mentions array, which
+ * is what marks the frame as a mention. The mentioned person was never notified.
+ *
+ * Also checks that a LOCAL RENAME wins, since that is the name you know someone by.
+ *
+ *   node drive/scenarios/mention-names-1064.mjs
+ */
+import { createAccount, pair, group, poll, shot, sweep, done } from '../driver.mjs';
+
+// Handles are claimed for good on the dev directory, so keep them unique per run — while
+// preserving the SHAPES under test: one with a DOT, one with underscore+digits.
+const n = String(Date.now()).slice(-6);
+const dotted = `parham.hoseini${n}`;
+const plain = `ashk_1989_${n}`;
+
+const alice = await createAccount({ name: 'Alice' }); // desktop: Enter sends
+const parham = await createAccount({ name: 'Parham', username: dotted });
+const ashkan = await createAccount({ name: 'Ashkan', username: plain });
+
+await pair(alice, parham);
+await pair(alice, ashkan);
+const gid = await group(alice, 'Family', [parham, ashkan]);
+
+// Handles hydrate from the directory in the background; mentions resolve BY handle, so wait for
+// both to land before composing (the picker is likewise empty until then).
+for (const c of [parham, ashkan]) {
+  await poll(
+    () => alice.page.evaluate((id) => window.__ringTest.contactUsername(id), c.id),
+    (u) => !!u,
+    { timeout: 20_000, label: `${c.label} handle hydrated on Alice` },
+  );
+}
+
+// Alice renames Parham locally — a mention must show HER name for him, not the directory one.
+await alice.page.evaluate((id) => window.__ringTest.setContactLocalProfile(id, 'Dadi'), parham.id);
+
+// Send through the REAL composer — resolveMentions (the fix) lives in the chat page, so a
+// testhook send would bypass exactly what we are verifying.
+await alice.page.goto(`/chat/${gid}`);
+await alice.page.waitForSelector('ion-textarea.composer', { timeout: 15_000 });
+await alice.page.waitForTimeout(600);
+await alice.page.locator('ion-textarea.composer').click();
+await alice.page.keyboard.type(`salam @${dotted} and @${plain}`);
+await alice.page.waitForTimeout(300);
+await alice.page.keyboard.press('Enter');
+
+// 1) The STORED mentions array must contain BOTH ids — this is what drives the mention
+//    notification, the mute-piercing frame class and the "@" badge.
+const stored = await poll(
+  () => alice.page.evaluate((g) => window.__ringTest.messages(g), gid),
+  (ms) => ms.some((m) => (m.body ?? '').includes('salam @')),
+  { timeout: 20_000, label: 'message stored' },
+);
+const sent = stored.find((m) => (m.body ?? '').includes('salam @'));
+const ids = sent.mentions ?? [];
+console.log('[1064] stored mentions:', ids.length, 'of 2 expected');
+if (!ids.includes(parham.id)) throw new Error('FAIL: the DOTTED handle did not register a mention');
+if (!ids.includes(ashkan.id)) throw new Error('FAIL: the underscore handle regressed');
+
+// 2) The bubble must render NAMES, not handles — and the local rename must win.
+await alice.page.waitForTimeout(1500);
+const chips = await alice.page.evaluate(() =>
+  Array.from(document.querySelectorAll('.mention')).map((e) => e.textContent?.trim()),
+);
+const bodyText = await alice.page.evaluate(() =>
+  Array.from(document.querySelectorAll('.bubble')).map((e) => e.textContent?.trim()).join(' | '),
+);
+console.log('[1064] mention chips rendered:', JSON.stringify(chips));
+if (!chips.includes('@Dadi')) throw new Error(`FAIL: local rename not used — chips were ${JSON.stringify(chips)}`);
+if (!chips.includes('@Ashkan')) throw new Error(`FAIL: control mention missing — ${JSON.stringify(chips)}`);
+if (bodyText.includes(dotted) || bodyText.includes(plain)) throw new Error('FAIL: a raw handle is still on screen');
+
+// 3) Parham's device must see itself mentioned (the notification/badge precondition).
+const his = await poll(
+  () => parham.page.evaluate((g) => window.__ringTest.messages(g), gid),
+  (ms) => ms.some((m) => (m.body ?? '').includes('salam @')),
+  { timeout: 20_000, label: 'delivered to Parham' },
+);
+const hisCopy = his.find((m) => (m.body ?? '').includes('salam @'));
+if (!(hisCopy.mentions ?? []).includes(parham.id)) {
+  throw new Error('FAIL: the recipient copy does not carry the mention');
+}
+console.log('[1064] recipient copy carries the mention ✓');
+
+console.log('[1064] PASS — dotted handle mentions resolve, render by local name, and notify ✓');
+await shot(alice, 'mention-names-1064', { route: `/chat/${gid}` });
+
+await sweep([alice, parham, ashkan]);
+await done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/1064-mention-names/spec.md
+++ b/specs/1064-mention-names/spec.md
@@ -1,0 +1,162 @@
+# Feature Specification: Mentions show the name you know someone by, and stay readable
+
+**Feature Branch**: `feat/1064-mention-names`
+
+**Created**: 2026-07-28
+
+**Status**: in-review
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User request (with screenshots): "When tagging someone in a message, let's use their defined name in a hyperlinked manner which opens their contact info, if a user has customized the name for them let's use their defined customized name as well, let's make the tags bold and green as the logo color if possible in the chat bubbles as long as it doesn't collide with background color and become hard to read in bright or dark themes, do the same for in app notifications as well."
+
+## Context: why this exists
+
+Spec 1020 already built most of what was asked: a mention resolves to the member's **current display name**, renders as a tappable chip that opens their contact page, and is styled in the brand green. The request landed because in practice it didn't look like that — the reporter's screenshot shows a bare `@parham.hoseini`. Three gaps explain it.
+
+**1. The handle charset excluded dots — and this is not cosmetic.** A username may legally contain interior dots (`^[A-Za-z0-9_](?:[A-Za-z0-9_.]{1,28}[A-Za-z0-9_])$`, enforced identically on client and server). But all four places that read a handle used `[a-zA-Z0-9_]+`, so `@parham.hoseini` matched only as `@parham`, which resolves to nobody. The visible symptom was raw text. The invisible one was worse: the same narrow charset is used by the **send-time resolve**, so the message stored an **empty mentions array** — and that array is what marks the frame as a mention. A person whose handle contains a dot was therefore never notified, never pierced a mute, and never lit the "@" badge. Every handle built from letters, digits and underscores worked; only dotted ones silently failed. Verified by A/B: pre-fix a message mentioning one dotted and one underscore handle registered **1 of 2**; post-fix, **2 of 2**.
+
+**2. The brand green is unreadable on the light bubbles.** The reporter's proviso — "as long as it doesn't collide with background colour" — was already being violated. The brand green `#10b981` is a *light* green; measured against the bubbles:
+
+| bubble | contrast | |
+|---|---|---|
+| dark incoming `#232d33` | 5.54:1 | fine |
+| dark outgoing `#103a2c` | 4.98:1 | fine |
+| light incoming `#e7e8ec` | **2.07:1** | unreadable |
+| light outgoing `#d6f3cc` | **2.12:1** | unreadable |
+
+Separately, the "mentions me" pill painted white text on the brand green — **2.54:1**, also failing, in the theme where it is most used.
+
+**3. Notifications showed the raw handle.** The chat bubble resolved names; the notification body was the message text verbatim, so a mention read as a directory handle in exactly the surface where you have least context.
+
+Nothing here needs new data: `Contact.name` already holds the local rename, so "use their customized name" falls out of resolving at display time on each device.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Mentioning someone actually notifies them (Priority: P1)
+
+I @mention a group member and they are alerted, whatever their handle looks like.
+
+**Why this priority**: Silent failure of the core purpose of a mention. The sender believes they got someone's attention; the recipient never hears about it.
+
+**Independent Test**: In a group, mention one member whose handle contains a dot and one whose doesn't; confirm both are recorded as mentioned on the sender's and recipients' copies.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member whose handle contains a dot, **When** I mention them, **Then** the message records them as mentioned and they are alerted.
+2. **Given** a member with a plain handle, **When** I mention them, **Then** behaviour is unchanged.
+3. **Given** I type a dotted handle, **When** the autocomplete is open, **Then** it stays open across the dot and completes the whole handle.
+
+---
+
+### User Story 2 - A mention reads as the person, not a handle (Priority: P1)
+
+A mention displays the name I know that person by — including a name I set myself — and tapping it opens their contact info.
+
+**Why this priority**: The stated request, and the visible half of the same defect.
+
+**Independent Test**: Rename a contact locally, mention them, and confirm the bubble shows the local name and no raw handle.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mentioned contact, **When** the message renders, **Then** it shows their display name, not the handle.
+2. **Given** I renamed that contact locally, **Then** my name for them is used.
+3. **Given** a rendered mention, **When** I tap it, **Then** their contact page opens.
+4. **Given** an "@word" that matches nobody, **Then** it stays ordinary text.
+5. **Given** an email address in a message, **Then** it is never treated as a mention (it remains its own tappable entity).
+
+---
+
+### User Story 3 - Mentions stay readable in both themes (Priority: P2)
+
+Mentions are bold and brand-coloured, and legible on every bubble in light and dark.
+
+**Why this priority**: Explicitly asked for, and today's colour fails in light mode.
+
+**Independent Test**: View a mention on incoming and outgoing bubbles in both themes and check contrast.
+
+**Acceptance Scenarios**:
+
+1. **Given** either theme, **When** a mention renders, **Then** its contrast against the bubble meets at least 4.5:1.
+2. **Given** a mention of me, **When** it renders as a filled pill, **Then** the pill's text also meets 4.5:1.
+3. **Given** either theme, **Then** the mention still reads as the brand accent, bold.
+
+---
+
+### User Story 4 - Notifications name the person too (Priority: P3)
+
+A notification mentioning someone shows their name rather than a handle.
+
+**Why this priority**: Requested, and the surface with least surrounding context — but it follows the same resolution as the bubble.
+
+**Independent Test**: Trigger a notification for a message containing a mention and confirm the body shows the name.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message containing a mention, **When** it surfaces as an in-app banner, **Then** the mention shows the display name.
+2. **Given** the same message arriving via push, **Then** the system notification also shows the name.
+3. **Given** an unresolvable handle, **Then** the notification text is left untouched.
+
+---
+
+### Edge Cases
+
+- **A trailing sentence period** after a handle must not be absorbed into it.
+- **An email address** must never be parsed as a mention — a live hazard now that dots are legal.
+- **A handle must not begin or end with a dot**, matching the username rule.
+- **Consecutive mentions** separated by one space must all resolve.
+- **A handle that resolves to nobody** must render and read as plain text everywhere.
+- **Mentions remain a group concept** (unchanged from spec 1020); 1:1 chats are not in scope.
+
+## Zero-Knowledge Impact *(mandatory)*
+
+- **What crosses the wire**: unchanged. The message body still carries the handle the sender typed, alongside the existing list of mentioned ids. No new field.
+- **Where processing happens**: entirely on-device. Each device resolves handles against its OWN contacts, which is also why a local rename shows only to the person who set it.
+- **Unavoidably-visible metadata**: unchanged. No new lookup leaves the device; the mentioned ids were already part of the sealed payload.
+- **Why it stays zero-knowledge**: display-time naming from data already held locally.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Handle parsing MUST accept the full username charset, including interior dots, and MUST be defined once and shared by rendering, autocomplete, insertion and send-time resolution so they cannot diverge.
+- **FR-002**: A mention of a dotted handle MUST be recorded in the message's mentions, so the mention alert, mute-piercing and "@" badge behave as for any other handle.
+- **FR-003**: A handle MUST require a start-or-whitespace boundary, so an email address is never parsed as a mention.
+- **FR-004**: A rendered mention MUST show the mentioned person's display name, preferring a locally set name.
+- **FR-005**: A rendered mention MUST open that person's contact page when tapped.
+- **FR-006**: A mention MUST be bold and brand-accented, with at least 4.5:1 contrast against every bubble background in both themes.
+- **FR-007**: The "mentions me" pill MUST meet the same contrast bar for its own text.
+- **FR-008**: Notification bodies (in-app and system) MUST show mention display names, leaving unresolvable handles untouched.
+- **FR-009**: Text that resolves to nobody MUST remain plain text.
+
+### Key Entities *(include if feature involves data)*
+
+- **Handle**: the directory username, unchanged. This spec only fixes what counts as one when reading text.
+- **Contact.name**: already the locally-renamed name; reused as the mention's display name. No schema change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A mention of a dotted handle registers as a mention (A/B: 1-of-2 before, 2-of-2 after).
+- **SC-002**: A rendered mention shows the display name, with a local rename winning, and no raw handle remains on screen.
+- **SC-003**: Tapping a mention opens that contact.
+- **SC-004**: Mention contrast is at least 4.5:1 on all four bubble backgrounds, and for the pill's text.
+- **SC-005**: Notification bodies show mention names.
+- **SC-006**: Email addresses and unmatched "@word" text are unaffected.
+
+## Assumptions
+
+- Resolving names per device is correct: a local rename is personal, so the sender and recipient may legitimately see different names for the same mention.
+- A still-unresolvable handle is better left verbatim than guessed at.
+- Matching the username charset exactly is safer than a looser pattern, which would start eating punctuation.
+
+## Out of Scope
+
+- Mentions in 1:1 chats (a deliberate spec 1020 decision).
+- Rewriting the stored message body to contain names — the handle stays the durable reference so each device can resolve it independently.
+- Restyling other accented inline text (links, phone/email entities), which share the brand colour and the same light-theme weakness.
+- Mention autocomplete ranking or an @everyone redesign.

--- a/specs/2057-signal-clock/spec.md
+++ b/specs/2057-signal-clock/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-28
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -40,6 +40,7 @@ import { setCompressProgress, setUploadProgress, resetJobProgress, clearJobProgr
 import { readVideoMeta, readImageMeta, generateVideoPoster, makeImageThumb, deriveTiers, blobToDataUrl } from '@/utils/media-meta';
 import { createLimiter, createByteBudget, raceTimeout } from '@/utils/concurrency';
 import { resolveIncomingTimestamp, senderClockIsSkewed } from '@/utils/message-time';
+import { substituteMentionNames, mentionNameResolver } from '@/utils/mention';
 import { THUMB_TIERS, isOwnThumbnail } from '@/utils/thumbs';
 import { notifyPreview } from '@/utils/notify-preview';
 import { firstLink, buildLinkPreview, shouldBuildLinkPreview } from '@/services/link-preview';
@@ -6639,6 +6640,16 @@ async function receiveIncomingInner(
   // incoming item is never acked/drained before it has been surfaced to the user
   // (the message is also already persisted above, so it is never lost either way).
   // A notify error must never block the ack/dedup that follow, so it's swallowed.
+  // (spec 1064) Render @mentions in the notification with the name this device knows the person
+  // by (a local rename included), matching the chat bubble. Only the ids this message actually
+  // mentions are looked up — usually none, at most a couple — so the receive path stays light.
+  let notifyBody = notifyPreview(payload);
+  if (payload.mentions?.length) {
+    const named = (await Promise.all(payload.mentions.map((id) => getContact(id)))).filter(
+      (c): c is Contact => !!c,
+    );
+    notifyBody = substituteMentionNames(notifyBody, mentionNameResolver(named));
+  }
   await notifyIncoming({
     kind: 'message',
     chatId: targetChatId,
@@ -6647,7 +6658,7 @@ async function receiveIncomingInner(
     name: chat?.isGroup ? chat.name : contact.name,
     // The notification spells out shared location / contact / poll (no icon to lean
     // on), unlike the terser `preview` used for the chats list above.
-    body: isGroupMsg ? `${contact.name}: ${notifyPreview(payload)}` : notifyPreview(payload) || 'New message',
+    body: isGroupMsg ? `${contact.name}: ${notifyBody}` : notifyBody || 'New message',
     // @mentions (spec 1020): a mention escalates past mute/quiet and names the mentioner.
     // A direct reply to my message (spec 1048) escalates identically, with its own wording.
     mention: selfMentioned,

--- a/src/services/sw-inbox.ts
+++ b/src/services/sw-inbox.ts
@@ -36,6 +36,7 @@ import { readHiddenSet, readHiddenSetOrNull } from './hidden-chats';
 import { readSessionToken, readSessionUserId } from './session';
 import { get, getAll, put } from '@/db/idb';
 import { notifyPreview } from '@/utils/notify-preview';
+import { substituteMentionNames, mentionNameResolver } from '@/utils/mention';
 import { GAMES } from '@/games/registry';
 import { applySignal as applyGameSignal, deriveStatus as deriveGameStatus } from '@/games/session';
 import { playerIndexOf, lockOpponent, buildWallSession, challengePhase, type WallGameRow } from '@/games/challenge';
@@ -367,6 +368,9 @@ export function noteForPayload(
   const showGroups = surfaces?.showGroups !== false;
   const from = f.from as string;
   const known = contacts.find((c) => c.id === from)?.name;
+  // (spec 1064) Show @mentions by the name this device knows the person by — including a local
+  // rename — so a push reads like the chat bubble instead of exposing a raw directory handle.
+  const mentionNames = (t: string): string => substituteMentionNames(t, mentionNameResolver(contacts));
 
   // Friend request (ContactCard 'request') always surfaces, like the live path.
   if (payload.card) {
@@ -664,7 +668,9 @@ export function noteForPayload(
       note: {
         ids: [f.id as string],
         title: groupChat?.name || 'Group',
-        body: showText ? `${senderName} ${verb}: ${notifyPreview(payload)}` : `${senderName} ${verb}`,
+        body: showText
+          ? `${senderName} ${verb}: ${mentionNames(notifyPreview(payload))}`
+          : `${senderName} ${verb}`,
         url: chat?.id ? `/chat/${chat.id}` : '/tabs/chats',
         tag: chat?.id ? `ring:${chat.id}` : `ring:from:${from}`,
       },
@@ -682,7 +688,7 @@ export function noteForPayload(
   // Show the decrypted text only when the chat allows full content AND the global
   // "Show preview" is on (most-private-wins); otherwise a content-free placeholder.
   const showText = content === 'full' && showPreview;
-  const preview = showText ? notifyPreview(payload) : 'New message';
+  const preview = showText ? mentionNames(notifyPreview(payload)) : 'New message';
   const chatId = chat?.id;
   // "Show preview" off hides WHO it's from too, not just the body: use a generic title instead of
   // the sender / group name. (Hidden chats and @mentions are handled above and keep their own rules.)

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -560,6 +560,10 @@ export function installTestHook(): void {
         senderId: m.senderId,
         outgoing: m.outgoing,
         reactions: m.reactions ?? [],
+        // (spec 1064) the resolved @mention ids — what actually drives the mention
+        // notification, the mute-piercing frame class and the "@" badge.
+        mentions: m.mentions ?? [],
+        mentionsEveryone: !!m.mentionsEveryone,
         replyTo: m.replyTo ?? null,
         albumId: m.albumId ?? null,
         expiresAt: m.expiresAt ?? null, // disappearing messages: when this self-destructs
@@ -1049,6 +1053,9 @@ export function installTestHook(): void {
     /** A contact's display name (to verify profiles propagated), or '' if none.
      *  Reads the contact record directly (listContacts hides ghosted ones). */
     contactName: async (id: string): Promise<string> => (await dbGetContact(id))?.name ?? '',
+    /** (spec 1064) A contact's directory handle, or '' until it has been hydrated. Mentions
+     *  resolve by handle, so a test must wait for this before composing one. */
+    contactUsername: async (id: string): Promise<string> => (await dbGetContact(id))?.username ?? '',
     /** Set a LOCAL name/avatar override for a contact. */
     setContactLocalProfile: (id: string, name?: string, avatar?: string) => dbSetContactLocalProfile(id, { name, avatar }),
     /** Reset a contact to the peer's CURRENT name/photo (revert + re-pull from directory). */

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -27,6 +27,13 @@
      bleed through the text. Incoming = light grey, outgoing = soft green. */
   --app-bubble-in: #e7e8ec;
   --app-bubble-out: #d6f3cc;
+  /* (spec 1064) @mention accent. The brand green is the right colour for a mention, but it is a
+     LIGHT green: on the pale bubbles it lands at ~2.1:1, which is unreadable. So light mode uses a
+     darkened brand green (~5.4:1 on both bubbles) while dark mode keeps the brand green itself
+     (~5.0–5.5:1 there). --app-mention-contrast is the text colour for the filled "mentions me"
+     pill, which flips with the accent's own lightness rather than being assumed white. */
+  --app-mention: #0a6b48;
+  --app-mention-contrast: #ffffff;
   /* Wall pending/unfinished post card — a warm amber so an unsent, uploading or failed post reads
      as "not final yet" against the settled green posts. Opaque, like the bubbles, for legible text. */
   --app-bubble-pending: #ffe6ad;
@@ -63,6 +70,10 @@
   /* Opaque dark bubbles (WhatsApp-style): grey incoming, deep-green outgoing. */
   --app-bubble-in: #232d33;
   --app-bubble-out: #103a2c;
+  /* (spec 1064) On the dark bubbles the brand green IS the readable choice. The pill's text goes
+     BLACK here: white on the brand green is only ~2.5:1, whereas black reaches ~8.3:1. */
+  --app-mention: var(--ion-color-primary);
+  --app-mention-contrast: #000000;
   /* Deep amber pending card for dark mode (mirrors the light --app-bubble-pending). */
   --app-bubble-pending: #43320c;
   /* Game cards, dark (spec 1033 handoff). */

--- a/src/utils/mention.test.ts
+++ b/src/utils/mention.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { findMentions, mentionQueryAt, replaceMentionQuery, substituteMentionNames } from './mention';
+
+const handles = (t: string): string[] => findMentions(t).map((m) => m.handle);
+
+describe('findMentions (spec 1064)', () => {
+  it('reads a DOTTED handle whole — the reported bug', () => {
+    // Previously the charset stopped at the dot, yielding "parham", which matches no member:
+    // the mention rendered as raw text and the send-time resolve produced an EMPTY mentions
+    // array, so the mentioned person was never notified.
+    expect(handles('Khosh oomadi dayi @parham.hoseini')).toEqual(['parham.hoseini']);
+  });
+
+  it('still reads the handle shapes that already worked', () => {
+    expect(handles('@sonia hi')).toEqual(['sonia']);
+    expect(handles('hey @ashk_1989')).toEqual(['ashk_1989']);
+    expect(handles('@amir1353 and @sb74ptud')).toEqual(['amir1353', 'sb74ptud']);
+    expect(handles('@shahdokht_1331')).toEqual(['shahdokht_1331']);
+  });
+
+  it('does not swallow a sentence-ending period', () => {
+    expect(handles('ask @parham.hoseini.')).toEqual(['parham.hoseini']);
+    expect(handles('ask @sonia.')).toEqual(['sonia']);
+  });
+
+  it('never mistakes an email address for a mention (the dot-charset hazard)', () => {
+    // Emails render as their own tappable entity; a mention must not eat one.
+    expect(handles('mail me at foo@bar.com')).toEqual([]);
+    expect(handles('foo@bar.com')).toEqual([]);
+  });
+
+  it('requires a start-or-whitespace boundary', () => {
+    expect(handles('a@b')).toEqual([]);
+    expect(handles('@b')).toEqual(['b']);
+    expect(handles('x @b')).toEqual(['b']);
+  });
+
+  it('finds consecutive mentions separated by a single space', () => {
+    expect(handles('@a.b @c_d @e')).toEqual(['a.b', 'c_d', 'e']);
+  });
+
+  it('reports offsets that slice the token exactly', () => {
+    const text = 'hi @parham.hoseini there';
+    const [m] = findMentions(text);
+    expect(text.slice(m.start, m.end)).toBe('@parham.hoseini');
+    expect(text.slice(0, m.start)).toBe('hi ');
+    expect(text.slice(m.end)).toBe(' there');
+  });
+
+  it('handles a mention at the very start of the text', () => {
+    const [m] = findMentions('@sonia hello');
+    expect(m.start).toBe(0);
+    expect(m.handle).toBe('sonia');
+  });
+
+  it('ignores a bare @ and a handle that would start with a dot', () => {
+    expect(handles('@ ')).toEqual([]);
+    expect(handles('@.foo')).toEqual([]);
+  });
+});
+
+describe('mentionQueryAt', () => {
+  it('opens on a bare @ and tracks the query as it is typed', () => {
+    expect(mentionQueryAt('@')).toBe('');
+    expect(mentionQueryAt('hi @par')).toBe('par');
+  });
+
+  it('stays open across the dot, so a dotted handle can be completed', () => {
+    expect(mentionQueryAt('hi @parham.')).toBe('parham.');
+    expect(mentionQueryAt('hi @parham.hos')).toBe('parham.hos');
+  });
+
+  it('closes once the mention is finished or the caret leaves it', () => {
+    expect(mentionQueryAt('hi @parham.hoseini ')).toBeNull();
+    expect(mentionQueryAt('hi there')).toBeNull();
+    expect(mentionQueryAt('')).toBeNull();
+  });
+
+  it('does not open inside an email address', () => {
+    expect(mentionQueryAt('foo@bar')).toBeNull();
+  });
+});
+
+describe('replaceMentionQuery', () => {
+  it('completes a partial handle and leaves a trailing space', () => {
+    expect(replaceMentionQuery('hi @par', 'parham.hoseini')).toBe('hi @parham.hoseini ');
+  });
+
+  it('completes from a partially typed DOTTED handle', () => {
+    expect(replaceMentionQuery('hi @parham.', 'parham.hoseini')).toBe('hi @parham.hoseini ');
+  });
+
+  it('completes a bare @ at the start', () => {
+    expect(replaceMentionQuery('@', 'sonia')).toBe('@sonia ');
+  });
+
+  it('leaves earlier text and mentions untouched', () => {
+    expect(replaceMentionQuery('yo @a.b and @so', 'sonia')).toBe('yo @a.b and @sonia ');
+  });
+});
+
+describe('substituteMentionNames (spec 1064)', () => {
+  const names: Record<string, string> = { 'parham.hoseini': 'Parham', 'farhad_1328': 'Dadi' };
+  const nameFor = (h: string): string | undefined => names[h];
+
+  it('rewrites a dotted handle as the display name', () => {
+    expect(substituteMentionNames('Khosh oomadi dayi @parham.hoseini', nameFor)).toBe(
+      'Khosh oomadi dayi @Parham',
+    );
+  });
+
+  it('uses the LOCAL name for a renamed contact', () => {
+    // "Dadi" is a local rename of the contact whose handle is farhad_1328.
+    expect(substituteMentionNames('salam @farhad_1328', nameFor)).toBe('salam @Dadi');
+  });
+
+  it('rewrites several mentions and keeps the surrounding text', () => {
+    expect(substituteMentionNames('@parham.hoseini and @farhad_1328 both', nameFor)).toBe(
+      '@Parham and @Dadi both',
+    );
+  });
+
+  it('leaves an unknown handle exactly as written', () => {
+    expect(substituteMentionNames('hi @nobody there', nameFor)).toBe('hi @nobody there');
+  });
+
+  it('leaves an email address alone', () => {
+    expect(substituteMentionNames('mail foo@bar.com now', nameFor)).toBe('mail foo@bar.com now');
+  });
+
+  it('returns the text untouched when there are no mentions', () => {
+    expect(substituteMentionNames('just a message', nameFor)).toBe('just a message');
+  });
+
+  it('handles a name containing spaces', () => {
+    expect(substituteMentionNames('@parham.hoseini!', (h) => (h === 'parham.hoseini' ? 'Parham H' : undefined))).toBe(
+      '@Parham H!',
+    );
+  });
+});

--- a/src/utils/mention.ts
+++ b/src/utils/mention.ts
@@ -1,0 +1,115 @@
+/**
+ * (spec 1064) @mention handle parsing — ONE definition of what a handle looks like, shared by
+ * every site that reads or writes one.
+ *
+ * Why this module exists: the charset was previously inlined in four separate regexes (render,
+ * autocomplete query, pick-insert, and the send-time resolve), and all four omitted the dot that
+ * usernames are allowed to contain. A handle like `parham.hoseini` therefore matched only as
+ * `parham`, which resolves to nobody — so the mention rendered as raw text AND, far worse, the
+ * send-time resolve produced an EMPTY mentions array. That array is what marks the frame as a
+ * mention, so a person whose handle contains a dot was never notified, never pierced a mute, and
+ * never lit the "@" badge. Keeping the charset here means the render and the send can't disagree.
+ *
+ * The charset mirrors the username rule enforced by BOTH sides (`USERNAME_RE` in services/auth.ts
+ * and `usernameRE` in the server's internal/api/username.go): letters, digits and underscore,
+ * with dots allowed only INSIDE — never leading or trailing.
+ */
+
+/** A handle body: starts and ends with an alphanumeric/underscore, dots permitted between. */
+const HANDLE = '[A-Za-z0-9_](?:[A-Za-z0-9_.]*[A-Za-z0-9_])?';
+
+/**
+ * Handles must sit at the start of the text or follow whitespace. That boundary is what keeps an
+ * email address out of the mention path — now that dots are legal, an unguarded scan would read
+ * `foo@bar.com` as a mention of `bar.com`. Emails are recognised separately as tappable entities,
+ * so a mention must never swallow one.
+ */
+const SCAN = new RegExp(`(^|\\s)@(${HANDLE})`, 'g');
+
+/** While TYPING, a trailing dot is still a valid prefix (`@parham.` on the way to
+ *  `@parham.hoseini`), so the picker must stay open for it — unlike a completed handle. */
+const QUERY = /(?:^|\s)@([A-Za-z0-9_.]*)$/;
+
+export interface MentionToken {
+  /** The handle without the leading '@', exactly as written. */
+  handle: string;
+  /** Index of the '@' in the source text. */
+  start: number;
+  /** Index one past the last handle character. */
+  end: number;
+}
+
+/**
+ * Every @handle token in `text`, in order, with the offsets a renderer needs to slice around
+ * them. Offsets point at the '@' itself, not the boundary character before it.
+ */
+export function findMentions(text: string): MentionToken[] {
+  const out: MentionToken[] = [];
+  SCAN.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SCAN.exec(text))) {
+    const start = m.index + m[1].length; // skip the consumed boundary char (empty at string start)
+    const end = start + 1 + m[2].length;
+    out.push({ handle: m[2], start, end });
+    // Resume AT the token's end so the character following it can serve as the next boundary
+    // ("@a @b" must yield both), rather than after the boundary the engine would otherwise eat.
+    SCAN.lastIndex = end;
+  }
+  return out;
+}
+
+/** The @query being typed at the very end of `text` (caret position), or null when the caret
+ *  isn't in a mention. Empty string means "@" was just typed — the picker should open. */
+export function mentionQueryAt(text: string): string | null {
+  const m = QUERY.exec(text);
+  return m ? m[1] : null;
+}
+
+/** Replace the in-progress @query at the end of `text` with a chosen handle, leaving a trailing
+ *  space so typing continues naturally. Preserves the boundary character before the '@'. */
+export function replaceMentionQuery(text: string, username: string): string {
+  return text.replace(/(^|\s)@[A-Za-z0-9_.]*$/, `$1@${username} `);
+}
+
+/**
+ * (spec 1064) Rewrite `@handle` tokens as `@Display Name` for the handles `nameFor` recognises,
+ * so a notification reads the way the chat bubble does — with the name you know a person by,
+ * including a local rename — instead of a raw directory handle.
+ *
+ * Unknown handles are left exactly as written: a plain "@word" that resolves to nobody is not a
+ * mention and must not be reworded. Pure (no storage access) so the service worker can use it on
+ * the push path alongside the page.
+ */
+/** The minimum a directory entry needs for mention naming — structural, so both the page's
+ *  Contact rows and the service worker's copies satisfy it without importing the db types. */
+export interface MentionNamed {
+  name: string;
+  username?: string;
+}
+
+/** Build a handle → display-name resolver over the people this device knows. `name` is already
+ *  the locally-renamed name where one was set, so a rename flows through for free. */
+export function mentionNameResolver(people: readonly MentionNamed[]): (handle: string) => string | undefined {
+  const byHandle = new Map<string, string>();
+  for (const p of people) {
+    if (p.username && p.name) byHandle.set(p.username.toLowerCase(), p.name);
+  }
+  return (handle) => byHandle.get(handle);
+}
+
+export function substituteMentionNames(
+  text: string,
+  nameFor: (handle: string) => string | undefined,
+): string {
+  const toks = findMentions(text);
+  if (!toks.length) return text;
+  let out = '';
+  let last = 0;
+  for (const t of toks) {
+    const name = nameFor(t.handle.toLowerCase());
+    if (!name) continue; // not a known mention → leave the raw token in place
+    out += text.slice(last, t.start) + '@' + name;
+    last = t.end;
+  }
+  return out + text.slice(last);
+}

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -1270,6 +1270,7 @@ import { generateVideoPoster, generateImageThumb, isAnimatedImage } from '@/util
 import { type Quality } from '@/services/media-encode';
 import { openExternal } from '@/utils/external';
 import { segmentContacts, telHref, mailtoHref } from '@/utils/linkify';
+import { findMentions, mentionQueryAt, replaceMentionQuery } from '@/utils/mention';
 import { firstLink, buildLinkPreview } from '@/services/link-preview';
 import type { LinkPreview } from '@/services/crypto/message';
 import { presentEntityActions, type ContactEntity } from '@/services/entity-actions';
@@ -1879,7 +1880,6 @@ interface BodySeg {
   everyone?: boolean;
   contact?: ContactEntity; // spec 1029: a tappable phone number / email address
 }
-const MENTION_RE = /@([a-zA-Z0-9_]+)/g;
 
 // Split a message body into render segments. @mentions (spec 1020): an "@handle" token
 // becomes a mention chip ONLY when it resolves to a member this message actually mentions
@@ -1912,18 +1912,18 @@ function bodyParts(m: Message): BodySeg[] {
     }
     const text = p.text ?? '';
     let last = 0;
-    let mm: RegExpExecArray | null;
-    MENTION_RE.lastIndex = 0;
-    while ((mm = MENTION_RE.exec(text))) {
-      const handle = mm[1].toLowerCase();
+    // (spec 1064) Tokens come from the shared parser, so the handle charset here is exactly the
+    // one the send path resolved against — they can no longer disagree about where a handle ends.
+    for (const tok of findMentions(text)) {
+      const handle = tok.handle.toLowerCase();
       const isEveryone = handle === 'everyone' && !!m.mentionsEveryone;
       const member = members.get(handle);
       const isMember = !!member && mentioned.has(member.id);
       if (!isEveryone && !isMember) continue; // plain "@word", leave in text
-      if (mm.index > last) emit(text.slice(last, mm.index));
+      if (tok.start > last) emit(text.slice(last, tok.start));
       if (isEveryone) out.push({ everyone: true });
       else out.push({ mention: { id: member!.id, name: member!.name, me: member!.id === selfId } });
-      last = mm.index + mm[0].length;
+      last = tok.end;
     }
     if (last < text.length) emit(text.slice(last));
   }
@@ -1959,11 +1959,10 @@ const mentionCandidates = computed<MentionCandidate[]>(() => {
 // An "@token" at the end of the draft (assumed cursor position) starts an autocomplete.
 function updateMentionQuery(): void {
   if (!chat.value?.isGroup) { mentionQuery.value = null; return; }
-  const m = /(?:^|\s)@([a-zA-Z0-9_]*)$/.exec(draft.value);
-  mentionQuery.value = m ? m[1] : null;
+  mentionQuery.value = mentionQueryAt(draft.value);
 }
 function pickMention(c: MentionCandidate): void {
-  draft.value = draft.value.replace(/(^|\s)@([a-zA-Z0-9_]*)$/, `$1@${c.username} `);
+  draft.value = replaceMentionQuery(draft.value, c.username);
   mentionQuery.value = null;
   void composerEl.value?.$el?.setFocus?.();
 }
@@ -1972,8 +1971,8 @@ function resolveMentions(text: string): { mentions: string[]; everyone: boolean 
   const byU = new Map(groupMembers.value.map((m) => [m.username.toLowerCase(), m.id]));
   const ids = new Set<string>();
   let everyone = false;
-  for (const mm of text.matchAll(/(?:^|\s)@([a-zA-Z0-9_]+)/g)) {
-    const h = mm[1].toLowerCase();
+  for (const mm of findMentions(text)) {
+    const h = mm.handle.toLowerCase();
     if (h === 'everyone' && isGroupOwner.value) everyone = true;
     else {
       const id = byU.get(h);
@@ -5878,13 +5877,15 @@ function cancelRecording() {
 /* @mention chip (spec 1020): a highlighted, tappable name. A mention of ME is
    emphasized (filled pill) so "this is about me" pops at a glance. */
 .mention {
-  color: var(--ion-color-primary);
-  font-weight: 600;
+  /* (spec 1064) Theme-aware accent: the brand green reads well on the dark bubbles but is
+     unreadable (~2.1:1) on the pale ones, so light mode substitutes a darkened brand green. */
+  color: var(--app-mention);
+  font-weight: 700;
   cursor: pointer;
 }
 .mention.me {
-  background: var(--ion-color-primary);
-  color: #fff;
+  background: var(--app-mention);
+  color: var(--app-mention-contrast);
   border-radius: 6px;
   padding: 0 4px;
 }


### PR DESCRIPTION
## Ring 1.0.32

### Fixed

**Mentions show the name you know someone by, and stay readable** (spec 1064)

Tagging someone showed a bare `@parham.hoseini` instead of their name. Most of this already existed — mentions were built to resolve to a member's name, be tappable and render in the brand green. Three gaps stopped it working.

**1. The handle charset excluded dots — and this was not cosmetic.** A username may legally contain interior dots, but every place that read a handle used `[a-zA-Z0-9_]+`, so `@parham.hoseini` matched only `@parham` and resolved to nobody. The visible symptom was raw text; the invisible one was worse. The send-time resolve shares that charset, so the message stored an **empty mentions array** — and that array is what marks a frame as a mention. Anyone whose handle contains a dot was **never notified**, never pierced a mute, and never lit the "@" badge. Handles of letters, digits and underscores always worked; only dotted ones failed, silently.

A/B on a group message mentioning one dotted and one underscore handle: **1 of 2** registered before, **2 of 2** after.

The charset now lives in one shared parser mirroring the username rule, so the renderer and the sender can't disagree about where a handle ends. It also requires a word boundary, which stops an email address being read as a mention — a hazard introduced by allowing dots.

**2. The brand green was unreadable in light mode.** Measured against the bubbles: dark 5.5:1 and 5.0:1 (fine), light **2.07:1** and **2.12:1** (not). The "mentions me" pill was painting white on the brand green at **2.54:1**. Light mode now uses a darkened brand green (~5.4:1), and the pill's text follows the accent's lightness — black on the bright green in dark mode (8.3:1).

**3. Notifications showed the raw handle.** In-app banners and system pushes now substitute display names, leaving unresolvable handles untouched.

A local rename comes along for free: each device resolves against its own contacts, so you see the name you chose.

### Verification

Full CI green on #1108 including the Playwright e2e suite. 24 unit tests over the shared parser (dotted handles, trailing periods, emails, boundaries, offsets, substitution). A drive scenario sends through the real composer and asserts the stored mentions, the rendered chips and the recipient's copy — and fails on the pre-fix tree. Light and dark screenshots checked.

### Zero-knowledge

Unchanged. The body still carries the handle the sender typed alongside the existing mentioned ids; naming happens on-device against local contacts. Nothing new leaves the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i