### PR TITLE
chore: mark spec 1064 shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Specs are grouped by category band; status moves
 | [1055](specs/1055-ciphertext-push-instant/spec.md) | Instant rich notifications (bounded encrypted preview in push) | 🟡 in-progress |
 | [1062](specs/1062-list-status-presence/spec.md) | Message status and presence on the chat list | 🟢 shipped |
 | [1063](specs/1063-full-size-media/spec.md) | Full-size aspect-preserving media thumbnails in chat | 🟡 in-progress |
-| [1064](specs/1064-mention-names/spec.md) | Mentions show the name you know someone by, and stay readable | 🔵 in-review |
+| [1064](specs/1064-mention-names/spec.md) | Mentions show the name you know someone by, and stay readable | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1064-mention-names/spec.md
+++ b/specs/1064-mention-names/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-28
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
Spec 1064 (mentions show the name you know someone by) went out in **1.0.32** but its status line still read `in-review`, so ROADMAP.md understated what is live. A spec can't mark itself shipped in the PR that ships it, hence this follow-up.

No code change — spec status line + regenerated roadmap. Every spec is now accounted for (`in-review` count: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i