### PR TITLE
fix(chat): voice messages you receive while the app is closed no longer show up blank

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,5 +281,5 @@ but the subject is the real lever.)
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/2050-media-interop/plan.md`
+`specs/2058-voice-messages-arrive/plan.md`
 <!-- SPECKIT END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,3 +145,4 @@ Specs are grouped by category band; status moves
 | [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🟢 shipped |
 | [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🟢 shipped |
 | [2057](specs/2057-signal-clock/spec.md) | Reactions and game moves still trust the sender's clock | 🟢 shipped |
+| [2058](specs/2058-voice-messages-arrive/spec.md) | Voice messages never arrive as an empty bubble | ⚪ planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,4 +145,4 @@ Specs are grouped by category band; status moves
 | [2055](specs/2055-poster-budget/spec.md) | An oversized preview must never block a send | 🟢 shipped |
 | [2056](specs/2056-sender-clock-skew/spec.md) | Messages from a device with a wrong clock must not sort into the past | 🟢 shipped |
 | [2057](specs/2057-signal-clock/spec.md) | Reactions and game moves still trust the sender's clock | 🟢 shipped |
-| [2058](specs/2058-voice-messages-arrive/spec.md) | Voice messages never arrive as an empty bubble | ⚪ planned |
+| [2058](specs/2058-voice-messages-arrive/spec.md) | Voice messages never arrive as an empty bubble | 🟡 in-progress |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Specs are grouped by category band; status moves
 | [1055](specs/1055-ciphertext-push-instant/spec.md) | Instant rich notifications (bounded encrypted preview in push) | 🟡 in-progress |
 | [1062](specs/1062-list-status-presence/spec.md) | Message status and presence on the chat list | 🟢 shipped |
 | [1063](specs/1063-full-size-media/spec.md) | Full-size aspect-preserving media thumbnails in chat | 🟡 in-progress |
-| [1064](specs/1064-mention-names/spec.md) | Mentions show the name you know someone by, and stay readable | 🔵 in-review |
+| [1064](specs/1064-mention-names/spec.md) | Mentions show the name you know someone by, and stay readable | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/e2e/voice-pending.spec.ts
+++ b/e2e/voice-pending.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+import { createAccount, pair, chatWith, type RingClient } from './helpers';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Spec 2058 — a voice message must never arrive as an empty bubble.
+ *
+ * The reported bug: a voice message whose audio bytes are not on the device yet rendered as
+ * an outline with a timestamp and nothing else. No player, no duration, no download button,
+ * no error — and no way to get the audio. It happened whenever the message arrived while the
+ * app was closed (the push path stores the reference and never fetches bytes) or whenever a
+ * fetch failed (both the live path and the app-start backfill quietly left it pending "for a
+ * manual retry" that, for voice, did not exist).
+ *
+ * These tests seed that state directly rather than racing a real push, because the window
+ * between arrival and backfill is short on a fast connection — and because the genuine
+ * trigger, a Web Push into a closed iOS PWA, is not something headless can produce. The state
+ * is the right unit to test; the real-device pass is tracked separately on the spec.
+ *
+ * The assertions are deliberately on RENDERED CONTENT. Asserting `pending === true` would
+ * pass identically before and after the fix and prove nothing at all.
+ */
+
+const seedPending = (
+  c: RingClient,
+  chatId: string,
+  kind: 'voice' | 'video' | 'image' = 'voice',
+  opts: { broken?: boolean; videoNote?: boolean; agedMs?: number } = {},
+): Promise<string> =>
+  c.page.evaluate(
+    ([id, k, o]: [string, string, Record<string, unknown>]) =>
+      (window as any).__ringTest.seedPendingIncoming(id, k, o),
+    [chatId, kind, opts] as [string, string, Record<string, unknown>],
+  );
+
+const info = (c: RingClient, msgId: string) =>
+  c.page.evaluate((id: string) => (window as any).__ringTest.mediaInfo(id), msgId) as Promise<{
+    hasMedia: boolean;
+    pending: boolean;
+  }>;
+
+/** The bubble body must contain something the user can see and act on. */
+const bubble = (c: RingClient, mid: string) => c.page.locator(`.bubble[data-mid="${mid}"]`);
+
+test('a voice message whose audio is not on the device yet still renders, and recovers itself', async ({
+  browser,
+}) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'VOICEPEND1');
+  const b = await createAccount(ctxB, 'VOICEPEND2');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+  expect(bChat).toBeTruthy();
+
+  // Hold the blob fetch for a couple of seconds. Without this the seeded audio (a few hundred
+  // bytes against a local server) lands so fast that the placeholder is gone before the first
+  // assertion can look at it — the test would be racing its own fixture rather than checking
+  // behavior. The delay makes the pending window observable; it does not change what happens.
+  await b.page.route('**/v1/blobs/**', async (route) => {
+    await new Promise((r) => setTimeout(r, 2500));
+    await route.continue();
+  });
+
+  // Seed the exact reported state on B: an incoming voice message, bytes not fetched.
+  // The reference is real, so recovery can genuinely succeed.
+  const mid = await seedPending(b, bChat, 'voice');
+  expect(mid).toBeTruthy();
+  expect((await info(b, mid)).pending).toBe(true);
+
+  await b.page.goto(`/chat/${bChat}`);
+
+  // THE REGRESSION: before the fix this bubble rendered with an empty body.
+  const row = bubble(b, mid);
+  await expect(row).toBeVisible({ timeout: 15_000 });
+  await expect(row.locator('.vp-pending')).toBeVisible({ timeout: 10_000 });
+
+  // FR-002: it reads as a voice message and shows how long it is.
+  await expect(row).toContainText(/0:0\d|Voice message/);
+
+  // FR-005 + FR-007 + SC-002: it fetches itself on view and becomes a real player, without
+  // any tap and without leaving the chat.
+  await expect(row.locator('.vp-pending')).toHaveCount(0, { timeout: 15_000 });
+  await expect(row.locator('.vp')).toBeVisible({ timeout: 20_000 });
+  await expect.poll(() => info(b, mid).then((i) => i.hasMedia), { timeout: 15_000 }).toBe(true);
+});
+
+test('a voice message stranded before this fix recovers on the next open of its chat', async ({
+  browser,
+}) => {
+  // FR-013 / SC-004: the blank bubbles already sitting on people's devices must heal
+  // themselves — no reinstall, and no asking the sender to send it again.
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'VOICEPEND3');
+  const b = await createAccount(ctxB, 'VOICEPEND4');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+  // Backdated a week: a message left pending by an older build, not one that just arrived.
+  const mid = await seedPending(b, bChat, 'voice', { agedMs: 7 * 24 * 60 * 60 * 1000 });
+
+  await b.page.goto(`/chat/${bChat}`);
+
+  const row = bubble(b, mid);
+  await expect(row).toBeVisible({ timeout: 15_000 });
+  await expect(row.locator('.vp')).toBeVisible({ timeout: 20_000 });
+  expect((await info(b, mid)).hasMedia).toBe(true);
+});
+
+test('a voice message whose audio cannot be fetched says so, and can be retried', async ({
+  browser,
+}) => {
+  // US2: the permanent-damage half. A failed fetch must not strand the message silently.
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'VOICEPEND5');
+  const b = await createAccount(ctxB, 'VOICEPEND6');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+  // A reference pointing at bytes that were never uploaded: every fetch will fail.
+  const mid = await seedPending(b, bChat, 'voice', { broken: true });
+
+  await b.page.goto(`/chat/${bChat}`);
+
+  const row = bubble(b, mid);
+  await expect(row).toBeVisible({ timeout: 15_000 });
+
+  // FR-001/FR-002: still not blank, and still legible as a voice message with its length.
+  await expect(row.locator('.vp-pending')).toBeVisible({ timeout: 10_000 });
+  await expect(row).toContainText(/0:0\d|Voice message/);
+
+  // FR-008: once the automatic attempts fail it reads as FAILED, not as forever-loading.
+  await expect(row.locator('.vp-pending.failed')).toBeVisible({ timeout: 25_000 });
+
+  // FR-008 again, the part that matters: the failure survives leaving and coming back. A
+  // component-local flag would pass every assertion above and fail this one.
+  await b.page.goto('/tabs/chats');
+  await b.page.goto(`/chat/${bChat}`);
+  await expect(bubble(b, mid).locator('.vp-pending.failed')).toBeVisible({ timeout: 15_000 });
+
+  // FR-003: it is still a real control the user can press to try again.
+  await expect(bubble(b, mid).locator('.vp-pending')).toBeEnabled();
+});

--- a/e2e/voice-pending.spec.ts
+++ b/e2e/voice-pending.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { createAccount, pair, chatWith, type RingClient } from './helpers';
+import { createAccount, pair, chatWith, waitHook, type RingClient } from './helpers';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -22,10 +22,12 @@ import { createAccount, pair, chatWith, type RingClient } from './helpers';
  * pass identically before and after the fix and prove nothing at all.
  */
 
+type PendingKind = 'voice' | 'video' | 'image' | 'audio' | 'file';
+
 const seedPending = (
   c: RingClient,
   chatId: string,
-  kind: 'voice' | 'video' | 'image' = 'voice',
+  kind: PendingKind = 'voice',
   opts: { broken?: boolean; videoNote?: boolean; agedMs?: number } = {},
 ): Promise<string> =>
   c.page.evaluate(
@@ -42,6 +44,44 @@ const info = (c: RingClient, msgId: string) =>
 
 /** The bubble body must contain something the user can see and act on. */
 const bubble = (c: RingClient, mid: string) => c.page.locator(`.bubble[data-mid="${mid}"]`);
+
+const setSetting = (c: RingClient, key: string, value: unknown) =>
+  c.page.evaluate(
+    ([k, v]: [string, unknown]) => (window as any).__ringTest.setSetting(k, v),
+    [key, value] as [string, unknown],
+  );
+
+/** Arm a watcher for a functional toast BEFORE the action that raises it — the shared
+ *  banner overlay only holds it for a couple of seconds, so polling afterwards races it. */
+const bannerContaining = (c: RingClient, text: string) =>
+  c.page.waitForFunction(
+    (t: string) =>
+      ((window as any).__ringTest.notices() as { name: string; body: string }[]).some((n) =>
+        (n.name + n.body).includes(t),
+      ),
+    text,
+    { timeout: 20_000 },
+  );
+
+/**
+ * Every affordance a bubble may legitimately draw for an attachment, in any state: the
+ * pending placeholders, the failed states, and the resolved players. SC-001 says a bubble is
+ * never empty, so for a message carrying media at least one of these must be present. Listing
+ * them explicitly (rather than checking "the bubble has some child") means a future kind that
+ * renders nothing is caught rather than passing on the strength of its timestamp.
+ */
+const MEDIA_AFFORDANCES = [
+  '.vp-pending', // voice, not here yet
+  '.note-pending', // round note, not here yet
+  '.video-poster.pending', // photo / video, not here yet
+  '.file-chip.pending-chip', // audio file / document, not here yet
+  '.vp', // voice player
+  '.vnp', // round note player
+  '.bubble-image', // photo / video poster
+  '.audio-card', // audio file card
+  '.file-chip', // document chip
+  '.media-cleared', // removed to free space
+].join(', ');
 
 test('a voice message whose audio is not on the device yet still renders, and recovers itself', async ({
   browser,
@@ -144,4 +184,221 @@ test('a voice message whose audio cannot be fetched says so, and can be retried'
 
   // FR-003: it is still a real control the user can press to try again.
   await expect(bubble(b, mid).locator('.vp-pending')).toBeEnabled();
+});
+
+test('a voice message that failed comes back with a single tap, once the audio is reachable', async ({
+  browser,
+}) => {
+  // SC-003. The "broken seed" test above proves we report failure; this one proves the other
+  // half — that the retry actually WORKS when the thing that was wrong gets fixed. A failure
+  // path with a dead retry button would satisfy every assertion in that test and none here.
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'VOICERETRY1');
+  const b = await createAccount(ctxB, 'VOICERETRY2');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+
+  // The reference is real and the bytes ARE on the server — we simply refuse to let the
+  // device reach them for a while, the way a flaky connection would.
+  let reachable = false;
+  await b.page.route('**/v1/blobs/**', async (route) => {
+    if (reachable) await route.continue();
+    else await route.abort();
+  });
+
+  const mid = await seedPending(b, bChat, 'voice');
+  await b.page.goto(`/chat/${bChat}`);
+
+  const row = bubble(b, mid);
+  // Automatic recovery tries, and keeps failing, until it gives up and says so.
+  await expect(row.locator('.vp-pending.failed')).toBeVisible({ timeout: 30_000 });
+  expect((await info(b, mid)).hasMedia).toBe(false);
+
+  // The network comes back. ONE tap — the automatic path has already given up, so this is
+  // purely the manual retry doing the work (FR-003, and the cap in FR-006 not blocking it).
+  reachable = true;
+  await row.locator('.vp-pending').click();
+
+  await expect(row.locator('.vp')).toBeVisible({ timeout: 20_000 });
+  expect((await info(b, mid)).hasMedia).toBe(true);
+});
+
+test('a round video note renders while pending, recovers, and reports failure', async ({
+  browser,
+}) => {
+  // US3. Round notes had the identical gap for the identical reason — excluded from the
+  // square photo/video pending block — so they rendered nothing too.
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'ROUNDNOTE1');
+  const b = await createAccount(ctxB, 'ROUNDNOTE2');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+
+  // One that can be fetched, and one that never will be. Seeding both in the same chat also
+  // checks the two branches don't fight over the same bubble.
+  const okId = await seedPending(b, bChat, 'video', { videoNote: true });
+  const badId = await seedPending(b, bChat, 'video', { videoNote: true, broken: true });
+
+  await b.page.goto(`/chat/${bChat}`);
+
+  // The fetchable one ends up as a real round-note player, no tap.
+  await expect(bubble(b, okId).locator('.vnp')).toBeVisible({ timeout: 25_000 });
+
+  // The unfetchable one stays visible and says it failed — round, not a square patch.
+  const bad = bubble(b, badId);
+  await expect(bad.locator('.note-pending')).toBeVisible({ timeout: 15_000 });
+  await expect(bad.locator('.note-pending.failed')).toBeVisible({ timeout: 30_000 });
+});
+
+test('a photo that will not load tells you when you tap it', async ({ browser }) => {
+  // US4 / SC-007. Photos already had a pending placeholder, so they were never blank — but a
+  // tap that failed did nothing whatsoever, leaving no way to tell a slow load from a dead
+  // one. The fix reaches every kind because they all share one tap handler.
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'PHOTOFAIL1');
+  const b = await createAccount(ctxB, 'PHOTOFAIL2');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+  const mid = await seedPending(b, bChat, 'image', { broken: true });
+
+  await b.page.goto(`/chat/${bChat}`);
+
+  const row = bubble(b, mid);
+  await expect(row.locator('.video-poster.pending')).toBeVisible({ timeout: 15_000 });
+  await expect(row.locator('.video-poster.pending.failed')).toBeVisible({ timeout: 30_000 });
+
+  // Arm the watcher first: the banner is transient.
+  const told = bannerContaining(b, "Couldn't load this");
+  await row.locator('.video-poster.pending').click();
+  await told; // the tap was answered, out loud (FR-009)
+});
+
+test('a photo you chose to leave deferred is not fetched behind your back', async ({ browser }) => {
+  // FR-015. On-view recovery must not quietly undo a deliberate setting. This is only a real
+  // test because the recovery path asks the SAME function the arrival path asks, rather than
+  // carrying its own list of kinds — a hardcoded "voice and round notes only" would pass this
+  // while ignoring the setting entirely.
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'DEFERPHOTO1');
+  const b = await createAccount(ctxB, 'DEFERPHOTO2');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+  await setSetting(b, 'storage.autoDownload.photos', 'never');
+
+  // Perfectly fetchable — the only reason not to fetch it is that the user said not to.
+  const mid = await seedPending(b, bChat, 'image');
+  await b.page.goto(`/chat/${bChat}`);
+
+  const row = bubble(b, mid);
+  await expect(row.locator('.video-poster.pending')).toBeVisible({ timeout: 15_000 });
+
+  // Sit on the bubble well past the recovery debounce and give it every chance to misbehave.
+  await b.page.waitForTimeout(4_000);
+  const st = await info(b, mid);
+  expect(st.hasMedia).toBe(false);
+  expect(st.pending).toBe(true);
+
+  // And it is still a thing you can choose to load yourself.
+  await expect(row.locator('.video-poster.pending')).toBeVisible();
+});
+
+test('a run of pending voice messages all recover without stampeding the network', async ({
+  browser,
+}) => {
+  // SC-005. Recovery fires per visible bubble, and before this spec downloads had no limiter
+  // at all — the app-start backfill alone fired one unawaited fetch per pending message. A
+  // chat full of them would have opened a fetch each, at once.
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'STAMPEDE1');
+  const b = await createAccount(ctxB, 'STAMPEDE2');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+
+  const ids: string[] = [];
+  for (let i = 0; i < 10; i++) ids.push(await seedPending(b, bChat, 'voice'));
+
+  // Count AFTER seeding, so the uploads the seeder itself performed aren't mistaken for
+  // downloads. Slow each fetch down so genuine overlap is possible — without a delay the
+  // fetches finish so fast they'd serialise by accident and the test would prove nothing.
+  let inFlight = 0;
+  let peak = 0;
+  await b.page.route('**/v1/blobs/**', async (route) => {
+    inFlight++;
+    peak = Math.max(peak, inFlight);
+    await new Promise((r) => setTimeout(r, 700));
+    try {
+      await route.continue();
+    } finally {
+      inFlight--;
+    }
+  });
+
+  await b.page.goto(`/chat/${bChat}`);
+  await waitHook(b.page); // the reload drops __ringTest until the app boots again
+  await expect(bubble(b, ids[0])).toBeVisible({ timeout: 20_000 });
+
+  // Every one of them arrives.
+  for (const id of ids) {
+    await expect.poll(() => info(b, id).then((i) => i.hasMedia), { timeout: 60_000 }).toBe(true);
+  }
+  // And never more than the shared lane allows at once.
+  expect(peak).toBeGreaterThan(0);
+  expect(peak).toBeLessThanOrEqual(3);
+});
+
+test('no kind of attachment ever renders an empty bubble', async ({ browser }) => {
+  // SC-001, swept across kinds. The reported bug was one cell of this matrix (voice × not
+  // here yet) that nobody had ever looked at. This walks the rest so the next kind added
+  // can't quietly reintroduce it.
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await createAccount(ctxA, 'MATRIX1');
+  const b = await createAccount(ctxB, 'MATRIX2');
+  await pair(a, b);
+
+  const bChat = (await chatWith(b, a.id)) as string;
+
+  const kinds: Array<{ kind: PendingKind; videoNote?: boolean; label: string }> = [
+    { kind: 'voice', label: 'voice message' },
+    { kind: 'video', videoNote: true, label: 'round video note' },
+    { kind: 'image', label: 'photo' },
+    { kind: 'video', label: 'video' },
+    { kind: 'audio', label: 'audio file' },
+    { kind: 'file', label: 'document' },
+  ];
+
+  // `broken` keeps each one deterministically in the not-here-yet / failed states, which are
+  // the two the bug lived in. The resolved state is covered by the tests above and the
+  // "removed to free space" state by media-cleanup.spec.ts — noted rather than skipped
+  // silently, so the coverage claim stays honest.
+  const seeded: Array<{ id: string; label: string }> = [];
+  for (const k of kinds) {
+    seeded.push({
+      id: await seedPending(b, bChat, k.kind, { broken: true, videoNote: k.videoNote }),
+      label: k.label,
+    });
+  }
+
+  await b.page.goto(`/chat/${bChat}`);
+
+  for (const s of seeded) {
+    const row = bubble(b, s.id);
+    await expect(row, `${s.label} bubble should exist`).toBeVisible({ timeout: 20_000 });
+    // THE invariant: something is drawn. Before the fix, voice and round notes drew nothing
+    // at all here — an outline with a timestamp in it.
+    await expect(
+      row.locator(MEDIA_AFFORDANCES),
+      `${s.label} rendered an EMPTY bubble`,
+    ).not.toHaveCount(0, { timeout: 20_000 });
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-client",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-client",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg/core": "^0.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-client",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Zuptalo",

--- a/specs/1064-mention-names/spec.md
+++ b/specs/1064-mention-names/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-28
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2058-voice-messages-arrive/checklists/requirements.md
+++ b/specs/2058-voice-messages-arrive/checklists/requirements.md
@@ -1,0 +1,47 @@
+# Specification Quality Checklist: Voice messages never arrive as an empty bubble
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The **Context** section deliberately describes the two internal paths that strand a voice
+  message (background arrival, failed fetch) in plain language, without naming files or functions.
+  This follows the house style of spec 2050 for hotfixes, where the reader needs to know *why* the
+  bug exists to judge whether the fix covers it. Requirements and success criteria themselves stay
+  free of implementation detail.
+- FR-006's retry bound is now a concrete number (3 automatic attempts per message per session,
+  reset on restart) rather than being deferred to the plan — an earlier draft of this note said it
+  was left open, which is no longer true.
+- No crypto surface (Principle IV) and no wire-format change (FR-014). Principle I is *documented*
+  rather than modified, but rather than argue where the "touching Principle I" line sits, a
+  zero-knowledge checklist was produced anyway: [zero-knowledge.md](./zero-knowledge.md).
+- Revised 2026-07-29 after `/speckit-analyze` returned 4 CRITICAL + 6 HIGH findings against the
+  spec/plan/tasks set; the spec-level remediations (FR-002 fallback, FR-006 bound, measurable
+  SC-001/002/005, and a new *Complexity & Exceptions* section) are reflected above.

--- a/specs/2058-voice-messages-arrive/checklists/zero-knowledge.md
+++ b/specs/2058-voice-messages-arrive/checklists/zero-knowledge.md
@@ -1,0 +1,59 @@
+# Zero-Knowledge Checklist: spec 2058
+
+**Purpose**: Constitution Principle I is non-negotiable and gate sequencing requires this checklist
+for any spec touching it. Run before `/speckit-implement` and re-confirm before merge.
+**Created**: 2026-07-29
+**Feature**: [spec.md](../spec.md) · [Zero-Knowledge Impact section](../spec.md)
+
+## What crosses the wire
+
+- [x] The change adds **no** new field to any sealed payload — verified: no edit to
+      `src/services/crypto/message.ts` or the `MediaRef` shape is planned.
+- [x] The change adds **no** new endpoint, and no new parameter on an existing one — the fetch
+      reuses `receiveIncomingMedia` unmodified.
+- [x] The change adds **no** new identifier visible to the server. The blob id used was already
+      inside the sealed message and already fetched on the success path.
+- [x] Nothing that was previously encrypted becomes plaintext.
+
+## What the server can observe
+
+- [x] **No new observable is introduced.** The server already sees that some authenticated device
+      fetched some blob id at some time — inherent to relaying the bytes at all.
+- [x] **Timing delta acknowledged and bounded.** A fetch that previously never happened (the
+      stranded case) now happens. This reveals nothing the ordinary success path would not have
+      revealed moments earlier, and the FR-006 attempt cap (3 per message per session) stops a
+      permanently-failing message from emitting an unbounded repeating fetch pattern at the relay.
+- [x] No log line, metric, error payload, or debug aid added by this change carries user content.
+
+## New state
+
+- [x] `dlFailedAt` is written to the **device's** IndexedDB only.
+- [x] It is **not** included in own-data sync — **verified by citation, not assumption**:
+      `src/services/ownsync.ts:28` declares `const SYNCED: StoreName[] = ['contacts', 'chats',
+      'chatlists']`, and `pushSyncRecords` has a single caller (`:153`) that never touches the
+      `messages` store. No `Message` field can ride own-data sync under any implementation.
+- [x] The auto-retry counter never persists at all (in-memory, session-scoped).
+- [x] Neither is derived from, or reported to, anything server-side.
+
+## Crypto surface
+
+- [x] No change to X3DH, the Double Ratchet, sender keys, or libsodium usage.
+- [x] No new key material, no change to at-rest wrapping (Argon2id/PIN).
+- [x] No hand-rolled primitive introduced.
+
+## Server surface
+
+- [x] No Go change, no handler change, no SQL migration.
+- [x] No change to `SECRETS_KEY` handling or anything encrypted at rest server-side.
+
+## Sign-off
+
+- [x] All boxes above checked, each against source rather than assumption.
+- [x] No open items. The one item originally flagged for investigation (whether own-data sync could
+      pick up a new `Message` field implicitly) was closed by reading `ownsync.ts`: the `messages`
+      store is not in the synced set at all, so the risk does not exist.
+
+**Verdict**: Principle I is preserved. This change is receive-side rendering plus a local recovery
+trigger; the only behavioral delta the server could observe is that a fetch which previously never
+happened now happens, over the existing path with the existing capability id, bounded by the
+FR-006 attempt cap.

--- a/specs/2058-voice-messages-arrive/data-model.md
+++ b/specs/2058-voice-messages-arrive/data-model.md
@@ -1,0 +1,89 @@
+# Phase 1 Data Model: spec 2058
+
+Only one existing entity changes, and only by one optional field. No new object store, no new
+server table, no wire-format change.
+
+## Changed entity: `Message` (`src/db/types.ts:322-401`)
+
+### New fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `dlFailedAt?` | `number` | Epoch ms of the most recent **failed** attachment fetch for this message. Absent = never failed. Cleared back to `undefined` when a fetch succeeds. Drives the bubble's failed state (FR-008). |
+
+Only **one** field is persisted. The auto-retry counter is deliberately **not** stored — see below.
+
+### Session-scoped state (NOT persisted)
+
+| State | Where | Meaning |
+|---|---|---|
+| auto-attempt count | in-memory `Map<messageId, number>`, module-scoped | Counts **automatic** on-view fetch attempts, capped at 3 per message (FR-006). Reset implicitly when the app restarts, because the map dies with the session. A manual tap neither reads nor increments it. |
+
+**Why this one is not a `Message` field**: persisting it would let a message that exhausted its
+three attempts during a single offline session become permanently manual-only, directly
+contradicting FR-013 / SC-004 ("stranded messages recover on the next open, no re-send"). The
+counter's job is to stop a tight loop *within* a session, which a session-scoped map does exactly.
+
+### Why this is local-only
+
+`dlFailedAt` is device-local receive-side bookkeeping. It is never sent, never synced through
+own-data sync, and never read from the server (see the spec's Zero-Knowledge Impact section).
+
+### Why no `DB_VERSION` bump
+
+Constitution V mandates a bump when *adding or altering an object store*. This is one optional field
+on records in the existing `messages` store; IndexedDB records carry no schema, so old rows read
+`undefined` — the correct "never failed" default. This matches how `failReason`, `jobAttempts`,
+`mediaCleared` and `posterData` were each added. Verified against `src/db/idb.ts` (`DB_VERSION = 12`,
+`:46`): every branch of the upgrade path is a `createObjectStore` or index creation, none of which
+this touches.
+
+### Existing fields this feature reads (unchanged)
+
+| Field | Role here |
+|---|---|
+| `mediaId?` | Absent + `pendingMedia` present = the bytes are not local. The condition the whole feature keys on. |
+| `pendingMedia?` (`MediaRef`) | The sender's reference used to fetch the bytes. |
+| `kind` | Selects the placeholder: `voice` vs round note vs the existing photo/video/audio/file blocks. |
+| `videoNote?` | Distinguishes a round note from a normal video. |
+| `durationSec?` | Shown on the voice placeholder (FR-002). |
+| `mediaSize?` | Feeds the existing `dlSizeLabel` progress counter. |
+| `mediaCleared?` | Mutually exclusive with the pending state — keeps its own presentation (FR-012). |
+| `outgoing`, `deleted`, `expiresAt` | Guards: recovery only applies to incoming, undeleted, unexpired messages. |
+
+## Attachment state machine (per message)
+
+```
+                    bytes fetched OK
+   ┌──────────────┐ ───────────────────► ┌─────────────┐
+   │   PENDING    │                      │  RESOLVED   │  mediaId set → the real player renders
+   │ pendingMedia │ ◄─────────┐          └─────────────┘
+   │  no mediaId  │           │ retry            │
+   └──────┬───────┘           │                  │ user frees space
+          │ fetch fails       │                  ▼
+          ▼                   │          ┌─────────────┐
+   ┌──────────────┐           │          │   CLEARED   │  mediaCleared, its own presentation
+   │    FAILED    │ ──────────┘          └─────────────┘
+   │ dlFailedAt   │
+   └──────────────┘
+```
+
+- **PENDING → RESOLVED**: `mediaId` set, `pendingMedia` and `dlFailedAt` cleared.
+- **PENDING → FAILED**: `dlFailedAt` stamped; `pendingMedia` is **retained** so a retry is possible.
+- **FAILED → PENDING/RESOLVED**: any retry clears `dlFailedAt` on success; a further failure
+  re-stamps it.
+- **CLEARED** is reached only from RESOLVED, by the user freeing space. It is disjoint from PENDING
+  (`mediaCleared(m)` at `ChatDetailPage.vue:2012` already requires `!m.pendingMedia`), which is what
+  keeps FR-012 true without extra work.
+
+## Invariants
+
+- **INV-1**: A message is in exactly one of RESOLVED / PENDING / FAILED / CLEARED. No bubble may
+  render empty in any of them (SC-001).
+- **INV-2**: `dlFailedAt` set implies `pendingMedia` set — a failed fetch never discards the
+  reference, or the message would become unrecoverable.
+- **INV-3**: The attempt counter bounds only the automatic path. A manual tap always attempts,
+  regardless of its value, and never increments it (FR-006 vs FR-003).
+- **INV-4**: The attempt counter never persists — a new session always grants a message a fresh
+  three automatic attempts, which is what keeps FR-013 true for messages stranded before this fix.
+- **INV-5**: `dlFailedAt` never leaves the device.

--- a/specs/2058-voice-messages-arrive/plan.md
+++ b/specs/2058-voice-messages-arrive/plan.md
@@ -1,0 +1,184 @@
+# Implementation Plan: Voice messages never arrive as an empty bubble
+
+**Branch**: `fix/2058-voice-messages-arrive` | **Date**: 2026-07-29 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/2058-voice-messages-arrive/spec.md`
+
+## Summary
+
+An incoming voice message whose audio bytes are not yet on the device renders as a **completely
+empty bubble**, because the voice/round-note render is gated on the bytes being local
+(`ChatDetailPage.vue:306`) and the "not downloaded yet" fallbacks were only ever built for
+photo/video (`:360`) and audio/file (`:380`). Voice matches neither.
+
+The fix is three moves in the chat page plus one in the data layer:
+
+1. **Draw something.** Add pending branches for `voice` (a voice-shaped placeholder matching
+   `VoicePlayer`'s row height so the resolve is a swap, not a reflow) and for round video notes.
+2. **Recover on its own.** Hang a debounced pending-recovery handler off the per-bubble
+   `IntersectionObserver` that already exists for read receipts (`:3284`), so a message that arrived
+   via push while the app was closed fetches itself when you scroll to it — bounded per message.
+3. **Fail honestly.** The single shared tap handler `downloadPendingMedia` (`:1441`) currently
+   swallows every failure. Mark the message failed and toast on a user-initiated tap. Because every
+   kind funnels through that one function, this delivers User Story 4 across all attachment kinds
+   for the same edit.
+4. **Stop the stampede.** Route downloads through a `createLimiter(3)` lane. Downloads are
+   completely unbounded today (`resumePendingMediaJobs` fires one `void` call per pending message),
+   so adding on-view recovery without this would make an existing latent problem worse.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (ES modules, `@/` → `src/`), Vue 3 `<script setup>`
+
+**Primary Dependencies**: Ionic Vue, existing in-repo `createLimiter` (`src/utils/concurrency.ts`),
+existing `appToast` (`src/services/toast.ts`). **No new dependency.**
+
+**Storage**: IndexedDB via `src/db/idb.ts`. **One** optional field (`dlFailedAt`) added to existing
+`messages` records; **no `DB_VERSION` bump** (see data-model.md). The auto-retry counter is
+deliberately **in-memory and session-scoped**, not persisted — a persisted counter would strand a
+message that burned its attempts while offline, contradicting FR-013.
+
+**Testing**: Playwright e2e (`e2e/`) is the behavioral gate — the red regression test comes first
+per Constitution III. Vitest covers the one genuinely pure piece this adds: the auto-retry
+attempt-bound decision, extracted as a pure function so it is testable without IndexedDB (the
+failure *marking* is an IDB write and is covered by e2e instead). `npm run build` is the typecheck.
+
+**Test seam caveat (found in analysis)**: a seeded pending message must reference a blob that was
+really uploaded, or every fetch fails and the *success* path — the whole of US1 — is unreachable
+from the harness. The seeder therefore seals and uploads a real tiny audio blob, and takes an
+explicit "broken" option for the failure cases.
+
+**Target Platform**: the PWA on iOS Safari + Chrome/Android; the reported failure is an iOS PWA
+receiving via Web Push while closed.
+
+**Project Type**: client-only change. **No server, no Go, no migration, no wire change.**
+
+**Performance Goals**: recovered and playable within 3s of opening the chat on a normal connection
+(SC-002); ten consecutive pending messages recover without stalling scroll (SC-005).
+
+**Constraints**: must not reflow the message list when a placeholder resolves (the spec 1011 scroll-
+anchor lesson, `ChatDetailPage.vue:250-256`); must not disturb the read-receipt observer path; must
+not auto-fetch attachments the user deliberately deferred (FR-015).
+
+**Scale/Scope**: ~2 files of substance (`ChatDetailPage.vue`, `src/db/queries.ts`), plus
+`src/db/types.ts` (1 field) and `src/services/testhook.ts` (test seam). One new e2e spec.
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 and re-evaluated after Phase 1 design. Both passes clean.*
+
+| Principle | Verdict | Basis |
+|---|---|---|
+| **I. Zero-Knowledge (NON-NEGOTIABLE)** | ✅ PASS | No wire change. Reuses the existing fetch of a blob id already inside the sealed message. The one new field is device-local and never synced (`ownsync.ts:28` excludes `messages` entirely); the retry counter never persists at all. Spec carries the mandatory **Zero-Knowledge Impact** section. |
+| **II. Spec-Driven** | ✅ PASS | specify → clarify → plan complete; tasks → analyze precede implement. Branch `fix/2058-…`, flat dir `specs/2058-…`, hotfix band. |
+| **III. Test-Driven** | ✅ PASS *(binding)* | A 2001+ fix MUST open with a failing regression test. Phase ordering puts the test seam + red e2e before any fix, and the e2e asserts **rendered content**, not just the `pending` flag — a flag-only assertion would pass before and after and prove nothing. |
+| **IV. Crypto Discipline** | ✅ N/A | Crypto core untouched; no key handling, no new primitive. |
+| **Gate sequencing — `/speckit-checklist`** | ✅ PASS | Required for any spec touching Principle I or IV. IV is untouched. I is *documented* (the mandatory Zero-Knowledge Impact section) but not *modified* — no new wire field, endpoint, identifier, or stored server value. The only delta is that a fetch which previously never happened now happens, using the existing capability id over the existing path. Ran `/speckit-checklist` anyway rather than argue the boundary: `checklists/zero-knowledge.md`. |
+| **Development Workflow — start-of-cycle version bump** | ⚠️ **Owed, tasked** | `package.json` is at 1.0.32 and tag `v1.0.32` exists, so `develop` and `main` are level and this is the first change of a new cycle. The constitution makes the bump to 1.0.33 mandatory on this branch or the release guard blocks the release PR. Carried as T039; recorded in spec.md → Complexity & Exceptions (E-3). |
+| **V. Offline-First Data** | ✅ PASS | Writes go through the `idb` wrapper; the UI stays reactive via the existing change bus. No store added or altered → no `DB_VERSION` bump (justified in data-model.md). Old rows read `undefined` = correct default. |
+| **VI. Stateless Server** | ✅ N/A | No server change, no migration. |
+| **VII. Quality Gates** | ✅ PASS | `npm run build` + vitest + the new e2e. Commit subject will be plain-language release-note copy with no spec/issue refs. |
+| **VIII. Traceable Delivery** | ✅ PASS | Tasks → issues → `Closes #N` on the PR; `ROADMAP.md` regenerated via `make roadmap`. |
+| **IX. Privacy** | ✅ PASS | No telemetry. The retry bound also stops a permanently-broken message emitting an unbounded repeating fetch pattern. |
+| **X. Accessibility & i18n** | ✅ PASS | Placeholder carries an accessible label and is a real focusable control; text is the existing "Voice message" string (already used by `clearedLabel`, `:2014-2029`), so bidi behavior is unchanged. |
+| **XI. Ionic-First UI** | ⚠️ **Justified deviation** | See Complexity Tracking. |
+
+### Supply-chain scan (Development Workflow, MUST)
+
+The constitution requires reviewing the Docker Scout report for the current `zuptalo/ring` tag at
+the start of new work and applying any vulnerability that has a fix. **Not performed — this
+environment has no Docker Hub access.** This is an open obligation on this branch, flagged to the
+maintainer rather than silently skipped. It does not block the code work (client-only change, no Go
+module or base-image surface), but it must be discharged before the release PR.
+
+Per Governance, an unmet MUST belongs in the **spec's** *Complexity & Exceptions* section, not only
+here — recorded there as **E-1**, still awaiting maintainer sign-off.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|---|---|---|
+| **XI. Ionic-First** — the voice placeholder is hand-rolled markup rather than a stock Ionic component | There is no Ionic primitive for a voice-message bubble. The placeholder must match the row metrics of its sibling `VoicePlayer` (`.vp`, ~34-38px flex row) or the bubble visibly resizes when the fetch lands — the exact scroll-anchor reflow spec 1011 was written to prevent. | *Stock `ion-item`/`ion-chip`*: wrong height and wrong semantics, causes the reflow. *Reuse the existing `.pending-chip`*: same reflow problem, and reads as a file rather than a voice message. *Render `VoicePlayer` with an empty `src`*: it owns playback state and registers with the global single-source player (`useAudioPlayer`), so a src-less instance risks a half-live entry in the global registry. Mitigation: the placeholder is composed from the **existing** `.dl-ring`/`.dl-btn` download vocabulary, uses `ion-icon`, and adds no new colour or spacing tokens — exactly as its hand-rolled sibling `VoicePlayer` does. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/2058-voice-messages-arrive/
+├── spec.md                 # /speckit-specify + /speckit-clarify output
+├── plan.md                 # this file
+├── research.md             # Phase 0 — R1..R7 decisions
+├── data-model.md           # Phase 1 — Message delta + state machine
+├── quickstart.md           # Phase 1 — how to reproduce and verify
+├── checklists/
+│   ├── requirements.md     # spec quality gate (all green)
+│   └── zero-knowledge.md   # Principle I gate
+└── tasks.md                # /speckit-tasks output (NOT created here)
+```
+
+**No `contracts/`**: this feature exposes no external interface. It adds no endpoint, no wire field,
+and no change to the sealed message payload — it is receive-side rendering plus a local recovery
+trigger. The plan template calls for contracts only where such a surface exists.
+
+### Source Code (repository root)
+
+```text
+src/
+├── views/detail/
+│   └── ChatDetailPage.vue      # (1) pending voice + round-note branches in the v-if chain
+│                               # (2) recovery handler beside markVisibleSeen()
+│                               # (3) honest failure in downloadPendingMedia's catch
+│                               # (4) a dedicated sibling branch for pending round notes
+│                               # NOTE: do NOT flip mediaBubble()/.bubble-media on for pending
+│                               # voice — a resolved voice message is not a media bubble, so
+│                               # toggling the class adds then removes padding = the reflow
+│                               # this design exists to avoid
+├── db/
+│   ├── types.ts                # Message.dlFailedAt?  (one field; counter is in-memory)
+│   └── queries.ts              # downloadLane = createLimiter(3); mark/clear failure;
+│                               # route downloadMessageMedia + resumePendingMediaJobs through it
+├── services/
+│   └── testhook.ts             # seedPendingIncoming(); expose pending + dlFailedAt on messages()
+└── utils/
+    └── concurrency.ts          # reused as-is (createLimiter) — no change
+
+e2e/
+└── voice-pending.spec.ts       # NEW — the red regression test (US1/US2), then US3/US4 coverage
+```
+
+**Structure Decision**: no new module or directory. The bug is a missing branch in an existing
+template chain and a missing recovery trigger next to an existing observer, so the change stays
+inside the files that already own those concerns. `src/utils/concurrency.ts` is reused unmodified.
+
+## Phase ordering (drives `/speckit-tasks`)
+
+Constitution III is binding here, so the order is not negotiable:
+
+1. **Test seam** — `testhook.seedPendingIncoming()` + `pending`/`dlFailedAt` on `messages()`.
+   Without this the bug's state is unreachable from a test (research R7).
+2. **RED** — `e2e/voice-pending.spec.ts` asserting a pending incoming voice bubble renders visible
+   content. Must fail against the current tree for the right reason (empty bubble), and that
+   failure must be observed and recorded before any fix lands.
+3. **US1 + US2 (both P1)** — placeholder branch, then the local failure marking + limiter, then the
+   on-view recovery. Turns the red test green.
+4. **US3 (P3)** — round-note placeholder (same branch, one condition).
+5. **US4 (P2)** — honest failure across all kinds, at the shared `catch`.
+6. **Gates** — `npm run build`, vitest, the new e2e, then a real two-device pass against the dev
+   stack for the reporter's exact scenario (SC-006), since the failure only reproduces with a real
+   push to a closed app.
+
+## Risks
+
+- **The read-receipt observer is delicate.** Its callback is deliberately a cheap trigger with an
+  authoritative geometry re-scan and several gates (`seenSettled`, `seeking`, page visibility). The
+  recovery handler must sit *beside* `markVisibleSeen()`, not inside it, and `e2e/seen-on-view.spec.ts`
+  must stay green as the proof.
+- **Headless can't reproduce the real trigger.** The genuine path is a Web Push into a closed iOS
+  PWA. The e2e seeds the resulting *state* instead, which is the right unit to test, but SC-006
+  still requires a real-device confirmation before this is called done.
+- **`v-memo` on the bubble row** — most likely a non-issue, but verify rather than assume. The list
+  opens with `m.updatedAt` (`:154`), and the failure write bumps `updatedAt` the same way the
+  success path already does (`queries.ts:2963`), so the row should repaint on its own. Only if the
+  failure write is implemented *without* bumping `updatedAt` does `m.dlFailedAt` need adding to the
+  list at `:159`.

--- a/specs/2058-voice-messages-arrive/quickstart.md
+++ b/specs/2058-voice-messages-arrive/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: reproducing and verifying spec 2058
+
+## The bug in one sentence
+
+An incoming voice message whose audio bytes are not on the device yet renders as an empty bubble —
+timestamp and reaction button, nothing else — with no player, no download button, and no way back.
+
+## Reproduce it by hand (dev stack)
+
+The genuine trigger needs a push into a closed app, so the fastest honest reproduction uses two
+devices against the dev stack.
+
+```sh
+make start        # Vite :5173 → ringd :8080
+```
+
+1. Pair two accounts and open a 1:1 chat.
+2. **Fully close** the receiving side (close the PWA / background the tab — it must not be the
+   foreground page, or the live path fetches the audio inline and the bug hides).
+3. Send a voice message from the other account.
+4. Open the receiving side and go to the chat **before** it finishes backfilling.
+
+Expected today: a blank bubble. The window is short on a fast connection, which is why the
+automated test seeds the state directly rather than racing it.
+
+The second, permanent path: put the receiving device offline, receive a voice message, and observe
+that it never recovers — a failed fetch strands it with no retry affordance.
+
+## Reproduce it deterministically (the test seam)
+
+The state is unreachable from a test today — `testhook.seedMedia` always sets `mediaId` and
+`outgoing: true`. This feature adds `seedPendingIncoming(chatId, kind)` for exactly this:
+
+```js
+// in the receiving page context
+const mid = await window.__ringTest.seedPendingIncoming(chatId, 'voice');
+await window.__ringTest.mediaInfo(mid);   // → { hasMedia: false, pending: true, ... }
+```
+
+Then assert on what the bubble actually renders. **Assert rendered content, not the flag** — a test
+that only checks `pending === true` passes both before and after the fix and proves nothing:
+
+```js
+const bubble = page.locator(`.bubble[data-mid="${mid}"]`);
+await expect(bubble).toBeVisible();
+// the real assertion: the bubble body is not empty
+await expect(bubble.locator('.vp-pending')).toBeVisible();
+```
+
+## Verify the fix
+
+| What | How | Covers |
+|---|---|---|
+| Blank bubble is gone | Seed a pending incoming voice message; the bubble shows a voice placeholder with its duration | US1, FR-001, FR-002, SC-001 |
+| Self-heals on view | Seed pending, scroll the bubble into view, wait; it becomes a real player with no tap | US1, FR-005, FR-007, SC-002 |
+| Manual retry works | Go offline, seed pending, tap → fails visibly; go online, tap → plays | US2, FR-003, FR-008, SC-003 |
+| No double fetch | Tap repeatedly during a fetch; only one runs | FR-004 |
+| Retry is bounded | Keep the fetch failing, scroll in/out repeatedly; automatic attempts stop, manual tap still works | FR-006 |
+| Round notes too | Same as row 1 with a round video note | US3, FR-011 |
+| Nothing fails silently | Offline, tap a pending photo/video/audio/document → told at that moment, bubble reads failed after | US4, FR-009, FR-010, SC-007 |
+| Deferred media untouched | Set photo auto-download to never; a pending photo scrolled into view does **not** self-fetch | FR-015 |
+| Cleared media untouched | Free space on a downloaded voice message; it keeps "removed to free space" | FR-012 |
+| No stampede | Seed 10 consecutive pending voice messages; all recover, scroll stays smooth, ≤3 fetches at once | SC-005 |
+| Read receipts unharmed | `e2e/seen-on-view.spec.ts` still green | Risk mitigation |
+
+## Gates
+
+```sh
+npm run build                      # typecheck (vue-tsc) + build
+npx vitest run                     # unit
+npx playwright test e2e/voice-pending.spec.ts e2e/seen-on-view.spec.ts
+```
+
+`make db-up` must be running for e2e; the harness boots its own isolated `ringd` on :8081 and Vite
+on :5174 and does not touch the `make start` stack.
+
+## Still owed after the gates are green
+
+**SC-006 is a real-device check.** The reported failure is a Web Push into a closed iOS PWA, which
+headless cannot produce. Before calling this shipped: send a voice message, and a reply carrying a
+voice message, to a genuinely closed phone, and confirm both play.

--- a/specs/2058-voice-messages-arrive/research.md
+++ b/specs/2058-voice-messages-arrive/research.md
@@ -1,0 +1,153 @@
+# Phase 0 Research: Voice messages never arrive as an empty bubble (spec 2058)
+
+All findings verified against the tree on `fix/2058-voice-messages-arrive` at 2026-07-29.
+
+## R1 — Where the blank actually comes from
+
+**Finding**: `ChatDetailPage.vue:306` opens a `<template v-else-if="m.mediaId && mediaInfo[m.mediaId]">`
+that contains the round note, `<voice-player>` (316), `<audio-card>` (328) and the file chip (343).
+The two pending fallbacks that follow are a mutually-exclusive `v-if` / `v-else-if` pair:
+
+- `356-378`: `((m.kind === 'video' && !m.videoNote) || m.kind === 'image') && !m.mediaId && m.pendingMedia`
+- `379-394`: `(m.kind === 'audio' || m.kind === 'file') && !m.mediaId && m.pendingMedia`
+
+`kind === 'voice'` matches neither, and a round note is explicitly excluded by `!m.videoNote`. With
+no branch taken, the bubble body is empty.
+
+**Decision**: fix in the template chain, not in the data layer — the message row is already correct
+in IndexedDB, so this is purely a missing render branch plus a recovery trigger.
+
+## R2 — Placeholder shape: chip vs. voice-shaped
+
+**Decision**: a **voice-shaped** placeholder that matches `VoicePlayer`'s row metrics, not the
+generic `.pending-chip`.
+
+**Rationale**: `VoicePlayer` renders a ~34-38px flex row (`.vp`, CSS 160-171: play disc 34x34 +
+`.vp-wave` 24px + `.vp-time` + speed pill). A `.pending-chip` is a different height, so the bubble
+would visibly resize the moment the fetch lands. Spec 1011 already paid for that lesson on images —
+gating a frame on `mediaInfo` inserted ~0-height rows that expanded later and broke the scroll
+anchor (comment at `ChatDetailPage.vue:250-256`). A same-height placeholder means the resolve is a
+swap, not a reflow.
+
+**Alternatives considered**:
+- *Reuse `.pending-chip` verbatim* — cheapest, but reintroduces the reflow the codebase explicitly
+  designs against, and reads as a file rather than a voice message.
+- *Render `VoicePlayer` itself with a null src* — rejected: it owns playback state and registers
+  with the global single-source player (`useAudioPlayer`); driving it with no audio invites a
+  half-live player in the global registry.
+
+**Constitution XI note**: this is hand-rolled markup rather than a stock Ionic component. Justified:
+there is no Ionic primitive for a voice bubble; its sibling `VoicePlayer` is itself hand-rolled
+(Ionic only for `ion-icon`); and the placeholder is composed from the **existing** `.dl-ring` /
+`.dl-btn` download vocabulary and existing theme tokens rather than inventing new ones.
+
+## R3 — Where to persist the failed state
+
+**Decision**: **one** new optional field on `Message` — `dlFailedAt?: number`. The auto-retry counter
+is **not** persisted; it lives in a module-scoped in-memory `Map`, capped at 3 attempts per message
+per session.
+
+> **Revised after analysis.** This decision originally added a second persisted field,
+> `dlAttempts?`. That was wrong: a persisted counter means a message that burns its three attempts
+> during one offline session becomes permanently manual-only, which directly contradicts FR-013 /
+> SC-004 ("messages stranded before this fix recover on the next open, with no re-send"). The
+> counter's only job is to stop a tight loop *within* a session, which a session-scoped map does
+> exactly — and it resets for free on restart, which is precisely the FR-013 behavior.
+
+**Rationale**: FR-008 requires the failed state to survive the recipient navigating away and coming
+back, which a component-local reactive map cannot do (leaving the chat unmounts the page). The
+`Message` row is already the home for the parallel send-side concept (`failReason?: 'too-large' |
+'cant-convert'`, `types.ts:340`, and `jobAttempts?`, `:336`), so this mirrors an established shape
+rather than inventing one.
+
+**DB_VERSION**: **no bump needed.** Constitution V requires a bump when *adding or altering an
+object store*; IndexedDB records are schemaless, and this is one optional field on an existing
+`messages` record. Existing optional fields (`failReason`, `mediaCleared`, `posterData`) were added
+the same way. Old rows simply read `undefined`, which is exactly "never failed".
+
+**Alternatives considered**:
+- *Reactive map in the page* — rejected, does not survive unmount (fails FR-008's "later").
+- *Reuse `status: 'failed'`* — rejected: `MessageStatus` (`types.ts:262`) is the **send** lifecycle
+  and an incoming message is `'delivered'`/`'seen'`. Overloading it would corrupt receipt logic.
+
+## R4 — On-view recovery trigger
+
+**Decision**: reuse the existing per-bubble `IntersectionObserver` (`ChatDetailPage.vue:3284`,
+spec 1013's read-receipt observer) as the trigger, adding a **separate debounced handler** beside
+`markVisibleSeen()` rather than entangling the two.
+
+**Rationale**: the observer already observes exactly the right nodes — every bubble carries
+`:data-mid="m.id"` (template 213) and re-observation on window slide is already handled
+(watcher 4011-4015). Its callback is deliberately "just a cheap TRIGGER" (comment 3281-3283) that
+discards entry data and re-runs an authoritative geometry scan, so hanging a second consumer off it
+is the intended extension point. Keeping the handlers separate protects the read-receipt path,
+which is delicate (`seenSettled` / `seeking` / visibility gates at 3303-3306).
+
+**Alternatives considered**:
+- *A third IntersectionObserver* — rejected as redundant; same nodes, same lifecycle, more teardown
+  surface.
+- *Recover on chat open only* — rejected: fails a long chat where the pending message is far up the
+  scrollback, and duplicates what `resumePendingMediaJobs()` already does at app start.
+
+## R5 — Download concurrency
+
+**Finding**: **downloads are completely unbounded today.** Spec 2053's lanes (`queries.ts:2498-2553`,
+`heavyLane = createLimiter(1)`, `lightLane = createLimiter(3)`) are entered only by
+`scheduleMediaJob()`, which wraps the outgoing compress+seal+upload path. `downloadMessageMedia`
+(`queries.ts:2940`) calls `receiveIncomingMedia` directly with no limiter, and
+`resumePendingMediaJobs` (`:2982-2986`) fires `void downloadMessageMedia(m.id).catch(() => {})` in
+an unbounded loop over every pending message on the device.
+
+**Decision**: add a `downloadLane = createLimiter(3)` in `queries.ts` and route
+`downloadMessageMedia` through it. Reuses `createLimiter` from `src/utils/concurrency.ts`, which is
+already unit-tested (`src/utils/concurrency.test.ts`).
+
+**Rationale**: SC-005 requires that recovering ten consecutive pending voice messages not stampede.
+Adding on-view recovery to an already-unbounded path would make an existing latent problem worse,
+so the limiter is a precondition of the feature, not a nice-to-have. `3` matches `lightLane`, the
+established figure for non-heavy media work.
+
+## R6 — Honest failure across all kinds (US4) is nearly free
+
+**Finding**: `downloadPendingMedia(id)` (`ChatDetailPage.vue:1441`) is the **single shared tap
+handler** for every pending kind, and its `catch` is empty (`:1446-1448`, "leave it pending so the
+user can tap again").
+
+**Decision**: mark the failure and raise an `appToast` in that one `catch`, giving US4 across photo,
+video, audio and document for the same edit. Auto-recovery calls the underlying query function with
+a flag so it fails quietly (FR-009) — only a user-initiated tap talks back.
+
+**Rationale**: this is why the clarification's "extend to all media" answer is cheap: the honest
+failure lands at a single choke point that all kinds already funnel through.
+
+## R7 — Test seam (Constitution III: a 2001+ fix MUST start with a failing regression test)
+
+**Finding**: there is **no** e2e coverage asserting a voice bubble renders, and no way to **seed**
+the bug's state — `testhook.seedMedia` (`testhook.ts:1143-1166`) always sets `mediaId` and
+`outgoing: true`, so it cannot produce a *pending incoming* message.
+
+> **Correction after analysis.** An earlier draft of this note also claimed a test "cannot currently
+> distinguish a pending voice message from a downloaded one". That is false —
+> `testhook.mediaInfo(messageId)` (`:585-604`) already returns `{ hasMedia, pending }`, and
+> quickstart.md relies on it. Only the *seeding* half of the gap is real. Extending the
+> `messages()` projection is therefore a convenience, not a blocker.
+
+**Decision**: extend the dev-only test hook with (a) `seedPendingIncoming(chatId, kind, opts?)` that
+writes an incoming message carrying `pendingMedia` and no `mediaId`, and (b) `pending` +
+`dlFailedAt` on the `messages()` projection.
+
+**The seeded reference must be real.** `receiveIncomingMedia` (`media-transfer.ts:228`) fetches
+`ref.blobId` from the relay, so a *fabricated* `MediaRef` can never be fetched — every seeded
+message would fail, and the whole success path (US1, FR-005, FR-007) would be unreachable from the
+harness. The seeder therefore seals and genuinely uploads a tiny audio blob via
+`prepareOutgoingMedia` (`media-transfer.ts:203`) and stores the resulting real ref. Note
+`seedMedia` (`testhook.ts:1143-1166`) is **not** the seam to copy — it writes a local `Media` blob
+and uploads nothing. An explicit `opts.broken` produces the unfetchable ref for the failure cases. Then write the red e2e that asserts the voice bubble has visible content.
+
+**Rationale**: the regression test must reproduce *the reported state* (pending incoming voice), and
+that state is currently unreachable from a test. The hook is stripped from production builds
+(`src/services/testhook.ts`, per CLAUDE.md), so this adds no shipped surface.
+
+**Assertion shape**: the bug is "the bubble body is empty", so the test asserts on rendered content —
+the bubble for a pending incoming voice message must contain a non-empty, visible element. A test
+that only checked `pending === true` would pass both before and after the fix and prove nothing.

--- a/specs/2058-voice-messages-arrive/spec.md
+++ b/specs/2058-voice-messages-arrive/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-29
 
-**Status**: planned
+**Status**: in-progress
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category

--- a/specs/2058-voice-messages-arrive/spec.md
+++ b/specs/2058-voice-messages-arrive/spec.md
@@ -1,0 +1,316 @@
+# Feature Specification: Voice messages never arrive as an empty bubble
+
+**Feature Branch**: `fix/2058-voice-messages-arrive`
+
+**Created**: 2026-07-29
+
+**Status**: planned
+<!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
+     This line is the source of truth for the spec's row in ROADMAP.md;
+     bump it as the work moves through the pipeline. The spec id and category
+     are derived from the directory number (0001+ planned, 1001+ ad-hoc,
+     2001+ hotfix), so do not restate them by hand. -->
+
+**Input**: User report (with screenshots from both sides of the conversation): "When replying with audio message, the other party doesn't see the audio message to play."
+
+## Context: why this hotfix exists
+
+The reporter's recipient saw two voice messages arrive as **completely blank bubbles** — bubble
+outline, timestamp, and reaction button, and nothing else. No player, no duration, no download
+button, no error. The sender's own screen showed both messages sent and delivered normally.
+
+The report framed this as reply-specific because the blank bubble that prompted it happened to
+carry a reply quote (the quote *did* render, since a quote is plain message metadata that needs no
+attachment). **It is not reply-specific** — the plain voice note directly above it was equally
+blank. Any incoming voice message can land in this state.
+
+A voice bubble only draws once the audio bytes are on the device. There is a separate
+"not downloaded yet" presentation for attachments whose bytes are still pending, but it was only
+ever built for photos, non-note videos, shared audio files, and documents. **Voice messages — and
+round video notes — have no pending presentation at all**, so when their bytes aren't local yet
+there is simply nothing to draw.
+
+Voice is never *deliberately* deferred (it is exempt from the auto-download preferences and the
+size cap, on the reasoning that voice notes are small and expected to play instantly). So every
+occurrence of this bug is one of two transient-or-failed states that were never given a face:
+
+1. **It arrived while the app was closed or backgrounded.** The background-notification path
+   deliberately stores only the reference and never fetches bytes (fetching needs a media pipeline
+   and far more time than a notification wake-up is given). The bytes are fetched on the next app
+   start. Between arrival and that fetch, the bubble is blank — and this is the common case, since
+   the whole point of a voice note is that it arrives while you are not looking at the app.
+2. **The fetch failed.** Both the live receive path and the app-start backfill swallow a fetch
+   failure and leave the attachment pending, with an explicit "allow a manual retry" / "failure
+   keeps the manual tap path" intent. For voice there *is* no manual tap path, so a single failed
+   fetch strands the message permanently — it stays blank for the life of the message.
+
+The unifying principle of this fix, matching spec 2050's: **an attachment must either render
+something the user can act on, or say plainly what happened — never a silent blank.**
+
+## Clarifications
+
+### Session 2026-07-29
+
+- Q: When a pending voice message's audio can't be fetched, how should the recipient be told? → A:
+  Both an inline failed state on the bubble and a message when a manual retry fails — and extend
+  the same honest-failure treatment to every pending attachment kind, not just voice. Today a
+  failed fetch on a pending photo or video is swallowed silently too, so the same "never a silent
+  blank" principle is applied across the board rather than fixing voice alone.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A voice message received while the app was closed plays on its own (Priority: P1)
+
+Someone sends a voice message while the recipient's app is closed or in the background. The
+recipient opens the chat and the message is there, ready to play, without them having to do
+anything or knowing anything went wrong.
+
+**Why this priority**: This is the reported defect and by far the most common path — a voice note
+almost always arrives while the recipient isn't looking at the app. Today it produces a blank
+bubble with no explanation and no recourse, which reads as the message simply being broken.
+
+**Independent Test**: Send a voice message to a recipient whose app is closed. Open the app,
+go to the chat, and confirm the message shows as a playable voice note without any tap.
+
+**Acceptance Scenarios**:
+
+1. **Given** the recipient's app is closed, **When** a voice message arrives and the recipient
+   later opens the chat, **Then** the message appears as a playable voice note.
+2. **Given** the bytes have not been fetched yet at the moment the chat opens, **When** the bubble
+   is on screen, **Then** the fetch starts on its own and the bubble becomes playable when it
+   completes — with a visible indication that it is loading in the meantime.
+3. **Given** a voice message that has been sitting blank on the device from before this fix,
+   **When** the recipient opens that chat, **Then** it recovers the same way — no reinstall,
+   no re-send from the sender.
+
+---
+
+### User Story 2 - A voice message whose audio can't be fetched says so and can be retried (Priority: P1)
+
+The recipient's device can't fetch the audio — they're offline, the network drops mid-fetch, or the
+attempt fails. Instead of a blank bubble, they see a voice message placeholder that shows how long
+the message is and can be tapped to try again.
+
+**Why this priority**: This is the permanent-damage half of the bug. Without a visible retry, one
+failed fetch strands the message forever, and the recipient has no way to tell a broken message
+from an empty one. Shipping only User Story 1 would leave failures silent.
+
+**Independent Test**: Put the device offline, receive a voice message, and confirm the bubble shows
+a voice placeholder with its duration; go back online, tap it, and confirm it fetches and plays.
+
+**Acceptance Scenarios**:
+
+1. **Given** the audio has not been fetched, **When** the recipient looks at the bubble, **Then**
+   they see it is a voice message, how long it is, and that it can be tapped to load.
+2. **Given** a fetch attempt fails, **When** the recipient taps the placeholder, **Then** a fresh
+   attempt starts and shows its progress.
+3. **Given** a fetch is in progress, **When** the recipient looks at the bubble, **Then** progress
+   is visible, and repeated taps do not start overlapping attempts.
+4. **Given** a fetch attempt has failed, **When** the recipient looks at the bubble, **Then** the
+   placeholder shows a failed state that says so and offers a retry, and it keeps saying so when
+   they scroll back to it later.
+5. **Given** the audio can never be fetched because it is no longer available to fetch, **When**
+   the recipient taps to retry, **Then** they are told plainly rather than left tapping a
+   placeholder that silently does nothing.
+
+---
+
+### User Story 3 - Round video notes get the same treatment (Priority: P3)
+
+A round video note that arrives while the app is closed behaves like a voice message: it recovers
+on its own, and shows a tappable placeholder if it can't.
+
+**Why this priority**: Round notes have exactly the same gap for exactly the same reason, and are
+fixed by the same change — but they are used far less than voice, so no one has reported it. Worth
+closing while the code is open; not worth blocking the voice fix on.
+
+**Independent Test**: Send a round video note to a recipient whose app is closed, open the app,
+and confirm it plays without a tap.
+
+**Acceptance Scenarios**:
+
+1. **Given** the recipient's app is closed, **When** a round video note arrives and the recipient
+   later opens the chat, **Then** it is playable without any tap.
+2. **Given** its bytes cannot be fetched, **When** the recipient looks at the bubble, **Then** they
+   see a round-note placeholder they can tap to retry, not a blank bubble.
+
+---
+
+### User Story 4 - No attachment fails silently (Priority: P2)
+
+A recipient taps to load any pending attachment — a photo, a video, a shared audio file, a
+document — and the load fails. They are told it failed, and the bubble goes on saying so, instead
+of the tap appearing to do nothing.
+
+**Why this priority**: Today a failed tap on a pending photo or video is swallowed with no
+feedback at all, so the recipient cannot tell a slow load from a broken one and re-taps blindly.
+It is the same "never a silent blank" principle as the voice fix and shares its mechanism, but it
+is a pre-existing wart rather than the reported defect, so it should not block the voice fix.
+
+**Independent Test**: Go offline, tap a pending photo, and confirm both an immediate message that
+it failed and a bubble that still reads as failed afterwards.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pending photo, video, audio file, or document, **When** the recipient taps it and
+   the fetch fails, **Then** they are told at that moment and the bubble shows a failed state.
+2. **Given** a bubble in the failed state, **When** the recipient taps it again and the network has
+   recovered, **Then** it fetches and renders normally.
+3. **Given** a photo or video the recipient deliberately left deferred, **When** its bubble comes
+   into view, **Then** it does NOT start fetching on its own.
+
+---
+
+### Edge Cases
+
+- **Message deleted or expired before the fetch lands**: a disappearing message that expires, or a
+  message the sender unsends, while its audio is still pending — the bubble follows the normal
+  deleted/expired presentation and no orphan fetch keeps running.
+- **Audio deliberately removed from this device to free space**: this is a different state from
+  "not fetched yet" and keeps its existing "removed to free space" presentation — the fix must not
+  make cleared media look re-fetchable when it isn't.
+- **Attachment no longer available on the relay**: an old message whose stored ciphertext has aged
+  out. The retry must fail honestly rather than retry forever.
+- **Offline with several pending voice messages in one chat**: the recipient scrolls a chat with a
+  run of them. Recovery must not stampede the network or the device with simultaneous fetches.
+- **Repeated on-view retries for a message that keeps failing**: scrolling a permanently-broken
+  message in and out of view must not retry endlessly in a loop.
+- **Group chats**: the same behavior applies to voice messages from any group member.
+- **A voice message the recipient is already playing**: recovery of *other* pending messages must
+  not interrupt playback in progress.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: An incoming voice message whose audio is not yet on the device MUST render a visible
+  placeholder in place of the player — never an empty bubble.
+- **FR-002**: The placeholder MUST identify the message as a voice message and show its duration
+  when the duration is known. When the duration is not known it MUST still read as a voice message
+  rather than leaving an empty slot where the duration would be.
+- **FR-003**: The placeholder MUST be tappable to fetch the audio, and MUST show fetch progress
+  while a fetch is running.
+- **FR-004**: Tapping a placeholder whose fetch is already in progress MUST NOT start a second
+  overlapping fetch.
+- **FR-005**: A pending voice message MUST attempt its fetch automatically when its bubble comes
+  into view, so the common "arrived while the app was closed" case resolves without any tap.
+- **FR-006**: Automatic on-view retries MUST be bounded at **3 attempts per message per app
+  session**, so a message that cannot be fetched stops retrying and falls back to the manual tap
+  rather than looping. The count MUST reset when the app restarts — a message that exhausted its
+  attempts while the device was offline must still recover on a later launch (FR-013).
+- **FR-007**: When a fetch completes, the bubble MUST become the normal playable voice player
+  without the user leaving or reopening the chat.
+- **FR-008**: When a fetch fails, the placeholder MUST enter a visible failed state that names the
+  failure and offers a retry, and that state MUST persist so it still reads as failed when the
+  recipient returns to the message later.
+- **FR-009**: When a fetch the recipient started by tapping fails, the app MUST additionally tell
+  them at the moment of the failure, rather than only changing the bubble they may not be looking
+  at. Automatic on-view retries MUST fail quietly into the failed state without interrupting the
+  recipient.
+- **FR-010**: The failed state and the on-tap message of FR-008 and FR-009 MUST apply to every
+  pending attachment kind — voice, round video note, photo, video, audio file, and document — so
+  no kind fails silently.
+- **FR-011**: Round video notes MUST follow FR-001 through FR-007, with a round-note placeholder
+  in place of the voice placeholder.
+- **FR-012**: Audio deliberately removed from the device to free space MUST keep its existing
+  distinct presentation and MUST NOT be shown as a pending fetch.
+- **FR-013**: The fix MUST apply to voice messages already stranded on devices before it ships,
+  with no reinstall and no re-send by the sender.
+- **FR-014**: The fix MUST NOT change what is sent over the wire, how it is encrypted, or what the
+  server can observe — it is a receive-side rendering and recovery change only.
+- **FR-015**: Attachments the recipient deliberately deferred (a photo or video left for a manual
+  tap by their auto-download preference or the size cap) MUST keep that behavior — they MUST NOT
+  start fetching automatically on view just because voice does.
+
+### Key Entities
+
+- **Voice message**: an incoming chat message carrying recorded audio, with a known duration and
+  a reference to its stored ciphertext, in one of three states on the device — audio present,
+  audio pending, or audio removed to free space.
+- **Pending attachment reference**: the sender's reference to the stored ciphertext, kept on the
+  message so the audio can be fetched later. Its presence alongside absent audio is what
+  identifies the pending state.
+
+## Zero-Knowledge Impact *(mandatory — Constitution Principle I)*
+
+**What crosses the wire**: nothing new. This fix changes only how the receiving device draws a
+message it already has, and when it fetches attachment bytes it was already entitled to fetch.
+
+- **Sending**: unchanged. No change to what is sealed, how it is sealed, or what accompanies it.
+- **Fetching**: the fix reuses the existing attachment fetch unchanged — the same capability-style
+  blob id the sender already put in the sealed message, fetched over the existing endpoint, and
+  decrypted on the device. No new endpoint, no new parameter, no new identifier.
+- **New state**: the failure marker lives **only in the device's local database** — never synced,
+  never sent, never derived from anything the server provides. The retry count is weaker still: it
+  is held in memory for the session and never written down at all.
+- **Metadata visible to the server**: unchanged in kind. The server already observes that some
+  device fetched some blob id at some time — that is inherent to relaying the bytes at all. This
+  fix does not add a new observable; it can only change *timing*, since a fetch that previously
+  never happened (the stranded case) now happens. It reveals nothing the ordinary success path
+  would not have revealed moments earlier.
+- **Retry bound**: the per-message attempt cap (FR-006) additionally keeps a permanently-failing
+  message from generating an unbounded, repeating fetch pattern against the relay.
+
+**Not affected**: no change to the crypto core, key handling, session state, or the at-rest
+wrapping of secrets. No new plaintext reaches the server, no log line or error payload gains user
+content, and no migration touches server-side storage.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero blank bubbles across the full matrix of message kind × attachment state:
+  the six attachment kinds (voice, round video note, photo, video, audio file, document) in each of
+  the four states (audio present, pending, failed, removed to free space) — 24 cells, none of which
+  renders a bubble with no content.
+- **SC-002**: A voice message that arrives while the app is closed is playable within 3 seconds of
+  the recipient opening the chat, with no taps, measured on an unthrottled local connection. The
+  measured moment is the placeholder being replaced by a working player, not merely the fetch
+  returning.
+- **SC-003**: A voice message whose fetch failed can be recovered by the recipient in a single tap,
+  100% of the time the audio is still available to fetch.
+- **SC-004**: A voice message stranded blank before this fix becomes playable on the next open of
+  its chat, with no reinstall and no re-send.
+- **SC-005**: Scrolling a chat containing 10 consecutive pending voice messages recovers all 10,
+  with **at most 3 fetches in flight at any moment**, and the scroll position stays stable
+  throughout (no jump, no blank frame) by the same measure the existing chat-media scroll coverage
+  applies.
+- **SC-006**: The reporter's exact scenario — a voice message, and a reply carrying a voice
+  message, sent to a recipient whose app is closed — plays on both sides.
+- **SC-007**: Zero silent failures: for every pending attachment kind, a failed manual load
+  produces both an immediate message to the recipient and a bubble that still reads as failed
+  afterwards — no kind swallows the failure.
+
+## Complexity & Exceptions
+
+*Governance requires a waived or unmet **MUST** to be recorded here and accepted by a maintainer.*
+
+| # | Principle / rule | Status | Detail |
+|---|---|---|---|
+| E-1 | **Development Workflow — supply-chain scan at the start of new work** (MUST) | ⏳ **Unmet, awaiting maintainer** | The Docker Scout report for the current `zuptalo/ring` tag has not been reviewed; this environment has no Docker Hub access. No Go module or base-image surface is touched by this client-only change, so it does not block the code, but it MUST be discharged before the release PR. **Maintainer sign-off: not yet recorded.** |
+| E-2 | **Principle XI — Ionic-First UI** | ✅ Justified deviation | The voice placeholder is hand-rolled rather than a stock Ionic component, because no Ionic primitive exists for a voice bubble and the placeholder must match `VoicePlayer`'s row metrics or the bubble reflows when the fetch lands. Composed from the existing download vocabulary and existing theme tokens, exactly as its hand-rolled sibling does. Full reasoning in plan.md → Complexity Tracking. |
+| E-3 | **Development Workflow — version bump at the start of a release cycle** (MUST) | ✅ Addressed | `develop` and `main` are level at 1.0.32 (tag `v1.0.32` exists), so this is the first change of a new cycle and `package.json` must move to 1.0.33 on this branch or the release guard blocks the eventual release PR. Carried as a task. |
+
+## Assumptions
+
+- The recipients in the report were not deliberately deferring media: voice is exempt from the
+  auto-download preferences and the size cap, so their messages were pending because of the
+  background-arrival path or a failed fetch, not a setting. No change to the auto-download
+  preferences is in scope.
+- The placeholder reuses the visual language already established for pending photos, videos,
+  audio files, and documents (a duration/size label plus a download affordance with a progress
+  ring), rather than introducing a new one.
+- The honest-failure extension to all attachment kinds (User Story 4) is deliberately in scope per
+  the 2026-07-29 clarification, on the grounds that it is the same principle and the same
+  mechanism. It stays a strictly additive change to how a failure is presented — it does not
+  change when any kind is fetched.
+- The automatic-retry bound is **in-memory and per session** (FR-006). It deliberately does not
+  persist: a persistent counter would let a message that burned its attempts during one offline
+  session become permanently manual-only, which would contradict FR-013's promise that stranded
+  messages recover on a later open.
+- Fixing the send side is out of scope — the sender's own copy renders correctly today, and the
+  report's screenshots confirm the messages were sent, delivered, and readable on the sender's
+  device.
+- Existing background-notification behavior stays as-is: it is deliberate that the notification
+  path does not fetch attachment bytes, and this fix repairs the recipient experience downstream
+  of that rather than changing it.

--- a/specs/2058-voice-messages-arrive/tasks.md
+++ b/specs/2058-voice-messages-arrive/tasks.md
@@ -27,8 +27,8 @@ gate: it must be observed failing, for the right reason, before any task in Phas
 
 **Purpose**: know the tree is green before touching it, so a later failure is attributable.
 
-- [ ] T001 Run `npm run build` and record it passing on the untouched branch
-- [ ] T002 Run `npx playwright test e2e/seen-on-view.spec.ts` and record it passing — this is the
+- [x] T001 Run `npm run build` and record it passing on the untouched branch
+- [x] T002 Run `npx playwright test e2e/seen-on-view.spec.ts` and record it passing — this is the
       canary for the read-receipt observer that Phase 4 extends (plan.md "Risks")
 
 **Checkpoint**: baseline green and recorded.
@@ -43,13 +43,13 @@ reproduce at the end of this phase, or the Phase 3 red test proves nothing.
 
 **⚠️ CRITICAL**: no user-story work may begin until Phase 3's red test has been observed failing.
 
-- [ ] T003 Add optional `dlFailedAt?: number` to the `Message` interface in `src/db/types.ts` (near
+- [x] T003 Add optional `dlFailedAt?: number` to the `Message` interface in `src/db/types.ts` (near
       the existing `failReason?` / `jobAttempts?` send-side fields, ~:336-340), commented as
       device-local receive-side bookkeeping that is never synced. (No sync exclusion work is needed:
       own-data sync covers only `contacts`/`chats`/`chatlists` — `ownsync.ts:28` — so no `Message`
       field can ride it. Verified in `checklists/zero-knowledge.md`; noted here so the next reader
       doesn't re-derive it.)
-- [ ] T004 Add `seedPendingIncoming(chatId, kind, opts?)` to `src/services/testhook.ts` that writes
+- [x] T004 Add `seedPendingIncoming(chatId, kind, opts?)` to `src/services/testhook.ts` that writes
       an **incoming** message (`outgoing: false`, `status: 'delivered'`) with `pendingMedia` set,
       **no** `mediaId`, and a `durationSec`. It MUST seal and **really upload** a tiny audio blob
       via `prepareOutgoingMedia` (`src/services/media-transfer.ts:203`) and store the resulting
@@ -58,18 +58,18 @@ reproduce at the end of this phase, or the Phase 3 red test proves nothing.
       instead stores a ref pointing at a blob id that was never uploaded, for the failure cases;
       `opts.videoNote: true` seeds a round note. **A fabricated ref for every case would make the
       entire success path — US1 — untestable**
-- [ ] T005 [P] Extend the `messages(chatId)` projection in `src/services/testhook.ts` (~:551-581) to
+- [x] T005 [P] Extend the `messages(chatId)` projection in `src/services/testhook.ts` (~:551-581) to
       expose `pending: !!m.pendingMedia` and `dlFailedAt: m.dlFailedAt ?? null`. (Convenience only —
       `mediaInfo()` at ~:585-604 already reports `hasMedia`/`pending`; this just spares the tests a
       second call per row)
-- [ ] T006 **RED (unit)**: write the vitest for the auto-retry bound *before* the function exists —
+- [x] T006 **RED (unit)**: write the vitest for the auto-retry bound *before* the function exists —
       0/1/2 attempts → retry, 3+ → stop. Constitution III requires tests to be ordered before the
       implementation that satisfies them, and this is the only genuinely pure piece the fix adds.
       Run it and watch it fail to resolve the import
-- [ ] T007 Extract the auto-retry bound as a **pure** function in `src/utils/` (or beside the
+- [x] T007 Extract the auto-retry bound as a **pure** function in `src/utils/` (or beside the
       existing helpers) — `shouldAutoRetry(attempts: number): boolean`, capped at 3 per FR-006 —
       testable without IndexedDB. T006 now passes
-- [ ] T008 Run `npm run build` — types compile, behavior unchanged, bug still reproduces by hand
+- [x] T008 Run `npm run build` — types compile, behavior unchanged, bug still reproduces by hand
 
 **Checkpoint**: both flavors of the bug's state are reachable from a test, and nothing is fixed yet.
 
@@ -82,20 +82,20 @@ reproduce at the end of this phase, or the Phase 3 red test proves nothing.
 **Goal**: a test that fails today **because the bubble body is empty**, and passes only once the
 placeholder exists and the fetch resolves into a real player.
 
-- [ ] T009 Create `e2e/voice-pending.spec.ts` with the US1 case: seed a **fetchable** pending
+- [x] T009 Create `e2e/voice-pending.spec.ts` with the US1 case: seed a **fetchable** pending
       incoming voice message, open the chat, assert the bubble `[data-mid]` contains a visible,
       non-empty body, **and then** assert the placeholder is replaced by the real player
       (`.vp-pending` gone, `VoicePlayer`'s `.vp` present) without navigating away — FR-007, within a
       timeout encoding SC-002's 3 seconds
-- [ ] T010 [US2] Add the US2 case: with a `broken: true` seed, the bubble shows a placeholder
+- [x] T010 [US2] Add the US2 case: with a `broken: true` seed, the bubble shows a placeholder
       carrying the duration, a tap starts a retry, and the failure is surfaced
-- [ ] T011 [US2] Add the FR-008 persistence case: after a failed fetch, **leave the chat and
+- [x] T011 [US2] Add the FR-008 persistence case: after a failed fetch, **leave the chat and
       re-enter**, and assert the bubble still reads as failed. Without this step a component-local
       implementation would pass every other assertion
-- [ ] T012 Add the FR-013 / SC-004 case: seed a pending incoming voice message with an old
+- [x] T012 Add the FR-013 / SC-004 case: seed a pending incoming voice message with an old
       `updatedAt` (a message stranded before this fix), open the chat, assert it recovers with no
       tap and no re-send
-- [ ] T013 **Run the new spec and observe it FAIL.** Record the failure output in the PR/commit
+- [x] T013 **Run the new spec and observe it FAIL.** Record the failure output in the PR/commit
       message. Confirm it fails because the bubble renders empty — not because the seam is wrong,
       the selector is wrong, or the test errored before asserting. **Rule out self-resolution**:
       `resumePendingMediaJobs` already auto-downloads voice on app start *and on reconnect*
@@ -113,7 +113,7 @@ placeholder exists and the fetch resolves into a real player.
 
 **Independent test**: T009 + T012 pass.
 
-- [ ] T014 [US1] Add the pending-voice branch to the `v-if` chain in
+- [x] T014 [US1] Add the pending-voice branch to the `v-if` chain in
       `src/views/detail/ChatDetailPage.vue` (after the audio/file chip at ~:379-394): condition
       `m.kind === 'voice' && !m.mediaId && m.pendingMedia`, rendering a `.vp-pending` row — a
       download disc reusing the existing `.dl-ring` progress SVG where `VoicePlayer`'s play button
@@ -121,20 +121,20 @@ placeholder exists and the fetch resolves into a real player.
       label when the duration is unknown, per FR-002). Render the tap target as a `<button>` with an
       explicit accessible label, as the sibling `.pending-chip` at ~:379 already does — Constitution
       X makes labels and focus part of every UI change. Tap calls `downloadPendingMedia(m.id)`
-- [ ] T015 [US1] Add `.vp-pending` CSS to the same file's `<style>` block beside the existing
+- [x] T015 [US1] Add `.vp-pending` CSS to the same file's `<style>` block beside the existing
       `.dl-ring` / `.chip-ico` rules (~:5727-5773), matching `VoicePlayer`'s `.vp` row metrics
       (`display:flex; align-items:center; gap:10px`, 34px disc, 24px wave strip) so the bubble does
       **not** change height when the fetch resolves. Keep the placeholder inside the ordinary
       text-padding bubble — do **not** flip `mediaBubble()`/`.bubble-media` on for pending voice: a
       *resolved* voice message is not a media bubble, so toggling the class would add then remove
       the media padding and produce exactly the reflow this design exists to avoid
-- [ ] T016 [US1] Add `downloadLane = createLimiter(3)` in `src/db/queries.ts` beside the existing
+- [x] T016 [US1] Add `downloadLane = createLimiter(3)` in `src/db/queries.ts` beside the existing
       spec-2053 lanes (~:2498-2515), import from `@/utils/concurrency`, and route the fetch **inside**
       `downloadMessageMedia` (~:2940) through it. This single choke point covers every caller —
       including the `resumePendingMediaJobs` backfill loop (~:2982-2986), whose body is just
       `void downloadMessageMedia(m.id)`. Do **not** also wrap the call sites: double-wrapping halves
       effective concurrency and risks a re-entrant stall
-- [ ] T017 [US1] Add a debounced `recoverVisiblePending()` in `src/views/detail/ChatDetailPage.vue`
+- [x] T017 [US1] Add a debounced `recoverVisiblePending()` in `src/views/detail/ChatDetailPage.vue`
       **beside** `markVisibleSeen()` (~:3298), driven by the existing bubble observer (~:3284). It
       walks visible `.bubble[data-mid]` rows and, for rows that are `!m.outgoing && m.pendingMedia
       && !m.mediaId && !m.deleted` and not past `expiresAt` (so a message deleted or expired
@@ -145,11 +145,11 @@ placeholder exists and the fetch resolves into a real player.
       allowlist: that function already encodes "voice and round notes always, everything else per
       preference and size cap", which is exactly FR-015. Do **not** modify
       `markVisibleSeen`/`runMarkVisibleSeen` themselves
-- [ ] T018 [US1] Bound the automatic path with the pure `shouldAutoRetry` from T007, backed by a
+- [x] T018 [US1] Bound the automatic path with the pure `shouldAutoRetry` from T007, backed by a
       module-scoped in-memory `Map<messageId, number>` — **not** a persisted field. A persisted
       counter would strand a message that burned its attempts offline, contradicting FR-013. A
       manual tap ignores the cap and never increments it (data-model INV-3, INV-4)
-- [ ] T019 [US1] Run `npx playwright test e2e/voice-pending.spec.ts` — the US1 and FR-013 cases pass
+- [x] T019 [US1] Run `npx playwright test e2e/voice-pending.spec.ts` — the US1 and FR-013 cases pass
 
 **Checkpoint**: the reported bug is fixed and the red test is green.
 
@@ -159,29 +159,29 @@ placeholder exists and the fetch resolves into a real player.
 
 **Goal**: a voice message whose audio can't be fetched says so and can be retried.
 
-- [ ] T020 [US2] In `src/db/queries.ts` `downloadMessageMedia`, stamp `dlFailedAt = now()` on failure
+- [x] T020 [US2] In `src/db/queries.ts` `downloadMessageMedia`, stamp `dlFailedAt = now()` on failure
       and clear it on success, writing through the `idb` wrapper (and bumping `updatedAt`, as the
       success path already does at ~:2963) so the change bus repaints the bubble. Keep
       `pendingMedia` intact on failure (data-model INV-2)
-- [ ] T021 [US2] Give the failed state a face in `src/views/detail/ChatDetailPage.vue`: when
+- [x] T021 [US2] Give the failed state a face in `src/views/detail/ChatDetailPage.vue`: when
       `m.dlFailedAt` is set the placeholder reads as failed and offers a retry, rather than looking
       like it is still loading
-- [ ] T022 [US2] Change `downloadPendingMedia` (~:1441) to
+- [x] T022 [US2] Change `downloadPendingMedia` (~:1441) to
       `downloadPendingMedia(id: string, opts: { silent?: boolean } = {})` — note the **default `{}`**,
       or the existing template call sites (~:362, ~:383) that pass only the id would throw. The
       automatic path and the tap path then share the existing `if (id in downloadProgress) return`
       guard (~:1442), so a tap and an on-view attempt cannot race (FR-004), differing only in
       whether they speak up
-- [ ] T023 [US2] Confirm the bubble repaints on the failed flip: T020 bumps `updatedAt`, which is
+- [x] T023 [US2] Confirm the bubble repaints on the failed flip: T020 bumps `updatedAt`, which is
       already the first entry of the row's `v-memo` list (~:154), so no `v-memo` change should be
       needed. **Verify this rather than assume it** — if T020 is implemented without bumping
       `updatedAt`, add `m.dlFailedAt` to the `v-memo` list at ~:159 instead
-- [ ] T024 [US2] Add the SC-003 recovery case to `e2e/voice-pending.spec.ts`: seed a **fetchable**
+- [x] T024 [US2] Add the SC-003 recovery case to `e2e/voice-pending.spec.ts`: seed a **fetchable**
       voice message, force the first fetch to fail, confirm the failed state, then tap **once** and
       assert it plays. T010's `broken` seed can never succeed, so without this the "single tap
       recovers it, 100% of the time the audio is still available" promise is never actually
       exercised
-- [ ] T025 [US2] Run `npx playwright test e2e/voice-pending.spec.ts` — the US2, FR-008 persistence
+- [x] T025 [US2] Run `npx playwright test e2e/voice-pending.spec.ts` — the US2, FR-008 persistence
       and SC-003 cases pass
 
 **Checkpoint**: MVP complete. US1+US2 together deliver the reported fix end to end.
@@ -192,7 +192,7 @@ placeholder exists and the fetch resolves into a real player.
 
 **Goal**: round notes behave like voice messages.
 
-- [ ] T026 [US3] Add a **dedicated sibling branch** for pending round notes in
+- [x] T026 [US3] Add a **dedicated sibling branch** for pending round notes in
       `src/views/detail/ChatDetailPage.vue` — condition `m.kind === 'video' && m.videoNote &&
       !m.mediaId && m.pendingMedia` — rendering a circular placeholder with the same `.dl-ring`
       affordance, **including the failed state** from T021 so FR-010 holds for round notes and the
@@ -201,7 +201,7 @@ placeholder exists and the fetch resolves into a real player.
       poster-or-skeleton box and would render a round note as a square, and the round-note bubble is
       already chromeless via `'bubble-plain': m.videoNote && !m.deleted` (~:212), so a square
       pending frame inside it would render bare
-- [ ] T027 [P] [US3] Add the round-note cases to `e2e/voice-pending.spec.ts` via
+- [x] T027 [P] [US3] Add the round-note cases to `e2e/voice-pending.spec.ts` via
       `seedPendingIncoming(chatId, 'video', { videoNote: true })` — both the recovery case and the
       failed-state case
 
@@ -211,16 +211,16 @@ placeholder exists and the fetch resolves into a real player.
 
 **Goal**: every pending kind fails honestly, not just voice.
 
-- [ ] T028 [US4] Replace the swallowing `catch` in `downloadPendingMedia`
+- [x] T028 [US4] Replace the swallowing `catch` in `downloadPendingMedia`
       (`src/views/detail/ChatDetailPage.vue` ~:1446-1448) with one that raises an `appToast` **when
       `silent` is false** and lets T020's failure marking stand. `appToast` is already imported at
       ~:1230. This is the single shared tap handler for every kind, so it covers photo, video, audio
       and document at once (research R6)
-- [ ] T029 [US4] Show the failed state on the existing pending photo/video block and audio/file chip
+- [x] T029 [US4] Show the failed state on the existing pending photo/video block and audio/file chip
       so those kinds read as failed too (FR-010)
-- [ ] T030 [P] [US4] Add the US4 case to `e2e/voice-pending.spec.ts`: a pending **photo** whose tap
+- [x] T030 [P] [US4] Add the US4 case to `e2e/voice-pending.spec.ts`: a pending **photo** whose tap
       fails produces a visible message and a failed-looking bubble
-- [ ] T031 [P] [US4] Add the FR-015 guard case: with photo auto-download set to never, a pending
+- [x] T031 [P] [US4] Add the FR-015 guard case: with photo auto-download set to never, a pending
       photo scrolled into view does **not** self-fetch. (Meaningful only because T017 defers to
       `shouldAutoDownloadMedia` rather than a hardcoded allowlist)
 
@@ -228,22 +228,22 @@ placeholder exists and the fetch resolves into a real player.
 
 ## Phase 8: Polish & Gates
 
-- [ ] T032 Add the SC-005 stampede case to `e2e/voice-pending.spec.ts`: seed 10 consecutive pending
+- [x] T032 Add the SC-005 stampede case to `e2e/voice-pending.spec.ts`: seed 10 consecutive pending
       voice messages, scroll through them, assert all 10 recover, **at most 3 fetches in flight**,
       and the scroll position stays stable
-- [ ] T033 Add the SC-001 matrix case: walk the six kinds × four states and assert **no** bubble
+- [x] T033 Add the SC-001 matrix case: walk the six kinds × four states and assert **no** bubble
       renders empty. Scope explicitly to the states reachable from the harness and log any cell left
       to manual check rather than silently omitting it
-- [ ] T034 Run `npx playwright test e2e/seen-on-view.spec.ts` — the read-receipt observer is
+- [x] T034 Run `npx playwright test e2e/seen-on-view.spec.ts` — the read-receipt observer is
       unharmed by T017 (the canary from T002)
-- [ ] T035 [P] Run `npx playwright test e2e/media-blob-delete.spec.ts e2e/chat-media-scroll.spec.ts
+- [x] T035 [P] Run `npx playwright test e2e/media-blob-delete.spec.ts e2e/chat-media-scroll.spec.ts
       e2e/media-cleanup.spec.ts` — pending/download and scroll-anchor behavior unregressed
-- [ ] T036 [P] Run `npx vitest run` and `npm run build` — unit (now including T006) + typecheck green
+- [x] T036 [P] Run `npx vitest run` and `npm run build` — unit (now including T006) + typecheck green
 - [ ] T037 Confirm FR-012 by hand: free space on a downloaded voice message and check it still reads
       "removed to free space" rather than appearing re-fetchable
-- [ ] T038 Flip `**Status**:` to `in-progress` (then `in-review`) in
+- [x] T038 Flip `**Status**:` to `in-progress` (then `in-review`) in
       `specs/2058-voice-messages-arrive/spec.md` and run `make roadmap`
-- [ ] T039 **Bump `package.json` to 1.0.33.** `develop` and `main` are level at 1.0.32 (tag
+- [x] T039 **Bump `package.json` to 1.0.33.** `develop` and `main` are level at 1.0.32 (tag
       `v1.0.32` exists), so this is the first change of a new release cycle and the constitution
       makes the bump mandatory — without it the release guard blocks the eventual `develop → main`
       PR (spec.md → Complexity & Exceptions, E-3)

--- a/specs/2058-voice-messages-arrive/tasks.md
+++ b/specs/2058-voice-messages-arrive/tasks.md
@@ -1,0 +1,338 @@
+---
+
+description: "Task list for spec 2058 — Voice messages never arrive as an empty bubble"
+---
+
+# Tasks: Voice messages never arrive as an empty bubble
+
+**Input**: Design documents from `/specs/2058-voice-messages-arrive/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: **REQUIRED, not optional.** Constitution Principle III states a `2001+` bug fix *MUST*
+begin with a failing regression test that reproduces the bug before the fix lands. Phase 3 is a hard
+gate: it must be observed failing, for the right reason, before any task in Phase 4+ starts.
+
+**Revision**: rewritten after `/speckit-analyze` returned 4 CRITICAL + 6 HIGH findings. See
+"Analysis remediation" at the foot for the mapping from finding to task.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 / US4 from spec.md
+
+---
+
+## Phase 1: Setup (Baseline)
+
+**Purpose**: know the tree is green before touching it, so a later failure is attributable.
+
+- [ ] T001 Run `npm run build` and record it passing on the untouched branch
+- [ ] T002 Run `npx playwright test e2e/seen-on-view.spec.ts` and record it passing — this is the
+      canary for the read-receipt observer that Phase 4 extends (plan.md "Risks")
+
+**Checkpoint**: baseline green and recorded.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: the one persisted field and a test seam that can produce **both** a fetchable and a
+broken pending message. **Nothing here changes user-visible behavior** — the bug must still
+reproduce at the end of this phase, or the Phase 3 red test proves nothing.
+
+**⚠️ CRITICAL**: no user-story work may begin until Phase 3's red test has been observed failing.
+
+- [ ] T003 Add optional `dlFailedAt?: number` to the `Message` interface in `src/db/types.ts` (near
+      the existing `failReason?` / `jobAttempts?` send-side fields, ~:336-340), commented as
+      device-local receive-side bookkeeping that is never synced. (No sync exclusion work is needed:
+      own-data sync covers only `contacts`/`chats`/`chatlists` — `ownsync.ts:28` — so no `Message`
+      field can ride it. Verified in `checklists/zero-knowledge.md`; noted here so the next reader
+      doesn't re-derive it.)
+- [ ] T004 Add `seedPendingIncoming(chatId, kind, opts?)` to `src/services/testhook.ts` that writes
+      an **incoming** message (`outgoing: false`, `status: 'delivered'`) with `pendingMedia` set,
+      **no** `mediaId`, and a `durationSec`. It MUST seal and **really upload** a tiny audio blob
+      via `prepareOutgoingMedia` (`src/services/media-transfer.ts:203`) and store the resulting
+      genuine `MediaRef`, so a fetch can actually succeed. Note `seedMedia` (~:1143-1166) is **not**
+      the seam to copy — it writes a local `Media` blob and uploads nothing. `opts.broken: true`
+      instead stores a ref pointing at a blob id that was never uploaded, for the failure cases;
+      `opts.videoNote: true` seeds a round note. **A fabricated ref for every case would make the
+      entire success path — US1 — untestable**
+- [ ] T005 [P] Extend the `messages(chatId)` projection in `src/services/testhook.ts` (~:551-581) to
+      expose `pending: !!m.pendingMedia` and `dlFailedAt: m.dlFailedAt ?? null`. (Convenience only —
+      `mediaInfo()` at ~:585-604 already reports `hasMedia`/`pending`; this just spares the tests a
+      second call per row)
+- [ ] T006 **RED (unit)**: write the vitest for the auto-retry bound *before* the function exists —
+      0/1/2 attempts → retry, 3+ → stop. Constitution III requires tests to be ordered before the
+      implementation that satisfies them, and this is the only genuinely pure piece the fix adds.
+      Run it and watch it fail to resolve the import
+- [ ] T007 Extract the auto-retry bound as a **pure** function in `src/utils/` (or beside the
+      existing helpers) — `shouldAutoRetry(attempts: number): boolean`, capped at 3 per FR-006 —
+      testable without IndexedDB. T006 now passes
+- [ ] T008 Run `npm run build` — types compile, behavior unchanged, bug still reproduces by hand
+
+**Checkpoint**: both flavors of the bug's state are reachable from a test, and nothing is fixed yet.
+
+---
+
+## Phase 3: RED — the regression test (Constitution III gate) 🚨
+
+**Purpose**: reproduce the reported defect automatically, and watch it fail, before any fix.
+
+**Goal**: a test that fails today **because the bubble body is empty**, and passes only once the
+placeholder exists and the fetch resolves into a real player.
+
+- [ ] T009 Create `e2e/voice-pending.spec.ts` with the US1 case: seed a **fetchable** pending
+      incoming voice message, open the chat, assert the bubble `[data-mid]` contains a visible,
+      non-empty body, **and then** assert the placeholder is replaced by the real player
+      (`.vp-pending` gone, `VoicePlayer`'s `.vp` present) without navigating away — FR-007, within a
+      timeout encoding SC-002's 3 seconds
+- [ ] T010 [US2] Add the US2 case: with a `broken: true` seed, the bubble shows a placeholder
+      carrying the duration, a tap starts a retry, and the failure is surfaced
+- [ ] T011 [US2] Add the FR-008 persistence case: after a failed fetch, **leave the chat and
+      re-enter**, and assert the bubble still reads as failed. Without this step a component-local
+      implementation would pass every other assertion
+- [ ] T012 Add the FR-013 / SC-004 case: seed a pending incoming voice message with an old
+      `updatedAt` (a message stranded before this fix), open the chat, assert it recovers with no
+      tap and no re-send
+- [ ] T013 **Run the new spec and observe it FAIL.** Record the failure output in the PR/commit
+      message. Confirm it fails because the bubble renders empty — not because the seam is wrong,
+      the selector is wrong, or the test errored before asserting. **Rule out self-resolution**:
+      `resumePendingMediaJobs` already auto-downloads voice on app start *and on reconnect*
+      (`queries.ts:2982-2986`), so a fetchable seed can quietly resolve itself mid-test and turn the
+      red gate green for the wrong reason. Assert the pending state still holds at the moment of the
+      bubble assertion, or seed after the reconnect settles
+
+**Checkpoint**: red, for the right reason, and recorded. Only now may Phase 4 begin.
+
+---
+
+## Phase 4: User Story 1 — self-healing voice message (Priority: P1) 🎯 MVP
+
+**Goal**: a voice message that arrived while the app was closed renders, and fetches itself on view.
+
+**Independent test**: T009 + T012 pass.
+
+- [ ] T014 [US1] Add the pending-voice branch to the `v-if` chain in
+      `src/views/detail/ChatDetailPage.vue` (after the audio/file chip at ~:379-394): condition
+      `m.kind === 'voice' && !m.mediaId && m.pendingMedia`, rendering a `.vp-pending` row — a
+      download disc reusing the existing `.dl-ring` progress SVG where `VoicePlayer`'s play button
+      sits, a flat inert waveform, and `m.durationSec` (falling back to the plain "Voice message"
+      label when the duration is unknown, per FR-002). Render the tap target as a `<button>` with an
+      explicit accessible label, as the sibling `.pending-chip` at ~:379 already does — Constitution
+      X makes labels and focus part of every UI change. Tap calls `downloadPendingMedia(m.id)`
+- [ ] T015 [US1] Add `.vp-pending` CSS to the same file's `<style>` block beside the existing
+      `.dl-ring` / `.chip-ico` rules (~:5727-5773), matching `VoicePlayer`'s `.vp` row metrics
+      (`display:flex; align-items:center; gap:10px`, 34px disc, 24px wave strip) so the bubble does
+      **not** change height when the fetch resolves. Keep the placeholder inside the ordinary
+      text-padding bubble — do **not** flip `mediaBubble()`/`.bubble-media` on for pending voice: a
+      *resolved* voice message is not a media bubble, so toggling the class would add then remove
+      the media padding and produce exactly the reflow this design exists to avoid
+- [ ] T016 [US1] Add `downloadLane = createLimiter(3)` in `src/db/queries.ts` beside the existing
+      spec-2053 lanes (~:2498-2515), import from `@/utils/concurrency`, and route the fetch **inside**
+      `downloadMessageMedia` (~:2940) through it. This single choke point covers every caller —
+      including the `resumePendingMediaJobs` backfill loop (~:2982-2986), whose body is just
+      `void downloadMessageMedia(m.id)`. Do **not** also wrap the call sites: double-wrapping halves
+      effective concurrency and risks a re-entrant stall
+- [ ] T017 [US1] Add a debounced `recoverVisiblePending()` in `src/views/detail/ChatDetailPage.vue`
+      **beside** `markVisibleSeen()` (~:3298), driven by the existing bubble observer (~:3284). It
+      walks visible `.bubble[data-mid]` rows and, for rows that are `!m.outgoing && m.pendingMedia
+      && !m.mediaId && !m.deleted` and not past `expiresAt` (so a message deleted or expired
+      mid-flight starts no orphan fetch), calls `downloadPendingMedia(m.id, { silent: true })`
+      (signature per T022). It defers the should-I-fetch decision to the **existing**
+      `shouldAutoDownloadMedia` (`queries.ts:2862` — add `export`; it is currently module-private
+      with only two in-file callers, so exporting breaks nothing) rather than restating a kind
+      allowlist: that function already encodes "voice and round notes always, everything else per
+      preference and size cap", which is exactly FR-015. Do **not** modify
+      `markVisibleSeen`/`runMarkVisibleSeen` themselves
+- [ ] T018 [US1] Bound the automatic path with the pure `shouldAutoRetry` from T007, backed by a
+      module-scoped in-memory `Map<messageId, number>` — **not** a persisted field. A persisted
+      counter would strand a message that burned its attempts offline, contradicting FR-013. A
+      manual tap ignores the cap and never increments it (data-model INV-3, INV-4)
+- [ ] T019 [US1] Run `npx playwright test e2e/voice-pending.spec.ts` — the US1 and FR-013 cases pass
+
+**Checkpoint**: the reported bug is fixed and the red test is green.
+
+---
+
+## Phase 5: User Story 2 — honest failure + retry for voice (Priority: P1)
+
+**Goal**: a voice message whose audio can't be fetched says so and can be retried.
+
+- [ ] T020 [US2] In `src/db/queries.ts` `downloadMessageMedia`, stamp `dlFailedAt = now()` on failure
+      and clear it on success, writing through the `idb` wrapper (and bumping `updatedAt`, as the
+      success path already does at ~:2963) so the change bus repaints the bubble. Keep
+      `pendingMedia` intact on failure (data-model INV-2)
+- [ ] T021 [US2] Give the failed state a face in `src/views/detail/ChatDetailPage.vue`: when
+      `m.dlFailedAt` is set the placeholder reads as failed and offers a retry, rather than looking
+      like it is still loading
+- [ ] T022 [US2] Change `downloadPendingMedia` (~:1441) to
+      `downloadPendingMedia(id: string, opts: { silent?: boolean } = {})` — note the **default `{}`**,
+      or the existing template call sites (~:362, ~:383) that pass only the id would throw. The
+      automatic path and the tap path then share the existing `if (id in downloadProgress) return`
+      guard (~:1442), so a tap and an on-view attempt cannot race (FR-004), differing only in
+      whether they speak up
+- [ ] T023 [US2] Confirm the bubble repaints on the failed flip: T020 bumps `updatedAt`, which is
+      already the first entry of the row's `v-memo` list (~:154), so no `v-memo` change should be
+      needed. **Verify this rather than assume it** — if T020 is implemented without bumping
+      `updatedAt`, add `m.dlFailedAt` to the `v-memo` list at ~:159 instead
+- [ ] T024 [US2] Add the SC-003 recovery case to `e2e/voice-pending.spec.ts`: seed a **fetchable**
+      voice message, force the first fetch to fail, confirm the failed state, then tap **once** and
+      assert it plays. T010's `broken` seed can never succeed, so without this the "single tap
+      recovers it, 100% of the time the audio is still available" promise is never actually
+      exercised
+- [ ] T025 [US2] Run `npx playwright test e2e/voice-pending.spec.ts` — the US2, FR-008 persistence
+      and SC-003 cases pass
+
+**Checkpoint**: MVP complete. US1+US2 together deliver the reported fix end to end.
+
+---
+
+## Phase 6: User Story 3 — round video notes (Priority: P3)
+
+**Goal**: round notes behave like voice messages.
+
+- [ ] T026 [US3] Add a **dedicated sibling branch** for pending round notes in
+      `src/views/detail/ChatDetailPage.vue` — condition `m.kind === 'video' && m.videoNote &&
+      !m.mediaId && m.pendingMedia` — rendering a circular placeholder with the same `.dl-ring`
+      affordance, **including the failed state** from T021 so FR-010 holds for round notes and the
+      SC-001 round-note × failed cell is covered. Do **not** simply drop the `!m.videoNote`
+      exclusion from the square photo/video block at ~:360: that frame is a square
+      poster-or-skeleton box and would render a round note as a square, and the round-note bubble is
+      already chromeless via `'bubble-plain': m.videoNote && !m.deleted` (~:212), so a square
+      pending frame inside it would render bare
+- [ ] T027 [P] [US3] Add the round-note cases to `e2e/voice-pending.spec.ts` via
+      `seedPendingIncoming(chatId, 'video', { videoNote: true })` — both the recovery case and the
+      failed-state case
+
+---
+
+## Phase 7: User Story 4 — no attachment fails silently (Priority: P2)
+
+**Goal**: every pending kind fails honestly, not just voice.
+
+- [ ] T028 [US4] Replace the swallowing `catch` in `downloadPendingMedia`
+      (`src/views/detail/ChatDetailPage.vue` ~:1446-1448) with one that raises an `appToast` **when
+      `silent` is false** and lets T020's failure marking stand. `appToast` is already imported at
+      ~:1230. This is the single shared tap handler for every kind, so it covers photo, video, audio
+      and document at once (research R6)
+- [ ] T029 [US4] Show the failed state on the existing pending photo/video block and audio/file chip
+      so those kinds read as failed too (FR-010)
+- [ ] T030 [P] [US4] Add the US4 case to `e2e/voice-pending.spec.ts`: a pending **photo** whose tap
+      fails produces a visible message and a failed-looking bubble
+- [ ] T031 [P] [US4] Add the FR-015 guard case: with photo auto-download set to never, a pending
+      photo scrolled into view does **not** self-fetch. (Meaningful only because T017 defers to
+      `shouldAutoDownloadMedia` rather than a hardcoded allowlist)
+
+---
+
+## Phase 8: Polish & Gates
+
+- [ ] T032 Add the SC-005 stampede case to `e2e/voice-pending.spec.ts`: seed 10 consecutive pending
+      voice messages, scroll through them, assert all 10 recover, **at most 3 fetches in flight**,
+      and the scroll position stays stable
+- [ ] T033 Add the SC-001 matrix case: walk the six kinds × four states and assert **no** bubble
+      renders empty. Scope explicitly to the states reachable from the harness and log any cell left
+      to manual check rather than silently omitting it
+- [ ] T034 Run `npx playwright test e2e/seen-on-view.spec.ts` — the read-receipt observer is
+      unharmed by T017 (the canary from T002)
+- [ ] T035 [P] Run `npx playwright test e2e/media-blob-delete.spec.ts e2e/chat-media-scroll.spec.ts
+      e2e/media-cleanup.spec.ts` — pending/download and scroll-anchor behavior unregressed
+- [ ] T036 [P] Run `npx vitest run` and `npm run build` — unit (now including T006) + typecheck green
+- [ ] T037 Confirm FR-012 by hand: free space on a downloaded voice message and check it still reads
+      "removed to free space" rather than appearing re-fetchable
+- [ ] T038 Flip `**Status**:` to `in-progress` (then `in-review`) in
+      `specs/2058-voice-messages-arrive/spec.md` and run `make roadmap`
+- [ ] T039 **Bump `package.json` to 1.0.33.** `develop` and `main` are level at 1.0.32 (tag
+      `v1.0.32` exists), so this is the first change of a new release cycle and the constitution
+      makes the bump mandatory — without it the release guard blocks the eventual `develop → main`
+      PR (spec.md → Complexity & Exceptions, E-3)
+- [ ] T040 **SC-006 real-device pass**: send a voice message, and a reply carrying a voice message,
+      to a genuinely closed phone and confirm both play. Headless cannot produce a Web Push into a
+      closed iOS PWA, so this is owed before the spec is called shipped
+- [ ] T041 Discharge the supply-chain obligation (spec.md E-1): review the Docker Scout report for
+      the current `zuptalo/ring` tag and apply any vulnerability with a fix version, riding this
+      branch. Blocked in this environment (no Docker Hub access) — needs the maintainer
+
+---
+
+## Dependencies
+
+```
+Phase 1 (baseline)
+      ↓
+Phase 2 (field + REAL test seam + pure retry bound)   ← no behavior change
+      ↓
+Phase 3 (RED — observed failing)                      ← HARD GATE, Constitution III
+      ↓
+Phase 4 (US1) ──► Phase 5 (US2)                       ← US2's failed state renders on US1's placeholder
+      ↓                 ↓
+Phase 6 (US3)     Phase 7 (US4)                       ← both need T020's marking; independent of each other
+      ↓                 ↓
+            Phase 8 (gates + version bump)
+```
+
+- **T004 gates everything**: a seam that cannot produce a *successful* fetch makes US1 untestable.
+- **US1 → US2**: the failed state renders *on* the placeholder US1 introduces.
+- **US2 → US4**: US4 reuses T020's marking and T022's `silent` flag.
+- **US3** depends on T021's failed state (T026 renders it for round notes too); T026/T027 can
+  otherwise run alongside Phase 7.
+- `[P]`: T005, T027, T030, T031, T035, T036 — separate files or read-only runs.
+
+## Implementation Strategy
+
+**MVP = Phase 1-5** (US1 + US2). That is the reported bug fixed: no blank bubble, self-healing, a
+visible retry when the fetch fails, and stranded pre-fix messages recovering.
+
+**Stop-and-check points**:
+1. End of Phase 3 — do not proceed until the red test has actually been seen failing for the right
+   reason. The one gate the constitution makes non-negotiable for a `2001+` fix.
+2. End of Phase 5 — the reporter's scenario should now work; worth the real-device look (T040)
+   before investing in Phases 6-7.
+
+## Analysis remediation
+
+Mapping from the `/speckit-analyze` findings to their resolution.
+
+| Finding | Severity | Resolution |
+|---|---|---|
+| A1 seeded ref never fetchable → US1 untestable | CRITICAL | T004 rewritten to really upload a blob, with an explicit `broken` option |
+| A2 missed start-of-cycle version bump | CRITICAL | T039; plan Constitution Check row; spec E-3 |
+| A3 FR-013 / SC-004 zero coverage | CRITICAL | T012 |
+| A4 FR-007 / SC-002 zero coverage | CRITICAL | T009 extended to assert the placeholder→player swap within SC-002's budget |
+| A5 `mediaBubble`/`mediaVars` wrong for voice | HIGH | old T012 deleted; T015 now explicitly says keep the ordinary bubble box |
+| A6 session-vs-persistent retry contradiction | HIGH | counter made in-memory: spec FR-006 + Assumptions, data-model, T018 |
+| A7 `/speckit-checklist` for Principle I | HIGH | `checklists/zero-knowledge.md` added; plan row records the reasoning |
+| A8/A21 waiver in the wrong artifact | HIGH | spec.md gains a *Complexity & Exceptions* section (E-1..E-3) |
+| A9 vitest promised, none written | HIGH | T006 writes the failing unit test, T007 makes it pass |
+| A10 T013/T014 double-wrapped the lane | HIGH | merged into T016, single choke point |
+| A11 `silent` flag signature unspecified | MEDIUM | T022 states the signature; T017 and T028 reference it |
+| A12 hardcoded kind allowlist | MEDIUM | T017 defers to `shouldAutoDownloadMedia`, making T031 meaningful |
+| A13 a11y claim with no task | MEDIUM | T014 requires a `<button>` with an accessible label |
+| A14 T023 offered the implementer a fork | MEDIUM | T026 decides it: a dedicated sibling branch |
+| A15 retry cap number undefined | MEDIUM | fixed at 3 in FR-006, data-model, T006/T007 |
+| A16 FR-008 persistence untested | MEDIUM | T011 leaves and re-enters the chat |
+| A17 unmeasurable SC-001/002/005 | MEDIUM | criteria tightened in spec; T032 and T033 verify them |
+| A18 FR-002 unknown-duration fallback | LOW | FR-002 amended; T014 renders the fallback |
+| A19 FR-010/FR-011 are scope qualifiers | LOW | **accepted as-is** — merging would renumber every FR for no behavioral gain |
+| A20 T020 `v-memo` likely a no-op | LOW | T023 turned into a verify-don't-assume step |
+| A22 stale claim in research R7 | LOW | research.md R7 corrected in place; T005 downgraded to a convenience |
+
+### Second-pass remediation (re-run of `/speckit-analyze`)
+
+The re-run confirmed the design was sound but caught the rewrite leaving three artifacts stale.
+
+| Finding | Severity | Resolution |
+|---|---|---|
+| N1 plan.md still carried `dlAttempts`, the `mediaBubble()` extension, and the `v-memo` mandate | HIGH | plan.md Technical Context, source tree, and Risks all corrected |
+| N2 research.md R3 still recorded the persisted counter; R7 the false seam claim | MEDIUM | both revised in place, with a note explaining the reversal |
+| N3 `checklists/requirements.md` contradicted the A7 and A15 fixes | MEDIUM | notes rewritten; FR-012→FR-014 mis-citation fixed |
+| N4 T006 (impl) preceded T007 (its test) — literal Principle III inversion | MEDIUM | swapped: T006 is now the failing unit test, T007 the implementation |
+| N5 round-note failed state untasked (FR-010, SC-001 cell) | MEDIUM | folded into T026 |
+| N6 SC-003 (failed → single tap → success) had no automated case | MEDIUM | new T024 using a *fetchable* seed, since T010's `broken` seed can never succeed |
+| N8 `{ silent = false }` was invalid TS and would break existing call sites | LOW | T022 now specifies `opts: { silent?: boolean } = {}` |
+| N9 T017 omitted the guards and never named the function it calls | LOW | T017 now states the full predicate and the `{ silent: true }` call |
+| N10 T004 mis-cited `seedMedia` as an upload seam (it uploads nothing) | LOW | corrected to `prepareOutgoingMedia` (`media-transfer.ts:203`) |
+| N11 a fetchable seed can self-resolve via reconnect and green the red gate | LOW | T013 now requires ruling that out explicitly |
+| N12 the ZK checklist's open item rested on a false premise | LOW | closed by citation — `ownsync.ts:28` excludes `messages` from sync entirely |
+| N7, N13 | LOW | **accepted** — FR-004 is covered by implementation (T022) and exercised indirectly; the "don't interrupt playback in progress" edge case is left to the manual pass |

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2507,6 +2507,15 @@ const jobsInFlight = new Set<string>();
 const heavyLane = createLimiter(1);
 const lightLane = createLimiter(3);
 
+// Those two lanes govern SENDING. Receiving had no limiter at all: every path that fetches a
+// deferred attachment went straight at the network, and the app-start backfill fired one
+// unawaited fetch per pending message on the device. That was survivable only because
+// fetches were rare. Spec 2058 makes pending attachments recover whenever their bubble
+// scrolls into view, so a chat full of them would otherwise open a fetch each, all at once.
+// Every download now funnels through here — the choke point sits INSIDE
+// downloadMessageMedia, so callers can't forget it and nothing double-wraps.
+const downloadLane = createLimiter(3);
+
 // Peak-memory guard shared across BOTH lanes. Sealing holds plaintext + ciphertext in the heap
 // together (encryptBlob), so several large uploads at once is the jetsam (OOM) risk spec 2041
 // fought. The seal+upload phase of every job acquires from this budget: small items parallelize,
@@ -2859,7 +2868,7 @@ function onUnmeteredOrUnknown(): boolean {
  *  auto-download (a per-kind 'never' | 'wifi' | 'wifi-cellular' choice), the network, AND a size
  *  limit (anything larger is left for a manual tap). Voice notes and round video notes always
  *  download — they're small and expected to play instantly. Uses the media metadata (kind + size). */
-async function shouldAutoDownloadMedia(kind: MessageKind, videoNote: boolean, size: number): Promise<boolean> {
+export async function shouldAutoDownloadMedia(kind: MessageKind, videoNote: boolean, size: number): Promise<boolean> {
   if (kind === 'voice') return true; // voice messages are always downloaded
   if (kind === 'video' && videoNote) return true; // round video notes always download
   const key =
@@ -2944,8 +2953,23 @@ export async function downloadMessageMedia(
   const m = await getMessage(messageId);
   if (!m?.pendingMedia || m.mediaId) return;
   const ref = m.pendingMedia;
-  const blob = await receiveIncomingMedia(ref, onProgress);
-  if (!blob) throw new Error('download failed');
+  let blob: Blob | null;
+  try {
+    // (spec 2058) Through the lane: recovery can now fire for every pending attachment
+    // scrolled into view, so without a cap a chat full of them would open a fetch each.
+    blob = await downloadLane(() => receiveIncomingMedia(ref, onProgress));
+  } catch (e) {
+    await markDownloadFailed(messageId);
+    throw e;
+  }
+  if (!blob) {
+    // The bytes are genuinely not there (blob aged off the relay, or never finished
+    // uploading). Remember that we tried and lost, so the bubble can say so instead of
+    // sitting there looking like it is still loading (spec 2058, FR-008). pendingMedia is
+    // deliberately kept — dropping it would make the message permanently unrecoverable.
+    await markDownloadFailed(messageId);
+    throw new Error('download failed');
+  }
   const mediaId = uid();
   await put<Media>('media', {
     id: mediaId,
@@ -2960,7 +2984,19 @@ export async function downloadMessageMedia(
   await applyThumbTiers(mediaId, await bubbleFromDataUrl(ref.poster)); // spec 1014 tiers from the sent poster
   m.mediaId = mediaId;
   m.pendingMedia = undefined;
+  m.dlFailedAt = undefined; // it worked — clear any earlier failure (spec 2058)
   m.updatedAt = now();
+  await put('messages', m);
+}
+
+/** (spec 2058) Mark a message's attachment fetch as failed, so its bubble shows a retry
+ *  affordance rather than a perpetual loading state. Re-read inside so a fetch that raced a
+ *  concurrent success doesn't resurrect a failure on an already-resolved message. */
+async function markDownloadFailed(messageId: string): Promise<void> {
+  const m = await getMessage(messageId);
+  if (!m || m.mediaId || !m.pendingMedia) return; // resolved or gone in the meantime
+  m.dlFailedAt = now();
+  m.updatedAt = now(); // bumps the bubble's v-memo key so the row repaints
   await put('messages', m);
 }
 

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -363,6 +363,18 @@ export interface Message {
   // Set on a received media message that hasn't been downloaded yet (auto-download
   // off / deferred): the encrypted reference used to fetch it on demand.
   pendingMedia?: import('@/services/crypto/message').MediaRef;
+  // Spec 2058: when the most recent attempt to fetch `pendingMedia` FAILED (epoch ms).
+  // Cleared back to undefined the moment a fetch succeeds. Drives the bubble's "couldn't
+  // load this, tap to retry" face, so a failed fetch is visible instead of leaving the
+  // attachment looking like it is still loading forever.
+  //
+  // Persisted (rather than a component-local map) because the failure must still read as a
+  // failure when you leave the chat and come back. Device-local: never sent, never
+  // own-data-synced (ownsync only carries contacts/chats/chatlists), never server-derived.
+  // The companion auto-retry COUNT is deliberately NOT stored — it lives in memory for the
+  // session, so a message that burned its retries while offline gets a fresh chance on the
+  // next launch instead of being stuck on manual-tap forever.
+  dlFailedAt?: number;
   // Sender side: the server blob id we uploaded for this message's media, kept so we can
   // DELETE it once every recipient has downloaded the bytes (and on chat delete). Cleared
   // to undefined once the blob is deleted, so we never try twice.

--- a/src/services/testhook.ts
+++ b/src/services/testhook.ts
@@ -145,7 +145,7 @@ import { resetHiddenChats as hcReset } from '@/services/hidden-chats-reset';
 import { canHide, canUnhide } from '@/services/hidden-pair';
 import { hiddenIdsSync } from '@/services/hidden-state';
 import { revealWithPin as hcReveal, relockHidden as hcRelock } from '@/composables/useHiddenChats';
-import { downloadBlob } from '@/services/media-transfer';
+import { downloadBlob, prepareOutgoingMedia } from '@/services/media-transfer';
 import {
   chatMatchesFilter,
   type FilterId,
@@ -557,6 +557,11 @@ export function installTestHook(): void {
         status: m.status,
         hasPoster: !!m.posterData, // spec 1014: the bubble-tier preview rode the sealed envelope
         seenReportedAt: m.seenReportedAt ?? null, // spec 1013: this device reported it Seen
+        // (spec 2058) attachment state, so a test can tell "bytes are here" from "still
+        // pending" from "the fetch failed" without a second call per row.
+        pending: !!m.pendingMedia,
+        hasMedia: !!m.mediaId,
+        dlFailedAt: m.dlFailedAt ?? null,
         senderId: m.senderId,
         outgoing: m.outgoing,
         reactions: m.reactions ?? [],
@@ -1137,6 +1142,57 @@ export function installTestHook(): void {
         direction: c.direction,
         isGroup: c.isGroup,
       })),
+
+    /* ---- pending incoming media (spec 2058) ---- */
+    /** Seed an INCOMING message whose attachment bytes are not on the device yet — the exact
+     *  state a voice message lands in when it arrives while the app is closed (the push drain
+     *  stores the reference and never fetches bytes) or when a fetch fails.
+     *
+     *  `seedMedia` below cannot produce this: it always sets `mediaId` and `outgoing: true`.
+     *
+     *  By default the reference is REAL — the blob is encrypted and genuinely uploaded — so a
+     *  fetch can actually succeed and the recovery path is exercisable. That matters: with a
+     *  fabricated reference every fetch fails, and a test suite built on it could only ever
+     *  prove the failure half of the feature while quietly never testing the half that
+     *  matters. Pass `broken: true` to get an unfetchable reference on purpose, for the
+     *  failure cases. */
+    seedPendingIncoming: async (
+      chatId: string,
+      kind: 'voice' | 'video' | 'image' | 'audio' | 'file' = 'voice',
+      opts: { broken?: boolean; videoNote?: boolean; durationSec?: number; agedMs?: number } = {},
+    ): Promise<string> => {
+      const durationSec = opts.durationSec ?? 4;
+      // A tiny payload is enough — nothing decodes it; the test asserts on the bubble, and
+      // the fetch either resolves bytes or it doesn't.
+      const blob = new Blob([new Uint8Array(256)], { type: kind === 'voice' ? 'audio/webm' : 'application/octet-stream' });
+      const ref = await prepareOutgoingMedia(blob, `seed-pending.${kind}`, durationSec);
+      if (opts.broken) {
+        // Point at a blob id that was never uploaded. The fileKey stays valid, so the failure
+        // is a genuine "the bytes aren't there" 404 rather than a decrypt error.
+        ref.blobId = `never-uploaded-${uid()}`;
+      }
+      const id = uid();
+      // `agedMs` backdates the row so a test can seed a message that was stranded by an older
+      // build, rather than one that just arrived (FR-013).
+      const when = Date.now() - (opts.agedMs ?? 0);
+      await put<Message>('messages', {
+        id,
+        chatId,
+        senderId: 'peer',
+        senderName: 'Peer',
+        body: '',
+        kind,
+        durationSec,
+        timestamp: when,
+        outgoing: false,
+        status: 'delivered',
+        videoNote: opts.videoNote || undefined,
+        mediaSize: ref.size,
+        pendingMedia: ref,
+        updatedAt: when,
+      });
+      return id;
+    },
 
     /* ---- media storage cleanup ---- */
     /** Seed a fake media blob + a message linking it (for storage tests). */

--- a/src/utils/media-retry.test.ts
+++ b/src/utils/media-retry.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { AUTO_RETRY_LIMIT, shouldAutoRetry } from './media-retry';
+
+// Spec 2058 FR-006. The on-view recovery re-fires every time a pending bubble scrolls back
+// into view, so an attachment that can never be fetched (its blob aged off the relay, say)
+// would otherwise retry forever — a tight loop against the relay for a message that will
+// never load. The bound stops that while leaving the manual tap always available.
+describe('shouldAutoRetry', () => {
+  it('allows the first attempt on a message never tried before', () => {
+    expect(shouldAutoRetry(0)).toBe(true);
+  });
+
+  it('keeps allowing attempts below the limit', () => {
+    expect(shouldAutoRetry(1)).toBe(true);
+    expect(shouldAutoRetry(2)).toBe(true);
+  });
+
+  it('stops at the limit', () => {
+    expect(shouldAutoRetry(AUTO_RETRY_LIMIT)).toBe(false);
+  });
+
+  it('stays stopped past the limit', () => {
+    expect(shouldAutoRetry(AUTO_RETRY_LIMIT + 1)).toBe(false);
+    expect(shouldAutoRetry(99)).toBe(false);
+  });
+
+  it('caps at three attempts per message per session', () => {
+    expect(AUTO_RETRY_LIMIT).toBe(3);
+  });
+
+  // Defensive: the caller reads from a Map that may have no entry yet, so undefined/NaN
+  // must not be read as "already exhausted" — that would silently disable recovery.
+  it('treats a missing count as zero attempts', () => {
+    expect(shouldAutoRetry(undefined as unknown as number)).toBe(true);
+    expect(shouldAutoRetry(NaN)).toBe(true);
+  });
+});

--- a/src/utils/media-retry.ts
+++ b/src/utils/media-retry.ts
@@ -1,0 +1,29 @@
+/**
+ * Spec 2058: how many times the chat may re-try fetching one attachment BY ITSELF.
+ *
+ * A pending attachment recovers on its own when its bubble scrolls into view, which is what
+ * makes a voice message that arrived while the app was closed simply work. But that trigger
+ * fires every time the bubble comes back into view, so an attachment that can never be
+ * fetched — its blob aged off the relay, the sender's device never finished the upload —
+ * would retry every single time you scrolled past it, forever.
+ *
+ * The bound only ever restrains the AUTOMATIC path. A deliberate tap always attempts, however
+ * many times the automatic path has already given up (a tap usually means the person just
+ * fixed the thing that was broken — they reconnected).
+ *
+ * The count deliberately lives in memory for the session rather than on the message. If it
+ * were persisted, a message that burned its attempts during one offline stretch would be
+ * stuck on manual-tap for the rest of that install; letting it die with the session means the
+ * next launch quietly tries again, which is exactly what a message stranded by an older build
+ * needs.
+ */
+export const AUTO_RETRY_LIMIT = 3;
+
+/** Whether the automatic on-view recovery may attempt this message again. */
+export function shouldAutoRetry(attempts: number): boolean {
+  // Callers read from a Map that has no entry until the first attempt, so treat a missing or
+  // nonsensical count as "never tried" — reading it as "exhausted" would silently turn
+  // recovery off for every message.
+  if (!Number.isFinite(attempts) || attempts < 0) return true;
+  return attempts < AUTO_RETRY_LIMIT;
+}

--- a/src/views/detail/ChatDetailPage.vue
+++ b/src/views/detail/ChatDetailPage.vue
@@ -359,6 +359,7 @@
               <div
                 v-if="((m.kind === 'video' && !m.videoNote) || m.kind === 'image') && !m.mediaId && m.pendingMedia"
                 class="video-poster pending"
+                :class="{ failed: !!m.dlFailedAt && !(m.id in downloadProgress) }"
                 @click.stop="downloadPendingMedia(m.id)"
               >
                 <img v-if="m.posterData" class="bubble-image" :src="m.posterData" :alt="m.kind" />
@@ -369,7 +370,7 @@
                     <circle class="dl-ring-track" cx="18" cy="18" r="16" pathLength="100" />
                     <circle class="dl-ring-fill" cx="18" cy="18" r="16" pathLength="100" :stroke-dasharray="`${(downloadProgress[m.id] || 0) * 100} 100`" />
                   </svg>
-                  <ion-icon :icon="downloadOutline" />
+                  <ion-icon :icon="m.dlFailedAt && !(m.id in downloadProgress) ? refreshOutline : downloadOutline" />
                 </span>
                 <!-- Attachment size (climbs live while downloading), so a large clip is obvious
                      before you spend the data. -->
@@ -380,6 +381,7 @@
                 v-else-if="(m.kind === 'audio' || m.kind === 'file') && !m.mediaId && m.pendingMedia"
                 type="button"
                 class="file-chip pending-chip"
+                :class="{ failed: !!m.dlFailedAt && !(m.id in downloadProgress) }"
                 @click.stop="downloadPendingMedia(m.id)"
               >
                 <span class="chip-ico">
@@ -387,10 +389,53 @@
                     <circle class="dl-ring-track" cx="18" cy="18" r="16" pathLength="100" />
                     <circle class="dl-ring-fill" cx="18" cy="18" r="16" pathLength="100" :stroke-dasharray="`${(downloadProgress[m.id] || 0) * 100} 100`" />
                   </svg>
-                  <ion-icon :icon="m.id in downloadProgress ? downloadOutline : (m.kind === 'audio' ? musicalNotesOutline : downloadOutline)" />
+                  <ion-icon :icon="m.dlFailedAt && !(m.id in downloadProgress) ? refreshOutline : (m.id in downloadProgress ? downloadOutline : (m.kind === 'audio' ? musicalNotesOutline : downloadOutline))" />
                 </span>
                 <span>{{ m.pendingMedia.name || (m.kind === 'audio' ? 'Audio' : 'File') }}</span>
                 <span v-if="m.mediaSize" class="chip-size">{{ dlSizeLabel(m) }}</span>
+              </button>
+              <!-- Voice message whose audio isn't on the device yet (spec 2058). Without this
+                   branch the bubble rendered COMPLETELY EMPTY — the voice player above needs
+                   the resolved blob, and neither pending fallback matched 'voice', so nothing
+                   was drawn at all. Shaped to VoicePlayer's row (disc + wave strip + time) so
+                   the swap to the real player doesn't change the bubble's height; a chip here
+                   would reflow the list mid-scroll, which is the trap spec 1011 documents. -->
+              <button
+                v-else-if="m.kind === 'voice' && !m.mediaId && m.pendingMedia"
+                type="button"
+                class="vp-pending"
+                :class="{ failed: !!m.dlFailedAt && !(m.id in downloadProgress) }"
+                :aria-label="pendingVoiceLabel(m)"
+                @click.stop="downloadPendingMedia(m.id)"
+              >
+                <span class="vpp-disc">
+                  <svg v-if="m.id in downloadProgress" class="dl-ring" viewBox="0 0 36 36" aria-hidden="true">
+                    <circle class="dl-ring-track" cx="18" cy="18" r="16" pathLength="100" />
+                    <circle class="dl-ring-fill" cx="18" cy="18" r="16" pathLength="100" :stroke-dasharray="`${(downloadProgress[m.id] || 0) * 100} 100`" />
+                  </svg>
+                  <ion-icon :icon="m.dlFailedAt && !(m.id in downloadProgress) ? refreshOutline : micOutline" />
+                </span>
+                <!-- Inert flat bars: the same visual footprint the real waveform will occupy. -->
+                <span class="vpp-wave" aria-hidden="true"><i v-for="n in 28" :key="n"></i></span>
+                <span class="vpp-time">{{ pendingVoiceTime(m) }}</span>
+              </button>
+              <!-- Round video note, same story (spec 2058). Kept as its own branch rather than
+                   folded into the square photo/video block above: that frame is a square
+                   poster box, and a round note's bubble is already chromeless, so reusing it
+                   would render a square patch where a circle belongs. -->
+              <button
+                v-else-if="m.kind === 'video' && m.videoNote && !m.mediaId && m.pendingMedia"
+                type="button"
+                class="note-pending"
+                :class="{ failed: !!m.dlFailedAt && !(m.id in downloadProgress) }"
+                :aria-label="m.dlFailedAt ? 'Video note — couldn\'t load, tap to try again' : 'Video note — tap to load'"
+                @click.stop="downloadPendingMedia(m.id)"
+              >
+                <svg v-if="m.id in downloadProgress" class="dl-ring" viewBox="0 0 36 36" aria-hidden="true">
+                  <circle class="dl-ring-track" cx="18" cy="18" r="16" pathLength="100" />
+                  <circle class="dl-ring-fill" cx="18" cy="18" r="16" pathLength="100" :stroke-dasharray="`${(downloadProgress[m.id] || 0) * 100} 100`" />
+                </svg>
+                <ion-icon :icon="m.dlFailedAt && !(m.id in downloadProgress) ? refreshOutline : videocamOutline" />
               </button>
 
               <!-- Media removed from THIS device to free space: a placeholder so the
@@ -1226,7 +1271,9 @@ import {
   unblockContact, detectTerminated, firstMessageOnOrAfter, countUnread,
   CAPTION_MAX, getSetting, listChatMediaAll, getMessage, listMessagesOlder,
   backfillThumbTiers, getDraft, saveDraft, clearDraft, getDraftMedia, saveDraftMedia, clearDraftMedia,
+  shouldAutoDownloadMedia,
 } from '@/db/queries';
+import { shouldAutoRetry } from '@/utils/media-retry'; // spec 2058: bound the automatic refetch
 import { appToast } from '@/services/toast';
 import { describeMediaError } from '@/services/media-errors';
 import { hasRoomFor } from '@/services/storage-estimate';
@@ -1280,7 +1327,7 @@ import { vEnterSend } from '@/directives/enter-send';
 import { formatBytes } from '@/utils/bytes';
 import { readAudioTags, readAudioDuration } from '@/utils/id3';
 import { get, put } from '@/db/idb';
-import type { Chat, Contact, Media, Message, MessageStatus, Reaction, ReplyRef, SharedContact, DraftMediaItem } from '@/db/types';
+import type { Chat, Contact, Media, Message, MessageKind, MessageStatus, Reaction, ReplyRef, SharedContact, DraftMediaItem } from '@/db/types';
 import { useLiveQuery } from '@/composables/useLiveQuery';
 import { useChatHistory } from '@/composables/useChatHistory';
 import { LOOK_AHEAD_PX } from '@/utils/chat-window';
@@ -1438,13 +1485,28 @@ function closeSearch() {
 // Per-message download progress (0..1) while a deferred attachment is being fetched; presence in the
 // map means "downloading now" and drives the circular progress ring on the download button.
 const downloadProgress = reactive<Record<string, number>>({});
-async function downloadPendingMedia(id: string): Promise<void> {
+async function downloadPendingMedia(id: string, opts: { silent?: boolean } = {}): Promise<void> {
   if (id in downloadProgress) return;
   downloadProgress[id] = 0;
   try {
     await downloadMessageMedia(id, (f) => (downloadProgress[id] = f));
+    // (spec 2058) Resolve the freshly-stored blob into an object URL right now.
+    // The bubble needs BOTH the row's new mediaId and an entry in mediaInfo before it can
+    // draw the player; mediaInfo is otherwise only rebuilt by a watcher over the visible
+    // window, which doesn't observe a row being patched in place. Without this the bubble
+    // goes from placeholder to EMPTY the moment the fetch lands and stays that way until the
+    // chat is reopened — the very blank this spec is here to remove (FR-007).
+    const fresh = await getMessage(id);
+    if (fresh?.mediaId) await resolveMediaFor([fresh]);
   } catch {
-    /* leave it pending so the user can tap again */
+    // (spec 2058) The attachment stays pending so it can be tapped again, and the message is
+    // now marked failed so the bubble SHOWS that rather than looking eternally busy. When the
+    // person asked for this themselves, say so at the moment it happens — a silent no-op after
+    // a deliberate tap reads as the app ignoring them. Automatic recovery stays quiet: it
+    // fires on scroll, and toasting for something they never asked for would be noise.
+    if (!opts.silent) {
+      void appToast({ message: "Couldn't load this. Tap to try again.", duration: 2000, color: 'danger' });
+    }
   } finally {
     delete downloadProgress[id];
   }
@@ -1456,6 +1518,24 @@ function dlSizeLabel(m: Message): string {
   if (!total) return '';
   const p = downloadProgress[m.id];
   return p === undefined ? formatBytes(total) : `${formatBytes(p * total)} / ${formatBytes(total)}`;
+}
+
+// (spec 2058) The length shown on a voice message whose audio hasn't arrived yet. The sender
+// puts the duration in the message itself, so we can say how long it is before we hold a
+// single byte of the audio. Older rows may not carry one — then we say what it IS, rather
+// than leaving an empty slot where a number should be (FR-002).
+function pendingVoiceTime(m: Message): string {
+  const s = Math.round(m.durationSec || 0);
+  if (!s) return 'Voice message';
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+}
+// Spoken label for the same control. The failed wording matters: "couldn't load" tells the
+// person the app tried and lost, rather than implying they never asked.
+function pendingVoiceLabel(m: Message): string {
+  const len = m.durationSec ? `, ${pendingVoiceTime(m)}` : '';
+  return m.dlFailedAt
+    ? `Voice message${len} — couldn't load, tap to try again`
+    : `Voice message${len} — tap to load`;
 }
 
 
@@ -3281,7 +3361,15 @@ function setupBubbleObserver(root: HTMLElement | null): void {
   // The observer is just a cheap TRIGGER: any bubble crossing in/out re-runs the authoritative
   // geometry scan in markVisibleSeen. (We don't trust the observer's own ratio bookkeeping, which
   // can lag a programmatic jump.)
-  bubbleVisObs = new IntersectionObserver(() => markVisibleSeen(), { root, threshold: [0, 0.5, 1] });
+  // (spec 2058) The same trigger also drives pending-attachment recovery — separate handler,
+  // separate debounce, so a fetch can never perturb the Seen path.
+  bubbleVisObs = new IntersectionObserver(
+    () => {
+      markVisibleSeen();
+      recoverVisiblePending();
+    },
+    { root, threshold: [0, 0.5, 1] },
+  );
   observeBubbles();
 }
 function observeBubbles(): void {
@@ -3325,6 +3413,51 @@ async function runMarkVisibleSeen(): Promise<void> {
   if (!newestId) return;
   await reportSeenUpTo(chatId, newestId);
   await recomputeUnread(); // the marks dropped the not-yet-Seen count → shrink the pill
+}
+
+// (spec 2058) Fetch the attachments of pending messages that are on screen.
+//
+// The common way a voice message ends up with no audio is that it arrived while the app was
+// closed: the push path stores the reference and never fetches bytes, because a notification
+// wake-up has neither the time nor the media pipeline to do it. The bytes are collected at
+// next app start — but until then the bubble has nothing to play, and if that fetch fails
+// nothing ever tries again. Recovering what you are actually looking at closes both gaps.
+//
+// Deliberately a SEPARATE handler from markVisibleSeen rather than folded into it: the Seen
+// path is delicate (settle/seek/visibility gates, receipt writes) and has its own e2e, and a
+// fetch has no business being able to perturb it.
+let recoverTimer: ReturnType<typeof setTimeout> | undefined;
+// Attempts live for the session only. Persisting them would mean a message that used up its
+// tries during one offline stretch is stuck on manual-tap for good — the opposite of what a
+// message stranded by an older build needs (FR-013).
+const autoFetchAttempts = new Map<string, number>();
+function recoverVisiblePending(): void {
+  clearTimeout(recoverTimer);
+  recoverTimer = setTimeout(() => void runRecoverVisiblePending(), 260);
+}
+async function runRecoverVisiblePending(): Promise<void> {
+  if (!viewActive.value || document.visibilityState !== 'visible') return;
+  const el = scrollEl;
+  if (!el) return;
+  const vTop = el.getBoundingClientRect().top;
+  const vBot = vTop + el.clientHeight;
+  for (const n of Array.from(listEl.value?.querySelectorAll<HTMLElement>('.bubble[data-mid]') ?? [])) {
+    const r = n.getBoundingClientRect();
+    if (r.height <= 0) continue;
+    if (r.bottom < vTop || r.top > vBot) continue; // off screen
+    const mid = n.dataset.mid;
+    const m = mid ? rows.value.find((x) => x.id === mid) : undefined;
+    if (!m || m.outgoing || m.mediaId || !m.pendingMedia || m.deleted) continue;
+    if (m.expiresAt && m.expiresAt <= Date.now()) continue; // about to vanish; don't fetch for it
+    if (m.id in downloadProgress) continue; // already fetching (shared guard with the tap path)
+    const tries = autoFetchAttempts.get(m.id) ?? 0;
+    if (!shouldAutoRetry(tries)) continue; // gave up automatically; the tap still works
+    // Whether this KIND should fetch itself is not our call to re-invent — the same rule the
+    // arrival path uses decides, so a photo the user chose to leave deferred stays deferred.
+    if (!(await shouldAutoDownloadMedia(m.kind as MessageKind, !!m.videoNote, m.pendingMedia.size))) continue;
+    autoFetchAttempts.set(m.id, tries + 1);
+    void downloadPendingMedia(m.id, { silent: true }); // automatic: never interrupts with a toast
+  }
 }
 // Re-attempt Seen for what's on screen when the transport reconnects (offline sends are retried).
 const { syncState } = useSync();
@@ -5771,6 +5904,106 @@ function cancelRecording() {
 .chip-ico .dl-ring-fill {
   stroke: var(--ion-color-primary);
 }
+
+/* (spec 2058) Voice message whose audio hasn't arrived yet. The metrics deliberately mirror
+   VoicePlayer's .vp row — 34px disc, 24px wave strip, same gap and vertical padding — so
+   when the audio lands and the real player takes over, the bubble doesn't change height.
+   A different-sized placeholder would shove every message below it as each one resolved. */
+.vp-pending {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  max-width: 100%;
+  padding: 2px 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+.vpp-disc {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--ion-color-primary);
+  color: #fff;
+  font-size: 18px;
+}
+/* The inert stand-in for the waveform: same 24px strip the real bars occupy, held at a low
+   flat height so it reads as "not here yet" rather than as a real, playable waveform. */
+.vpp-wave {
+  flex: 1;
+  min-width: 40px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  overflow: hidden;
+}
+.vpp-wave i {
+  flex: 1;
+  height: 4px;
+  border-radius: 1px;
+  background: currentColor;
+  opacity: 0.28;
+}
+.vpp-time {
+  min-width: 32px;
+  font-size: 12px;
+  opacity: 0.65;
+  font-variant-numeric: tabular-nums;
+  flex: none;
+}
+/* Tried and lost. Warm colour + a retry glyph in the disc, so it reads as something that
+   went wrong and can be poked, not as something still quietly loading. */
+.vp-pending.failed .vpp-disc {
+  background: var(--ion-color-warning, #e0a030);
+}
+.vp-pending.failed .vpp-time {
+  opacity: 0.85;
+}
+
+/* (spec 2058) The same "we tried and lost" treatment for the kinds that already had a pending
+   presentation. They were silent about failure too — a tap that failed simply did nothing. */
+.video-poster.pending.failed .dl-btn,
+.pending-chip.failed .chip-ico {
+  color: var(--ion-color-warning, #e0a030);
+}
+.pending-chip.failed {
+  border-color: var(--ion-color-warning, #e0a030);
+}
+
+/* (spec 2058) Round video note, same idea — circular so it matches the note it becomes. */
+.note-pending {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  border: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(128, 128, 128, 0.18);
+  color: var(--ion-color-primary);
+  font-size: 30px;
+  cursor: pointer;
+}
+.note-pending.failed {
+  color: var(--ion-color-warning, #e0a030);
+}
+.note-pending .dl-ring {
+  position: absolute;
+  inset: 0;
+  transform: rotate(-90deg);
+}
+
 /* Link preview card (privacy-safe: domain + icon, no remote fetch). */
 .link-card {
   display: flex;


### PR DESCRIPTION
## The bug

A voice message whose audio had not reached the device yet drew a **completely empty bubble** — outline, timestamp, reaction button, nothing else. No player, no length, no way to fetch it. Reported from a real conversation where two voice messages arrived blank.

The voice/round-note render is gated on the bytes being local, and the "not downloaded yet" fallbacks were only ever built for photo/video and audio/file. Voice matched neither, so nothing was drawn. It is **not** reply-specific — the reply quote rendered because a quote is plain metadata needing no attachment.

## What changed

- A voice placeholder showing the message's length, tappable to load
- Pending attachments fetch themselves when the bubble scrolls into view, bounded to 3 automatic attempts per message per session
- A visible failed state with retry that survives leaving and re-entering the chat
- Round video notes get the same treatment
- Every other attachment kind now reports a failed load instead of silently doing nothing

## Two things this turned up

**Downloads had no concurrency limit at all.** Sending has had lanes since spec 2053, but receiving went straight at the network, and the app-start backfill fired one unawaited fetch per pending message. Recovering on view would have made that worse, so downloads now share a lane of three.

**A fetch completing while the chat was open left the bubble empty anyway.** The row patches in place, but the resolved-blob map is only rebuilt by a watcher that does not observe that mutation — so the bubble went placeholder → blank and stayed blank until reopened. The e2e caught it.

## Verification

1298 unit tests · 9 e2e in `voice-pending.spec.ts` · read-receipt canary (`seen-on-view`) intact · media regression set (blob-delete, media-scroll, media-cleanup) green · typecheck clean. The red regression test was observed failing before any fix landed.

Real-device pass confirmed by the maintainer.

## Notes for review

- Carries `4eb55c2 chore: mark spec 1064 shipped` — the branch was cut from `chore/1064-shipped`. That makes PR #1110 redundant; it should close automatically.
- Bumps `package.json` to 1.0.33 (start of a new release cycle).
- The Docker Scout supply-chain scan is waived to the release PR by maintainer decision, recorded in the spec's Complexity & Exceptions.

Closes #1111
Closes #1112
Closes #1113
Closes #1114
Closes #1115
Closes #1116
Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4fKAHwfJWp2SpSzDbNP3i