### PR TITLE
docs(spec): mark audience insight shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,7 +84,7 @@ Specs are grouped by category band; status moves
 | [1062](specs/1062-list-status-presence/spec.md) | Message status and presence on the chat list | 🟢 shipped |
 | [1063](specs/1063-full-size-media/spec.md) | Full-size aspect-preserving media thumbnails in chat | 🟢 shipped |
 | [1064](specs/1064-mention-names/spec.md) | Mentions show the name you know someone by, and stay readable | 🟢 shipped |
-| [1065](specs/1065-message-and-post/spec.md) | Message and Post Audience Insight | 🔵 in-review |
+| [1065](specs/1065-message-and-post/spec.md) | Message and Post Audience Insight | 🟢 shipped |
 
 ## 🐛 Hotfixes & Bug Fixes (2001+)
 

--- a/specs/1065-message-and-post/spec.md
+++ b/specs/1065-message-and-post/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-30
 
-**Status**: in-review
+**Status**: shipped
 <!-- Ring spec lifecycle: planned → in-progress → in-review → shipped.
      This line is the source of truth for the spec's row in ROADMAP.md;
      bump it as the work moves through the pipeline. The spec id and category


### PR DESCRIPTION
## Summary

- move spec 1065 from in-review to shipped after its implementation PR landed
- regenerate ROADMAP.md from the spec source of truth

## Verification

- `make roadmap`
- `git diff --check`